### PR TITLE
Convert all uses of RefPtr<WebCore::StaticRange> to Ref<WebCore::StaticRange>.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/inputevent-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/inputevent-constructor-expected.txt
@@ -3,4 +3,8 @@ PASS InputEvent constructor without InputEventInit.
 PASS InputEvent construtor with InputEventInit where data is null
 PASS InputEvent construtor with InputEventInit where data is empty string
 PASS InputEvent construtor with InputEventInit where data is non empty string
+PASS InputEvent constructor with InputEventInit where dataTransfer is null
+PASS InputEvent constructor with InputEventInit where dataTransfer is set
+PASS InputEvent constructor with InputEventInit where targetRanges is empty
+PASS InputEvent constructor with InputEventInit where targetRanges has one item
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/inputevent-constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/inputevent-constructor.html
@@ -22,4 +22,37 @@ test(function() {
 test(function() {
   assert_equals(new InputEvent('type', { data: 'data' }).data, 'data', '.data');
 }, 'InputEvent construtor with InputEventInit where data is non empty string');
+
+test(function() {
+  var e = new InputEvent('type', { dataTransfer: null });
+  assert_equals(e.dataTransfer, null, '.dataTransfer');
+}, 'InputEvent constructor with InputEventInit where dataTransfer is null');
+
+test(function() {
+  var dataTransfer = new DataTransfer();
+  var e = new InputEvent('type', { dataTransfer: dataTransfer });
+  assert_equals(e.dataTransfer, dataTransfer, '.dataTransfer');
+}, 'InputEvent constructor with InputEventInit where dataTransfer is set');
+
+test(function() {
+  var e = new InputEvent('type', { targetRanges: [] });
+  assert_equals(e.getTargetRanges().length, 0, '.targetRanges');
+}, 'InputEvent constructor with InputEventInit where targetRanges is empty');
+
+test(function() {
+  // Create a StaticRange with arguments (startContainer, startOffset, endContainer, endOffset)
+  var startContainer = document.createTextNode("example");
+  var endContainer = document.createTextNode("example");
+  var staticRange = new StaticRange({
+    startContainer: startContainer,
+    startOffset: 0,
+    endContainer: endContainer,
+    endOffset: 1
+  });
+
+  var e = new InputEvent('type', { targetRanges: [staticRange] });
+
+  assert_equals(e.getTargetRanges().length, 1, '.targetRanges');
+}, 'InputEvent constructor with InputEventInit where targetRanges has one item');
+
 </script>

--- a/Source/WebCore/dom/InputEvent.cpp
+++ b/Source/WebCore/dom/InputEvent.cpp
@@ -57,6 +57,8 @@ InputEvent::InputEvent(const AtomString& eventType, const Init& initializer)
     : UIEvent(EventInterfaceType::InputEvent, eventType, initializer)
     , m_inputType(initializer.inputType)
     , m_data(initializer.data)
+    , m_dataTransfer(initializer.dataTransfer)
+    , m_targetRanges(initializer.targetRanges)
     , m_isInputMethodComposing(initializer.isComposing)
 {
 }

--- a/Source/WebCore/dom/InputEvent.cpp
+++ b/Source/WebCore/dom/InputEvent.cpp
@@ -37,13 +37,13 @@ namespace WebCore {
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(InputEvent);
 
 Ref<InputEvent> InputEvent::create(const AtomString& eventType, const String& inputType, IsCancelable cancelable, RefPtr<WindowProxy>&& view,
-    const String& data, RefPtr<DataTransfer>&& dataTransfer, const Vector<RefPtr<StaticRange>>& targetRanges, int detail, IsInputMethodComposing isInputMethodComposing)
+    const String& data, RefPtr<DataTransfer>&& dataTransfer, const Vector<Ref<StaticRange>>& targetRanges, int detail, IsInputMethodComposing isInputMethodComposing)
 {
     return adoptRef(*new InputEvent(eventType, inputType, cancelable, WTFMove(view), data, WTFMove(dataTransfer), targetRanges, detail, isInputMethodComposing));
 }
 
 InputEvent::InputEvent(const AtomString& eventType, const String& inputType, IsCancelable cancelable, RefPtr<WindowProxy>&& view,
-    const String& data, RefPtr<DataTransfer>&& dataTransfer, const Vector<RefPtr<StaticRange>>& targetRanges, int detail, IsInputMethodComposing isInputMethodComposing)
+    const String& data, RefPtr<DataTransfer>&& dataTransfer, const Vector<Ref<StaticRange>>& targetRanges, int detail, IsInputMethodComposing isInputMethodComposing)
     : UIEvent(EventInterfaceType::InputEvent, eventType, CanBubble::Yes, cancelable, IsComposed::Yes, WTFMove(view), detail)
     , m_inputType(inputType)
     , m_data(data)

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -43,13 +43,13 @@ public:
         bool isComposing { false }; // input method
         String inputType;
         RefPtr<DataTransfer> dataTransfer;
-        Vector<RefPtr<StaticRange>> targetRanges;
+        Vector<Ref<StaticRange>> targetRanges;
     };
 
     virtual ~InputEvent();
 
     static Ref<InputEvent> create(const AtomString& eventType, const String& inputType, IsCancelable, RefPtr<WindowProxy>&& view,
-        const String& data, RefPtr<DataTransfer>&&, const Vector<RefPtr<StaticRange>>& targetRanges, int detail, IsInputMethodComposing);
+        const String& data, RefPtr<DataTransfer>&&, const Vector<Ref<StaticRange>>& targetRanges, int detail, IsInputMethodComposing);
 
     static Ref<InputEvent> create(const AtomString& type, const Init& initializer)
     {
@@ -60,18 +60,18 @@ public:
     const String& inputType() const { return m_inputType; }
     const String& data() const { return m_data; }
     RefPtr<DataTransfer> dataTransfer() const;
-    const Vector<RefPtr<StaticRange>>& getTargetRanges() { return m_targetRanges; }
+    const Vector<Ref<StaticRange>>& getTargetRanges() { return m_targetRanges; }
     bool isInputMethodComposing() const { return m_isInputMethodComposing; }
 
 private:
     InputEvent(const AtomString& eventType, const String& inputType, IsCancelable, RefPtr<WindowProxy>&&,
-        const String& data, RefPtr<DataTransfer>&&, const Vector<RefPtr<StaticRange>>& targetRanges, int detail, IsInputMethodComposing);
+        const String& data, RefPtr<DataTransfer>&&, const Vector<Ref<StaticRange>>& targetRanges, int detail, IsInputMethodComposing);
     InputEvent(const AtomString& eventType, const Init&);
 
     String m_inputType;
     String m_data;
     RefPtr<DataTransfer> m_dataTransfer;
-    Vector<RefPtr<StaticRange>> m_targetRanges;
+    Vector<Ref<StaticRange>> m_targetRanges;
     bool m_isInputMethodComposing;
 };
 

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -42,6 +42,8 @@ public:
         String data;
         bool isComposing { false }; // input method
         String inputType;
+        RefPtr<DataTransfer> dataTransfer;
+        Vector<RefPtr<StaticRange>> targetRanges;
     };
 
     virtual ~InputEvent();

--- a/Source/WebCore/dom/InputEvent.idl
+++ b/Source/WebCore/dom/InputEvent.idl
@@ -44,4 +44,6 @@ dictionary InputEventInit : UIEventInit {
     DOMString? data = null;
     boolean isComposing = false;
     DOMString inputType = "";
+    DataTransfer? dataTransfer;
+    sequence<StaticRange> targetRanges;
 };

--- a/Source/WebCore/dom/InputEvent.idl
+++ b/Source/WebCore/dom/InputEvent.idl
@@ -44,6 +44,6 @@ dictionary InputEventInit : UIEventInit {
     DOMString? data = null;
     boolean isComposing = false;
     DOMString inputType = "";
-    DataTransfer? dataTransfer;
-    sequence<StaticRange> targetRanges;
+    DataTransfer? dataTransfer = null;
+    sequence<StaticRange> targetRanges = [];
 };

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -427,7 +427,7 @@ void CompositeEditCommand::didApplyCommand()
     protectedDocument()->editor().appliedEditing(*this);
 }
 
-Vector<RefPtr<StaticRange>> CompositeEditCommand::targetRanges() const
+Vector<Ref<StaticRange>> CompositeEditCommand::targetRanges() const
 {
     ASSERT(!isEditingTextAreaOrTextInput());
     auto firstRange = document().selection().selection().firstRange();
@@ -437,7 +437,7 @@ Vector<RefPtr<StaticRange>> CompositeEditCommand::targetRanges() const
     return { 1, StaticRange::create(WTFMove(*firstRange)) };
 }
 
-Vector<RefPtr<StaticRange>> CompositeEditCommand::targetRangesForBindings() const
+Vector<Ref<StaticRange>> CompositeEditCommand::targetRangesForBindings() const
 {
     if (isEditingTextAreaOrTextInput())
         return { };

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -133,7 +133,7 @@ public:
     virtual String inputEventData() const { return { }; }
     virtual bool isBeforeInputEventCancelable() const { return true; }
     virtual bool shouldDispatchInputEvents() const { return true; }
-    Vector<RefPtr<StaticRange>> targetRangesForBindings() const;
+    Vector<Ref<StaticRange>> targetRangesForBindings() const;
     virtual RefPtr<DataTransfer> inputEventDataTransfer() const;
 
 protected:
@@ -143,7 +143,7 @@ protected:
     virtual bool willApplyCommand();
     virtual void didApplyCommand();
 
-    virtual Vector<RefPtr<StaticRange>> targetRanges() const;
+    virtual Vector<Ref<StaticRange>> targetRanges() const;
 
     //
     // sugary-sweet convenience functions to help create and apply edit commands in composite commands

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -152,7 +152,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(IgnoreSelectionChangeForScope);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Editor);
 
 static bool dispatchBeforeInputEvent(Element& element, const AtomString& inputType, IsInputMethodComposing isInputMethodComposing, const String& data = { },
-    RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<RefPtr<StaticRange>>& targetRanges = { }, Event::IsCancelable cancelable = Event::IsCancelable::Yes)
+    RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<Ref<StaticRange>>& targetRanges = { }, Event::IsCancelable cancelable = Event::IsCancelable::Yes)
 {
     auto event = InputEvent::create(eventNames().beforeinputEvent, inputType, cancelable, element.document().windowProxy(), data,
         WTFMove(dataTransfer), targetRanges, 0, isInputMethodComposing);
@@ -161,7 +161,7 @@ static bool dispatchBeforeInputEvent(Element& element, const AtomString& inputTy
 }
 
 static void dispatchInputEvent(Element& element, const AtomString& inputType, IsInputMethodComposing isInputMethodComposing, const String& data = { },
-    RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<RefPtr<StaticRange>>& targetRanges = { })
+    RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<Ref<StaticRange>>& targetRanges = { })
 {
     // FIXME: We should not be dispatching to the scoped queue here. Normally, input events are dispatched in CompositeEditCommand::apply after the end of the scope,
     // but TypingCommands are special in that existing TypingCommands that are applied again fire input events *from within* the scope by calling typingAddedToOpenCommand.
@@ -1179,7 +1179,7 @@ static inline void adjustMarkerTypesToRemoveForWordsAffectedByEditing(OptionSet<
 }
 
 static bool dispatchBeforeInputEvents(RefPtr<Element> startRoot, RefPtr<Element> endRoot, const AtomString& inputTypeName, IsInputMethodComposing isInputMethodComposing,
-    const String& data = { }, RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<RefPtr<StaticRange>>& targetRanges = { }, Event::IsCancelable cancelable = Event::IsCancelable::Yes)
+    const String& data = { }, RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<Ref<StaticRange>>& targetRanges = { }, Event::IsCancelable cancelable = Event::IsCancelable::Yes)
 {
     bool continueWithDefaultBehavior = true;
     if (startRoot)
@@ -1190,7 +1190,7 @@ static bool dispatchBeforeInputEvents(RefPtr<Element> startRoot, RefPtr<Element>
 }
 
 static void dispatchInputEvents(RefPtr<Element> startRoot, RefPtr<Element> endRoot, const AtomString& inputTypeName, IsInputMethodComposing isInputMethodComposing,
-    const String& data = { }, RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<RefPtr<StaticRange>>& targetRanges = { })
+    const String& data = { }, RefPtr<DataTransfer>&& dataTransfer = nullptr, const Vector<Ref<StaticRange>>& targetRanges = { })
 {
     if (startRoot)
         dispatchInputEvent(*startRoot, inputTypeName, isInputMethodComposing, data, WTFMove(dataTransfer), targetRanges);
@@ -1198,7 +1198,7 @@ static void dispatchInputEvents(RefPtr<Element> startRoot, RefPtr<Element> endRo
         dispatchInputEvent(*endRoot, inputTypeName, isInputMethodComposing, data, WTFMove(dataTransfer), targetRanges);
 }
 
-bool Editor::willApplyEditing(CompositeEditCommand& command, Vector<RefPtr<StaticRange>>&& targetRanges)
+bool Editor::willApplyEditing(CompositeEditCommand& command, Vector<Ref<StaticRange>>&& targetRanges)
 {
 #if ENABLE(WRITING_TOOLS)
     if (suppressEditingForWritingTools()) {

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -293,7 +293,7 @@ public:
 #endif
 
     // Returns whether or not we should proceed with editing.
-    bool willApplyEditing(CompositeEditCommand&, Vector<RefPtr<StaticRange>>&&);
+    bool willApplyEditing(CompositeEditCommand&, Vector<Ref<StaticRange>>&&);
     bool willUnapplyEditing(const EditCommandComposition&) const;
     bool willReapplyEditing(const EditCommandComposition&) const;
 

--- a/Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp
+++ b/Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp
@@ -83,7 +83,7 @@ RefPtr<DataTransfer> ReplaceRangeWithTextCommand::inputEventDataTransfer() const
     return CompositeEditCommand::inputEventDataTransfer();
 }
 
-Vector<RefPtr<StaticRange>> ReplaceRangeWithTextCommand::targetRanges() const
+Vector<Ref<StaticRange>> ReplaceRangeWithTextCommand::targetRanges() const
 {
     return { 1, StaticRange::create(m_rangeToBeReplaced) };
 }

--- a/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
+++ b/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
@@ -44,7 +44,7 @@ private:
     void doApply() override;
     String inputEventData() const final;
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
-    Vector<RefPtr<StaticRange>> targetRanges() const final;
+    Vector<Ref<StaticRange>> targetRanges() const final;
 
     RefPtr<DocumentFragment> protectedTextFragment() const { return m_textFragment; }
 

--- a/Source/WebCore/editing/SpellingCorrectionCommand.cpp
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.cpp
@@ -128,7 +128,7 @@ String SpellingCorrectionCommand::inputEventData() const
     return CompositeEditCommand::inputEventData();
 }
 
-Vector<RefPtr<StaticRange>> SpellingCorrectionCommand::targetRanges() const
+Vector<Ref<StaticRange>> SpellingCorrectionCommand::targetRanges() const
 {
     return { 1, StaticRange::create(m_rangeToBeCorrected) };
 }

--- a/Source/WebCore/editing/SpellingCorrectionCommand.h
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.h
@@ -41,7 +41,7 @@ private:
     bool shouldRetainAutocorrectionIndicator() const override;
 
     String inputEventData() const final;
-    Vector<RefPtr<StaticRange>> targetRanges() const final;
+    Vector<Ref<StaticRange>> targetRanges() const final;
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
 
     RefPtr<DocumentFragment> protectedCorrectionFragment() const { return m_correctionFragment; }


### PR DESCRIPTION
#### dd6a9e3510cec677419e5b242161d88fdeb0e077
<pre>
Convert all uses of RefPtr&lt;WebCore::StaticRange&gt; to Ref&lt;WebCore::StaticRange&gt;.
</pre>
----------------------------------------------------------------------
#### 30ec2970898cea0ee75c137ec6bf1ad3475d1f6b
<pre>
Default initialize InputEventInit IDL members
</pre>
----------------------------------------------------------------------
#### 42b41cb804fdb56afc99d70fd0bf19c1577b03f4
<pre>
Support InputEventInit.{inputType, dataTransfer, isComposing, targetRanges}
<a href="https://bugs.webkit.org/show_bug.cgi?id=170416">https://bugs.webkit.org/show_bug.cgi?id=170416</a>

Reviewed by NOBODY (OOPS!).

This adds support for more initialization parameters for InputEvent, such as dataTransfer and targetRanges.

* LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/inputevent-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/inputevent-constructor.html:
* Source/WebCore/dom/InputEvent.cpp:
(WebCore::InputEvent::InputEvent):
* Source/WebCore/dom/InputEvent.h:
* Source/WebCore/dom/InputEvent.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd6a9e3510cec677419e5b242161d88fdeb0e077

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58551 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16850 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21552 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66822 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66107 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10043 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8199 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4561 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->