### PR TITLE
[WebGPU] "unorm10-10-10-2" vertex format is not implemented

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUVertexFormat.h
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexFormat.h
@@ -61,6 +61,7 @@ enum class GPUVertexFormat : uint8_t {
     Sint32x2,
     Sint32x3,
     Sint32x4,
+    Unorm1010102,
 };
 
 inline WebGPU::VertexFormat convertToBacking(GPUVertexFormat vertexFormat)
@@ -126,6 +127,8 @@ inline WebGPU::VertexFormat convertToBacking(GPUVertexFormat vertexFormat)
         return WebGPU::VertexFormat::Sint32x3;
     case GPUVertexFormat::Sint32x4:
         return WebGPU::VertexFormat::Sint32x4;
+    case GPUVertexFormat::Unorm1010102:
+        return WebGPU::VertexFormat::Unorm10_10_10_2;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl
@@ -58,5 +58,6 @@ enum GPUVertexFormat {
     "sint32",
     "sint32x2",
     "sint32x3",
-    "sint32x4"
+    "sint32x4",
+    "unorm10-10-10-2"
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -692,6 +692,8 @@ WGPUVertexFormat ConvertToBackingContext::convertToBacking(VertexFormat vertexFo
         return WGPUVertexFormat_Sint32x3;
     case VertexFormat::Sint32x4:
         return WGPUVertexFormat_Sint32x4;
+    case VertexFormat::Unorm10_10_10_2:
+        return WGPUVertexFormat_Unorm10_10_10_2;
     }
 }
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -165,6 +165,7 @@ enum class WebCore::WebGPU::VertexFormat : uint8_t {
     Sint32x2,
     Sint32x3,
     Sint32x4,
+    Unorm10_10_10_2,
 };
 
 header: <WebCore/WebGPUShaderStage.h>

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexFormat.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexFormat.h
@@ -60,6 +60,7 @@ enum class VertexFormat : uint8_t {
     Sint32x2,
     Sint32x3,
     Sint32x4,
+    Unorm10_10_10_2,
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -304,6 +304,8 @@ static MTLVertexFormat vertexFormat(WGPUVertexFormat vertexFormat)
         return MTLVertexFormatInt3;
     case WGPUVertexFormat_Sint32x4:
         return MTLVertexFormatInt4;
+    case WGPUVertexFormat_Unorm10_10_10_2:
+        return MTLVertexFormatUInt1010102Normalized;
     case WGPUVertexFormat_Force32:
     case WGPUVertexFormat_Undefined:
         ASSERT_NOT_REACHED();

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -673,6 +673,7 @@ typedef enum WGPUVertexFormat {
     WGPUVertexFormat_Sint32x2 = 0x0000001C,
     WGPUVertexFormat_Sint32x3 = 0x0000001D,
     WGPUVertexFormat_Sint32x4 = 0x0000001E,
+    WGPUVertexFormat_Unorm10_10_10_2 = 0x0000001F,
     WGPUVertexFormat_Force32 = 0x7FFFFFFF
 } WGPUVertexFormat WGPU_ENUM_ATTRIBUTE;
 


### PR DESCRIPTION
#### c22f641da18b8c4eee23b8021b37aeec69268675
<pre>
[WebGPU] &quot;unorm10-10-10-2&quot; vertex format is not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=263482">https://bugs.webkit.org/show_bug.cgi?id=263482</a>
&lt;radar://117284162&gt;

Reviewed by Tadeu Zagallo.

This format was added a few weeks ago.

* Source/WebCore/Modules/WebGPU/GPUVertexFormat.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexFormat.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::vertexFormat):
* Source/WebGPU/WebGPU/WebGPU.h:

Canonical link: <a href="https://commits.webkit.org/269660@main">https://commits.webkit.org/269660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fc4b91c036d82f6888b0c5e9f4f9fa86c01269f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22173 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25807 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27038 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24904 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18336 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/472 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5533 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->