### PR TITLE
[WebGPU] rgb10a2 is incorrectly listed as a non-renderable format

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -757,6 +757,7 @@ static bool isRenderableFormat(WGPUTextureFormat format)
     case WGPUTextureFormat_RGBA8Sint:
     case WGPUTextureFormat_BGRA8Unorm:
     case WGPUTextureFormat_BGRA8UnormSrgb:
+    case WGPUTextureFormat_RGB10A2Uint:
     case WGPUTextureFormat_RGB10A2Unorm:
     case WGPUTextureFormat_RG32Float:
     case WGPUTextureFormat_RG32Uint:
@@ -779,7 +780,6 @@ static bool isRenderableFormat(WGPUTextureFormat format)
     case WGPUTextureFormat_RG8Snorm:
     case WGPUTextureFormat_RGBA8Snorm:
     case WGPUTextureFormat_RGB9E5Ufloat:
-    case WGPUTextureFormat_RGB10A2Uint:
     case WGPUTextureFormat_BC1RGBAUnorm:
     case WGPUTextureFormat_BC1RGBAUnormSrgb:
     case WGPUTextureFormat_BC2RGBAUnorm:


### PR DESCRIPTION
#### cd905f2c70f153e08bfe28e1d7dd64caa1296a56
<pre>
[WebGPU] rgb10a2 is incorrectly listed as a non-renderable format
<a href="https://bugs.webkit.org/show_bug.cgi?id=263458">https://bugs.webkit.org/show_bug.cgi?id=263458</a>
&lt;radar://117271426&gt;

Reviewed by Tadeu Zagallo.

Listed incorrectly in switch statement, rgb10a2uint is renderable.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::isRenderableFormat):

Canonical link: <a href="https://commits.webkit.org/269656@main">https://commits.webkit.org/269656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be331bbd448f9f6f87c4eed72cdec7519821f98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24900 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21271 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22142 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25754 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/410 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27010 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20785 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24869 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18309 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/427 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5529 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->