### PR TITLE
synthesizedBaseline uses incorrect line under edge for vertical-lr and sideways items

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4603,7 +4603,6 @@ webkit.org/b/221473 imported/w3c/web-platform-tests/css/css-flexbox/table-as-ite
 webkit.org/b/221474 imported/w3c/web-platform-tests/css/css-flexbox/svg-root-as-flex-item-002.html [ ImageOnlyFailure ]
 
 # align baseline in flexbox.
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-006.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-baseline-multi-line-vert-001.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-baseline-multi-line-vert-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-vert-lr-line-under-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-vert-lr-line-under-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-vert-lr-line-under.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-vert-lr-line-under.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<head>
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-export">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#line-under">
+<meta name="assert" content="Line under edge of vertical-lr/sideways item is at its block start edge">
+<style>
+.flexbox {
+    display: flex;
+    writing-mode: vertical-lr;
+    text-orientation: sideways;
+    align-items: baseline;
+    background-color: red;
+    position: relative;
+}
+.item {
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.wide {
+    width: 100px;
+}
+.absolute {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+}
+</style>
+</head>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<body>
+    <div class="flexbox">
+        <div class="item wide"></div>
+        <div class="item"></div>
+        <div class="item absolute"></div>
+    </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-container-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-container-baseline-001-expected.txt
@@ -34,7 +34,7 @@ FAIL .wrapper 4 assert_equals:
   </div>
   <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
 </div>
-offsetLeft expected 0 but got 75
+offsetLeft expected 0 but got 150
 FAIL .wrapper 5 assert_equals:
 <div class="wrapper" style="writing-mode: vertical-lr; text-orientation: sideways;">
   <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
@@ -45,7 +45,7 @@ FAIL .wrapper 5 assert_equals:
   </div>
   <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
 </div>
-offsetLeft expected 0 but got 75
+offsetLeft expected 0 but got 150
 FAIL .wrapper 6 assert_equals:
 <div class="wrapper" style="writing-mode: vertical-lr; text-orientation: sideways;">
   <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
@@ -56,7 +56,7 @@ FAIL .wrapper 6 assert_equals:
   </div>
   <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
 </div>
-offsetLeft expected 0 but got 75
+offsetLeft expected 0 but got 150
 FAIL .wrapper 7 assert_equals:
 <div class="wrapper" style="writing-mode: vertical-lr; text-orientation: sideways;">
   <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
@@ -67,7 +67,7 @@ FAIL .wrapper 7 assert_equals:
   </div>
   <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
 </div>
-offsetLeft expected 0 but got 75
+offsetLeft expected 0 but got 150
 PASS .wrapper 8
 PASS .wrapper 9
 PASS .wrapper 10


### PR DESCRIPTION
#### bc94fc496ea98de389ed201f55ab2b4f089a0f7e
<pre>
synthesizedBaseline uses incorrect line under edge for vertical-lr and sideways items
<a href="https://bugs.webkit.org/show_bug.cgi?id=263461">https://bugs.webkit.org/show_bug.cgi?id=263461</a>
rdar://117273063

Reviewed by Alan Baradlay.

To synthesize a baseline, the spec says the following: &quot;synthesize the
alphabetic baseline from the line-under line, and the central baseline
by averaging the positions of the two edges or lines.&quot;

When the writing mode is vertical-lr and text-orientation is sideways,
we must synthesize the alphabetic baseline. This means that the baseline
for the item in this writing-mode is its block-start and not the
block-end like in vertical-rl writing mode.

We can first determine the baseline that we are synthesizing according
to the logic in: <a href="https://drafts.csswg.org/css-inline-3/#dominant-baseline-property">https://drafts.csswg.org/css-inline-3/#dominant-baseline-property</a>
If the baseline type is alphabetic and we are in a vertical-lr writing
mode according to the formatting context root, then we can return 0_lu
for the synthesized baseline.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-vert-lr-line-under-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-vert-lr-line-under.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-container-baseline-001-expected.txt:
* Source/WebCore/rendering/RenderBox.cpp:
 (WebCore::synthesizedBaseline):

Canonical link: <a href="https://commits.webkit.org/269668@main">https://commits.webkit.org/269668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d131b8a3f9733277e8a9686699e3b0fe808850b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21437 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22289 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25958 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27156 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25031 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18459 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20765 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5540 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->