### PR TITLE
[git-webkit revert] Commit message should present more useful information

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -76,7 +76,6 @@ def set_env_variables_from_branch_config():
             if error.returncode != 1:
                 sys.stderr.write(error.stderr)
 
-
 def get_bugs_string():
     """Determines what bug URLs to fill or suggest in a WebKit commit message."""
     need_the_bug_url = 'Need the bug URL (OOPS!).'
@@ -136,7 +135,15 @@ def message(source=None, sha=None):
 
     bugs_string = get_bugs_string()
 
-    return '''{title}
+    revert_msg = os.environ.get('COMMIT_MESSAGE_REVERT', '')
+    if revert_msg:
+        return '''{title}\n{revert}\n{bugs}\n'''.format(
+            title=os.environ.get('COMMIT_MESSAGE_TITLE', ''),
+            revert=revert_msg,
+            bugs=bugs_string,
+        )
+    else:
+        return '''{title}
 {bugs}
 
 Reviewed by NOBODY (OOPS!).
@@ -149,7 +156,6 @@ Explanation of why this fixes the bug (OOPS!).
         bugs=bugs_string,
         content='\n'.join(commit_message) + os.environ.get('COMMIT_MESSAGE_CONTENT', ''),
     )
-
 
 def source_branches():
     proc = None
@@ -180,7 +186,6 @@ def source_branches():
             proc.kill()
 
     return []
-
 
 def cherry_pick(content):
     cherry_picked = os.environ.get('GIT_WEBKIT_CHERRY_PICKED')
@@ -305,7 +310,6 @@ def cherry_pick(content):
             result.append(line)
     return '\n'.join(result)
 
-
 def main(file_name=None, source=None, sha=None):
     with open(file_name, 'r') as commit_message_file:
         content = commit_message_file.read()
@@ -314,7 +318,7 @@ def main(file_name=None, source=None, sha=None):
         return 0
 
     if os.environ.get('COMMIT_MESSAGE_TITLE', '').startswith('Unreviewed, reverting'):
-        pass  # TODO: Implement more useful revert commit message
+        pass
     elif source == 'merge' and content.startswith('Revert'):
         return 0
     else:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -24,8 +24,10 @@ import logging
 import os
 
 from mock import patch
+from webkitbugspy import bugzilla, mocks as bmocks, radar, Tracker
 from webkitcorepy import OutputCapture, testing
 from webkitscmpy import local, program, mocks
+from webkitcorepy.mocks import Time as MockTime, Terminal as MockTerminal, Environment
 
 
 class TestRevert(testing.PathTestCase):
@@ -39,13 +41,19 @@ class TestRevert(testing.PathTestCase):
         os.mkdir(os.path.join(self.path, '.svn'))
 
     def test_github(self):
-        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+        with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)), OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
             self.path, remote='https://{}'.format(remote.remote),
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
-        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
-
+        ) as repo, bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-i', 'pr-branch', '-v', '--no-history', '--pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v', '--no-history', '--pr'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -56,7 +64,8 @@ class TestRevert(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created the local development branch 'eng/pr-branch'\n"
+            "Enter issue URL or title of new issue for the revert: \n"
+            "Created the local development branch 'eng/Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
@@ -64,28 +73,34 @@ class TestRevert(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/pr-branch'...",
+                "Creating the local development branch 'eng/Example-feature-1'...",
                 'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
-                "Rebasing 'eng/pr-branch' on 'main'...",
-                "Rebased 'eng/pr-branch' on 'main!'",
+                "Rebasing 'eng/Example-feature-1' on 'main'...",
+                "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/pr-branch' to 'fork'...",
-                "Creating pull-request for 'eng/pr-branch'...",
+                "Pushing 'eng/Example-feature-1' to 'fork'...",
+                "Creating pull-request for 'eng/Example-feature-1'...",
             ],
         )
 
     def test_github_two_step(self):
-        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+        with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)), OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
             self.path, remote='https://{}'.format(remote.remote),
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
-        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
-
+        ) as repo, bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-i', 'pr-branch', '-v'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -98,7 +113,8 @@ class TestRevert(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created the local development branch 'eng/pr-branch'\n"
+            "Enter issue URL or title of new issue for the revert: \n"
+            "Created the local development branch 'eng/Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
@@ -106,18 +122,67 @@ class TestRevert(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/pr-branch'...",
+                "Creating the local development branch 'eng/Example-feature-1'...",
                 'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
                 'Using committed changes...',
-                "Rebasing 'eng/pr-branch' on 'main'...",
-                "Rebased 'eng/pr-branch' on 'main!'",
+                "Rebasing 'eng/Example-feature-1' on 'main'...",
+                "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/pr-branch' to 'fork'...",
-                "Creating pull-request for 'eng/pr-branch'...",
+                "Pushing 'eng/Example-feature-1' to 'fork'...",
+                "Creating pull-request for 'eng/Example-feature-1'...",
+            ],
+        )
+
+    def test_args(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            result = program.main(
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--revert-issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+            self.assertDictEqual(repo.modified, dict())
+            self.assertDictEqual(repo.staged, dict())
+            self.assertEqual(True, 'Unreviewed, reverting 5@main' in repo.head.message)
+            result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
+            self.assertEqual(0, result)
+            self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created the local development branch 'eng/Example-feature-1'\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
+            "https://github.example.com/WebKit/WebKit/pull/1\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                "Creating the local development branch 'eng/Example-feature-1'...",
+                'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
+                'Using committed changes...',
+                "Rebasing 'eng/Example-feature-1' on 'main'...",
+                "Rebased 'eng/Example-feature-1' on 'main!'",
+                'Running pre-PR checks...',
+                'No pre-PR checks to run',
+                'Checking if PR already exists...',
+                'PR not found.',
+                "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
+                "Pushing 'eng/Example-feature-1' to 'fork'...",
+                "Creating pull-request for 'eng/Example-feature-1'...",
             ],
         )
 
@@ -147,13 +212,19 @@ index 05e8751..0bf3c85 100644
         self.assertEqual(captured.stderr.getvalue(), 'Please commit your changes or stash them before you revert commit: d8bce26fa65c6fc8f39c17927abb77f69fab82fc')
 
     def test_update(self):
-        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+        with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)), OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
             self.path, remote='https://{}'.format(remote.remote),
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
-        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
-
+        ) as repo, bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-i', 'pr-branch', '-v', '--pr'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v', '--pr'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -165,7 +236,8 @@ index 05e8751..0bf3c85 100644
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created the local development branch 'eng/pr-branch'\n"
+            "Enter issue URL or title of new issue for the revert: \n"
+            "Created the local development branch 'eng/Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n"
             "Updated 'PR 1 | Unreviewed, reverting 5@main'!\n"
@@ -175,28 +247,28 @@ index 05e8751..0bf3c85 100644
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/pr-branch'...",
+                "Creating the local development branch 'eng/Example-feature-1'...",
                 'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
-                "Rebasing 'eng/pr-branch' on 'main'...",
-                "Rebased 'eng/pr-branch' on 'main!'",
+                "Rebasing 'eng/Example-feature-1' on 'main'...",
+                "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/pr-branch' to 'fork'...",
-                "Creating 'eng/pr-branch-1' as a reference branch",
-                "Creating pull-request for 'eng/pr-branch'...",
+                "Pushing 'eng/Example-feature-1' to 'fork'...",
+                "Creating 'eng/Example-feature-1-1' as a reference branch",
+                "Creating pull-request for 'eng/Example-feature-1'...",
                 'Using committed changes...',
-                "Rebasing 'eng/pr-branch' on 'main'...",
-                "Rebased 'eng/pr-branch' on 'main!'",
+                "Rebasing 'eng/Example-feature-1' on 'main'...",
+                "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR #1 found.',
                 'Checking PR labels for active labels...',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/pr-branch' to 'fork'...",
-                "Updating pull-request for 'eng/pr-branch'..."
+                "Pushing 'eng/Example-feature-1' to 'fork'...",
+                "Updating pull-request for 'eng/Example-feature-1'..."
             ],
         )


### PR DESCRIPTION
#### cab7e2d834d95d64c75955f7d66e154f262b52ad
<pre>
[git-webkit revert] Commit message should present more useful information
<a href="https://bugs.webkit.org/show_bug.cgi?id=263456">https://bugs.webkit.org/show_bug.cgi?id=263456</a>
<a href="https://rdar.apple.com/117270674">rdar://117270674</a>

Reviewed by Jonathan Bedard.

Commit message is formatted after webkit patch workflow.
Changed git-webkit revert logic to support these changes and future work.

* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.parser):
(Revert.get_issue_info):
(Revert):
(Revert.create_revert_commit_msg):
(Revert.revert_commit):
(Revert.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:

Canonical link: <a href="https://commits.webkit.org/270930@main">https://commits.webkit.org/270930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b2b4bd79713089ef2434ea8230a9ac2f554105d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24396 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3719 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/26969 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30010 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27918 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/26581 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5250 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6451 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->