### PR TITLE
Stabilise attachment-uti.html with reftest-wait and takeScreenshotWhenAttachmentsSettled

### DIFF
--- a/LayoutTests/fast/attachment/attachment-uti-expected.html
+++ b/LayoutTests/fast/attachment/attachment-uti-expected.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment title=" " type="image/jpeg"></attachment>
 <attachment title=" " type="text/plain"></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeExpectedScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-uti.html
+++ b/LayoutTests/fast/attachment/attachment-uti.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment title=" " type="public.jpeg"></attachment>
 <attachment title=" " type="public.plain-text"></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1850,6 +1850,7 @@ imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-conten
 
 # "reftest-wait" blocks attachment rendering.
 webkit.org/b/263367 fast/attachment/attachment-icon-from-file-extension.html [ Skip ]
+webkit.org/b/263367 fast/attachment/attachment-uti.html [ Skip ]
 
 # <rdar://problem/42625657> REGRESSION (Mojave): 12 fast/images tests timing out on WK1
 fast/images/animated-heics-draw.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2000,8 +2000,6 @@ webkit.org/b/177397 [ Sonoma+ Release ] compositing/masks/compositing-clip-path-
 
 webkit.org/b/263049 [ Sonoma+ ] fast/forms/scroll-into-view-and-show-validation-message.html [ Pass Failure ]
 
-webkit.org/b/263085 [ Sonoma+ Release ] fast/attachment/attachment-uti.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/263095 [ Sonoma+ ] svg/clip-path/clip-path-objectboundingbox-003.svg [ Pass ImageOnlyFailure ]
 
 webkit.org/b/263136 [ Sonoma+ ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-011.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 68f1a337127aec08290217e19bc40ac142103093
<pre>
Stabilise attachment-uti.html with reftest-wait and takeScreenshotWhenAttachmentsSettled
<a href="https://bugs.webkit.org/show_bug.cgi?id=263085">https://bugs.webkit.org/show_bug.cgi?id=263085</a>
rdar://116877284

Reviewed by Aditya Keerthi.

Attachment-uti.html was flaky, with the actual and/or expected rendering
sometimes missing the icon, because that icon is only fetched during the
first rendering. Use reftest-wait and takeScreenshotWhenAttachmentsSettled
to delay the test screenshot until there is an icon.

* LayoutTests/fast/attachment/attachment-uti-expected.html:
* LayoutTests/fast/attachment/attachment-uti.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269670@main">https://commits.webkit.org/269670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f28a330d7e0be90821dd430f45280774a8277b20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21400 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22253 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25911 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27119 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24987 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20729 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5545 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->