### PR TITLE
[results.webkit.org] Handle bad commitRepresentation cookie

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js
@@ -206,8 +206,11 @@ class _CommitBank {
                 continue;
 
             this._representationCache = JSON.parse(cookies[index].substring(COOKIE_NAME.length + 1));
-            callback(this._representationCache);
-            return;
+            if (!this._representationCache.error) {
+                callback(this._representationCache);
+                return;
+            }
+            this._representationCache = null;
         }
 
         fetch('api/commits/representations').then(response => {


### PR DESCRIPTION
#### 99d0e691dee42c4a2b3b0f58f9495e6b308186c5
<pre>
[results.webkit.org] Handle bad commitRepresentation cookie
<a href="https://bugs.webkit.org/show_bug.cgi?id=263483">https://bugs.webkit.org/show_bug.cgi?id=263483</a>
<a href="https://rdar.apple.com/117284674">rdar://117284674</a>

Reviewed by Dewei Zhu.

The &apos;commitRepresentation&apos; cookie is derived from a response from
the results database, if that response was an error, we should ignore the cookie.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js:
(_CommitBank.prototype.commitRepresentations):

Canonical link: <a href="https://commits.webkit.org/278200@main">https://commits.webkit.org/278200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59283dc07ca8581827e7501d1dcdb79ea236b0d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22172 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19971 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/1040 "Found 1 new API test failure: /WPE/TestLoaderClient:/webkit/WebKitWebPage/get-uri (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23226 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20854 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25806 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27037 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22839 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/471 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24903 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/954 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7177 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->