### PR TITLE
TestWebKitAPI.GPUProcess.WebProcessTerminationAfterTooManyGPUProcessCrashes is a flaky failure.

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1033,6 +1033,11 @@ void Connection::connectionDidClose()
     }
     m_waitForMessageCondition.notifyAll();
 
+    {
+        Locker locker { m_outgoingMessagesLock };
+        m_outgoingMessages.clear();
+    }
+
     if (m_didCloseOnConnectionWorkQueueCallback)
         m_didCloseOnConnectionWorkQueueCallback(this);
 


### PR DESCRIPTION
#### 4bd0c17eea89ee6f3c609105a538196e5d518886
<pre>
TestWebKitAPI.GPUProcess.WebProcessTerminationAfterTooManyGPUProcessCrashes is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263338">https://bugs.webkit.org/show_bug.cgi?id=263338</a>
&lt;rdar://117166263&gt;

Reviewed by Kimmo Kinnunen.

nderingBackendProxy::ensureGPUProcessConnection can create both the main connection to the GPU process, and then send the
creation for the stream connection over that.

If the GPUP crashes before that main connection finishes connecting, then the message containing the stream connection
constructor is still in m_outgoingMessages.

We then block the main thread waiting on a sync message from the stream connection. We can’t process the incoming did
close message from the main connection, since we’re blocking the thread, and the stream connection doesn’t stop waiting
because the construction handle is still alive.

Making Connection::connectionDidClose() also clear m_outgoingMessages fixes the timeout.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::connectionDidClose):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::MockTestSyncMessage::name):
(TestWebKitAPI::MockTestSyncMessage::arguments):
(TestWebKitAPI::MockTestSyncMessage::MockTestSyncMessage):
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/269773@main">https://commits.webkit.org/269773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2577f1cd6a39f1782b4cd6c06161312038f793c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24568 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23990 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26205 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21183 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27434 "2 flakes 112 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21369 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25200 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18623 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/862 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5619 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->