### PR TITLE
[text-wrap] Enable `text-wrap: balance` in STP

### DIFF
--- a/LayoutTests/fast/css/text-wrap-pretty-disabled-expected.txt
+++ b/LayoutTests/fast/css/text-wrap-pretty-disabled-expected.txt
@@ -1,0 +1,10 @@
+When text-wrap: pretty is disabled, the following should not parse:
+
+
+PASS e.style['text-wrap-style'] = "pretty" should not set the property value
+PASS e.style['text-wrap'] = "pretty" should not set the property value
+PASS e.style['text-wrap'] = "pretty wrap" should not set the property value
+PASS e.style['text-wrap'] = "pretty nowrap" should not set the property value
+PASS e.style['text-wrap'] = "wrap pretty" should not set the property value
+PASS e.style['text-wrap'] = "nowrap pretty" should not set the property value
+

--- a/LayoutTests/fast/css/text-wrap-pretty-disabled.html
+++ b/LayoutTests/fast/css/text-wrap-pretty-disabled.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ CSSTextWrapPrettyEnabled=false ]-->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test text-wrap parsing when text-wrap: pretty is disabled</title>
+<meta charset="utf-8">
+</head>
+<body>
+<p>When text-wrap: pretty is disabled, the following should not parse:</p>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/css/support/parsing-testcommon.js"></script>
+<script>
+test_invalid_value("text-wrap-style", "pretty");
+test_invalid_value("text-wrap", "pretty");
+test_invalid_value("text-wrap", "pretty wrap");
+test_invalid_value("text-wrap", "pretty nowrap");
+test_invalid_value("text-wrap", "wrap pretty");
+test_invalid_value("text-wrap", "nowrap pretty");
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1438,9 +1438,23 @@ CSSTextUnderlinePositionLeftRightEnabled:
     WebCore:
       default: false
 
-CSSTextWrapStyleEnabled:
+CSSTextWrapPrettyEnabled:
   type: bool
   status: testable
+  category: css
+  humanReadableName: "CSS text-wrap: pretty"
+  humanReadableDescription: "Enable the pretty value for text-wrap-style"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
+CSSTextWrapStyleEnabled:
+  type: bool
+  status: preview
   category: css
   humanReadableName: "CSS text-wrap-style property"
   humanReadableDescription: "Enable the property text-wrap-style, defined in CSS Text 4"

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5951,7 +5951,10 @@
             "values": [
                 "auto",
                 "balance",
-                "pretty",
+                {
+                    "value": "pretty",
+                    "settings-flag": "cssTextWrapPrettyEnabled"
+                },
                 "stable"
             ],
             "codegen-properties": {
@@ -5963,7 +5966,7 @@
                 "category": "css-text",
                 "url": "https://drafts.csswg.org/css-text-4/#text-wrap-style"
             },
-            "status": "in development"
+            "status": "experimental"
         },
         "top": {
             "values": [

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -104,6 +104,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssWordBreakAutoPhraseEnabled { document.settings().cssWordBreakAutoPhraseEnabled() }
     , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }
     , sidewaysWritingModesEnabled { document.settings().sidewaysWritingModesEnabled() }
+    , cssTextWrapPrettyEnabled { document.settings().cssTextWrapPrettyEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -138,7 +139,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssWordBreakAutoPhraseEnabled             << 23
         | context.popoverAttributeEnabled                   << 24
         | context.sidewaysWritingModesEnabled               << 25
-        | (uint64_t)context.mode                            << 26; // This is multiple bits, so keep it last.
+        | context.cssTextWrapPrettyEnabled                  << 26
+        | (uint64_t)context.mode                            << 27; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -97,6 +97,7 @@ struct CSSParserContext {
     bool cssWordBreakAutoPhraseEnabled { false };
     bool popoverAttributeEnabled { false };
     bool sidewaysWritingModesEnabled { false };
+    bool cssTextWrapPrettyEnabled { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -2544,7 +2544,7 @@ bool CSSPropertyParser::consumeTextWrapShorthand(bool important)
     for (unsigned propertiesParsed = 0; propertiesParsed < 2 && !m_range.atEnd(); ++propertiesParsed) {
         if (!mode && (mode = CSSPropertyParsing::consumeTextWrapMode(m_range)))
             continue;
-        if (!style && m_context.propertySettings.cssTextWrapStyleEnabled && (style = CSSPropertyParsing::consumeTextWrapStyle(m_range)))
+        if (m_context.propertySettings.cssTextWrapStyleEnabled && !style && (style = CSSPropertyParsing::consumeTextWrapStyle(m_range, m_context)))
             continue;
         // If we didn't find at least one match, this is an invalid shorthand and we have to ignore it.
         return false;


### PR DESCRIPTION
#### c07a3c339c79176f5c06ffc5a285a450f4db7f8a
<pre>
[text-wrap] Enable `text-wrap: balance` in STP
<a href="https://bugs.webkit.org/show_bug.cgi?id=263516">https://bugs.webkit.org/show_bug.cgi?id=263516</a>
rdar://117336969

Reviewed by Brent Fulgham.

Enable the `text-wrap-style` property in STP (and hence `text-wrap: balance`).

Also split out `text-wrap-style: pretty` in its own preference since it is not currently implemented.

* LayoutTests/fast/css/text-wrap-pretty-disabled-expected.txt: Added.
* LayoutTests/fast/css/text-wrap-pretty-disabled.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeTextWrapShorthand):

Canonical link: <a href="https://commits.webkit.org/269680@main">https://commits.webkit.org/269680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1eb539b15954e50e1e7f4b3db53547b1172ce70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22270 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25934 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27138 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20161 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25008 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22534 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/670 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18438 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.* (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29910 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20749 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6189 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5547 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1081 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29862 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/879 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6082 "Passed tests") | 
<!--EWS-Status-Bubble-End-->