### PR TITLE
Add some more deprecation macros

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -814,7 +814,9 @@ void WebInspectorUIProxy::inspectedViewFrameDidChange(CGFloat currentDimension)
         return;
 
     // Disable screen updates to make sure the layers for both views resize in sync.
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [inspectorView.window disableScreenUpdatesUntilFlush];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     [inspectorView setFrame:newInspectorViewFrame];
     [inspectedView setFrame:inspectedViewFrame];

--- a/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultUIDelegate.mm
+++ b/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultUIDelegate.mm
@@ -150,7 +150,9 @@
 #if PLATFORM(IOS_FAMILY)
     return NO;
 #else
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return [[wv window] showsResizeIndicator];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 }
 
@@ -159,7 +161,9 @@
 #if PLATFORM(MAC)
     // FIXME: This doesn't actually change the resizability of the window,
     // only visibility of the indicator.
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [[wv window] setShowsResizeIndicator:resizable];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
@@ -226,7 +226,9 @@ using namespace WebCore;
 {
     ASSERT(_targetView);
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [[_targetView window] disableScreenUpdatesUntilFlush];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Mark the whole highlight view as needing display since we don't know what areas
     // need updated, since the highlight can be larger than the element to show margins.
@@ -285,7 +287,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
 
     // Disable screen updates so the highlight moves in sync with the view.
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [[_targetView window] disableScreenUpdatesUntilFlush];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     [_highlightWindow setFrame:[self _computeHighlightWindowFrame] display:YES];
 }

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -3960,11 +3960,11 @@ static BOOL currentScrollIsBlit(NSView *clipView)
     // we risk disabling screen updates when no flush is pending.
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if ([NSGraphicsContext currentContext] == [[self window] graphicsContext] && [webView _needsOneShotDrawingSynchronization]) {
-ALLOW_DEPRECATED_DECLARATIONS_END
         // Disable screen updates to minimize the chances of the race between the CA
         // display link and AppKit drawing causing flashes.
         [[self window] disableScreenUpdatesUntilFlush];
-        
+ALLOW_DEPRECATED_DECLARATIONS_END
+
         // Make sure any layer changes that happened as a result of layout
         // via -viewWillDraw are committed.
         [CATransaction flush];


### PR DESCRIPTION
#### c954b58bc09c4e4d42e5cdf24398a197008c8ab0
<pre>
Add some more deprecation macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=263493">https://bugs.webkit.org/show_bug.cgi?id=263493</a>
rdar://117294813

Unreviewed build fix.

* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::inspectedViewFrameDidChange):
* Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultUIDelegate.mm:
(-[WebDefaultUIDelegate webViewIsResizable:]):
(-[WebDefaultUIDelegate webView:setResizable:]):
* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView drawRect:]):

Canonical link: <a href="https://commits.webkit.org/269617@main">https://commits.webkit.org/269617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64088848dc4457e638edb52e69029222e5b9e4c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24978 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23598 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23304 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25829 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2930 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->