### PR TITLE
[GPU Process] REGRESSION: display-p3 stroke color in canvas crashes the webpage

### DIFF
--- a/LayoutTests/fast/canvas/canvas-line-no-change-display-p3-stroke-expected.html
+++ b/LayoutTests/fast/canvas/canvas-line-no-change-display-p3-stroke-expected.html
@@ -1,0 +1,38 @@
+<body>
+    <canvas id="canvas"></canvas>
+    <script>
+        const c = document.getElementById("canvas");
+        const ctx = c.getContext("2d");
+
+        ctx.strokeStyle = "red";
+
+        ctx.beginPath();
+        ctx.moveTo(10, 10);
+        ctx.lineTo(290, 10);
+        ctx.stroke();
+
+        ctx.strokeStyle = "color(display-p3 1 0 0 / 1)";
+        ctx.lineWidth = 2;
+
+        ctx.beginPath();
+        ctx.moveTo(10, 50);
+        ctx.lineTo(290, 50);
+        ctx.stroke();
+
+        ctx.strokeStyle = "color(display-p3 0 1 0 / 1)";
+
+        ctx.beginPath();
+        ctx.moveTo(10, 90);
+        ctx.lineTo(290, 90);
+        ctx.stroke();
+
+        ctx.strokeStyle = "color(display-p3 0 0 1 / 1)";
+        ctx.lineWidth = 1;
+
+        ctx.beginPath();
+        ctx.moveTo(10, 130);
+        ctx.lineTo(290, 130);
+        ctx.stroke();
+
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-line-no-change-display-p3-stroke.html
+++ b/LayoutTests/fast/canvas/canvas-line-no-change-display-p3-stroke.html
@@ -1,0 +1,38 @@
+<meta name="fuzzy" content="maxDifference=0-66; totalPixels=0-1680" />
+<body>
+    <canvas id="canvas"></canvas>
+    <script>
+        const c = document.getElementById("canvas");
+        const ctx = c.getContext("2d");
+
+        ctx.strokeStyle = "color(display-p3 1 0 0 / 1)";
+
+        ctx.beginPath();
+        ctx.moveTo(10, 10);
+        ctx.lineTo(290, 10);
+        ctx.stroke();
+
+        ctx.lineWidth = 2;
+
+        ctx.beginPath();
+        ctx.moveTo(10, 50);
+        ctx.lineTo(290, 50);
+        ctx.stroke();
+
+        ctx.strokeStyle = "rgb(0, 255, 0)";
+
+        ctx.beginPath();
+        ctx.moveTo(10, 90);
+        ctx.lineTo(290, 90);
+        ctx.stroke();
+
+        ctx.strokeStyle = "rgb(0, 0, 255)";
+        ctx.lineWidth = 1;
+
+        ctx.beginPath();
+        ctx.moveTo(10, 130);
+        ctx.lineTo(290, 130);
+        ctx.stroke();
+
+    </script>
+</body>

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -142,7 +142,8 @@ public:
 
     Color semanticColor() const;
 
-    // Returns the underlying color if its type is SRGBA<uint8_t>.
+    // Returns the underlying color if its type is inline.
+    std::optional<PackedColor::RGBA> tryGetAsPackedInline() const;
     std::optional<SRGBA<uint8_t>> tryGetAsSRGBABytes() const;
 
 #if PLATFORM(GTK)
@@ -470,6 +471,13 @@ inline PackedColor::RGBA Color::asPackedInline() const
 {
     ASSERT(isInline());
     return decodedPackedInlineColor(m_colorAndFlags);
+}
+
+inline std::optional<PackedColor::RGBA> Color::tryGetAsPackedInline() const
+{
+    if (isInline())
+        return asPackedInline();
+    return std::nullopt;
 }
 
 inline std::optional<SRGBA<uint8_t>> Color::tryGetAsSRGBABytes() const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -86,13 +86,12 @@ class Save;
 class Scale;
 class SetCTM;
 class SetInlineFillColor;
-class SetInlineStrokeColor;
+class SetInlineStroke;
 class SetLineCap;
 class SetLineDash;
 class SetLineJoin;
 class SetMiterLimit;
 class SetState;
-class SetStrokeThickness;
 class StrokeEllipse;
 class StrokeLine;
 class StrokePathSegment;
@@ -162,13 +161,12 @@ using Item = std::variant
     , Scale
     , SetCTM
     , SetInlineFillColor
-    , SetInlineStrokeColor
+    , SetInlineStroke
     , SetLineCap
     , SetLineDash
     , SetLineJoin
     , SetMiterLimit
     , SetState
-    , SetStrokeThickness
     , StrokeEllipse
     , StrokeLine
     , StrokePathSegment

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -109,24 +109,20 @@ void SetInlineFillColor::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("color", color());
 }
 
-void SetInlineStrokeColor::apply(GraphicsContext& context) const
+void SetInlineStroke::apply(GraphicsContext& context) const
 {
-    context.setStrokeColor(color());
+    if (auto color = this->color())
+        context.setStrokeColor(*color);
+    if (auto thickness = this->thickness())
+        context.setStrokeThickness(*thickness);
 }
 
-void SetInlineStrokeColor::dump(TextStream& ts, OptionSet<AsTextFlag>) const
+void SetInlineStroke::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 {
-    ts.dumpProperty("color", color());
-}
-
-void SetStrokeThickness::apply(GraphicsContext& context) const
-{
-    context.setStrokeThickness(m_thickness);
-}
-
-void SetStrokeThickness::dump(TextStream& ts, OptionSet<AsTextFlag>) const
-{
-    ts.dumpProperty("thickness", thickness());
+    if (auto color = this->color())
+        ts.dumpProperty("color", *color);
+    if (auto thickness = this->thickness())
+        ts.dumpProperty("thickness", *thickness);
 }
 
 SetState::SetState(const GraphicsContextState& state)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -164,62 +164,57 @@ class SetInlineFillColor {
 public:
     static constexpr char name[] = "set-inline-fill-color";
 
-    SetInlineFillColor() = default;
+    SetInlineFillColor(PackedColor::RGBA colorData)
+        : m_colorData(colorData)
+    {
+    }
+
     SetInlineFillColor(SRGBA<uint8_t> colorData)
-        : m_colorData(colorData)
+        : m_colorData(*Color(colorData).tryGetAsPackedInline())
     {
     }
-    SetInlineFillColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha)
-        : SetInlineFillColor(SRGBA<uint8_t> { red, green, blue, alpha }) { }
 
-    Color color() const { return { m_colorData }; }
-    const SRGBA<uint8_t>& colorData() const { return m_colorData; }
+    Color color() const { return { asSRGBA(colorData()) }; }
+    const PackedColor::RGBA& colorData() const { return m_colorData; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    SRGBA<uint8_t> m_colorData;
+    PackedColor::RGBA m_colorData;
 };
 
-class SetInlineStrokeColor {
+class SetInlineStroke {
 public:
-    static constexpr char name[] = "set-inline-stroke-color";
+    static constexpr char name[] = "set-inline-stroke";
 
-    SetInlineStrokeColor() = default;
-    SetInlineStrokeColor(SRGBA<uint8_t> colorData)
+    SetInlineStroke(std::optional<PackedColor::RGBA> colorData, std::optional<float> thickness = std::nullopt)
         : m_colorData(colorData)
+        , m_thickness(thickness)
     {
+        ASSERT(m_colorData || m_thickness);
     }
-    SetInlineStrokeColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha)
-        : SetInlineStrokeColor(SRGBA<uint8_t> { red, green, blue, alpha }) { }
 
-    Color color() const { return { m_colorData }; }
-    const SRGBA<uint8_t>& colorData() const { return m_colorData; }
-
-    WEBCORE_EXPORT void apply(GraphicsContext&) const;
-    void dump(TextStream&, OptionSet<AsTextFlag>) const;
-
-private:
-    SRGBA<uint8_t> m_colorData;
-};
-
-class SetStrokeThickness {
-public:
-    static constexpr char name[] = "set-stroke-thickness";
-
-    SetStrokeThickness(float thickness)
+    SetInlineStroke(float thickness)
         : m_thickness(thickness)
     {
     }
 
-    float thickness() const { return m_thickness; }
+    SetInlineStroke(SRGBA<uint8_t> colorData)
+        : m_colorData(*Color(colorData).tryGetAsPackedInline())
+    {
+    }
+
+    std::optional<Color> color() const { return m_colorData ? std::optional<Color>(asSRGBA(*m_colorData)) : std::nullopt; }
+    std::optional<PackedColor::RGBA> colorData() const { return m_colorData; }
+    std::optional<float> thickness() const { return m_thickness; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    float m_thickness { 0 };
+    std::optional<PackedColor::RGBA> m_colorData;
+    std::optional<float> m_thickness;
 };
 
 class SetState {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -77,9 +77,8 @@ protected:
     virtual void recordScale(const FloatSize&) = 0;
     virtual void recordSetCTM(const AffineTransform&) = 0;
     virtual void recordConcatenateCTM(const AffineTransform&) = 0;
-    virtual void recordSetInlineFillColor(SRGBA<uint8_t>) = 0;
-    virtual void recordSetInlineStrokeColor(SRGBA<uint8_t>) = 0;
-    virtual void recordSetStrokeThickness(float) = 0;
+    virtual void recordSetInlineFillColor(PackedColor::RGBA) = 0;
+    virtual void recordSetInlineStroke(SetInlineStroke&&) = 0;
     virtual void recordSetState(const GraphicsContextState&) = 0;
     virtual void recordSetLineCap(LineCap) = 0;
     virtual void recordSetLineDash(const DashArray&, float dashOffset) = 0;
@@ -133,7 +132,7 @@ protected:
     virtual void recordStrokeRect(const FloatRect&, float) = 0;
 #if ENABLE(INLINE_PATH_DATA)
     virtual void recordStrokeLine(const PathDataLine&) = 0;
-    virtual void recordStrokeLineWithColorAndThickness(const PathDataLine&, SRGBA<uint8_t>, float thickness) = 0;
+    virtual void recordStrokeLineWithColorAndThickness(const PathDataLine&, SetInlineStroke&&) = 0;
     virtual void recordStrokeArc(const PathArc&) = 0;
     virtual void recordStrokeQuadCurve(const PathDataQuadCurve&) = 0;
     virtual void recordStrokeBezierCurve(const PathDataBezierCurve&) = 0;
@@ -286,6 +285,8 @@ private:
 
     void appendStateChangeItemIfNecessary();
     void appendStateChangeItem(const GraphicsContextState&);
+
+    SetInlineStroke buildSetInlineStroke(const GraphicsContextState&);
 
     const AffineTransform& ctm() const;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -89,19 +89,14 @@ void RecorderImpl::recordConcatenateCTM(const AffineTransform& transform)
     append(ConcatenateCTM(transform));
 }
 
-void RecorderImpl::recordSetInlineFillColor(SRGBA<uint8_t> inlineColor)
+void RecorderImpl::recordSetInlineFillColor(PackedColor::RGBA inlineColor)
 {
     append(SetInlineFillColor(inlineColor));
 }
 
-void RecorderImpl::recordSetInlineStrokeColor(SRGBA<uint8_t> inlineColor)
+void RecorderImpl::recordSetInlineStroke(SetInlineStroke&& strokeItem)
 {
-    append(SetInlineStrokeColor(inlineColor));
-}
-
-void RecorderImpl::recordSetStrokeThickness(float thickness)
-{
-    append(SetStrokeThickness(thickness));
+    append(strokeItem);
 }
 
 void RecorderImpl::recordSetState(const GraphicsContextState& state)
@@ -355,10 +350,9 @@ void RecorderImpl::recordStrokeLine(const PathDataLine& line)
     append(StrokeLine(line));
 }
 
-void RecorderImpl::recordStrokeLineWithColorAndThickness(const PathDataLine& line, SRGBA<uint8_t> color, float thickness)
+void RecorderImpl::recordStrokeLineWithColorAndThickness(const PathDataLine& line, SetInlineStroke&& strokeItem)
 {
-    append(SetInlineStrokeColor(color));
-    append(SetStrokeThickness(thickness));
+    append(strokeItem);
     append(StrokePathSegment(PathSegment { line }));
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -48,9 +48,8 @@ private:
     void recordScale(const FloatSize&) final;
     void recordSetCTM(const AffineTransform&) final;
     void recordConcatenateCTM(const AffineTransform&) final;
-    void recordSetInlineFillColor(SRGBA<uint8_t>) final;
-    void recordSetInlineStrokeColor(SRGBA<uint8_t>) final;
-    void recordSetStrokeThickness(float) final;
+    void recordSetInlineFillColor(PackedColor::RGBA) final;
+    void recordSetInlineStroke(SetInlineStroke&&) final;
     void recordSetState(const GraphicsContextState&) final;
     void recordSetLineCap(LineCap) final;
     void recordSetLineDash(const DashArray&, float dashOffset) final;
@@ -104,7 +103,7 @@ private:
     void recordStrokeRect(const FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordStrokeLine(const PathDataLine&) final;
-    void recordStrokeLineWithColorAndThickness(const PathDataLine&, SRGBA<uint8_t>, float thickness) final;
+    void recordStrokeLineWithColorAndThickness(const PathDataLine&, SetInlineStroke&&) final;
     void recordStrokeArc(const PathArc&) final;
     void recordStrokeQuadCurve(const PathDataQuadCurve&) final;
     void recordStrokeBezierCurve(const PathDataBezierCurve&) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -126,19 +126,14 @@ void RemoteDisplayListRecorder::concatenateCTM(const AffineTransform& ctm)
     handleItem(DisplayList::ConcatenateCTM(ctm));
 }
 
-void RemoteDisplayListRecorder::setInlineFillColor(DisplayList::SetInlineFillColor&& item)
+void RemoteDisplayListRecorder::setInlineFillColor(DisplayList::SetInlineFillColor&& fillColorItem)
 {
-    handleItem(WTFMove(item));
+    handleItem(WTFMove(fillColorItem));
 }
 
-void RemoteDisplayListRecorder::setInlineStrokeColor(DisplayList::SetInlineStrokeColor&& item)
+void RemoteDisplayListRecorder::setInlineStroke(DisplayList::SetInlineStroke&& strokeItem)
 {
-    handleItem(WTFMove(item));
-}
-
-void RemoteDisplayListRecorder::setStrokeThickness(float thickness)
-{
-    handleItem(DisplayList::SetStrokeThickness(thickness));
+    handleItem(WTFMove(strokeItem));
 }
 
 void RemoteDisplayListRecorder::setState(DisplayList::SetState&& item)
@@ -539,10 +534,9 @@ void RemoteDisplayListRecorder::strokeLine(const PathDataLine& line)
     handleItem(DisplayList::StrokeLine(line));
 }
 
-void RemoteDisplayListRecorder::strokeLineWithColorAndThickness(const PathDataLine& line, DisplayList::SetInlineStrokeColor&& color, float thickness)
+void RemoteDisplayListRecorder::strokeLineWithColorAndThickness(const PathDataLine& line, DisplayList::SetInlineStroke&& strokeItem)
 {
-    handleItem(WTFMove(color));
-    handleItem(DisplayList::SetStrokeThickness(thickness));
+    handleItem(WTFMove(strokeItem));
     handleItem(DisplayList::StrokeLine(line));
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -63,8 +63,7 @@ public:
     void setCTM(const WebCore::AffineTransform&);
     void concatenateCTM(const WebCore::AffineTransform&);
     void setInlineFillColor(WebCore::DisplayList::SetInlineFillColor&&);
-    void setInlineStrokeColor(WebCore::DisplayList::SetInlineStrokeColor&&);
-    void setStrokeThickness(float);
+    void setInlineStroke(WebCore::DisplayList::SetInlineStroke&&);
     void setState(WebCore::DisplayList::SetState&&);
     void setLineCap(WebCore::LineCap);
     void setLineDash(WebCore::DisplayList::SetLineDash&&);
@@ -117,7 +116,7 @@ public:
     void strokeRect(const WebCore::FloatRect&, float lineWidth);
 #if ENABLE(INLINE_PATH_DATA)
     void strokeLine(const WebCore::PathDataLine&);
-    void strokeLineWithColorAndThickness(const WebCore::PathDataLine&, WebCore::DisplayList::SetInlineStrokeColor&&, float thickness);
+    void strokeLineWithColorAndThickness(const WebCore::PathDataLine&, WebCore::DisplayList::SetInlineStroke&&);
     void strokeArc(const WebCore::PathArc&);
     void strokeQuadCurve(const WebCore::PathDataQuadCurve&);
     void strokeBezierCurve(const WebCore::PathDataBezierCurve&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -30,9 +30,8 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     Scale(WebCore::FloatSize scale) StreamBatched
     SetCTM(WebCore::AffineTransform ctm) StreamBatched
     ConcatenateCTM(WebCore::AffineTransform ctm) StreamBatched
-    SetInlineFillColor(WebCore::DisplayList::SetInlineFillColor item) StreamBatched
-    SetInlineStrokeColor(WebCore::DisplayList::SetInlineStrokeColor item) StreamBatched
-    SetStrokeThickness(float thickness) StreamBatched
+    SetInlineFillColor(WebCore::DisplayList::SetInlineFillColor fillColorItem) StreamBatched
+    SetInlineStroke(WebCore::DisplayList::SetInlineStroke strokeItem) StreamBatched
     SetState(WebCore::DisplayList::SetState item) StreamBatched
     SetLineCap(enum:uint8_t WebCore::LineCap lineCap) StreamBatched
     SetLineDash(WebCore::DisplayList::SetLineDash item) StreamBatched
@@ -85,7 +84,7 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     StrokeRect(WebCore::FloatRect rect, float lineWidth)
 #if ENABLE(INLINE_PATH_DATA)
     StrokeLine(struct WebCore::PathDataLine line) StreamBatched
-    StrokeLineWithColorAndThickness(struct WebCore::PathDataLine line, WebCore::DisplayList::SetInlineStrokeColor color, float thickness) StreamBatched
+    StrokeLineWithColorAndThickness(struct WebCore::PathDataLine line, WebCore::DisplayList::SetInlineStroke strokeItem) StreamBatched
     StrokeArc(struct WebCore::PathArc arc) StreamBatched
     StrokeQuadCurve(struct WebCore::PathDataQuadCurve curve) StreamBatched
     StrokeBezierCurve(struct WebCore::PathDataBezierCurve curve) StreamBatched

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1792,17 +1792,12 @@ struct WebCore::ViewportArguments {
 
 header: <WebCore/DisplayListItems.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineFillColor {
-    uint8_t colorData().resolved().red
-    uint8_t colorData().resolved().green
-    uint8_t colorData().resolved().blue
-    uint8_t colorData().resolved().alpha
+    WebCore::PackedColor::RGBA colorData()
 }
 
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineStrokeColor {
-    uint8_t colorData().resolved().red
-    uint8_t colorData().resolved().green
-    uint8_t colorData().resolved().blue
-    uint8_t colorData().resolved().alpha
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineStroke {
+    std::optional<WebCore::PackedColor::RGBA> colorData()
+    std::optional<float> thickness()
 }
 
 header: <WebCore/HTTPHeaderMap.h>

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -118,19 +118,14 @@ void RemoteDisplayListRecorderProxy::recordConcatenateCTM(const AffineTransform&
     send(Messages::RemoteDisplayListRecorder::ConcatenateCTM(transform));
 }
 
-void RemoteDisplayListRecorderProxy::recordSetInlineFillColor(SRGBA<uint8_t> color)
+void RemoteDisplayListRecorderProxy::recordSetInlineFillColor(PackedColor::RGBA color)
 {
     send(Messages::RemoteDisplayListRecorder::SetInlineFillColor(DisplayList::SetInlineFillColor { color }));
 }
 
-void RemoteDisplayListRecorderProxy::recordSetInlineStrokeColor(SRGBA<uint8_t> color)
+void RemoteDisplayListRecorderProxy::recordSetInlineStroke(DisplayList::SetInlineStroke&& strokeItem)
 {
-    send(Messages::RemoteDisplayListRecorder::SetInlineStrokeColor(DisplayList::SetInlineStrokeColor { color }));
-}
-
-void RemoteDisplayListRecorderProxy::recordSetStrokeThickness(float thickness)
-{
-    send(Messages::RemoteDisplayListRecorder::SetStrokeThickness(thickness));
+    send(Messages::RemoteDisplayListRecorder::SetInlineStroke(strokeItem));
 }
 
 void RemoteDisplayListRecorderProxy::recordSetState(const GraphicsContextState& state)
@@ -398,9 +393,9 @@ void RemoteDisplayListRecorderProxy::recordStrokeLine(const PathDataLine& line)
     send(Messages::RemoteDisplayListRecorder::StrokeLine(line));
 }
 
-void RemoteDisplayListRecorderProxy::recordStrokeLineWithColorAndThickness(const PathDataLine& line, SRGBA<uint8_t> color, float thickness)
+void RemoteDisplayListRecorderProxy::recordStrokeLineWithColorAndThickness(const PathDataLine& line, DisplayList::SetInlineStroke&& strokeItem)
 {
-    send(Messages::RemoteDisplayListRecorder::StrokeLineWithColorAndThickness(line, color, thickness));
+    send(Messages::RemoteDisplayListRecorder::StrokeLineWithColorAndThickness(line, strokeItem));
 }
 
 void RemoteDisplayListRecorderProxy::recordStrokeArc(const PathArc& arc)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -65,9 +65,8 @@ private:
     void recordScale(const WebCore::FloatSize&) final;
     void recordSetCTM(const WebCore::AffineTransform&) final;
     void recordConcatenateCTM(const WebCore::AffineTransform&) final;
-    void recordSetInlineFillColor(WebCore::SRGBA<uint8_t>) final;
-    void recordSetInlineStrokeColor(WebCore::SRGBA<uint8_t>) final;
-    void recordSetStrokeThickness(float) final;
+    void recordSetInlineFillColor(WebCore::PackedColor::RGBA) final;
+    void recordSetInlineStroke(WebCore::DisplayList::SetInlineStroke&&) final;
     void recordSetState(const WebCore::GraphicsContextState&) final;
     void recordSetLineCap(WebCore::LineCap) final;
     void recordSetLineDash(const WebCore::DashArray&, float dashOffset) final;
@@ -121,7 +120,7 @@ private:
     void recordStrokeRect(const WebCore::FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordStrokeLine(const WebCore::PathDataLine&) final;
-    void recordStrokeLineWithColorAndThickness(const WebCore::PathDataLine&, WebCore::SRGBA<uint8_t>, float thickness) final;
+    void recordStrokeLineWithColorAndThickness(const WebCore::PathDataLine&, WebCore::DisplayList::SetInlineStroke&&) final;
     void recordStrokeArc(const WebCore::PathArc&) final;
     void recordStrokeQuadCurve(const WebCore::PathDataQuadCurve&) final;
     void recordStrokeBezierCurve(const WebCore::PathDataBezierCurve&) final;

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
@@ -64,7 +64,7 @@ TEST(DisplayListTests, AppendItems)
     auto path = createComplexPath();
 
     for (int i = 0; i < 50; ++i) {
-        list.append(SetStrokeThickness(1.5));
+        list.append(SetInlineStroke(1.5));
         list.append(FillPath(path));
         list.append(FillRectWithGradient(FloatRect { 1., 1., 10., 10. }, gradient));
         list.append(SetInlineFillColor(Color::red));
@@ -78,7 +78,7 @@ TEST(DisplayListTests, AppendItems)
     bool observedUnexpectedItem = false;
     for (const auto& item : list.items()) {
         WTF::switchOn(item,
-        [&](const SetStrokeThickness& item) {
+        [&](const SetInlineStroke& item) {
             EXPECT_EQ(item.thickness(), 1.5);
         }, [&](const FillPath& item) {
             EXPECT_EQ(item.path(), path);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -60,7 +60,7 @@ TEST(DisplayListTests, ReplayWithMissingResource)
     list.append(SetInlineFillColor(Color::green));
     list.append(FillRect(contextBounds));
     list.append(DrawImageBuffer(imageBufferIdentifier, contextBounds, contextBounds, ImagePaintingOptions { }));
-    list.append(SetInlineStrokeColor(Color::red));
+    list.append(SetInlineStroke(Color::red));
     list.append(StrokeLine(FloatPoint { 0, contextHeight }, FloatPoint { contextWidth, 0 }));
 
     {


### PR DESCRIPTION
#### 922c037bca6e8cdf1186b3731e3e91a70372333a
<pre>
[GPU Process] REGRESSION: display-p3 stroke color in canvas crashes the webpage
<a href="https://bugs.webkit.org/show_bug.cgi?id=263387">https://bugs.webkit.org/show_bug.cgi?id=263387</a>
rdar://117226767

Reviewed by Simon Fraser.

Recording the inline path data items is enabled only if the state stroke has an
inline color or if the stroke color was not changed since last time the state was
committed.

A crash will happen when the current stroke color is not inline (display-p3 for
example) and it has been committed to the destination context in GPUP but the
stroke thickness was changed. The item SetInlineStrokeColor tries to get the
inline data a non inline color although the current stroke color is not inline
and it has not changed. So the crash happens.

The fix is to merge the inline stroke changes into one DisplayList item named
SetInlineStroke. It has two optional members: the inline color data and the
thickness. Each member will be set only if it was changed since last commit.

For representing the color in SetInlineStroke, PackedColor::RGBA will be used
instead of SRGBA&lt;uint8_t&gt; since it is easier to be encoded.

* LayoutTests/fast/canvas/canvas-line-no-change-display-p3-stroke-expected.html: Added.
* LayoutTests/fast/canvas/canvas-line-no-change-display-p3-stroke.html: Added.
* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::tryGetAsPackedInline const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::SetInlineStroke::apply const):
(WebCore::DisplayList::SetInlineStroke::dump const):
(WebCore::DisplayList::SetInlineStrokeColor::apply const): Deleted.
(WebCore::DisplayList::SetInlineStrokeColor::dump const): Deleted.
(WebCore::DisplayList::SetStrokeThickness::apply const): Deleted.
(WebCore::DisplayList::SetStrokeThickness::dump const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::SetInlineFillColor::SetInlineFillColor):
(WebCore::DisplayList::SetInlineFillColor::color const):
(WebCore::DisplayList::SetInlineFillColor::colorData const):
(WebCore::DisplayList::SetInlineStroke::SetInlineStroke):
(WebCore::DisplayList::SetInlineStroke::color const):
(WebCore::DisplayList::SetInlineStroke::colorData const):
(WebCore::DisplayList::SetInlineStroke::thickness const):
(WebCore::DisplayList::SetInlineStrokeColor::SetInlineStrokeColor): Deleted.
(WebCore::DisplayList::SetInlineStrokeColor::color const): Deleted.
(WebCore::DisplayList::SetInlineStrokeColor::colorData const): Deleted.
(WebCore::DisplayList::SetStrokeThickness::SetStrokeThickness): Deleted.
(WebCore::DisplayList::SetStrokeThickness::thickness const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::appendStateChangeItem):
(WebCore::DisplayList::Recorder::buildSetInlineStroke):
(WebCore::DisplayList::Recorder::strokePath):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordSetInlineFillColor):
(WebCore::DisplayList::RecorderImpl::recordSetInlineStroke):
(WebCore::DisplayList::RecorderImpl::recordStrokeLineWithColorAndThickness):
(WebCore::DisplayList::RecorderImpl::recordSetInlineStrokeColor): Deleted.
(WebCore::DisplayList::RecorderImpl::recordSetStrokeThickness): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::setInlineFillColor):
(WebKit::RemoteDisplayListRecorder::setInlineStroke):
(WebKit::RemoteDisplayListRecorder::strokeLineWithColorAndThickness):
(WebKit::RemoteDisplayListRecorder::setInlineStrokeColor): Deleted.
(WebKit::RemoteDisplayListRecorder::setStrokeThickness): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordSetInlineFillColor):
(WebKit::RemoteDisplayListRecorderProxy::recordSetInlineStroke):
(WebKit::RemoteDisplayListRecorderProxy::recordStrokeLineWithColorAndThickness):
(WebKit::RemoteDisplayListRecorderProxy::recordSetInlineStrokeColor): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::recordSetStrokeThickness): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/269664@main">https://commits.webkit.org/269664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa1dc22678bf8ada5512e339b31196be073bef56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25874 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27092 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24959 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18393 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20703 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5537 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->