### PR TITLE
Adopt even more smart pointers in DOM code

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5488,6 +5488,11 @@ WindowProxy* Document::windowProxy() const
     return &m_frame->windowProxy();
 }
 
+RefPtr<WindowProxy> Document::protectedWindowProxy() const
+{
+    return windowProxy();
+}
+
 Document& Document::contextDocument() const
 {
     if (m_contextDocument)
@@ -7426,6 +7431,16 @@ void Document::clearScriptedAnimationController()
     // FIXME: consider using ActiveDOMObject.
     if (RefPtr scriptedAnimationController = std::exchange(m_scriptedAnimationController, nullptr))
         scriptedAnimationController->clearDocumentPointer();
+}
+
+CheckedRef<FrameSelection> Document::checkedSelection()
+{
+    return m_selection.get();
+}
+
+CheckedRef<const FrameSelection> Document::checkedSelection() const
+{
+    return m_selection.get();
 }
 
 int Document::requestIdleCallback(Ref<IdleRequestCallback>&& callback, Seconds timeout)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -948,6 +948,7 @@ public:
 
     // In DOM Level 2, the Document's LocalDOMWindow is called the defaultView.
     WEBCORE_EXPORT WindowProxy* windowProxy() const;
+    RefPtr<WindowProxy> protectedWindowProxy() const;
 
     inline bool hasBrowsingContext() const; // Defined in DocumentInlines.h.
 
@@ -1775,6 +1776,8 @@ public:
     const Editor& editor() const { return m_editor; }
     FrameSelection& selection() { return m_selection; }
     const FrameSelection& selection() const { return m_selection; }
+    CheckedRef<FrameSelection> checkedSelection();
+    CheckedRef<const FrameSelection> checkedSelection() const;
         
     void setFragmentDirective(const String& fragmentDirective) { m_fragmentDirective = fragmentDirective; }
     const String& fragmentDirective() const { return m_fragmentDirective; }

--- a/Source/WebCore/dom/DocumentParser.cpp
+++ b/Source/WebCore/dom/DocumentParser.cpp
@@ -77,4 +77,9 @@ void DocumentParser::resumeScheduledTasks()
 {
 }
 
+RefPtr<Document> DocumentParser::protectedDocument() const
+{
+    return document();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -64,6 +64,7 @@ public:
 
     // document() will return 0 after detach() is called.
     Document* document() const { ASSERT(m_document); return m_document.get(); }
+    RefPtr<Document> protectedDocument() const;
 
     bool isParsing() const { return m_state == ParserState::Parsing; }
     bool isStopping() const { return m_state == ParserState::Stopping; }

--- a/Source/WebCore/dom/PendingScript.h
+++ b/Source/WebCore/dom/PendingScript.h
@@ -53,6 +53,8 @@ public:
 
     ScriptElement& element() { return m_element.get(); }
     const ScriptElement& element() const { return m_element.get(); }
+    Ref<ScriptElement> protectedElement() { return m_element; }
+    Ref<const ScriptElement> protectedElement() const { return m_element; }
 
     LoadableScript* loadableScript() const;
     bool needsLoading() const { return loadableScript(); }

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -79,7 +79,7 @@ inline Range::Range(Document& ownerDocument)
     rangeCounter.increment();
 #endif
 
-    m_ownerDocument->attachRange(*this);
+    protectedOwnerDocument()->attachRange(*this);
 }
 
 Ref<Range> Range::create(Document& ownerDocument)
@@ -90,11 +90,16 @@ Ref<Range> Range::create(Document& ownerDocument)
 Range::~Range()
 {
     ASSERT(!m_isAssociatedWithSelection);
-    m_ownerDocument->detachRange(*this);
+    protectedOwnerDocument()->detachRange(*this);
 
 #ifndef NDEBUG
     rangeCounter.decrement();
 #endif
+}
+
+Ref<Document> Range::protectedOwnerDocument()
+{
+    return m_ownerDocument;
 }
 
 Node* Range::commonAncestorContainer() const
@@ -105,26 +110,26 @@ Node* Range::commonAncestorContainer() const
 void Range::updateAssociatedSelection()
 {
     if (m_isAssociatedWithSelection)
-        m_ownerDocument->selection().updateFromAssociatedLiveRange();
+        protectedOwnerDocument()->checkedSelection()->updateFromAssociatedLiveRange();
 }
 
 void Range::updateAssociatedHighlight()
 {
     if (m_isAssociatedWithHighlight) {
         m_didChangeForHighlight = true;
-        m_ownerDocument->scheduleRenderingUpdate({ });
+        protectedOwnerDocument()->scheduleRenderingUpdate({ });
     }
 }
 
 void Range::updateDocument()
 {
-    auto& document = startContainer().document();
-    if (m_ownerDocument.ptr() == &document)
+    Ref document = startContainer().document();
+    if (m_ownerDocument.ptr() == document.ptr())
         return;
     ASSERT(!m_isAssociatedWithSelection);
-    m_ownerDocument->detachRange(*this);
-    m_ownerDocument = document;
-    m_ownerDocument->attachRange(*this);
+    protectedOwnerDocument()->detachRange(*this);
+    m_ownerDocument = WTFMove(document);
+    protectedOwnerDocument()->attachRange(*this);
 }
 
 ExceptionOr<void> Range::setStart(Ref<Node>&& container, unsigned offset)
@@ -297,7 +302,7 @@ static inline Node* childOfCommonRootBeforeOffset(Node* container, unsigned offs
     ASSERT(commonRoot);
     
     if (!commonRoot->contains(container))
-        return 0;
+        return nullptr;
 
     if (container == commonRoot) {
         container = container->firstChild();
@@ -311,16 +316,26 @@ static inline Node* childOfCommonRootBeforeOffset(Node* container, unsigned offs
     return container;
 }
 
+Ref<Node> Range::protectedStartContainer() const
+{
+    return startContainer();
+}
+
+Ref<Node> Range::protectedEndContainer() const
+{
+    return endContainer();
+}
+
 ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
 {
     RefPtr<DocumentFragment> fragment;
     if (action == Extract || action == Clone)
-        fragment = DocumentFragment::create(m_ownerDocument);
+        fragment = DocumentFragment::create(protectedOwnerDocument());
 
     if (collapsed())
         return fragment;
 
-    RefPtr<Node> commonRoot = commonAncestorContainer();
+    RefPtr commonRoot = commonAncestorContainer();
     ASSERT(commonRoot);
     
     if (action == Extract) {
@@ -331,7 +346,7 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
     }
 
     if (&startContainer() == &endContainer()) {
-        auto result = processContentsBetweenOffsets(action, fragment, &startContainer(), m_start.offset(), m_end.offset());
+        auto result = processContentsBetweenOffsets(action, fragment, protectedStartContainer().ptr(), m_start.offset(), m_end.offset());
         if (result.hasException())
             return result.releaseException();
         return fragment;
@@ -371,8 +386,8 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
 
         RefPtr<Node> leftContents;
         if (&originalStart.container() != commonRoot && commonRoot->contains(originalStart.container())) {
-            auto firstResult = processContentsBetweenOffsets(action, nullptr, &originalStart.container(), originalStart.offset(), originalStart.container().length());
-            auto secondResult = processAncestorsAndTheirSiblings(action, &originalStart.container(), ProcessContentsForward, WTFMove(firstResult), commonRoot.get());
+            auto firstResult = processContentsBetweenOffsets(action, nullptr, originalStart.protectedContainer().ptr(), originalStart.offset(), originalStart.container().length());
+            auto secondResult = processAncestorsAndTheirSiblings(action, originalStart.protectedContainer().ptr(), ProcessContentsForward, WTFMove(firstResult), commonRoot.get());
             // FIXME: A bit peculiar that we silently ignore the exception here, but we do have at least some regression tests that rely on this behavior.
             if (!secondResult.hasException())
                 leftContents = secondResult.releaseReturnValue();
@@ -380,27 +395,27 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
 
         RefPtr<Node> rightContents;
         if (&endContainer() != commonRoot && commonRoot->contains(originalEnd.container())) {
-            auto firstResult = processContentsBetweenOffsets(action, nullptr, &originalEnd.container(), 0, originalEnd.offset());
-            auto secondResult = processAncestorsAndTheirSiblings(action, &originalEnd.container(), ProcessContentsBackward, WTFMove(firstResult), commonRoot.get());
+            auto firstResult = processContentsBetweenOffsets(action, nullptr, originalEnd.protectedContainer().ptr(), 0, originalEnd.offset());
+            auto secondResult = processAncestorsAndTheirSiblings(action, originalEnd.protectedContainer().ptr(), ProcessContentsBackward, WTFMove(firstResult), commonRoot.get());
             // FIXME: A bit peculiar that we silently ignore the exception here, but we do have at least some regression tests that rely on this behavior.
             if (!secondResult.hasException())
                 rightContents = secondResult.releaseReturnValue();
         }
 
         // delete all children of commonRoot between the start and end container
-        RefPtr processStart = childOfCommonRootBeforeOffset(&originalStart.container(), originalStart.offset(), commonRoot.get());
+        RefPtr processStart = childOfCommonRootBeforeOffset(originalStart.protectedContainer().ptr(), originalStart.offset(), commonRoot.get());
         if (processStart && &originalStart.container() != commonRoot) // processStart contains nodes before m_start.
             processStart = processStart->nextSibling();
-        RefPtr processEnd = childOfCommonRootBeforeOffset(&originalEnd.container(), originalEnd.offset(), commonRoot.get());
+        RefPtr processEnd = childOfCommonRootBeforeOffset(originalEnd.protectedContainer().ptr(), originalEnd.offset(), commonRoot.get());
 
         // Collapse the range, making sure that the result is not within a node that was partially selected.
         if (action == Extract || action == Delete) {
             if (partialStart && commonRoot->contains(*partialStart)) {
-                auto result = setStart(*partialStart->parentNode(), partialStart->computeNodeIndex() + 1);
+                auto result = setStart(partialStart->protectedParentNode().releaseNonNull(), partialStart->computeNodeIndex() + 1);
                 if (result.hasException())
                     return result.releaseException();
             } else if (partialEnd && commonRoot->contains(*partialEnd)) {
-                auto result = setStart(*partialEnd->parentNode(), partialEnd->computeNodeIndex());
+                auto result = setStart(partialEnd->protectedParentNode().releaseNonNull(), partialEnd->computeNodeIndex());
                 if (result.hasException())
                     return result.releaseException();
             }
@@ -498,7 +513,7 @@ static ExceptionOr<RefPtr<Node>> processContentsBetweenOffsets(Range::ActionType
         endOffset = std::min(endOffset, downcast<ProcessingInstruction>(*container).data().length());
         startOffset = std::min(startOffset, endOffset);
         if (action == Range::Extract || action == Range::Clone) {
-            Ref<ProcessingInstruction> processingInstruction = downcast<ProcessingInstruction>(container->cloneNode(true).get());
+            Ref processingInstruction = downcast<ProcessingInstruction>(container->cloneNode(true).get());
             processingInstruction->setData(processingInstruction->data().substring(startOffset, endOffset - startOffset));
             if (fragment) {
                 result = fragment;
@@ -577,20 +592,20 @@ ExceptionOr<RefPtr<Node>> processAncestorsAndTheirSiblings(Range::ActionType act
     if (passedClonedContainer.hasException())
         return WTFMove(passedClonedContainer);
 
-    RefPtr<Node> clonedContainer = passedClonedContainer.releaseReturnValue();
+    RefPtr clonedContainer = passedClonedContainer.releaseReturnValue();
 
     Vector<Ref<ContainerNode>> ancestors;
     for (ContainerNode* ancestor = container->parentNode(); ancestor && ancestor != commonRoot; ancestor = ancestor->parentNode())
         ancestors.append(*ancestor);
 
-    RefPtr<Node> firstChildInAncestorToProcess = direction == ProcessContentsForward ? container->nextSibling() : container->previousSibling();
+    RefPtr firstChildInAncestorToProcess = direction == ProcessContentsForward ? container->nextSibling() : container->previousSibling();
     for (auto& ancestor : ancestors) {
         if (action == Range::Extract || action == Range::Clone) {
             if (auto shadowRoot = dynamicDowncast<ShadowRoot>(ancestor.get())) {
                 if (!shadowRoot->isCloneable())
                     continue;
             }
-            auto clonedAncestor = ancestor->cloneNode(false); // Might have been removed already during mutation event.
+            Ref clonedAncestor = ancestor->cloneNode(false); // Might have been removed already during mutation event.
             if (clonedContainer) {
                 auto result = clonedAncestor->appendChild(*clonedContainer);
                 if (result.hasException())
@@ -676,11 +691,9 @@ ExceptionOr<void> Range::insertNode(Ref<Node>&& node)
         return Exception { HierarchyRequestError };
 
     RefPtr<Node> referenceNode = startIsText ? &startContainer() : startContainer().traverseToChildAt(startOffset());
-    Node* parentNode = referenceNode ? referenceNode->parentNode() : &startContainer();
-    if (!is<ContainerNode>(parentNode))
+    RefPtr parent = dynamicDowncast<ContainerNode>(referenceNode ? referenceNode->parentNode() : &startContainer());
+    if (!parent)
         return Exception { HierarchyRequestError };
-
-    Ref<ContainerNode> parent = downcast<ContainerNode>(*parentNode);
 
     auto result = parent->ensurePreInsertionValidity(node, referenceNode.get());
     if (result.hasException())
@@ -688,7 +701,7 @@ ExceptionOr<void> Range::insertNode(Ref<Node>&& node)
 
     EventQueueScope scope;
     if (startIsText) {
-        auto result = downcast<Text>(startContainer()).splitText(startOffset());
+        auto result = downcast<Text>(protectedStartContainer().get()).splitText(startOffset());
         if (result.hasException())
             return result.releaseException();
         referenceNode = result.releaseReturnValue();
@@ -712,7 +725,7 @@ ExceptionOr<void> Range::insertNode(Ref<Node>&& node)
         return insertResult.releaseException();
 
     if (collapsed())
-        return setEnd(WTFMove(parent), newOffset);
+        return setEnd(parent.releaseNonNull(), newOffset);
 
     return { };
 }
@@ -721,10 +734,10 @@ String Range::toString() const
 {
     auto range = makeSimpleRange(*this);
     StringBuilder builder;
-    for (auto& node : intersectingNodes(range)) {
+    for (Ref node : intersectingNodes(range)) {
         if (is<Text>(node)) {
             auto offsetRange = characterDataOffsetRange(range, node);
-            builder.appendSubstring(downcast<Text>(node).data(), offsetRange.start, offsetRange.end - offsetRange.start);
+            builder.appendSubstring(downcast<Text>(node.get()).data(), offsetRange.start, offsetRange.end - offsetRange.start);
         }
     }
     return builder.toString();
@@ -742,11 +755,11 @@ ExceptionOr<Ref<DocumentFragment>> Range::createContextualFragment(const String&
     else
         element = node.parentElement();
     if (!element || (element->document().isHTMLDocument() && is<HTMLHtmlElement>(*element)))
-        element = HTMLBodyElement::create(node.document());
+        element = HTMLBodyElement::create(node.protectedDocument());
     return WebCore::createContextualFragment(*element, markup, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
 }
 
-ExceptionOr<Node*> Range::checkNodeOffsetPair(Node& node, unsigned offset)
+ExceptionOr<RefPtr<Node>> Range::checkNodeOffsetPair(Node& node, unsigned offset)
 {
     switch (node.nodeType()) {
     case Node::DOCUMENT_TYPE_NODE:
@@ -764,7 +777,7 @@ ExceptionOr<Node*> Range::checkNodeOffsetPair(Node& node, unsigned offset)
     case Node::ELEMENT_NODE:
         if (!offset)
             return nullptr;
-        auto childBefore = node.traverseToChildAt(offset - 1);
+        RefPtr childBefore = node.traverseToChildAt(offset - 1);
         if (!childBefore)
             return Exception { IndexSizeError };
         return childBefore;
@@ -776,45 +789,45 @@ ExceptionOr<Node*> Range::checkNodeOffsetPair(Node& node, unsigned offset)
 Ref<Range> Range::cloneRange() const
 {
     auto result = create(m_ownerDocument);
-    result->setStart(startContainer(), m_start.offset());
-    result->setEnd(endContainer(), m_end.offset());
+    result->setStart(protectedStartContainer(), m_start.offset());
+    result->setEnd(protectedEndContainer(), m_end.offset());
     return result;
 }
 
 ExceptionOr<void> Range::setStartAfter(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return Exception { InvalidNodeTypeError };
-    return setStart(*parent, node.computeNodeIndex() + 1);
+    return setStart(parent.releaseNonNull(), node.computeNodeIndex() + 1);
 }
 
 ExceptionOr<void> Range::setEndBefore(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return Exception { InvalidNodeTypeError };
-    return setEnd(*parent, node.computeNodeIndex());
+    return setEnd(parent.releaseNonNull(), node.computeNodeIndex());
 }
 
 ExceptionOr<void> Range::setEndAfter(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return Exception { InvalidNodeTypeError };
-    return setEnd(*parent, node.computeNodeIndex() + 1);
+    return setEnd(parent.releaseNonNull(), node.computeNodeIndex() + 1);
 }
 
 ExceptionOr<void> Range::selectNode(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return Exception { InvalidNodeTypeError };
     unsigned index = node.computeNodeIndex();
     auto result = setStart(*parent, index);
     if (result.hasException())
         return result.releaseException();
-    return setEnd(*parent, index + 1);
+    return setEnd(parent.releaseNonNull(), index + 1);
 }
 
 ExceptionOr<void> Range::selectNodeContents(Node& node)
@@ -831,7 +844,7 @@ ExceptionOr<void> Range::selectNodeContents(Node& node)
 // https://dom.spec.whatwg.org/#dom-range-surroundcontents
 ExceptionOr<void> Range::surroundContents(Node& newParent)
 {
-    Ref<Node> protectedNewParent(newParent);
+    Ref protectedNewParent = newParent;
 
     // Step 1: If a non-Text node is partially contained in the context object, then throw an InvalidStateError.
     Node* startNonTextContainer = &startContainer();
@@ -883,10 +896,10 @@ ExceptionOr<void> Range::surroundContents(Node& newParent)
 
 ExceptionOr<void> Range::setStartBefore(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return Exception { InvalidNodeTypeError };
-    return setStart(*parent, node.computeNodeIndex());
+    return setStart(parent.releaseNonNull(), node.computeNodeIndex());
 }
 
 #if ENABLE(TREE_DEBUGGING)
@@ -949,9 +962,9 @@ bool Range::parentlessNodeMovedToNewDocumentAffectsRange(Node& node)
 
 void Range::updateRangeForParentlessNodeMovedToNewDocument(Node& node)
 {
-    m_ownerDocument->detachRange(*this);
+    protectedOwnerDocument()->detachRange(*this);
     m_ownerDocument = node.document();
-    m_ownerDocument->attachRange(*this);
+    protectedOwnerDocument()->attachRange(*this);
 }
 
 static inline void boundaryTextInserted(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
@@ -996,9 +1009,9 @@ void Range::textRemoved(Node& text, unsigned offset, unsigned length)
 static inline void boundaryTextNodesMerged(RangeBoundaryPoint& boundary, NodeWithIndex& oldNode, unsigned offset)
 {
     if (&boundary.container() == oldNode.node())
-        boundary.set(*oldNode.node()->previousSibling(), boundary.offset() + offset, 0);
+        boundary.set(oldNode.node()->protectedPreviousSibling().releaseNonNull(), boundary.offset() + offset, nullptr);
     else if (&boundary.container() == oldNode.node()->parentNode() && boundary.offset() == static_cast<unsigned>(oldNode.index()))
-        boundary.set(*oldNode.node()->previousSibling(), offset, 0);
+        boundary.set(oldNode.node()->protectedPreviousSibling().releaseNonNull(), offset, nullptr);
 }
 
 void Range::textNodesMerged(NodeWithIndex& oldNode, unsigned offset)
@@ -1022,7 +1035,7 @@ static inline void boundaryTextNodesSplit(RangeBoundaryPoint& boundary, Text& ol
         unsigned boundaryOffset = boundary.offset();
         if (boundaryOffset > splitOffset) {
             if (parent)
-                boundary.set(*oldNode.nextSibling(), boundaryOffset - splitOffset, 0);
+                boundary.set(oldNode.protectedNextSibling().releaseNonNull(), boundaryOffset - splitOffset, nullptr);
             else
                 boundary.setOffset(splitOffset);
         }
@@ -1031,9 +1044,9 @@ static inline void boundaryTextNodesSplit(RangeBoundaryPoint& boundary, Text& ol
     if (!parent)
         return;
     if (&boundary.container() == parent && boundary.childBefore() == &oldNode) {
-        auto* newChild = oldNode.nextSibling();
+        RefPtr newChild = oldNode.nextSibling();
         ASSERT(newChild);
-        boundary.setToAfterNode(*newChild);
+        boundary.setToAfterNode(newChild.releaseNonNull());
     }
 }
 
@@ -1066,35 +1079,35 @@ ExceptionOr<void> Range::expand(const String& unit)
     } else
         return { };
 
-    auto* startContainer = start.deepEquivalent().containerNode();
+    RefPtr startContainer = start.deepEquivalent().containerNode();
     if (!startContainer)
         return Exception { TypeError };
-    auto result = setStart(*startContainer, start.deepEquivalent().computeOffsetInContainerNode());
+    auto result = setStart(startContainer.releaseNonNull(), start.deepEquivalent().computeOffsetInContainerNode());
     if (result.hasException())
         return result.releaseException();
-    auto* endContainer = end.deepEquivalent().containerNode();
+    RefPtr endContainer = end.deepEquivalent().containerNode();
     if (!endContainer)
         return Exception { TypeError };
-    return setEnd(*endContainer, end.deepEquivalent().computeOffsetInContainerNode());
+    return setEnd(endContainer.releaseNonNull(), end.deepEquivalent().computeOffsetInContainerNode());
 }
 
 Ref<DOMRectList> Range::getClientRects() const
 {
-    startContainer().document().updateLayout();
+    startContainer().protectedDocument()->updateLayout();
     return DOMRectList::create(RenderObject::clientBorderAndTextRects(makeSimpleRange(*this)));
 }
 
 Ref<DOMRect> Range::getBoundingClientRect() const
 {
-    startContainer().document().updateLayout();
+    startContainer().protectedDocument()->updateLayout();
     return DOMRect::create(unionRectIgnoringZeroRects(RenderObject::clientBorderAndTextRects(makeSimpleRange(*this))));
 }
 
 static void setBothEndpoints(Range& range, const SimpleRange& value)
 {
-    auto startContainer = value.start.container;
+    Ref startContainer = value.start.container;
     range.setStart(WTFMove(startContainer), value.start.offset);
-    auto endContainer = value.end.container;
+    Ref endContainer = value.end.container;
     range.setEnd(WTFMove(endContainer), value.end.offset);
 }
 
@@ -1113,7 +1126,7 @@ LocalDOMWindow* Range::window() const
 
 SimpleRange makeSimpleRange(const Range& range)
 {
-    return { { range.startContainer(), range.startOffset() }, { range.endContainer(), range.endOffset() } };
+    return { { range.protectedStartContainer(), range.startOffset() }, { range.protectedEndContainer(), range.endOffset() } };
 }
 
 SimpleRange makeSimpleRange(const Ref<Range>& range)
@@ -1135,7 +1148,7 @@ std::optional<SimpleRange> makeSimpleRange(const RefPtr<Range>& range)
 
 Ref<Range> createLiveRange(const SimpleRange& range)
 {
-    auto result = Range::create(range.start.document());
+    Ref result = Range::create(range.start.document());
     setBothEndpoints(result, range);
     return result;
 }

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -48,8 +48,10 @@ public:
     WEBCORE_EXPORT ~Range();
 
     Node& startContainer() const final { return m_start.container(); }
+    Ref<Node> protectedStartContainer() const;
     unsigned startOffset() const final { return m_start.offset(); }
     Node& endContainer() const final { return m_end.container(); }
+    Ref<Node> protectedEndContainer() const;
     unsigned endOffset() const final { return m_end.offset(); }
     bool collapsed() const final { return m_start == m_end; }
     WEBCORE_EXPORT Node* commonAncestorContainer() const;
@@ -121,7 +123,7 @@ public:
     // For use by garbage collection. Returns nullptr for ranges not assocated with selection.
     LocalDOMWindow* window() const;
 
-    static ExceptionOr<Node*> checkNodeOffsetPair(Node&, unsigned offset);
+    static ExceptionOr<RefPtr<Node>> checkNodeOffsetPair(Node&, unsigned offset);
 
 #if ENABLE(TREE_DEBUGGING)
     String debugDescription() const;
@@ -140,6 +142,7 @@ private:
     void updateAssociatedSelection();
     void updateAssociatedHighlight();
     ExceptionOr<RefPtr<DocumentFragment>> processContents(ActionType);
+    Ref<Document> protectedOwnerDocument();
 
     Ref<Document> m_ownerDocument;
     RangeBoundaryPoint m_start;

--- a/Source/WebCore/dom/RangeBoundaryPoint.h
+++ b/Source/WebCore/dom/RangeBoundaryPoint.h
@@ -39,11 +39,11 @@ public:
     unsigned offset() const;
     Node* childBefore() const;
 
-    void set(Ref<Node>&& container, unsigned offset, Node* childBefore);
+    void set(Ref<Node>&& container, unsigned offset, RefPtr<Node>&& childBefore);
     void setOffset(unsigned);
 
     void setToBeforeNode(Node&);
-    void setToAfterNode(Node&);
+    void setToAfterNode(Ref<Node>&&);
     void setToBeforeContents(Ref<Node>&&);
     void setToAfterContents(Ref<Node>&&);
 
@@ -78,12 +78,12 @@ inline unsigned RangeBoundaryPoint::offset() const
     return m_offset;
 }
 
-inline void RangeBoundaryPoint::set(Ref<Node>&& container, unsigned offset, Node* childBefore)
+inline void RangeBoundaryPoint::set(Ref<Node>&& container, unsigned offset, RefPtr<Node>&& childBefore)
 {
     ASSERT(childBefore == (offset ? container->traverseToChildAt(offset - 1) : nullptr));
     m_container = WTFMove(container);
     m_offset = offset;
-    m_childBefore = childBefore;
+    m_childBefore = WTFMove(childBefore);
 }
 
 inline void RangeBoundaryPoint::setOffset(unsigned offset)
@@ -102,12 +102,12 @@ inline void RangeBoundaryPoint::setToBeforeNode(Node& child)
     m_childBefore = child.previousSibling();
 }
 
-inline void RangeBoundaryPoint::setToAfterNode(Node& child)
+inline void RangeBoundaryPoint::setToAfterNode(Ref<Node>&& child)
 {
-    ASSERT(child.parentNode());
-    m_container = *child.parentNode();
-    m_offset = child.computeNodeIndex() + 1;
-    m_childBefore = &child;
+    ASSERT(child->parentNode());
+    m_container = *child->parentNode();
+    m_offset = child->computeNodeIndex() + 1;
+    m_childBefore = WTFMove(child);
 }
 
 inline void RangeBoundaryPoint::setToBeforeContents(Ref<Node>&& container)

--- a/Source/WebCore/dom/RawDataDocumentParser.h
+++ b/Source/WebCore/dom/RawDataDocumentParser.h
@@ -40,7 +40,7 @@ protected:
     void finish() override
     {
         if (!isStopped())
-            document()->finishedParsing();
+            protectedDocument()->finishedParsing();
     }
 
 private:

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -166,8 +166,8 @@ void RejectedPromiseTracker::reportUnhandledRejections(Vector<UnhandledPromise>&
         initializer.promise = &domPromise;
         initializer.reason = promise.result(vm);
 
-        auto event = PromiseRejectionEvent::create(eventNames().unhandledrejectionEvent, initializer);
-        auto target = m_context->errorEventTarget();
+        Ref event = PromiseRejectionEvent::create(eventNames().unhandledrejectionEvent, initializer);
+        RefPtr target = m_context->errorEventTarget();
         target->dispatchEvent(event);
 
         if (!event->defaultPrevented())
@@ -194,8 +194,8 @@ void RejectedPromiseTracker::reportRejectionHandled(Ref<DOMPromise>&& rejectedPr
     initializer.promise = rejectedPromise.ptr();
     initializer.reason = promise.result(vm);
 
-    auto event = PromiseRejectionEvent::create(eventNames().rejectionhandledEvent, initializer);
-    auto target = m_context->errorEventTarget();
+    Ref event = PromiseRejectionEvent::create(eventNames().rejectionhandledEvent, initializer);
+    RefPtr target = m_context->errorEventTarget();
     target->dispatchEvent(event);
 }
 

--- a/Source/WebCore/dom/ScopedEventQueue.cpp
+++ b/Source/WebCore/dom/ScopedEventQueue.cpp
@@ -58,7 +58,7 @@ void ScopedEventQueue::dispatchEvent(const ScopedEvent& event) const
 {
     if (event.event->eventInterface() == MutationEventInterfaceType && event.target->isInShadowTree())
         return;
-    event.target->dispatchEvent(event.event);
+    Ref { event.target.get() }->dispatchEvent(event.event);
 }
 
 void ScopedEventQueue::dispatchAllEvents()

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -595,12 +595,12 @@ String ScriptElement::scriptContent() const
     return TextNodeTraversal::childTextContent(protectedElement());
 }
 
-void ScriptElement::ref()
+void ScriptElement::ref() const
 {
     element().ref();
 }
 
-void ScriptElement::deref()
+void ScriptElement::deref() const
 {
     element().deref();
 }

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -81,8 +81,8 @@ public:
 
     JSC::SourceTaintedOrigin sourceTaintedOrigin() const { return m_taintedOrigin; }
 
-    void ref();
-    void deref();
+    void ref() const;
+    void deref() const;
 
     static std::optional<ScriptType> determineScriptType(const String& typeAttribute, const String& languageAttribute, bool isHTMLDocument = true);
 

--- a/Source/WebCore/dom/ScriptRunner.cpp
+++ b/Source/WebCore/dom/ScriptRunner.cpp
@@ -44,17 +44,17 @@ ScriptRunner::~ScriptRunner()
 {
     for (auto& pendingScript : m_scriptsToExecuteSoon) {
         UNUSED_PARAM(pendingScript);
-        m_document.decrementLoadEventDelayCount();
+        m_document->decrementLoadEventDelayCount();
     }
     for (auto& pendingScript : m_scriptsToExecuteInOrder) {
         if (pendingScript->watchingForLoad())
             pendingScript->clearClient();
-        m_document.decrementLoadEventDelayCount();
+        m_document->decrementLoadEventDelayCount();
     }
     for (auto& pendingScript : m_pendingAsyncScripts) {
         if (pendingScript->watchingForLoad())
             pendingScript->clearClient();
-        m_document.decrementLoadEventDelayCount();
+        m_document->decrementLoadEventDelayCount();
     }
 }
 
@@ -62,9 +62,9 @@ void ScriptRunner::queueScriptForExecution(ScriptElement& scriptElement, Loadabl
 {
     ASSERT(scriptElement.element().isConnected());
 
-    m_document.incrementLoadEventDelayCount();
+    m_document->incrementLoadEventDelayCount();
 
-    auto pendingScript = PendingScript::create(scriptElement, loadableScript);
+    Ref pendingScript = PendingScript::create(scriptElement, loadableScript);
     switch (executionType) {
     case ASYNC_EXECUTION:
         m_pendingAsyncScripts.add(pendingScript.copyRef());
@@ -83,7 +83,7 @@ void ScriptRunner::suspend()
 
 void ScriptRunner::resume()
 {
-    if (hasPendingScripts() && !m_document.hasActiveParserYieldToken())
+    if (hasPendingScripts() && !m_document->hasActiveParserYieldToken())
         m_timer.startOneShot(0_s);
 }
 
@@ -101,17 +101,17 @@ void ScriptRunner::notifyFinished(PendingScript& pendingScript)
         m_scriptsToExecuteSoon.append(m_pendingAsyncScripts.take(pendingScript).releaseNonNull());
     pendingScript.clearClient();
 
-    if (!m_document.hasActiveParserYieldToken())
+    if (!m_document->hasActiveParserYieldToken())
         m_timer.startOneShot(0_s);
 }
 
 void ScriptRunner::timerFired()
 {
-    Ref<Document> protect(m_document);
+    Ref document = m_document.get();
 
     Vector<RefPtr<PendingScript>> scripts;
 
-    if (m_document.shouldDeferAsynchronousScriptsUntilParsingFinishes()) {
+    if (document->shouldDeferAsynchronousScriptsUntilParsingFinishes()) {
         // Scripts not added by the parser are executed asynchronously and yet do not have the 'async' attribute set.
         // We only want to delay scripts that were explicitly marked as 'async' by the developer.
         m_scriptsToExecuteSoon.removeAllMatching([&](auto& pendingScript) {
@@ -130,14 +130,14 @@ void ScriptRunner::timerFired()
         m_scriptsToExecuteInOrder.remove(0, numInOrderScriptsToExecute);
 
     for (auto& currentScript : scripts) {
-        auto script = WTFMove(currentScript);
+        RefPtr script = WTFMove(currentScript);
         ASSERT(script);
         // Paper over https://bugs.webkit.org/show_bug.cgi?id=144050
         if (!script)
             continue;
         ASSERT(script->needsLoading());
-        script->element().executePendingScript(*script);
-        m_document.decrementLoadEventDelayCount();
+        script->protectedElement()->executePendingScript(*script);
+        document->decrementLoadEventDelayCount();
     }
 }
 

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -28,6 +28,7 @@
 
 #include "PendingScriptClient.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 
@@ -62,7 +63,7 @@ private:
 
     void notifyFinished(PendingScript&) override;
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
     Vector<Ref<PendingScript>> m_scriptsToExecuteInOrder;
     Vector<RefPtr<PendingScript>> m_scriptsToExecuteSoon; // http://www.whatwg.org/specs/web-apps/current-work/#set-of-scripts-that-will-execute-as-soon-as-possible
     HashSet<Ref<PendingScript>> m_pendingAsyncScripts;

--- a/Source/WebCore/dom/ScriptableDocumentParser.cpp
+++ b/Source/WebCore/dom/ScriptableDocumentParser.cpp
@@ -61,13 +61,14 @@ void ScriptableDocumentParser::scriptsWaitingForStylesheetsExecutionTimerFired()
 {
     ASSERT(!isDetached());
 
-    Ref<ScriptableDocumentParser> protectedThis(*this);
+    Ref protectedThis { *this };
 
-    if (!document()->styleScope().hasPendingSheets())
+    RefPtr document = this->document();
+    if (!document->styleScope().hasPendingSheets())
         executeScriptsWaitingForStylesheets();
 
     if (!isDetached())
-        document()->checkCompleted();
+        document->checkCompleted();
 }
 
 void ScriptableDocumentParser::detach()

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -75,6 +75,7 @@ private:
     bool isThrottledRelativeToPage() const;
     bool shouldRescheduleRequestAnimationFrame(ReducedResolutionSeconds) const;
     void scheduleAnimation();
+    RefPtr<Document> protectedDocument();
 
     struct CallbackData {
         Ref<RequestAnimationFrameCallback> callback;
@@ -83,7 +84,7 @@ private:
     };
     Vector<CallbackData> m_callbackDataList;
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    CheckedPtr<Document> m_document;
     CallbackId m_nextCallbackId { 0 };
     int m_suspendCount { 0 };
 

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -189,10 +189,15 @@ void SecurityContext::inheritPolicyContainerFrom(const PolicyContainer& policyCo
     if (!contentSecurityPolicy())
         setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { }, nullptr, nullptr));
 
-    contentSecurityPolicy()->inheritHeadersFrom(policyContainer.contentSecurityPolicyResponseHeaders);
+    checkedContentSecurityPolicy()->inheritHeadersFrom(policyContainer.contentSecurityPolicyResponseHeaders);
     setCrossOriginOpenerPolicy(policyContainer.crossOriginOpenerPolicy);
     setCrossOriginEmbedderPolicy(policyContainer.crossOriginEmbedderPolicy);
     setReferrerPolicy(policyContainer.referrerPolicy);
+}
+
+CheckedPtr<ContentSecurityPolicy> SecurityContext::checkedContentSecurityPolicy()
+{
+    return m_contentSecurityPolicy.get();
 }
 
 }

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -73,6 +73,7 @@ public:
 
     SandboxFlags sandboxFlags() const { return m_sandboxFlags; }
     ContentSecurityPolicy* contentSecurityPolicy() { return m_contentSecurityPolicy.get(); }
+    CheckedPtr<ContentSecurityPolicy> checkedContentSecurityPolicy();
 
     bool isSecureTransitionTo(const URL&) const;
 

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -187,7 +187,7 @@ inline bool hasShadowRootParent(const Node& node)
     return node.parentNode() && node.parentNode()->isShadowRoot();
 }
 
-Vector<ShadowRoot*> assignedShadowRootsIfSlotted(const Node&);
+Vector<Ref<ShadowRoot>> assignedShadowRootsIfSlotted(const Node&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -48,7 +48,7 @@ SimpleRange::SimpleRange(BoundaryPoint&& start, BoundaryPoint&& end)
 
 std::optional<SimpleRange> makeRangeSelectingNode(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return std::nullopt;
     unsigned offset = node.computeNodeIndex();

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -79,7 +79,7 @@ private:
 
 static void simulateMouseEvent(const AtomString& eventType, Element& element, Event* underlyingEvent, SimulatedClickSource source)
 {
-    element.dispatchEvent(SimulatedMouseEvent::create(eventType, element.document().windowProxy(), underlyingEvent, element, source));
+    element.dispatchEvent(SimulatedMouseEvent::create(eventType, element.document().protectedWindowProxy().get(), underlyingEvent, element, source));
 }
 
 bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouseEventOptions mouseEventOptions, SimulatedClickVisualOptions visualOptions, SimulatedClickSource creationOptions)
@@ -87,8 +87,8 @@ bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouse
     if (element.isDisabledFormControl())
         return false;
 
-    static MainThreadNeverDestroyed<HashSet<Element*>> elementsDispatchingSimulatedClicks;
-    if (!elementsDispatchingSimulatedClicks.get().add(&element).isNewEntry)
+    static MainThreadNeverDestroyed<HashSet<CheckedRef<Element>>> elementsDispatchingSimulatedClicks;
+    if (!elementsDispatchingSimulatedClicks.get().add(element).isNewEntry)
         return false;
 
     auto& eventNames = WebCore::eventNames();
@@ -105,7 +105,7 @@ bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouse
 
     simulateMouseEvent(eventNames.clickEvent, element, underlyingEvent, creationOptions);
 
-    elementsDispatchingSimulatedClicks.get().remove(&element);
+    elementsDispatchingSimulatedClicks.get().remove(element);
     return true;
 }
 

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -124,10 +124,12 @@ void NamedSlotAssignment::addSlotElementByName(const AtomString& name, HTMLSlotE
 #endif
 
     // FIXME: We should be able to do a targeted reconstruction.
-    shadowRoot.host()->invalidateStyleAndRenderersForSubtree();
+    ASSERT(shadowRoot.host());
+    Ref shadowRootHost = *shadowRoot.host();
+    shadowRootHost->invalidateStyleAndRenderersForSubtree();
 
     if (!m_slotElementCount)
-        shadowRoot.host()->setHasShadowRootContainingSlots(true);
+        shadowRootHost->setHasShadowRootContainingSlots(true);
     m_slotElementCount++;
 
     auto& slotName = slotNameFromAttributeValue(name);
@@ -296,8 +298,10 @@ void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowR
     if (!slot)
         return;
 
-    RenderTreeUpdater::tearDownRenderersAfterSlotChange(*shadowRoot.host());
-    shadowRoot.host()->invalidateStyleForSubtree();
+    ASSERT(shadowRoot.host());
+    Ref shadowRootHost = *shadowRoot.host();
+    RenderTreeUpdater::tearDownRenderersAfterSlotChange(shadowRootHost);
+    shadowRootHost->invalidateStyleForSubtree();
 
     slot->assignedNodes.clear();
     m_slotAssignmentsIsValid = false;
@@ -394,7 +398,7 @@ void NamedSlotAssignment::assignSlots(ShadowRoot& shadowRoot)
         entry.value->assignedNodes.shrink(0);
 
     if (auto* host = shadowRoot.host()) {
-        for (auto* child = host->firstChild(); child; child = child->nextSibling()) {
+        for (RefPtr child = host->firstChild(); child; child = child->nextSibling()) {
             if (!is<Text>(*child) && !is<Element>(*child))
                 continue;
             auto slotName = slotNameForHostChild(*child);
@@ -460,7 +464,7 @@ void ManualSlotAssignment::renameSlotElement(HTMLSlotElement&, const AtomString&
 void ManualSlotAssignment::addSlotElementByName(const AtomString&, HTMLSlotElement& slot, ShadowRoot& shadowRoot)
 {
     if (!m_slotElementCount)
-        shadowRoot.host()->setHasShadowRootContainingSlots(true);
+        shadowRoot.protectedHost()->setHasShadowRootContainingSlots(true);
     ++m_slotElementCount;
     ++m_slottableVersion;
 
@@ -522,8 +526,9 @@ void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, 
         }
     };
 
-    RenderTreeUpdater::tearDownRenderersAfterSlotChange(*shadowRoot.host());
-    shadowRoot.host()->invalidateStyleForSubtree();
+    RefPtr shadowRootHost = shadowRoot.host();
+    RenderTreeUpdater::tearDownRenderersAfterSlotChange(*shadowRootHost);
+    shadowRootHost->invalidateStyleForSubtree();
 
     if (!shadowRoot.shouldFireSlotchangeEvent())
         return;
@@ -543,10 +548,11 @@ void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, 
 void ManualSlotAssignment::didRemoveManuallyAssignedNode(HTMLSlotElement& slot, const Node& node, ShadowRoot& shadowRoot)
 {
     ASSERT(slot.containingShadowRoot() == &shadowRoot);
-    ASSERT_UNUSED(node, node.parentNode() == shadowRoot.host());
+    RefPtr shadowRootHost = shadowRoot.host();
+    ASSERT_UNUSED(node, node.parentNode() == shadowRootHost);
     ++m_slottableVersion;
-    RenderTreeUpdater::tearDownRenderersAfterSlotChange(*shadowRoot.host());
-    shadowRoot.host()->invalidateStyleForSubtree();
+    RenderTreeUpdater::tearDownRenderersAfterSlotChange(*shadowRootHost);
+    shadowRootHost->invalidateStyleForSubtree();
     if (shadowRoot.shouldFireSlotchangeEvent())
         slot.enqueueSlotChangeEvent();
 }

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -48,8 +48,7 @@ Ref<StaticRange> StaticRange::create(SimpleRange&& range)
 
 Ref<StaticRange> StaticRange::create(const SimpleRange& range)
 {
-    auto copiedRange = range;
-    return create(WTFMove(copiedRange));
+    return create(SimpleRange { range });
 }
 
 static bool isDocumentTypeOrAttr(Node& node)

--- a/Source/WebCore/dom/StringCallback.cpp
+++ b/Source/WebCore/dom/StringCallback.cpp
@@ -38,8 +38,7 @@ namespace WebCore {
 
 void StringCallback::scheduleCallback(ScriptExecutionContext& context, const String& data)
 {
-    RefPtr<StringCallback> protectedThis(this);
-    context.postTask([protectedThis, data] (ScriptExecutionContext&) {
+    context.postTask([protectedThis = Ref { *this }, data] (ScriptExecutionContext&) {
         protectedThis->handleEvent(data);
     });
 }

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -136,10 +136,10 @@ void StyledElement::setInlineStyleFromString(const AtomString& newStyleString)
     if (!inlineStyle)
         inlineStyle = CSSParser::parseInlineStyleDeclaration(newStyleString, this);
     else
-        downcast<MutableStyleProperties>(*inlineStyle).parseDeclaration(newStyleString, document());
+        Ref { downcast<MutableStyleProperties>(*inlineStyle) }->parseDeclaration(newStyleString, document());
 
     if (usesStyleBasedEditability(*inlineStyle))
-        document().setHasElementUsingStyleBasedEditability();
+        protectedDocument()->setHasElementUsingStyleBasedEditability();
 }
 
 void StyledElement::styleAttributeChanged(const AtomString& newStyleString, AttributeModificationReason reason)
@@ -163,7 +163,7 @@ void StyledElement::invalidateStyleAttribute()
 {
     if (auto* inlineStyle = this->inlineStyle()) {
         if (usesStyleBasedEditability(*inlineStyle))
-            document().setHasElementUsingStyleBasedEditability();
+            protectedDocument()->setHasElementUsingStyleBasedEditability();
     }
 
     elementData()->setStyleAttributeIsDirty(true);
@@ -267,7 +267,7 @@ void StyledElement::removeAllInlineStyleProperties()
 
 void StyledElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
-    auto* inlineStyle = this->inlineStyle();
+    RefPtr inlineStyle = this->inlineStyle();
     if (!inlineStyle)
         return;
     inlineStyle->traverseSubresources([&] (auto& resource) {

--- a/Source/WebCore/dom/TagCollection.cpp
+++ b/Source/WebCore/dom/TagCollection.cpp
@@ -44,7 +44,7 @@ TagCollectionNS::TagCollectionNS(ContainerNode& rootNode, const AtomString& name
 
 TagCollectionNS::~TagCollectionNS()
 {
-    ownerNode().nodeLists()->removeCachedTagCollectionNS(*this, m_namespaceURI, m_localName);
+    protectedOwnerNode()->nodeLists()->removeCachedTagCollectionNS(*this, m_namespaceURI, m_localName);
 }
 
 TagCollection::TagCollection(ContainerNode& rootNode, const AtomString& qualifiedName)
@@ -56,7 +56,7 @@ TagCollection::TagCollection(ContainerNode& rootNode, const AtomString& qualifie
 
 TagCollection::~TagCollection()
 {
-    ownerNode().nodeLists()->removeCachedCollection(this, m_qualifiedName);
+    protectedOwnerNode()->nodeLists()->removeCachedCollection(this, m_qualifiedName);
 }
 
 HTMLTagCollection::HTMLTagCollection(ContainerNode& rootNode, const AtomString& qualifiedName)
@@ -69,7 +69,7 @@ HTMLTagCollection::HTMLTagCollection(ContainerNode& rootNode, const AtomString& 
 
 HTMLTagCollection::~HTMLTagCollection()
 {
-    ownerNode().nodeLists()->removeCachedCollection(this, m_qualifiedName);
+    protectedOwnerNode()->nodeLists()->removeCachedCollection(this, m_qualifiedName);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -52,7 +52,7 @@ private:
 
     bool isTemplateContent() const override { return true; }
 
-    WeakPtr<const Element, WeakPtrImplWithEventTargetData> m_host;
+    CheckedPtr<const Element> m_host;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -63,18 +63,18 @@ ExceptionOr<Ref<Text>> Text::splitText(unsigned offset)
 
     EventQueueScope scope;
     auto oldData = data();
-    auto newText = virtualCreate(oldData.substring(offset));
+    Ref newText = virtualCreate(oldData.substring(offset));
     setDataWithoutUpdate(oldData.left(offset));
 
     dispatchModifiedEvent(oldData);
 
-    if (auto* parent = parentNode()) {
+    if (RefPtr parent = parentNode()) {
         auto insertResult = parent->insertBefore(newText, protectedNextSibling());
         if (insertResult.hasException())
             return insertResult.releaseException();
     }
 
-    document().textNodeSplit(*this);
+    protectedDocument()->textNodeSplit(*this);
 
     updateRendererAfterContentChange(0, oldData.length());
 
@@ -124,7 +124,7 @@ void Text::replaceWholeText(const String& newText)
 
     RefPtr parent = parentNode(); // Protect against mutation handlers moving this node during traversal
     for (RefPtr<Node> node = WTFMove(startText); is<Text>(node) && node != this && node->parentNode() == parent;) {
-        auto nodeToRemove = node.releaseNonNull();
+        Ref nodeToRemove = node.releaseNonNull();
         node = nodeToRemove->nextSibling();
         parent->removeChild(nodeToRemove);
     }
@@ -132,7 +132,7 @@ void Text::replaceWholeText(const String& newText)
     if (this != endText) {
         RefPtr nodePastEndText = endText->nextSibling();
         for (RefPtr node = nextSibling(); is<Text>(node) && node != nodePastEndText && node->parentNode() == parent;) {
-            auto nodeToRemove = node.releaseNonNull();
+            Ref nodeToRemove = node.releaseNonNull();
             node = nodeToRemove->nextSibling();
             parent->removeChild(nodeToRemove);
         }
@@ -189,7 +189,7 @@ RenderPtr<RenderText> Text::createTextRenderer(const RenderStyle& style)
 
 Ref<Text> Text::virtualCreate(String&& data)
 {
-    return create(document(), WTFMove(data));
+    return create(protectedDocument(), WTFMove(data));
 }
 
 void Text::updateRendererAfterContentChange(unsigned offsetOfReplacedData, unsigned lengthOfReplacedData)
@@ -200,7 +200,7 @@ void Text::updateRendererAfterContentChange(unsigned offsetOfReplacedData, unsig
     if (styleValidity() >= Style::Validity::SubtreeAndRenderersInvalid)
         return;
 
-    document().updateTextRenderer(*this, offsetOfReplacedData, lengthOfReplacedData);
+    protectedDocument()->updateTextRenderer(*this, offsetOfReplacedData, lengthOfReplacedData);
 }
 
 static void appendTextRepresentation(StringBuilder& builder, const Text& text)
@@ -245,7 +245,8 @@ void Text::setDataAndUpdate(const String& newData, unsigned offsetOfReplacedData
 
     // FIXME: Does not seem correct to do this for 0 offset only.
     if (!offsetOfReplacedData) {
-        auto* textManipulationController = document().textManipulationControllerIfExists();
+        Ref document = this->document();
+        CheckedPtr textManipulationController = document->textManipulationControllerIfExists();
         if (UNLIKELY(textManipulationController && oldData != newData))
             textManipulationController->didUpdateContentForNode(*this);
     }

--- a/Source/WebCore/dom/TextDecoderStreamDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoderStreamDecoder.cpp
@@ -43,12 +43,17 @@ TextDecoderStreamDecoder::TextDecoderStreamDecoder(Ref<TextDecoder>&& textDecode
 
 ExceptionOr<String> TextDecoderStreamDecoder::decode(std::optional<BufferSource::VariantType> value)
 {
-    return m_textDecoder->decode(WTFMove(value), { true });
+    return protectedTextDecoder()->decode(WTFMove(value), { true });
 }
 
 ExceptionOr<String> TextDecoderStreamDecoder::flush()
 {
-    return m_textDecoder->decode({ }, { false });
+    return protectedTextDecoder()->decode({ }, { false });
+}
+
+Ref<TextDecoder> TextDecoderStreamDecoder::protectedTextDecoder()
+{
+    return m_textDecoder;
 }
 
 }

--- a/Source/WebCore/dom/TextDecoderStreamDecoder.h
+++ b/Source/WebCore/dom/TextDecoderStreamDecoder.h
@@ -38,6 +38,7 @@ public:
 
 private:
     explicit TextDecoderStreamDecoder(Ref<TextDecoder>&&);
+    Ref<TextDecoder> protectedTextDecoder();
 
     Ref<TextDecoder> m_textDecoder;
 };

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2900,12 +2900,12 @@ void FrameSelection::setCaretColor(const Color& caretColor)
 
 #endif // PLATFORM(IOS_FAMILY)
 
-static bool containsEndpoints(const WeakPtr<Document, WeakPtrImplWithEventTargetData>& document, const std::optional<SimpleRange>& range)
+static bool containsEndpoints(const CheckedPtr<Document>& document, const std::optional<SimpleRange>& range)
 {
     return document && range && document->contains(range->start.container) && document->contains(range->end.container);
 }
 
-static bool containsEndpoints(const WeakPtr<Document, WeakPtrImplWithEventTargetData>& document, const Range& liveRange)
+static bool containsEndpoints(const CheckedPtr<Document>& document, const Range& liveRange)
 {
     // Only need to check the start container because live ranges enforce the invariant that start and end have a common ancestor.
     return document && document->contains(liveRange.startContainer());

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -36,6 +36,7 @@
 #include "ScrollAlignment.h"
 #include "ScrollBehavior.h"
 #include "VisibleSelection.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 
 namespace WebCore {
@@ -111,7 +112,7 @@ private:
     VisiblePosition m_position;
 };
 
-class FrameSelection final : private CaretBase, public CaretAnimationClient {
+class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(FrameSelection);
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -333,7 +334,7 @@ private:
     void updateAssociatedLiveRange();
     LayoutRect localCaretRect() const final { return localCaretRectWithoutUpdate(); }
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    CheckedPtr<Document> m_document;
     RefPtr<Range> m_associatedLiveRange;
     std::optional<LayoutUnit> m_xPosForVerticalArrowNavigation;
     VisibleSelection m_selection;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4531,6 +4531,16 @@ void FrameLoader::advanceStatePastInitialEmptyDocument()
         stateMachine().advanceTo(FrameLoaderStateMachine::CommittedFirstRealLoad);
 }
 
+void FrameLoader::incrementPtrCount() const
+{
+    m_frame.incrementPtrCount();
+}
+
+void FrameLoader::decrementPtrCount() const
+{
+    m_frame.decrementPtrCount();
+}
+
 } // namespace WebCore
 
 #undef PAGE_ID

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -98,12 +98,16 @@ WEBCORE_EXPORT bool isReload(FrameLoadType);
 
 using ContentPolicyDecisionFunction = Function<void(PolicyAction, PolicyCheckIdentifier)>;
 
-class FrameLoader final : public CanMakeCheckedPtr {
+class FrameLoader final {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(FrameLoader);
 public:
     FrameLoader(LocalFrame&, UniqueRef<LocalFrameLoaderClient>&&);
     ~FrameLoader();
+
+    // For use with CheckedPtr / CheckedRef. Forwards the pointer counting to the owning frame.
+    void incrementPtrCount() const;
+    void decrementPtrCount() const;
 
     WEBCORE_EXPORT void init();
     void initForSynthesizedDocument(const URL&);

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -80,7 +80,7 @@ enum class ContentSecurityPolicyModeForExtension : uint8_t {
     ManifestV3
 };
 
-class ContentSecurityPolicy {
+class ContentSecurityPolicy : public CanMakeThreadSafeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ContentSecurityPolicy(URL&&, ScriptExecutionContext&);


### PR DESCRIPTION
#### 0e12ca3ef084d8fe6459fb909e7a784d879adec6
<pre>
Adopt even more smart pointers in DOM code
<a href="https://bugs.webkit.org/show_bug.cgi?id=263505">https://bugs.webkit.org/show_bug.cgi?id=263505</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedWindowProxy const):
(WebCore::Document::checkedSelection):
(WebCore::Document::checkedSelection const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentParser.cpp:
(WebCore::DocumentParser::protectedDocument const):
* Source/WebCore/dom/DocumentParser.h:
* Source/WebCore/dom/PendingScript.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::Range):
(WebCore::Range::~Range):
(WebCore::Range::protectedOwnerDocument):
(WebCore::Range::updateAssociatedSelection):
(WebCore::Range::updateAssociatedHighlight):
(WebCore::Range::updateDocument):
(WebCore::childOfCommonRootBeforeOffset):
(WebCore::Range::protectedStartContainer const):
(WebCore::Range::protectedEndContainer const):
(WebCore::Range::processContents):
(WebCore::processContentsBetweenOffsets):
(WebCore::processAncestorsAndTheirSiblings):
(WebCore::Range::insertNode):
(WebCore::Range::toString const):
(WebCore::Range::createContextualFragment):
(WebCore::Range::checkNodeOffsetPair):
(WebCore::Range::cloneRange const):
(WebCore::Range::setStartAfter):
(WebCore::Range::setEndBefore):
(WebCore::Range::setEndAfter):
(WebCore::Range::selectNode):
(WebCore::Range::surroundContents):
(WebCore::Range::setStartBefore):
(WebCore::Range::updateRangeForParentlessNodeMovedToNewDocument):
(WebCore::boundaryTextNodesMerged):
(WebCore::boundaryTextNodesSplit):
(WebCore::Range::expand):
(WebCore::Range::getClientRects const):
(WebCore::Range::getBoundingClientRect const):
(WebCore::setBothEndpoints):
(WebCore::makeSimpleRange):
(WebCore::createLiveRange):
* Source/WebCore/dom/Range.h:
* Source/WebCore/dom/RangeBoundaryPoint.h:
(WebCore::RangeBoundaryPoint::set):
(WebCore::RangeBoundaryPoint::setToAfterNode):
* Source/WebCore/dom/RawDataDocumentParser.h:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
(WebCore::RejectedPromiseTracker::reportUnhandledRejections):
(WebCore::RejectedPromiseTracker::reportRejectionHandled):
* Source/WebCore/dom/ScopedEventQueue.cpp:
(WebCore::ScopedEventQueue::dispatchEvent const):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::ref const):
(WebCore::ScriptElement::deref const):
(WebCore::ScriptElement::ref): Deleted.
(WebCore::ScriptElement::deref): Deleted.
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/ScriptRunner.cpp:
(WebCore::ScriptRunner::~ScriptRunner):
(WebCore::ScriptRunner::queueScriptForExecution):
(WebCore::ScriptRunner::resume):
(WebCore::ScriptRunner::notifyFinished):
(WebCore::ScriptRunner::timerFired):
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/ScriptableDocumentParser.cpp:
(WebCore::ScriptableDocumentParser::scriptsWaitingForStylesheetsExecutionTimerFired):
* Source/WebCore/dom/ScriptedAnimationController.cpp:
(WebCore::ScriptedAnimationController::registerCallback):
(WebCore::ScriptedAnimationController::cancelCallback):
(WebCore::ScriptedAnimationController::serviceRequestAnimationFrameCallbacks):
(WebCore::ScriptedAnimationController::scheduleAnimation):
(WebCore::ScriptedAnimationController::protectedDocument):
* Source/WebCore/dom/ScriptedAnimationController.h:
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::inheritPolicyContainerFrom):
(WebCore::SecurityContext::checkedContentSecurityPolicy):
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::insertedIntoAncestor):
(WebCore::ShadowRoot::removedFromAncestor):
(WebCore::ShadowRoot::moveShadowRootToNewParentScope):
(WebCore::ShadowRoot::removeAllEventListeners):
(WebCore::ShadowRoot::findAssignedSlot):
(WebCore::ShadowRoot::assignedNodesForSlot):
(WebCore::assignedShadowRootsIfSlotted):
(): Deleted.
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SimpleRange.cpp:
(WebCore::makeRangeSelectingNode):
* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::simulateMouseEvent):
(WebCore::simulateClick):
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::addSlotElementByName):
(WebCore::NamedSlotAssignment::didChangeSlot):
(WebCore::NamedSlotAssignment::assignSlots):
(WebCore::ManualSlotAssignment::addSlotElementByName):
(WebCore::ManualSlotAssignment::slotManualAssignmentDidChange):
(WebCore::ManualSlotAssignment::didRemoveManuallyAssignedNode):
* Source/WebCore/dom/StaticRange.cpp:
(WebCore::StaticRange::create):
* Source/WebCore/dom/StringCallback.cpp:
(WebCore::StringCallback::scheduleCallback):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::setInlineStyleFromString):
(WebCore::StyledElement::invalidateStyleAttribute):
(WebCore::StyledElement::addSubresourceAttributeURLs const):
* Source/WebCore/dom/TagCollection.cpp:
(WebCore::TagCollectionNS::~TagCollectionNS):
(WebCore::TagCollection::~TagCollection):
(WebCore::HTMLTagCollection::~HTMLTagCollection):
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::splitText):
(WebCore::Text::replaceWholeText):
(WebCore::Text::virtualCreate):
(WebCore::Text::updateRendererAfterContentChange):
(WebCore::Text::setDataAndUpdate):
* Source/WebCore/dom/TextDecoderStreamDecoder.cpp:
(WebCore::TextDecoderStreamDecoder::decode):
(WebCore::TextDecoderStreamDecoder::flush):
(WebCore::TextDecoderStreamDecoder::protectedTextDecoder):
* Source/WebCore/dom/TextDecoderStreamDecoder.h:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.h:

Canonical link: <a href="https://commits.webkit.org/269644@main">https://commits.webkit.org/269644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3243c70fe144d5b475fd336d741516636a53307

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25065 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22256 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25914 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27120 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24988 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18421 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/580 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5521 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->