### PR TITLE
Adopt smart pointers in more Document-related classes

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -934,6 +934,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/DocumentInlines.h
     dom/DocumentMarker.h
     dom/DocumentMarkerController.h
+    dom/DocumentParser.h
     dom/DocumentStorageAccess.h
     dom/DocumentType.h
     dom/Element.h
@@ -1558,6 +1559,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/TextDirectionSubmenuInclusionBehavior.h
     page/TextIndicator.h
     page/TranslationContextMenuInfo.h
+    page/UndoManager.h
     page/UserContentController.h
     page/UserContentProvider.h
     page/UserContentTypes.h

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -601,7 +601,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     , m_styleScope(makeUnique<Style::Scope>(*this))
     , m_extensionStyleSheets(makeUnique<ExtensionStyleSheets>(*this))
     , m_visitedLinkState(makeUnique<VisitedLinkState>(*this))
-    , m_markers(makeUnique<DocumentMarkerController>(*this))
+    , m_markers(makeUniqueRef<DocumentMarkerController>(*this))
     , m_styleRecalcTimer([this] { updateStyleIfNeeded(); })
 #if !LOG_DISABLED
     , m_documentCreationTime(MonotonicTime::now())
@@ -1644,11 +1644,6 @@ void Document::setDocumentURI(const String& uri)
     updateBaseURL();
 }
 
-RefPtr<DocumentParser> Document::protectedParser() const
-{
-    return m_parser;
-}
-
 void Document::setContent(const String& content)
 {
     open();
@@ -1918,7 +1913,7 @@ template<typename TitleElement> Element* selectNewTitleElement(Document& documen
     return newTitleElement;
 }
 
-RefPtr<Element> Document::protectedTitleElement() const
+inline RefPtr<Element> Document::protectedTitleElement() const
 {
     return m_titleElement;
 }
@@ -2719,11 +2714,6 @@ void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)
     detachFromFrame();
 }
 
-RefPtr<Element> Document::protectedDocumentElement() const
-{
-    return m_documentElement;
-}
-
 void Document::destroyRenderTree()
 {
     ASSERT(hasLivingRenderTree());
@@ -2772,11 +2762,6 @@ void Document::destroyRenderTree()
 
     if (RefPtr view = this->view())
         view->didDestroyRenderTree();
-}
-
-Ref<UndoManager> Document::protectedUndoManager() const
-{
-    return m_undoManager;
 }
 
 void Document::willBeRemovedFromFrame()
@@ -2884,11 +2869,6 @@ void Document::willBeRemovedFromFrame()
     // was removed in an onpagehide event handler fired when the top-level frame is
     // about to enter the back/forward cache.
     RELEASE_ASSERT(m_backForwardCacheState != Document::InBackForwardCache);
-}
-
-Ref<ReportingScope> Document::protectedReportingScope() const
-{
-    return m_reportingScope;
 }
 
 void Document::removeAllEventListeners()
@@ -4577,11 +4557,6 @@ void Document::cloneDataFromDocument(const Document& other)
     setDecoder(other.protectedDecoder());
 }
 
-RefPtr<TextResourceDecoder> Document::protectedDecoder() const
-{
-    return m_decoder;
-}
-
 StyleSheetList& Document::styleSheets()
 {
     if (!m_styleSheetList)
@@ -5030,11 +5005,6 @@ void Document::invalidateRenderingDependentRegions()
 bool Document::setFocusedElement(Element* element)
 {
     return setFocusedElement(element, { });
-}
-
-RefPtr<Element> Document::protectedFocusedElement() const
-{
-    return m_focusedElement;
 }
 
 bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions& options)
@@ -5518,11 +5488,6 @@ Document& Document::contextDocument() const
     if (m_contextDocument)
         return *m_contextDocument.get();
     return const_cast<Document&>(*this);
-}
-
-Ref<Document> Document::protectedContextDocument() const
-{
-    return contextDocument();
 }
 
 void Document::setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& attributeValue, DOMWrapperWorld& isolatedWorld)
@@ -9779,16 +9744,6 @@ String Document::mediaKeysStorageDirectory()
 {
     CheckedPtr currentPage = page();
     return currentPage ? currentPage->ensureMediaKeysStorageDirectoryForOrigin(securityOrigin().data()) : emptyString();
-}
-
-RefPtr<LocalDOMWindow> Document::protectedWindow() const
-{
-    return m_domWindow;
-}
-
-Ref<CachedResourceLoader> Document::protectedCachedResourceLoader() const
-{
-    return m_cachedResourceLoader;
 }
 
 Ref<CSSFontSelector> Document::protectedFontSelector() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -462,7 +462,7 @@ public:
     WEBCORE_EXPORT DOMImplementation& implementation();
     
     Element* documentElement() const { return m_documentElement.get(); }
-    RefPtr<Element> protectedDocumentElement() const;
+    inline RefPtr<Element> protectedDocumentElement() const; // Defined in DocumentInlines.h.
     static ptrdiff_t documentElementMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentElement); }
 
     WEBCORE_EXPORT Element* activeElement();
@@ -697,7 +697,7 @@ public:
     WEBCORE_EXPORT void pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int& marginTop, int& marginRight, int& marginBottom, int& marginLeft);
 
     CachedResourceLoader& cachedResourceLoader() { return m_cachedResourceLoader; }
-    Ref<CachedResourceLoader> protectedCachedResourceLoader() const;
+    inline Ref<CachedResourceLoader> protectedCachedResourceLoader() const; // Defined in DocumentInlines.h.
 
     void didBecomeCurrentDocumentInFrame();
     void destroyRenderTree();
@@ -813,7 +813,7 @@ public:
     
     virtual Ref<DocumentParser> createParser();
     DocumentParser* parser() const { return m_parser.get(); }
-    RefPtr<DocumentParser> protectedParser() const;
+    inline RefPtr<DocumentParser> protectedParser() const; // Defined in DocumentInlines.h.
     ScriptableDocumentParser* scriptableDocumentParser() const;
     
     bool printing() const { return m_printing; }
@@ -866,7 +866,7 @@ public:
     WEBCORE_EXPORT bool setFocusedElement(Element*);
     WEBCORE_EXPORT bool setFocusedElement(Element*, const FocusOptions&);
     Element* focusedElement() const { return m_focusedElement.get(); }
-    RefPtr<Element> protectedFocusedElement() const;
+    inline RefPtr<Element> protectedFocusedElement() const; // Defined in DocumentInlines.h.
     inline bool wasLastFocusByClick() const;
     void setLatestFocusTrigger(FocusTrigger trigger) { m_latestFocusTrigger = trigger; }
     UserActionElementSet& userActionElements()  { return m_userActionElements; }
@@ -944,7 +944,7 @@ public:
 
     // FIXME: Consider renaming to window().
     LocalDOMWindow* domWindow() const { return m_domWindow.get(); }
-    RefPtr<LocalDOMWindow> protectedWindow() const;
+    inline RefPtr<LocalDOMWindow> protectedWindow() const; // Defined in DocumentInlines.h.
 
     // In DOM Level 2, the Document's LocalDOMWindow is called the defaultView.
     WEBCORE_EXPORT WindowProxy* windowProxy() const;
@@ -952,7 +952,7 @@ public:
     inline bool hasBrowsingContext() const; // Defined in DocumentInlines.h.
 
     Document& contextDocument() const;
-    Ref<Document> protectedContextDocument() const;
+    Ref<Document> protectedContextDocument() const { return contextDocument(); }
     void setContextDocument(Ref<Document>&& document) { m_contextDocument = WTFMove(document); }
     
     OptionSet<ParserContentPolicy> parserContentPolicy() const { return m_parserContentPolicy; }
@@ -1124,7 +1124,10 @@ public:
 
     WEBCORE_EXPORT HTMLHeadElement* head();
 
-    DocumentMarkerController& markers() const { return *m_markers; }
+    inline DocumentMarkerController& markers(); // Defined in DocumentInlines.h.
+    inline const DocumentMarkerController& markers() const; // Defined in DocumentInlines.h.
+    inline CheckedRef<DocumentMarkerController> checkedMarkers(); // Defined in DocumentInlines.h.
+    inline CheckedRef<const DocumentMarkerController> checkedMarkers() const; // Defined in DocumentInlines.h.
 
     WEBCORE_EXPORT ExceptionOr<bool> execCommand(const String& command, bool userInterface = false, const String& value = String());
     WEBCORE_EXPORT ExceptionOr<bool> queryCommandEnabled(const String& command);
@@ -1134,7 +1137,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<String> queryCommandValue(const String& command);
 
     UndoManager& undoManager() const { return m_undoManager.get(); }
-    Ref<UndoManager> protectedUndoManager() const;
+    inline Ref<UndoManager> protectedUndoManager() const; // Defined in DocumentInlines.h.
 
     // designMode support
     enum class DesignMode : bool { Off, On };
@@ -1251,7 +1254,7 @@ public:
 
     void setDecoder(RefPtr<TextResourceDecoder>&&);
     TextResourceDecoder* decoder() const { return m_decoder.get(); }
-    RefPtr<TextResourceDecoder> protectedDecoder() const;
+    inline RefPtr<TextResourceDecoder> protectedDecoder() const; // Defined in DocumentInlines.h.
 
     WEBCORE_EXPORT String displayStringModifiedByEncoding(const String&) const;
 
@@ -1305,6 +1308,8 @@ public:
 #if ENABLE(FULLSCREEN_API)
     FullscreenManager& fullscreenManager() { return m_fullscreenManager; }
     const FullscreenManager& fullscreenManager() const { return m_fullscreenManager; }
+    inline CheckedRef<FullscreenManager> checkedFullscreenManager(); // Defined in DocumentInlines.h.
+    inline CheckedRef<const FullscreenManager> checkedFullscreenManager() const; // Defined in DocumentInlines.h.
 #endif
 
 #if ENABLE(POINTER_LOCK)
@@ -1797,7 +1802,7 @@ public:
     std::optional<PAL::SessionID> sessionID() const final;
 
     ReportingScope& reportingScope() const { return m_reportingScope.get(); }
-    Ref<ReportingScope> protectedReportingScope() const;
+    inline Ref<ReportingScope> protectedReportingScope() const; // Defined in DocumentInlines.h.
     WEBCORE_EXPORT String endpointURIForToken(const String&) const final;
 
     bool hasSleepDisabler() const { return !!m_sleepDisabler; }
@@ -2032,7 +2037,7 @@ private:
     RefPtr<Element> m_titleElement;
 
     std::unique_ptr<AXObjectCache> m_axObjectCache;
-    const std::unique_ptr<DocumentMarkerController> m_markers;
+    UniqueRef<DocumentMarkerController> m_markers;
     
     Timer m_styleRecalcTimer;
 

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -58,7 +58,7 @@ CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiat
 
     CachedResourceRequest request(ResourceRequest(WTFMove(url)), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
-    return m_document.cachedResourceLoader().requestFont(WTFMove(request), isSVG).value_or(nullptr).get();
+    return m_document->protectedCachedResourceLoader()->requestFont(WTFMove(request), isSVG).value_or(nullptr).get();
 }
 
 void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
@@ -70,7 +70,7 @@ void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
     // Increment the request count now, in order to prevent didFinishLoad from being dispatched
     // after this font has been requested but before it began loading. Balanced by
     // decrementRequestCount() in fontLoadingTimerFired() and in stopLoadingAndClearFonts().
-    m_document.cachedResourceLoader().incrementRequestCount(font);
+    m_document->protectedCachedResourceLoader()->incrementRequestCount(font);
 
     if (!m_isFontLoadingSuspended && !m_fontLoadingTimer.isActive())
         m_fontLoadingTimer.startOneShot(0_s);
@@ -84,11 +84,11 @@ void DocumentFontLoader::loadPendingFonts()
     Vector<CachedResourceHandle<CachedFont>> fontsToBeginLoading;
     fontsToBeginLoading.swap(m_fontsToBeginLoading);
 
-    auto& cachedResourceLoader = m_document.cachedResourceLoader();
+    Ref cachedResourceLoader = m_document->cachedResourceLoader();
     for (auto& fontHandle : fontsToBeginLoading) {
         fontHandle->beginLoadIfNeeded(cachedResourceLoader);
         // Balances incrementRequestCount() in beginLoadingFontSoon().
-        cachedResourceLoader.decrementRequestCount(*fontHandle);
+        cachedResourceLoader->decrementRequestCount(*fontHandle);
     }
 }
 
@@ -98,12 +98,12 @@ void DocumentFontLoader::fontLoadingTimerFired()
 
     // FIXME: Use SubresourceLoader instead.
     // Call FrameLoader::loadDone before FrameLoader::subresourceLoadDone to match the order in SubresourceLoader::notifyDone.
-    m_document.cachedResourceLoader().loadDone(LoadCompletionType::Finish);
+    m_document->protectedCachedResourceLoader()->loadDone(LoadCompletionType::Finish);
     // Ensure that if the request count reaches zero, the frame loader will know about it.
     // New font loads may be triggered by layout after the document load is complete but before we have dispatched
     // didFinishLoading for the frame. Make sure the delegate is always dispatched by checking explicitly.
-    if (m_document.frame())
-        m_document.frame()->loader().checkLoadComplete();
+    if (RefPtr frame = m_document->frame())
+        frame->checkedLoader()->checkLoadComplete();
 }
 
 void DocumentFontLoader::stopLoadingAndClearFonts()
@@ -112,13 +112,13 @@ void DocumentFontLoader::stopLoadingAndClearFonts()
         return;
 
     m_fontLoadingTimer.stop();
-    auto& cachedResourceLoader = m_document.cachedResourceLoader();
+    Ref cachedResourceLoader = m_document->cachedResourceLoader();
     for (auto& fontHandle : m_fontsToBeginLoading) {
         // Balances incrementRequestCount() in beginLoadingFontSoon().
-        cachedResourceLoader.decrementRequestCount(*fontHandle);
+        cachedResourceLoader->decrementRequestCount(*fontHandle);
     }
     m_fontsToBeginLoading.clear();
-    m_document.fontSelector().clearFonts();
+    m_document->protectedFontSelector()->clearFonts();
 
     m_isFontLoadingSuspended = true;
     m_isStopped = true;

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -29,6 +29,7 @@
 #include "CachedResourceHandle.h"
 #include "Document.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -53,7 +54,7 @@ public:
 private:
     void fontLoadingTimerFired();
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
     Timer m_fontLoadingTimer;
     Vector<CachedResourceHandle<CachedFont>> m_fontsToBeginLoading;
     bool m_isFontLoadingSuspended { false };

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -73,7 +73,7 @@ bool DocumentFragment::childTypeAllowed(NodeType type) const
 
 Ref<Node> DocumentFragment::cloneNodeInternal(Document& targetDocument, CloningOperation type)
 {
-    Ref<DocumentFragment> clone = create(targetDocument);
+    Ref clone = create(targetDocument);
     switch (type) {
     case CloningOperation::OnlySelf:
     case CloningOperation::SelfWithTemplateContent:
@@ -87,15 +87,17 @@ Ref<Node> DocumentFragment::cloneNodeInternal(Document& targetDocument, CloningO
 
 void DocumentFragment::parseHTML(const String& source, Element& contextElement, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
-    if (tryFastParsingHTMLFragment(source, document(), *this, contextElement, parserContentPolicy)) {
+    Ref document = this->document();
+    if (tryFastParsingHTMLFragment(source, document, *this, contextElement, parserContentPolicy)) {
 #if ASSERT_ENABLED
         // As a sanity check for the fast-path, create another fragment using the full parser and compare the results.
-        auto referenceFragment = DocumentFragment::create(document());
+        auto referenceFragment = DocumentFragment::create(document);
         HTMLDocumentParser::parseDocumentFragment(source, referenceFragment, contextElement, parserContentPolicy);
         ASSERT(serializeFragment(*this, SerializedNodes::SubtreesOfChildren) == serializeFragment(referenceFragment, SerializedNodes::SubtreesOfChildren));
 #endif
         return;
-    } else if (hasChildNodes())
+    }
+    if (hasChildNodes())
         removeChildren();
 
     HTMLDocumentParser::parseDocumentFragment(source, *this, contextElement, parserContentPolicy);

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -41,13 +41,13 @@ void DocumentFullscreen::exitFullscreen(Document& document, RefPtr<DeferredPromi
         promise->reject(Exception { TypeError, "Not in fullscreen"_s });
         return;
     }
-    document.fullscreenManager().exitFullscreen(WTFMove(promise));
+    document.checkedFullscreenManager()->exitFullscreen(WTFMove(promise));
 }
 
 void DocumentFullscreen::webkitExitFullscreen(Document& document)
 {
     if (document.fullscreenManager().fullscreenElement())
-        document.fullscreenManager().exitFullscreen(nullptr);
+        document.checkedFullscreenManager()->exitFullscreen(nullptr);
 }
 
 // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled
@@ -55,7 +55,7 @@ bool DocumentFullscreen::fullscreenEnabled(Document& document)
 {
     if (!document.isFullyActive())
         return false;
-    return document.fullscreenManager().isFullscreenEnabled();
+    return document.checkedFullscreenManager()->isFullscreenEnabled();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -25,20 +25,28 @@
 
 #pragma once
 
+#include "CachedResourceLoader.h"
 #include "ClientOrigin.h"
 #include "Document.h"
+#include "DocumentMarkerController.h"
+#include "DocumentParser.h"
+#include "Element.h"
 #include "FocusOptions.h"
 #include "FrameDestructionObserverInlines.h"
+#include "FullscreenManager.h"
+#include "LocalDOMWindow.h"
 #include "MediaProducer.h"
+#include "ReportingScope.h"
 #include "SecurityOrigin.h"
 #include "TextResourceDecoder.h"
+#include "UndoManager.h"
 #include "WebCoreOpaqueRoot.h"
 
 namespace WebCore {
 
 inline PAL::TextEncoding Document::textEncoding() const
 {
-    if (auto* decoder = this->decoder())
+    if (RefPtr decoder = this->decoder())
         return decoder->encoding();
     return PAL::TextEncoding();
 }
@@ -127,5 +135,77 @@ inline Ref<Document> Node::protectedDocument() const
 {
     return document();
 }
+
+inline RefPtr<LocalDOMWindow> Document::protectedWindow() const
+{
+    return m_domWindow;
+}
+
+inline Ref<CachedResourceLoader> Document::protectedCachedResourceLoader() const
+{
+    return m_cachedResourceLoader;
+}
+
+inline RefPtr<DocumentParser> Document::protectedParser() const
+{
+    return m_parser;
+}
+
+inline RefPtr<Element> Document::protectedDocumentElement() const
+{
+    return m_documentElement;
+}
+
+inline Ref<UndoManager> Document::protectedUndoManager() const
+{
+    return m_undoManager;
+}
+
+inline Ref<ReportingScope> Document::protectedReportingScope() const
+{
+    return m_reportingScope;
+}
+
+inline RefPtr<TextResourceDecoder> Document::protectedDecoder() const
+{
+    return m_decoder;
+}
+
+inline RefPtr<Element> Document::protectedFocusedElement() const
+{
+    return m_focusedElement;
+}
+
+inline DocumentMarkerController& Document::markers()
+{
+    return m_markers.get();
+}
+
+inline const DocumentMarkerController& Document::markers() const
+{
+    return m_markers.get();
+}
+
+inline CheckedRef<DocumentMarkerController> Document::checkedMarkers()
+{
+    return m_markers.get();
+}
+
+inline CheckedRef<const DocumentMarkerController> Document::checkedMarkers() const
+{
+    return m_markers.get();
+}
+
+#if ENABLE(FULLSCREEN_API)
+inline CheckedRef<FullscreenManager> Document::checkedFullscreenManager()
+{
+    return m_fullscreenManager.get();
+}
+
+inline CheckedRef<const FullscreenManager> Document::checkedFullscreenManager() const
+{
+    return m_fullscreenManager.get();
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
@@ -38,8 +38,8 @@ namespace WebCore {
 // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement
 Element* DocumentOrShadowRootFullscreen::fullscreenElement(TreeScope& treeScope)
 {
-    auto& document = treeScope.documentScope();
-    return treeScope.ancestorElementInThisScope(document.fullscreenManager().fullscreenElement());
+    Ref document = treeScope.documentScope();
+    return treeScope.ancestorElementInThisScope(document->fullscreenManager().fullscreenElement());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -39,7 +40,7 @@ class DocumentParser : public RefCounted<DocumentParser> {
 public:
     virtual ~DocumentParser();
 
-    virtual ScriptableDocumentParser* asScriptableDocumentParser() { return 0; }
+    virtual ScriptableDocumentParser* asScriptableDocumentParser() { return nullptr; }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#insertion-point
     virtual bool hasInsertionPoint() { return true; }
@@ -113,8 +114,8 @@ private:
     bool m_documentWasLoadedAsPartOfNavigation;
 
     // Every DocumentParser needs a pointer back to the document.
-    // m_document will be 0 after the parser is stopped.
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    // m_document will be nullptr after the parser is stopped.
+    CheckedPtr<Document> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -76,24 +76,24 @@ void DocumentStorageAccess::hasStorageAccess(Document& document, Ref<DeferredPro
 
 std::optional<bool> DocumentStorageAccess::hasStorageAccessQuickCheck()
 {
-    ASSERT(m_document.settings().storageAccessAPIEnabled());
+    Ref document = m_document.get();
+    ASSERT(document->settings().storageAccessAPIEnabled());
 
-    auto* frame = m_document.frame();
+    RefPtr frame = document->frame();
     if (frame && hasFrameSpecificStorageAccess())
         return true;
 
-    auto& securityOrigin = m_document.securityOrigin();
+    auto& securityOrigin = document->securityOrigin();
     if (!frame || securityOrigin.isOpaque())
         return false;
 
     if (frame->isMainFrame())
         return true;
 
-    if (securityOrigin.equal(&m_document.topOrigin()))
+    if (securityOrigin.equal(&document->topOrigin()))
         return true;
 
-    auto* page = frame->page();
-    if (!page)
+    if (!frame->page())
         return false;
 
     return std::nullopt;
@@ -101,7 +101,8 @@ std::optional<bool> DocumentStorageAccess::hasStorageAccessQuickCheck()
 
 void DocumentStorageAccess::hasStorageAccess(Ref<DeferredPromise>&& promise)
 {
-    ASSERT(m_document.settings().storageAccessAPIEnabled());
+    Ref document = m_document.get();
+    ASSERT(document->settings().storageAccessAPIEnabled());
 
     auto quickCheckResult = hasStorageAccessQuickCheck();
     if (quickCheckResult) {
@@ -110,20 +111,20 @@ void DocumentStorageAccess::hasStorageAccess(Ref<DeferredPromise>&& promise)
     }
 
     // The existence of a frame and page has been checked in requestStorageAccessQuickCheck().
-    auto* frame = m_document.frame();
+    RefPtr frame = document->frame();
     if (!frame) {
         ASSERT_NOT_REACHED();
         promise->resolve<IDLBoolean>(false);
         return;
     }
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page) {
         ASSERT_NOT_REACHED();
         promise->resolve<IDLBoolean>(false);
         return;
     }
 
-    page->chrome().client().hasStorageAccess(RegistrableDomain::uncheckedCreateFromHost(m_document.securityOrigin().host()), RegistrableDomain::uncheckedCreateFromHost(m_document.topOrigin().host()), *frame, [weakThis = WeakPtr { *this }, promise = WTFMove(promise)] (bool hasAccess) {
+    page->chrome().client().hasStorageAccess(RegistrableDomain::uncheckedCreateFromHost(document->securityOrigin().host()), RegistrableDomain::uncheckedCreateFromHost(document->topOrigin().host()), *frame, [weakThis = WeakPtr { *this }, promise = WTFMove(promise)] (bool hasAccess) {
         if (!weakThis)
             return;
 
@@ -146,24 +147,25 @@ void DocumentStorageAccess::requestStorageAccess(Document& document, Ref<Deferre
 
 std::optional<StorageAccessQuickResult> DocumentStorageAccess::requestStorageAccessQuickCheck()
 {
-    ASSERT(m_document.settings().storageAccessAPIEnabled());
+    Ref document = m_document.get();
+    ASSERT(document->settings().storageAccessAPIEnabled());
 
-    auto* frame = m_document.frame();
+    RefPtr frame = document->frame();
     if (frame && hasFrameSpecificStorageAccess())
         return StorageAccessQuickResult::Grant;
 
-    auto& securityOrigin = m_document.securityOrigin();
+    auto& securityOrigin = document->securityOrigin();
     if (!frame || securityOrigin.isOpaque() || !isAllowedToRequestStorageAccess())
         return StorageAccessQuickResult::Reject;
 
     if (frame->isMainFrame())
         return StorageAccessQuickResult::Grant;
 
-    if (securityOrigin.equal(&m_document.topOrigin()))
+    if (securityOrigin.equal(&document->topOrigin()))
         return StorageAccessQuickResult::Grant;
 
     // If there is a sandbox, it has to allow the storage access API to be called.
-    if (m_document.sandboxFlags() != SandboxNone && m_document.isSandboxed(SandboxStorageAccessByUserActivation))
+    if (document->sandboxFlags() != SandboxNone && document->isSandboxed(SandboxStorageAccessByUserActivation))
         return StorageAccessQuickResult::Reject;
 
     if (!UserGestureIndicator::processingUserGesture())
@@ -174,7 +176,8 @@ std::optional<StorageAccessQuickResult> DocumentStorageAccess::requestStorageAcc
 
 void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
 {
-    ASSERT(m_document.settings().storageAccessAPIEnabled());
+    Ref document = m_document.get();
+    ASSERT(document->settings().storageAccessAPIEnabled());
 
     auto quickCheckResult = requestStorageAccessQuickCheck();
     if (quickCheckResult) {
@@ -183,13 +186,13 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
     }
 
     // The existence of a frame and page has been checked in requestStorageAccessQuickCheck().
-    auto* frame = m_document.frame();
+    RefPtr frame = document->frame();
     if (!frame) {
         ASSERT_NOT_REACHED();
         promise->reject();
         return;
     }
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page) {
         ASSERT_NOT_REACHED();
         promise->reject();
@@ -199,7 +202,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
     if (!page->settings().storageAccessAPIPerPageScopeEnabled())
         m_storageAccessScope = StorageAccessScope::PerFrame;
 
-    page->chrome().client().requestStorageAccess(RegistrableDomain::uncheckedCreateFromHost(m_document.securityOrigin().host()), RegistrableDomain::uncheckedCreateFromHost(m_document.topOrigin().host()), *frame, m_storageAccessScope, [this, weakThis = WeakPtr { *this }, promise = WTFMove(promise)] (RequestStorageAccessResult result) mutable {
+    page->chrome().client().requestStorageAccess(RegistrableDomain::uncheckedCreateFromHost(document->securityOrigin().host()), RegistrableDomain::uncheckedCreateFromHost(document->topOrigin().host()), *frame, m_storageAccessScope, [this, weakThis = WeakPtr { *this }, promise = WTFMove(promise)] (RequestStorageAccessResult result) mutable {
         if (!weakThis)
             return;
 
@@ -207,7 +210,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
         bool shouldPreserveUserGesture = result.wasGranted == StorageAccessWasGranted::Yes || result.promptWasShown == StorageAccessPromptWasShown::No;
 
         if (shouldPreserveUserGesture) {
-            m_document.eventLoop().queueMicrotask([this, weakThis] {
+            protectedDocument()->eventLoop().queueMicrotask([this, weakThis] {
                 if (weakThis)
                     enableTemporaryTimeUserGesture();
             });
@@ -222,12 +225,17 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
         }
 
         if (shouldPreserveUserGesture) {
-            m_document.eventLoop().queueMicrotask([this, weakThis] {
+            protectedDocument()->eventLoop().queueMicrotask([this, weakThis] {
                 if (weakThis)
                     consumeTemporaryTimeUserGesture();
             });
         }
     });
+}
+
+Ref<Document> DocumentStorageAccess::protectedDocument() const
+{
+    return m_document.get();
 }
 
 void DocumentStorageAccess::requestStorageAccessForDocumentQuirk(Document& document, CompletionHandler<void(StorageAccessWasGranted)>&& completionHandler)
@@ -242,7 +250,7 @@ void DocumentStorageAccess::requestStorageAccessForDocumentQuirk(CompletionHandl
         *quickCheckResult == StorageAccessQuickResult::Grant ? completionHandler(StorageAccessWasGranted::Yes) : completionHandler(StorageAccessWasGranted::No);
         return;
     }
-    requestStorageAccessQuirk(RegistrableDomain::uncheckedCreateFromHost(m_document.securityOrigin().host()), WTFMove(completionHandler));
+    requestStorageAccessQuirk(RegistrableDomain::uncheckedCreateFromHost(m_document->securityOrigin().host()), WTFMove(completionHandler));
 }
 
 void DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk(Document& hostingDocument, RegistrableDomain&& requestingDomain, CompletionHandler<void(StorageAccessWasGranted)>&& completionHandler)
@@ -252,7 +260,7 @@ void DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk(Document& ho
 
 void DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk(RegistrableDomain&& requestingDomain, CompletionHandler<void(StorageAccessWasGranted)>&& completionHandler)
 {
-    if (!m_document.frame() || !m_document.frame()->page() || !isAllowedToRequestStorageAccess()) {
+    if (!m_document->frame() || !m_document->frame()->page() || !isAllowedToRequestStorageAccess()) {
         completionHandler(StorageAccessWasGranted::No);
         return;
     }
@@ -261,12 +269,14 @@ void DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk(RegistrableD
 
 void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& requestingDomain, CompletionHandler<void(StorageAccessWasGranted)>&& completionHandler)
 {
-    ASSERT(m_document.settings().storageAccessAPIEnabled());
-    RELEASE_ASSERT(m_document.frame() && m_document.frame()->page());
+    Ref document = m_document.get();
+    ASSERT(document->settings().storageAccessAPIEnabled());
+    RELEASE_ASSERT(document->frame() && document->frame()->page());
 
-    auto topFrameDomain = RegistrableDomain(m_document.topDocument().url());
+    auto topFrameDomain = RegistrableDomain(document->topDocument().url());
 
-    m_document.frame()->page()->chrome().client().requestStorageAccess(WTFMove(requestingDomain), WTFMove(topFrameDomain), *m_document.frame(), m_storageAccessScope, [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RequestStorageAccessResult result) mutable {
+    RefPtr frame = document->frame();
+    frame->checkedPage()->chrome().client().requestStorageAccess(WTFMove(requestingDomain), WTFMove(topFrameDomain), *frame, m_storageAccessScope, [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RequestStorageAccessResult result) mutable {
         if (!weakThis)
             return;
 
@@ -274,7 +284,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         bool shouldPreserveUserGesture = result.wasGranted == StorageAccessWasGranted::Yes || result.promptWasShown == StorageAccessPromptWasShown::No;
 
         if (shouldPreserveUserGesture) {
-            m_document.eventLoop().queueMicrotask([this, weakThis] {
+            protectedDocument()->eventLoop().queueMicrotask([this, weakThis] {
                 if (weakThis)
                     enableTemporaryTimeUserGesture();
             });
@@ -289,7 +299,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         }
 
         if (shouldPreserveUserGesture) {
-            m_document.eventLoop().queueMicrotask([this, weakThis] {
+            protectedDocument()->eventLoop().queueMicrotask([this, weakThis] {
                 if (weakThis)
                     consumeTemporaryTimeUserGesture();
             });
@@ -299,7 +309,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
 
 void DocumentStorageAccess::enableTemporaryTimeUserGesture()
 {
-    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(ProcessingUserGesture, &m_document);
+    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(ProcessingUserGesture, protectedDocument().ptr());
 }
 
 void DocumentStorageAccess::consumeTemporaryTimeUserGesture()
@@ -309,7 +319,7 @@ void DocumentStorageAccess::consumeTemporaryTimeUserGesture()
 
 bool DocumentStorageAccess::hasFrameSpecificStorageAccess() const
 {
-    auto* frame = m_document.frame();
+    RefPtr frame = m_document->frame();
     return frame && frame->loader().client().hasFrameSpecificStorageAccess();
 }
 

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -29,6 +29,7 @@
 
 #include "RegistrableDomain.h"
 #include "Supplementable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -93,9 +94,11 @@ private:
     void enableTemporaryTimeUserGesture();
     void consumeTemporaryTimeUserGesture();
 
+    Ref<Document> protectedDocument() const;
+
     std::unique_ptr<UserGestureIndicator> m_temporaryUserGesture;
     
-    Document& m_document;
+    CheckedRef<Document> m_document;
 
     uint8_t m_numberOfTimesExplicitlyDeniedFrameSpecificStorageAccess = 0;
 

--- a/Source/WebCore/dom/DocumentTouch.cpp
+++ b/Source/WebCore/dom/DocumentTouch.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 Ref<Touch> DocumentTouch::createTouch(Document& document, RefPtr<WindowProxy>&& window, EventTarget* target, int identifier, int pageX, int pageY, int screenX, int screenY, int radiusX, int radiusY, float rotationAngle, float force)
 {
-    LocalFrame* frame;
+    RefPtr<LocalFrame> frame;
     if (window && is<LocalFrame>(window->frame()))
         frame = downcast<LocalFrame>(window->frame());
     else
@@ -49,7 +49,7 @@ Ref<Touch> DocumentTouch::createTouch(Document& document, RefPtr<WindowProxy>&& 
     // http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/DocumentAdditionsReference/DocumentAdditions/DocumentAdditions.html
     // when this method should throw and nor is it by inspection of iOS behavior. It would be nice to verify any cases where it throws under iOS
     // and implement them here. See https://bugs.webkit.org/show_bug.cgi?id=47819
-    return Touch::create(frame, target, identifier, screenX, screenY, pageX, pageY, radiusX, radiusY, rotationAngle, force);
+    return Touch::create(frame.get(), target, identifier, screenX, screenY, pageX, pageY, radiusX, radiusY, rotationAngle, force);
 }
 
 Ref<TouchList> DocumentTouch::createTouchList(Document&, FixedVector<std::reference_wrapper<Touch>>&& touches)

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -32,6 +32,7 @@
 #include "GCReachableRef.h"
 #include "LayoutRect.h"
 #include "Page.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>
 
@@ -40,7 +41,7 @@ namespace WebCore {
 class DeferredPromise;
 class RenderStyle;
 
-class FullscreenManager final : public CanMakeWeakPtr<FullscreenManager> {
+class FullscreenManager final : public CanMakeWeakPtr<FullscreenManager>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     FullscreenManager(Document&);

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -58,6 +58,7 @@ public:
     FrameTree& tree() const { return m_treeNode; }
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in Page.h.
+    inline CheckedPtr<Page> checkedPage() const; // Defined in Page.h.
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() const { return m_mainFrame; }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1460,6 +1460,11 @@ inline Page* Frame::page() const
     return m_page.get();
 }
 
+inline CheckedPtr<Page> Frame::checkedPage() const
+{
+    return m_page.get();
+}
+
 inline Page* Document::page() const
 {
     return m_frame ? m_frame->page() : nullptr;

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -239,11 +239,11 @@ String HitTestResult::spellingToolTip(TextDirection& dir) const
     if (!m_innerNonSharedNode)
         return String();
     
-    DocumentMarker* marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Grammar);
+    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Grammar);
     if (!marker)
         return String();
 
-    if (auto renderer = m_innerNonSharedNode->renderer())
+    if (CheckedPtr renderer = m_innerNonSharedNode->renderer())
         dir = renderer->style().direction();
     return marker->description();
 }
@@ -255,7 +255,7 @@ String HitTestResult::replacedString() const
     if (!m_innerNonSharedNode)
         return String();
     
-    DocumentMarker* marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Replacement);
+    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Replacement);
     if (!marker)
         return String();
     
@@ -774,11 +774,11 @@ Vector<String> HitTestResult::dictationAlternatives() const
     if (!m_innerNonSharedNode)
         return Vector<String>();
 
-    auto* marker = m_innerNonSharedNode->document().markers().markerContainingPoint(pointInInnerNodeFrame(), DocumentMarker::DictationAlternatives);
+    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(pointInInnerNodeFrame(), DocumentMarker::DictationAlternatives);
     if (!marker)
         return Vector<String>();
 
-    auto* frame = innerNonSharedNode()->document().frame();
+    RefPtr frame = innerNonSharedNode()->document().frame();
     if (!frame)
         return Vector<String>();
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -68,6 +68,7 @@
 #include "DisabledAdaptations.h"
 #include "DisplayList.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "DocumentLoader.h"
 #include "DocumentMarkerController.h"
 #include "DocumentTimeline.h"

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -42,6 +42,7 @@
 #import "WebRemoteObjectRegistry.h"
 #import <WebCore/DeprecatedGlobalSettings.h>
 #import <WebCore/DictionaryLookup.h>
+#import <WebCore/DocumentInlines.h>
 #import <WebCore/DocumentMarkerController.h>
 #import <WebCore/Editing.h>
 #import <WebCore/Editor.h>

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -36,6 +36,7 @@
 #include "WebImage.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/DocumentMarkerController.h>
 #include <WebCore/FloatQuad.h>
 #include <WebCore/FocusController.h>

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -29,6 +29,7 @@
 #include "WebPage.h"
 #include <WebCore/CharacterRange.h>
 #include <WebCore/Document.h>
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/DocumentMarkerController.h>
 #include <WebCore/Editor.h>
 #include <WebCore/FocusController.h>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -190,6 +190,7 @@
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentFragment.h>
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/DocumentMarkerController.h>
 #include <WebCore/DocumentStorageAccess.h>

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
@@ -29,6 +29,7 @@
 
 #import "DOMNodeInternal.h"
 #import "DOMRangeInternal.h"
+#import <WebCore/DocumentInlines.h>
 #import <WebCore/DocumentMarkerController.h>
 #import <WebCore/Editing.h>
 #import <WebCore/FrameSelection.h>

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -70,6 +70,7 @@
 #import <WebCore/CompositionHighlight.h>
 #import <WebCore/DatabaseManager.h>
 #import <WebCore/DocumentFragment.h>
+#import <WebCore/DocumentInlines.h>
 #import <WebCore/DocumentLoader.h>
 #import <WebCore/DocumentMarkerController.h>
 #import <WebCore/Editing.h>


### PR DESCRIPTION
#### f22e2c538682ea40208cd211384a67382b5480b8
<pre>
Adopt smart pointers in more Document-related classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263459">https://bugs.webkit.org/show_bug.cgi?id=263459</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
(WebCore::Document::protectedTitleElement const):
(WebCore::Document::protectedParser const): Deleted.
(WebCore::Document::protectedDocumentElement const): Deleted.
(WebCore::Document::protectedUndoManager const): Deleted.
(WebCore::Document::protectedReportingScope const): Deleted.
(WebCore::Document::protectedDecoder const): Deleted.
(WebCore::Document::protectedFocusedElement const): Deleted.
(WebCore::Document::protectedContextDocument const): Deleted.
(WebCore::Document::protectedWindow const): Deleted.
(WebCore::Document::protectedCachedResourceLoader const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::protectedContextDocument const):
(WebCore::Document::markers const): Deleted.
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::cachedFont):
(WebCore::DocumentFontLoader::beginLoadingFontSoon):
(WebCore::DocumentFontLoader::loadPendingFonts):
(WebCore::DocumentFontLoader::fontLoadingTimerFired):
(WebCore::DocumentFontLoader::stopLoadingAndClearFonts):
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::cloneNodeInternal):
(WebCore::DocumentFragment::parseHTML):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::exitFullscreen):
(WebCore::DocumentFullscreen::webkitExitFullscreen):
(WebCore::DocumentFullscreen::fullscreenEnabled):
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::textEncoding const):
(WebCore::Document::protectedWindow const):
(WebCore::Document::protectedCachedResourceLoader const):
(WebCore::Document::protectedParser const):
(WebCore::Document::protectedDocumentElement const):
(WebCore::Document::protectedUndoManager const):
(WebCore::Document::protectedReportingScope const):
(WebCore::Document::protectedDecoder const):
(WebCore::Document::protectedFocusedElement const):
(WebCore::Document::markers):
(WebCore::Document::markers const):
(WebCore::Document::checkedMarkers):
(WebCore::Document::checkedMarkers const):
(WebCore::Document::checkedFullscreenManager):
(WebCore::Document::checkedFullscreenManager const):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::invalidateRectsForAllMarkers):
(WebCore::DocumentMarkerController::invalidateRectsForMarkersInNode):
(WebCore::updateMainFrameLayoutIfNeeded):
(WebCore::DocumentMarkerController::protectedDocument const):
(WebCore::DocumentMarkerController::updateRectsForInvalidatedMarkersOfType):
(WebCore::DocumentMarkerController::renderedRectsForMarkers):
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::copyMarkers):
(WebCore::DocumentMarkerController::removeMarkers):
(WebCore::DocumentMarkerController::markerContainingPoint):
(WebCore::DocumentMarkerController::forEachOfTypes):
(WebCore::DocumentMarkerController::removeMarkersFromList):
(WebCore::DocumentMarkerController::repaintMarkers):
(WebCore::DocumentMarkerController::shiftMarkers):
(WebCore::DocumentMarkerController::fadeAnimationTimerFired):
(WebCore::addMarker):
(WebCore::removeMarkers):
(WebCore::DocumentMarkerController::showMarkers const):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp:
(WebCore::DocumentOrShadowRootFullscreen::fullscreenElement):
* Source/WebCore/dom/DocumentParser.h:
(WebCore::DocumentParser::asScriptableDocumentParser):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::hasStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::hasStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::requestStorageAccess):
(WebCore::DocumentStorageAccess::protectedDocument const):
(WebCore::DocumentStorageAccess::requestStorageAccessForDocumentQuirk):
(WebCore::DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk):
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
(WebCore::DocumentStorageAccess::enableTemporaryTimeUserGesture):
(WebCore::DocumentStorageAccess::hasFrameSpecificStorageAccess const):
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/dom/DocumentTouch.cpp:
(WebCore::DocumentTouch::createTouch):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/Page.h:
(WebCore::Frame::checkedPage const):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::spellingToolTip const):
(WebCore::HitTestResult::replacedString const):
(WebCore::HitTestResult::dictationAlternatives const):
* Source/WebCore/testing/Internals.cpp:

Canonical link: <a href="https://commits.webkit.org/269620@main">https://commits.webkit.org/269620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db501226ef81b5a96d6c99b41f99c22bca74b4ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24975 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23595 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25827 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23248 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20882 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21147 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/566 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/492 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5508 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->