### PR TITLE
REGRESSION(269613@main): `text-wrap: balance` parses even when `text-wrap-style` is disabled

### DIFF
--- a/LayoutTests/fast/css/text-wrap-style-disabled-expected.txt
+++ b/LayoutTests/fast/css/text-wrap-style-disabled-expected.txt
@@ -1,0 +1,28 @@
+When text-wrap-style is disabled, the following should not parse:
+
+
+PASS e.style['text-wrap-style'] = "auto" should not set the property value
+PASS e.style['text-wrap-style'] = "balance" should not set the property value
+PASS e.style['text-wrap-style'] = "stable" should not set the property value
+PASS e.style['text-wrap-style'] = "pretty" should not set the property value
+PASS e.style['text-wrap'] = "auto" should not set the property value
+PASS e.style['text-wrap'] = "balance" should not set the property value
+PASS e.style['text-wrap'] = "stable" should not set the property value
+PASS e.style['text-wrap'] = "pretty" should not set the property value
+PASS e.style['text-wrap'] = "wrap auto" should not set the property value
+PASS e.style['text-wrap'] = "wrap balance" should not set the property value
+PASS e.style['text-wrap'] = "wrap pretty" should not set the property value
+PASS e.style['text-wrap'] = "wrap stable" should not set the property value
+PASS e.style['text-wrap'] = "auto wrap" should not set the property value
+PASS e.style['text-wrap'] = "balance wrap" should not set the property value
+PASS e.style['text-wrap'] = "pretty wrap" should not set the property value
+PASS e.style['text-wrap'] = "stable wrap" should not set the property value
+PASS e.style['text-wrap'] = "nowrap auto" should not set the property value
+PASS e.style['text-wrap'] = "nowrap balance" should not set the property value
+PASS e.style['text-wrap'] = "nowrap pretty" should not set the property value
+PASS e.style['text-wrap'] = "nowrap stable" should not set the property value
+PASS e.style['text-wrap'] = "auto nowrap" should not set the property value
+PASS e.style['text-wrap'] = "balance nowrap" should not set the property value
+PASS e.style['text-wrap'] = "pretty nowrap" should not set the property value
+PASS e.style['text-wrap'] = "stable nowrap" should not set the property value
+

--- a/LayoutTests/fast/css/text-wrap-style-disabled.html
+++ b/LayoutTests/fast/css/text-wrap-style-disabled.html
@@ -1,0 +1,43 @@
+<!-- webkit-test-runner [ CSSTextWrapStyleEnabled=false ]-->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test text-wrap parsing when text-wrap-style is disabled</title>
+<meta charset="utf-8">
+</head>
+<body>
+<p>When text-wrap-style is disabled, the following should not parse:</p>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/css/support/parsing-testcommon.js"></script>
+<script>
+test_invalid_value("text-wrap-style", "auto");
+test_invalid_value("text-wrap-style", "balance");
+test_invalid_value("text-wrap-style", "stable");
+test_invalid_value("text-wrap-style", "pretty");
+
+test_invalid_value("text-wrap", "auto");
+test_invalid_value("text-wrap", "balance");
+test_invalid_value("text-wrap", "stable");
+test_invalid_value("text-wrap", "pretty");
+
+test_invalid_value("text-wrap", "wrap auto");
+test_invalid_value("text-wrap", "wrap balance");
+test_invalid_value("text-wrap", "wrap pretty");
+test_invalid_value("text-wrap", "wrap stable");
+test_invalid_value("text-wrap", "auto wrap");
+test_invalid_value("text-wrap", "balance wrap");
+test_invalid_value("text-wrap", "pretty wrap");
+test_invalid_value("text-wrap", "stable wrap");
+
+test_invalid_value("text-wrap", "nowrap auto");
+test_invalid_value("text-wrap", "nowrap balance");
+test_invalid_value("text-wrap", "nowrap pretty");
+test_invalid_value("text-wrap", "nowrap stable");
+test_invalid_value("text-wrap", "auto nowrap");
+test_invalid_value("text-wrap", "balance nowrap");
+test_invalid_value("text-wrap", "pretty nowrap");
+test_invalid_value("text-wrap", "stable nowrap");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -2544,7 +2544,7 @@ bool CSSPropertyParser::consumeTextWrapShorthand(bool important)
     for (unsigned propertiesParsed = 0; propertiesParsed < 2 && !m_range.atEnd(); ++propertiesParsed) {
         if (!mode && (mode = CSSPropertyParsing::consumeTextWrapMode(m_range)))
             continue;
-        if (!style && (style = CSSPropertyParsing::consumeTextWrapStyle(m_range)))
+        if (!style && m_context.propertySettings.cssTextWrapStyleEnabled && (style = CSSPropertyParsing::consumeTextWrapStyle(m_range)))
             continue;
         // If we didn't find at least one match, this is an invalid shorthand and we have to ignore it.
         return false;


### PR DESCRIPTION
#### 60512655e7aff3095432eedf8babf923d8c30cf6
<pre>
REGRESSION(269613@main): `text-wrap: balance` parses even when `text-wrap-style` is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=263495">https://bugs.webkit.org/show_bug.cgi?id=263495</a>
rdar://117295817

Reviewed by Alan Baradlay.

269613@main accidentally enabled `text-wrap: balance`. It was assuming the generated `text-wrap-style` parsing function
would check for the preference, but that is not the case.

Add a manual check for the preference to avoid exposing the `text-wrap-style` values in `text-wrap` when the longhand is disabled.

* LayoutTests/fast/css/text-wrap-style-disabled-expected.txt: Added.
* LayoutTests/fast/css/text-wrap-style-disabled.html: Added.
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeTextWrapShorthand):

Canonical link: <a href="https://commits.webkit.org/269624@main">https://commits.webkit.org/269624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a70817a97264b969d4fbbc7d000d431353a52831

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23603 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25834 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27058 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24926 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20667 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5509 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->