### PR TITLE
Update BufferedChangeEvent according to latest spec proposal

### DIFF
--- a/LayoutTests/media/media-source/mock-managedmse-bufferedchange-expected.txt
+++ b/LayoutTests/media/media-source/mock-managedmse-bufferedchange-expected.txt
@@ -15,36 +15,36 @@ EVENT(updateend)
 RUN(sourceBuffer.appendBuffer(syncSampleRun(5, 10)))
 onbufferedchange called.
 e.addedRanges = [5, 10)
-e.removedRanges = null
+e.removedRanges = []
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
 RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 5)))
 onbufferedchange called.
 e.addedRanges = [0, 5)
-e.removedRanges = null
+e.removedRanges = []
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
 Clean sourcebuffer of all content.
 RUN(sourceBuffer.remove(0, sourceBuffer.buffered.end(0)))
 onbufferedchange called.
-e.addedRanges = null
+e.addedRanges = []
 e.removedRanges = [0, 10)
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '0') OK
 RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 3)))
 onbufferedchange called.
 e.addedRanges = [0, 3)
-e.removedRanges = null
+e.removedRanges = []
 EVENT(update)
 RUN(sourceBuffer.appendBuffer(syncSampleRun(3, 6)))
 onbufferedchange called.
 e.addedRanges = [3, 6)
-e.removedRanges = null
+e.removedRanges = []
 EVENT(update)
 RUN(sourceBuffer.appendBuffer(syncSampleRun(6, 9)))
 onbufferedchange called.
 e.addedRanges = [6, 9)
-e.removedRanges = null
+e.removedRanges = []
 EVENT(update)
 Re-adding the same samples does not update the buffer
 RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 3)))
@@ -52,13 +52,13 @@ EVENT(update)
 Removing first sync sample, remove the first 3 seconds block
 RUN(sourceBuffer.remove(0, 1))
 onbufferedchange called.
-e.addedRanges = null
+e.addedRanges = []
 e.removedRanges = [0, 3)
 EVENT(update)
 Removing from 8 to infinity, remove to the end of existing buffer
 RUN(sourceBuffer.remove(8, Infinity))
 onbufferedchange called.
-e.addedRanges = null
+e.addedRanges = []
 e.removedRanges = [8, 9)
 EVENT(update)
 Removing from empty range, does not update the buffer
@@ -67,37 +67,37 @@ EVENT(update)
 Removing from non-sync sample
 RUN(sourceBuffer.remove(4, 5))
 onbufferedchange called.
-e.addedRanges = null
+e.addedRanges = []
 e.removedRanges = [4, 6)
 EVENT(update)
 Overriding sync sample, remove following block and only update buffer for missing samples
-before: [3, 4)[6, 8)
+before: [3, 4),[6, 8)
 RUN(sourceBuffer.appendBuffer(syncSampleRun(5, 7)))
 onbufferedchange called.
 e.addedRanges = [5, 6)
 e.removedRanges = [7, 8)
 EVENT(update)
-after: [3, 4)[5, 7)
+after: [3, 4),[5, 7)
 Only report samples added in missing intervals
 RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 10, 2)))
 onbufferedchange called.
-e.addedRanges = [0, 3)[4, 5)[7, 10)
-e.removedRanges = null
+e.addedRanges = [0, 3),[4, 5),[7, 10)
+e.removedRanges = []
 EVENT(update)
 RUN(sourceBuffer.remove(2, 4))
 onbufferedchange called.
-e.addedRanges = null
+e.addedRanges = []
 e.removedRanges = [2, 4)
 EVENT(update)
 RUN(sourceBuffer.remove(6, 8))
 onbufferedchange called.
-e.addedRanges = null
+e.addedRanges = []
 e.removedRanges = [6, 8)
 EVENT(update)
 RUN(sourceBuffer.remove(0, 10))
 onbufferedchange called.
-e.addedRanges = null
-e.removedRanges = [0, 2)[4, 6)[8, 10)
+e.addedRanges = []
+e.removedRanges = [0, 2),[4, 6),[8, 10)
 EVENT(update)
 END OF TEST
 

--- a/LayoutTests/media/utilities.js
+++ b/LayoutTests/media/utilities.js
@@ -79,14 +79,14 @@ function waitForVideoFrameUntil(video, time, cb) {
     return p;
 }
 
-function timeRangesToString(ranges) {
-    var str = "";
-    if (!!!ranges) {
-        str += "null";
-        return str;
+function timeRangesToString(timeRanges) {
+    if (!timeRanges?.length)
+        return "[]";
+
+    const ranges = [];
+    for (let i = 0; i < timeRanges?.length; i++) {
+      const range = "[" + [timeRanges.start(i)  + ", " + timeRanges.end(i)] + ")";
+      ranges.push(range);
     }
-    for (var i = 0; i < ranges.length; i++) {
-        str += "[" + ranges.start(i) + ", " + ranges.end(i) + ")";
-    }
-    return str;
+    return ranges.toString();
 }

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
@@ -28,8 +28,8 @@
     EnabledBySetting=ManagedMediaSourceEnabled
 ]
 dictionary BufferedChangeEventInit : EventInit {
-  TimeRanges? addedRanges = null;
-  TimeRanges? removedRanges = null;
+  TimeRanges addedRanges;
+  TimeRanges removedRanges;
 };
 
 [
@@ -38,7 +38,7 @@ dictionary BufferedChangeEventInit : EventInit {
     Exposed=Window
 ]
 interface BufferedChangeEvent : Event {
-  constructor([AtomString] DOMString type, optional BufferedChangeEventInit eventInitDict);
-  [SameObject] readonly attribute TimeRanges? addedRanges;
-  [SameObject] readonly attribute TimeRanges? removedRanges;
+  constructor([AtomString] DOMString type, BufferedChangeEventInit eventInitDict);
+  [SameObject] readonly attribute TimeRanges addedRanges;
+  [SameObject] readonly attribute TimeRanges removedRanges;
 };

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1370,13 +1370,12 @@ void SourceBuffer::sourceBufferPrivateBufferedChanged(const PlatformTimeRanges& 
     if (isManaged()) {
         auto addedRanges = ranges;
         addedRanges -= m_buffered->ranges();
-        auto addedTimeRanges = addedRanges.length() ? RefPtr { TimeRanges::create(WTFMove(addedRanges)) } : nullptr;
+        auto addedTimeRanges = TimeRanges::create(WTFMove(addedRanges));
 
         auto removedRanges = m_buffered->ranges();
         removedRanges -= ranges;
-        auto removedTimeRanges = removedRanges.length() ? RefPtr { TimeRanges::create(WTFMove(removedRanges)) } : nullptr;
+        auto removedTimeRanges = TimeRanges::create(WTFMove(removedRanges));
 
-        ASSERT(addedTimeRanges || removedTimeRanges, "Can't generate an empty dictionary");
         queueTaskToDispatchEvent(*this, TaskSource::MediaElement, BufferedChangeEvent::create(WTFMove(addedTimeRanges), WTFMove(removedTimeRanges)));
     }
 #endif


### PR DESCRIPTION
#### d9d71c746a46a76c25b0e3ed49abed792700b8cd
<pre>
Update BufferedChangeEvent according to latest spec proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=263460">https://bugs.webkit.org/show_bug.cgi?id=263460</a>
rdar://117272337

Reviewed by Jer Noble.

BufferedChangeEvent addedRange and removedRange are no longer optional.

* LayoutTests/media/media-source/mock-managedmse-bufferedchange-expected.txt:
* LayoutTests/media/utilities.js:
(timeRangesToString):
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateBufferedChanged):

Canonical link: <a href="https://commits.webkit.org/269831@main">https://commits.webkit.org/269831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bb6012a6229fd308748063f0036329d46ba668b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22144 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25756 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27011 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21089 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25045 "Found 1 new API test failure: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18310 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/428 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5669 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->