### PR TITLE
REGRESSION (263917@main): [ macOS ] 3 inspector/timeline/timeline-event-Timer tests are a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2621,9 +2621,6 @@ webkit.org/b/260888 [ Ventura+ ] media/track/track-user-stylesheet-override.html
 webkit.org/b/261312 inspector/timeline/timeline-event-CancelAnimationFrame.html [ Pass Failure ]
 webkit.org/b/261312 inspector/timeline/timeline-event-performance-mark.html [ Pass Failure ]
 webkit.org/b/261312 inspector/timeline/timeline-event-RequestAnimationFrame.html [ Pass Failure ]
-webkit.org/b/260360 inspector/timeline/timeline-event-TimerFire.html [ Failure ]
-webkit.org/b/260360 inspector/timeline/timeline-event-TimerInstall.html [ Failure ]
-webkit.org/b/260360 inspector/timeline/timeline-event-TimerRemove.html [ Failure ]
 
 webkit.org/b/260883 [ Monterey+ ] inspector/timeline/timeline-recording.html [ Skip ]
 

--- a/Source/WebCore/platform/RunLoopObserver.h
+++ b/Source/WebCore/platform/RunLoopObserver.h
@@ -47,6 +47,7 @@ public:
 
     enum class WellKnownOrder : uint8_t {
         GraphicsCommit,
+        PostGraphicsCommit,
         RenderingUpdate,
         ActivityStateChange,
         InspectorFrameBegin,

--- a/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
+++ b/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
@@ -36,6 +36,8 @@ static constexpr CFIndex cfRunLoopOrder(RunLoopObserver::WellKnownOrder order)
     switch (order) {
     case RunLoopObserver::WellKnownOrder::GraphicsCommit:
         return coreAnimationCommit;
+    case RunLoopObserver::WellKnownOrder::PostGraphicsCommit:
+        return coreAnimationCommit + 1;
     case RunLoopObserver::WellKnownOrder::RenderingUpdate:
         return coreAnimationCommit - 1;
     case RunLoopObserver::WellKnownOrder::ActivityStateChange:

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
@@ -40,10 +40,11 @@ public:
     void didCompleteRenderingUpdateDisplay();
     
 private:
-    void registerCACommitHandlers();
-
     void renderingUpdateRunLoopObserverCallback();
     void updateRendering();
+
+    void registerPostCommitObserver();
+    void postCommitCallback();
 
     void schedulePostRenderingUpdate();
     void postRenderingUpdateCallback();
@@ -51,9 +52,10 @@ private:
     WebView* m_webView;
 
     std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
+    std::unique_ptr<WebCore::RunLoopObserver> m_postCommitRunLoopObserver;
     std::unique_ptr<WebCore::RunLoopObserver> m_postRenderingUpdateRunLoopObserver;
 
     bool m_insideCallback { false };
     bool m_rescheduledInsideCallback { false };
-    bool m_haveRegisteredCommitHandlers { false };
+    bool m_haveRegisteredCommitObserver { false };
 };


### PR DESCRIPTION
#### 7fb2ade98313266b70a981a8c7d15a53051823c0
<pre>
REGRESSION (263917@main): [ macOS ] 3 inspector/timeline/timeline-event-Timer tests are a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=260360">https://bugs.webkit.org/show_bug.cgi?id=260360</a>
rdar://114041968

Reviewed by Cameron McCormack.

In 258248@main we started to use pre/post CoreAnimation commit handlers in WebKitLegacy to drive the
pre/post rendering update hooks that are used by Web Inspector to drive the frames timeline.

However, there is no guarantee that a given Page::updateRendering() results in a CA commit; it might
not trigger any drawing; the affected tests show this.

So stop using CA commit handlers in WebKitLegacy. Instead, call `[m_webView
_willStartRenderingUpdateDisplay]` right after `updateRendering()`, and use a new post-commit
runloop observer to track the end of the &quot;commit&quot; if one happened.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/RunLoopObserver.h:
* Source/WebCore/platform/cf/RunLoopObserverCF.cpp:
(WebCore::cfRunLoopOrder):
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h:
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm:
(WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler):
(WebViewRenderingUpdateScheduler::didCompleteRenderingUpdateDisplay):
(WebViewRenderingUpdateScheduler::registerPostCommitObserver):
(WebViewRenderingUpdateScheduler::postCommitCallback):
(WebViewRenderingUpdateScheduler::renderingUpdateRunLoopObserverCallback):
(WebViewRenderingUpdateScheduler::registerCACommitHandlers): Deleted.

Canonical link: <a href="https://commits.webkit.org/269859@main">https://commits.webkit.org/269859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2050a8ba0d93321aeeaf866e39f22868258c96c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22174 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25810 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27039 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24905 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18334 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/475 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->