### PR TITLE
Adopt more smart pointers in DOM code

### DIFF
--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "QualifiedName.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/Vector.h>
@@ -37,7 +38,7 @@ namespace WebCore {
 class Element;
 class WeakPtrImplWithEventTargetData;
 
-class CustomElementDefaultARIA {
+class CustomElementDefaultARIA : public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(CustomElementDefaultARIA);
 public:
     CustomElementDefaultARIA();

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -98,10 +98,10 @@ static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, con
 
 ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const AtomString& namespaceURI, const AtomString& qualifiedName, DocumentType* documentType)
 {
-    auto document = createXMLDocument(namespaceURI, m_document.settings());
+    auto document = createXMLDocument(namespaceURI, m_document->settings());
     document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
-    document->setContextDocument(m_document.contextDocument());
-    document->setSecurityOriginPolicy(m_document.securityOriginPolicy());
+    document->setContextDocument(m_document->contextDocument());
+    document->setSecurityOriginPolicy(m_document->securityOriginPolicy());
 
     RefPtr<Element> documentElement;
     if (!qualifiedName.isEmpty()) {
@@ -131,7 +131,7 @@ Ref<CSSStyleSheet> DOMImplementation::createCSSStyleSheet(const String&, const S
 
 Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
 {
-    auto document = HTMLDocument::create(nullptr, m_document.settings(), URL(), { });
+    auto document = HTMLDocument::create(nullptr, m_document->settings(), URL(), { });
     document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     document->open();
     document->write(nullptr, { "<!doctype html><html><head></head><body></body></html>"_s });
@@ -139,10 +139,10 @@ Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
         auto titleElement = HTMLTitleElement::create(titleTag, document);
         titleElement->appendChild(document->createTextNode(WTFMove(title)));
         ASSERT(document->head());
-        document->head()->appendChild(titleElement);
+        document->protectedHead()->appendChild(titleElement);
     }
-    document->setContextDocument(m_document.contextDocument());
-    document->setSecurityOriginPolicy(m_document.securityOriginPolicy());
+    document->setContextDocument(m_document->contextDocument());
+    document->setSecurityOriginPolicy(m_document->securityOriginPolicy());
     return document;
 }
 

--- a/Source/WebCore/dom/DOMImplementation.h
+++ b/Source/WebCore/dom/DOMImplementation.h
@@ -26,6 +26,7 @@
 #include "ExceptionOr.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "XMLDocument.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -34,8 +35,8 @@ class DOMImplementation final : public ScriptWrappable {
 public:
     explicit DOMImplementation(Document&);
 
-    void ref() { m_document.ref(); }
-    void deref() { m_document.deref(); }
+    void ref() { m_document->ref(); }
+    void deref() { m_document->deref(); }
     Document& document() { return m_document; }
 
     WEBCORE_EXPORT ExceptionOr<Ref<DocumentType>> createDocumentType(const AtomString& qualifiedName, const String& publicId, const String& systemId);
@@ -47,7 +48,7 @@ public:
     static Ref<Document> createDocument(const String& contentType, LocalFrame*, const Settings&, const URL&, ScriptExecutionContextIdentifier = { });
 
 private:
-    Document& m_document;
+    CheckedRef<Document> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3322,6 +3322,11 @@ HTMLHeadElement* Document::head()
     return nullptr;
 }
 
+RefPtr<HTMLHeadElement> Document::protectedHead()
+{
+    return head();
+}
+
 ExceptionOr<void> Document::closeForBindings()
 {
     // FIXME: We should follow the specification more closely:

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1123,6 +1123,7 @@ public:
     Location* location() const;
 
     WEBCORE_EXPORT HTMLHeadElement* head();
+    RefPtr<HTMLHeadElement> protectedHead();
 
     inline DocumentMarkerController& markers(); // Defined in DocumentInlines.h.
     inline const DocumentMarkerController& markers() const; // Defined in DocumentInlines.h.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3083,6 +3083,11 @@ CustomElementDefaultARIA& Element::customElementDefaultARIA()
     return *deafultARIA;
 }
 
+CheckedRef<CustomElementDefaultARIA> Element::checkedCustomElementDefaultARIA()
+{
+    return customElementDefaultARIA();
+}
+
 CustomElementDefaultARIA* Element::customElementDefaultARIAIfExists()
 {
     return isPrecustomizedOrDefinedCustomElement() && hasRareData() ? elementRareData()->customElementDefaultARIA() : nullptr;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -371,6 +371,7 @@ public:
     CustomElementReactionQueue* reactionQueue() const;
 
     CustomElementDefaultARIA& customElementDefaultARIA();
+    CheckedRef<CustomElementDefaultARIA> checkedCustomElementDefaultARIA();
     CustomElementDefaultARIA* customElementDefaultARIAIfExists();
 
     // FIXME: This should not be virtual. Please do not add additional overrides of this function.

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -92,7 +92,7 @@ inline const AtomString& Element::attributeWithoutSynchronization(const Qualifie
 
 inline URL Element::getURLAttributeForBindings(const QualifiedName& name) const
 {
-    return document().maskedURLForBindingsIfNeeded(getURLAttribute(name));
+    return protectedDocument()->maskedURLForBindingsIfNeeded(getURLAttribute(name));
 }
 
 inline bool Element::hasAttributesWithoutUpdate() const

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -41,12 +41,12 @@ using namespace HTMLNames;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ElementInternals);
 
-ShadowRoot* ElementInternals::shadowRoot() const
+RefPtr<ShadowRoot> ElementInternals::shadowRoot() const
 {
     RefPtr element = m_element.get();
     if (!element)
         return nullptr;
-    auto* shadowRoot = element->shadowRoot();
+    RefPtr shadowRoot = element->shadowRoot();
     if (!shadowRoot)
         return nullptr;
     if (!shadowRoot->isAvailableToElementInternals())
@@ -130,7 +130,7 @@ FormAssociatedCustomElement* ElementInternals::elementAsFormAssociatedCustom() c
 static const AtomString& computeValueForAttribute(Element& element, const QualifiedName& name)
 {
     auto& value = element.attributeWithoutSynchronization(name);
-    if (auto* defaultARIA = element.customElementDefaultARIAIfExists(); value.isNull() && defaultARIA)
+    if (CheckedPtr defaultARIA = element.customElementDefaultARIAIfExists(); value.isNull() && defaultARIA)
         return defaultARIA->valueForAttribute(element, name);
     return value;
 }
@@ -140,28 +140,24 @@ void ElementInternals::setAttributeWithoutSynchronization(const QualifiedName& n
     RefPtr element = m_element.get();
     auto oldValue = computeValueForAttribute(*element, name);
 
-    element->customElementDefaultARIA().setValueForAttribute(name, value);
+    element->checkedCustomElementDefaultARIA()->setValueForAttribute(name, value);
 
-    if (AXObjectCache* cache = element->document().existingAXObjectCache())
+    if (CheckedPtr cache = element->document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
 }
 
 const AtomString& ElementInternals::attributeWithoutSynchronization(const QualifiedName& name) const
 {
     RefPtr element = m_element.get();
-    auto* defaultARIA = element->customElementDefaultARIAIfExists();
-    if (!defaultARIA)
-        return nullAtom();
-    return defaultARIA->valueForAttribute(*element, name);
+    CheckedPtr defaultARIA = element->customElementDefaultARIAIfExists();
+    return defaultARIA ? defaultARIA->valueForAttribute(*element, name) : nullAtom();
 }
 
 RefPtr<Element> ElementInternals::getElementAttribute(const QualifiedName& name) const
 {
     RefPtr element = m_element.get();
-    auto* defaultARIA = m_element->customElementDefaultARIAIfExists();
-    if (!defaultARIA)
-        return nullptr;
-    return defaultARIA->elementForAttribute(*element, name);
+    CheckedPtr defaultARIA = m_element->customElementDefaultARIAIfExists();
+    return defaultARIA ? defaultARIA->elementForAttribute(*element, name) : nullptr;
 }
 
 void ElementInternals::setElementAttribute(const QualifiedName& name, Element* value)
@@ -169,16 +165,16 @@ void ElementInternals::setElementAttribute(const QualifiedName& name, Element* v
     RefPtr element = m_element.get();
     auto oldValue = computeValueForAttribute(*element, name);
 
-    element->customElementDefaultARIA().setElementForAttribute(name, value);
+    element->checkedCustomElementDefaultARIA()->setElementForAttribute(name, value);
 
-    if (AXObjectCache* cache = element->document().existingAXObjectCache())
+    if (CheckedPtr cache = element->document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
 }
 
 std::optional<Vector<RefPtr<Element>>> ElementInternals::getElementsArrayAttribute(const QualifiedName& name) const
 {
     RefPtr element = m_element.get();
-    auto* defaultARIA = m_element->customElementDefaultARIAIfExists();
+    CheckedPtr defaultARIA = m_element->customElementDefaultARIAIfExists();
     if (!defaultARIA)
         return std::nullopt;
     return defaultARIA->elementsForAttribute(*element, name);
@@ -189,9 +185,9 @@ void ElementInternals::setElementsArrayAttribute(const QualifiedName& name, std:
     RefPtr element = m_element.get();
     auto oldValue = computeValueForAttribute(*element, name);
 
-    element->customElementDefaultARIA().setElementsForAttribute(name, WTFMove(value));
+    element->checkedCustomElementDefaultARIA()->setElementsForAttribute(name, WTFMove(value));
 
-    if (AXObjectCache* cache = element->document().existingAXObjectCache())
+    if (CheckedPtr cache = element->document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
 }
 

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -47,7 +47,7 @@ public:
     }
 
     Element* element() const { return m_element.get(); }
-    ShadowRoot* shadowRoot() const;
+    RefPtr<ShadowRoot> shadowRoot() const;
 
     ExceptionOr<RefPtr<HTMLFormElement>> form() const;
 

--- a/Source/WebCore/dom/ElementIteratorAssertions.h
+++ b/Source/WebCore/dom/ElementIteratorAssertions.h
@@ -38,7 +38,7 @@ public:
     void clear();
 
 private:
-    const Document* m_document;
+    CheckedPtr<const Document> m_document;
     uint64_t m_initialDOMTreeVersion;
     std::optional<ScriptDisallowedScope> m_eventDispatchAssertion;
 };

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -132,10 +132,15 @@ void Event::setTarget(RefPtr<EventTarget>&& target)
         receivedTarget();
 }
 
-void Event::setCurrentTarget(EventTarget* currentTarget, std::optional<bool> isInShadowTree)
+RefPtr<EventTarget> Event::protectedCurrentTarget() const
 {
-    m_currentTarget = currentTarget;
-    m_currentTargetIsInShadowTree = isInShadowTree ? *isInShadowTree : (is<Node>(currentTarget) && downcast<Node>(*currentTarget).isInShadowTree());
+    return m_currentTarget;
+}
+
+void Event::setCurrentTarget(RefPtr<EventTarget>&& currentTarget, std::optional<bool> isInShadowTree)
+{
+    m_currentTarget = WTFMove(currentTarget);
+    m_currentTargetIsInShadowTree = isInShadowTree ? *isInShadowTree : (is<Node>(m_currentTarget) && downcast<Node>(*m_currentTarget).isInShadowTree());
 }
 
 void Event::setEventPath(const EventPath& path)
@@ -147,7 +152,7 @@ Vector<Ref<EventTarget>> Event::composedPath() const
 {
     if (!m_eventPath)
         return Vector<Ref<EventTarget>>();
-    return m_eventPath->computePathUnclosedToTarget(*m_currentTarget);
+    return m_eventPath->computePathUnclosedToTarget(*protectedCurrentTarget());
 }
 
 void Event::setUnderlyingEvent(Event* underlyingEvent)
@@ -162,10 +167,10 @@ void Event::setUnderlyingEvent(Event* underlyingEvent)
 
 DOMHighResTimeStamp Event::timeStampForBindings(ScriptExecutionContext& context) const
 {
-    Performance* performance = nullptr;
+    RefPtr<Performance> performance;
     if (is<WorkerGlobalScope>(context))
         performance = &downcast<WorkerGlobalScope>(context).performance();
-    else if (auto* window = downcast<Document>(context).domWindow())
+    else if (RefPtr window = downcast<Document>(context).domWindow())
         performance = &window->performance();
 
     if (!performance)

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -76,7 +76,8 @@ public:
     void setTarget(RefPtr<EventTarget>&&);
 
     EventTarget* currentTarget() const { return m_currentTarget.get(); }
-    void setCurrentTarget(EventTarget*, std::optional<bool> isInShadowTree = std::nullopt);
+    RefPtr<EventTarget> protectedCurrentTarget() const;
+    void setCurrentTarget(RefPtr<EventTarget>&&, std::optional<bool> isInShadowTree = std::nullopt);
     bool currentTargetIsInShadowTree() const { return m_currentTargetIsInShadowTree; }
 
     unsigned short eventPhase() const { return m_eventPhase; }

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -43,8 +43,8 @@ EventContext::~EventContext() = default;
 
 void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
 {
-    event.setTarget(m_target.get());
-    event.setCurrentTarget(m_currentTarget.get(), m_currentTargetIsInShadowTree);
+    event.setTarget(m_target.copyRef());
+    event.setCurrentTarget(m_currentTarget.copyRef(), m_currentTargetIsInShadowTree);
 
     if (m_relatedTargetIsSet) {
         ASSERT(!m_relatedTarget || m_type == Type::MouseOrFocus);
@@ -73,7 +73,7 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
 #endif
 
     if (!m_node || UNLIKELY(m_type == Type::Window)) {
-        m_currentTarget->fireEventListeners(event, phase);
+        protectedCurrentTarget()->fireEventListeners(event, phase);
         return;
     }
 
@@ -93,7 +93,7 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
     if (event.isTrusted() && is<Element>(m_node) && downcast<Element>(*m_node).isDisabledFormControl() && event.isMouseEvent() && !event.isWheelEvent() && !m_node->document().settings().sendMouseEventsToDisabledFormControlsEnabled())
         return;
 
-    m_node->fireEventListeners(event, phase);
+    protectedNode()->fireEventListeners(event, phase);
 }
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -49,7 +49,9 @@ public:
     ~EventContext();
 
     Node* node() const { return m_node.get(); }
+    RefPtr<Node> protectedNode() const { return m_node; }
     EventTarget* currentTarget() const { return m_currentTarget.get(); }
+    RefPtr<EventTarget> protectedCurrentTarget() const { return m_currentTarget; }
     bool isCurrentTargetInShadowTree() const { return m_currentTargetIsInShadowTree; }
     EventTarget* target() const { return m_target.get(); }
     int closedShadowDepth() const { return m_closedShadowDepth; }
@@ -61,7 +63,7 @@ public:
     bool isWindowContext() const { return m_type == Type::Window; }
 
     Node* relatedTarget() const { return m_relatedTarget.get(); }
-    void setRelatedTarget(Node*);
+    void setRelatedTarget(RefPtr<Node>&&);
 
 #if ENABLE(TOUCH_EVENTS)
     enum class TouchListType : uint8_t { Touches, TargetTouches, ChangedTouches };
@@ -124,10 +126,10 @@ inline EventContext::EventContext(Type type, Node& node, Node* currentTarget, Ev
     m_contextNodeIsFormElement = is<HTMLFormElement>(node);
 }
 
-inline void EventContext::setRelatedTarget(Node* relatedTarget)
+inline void EventContext::setRelatedTarget(RefPtr<Node>&& relatedTarget)
 {
-    ASSERT(!isUnreachableNode(relatedTarget));
-    m_relatedTarget = relatedTarget;
+    ASSERT(!isUnreachableNode(relatedTarget.get()));
+    m_relatedTarget = WTFMove(relatedTarget);
     m_relatedTargetIsSet = true;
 }
 

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -116,15 +116,15 @@ static bool shouldSuppressEventDispatchInDOM(Node& node, Event& event)
     if (!event.isTrusted())
         return false;
 
-    auto frame = node.document().frame();
+    RefPtr frame = node.document().frame();
     if (!frame)
         return false;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
     if (!localFrame)
         return false;
 
-    if (!localFrame->loader().shouldSuppressTextInputFromEditing())
+    if (!localFrame->checkedLoader()->shouldSuppressTextInputFromEditing())
         return false;
 
     if (is<TextEvent>(event)) {

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -233,6 +233,8 @@ public:
 private:
     enum class State : uint8_t { Running, Suspended, ReadyToStop, Stopped };
 
+    RefPtr<EventLoop> protectedEventLoop() const;
+
     WeakPtr<EventLoop> m_eventLoop;
     WeakHashSet<EventLoopTimer> m_timers;
     State m_state { State::Running };

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -320,7 +320,7 @@ void EventTarget::fireEventListeners(Event& event, EventInvokePhase phase)
 // https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke
 void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector listeners, EventInvokePhase phase)
 {
-    Ref<EventTarget> protectedThis(*this);
+    Ref protectedThis { *this };
     ASSERT(!listeners.isEmpty());
     ASSERT(scriptExecutionContext());
 
@@ -418,7 +418,7 @@ void EventTarget::invalidateEventListenerRegions()
         return;
     }
 
-    CheckedPtr document = [&]() -> Document* {
+    RefPtr document = [&]() -> Document* {
         if (is<Document>(*this))
             return &downcast<Document>(*this);
         if (is<LocalDOMWindow>(*this))


### PR DESCRIPTION
#### 3504caf0c0b87974da817a475dbe19a15f2c0957
<pre>
Adopt more smart pointers in DOM code
<a href="https://bugs.webkit.org/show_bug.cgi?id=263502">https://bugs.webkit.org/show_bug.cgi?id=263502</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/CustomElementDefaultARIA.h:
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createDocument):
(WebCore::DOMImplementation::createHTMLDocument):
* Source/WebCore/dom/DOMImplementation.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedHead):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::checkedCustomElementDefaultARIA):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Element::getURLAttributeForBindings const):
* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::shadowRoot const):
(WebCore::computeValueForAttribute):
(WebCore::ElementInternals::setAttributeWithoutSynchronization):
(WebCore::ElementInternals::attributeWithoutSynchronization const):
(WebCore::ElementInternals::getElementAttribute const):
(WebCore::ElementInternals::setElementAttribute):
(WebCore::ElementInternals::getElementsArrayAttribute const):
(WebCore::ElementInternals::setElementsArrayAttribute):
* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/ElementIteratorAssertions.h:
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::protectedCurrentTarget const):
(WebCore::Event::setCurrentTarget):
(WebCore::Event::composedPath const):
(WebCore::Event::timeStampForBindings const):
* Source/WebCore/dom/Event.h:
* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::handleLocalEvents const):
* Source/WebCore/dom/EventContext.h:
(WebCore::EventContext::protectedNode const):
(WebCore::EventContext::protectedCurrentTarget const):
(WebCore::EventContext::setRelatedTarget):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::shouldSuppressEventDispatchInDOM):
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTaskGroup::markAsReadyToStop):
(WebCore::EventLoopTaskGroup::protectedEventLoop const):
(WebCore::EventLoopTaskGroup::queueTask):
(WebCore::EventLoopTaskGroup::queueMicrotask):
(WebCore::EventLoopTaskGroup::performMicrotaskCheckpoint):
(WebCore::EventLoopTaskGroup::scheduleTask):
(WebCore::EventLoopTaskGroup::scheduleRepeatingTask):
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::EventPath):
(WebCore::EventPath::buildPath):
(WebCore::EventPath::setRelatedTarget):
(WebCore::EventPath::retargetTouch):
(WebCore::RelatedNodeRetargeter::RelatedNodeRetargeter):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::innerInvokeEventListeners):
(WebCore::EventTarget::invalidateEventListenerRegions):

Canonical link: <a href="https://commits.webkit.org/269641@main">https://commits.webkit.org/269641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce1b7fd81adbb536c6d99696a3ab404c34b05974

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22213 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25860 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27079 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21178 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24946 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18380 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/526 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5520 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->