### PR TITLE
Deploy smart pointers in ScriptElement.cpp

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6486,6 +6486,11 @@ Document& Document::topDocument() const
     return *document;
 }
 
+CheckedRef<ScriptRunner> Document::checkedScriptRunner()
+{
+    return *m_scriptRunner;
+}
+
 ExceptionOr<Ref<Attr>> Document::createAttribute(const AtomString& localName)
 {
     if (!isValidName(localName))

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1154,6 +1154,7 @@ public:
     bool isTopDocument() const { return &topDocument() == this; }
     
     ScriptRunner& scriptRunner() { return *m_scriptRunner; }
+    CheckedRef<ScriptRunner> checkedScriptRunner();
     ScriptModuleLoader& moduleLoader() { return *m_moduleLoader; }
 
     Element* currentScript() const { return !m_currentScriptStack.isEmpty() ? m_currentScriptStack.last().get() : nullptr; }

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -38,7 +38,7 @@ class Document;
 class ScriptElement;
 class LoadableScript;
 
-class ScriptRunner : private PendingScriptClient {
+class ScriptRunner : private PendingScriptClient, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(ScriptRunner); WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ScriptRunner(Document&);


### PR DESCRIPTION
#### 9abc7cc058f076eff92d7a800356e3782ee24b74
<pre>
Deploy smart pointers in ScriptElement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=263464">https://bugs.webkit.org/show_bug.cgi?id=263464</a>

Reviewed by Chris Dumez.

Deploy more smart pointers in ScriptElement.cpp as found by clang static analyzer.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::checkedScriptRunner):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::ScriptElement):
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::requestImportMap):
(WebCore::ScriptElement::executeClassicScript):
(WebCore::ScriptElement::executeScriptAndDispatchEvent):
(WebCore::ScriptElement::executePendingScript):
* Source/WebCore/dom/ScriptRunner.h:

Canonical link: <a href="https://commits.webkit.org/269679@main">https://commits.webkit.org/269679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d40f69a1e076764f1844fe458338086cde5a7be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24914 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22152 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25768 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27018 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/924 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2956 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->