### PR TITLE
Reduce size limit for item in the SVGPathElement cache

### DIFF
--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -51,7 +51,8 @@ private:
 
     HashMap<AtomString, SVGPathByteStream::Data> m_cache;
     uint64_t m_sizeInBytes { 0 };
-    static constexpr uint64_t maxSizeInBytes = 150 * 1024; // 150 Kb.
+    static constexpr uint64_t maxItemSizeInBytes = 5 * 1024; // 5 Kb.
+    static constexpr uint64_t maxCacheSizeInBytes = 150 * 1024; // 150 Kb.
 };
 
 PathSegListCache& PathSegListCache::singleton()
@@ -69,11 +70,11 @@ const SVGPathByteStream::Data* PathSegListCache::get(const AtomString& attribute
 void PathSegListCache::add(const AtomString& attributeValue, const SVGPathByteStream::Data& data)
 {
     size_t newDataSize = data.size();
-    if (UNLIKELY(newDataSize > (maxSizeInBytes / 2)))
+    if (UNLIKELY(newDataSize > maxItemSizeInBytes))
         return;
 
     m_sizeInBytes += newDataSize;
-    while (m_sizeInBytes > maxSizeInBytes) {
+    while (m_sizeInBytes > maxCacheSizeInBytes) {
         ASSERT(!m_cache.isEmpty());
         auto iteratorToRemove = m_cache.random();
         ASSERT(iteratorToRemove != m_cache.end());


### PR DESCRIPTION
#### 7b0da7dfd44117571174f1ed3d552206f5c00bf5
<pre>
Reduce size limit for item in the SVGPathElement cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=263503">https://bugs.webkit.org/show_bug.cgi?id=263503</a>

Reviewed by Said Abou-Hallawa.

Reduce size limit for item in the SVGPathElement cache. This is to avoid filling the cache
with very few items that are very large.

* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::PathSegListCache::add):

Canonical link: <a href="https://commits.webkit.org/269636@main">https://commits.webkit.org/269636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61154e3e792216297913ae45b1c83b03c110f982

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25015 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22216 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25866 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27084 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20948 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24950 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/533 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5517 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->