### PR TITLE
Remove 'libxml2' hacks called 'hackAroundLibXMLEntityBug' and 'hackAroundLibXMLEntityParsingBug'

### DIFF
--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -126,12 +126,6 @@ public:
     void internalSubset(const xmlChar* name, const xmlChar* externalID, const xmlChar* systemID);
     void endDocument();
 
-    bool isParsingEntityDeclaration() const { return m_isParsingEntityDeclaration; }
-    void setIsParsingEntityDeclaration(bool value) { m_isParsingEntityDeclaration = value; }
-
-    int depthTriggeringEntityExpansion() const { return m_depthTriggeringEntityExpansion; }
-    void setDepthTriggeringEntityExpansion(int depth) { m_depthTriggeringEntityExpansion = depth; }
-
 private:
     void initializeParserContext(const CString& chunk = CString());
 
@@ -156,8 +150,6 @@ private:
     RefPtr<XMLParserContext> m_context;
     std::unique_ptr<PendingCallbacks> m_pendingCallbacks;
     Vector<xmlChar> m_bufferedText;
-    int m_depthTriggeringEntityExpansion { -1 };
-    bool m_isParsingEntityDeclaration { false };
 
     ContainerNode* m_currentNode { nullptr };
     Vector<ContainerNode*> m_currentNodeStack;


### PR DESCRIPTION
#### 2b4d9ac4ad7211b883b024bd21450d0dbbf36fce
<pre>
Remove &apos;libxml2&apos; hacks called &apos;hackAroundLibXMLEntityBug&apos; and &apos;hackAroundLibXMLEntityParsingBug&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=263497">https://bugs.webkit.org/show_bug.cgi?id=263497</a>

Reviewed by Don Olmstead, David Kilzer and Michael Catanzaro.

Inspired by: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=149452 &amp;
<a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=149412

This patch removes old hacks to workaround `libxml2` bugs, which are no longer applicable.
These underlying bugs were fixed in upstream `libxml2` in following versions:

- hackAroundLibXMLEntityBug (fixed in 2.6.27)
- hackAroundLibXMLEntityParsingBug (fixed in 2.7.3)

All WebKit ports (via CMake) support following libxml2 version as required:

- mac (2.8.0 as required)
- Windows &amp; Playstation (2.9.7 as required)
- WPE (2.8.0 as required)
- GTK (2.8.0 as required)

* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(hackAroundLibXMLEntityParsingBug): Deleted
(XMLDocumentParser::startElementNs): Clean-up after &apos;function&apos; deletion
(XMLDocumentParser::endElementNs): Ditto
(hackAroundLibXMLEntityBug): Deleted
(startElementNsHandler): Clean-up after &apos;function&apos; deletion
(endElementNsHandler): Ditto
(charactersHandler): Ditto
(processingInstructionHandler): Ditto
(cdataBlockHandler): Ditto
(commentHandler): Ditto
(entityDeclarationHandler): Deleted
(getEntityHandler): Clean-up after &apos;function&apos; deletion
(XMLDocumentParser::initializeParserContext): Ditto
* Source/WebCore/xml/parser/XMLDocumentParser.h: Remove unused functions after clean-up

Canonical link: <a href="https://commits.webkit.org/269666@main">https://commits.webkit.org/269666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6ebd03f9fe329b626384a4d4bec2e5036cfe909

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21387 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22244 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25894 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27109 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18409 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/560 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5538 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->