### PR TITLE
[WebGPU] mip level validation is not handled correctly in copyBuffer/TextureToBuffer/Texture

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -154,8 +154,8 @@ void CommandEncoderImpl::copyBufferToTexture(
         nullptr, {
             nullptr,
             source.offset,
-            source.bytesPerRow.value_or(0),
-            source.rowsPerImage.value_or(1),
+            source.bytesPerRow.value_or(WGPU_COPY_STRIDE_UNDEFINED),
+            source.rowsPerImage.value_or(WGPU_COPY_STRIDE_UNDEFINED),
         },
         m_convertToBackingContext->convertToBacking(source.buffer),
     };
@@ -190,8 +190,8 @@ void CommandEncoderImpl::copyTextureToBuffer(
         nullptr, {
             nullptr,
             destination.offset,
-            destination.bytesPerRow.value_or(0),
-            destination.rowsPerImage.value_or(1),
+            destination.bytesPerRow.value_or(WGPU_COPY_STRIDE_UNDEFINED),
+            destination.rowsPerImage.value_or(WGPU_COPY_STRIDE_UNDEFINED),
         },
         m_convertToBackingContext->convertToBacking(destination.buffer),
     };

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -80,6 +80,7 @@ public:
     static std::optional<MTLPixelFormat> stencilOnlyAspectMetalFormat(WGPUTextureFormat);
     static WGPUTextureFormat removeSRGBSuffix(WGPUTextureFormat);
     static std::optional<WGPUTextureFormat> resolveTextureFormat(WGPUTextureFormat, WGPUTextureAspect);
+    static bool isCompressedFormat(WGPUTextureFormat);
 
     WGPUExtent3D logicalMiplevelSpecificTextureExtent(uint32_t mipLevel);
     WGPUExtent3D physicalMiplevelSpecificTextureExtent(uint32_t mipLevel);


### PR DESCRIPTION
#### 53f8f07b250856cd134cedc5466ff64eb12cd778
<pre>
[WebGPU] mip level validation is not handled correctly in copyBuffer/TextureToBuffer/Texture
<a href="https://bugs.webkit.org/show_bug.cgi?id=254175">https://bugs.webkit.org/show_bug.cgi?id=254175</a>
&lt;radar://106958194&gt;

Reviewed by Tadeu Zagallo.

Fix some validation that was preventing imageCopy tests from working.

Compressed texture formats are still not fully working, but all the other cases pass.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::copyBufferToTexture):
(WebCore::WebGPU::CommandEncoderImpl::copyTextureToBuffer):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::validateImageCopyBuffer):
(WebGPU::CommandEncoder::copyBufferToTexture):
(WebGPU::CommandEncoder::copyTextureToBuffer):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::isCompressedFormat):
(WebGPU::Device::validateCreateTexture):
(WebGPU::Texture::validateImageCopyTexture):
(WebGPU::Texture::validateLinearTextureData):
(WebGPU::isCompressedFormat): Deleted.

Canonical link: <a href="https://commits.webkit.org/269667@main">https://commits.webkit.org/269667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29532fd808fba760800563dcf857ddd4e00e36ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22161 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25790 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27027 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24900 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18325 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/457 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5541 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->