### PR TITLE
REGRESSION (264613@main): Strong password is clipped on ambetterhealth.com

### DIFF
--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height-expected.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+input {
+    background-color: white;
+    border: 1px solid black;
+    width: 200px;
+    height: 40px;
+    line-height: 30px;
+}
+
+#container {
+    position: relative;
+}
+
+#box {
+    position: absolute;
+    background-color: black;
+    top: 45px;
+    left: 50px;
+    height: 60px;
+    width: 160px;
+}
+</style>
+</head>
+<body>
+<div id="container">
+    <p>This tests that the Strong Password AutoFill text is visible in an autofilled input with a custom line-height. It can only be tested in the test runner.</p>
+    <input type="password" value="thisisaverystrongpassword">
+    <div id="box"></div>
+</div>
+<script>
+if (window.internals) {
+    var input = document.querySelector("input");
+    internals.setAutoFilledAndViewable(input, true);
+    internals.setShowAutoFillButton(input, "StrongPassword");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+input {
+    background-color: white;
+    border: 1px solid black;
+    width: 200px;
+    height: 40px;
+    line-height: 40px;
+}
+
+#container {
+    position: relative;
+}
+
+#box {
+    position: absolute;
+    background-color: black;
+    top: 45px;
+    left: 50px;
+    height: 60px;
+    width: 160px;
+}
+
+</style>
+</head>
+<body>
+<div id="container">
+    <p>This tests that the Strong Password AutoFill text is visible in an autofilled input with a custom line-height. It can only be tested in the test runner.</p>
+    <input type="password" value="thisisaverystrongpassword">
+    <div id="box"></div>
+</div>
+<script>
+if (window.internals) {
+    var input = document.querySelector("input");
+    internals.setAutoFilledAndViewable(input, true);
+    internals.setShowAutoFillButton(input, "StrongPassword");
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2260,7 +2260,7 @@ RenderStyle HTMLInputElement::createInnerTextStyle(const RenderStyle& style)
         // Do not allow line-height to be smaller than our default.
         if (textBlockStyle.metricsOfPrimaryFont().lineSpacing() > style.computedLineHeight())
             return true;
-        return isText() && !style.logicalHeight().isAuto();
+        return isText() && !style.logicalHeight().isAuto() && !hasAutoFillStrongPasswordButton();
     };
     if (shouldUseInitialLineHeight())
         textBlockStyle.setLineHeight(RenderStyle::initialLineHeight());


### PR DESCRIPTION
#### 3eca5e06b905dc7451687e13117b17bde6287cff
<pre>
REGRESSION (264613@main): Strong password is clipped on ambetterhealth.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=263427">https://bugs.webkit.org/show_bug.cgi?id=263427</a>
rdar://114359535

Reviewed by Alan Baradlay.

Consider the shadow tree for input elements:

&lt;input&gt;
    &lt;container&gt;
        &lt;inner-block&gt;
            &lt;inner-text&gt;

Input elements with a strong password autofilled force the height of the
container renderer to be equal to the height of the inner text renderer.

Following 264613@main, the height of the inner text renderer can be reduced, as
the line height is reset to initial if the input has an explicitly specified
height. However, the inner block renderer, which sits in between the inner text
and the container in the tree, does not have its line height adjusted.

Consequently, it&apos;s possible to have an inner block which is larger than both
the container and inner text elements, which themselves have equal height.
Since the container is center-aligned in the input, the inner block is
top-aligned in the container, and the inner text is center-aligned in the
inner block, it will be clipped.

To fix, partially revert 264613@main, for inputs that have been strong password
autofilled. This is fine since the height of the container renderer is forced
to be equal to the height of the inner text renderer.

* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height-expected.html: Added.
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-line-height.html: Added.

The added test uses two different line-heights on an input with the same height
and ensures the appearance is the same, since the strong password text should
be centered just the same in the input. A black box is added to the trailing edge
of the input in order to avoid differences due to the gradient password mask, and
another issue with the strong password &quot;button&quot; (tracked in rdar://113701243).

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::createInnerTextStyle):

Canonical link: <a href="https://commits.webkit.org/269606@main">https://commits.webkit.org/269606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec8e3fefd828ba06a598a56d2104f8664bfc24e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23509 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25739 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26998 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24857 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18296 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20590 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5498 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->