### PR TITLE
[Hardening] Add bounds check to StringView::operator[]

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -361,52 +361,53 @@ static double jsStrDecimalLiteral(const CharType*& data, const CharType* end)
     return PNaN;
 }
 
-template <typename CharType>
-static double toDouble(const CharType* characters, unsigned size)
+template <typename CharacterType>
+static double toDouble(std::span<const CharacterType> characters)
 {
-    const CharType* endCharacters = characters + size;
+    const auto* rawCharacters = characters.data();
+    const auto* endRawCharacters = rawCharacters + characters.size();
 
     // Skip leading white space.
-    for (; characters < endCharacters; ++characters) {
-        if (!isStrWhiteSpace(*characters))
+    for (; rawCharacters < endRawCharacters; ++rawCharacters) {
+        if (!isStrWhiteSpace(*rawCharacters))
             break;
     }
 
     // Empty string.
-    if (characters == endCharacters)
+    if (rawCharacters == endRawCharacters)
         return 0.0;
 
     double number;
-    if (characters[0] == '0' && characters + 2 < endCharacters) {
-        if ((characters[1] | 0x20) == 'x' && isASCIIHexDigit(characters[2]))
-            number = jsHexIntegerLiteral(characters, endCharacters);
-        else if ((characters[1] | 0x20) == 'o' && isASCIIOctalDigit(characters[2]))
-            number = jsOctalIntegerLiteral(characters, endCharacters);
-        else if ((characters[1] | 0x20) == 'b' && isASCIIBinaryDigit(characters[2]))
-            number = jsBinaryIntegerLiteral(characters, endCharacters);
+    if (rawCharacters[0] == '0' && rawCharacters + 2 < endRawCharacters) {
+        if ((rawCharacters[1] | 0x20) == 'x' && isASCIIHexDigit(rawCharacters[2]))
+            number = jsHexIntegerLiteral(rawCharacters, endRawCharacters);
+        else if ((rawCharacters[1] | 0x20) == 'o' && isASCIIOctalDigit(rawCharacters[2]))
+            number = jsOctalIntegerLiteral(rawCharacters, endRawCharacters);
+        else if ((rawCharacters[1] | 0x20) == 'b' && isASCIIBinaryDigit(rawCharacters[2]))
+            number = jsBinaryIntegerLiteral(rawCharacters, endRawCharacters);
         else
-            number = jsStrDecimalLiteral(characters, endCharacters);
+            number = jsStrDecimalLiteral(rawCharacters, endRawCharacters);
     } else
-        number = jsStrDecimalLiteral(characters, endCharacters);
+        number = jsStrDecimalLiteral(rawCharacters, endRawCharacters);
 
     // Allow trailing white space.
-    for (; characters < endCharacters; ++characters) {
-        if (!isStrWhiteSpace(*characters))
+    for (; rawCharacters < endRawCharacters; ++rawCharacters) {
+        if (!isStrWhiteSpace(*rawCharacters))
             break;
     }
-    if (characters != endCharacters)
+    if (rawCharacters != endRawCharacters)
         return PNaN;
 
     return number;
 }
 
 // See ecma-262 6th 11.8.3
-double jsToNumber(StringView s)
+template<typename CharacterType>
+static ALWAYS_INLINE double jsToNumber(std::span<const CharacterType> characters)
 {
-    unsigned size = s.length();
-
-    if (size == 1) {
-        UChar c = s[0];
+    auto* rawCharacters = characters.data();
+    if (characters.size() == 1) {
+        auto c = rawCharacters[0];
         if (isASCIIDigit(c))
             return c - '0';
         if (isStrWhiteSpace(c))
@@ -414,8 +415,8 @@ double jsToNumber(StringView s)
         return PNaN;
     }
 
-    if (size == 2 && s[0] == '-') {
-        UChar c = s[1];
+    if (characters.size() == 2 && rawCharacters[0] == '-') {
+        auto c = rawCharacters[1];
         if (c == '0')
             return -0.0;
         if (isASCIIDigit(c))
@@ -423,9 +424,14 @@ double jsToNumber(StringView s)
         return PNaN;
     }
 
+    return toDouble(characters);
+}
+
+double jsToNumber(StringView s)
+{
     if (s.is8Bit())
-        return toDouble(s.characters8(), size);
-    return toDouble(s.characters16(), size);
+        return jsToNumber(s.span8());
+    return jsToNumber(s.span16());
 }
 
 static double parseFloat(StringView s)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -305,6 +305,8 @@ public:
     bool is8Bit() const { return m_hashAndFlags & s_hashFlag8BitBuffer; }
     ALWAYS_INLINE const LChar* characters8() const { ASSERT(is8Bit()); return m_data8; }
     ALWAYS_INLINE const UChar* characters16() const { ASSERT(!is8Bit() || isEmpty()); return m_data16; }
+    ALWAYS_INLINE std::span<const LChar> span8() const { return { characters8(), length() }; }
+    ALWAYS_INLINE std::span<const UChar> span16() const { return { characters16(), length() }; }
 
     template<typename CharacterType> const CharacterType* characters() const;
 


### PR DESCRIPTION
#### 7eeecadfc0089a16915bad65ac206d82d16f5795
<pre>
[Hardening] Add bounds check to StringView::operator[]
<a href="https://bugs.webkit.org/show_bug.cgi?id=263491">https://bugs.webkit.org/show_bug.cgi?id=263491</a>

Reviewed by Darin Adler.

Add bounds check to StringView::operator[] and StringView::charactersAt() as a
hardening measure.

This patch was initialized a performance regression on Speedometer and Jetstream.
I used a profiler to find the call sites in hot code path and moved them away
from StringView::operator[].

As it stands, this patch is performance-neutral on Speedometer and Jetstream on
the various hardware models I A/B tested on.

* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::toDouble):
(JSC::jsToNumber):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::appendStringToData):
(JSC::joinStrings):
(JSC::JSStringJoiner::joinSlow):
* Source/JavaScriptCore/runtime/PropertyName.h:
(JSC::fastIsCanonicalNumericIndexString):
(JSC::isCanonicalNumericIndexString):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::span8 const):
(WTF::StringImpl::span16 const):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::characterAt const):
(WTF::StringView::unsafeCharacterAt const):
(WTF::StringView::CodeUnits::Iterator::operator* const):
(WTF::findCommon):

Canonical link: <a href="https://commits.webkit.org/269630@main">https://commits.webkit.org/269630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/479969ab2e9c7b5e31ba5ab799b24cd20a58879c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23618 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23322 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25848 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/515 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27073 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20080 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24940 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22447 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/585 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29819 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/514 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/994 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29771 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/787 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6058 "Passed tests") | 
<!--EWS-Status-Bubble-End-->