### PR TITLE
Make sensitive jsc global namespace properties not enumerable by Object.getOwnPropertyNames.

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1224,6 +1224,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/ScriptFetchParameters.h
     runtime/ScriptFetcher.h
     runtime/ShadowRealmObject.h
+    runtime/SideDataRepository.h
     runtime/SlowPathFunction.h
     runtime/SmallStrings.h
     runtime/SourceOrigin.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2113,6 +2113,7 @@
 		FE287D02252FB2E800D723F9 /* VerifierSlotVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = FE287D01252FB2E800D723F9 /* VerifierSlotVisitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE2A87601F02381600EB31B2 /* MinimumReservedZoneSize.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2A875F1F02381600EB31B2 /* MinimumReservedZoneSize.h */; };
 		FE2CC9302756B2B9003F5AB8 /* HeapSubspaceTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2CC92F2756B2B9003F5AB8 /* HeapSubspaceTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE2D0B382AE242B000A071A7 /* SideDataRepository.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2D0B362AE242AF00A071A7 /* SideDataRepository.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE3022D71E42857300BAC493 /* VMInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3022D51E42856700BAC493 /* VMInspector.h */; };
 		FE336B5325DB497D0098F034 /* MarkingConstraintExecutorPair.h in Headers */ = {isa = PBXBuildFile; fileRef = FE336B5225DB497D0098F034 /* MarkingConstraintExecutorPair.h */; };
 		FE3422121D6B81C30032BE88 /* ThrowScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3422111D6B818C0032BE88 /* ThrowScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5862,6 +5863,8 @@
 		FE2A875F1F02381600EB31B2 /* MinimumReservedZoneSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MinimumReservedZoneSize.h; sourceTree = "<group>"; };
 		FE2BD66E25C0DC8200999D3B /* VerifierSlotVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VerifierSlotVisitor.cpp; sourceTree = "<group>"; };
 		FE2CC92F2756B2B9003F5AB8 /* HeapSubspaceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeapSubspaceTypes.h; sourceTree = "<group>"; };
+		FE2D0B352AE242AF00A071A7 /* SideDataRepository.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SideDataRepository.cpp; sourceTree = "<group>"; };
+		FE2D0B362AE242AF00A071A7 /* SideDataRepository.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SideDataRepository.h; sourceTree = "<group>"; };
 		FE2E6A7A1D6EA5FE0060F896 /* ThrowScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThrowScope.cpp; sourceTree = "<group>"; };
 		FE3022D41E42856700BAC493 /* VMInspector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VMInspector.cpp; sourceTree = "<group>"; };
 		FE3022D51E42856700BAC493 /* VMInspector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMInspector.h; sourceTree = "<group>"; };
@@ -8605,6 +8608,8 @@
 				860295FA26FB552C0078EB62 /* ShadowRealmPrototype.cpp */,
 				860295FF26FB552D0078EB62 /* ShadowRealmPrototype.h */,
 				276B388E2A71D18700252F4E /* ShadowRealmPrototypeInlines.h */,
+				FE2D0B352AE242AF00A071A7 /* SideDataRepository.cpp */,
+				FE2D0B362AE242AF00A071A7 /* SideDataRepository.h */,
 				0F2B66D617B6B5AB00A7AE3F /* SimpleTypedArrayController.cpp */,
 				0F2B66D717B6B5AB00A7AE3F /* SimpleTypedArrayController.h */,
 				FE8C0311264A6910001A44AD /* SlowPathFunction.h */,
@@ -11553,6 +11558,7 @@
 				276B389B2A71D1A900252F4E /* ShadowRealmObjectInlines.h in Headers */,
 				8602960526FB552D0078EB62 /* ShadowRealmPrototype.h in Headers */,
 				276B38922A71D18800252F4E /* ShadowRealmPrototypeInlines.h in Headers */,
+				FE2D0B382AE242B000A071A7 /* SideDataRepository.h in Headers */,
 				4BC18E5628FDE6C800ECD68D /* SIMDInfo.h in Headers */,
 				E379B59029834EC5007C4C0E /* SIMDShuffle.h in Headers */,
 				0F4D8C781FCA3CFA001D32AC /* SimpleMarkingConstraint.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1025,6 +1025,7 @@ runtime/ScriptExecutable.cpp
 runtime/SetConstructor.cpp
 runtime/SetIteratorPrototype.cpp
 runtime/SetPrototype.cpp
+runtime/SideDataRepository.cpp
 runtime/SimpleTypedArrayController.cpp
 runtime/SmallStrings.cpp
 runtime/SparseArrayValueMap.cpp

--- a/Source/JavaScriptCore/runtime/SideDataRepository.cpp
+++ b/Source/JavaScriptCore/runtime/SideDataRepository.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SideDataRepository.h"
+
+namespace JSC {
+
+auto SideDataRepository::add(void* owner, void* key, std::unique_ptr<SideData> sideData) -> AddResult
+{
+    auto result = m_ownerStore.add(owner, KeyValueStore());
+    KeyValueStore& storage = result.iterator->value;
+    return storage.add(key, WTFMove(sideData));
+}
+
+void SideDataRepository::deleteAll(void* owner)
+{
+    Locker locker { m_lock };
+    m_ownerStore.remove(owner);
+}
+
+SideDataRepository& sideDataRepository()
+{
+    static LazyNeverDestroyed<SideDataRepository> repository;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        repository.construct();
+    });
+    return repository;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/SideDataRepository.h
+++ b/Source/JavaScriptCore/runtime/SideDataRepository.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashMap.h>
+#include <wtf/Locker.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace JSC {
+
+class SideDataRepository {
+public:
+    class SideData {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        virtual ~SideData() = default;
+    };
+
+    template<typename Type, typename Functor>
+    Type& ensure(void* owner, void* key, const Functor& functor)
+    {
+        static_assert(std::derived_from<Type, SideData>);
+        Locker lock { m_lock };
+        auto result = add(owner, key, nullptr);
+        if (result.isNewEntry)
+            result.iterator->value = functor();
+        return *reinterpret_cast<Type*>(result.iterator->value.get());
+    }
+
+    void deleteAll(void* owner);
+
+protected:
+    using KeyValueStore = HashMap<void*, std::unique_ptr<SideData>>;
+    using AddResult = KeyValueStore::AddResult;
+
+    SideDataRepository() = default;
+
+    JS_EXPORT_PRIVATE AddResult add(void* owner, void* key, std::unique_ptr<SideData>) WTF_REQUIRES_LOCK(m_lock);
+
+    HashMap<void*, KeyValueStore> m_ownerStore WTF_GUARDED_BY_LOCK(m_lock);
+    Lock m_lock;
+
+    friend class LazyNeverDestroyed<SideDataRepository>;
+};
+
+JS_EXPORT_PRIVATE SideDataRepository& sideDataRepository();
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -104,6 +104,7 @@
 #include "SamplingProfiler.h"
 #include "ScopedArguments.h"
 #include "ShadowChicken.h"
+#include "SideDataRepository.h"
 #include "SimpleTypedArrayController.h"
 #include "SourceProviderCache.h"
 #include "StrongInlines.h"
@@ -436,6 +437,9 @@ VM::~VM()
     m_traps.willDestroyVM();
     m_isInService = false;
     WTF::storeStoreFence();
+
+    if (m_hasSideData)
+        sideDataRepository().deleteAll(this);
 
     // Never GC, ever again.
     heap.incrementDeferralDepth();

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -354,6 +354,9 @@ public:
     WeakRandom& heapRandom() { return m_heapRandom; }
     Integrity::Random& integrityRandom() { return m_integrityRandom; }
 
+    template<typename Type, typename Functor>
+    Type& ensureSideData(void* key, const Functor&);
+
     bool hasTerminationRequest() const { return m_hasTerminationRequest; }
     void clearHasTerminationRequest()
     {
@@ -1129,6 +1132,7 @@ private:
     WTF::Function<void(VM&)> m_onEachMicrotaskTick;
     uintptr_t m_currentWeakRefVersion { 0 };
 
+    bool m_hasSideData { false };
     bool m_hasTerminationRequest { false };
     bool m_executionForbidden { false };
     bool m_executionForbiddenOnTermination { false };

--- a/Source/JavaScriptCore/runtime/VMInlines.h
+++ b/Source/JavaScriptCore/runtime/VMInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "EntryFrame.h"
 #include "FuzzerAgent.h"
 #include "ProfilerDatabase.h"
+#include "SideDataRepository.h"
 #include "VM.h"
 #include "Watchdog.h"
 
@@ -106,6 +107,13 @@ inline void VM::forEachDebugger(const Func& callback)
 
     for (auto* debugger = m_debuggers.head(); debugger; debugger = debugger->next())
         callback(*debugger);
+}
+
+template<typename Type, typename Functor>
+Type& VM::ensureSideData(void* key, const Functor& functor)
+{
+    m_hasSideData = true;
+    return sideDataRepository().ensure<Type>(this, key, functor);
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 15477a1fd6b58f51f29ef8ee00e63b139ce49fb1
<pre>
Make sensitive jsc global namespace properties not enumerable by Object.getOwnPropertyNames.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263506">https://bugs.webkit.org/show_bug.cgi?id=263506</a>
rdar://112815258

Reviewed by Alexey Shvayka and Justin Michaud.

Some functions in the jsc shell GlobalObject are only added as debugging aids.  They are meant
to be used carefully under controlled conditions for test development.  Though they are added
as DontEnum, Object.getOwnPropertyNames() still enumerates them.  We should filter out all
DontEnum properties of this GlobalObject so as not to trip up fuzzers that try to fuzz with
Object.getOwnPropertyNames.

Achieving this turned out to be somewhat challenging for the following reasons:
1. We want the jsc shell&apos;s GlobalObject to be allocated out of the same IsoHeap as JSGlobalObject.
2. To achieve (1), we cannot change the size of GlobalObject i.e. we cannot add a field.
3. In order to filter out the sensitive properties, we need to maintain a copy of this list of
   properties somewhere. We can&apos;t stash it in the GlobalObject.
4. The list consists of UniquedStringImpl pointers.  So, strictly speaking, we can stash it with
   the VM because UniquedStringImpls are unique to each VM.  However, this is an issue with the
   jsc shell&apos;s GlobalObject.  The jsc shell is by 1 client of the JSC framework.   We don&apos;t want
   the VM to have specific knowledge about the jsc shell.

To solve this, we&apos;re introducing a SideDataRepository that can be used to associate some side
data with some owner.  In this case, the owner here is the VM.  This SideDataRepository will also
come in handy for stashing side data for other slow or rarely used features that we don&apos;t want to
bloat commonly used data structures for.  For example, JIT comments could have been stashed as
side data.  JIT probe backing data can be stashed as side data.  For now, we&apos;re only using it to
store jsc shell&apos;s GlobalObject&apos;s property filter list.

We&apos;re still adding a VM::m_hasSideData bool so that we can optimize the VM destructor to avoid
checking for the need to clean up side data if non was ever added.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/SideDataRepository.cpp: Added.
(JSC::SideDataRepository::add):
(JSC::SideDataRepository::deleteAll):
(JSC::sideDataRepository):
* Source/JavaScriptCore/runtime/SideDataRepository.h: Added.
(JSC::SideDataRepository::ensure):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::~VM):
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/runtime/VMInlines.h:
(JSC::VM::ensureSideData):

Canonical link: <a href="https://commits.webkit.org/269639@main">https://commits.webkit.org/269639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/594fe220a93f4c75f4d5e02a5b7ddff3cfacec05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21397 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22252 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23381 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25908 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27118 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20137 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24986 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22505 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18417 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29879 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/574 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6177 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1052 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29831 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2940 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/850 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6071 "Passed tests") | 
<!--EWS-Status-Bubble-End-->