### PR TITLE
[GLIB] Install `libjxl` dependency if exits on Debian/Ubuntu

### DIFF
--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -47,6 +47,7 @@ PACKAGES=(
     libevent-dev
     libfile-copy-recursive-perl
     libinput-dev
+    $(aptIfExists libjxl-dev)
     $(aptIfElse libgcrypt20-dev libgcrypt11-dev)
     libgstreamer1.0-dev
     libgstreamer-plugins-bad1.0-dev


### PR DESCRIPTION
#### 55805b41a3fb5e16161645372e9afc06e9ca0ca5
<pre>
[GLIB] Install `libjxl` dependency if exits on Debian/Ubuntu
<a href="https://bugs.webkit.org/show_bug.cgi?id=263519">https://bugs.webkit.org/show_bug.cgi?id=263519</a>

Reviewed by Adrian Perez de Castro.

Ubuntu packages `libjxl` since 23.10.
<a href="https://packages.ubuntu.com/search?keywords=jpeg-xl&amp">https://packages.ubuntu.com/search?keywords=jpeg-xl&amp</a>;searchon=names&amp;suite=all&amp;section=all

* Tools/glib/dependencies/apt:

Canonical link: <a href="https://commits.webkit.org/269706@main">https://commits.webkit.org/269706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9e073e38719eab8ff7f819a4d8fd8cb44a684d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23441 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2748 "Hash b9e073e3 for PR 19412 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22274 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23415 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/2748 "Hash b9e073e3 for PR 19412 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25937 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/2748 "Hash b9e073e3 for PR 19412 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27141 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/2748 "Hash b9e073e3 for PR 19412 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25012 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/673 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18443 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.* (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/607 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5563 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1084 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->