### PR TITLE
[WebCodecs] Poor video frame rate exporting from Construct Animate

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource-expected.txt
@@ -1,0 +1,8 @@
+
+PASS VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: true, premultipliedAlpha: true
+PASS VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: true, premultipliedAlpha: false
+PASS VideoFrame from canvas snapshots drawing at call time, context: 2d offscreen: true
+FAIL VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: false, premultipliedAlpha: true assert_equals: expected 8388736 but got 4194432
+PASS VideoFrame from canvas snapshots drawing at call time, context: webgl offscreen: false, premultipliedAlpha: false
+PASS VideoFrame from canvas snapshots drawing at call time, context: 2d offscreen: false
+

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+let subtests = [];
+for (let offscreen of [true, false]) {
+  for (let premultipliedAlpha of [true, false])
+    subtests.push({context: "webgl", offscreen, premultipliedAlpha});
+  subtests.push({context: "2d", offscreen});
+}
+// In case of failure, run a single case with a variant of this:
+// subtests = [{context:"webgl", offscreen: true, premultipliedAlpha: true}];
+
+function makeCanvas(subtest) {
+  let canvas;
+  if (subtest.offscreen)
+    canvas = new OffscreenCanvas(32, 32);
+  else {
+    canvas = document.createElement("canvas");
+    canvas.width = 32;
+    canvas.height = 32;
+  }
+  // Image:
+  // red  | translucent green
+  // blue | transparent black
+  if (subtest.context == "2d") {
+    let ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(255, 0, 0, 1)';
+    ctx.fillRect(0, 0, 16, 16);
+    ctx.fillStyle = 'rgba(0, 128, 0, 0.5)';
+    ctx.fillRect(16, 0, 16, 16);
+    ctx.fillStyle = 'rgba(0, 0, 255, 1)';
+    ctx.fillRect(0, 16, 16, 16);
+  } else {
+    let gl = canvas.getContext('webgl', {alpha: true, premultipliedAlpha: subtest.premultipliedAlpha});
+    gl.viewport(0, 0, 32, 32);
+    gl.enable(gl.SCISSOR_TEST);
+    gl.scissor(0, 16, 16, 16);
+    gl.clearColor(1, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    let g = subtest.premultipliedAlpha ? 0.25 : 0.5;
+    gl.scissor(16, 16, 16, 16);
+    gl.clearColor(0, g, 0, 0.5);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    gl.scissor(0, 0, 16, 16);
+    gl.clearColor(0, 0, 1, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+  }
+  return canvas;
+}
+
+function drawMore(subtest, canvas) {
+  if (subtest.context == "2d") {
+    let ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(255, 0, 0, 255)';
+    ctx.fillRect(0, 0, 32, 32);
+    return;
+  }
+  let gl = canvas.getContext('webgl');
+  gl.scissor(0, 0, 32, 32);
+  gl.clearColor(1, 0, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+}
+
+function getPixel(ctx, x, y) {
+  let data = ctx.getImageData(x, y, 1, 1).data;
+  return data[0] * 2 ** 24 + data[1] * 2 ** 16 + data[2] * 2 ** 8 + data[3];
+}
+
+function verifyPicture(picture) {
+  let canvas = new OffscreenCanvas(32, 32, {alpha: true});
+  let ctx = canvas.getContext('2d');
+  ctx.drawImage(picture, 0, 0);
+  assert_equals(getPixel(ctx,  8,  8), 0xFF0000FF);
+  assert_equals(getPixel(ctx, 24,  8), 0x00800080);
+  assert_equals(getPixel(ctx,  8, 24), 0x0000FFFF);
+  assert_equals(getPixel(ctx, 24, 24), 0x00000000);
+}
+
+for (let subtest of subtests) {
+  let contextDescription = "";
+  if (subtest.context == "webgl")
+  contextDescription = ", premultipliedAlpha: " + subtest.premultipliedAlpha;
+  let description = `VideoFrame from canvas snapshots drawing at call time, context: ${subtest.context} offscreen: ${subtest.offscreen}${contextDescription}`
+  promise_test(async () => {
+    let src = makeCanvas(subtest);
+    let frame = new VideoFrame(src, {alpha: 'keep', timestamp: 0});
+    //drawMore(subtest, src);
+    verifyPicture(frame);
+    verifyPicture(await createImageBitmap(frame));
+  }, description);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -194,8 +194,13 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
 
     if (!m_canvas->originClean())
         return;
-
-    auto videoFrame = m_canvas->toVideoFrame();
+    RefPtr<VideoFrame> videoFrame = [&]() -> RefPtr<VideoFrame> {
+#if ENABLE(WEBGL)
+        if (auto* gl = dynamicDowncast<WebGLRenderingContextBase>(m_canvas->renderingContext()))
+            return gl->surfaceBufferToVideoFrame(WebGLRenderingContextBase::SurfaceBuffer::DisplayBuffer);
+#endif
+        return m_canvas->toVideoFrame();
+    }();
     if (!videoFrame)
         return;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -214,6 +214,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         if (!canvas->width() || !canvas->height())
             return Exception { InvalidStateError,  "Input canvas has a bad size"_s };
 
+        canvas->makeRenderingResultsAvailable();
         RefPtr imageBuffer = canvas->buffer();
         if (!imageBuffer)
             return Exception { InvalidStateError,  "Input canvas has no image buffer"_s };

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -799,7 +799,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
     if (document().settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logCanvasRead(document());
 
-    auto pixelBuffer = downcast<WebGLRenderingContextBase>(*m_context).paintRenderingResultsToPixelBuffer(GraphicsContextGL::FlipY::Yes);
+    auto pixelBuffer = downcast<WebGLRenderingContextBase>(*m_context).drawingBufferToPixelBuffer(GraphicsContextGL::FlipY::Yes);
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return nullptr;
 
@@ -821,9 +821,10 @@ RefPtr<VideoFrame> HTMLCanvasElement::toVideoFrame()
     if (is<WebGLRenderingContextBase>(m_context.get())) {
         if (document().settings().webAPIStatisticsEnabled())
             ResourceLoadObserver::shared().logCanvasRead(document());
-        return downcast<WebGLRenderingContextBase>(*m_context).paintCompositedResultsToVideoFrame();
+        return downcast<WebGLRenderingContextBase>(*m_context).surfaceBufferToVideoFrame(WebGLRenderingContextBase::SurfaceBuffer::DrawingBuffer);
     }
 #endif
+
     RefPtr imageBuffer = buffer();
     if (!imageBuffer)
         return nullptr;

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -112,6 +112,7 @@ public:
     void paint(GraphicsContext&, const LayoutRect&);
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
+    // Returns the context drawing buffer as a VideoFrame.
     RefPtr<VideoFrame> toVideoFrame();
 #endif
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -388,7 +388,7 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
             return { RefPtr<ImageBitmap> { nullptr } };
 
         auto* gc3d = webGLContext->graphicsContextGL();
-        gc3d->paintRenderingResultsToCanvas(*imageBitmap->buffer());
+        gc3d->drawSurfaceBufferToImageBuffer(WebGLRenderingContextBase::SurfaceBuffer::DrawingBuffer, *imageBitmap->buffer());
 
         // FIXME: The transfer algorithm requires that the canvas effectively
         // creates a new backing store. Since we're not doing that yet, we

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1039,7 +1039,7 @@ void WebGLRenderingContextBase::paintRenderingResultsToCanvas()
                 // Avoid leaking the WebGL content in the cases where a WebGL canvas element is drawn to a Context2D
                 // canvas element repeatedly.
                 buffer->flushDrawingContext();
-                m_context->paintCompositedResultsToCanvas(*buffer);
+                m_context->drawSurfaceBufferToImageBuffer(SurfaceBuffer::DisplayBuffer, *buffer);
             }
         }
         return;
@@ -1059,24 +1059,26 @@ void WebGLRenderingContextBase::paintRenderingResultsToCanvas()
         // Avoid leaking the WebGL content in the cases where a WebGL canvas element is drawn to a Context2D
         // canvas element repeatedly.
         buffer->flushDrawingContext();
-        m_context->paintRenderingResultsToCanvas(*buffer);
+        m_context->drawSurfaceBufferToImageBuffer(SurfaceBuffer::DrawingBuffer, *buffer);
     }
 }
 
-RefPtr<PixelBuffer> WebGLRenderingContextBase::paintRenderingResultsToPixelBuffer(GraphicsContextGL::FlipY flipY)
+RefPtr<PixelBuffer> WebGLRenderingContextBase::drawingBufferToPixelBuffer(GraphicsContextGL::FlipY flipY)
 {
     if (isContextLost())
         return nullptr;
     clearIfComposited(CallerTypeOther);
-    return m_context->paintRenderingResultsToPixelBuffer(flipY);
+    return m_context->drawingBufferToPixelBuffer(flipY);
 }
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-RefPtr<VideoFrame> WebGLRenderingContextBase::paintCompositedResultsToVideoFrame()
+RefPtr<VideoFrame> WebGLRenderingContextBase::surfaceBufferToVideoFrame(SurfaceBuffer buffer)
 {
     if (isContextLost())
         return nullptr;
-    return m_context->paintCompositedResultsToVideoFrame();
+    if (buffer == SurfaceBuffer::DrawingBuffer)
+        clearIfComposited(CallerTypeOther);
+    return m_context->surfaceBufferToVideoFrame(buffer);
 }
 #endif
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -133,6 +133,7 @@ class WebGLRenderingContextBase : public GraphicsContextGL::Client, public GPUBa
     WTF_MAKE_ISO_ALLOCATED(WebGLRenderingContextBase);
 public:
     using WebGLVersion = GraphicsContextGLWebGLVersion;
+    using SurfaceBuffer = GraphicsContextGL::SurfaceBuffer;
 
     using GPUBasedCanvasRenderingContext::weakPtrFactory;
     using GPUBasedCanvasRenderingContext::WeakValueType;
@@ -400,9 +401,9 @@ public:
 
     void prepareForDisplayWithPaint() final;
     void paintRenderingResultsToCanvas() final;
-    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer(GraphicsContextGL::FlipY);
+    RefPtr<PixelBuffer> drawingBufferToPixelBuffer(GraphicsContextGL::FlipY);
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    RefPtr<VideoFrame> paintCompositedResultsToVideoFrame();
+    RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer);
 #endif
 
     void removeSharedObject(WebGLObject&);

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1647,12 +1647,15 @@ public:
     // FIXME: these should be removed, they're part of drawing buffer and
     // display buffer abstractions that the caller should hold separate to
     // the context.
-    virtual void paintRenderingResultsToCanvas(ImageBuffer&) = 0;
-    virtual RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer(FlipY) = 0;
-    virtual void paintCompositedResultsToCanvas(ImageBuffer&) = 0;
+    enum class SurfaceBuffer : uint8_t {
+        DrawingBuffer,
+        DisplayBuffer
+    };
+    virtual void drawSurfaceBufferToImageBuffer(SurfaceBuffer, ImageBuffer&) = 0;
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    virtual RefPtr<VideoFrame> paintCompositedResultsToVideoFrame() = 0;
+    virtual RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) = 0;
 #endif
+    virtual RefPtr<PixelBuffer> drawingBufferToPixelBuffer(FlipY) = 0;
 
     // FIXME: this should be removed. The layer should be marked composited by
     // preparing for display, so that canvas image buffer and the layer agree
@@ -1770,5 +1773,17 @@ IMPLEMENT_GCGL_OWNED(Texture)
 #undef IMPLEMENT_GCGL_OWNED
 
 } // namespace WebCore
+
+namespace WTF {
+
+template <> struct EnumTraits<WebCore::GraphicsContextGL::SurfaceBuffer> {
+    using values = EnumValues<
+        WebCore::GraphicsContextGL::SurfaceBuffer,
+        WebCore::GraphicsContextGL::SurfaceBuffer::DrawingBuffer,
+        WebCore::GraphicsContextGL::SurfaceBuffer::DisplayBuffer
+    >;
+};
+
+}
 
 #endif

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -344,14 +344,12 @@ public:
     void deleteShader(PlatformGLObject) final;
     void deleteTexture(PlatformGLObject) final;
     void simulateEventForTesting(SimulatedEventForTesting) override;
-    void paintRenderingResultsToCanvas(ImageBuffer&) override;
-    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer(FlipY) override;
-    void paintCompositedResultsToCanvas(ImageBuffer&) override;
+    void drawSurfaceBufferToImageBuffer(SurfaceBuffer, ImageBuffer&) override;
+    RefPtr<PixelBuffer> drawingBufferToPixelBuffer(FlipY) override;
 
     RefPtr<PixelBuffer> readRenderingResultsForPainting();
 
-    virtual void withDrawingBufferAsNativeImage(Function<void(NativeImage&)>);
-    virtual void withDisplayBufferAsNativeImage(Function<void(NativeImage&)>);
+    virtual void withBufferAsNativeImage(SurfaceBuffer, Function<void(NativeImage&)>);
 
     // Reads pixels from positive pixel coordinates with tight packing.
     // Returns columns, rows of executed read on success.

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -88,15 +88,14 @@ public:
     GraphicsContextGLCV* asCV() final;
 #endif
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    RefPtr<VideoFrame> paintCompositedResultsToVideoFrame() final;
+    RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) final;
 #endif
     RefPtr<PixelBuffer> readCompositedResults() final;
     void setContextVisibility(bool) final;
     void setDrawingBufferColorSpace(const DestinationColorSpace&) final;
     void prepareForDisplay() override;
 
-    void withDrawingBufferAsNativeImage(Function<void(NativeImage&)>) override;
-    void withDisplayBufferAsNativeImage(Function<void(NativeImage&)>) override;
+    void withBufferAsNativeImage(SurfaceBuffer, Function<void(NativeImage&)>) override;
 
 #if PLATFORM(MAC)
     void updateContextOnDisplayReconfiguration();
@@ -124,6 +123,7 @@ protected:
     };
     IOSurfacePbuffer& drawingBuffer();
     IOSurfacePbuffer& displayBuffer();
+    IOSurfacePbuffer& surfaceBuffer(SurfaceBuffer);
     bool bindNextDrawingBuffer();
     void freeDrawingBuffers();
 

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -71,7 +71,7 @@ RefPtr<GraphicsLayerContentsDisplayDelegate> GraphicsContextGLGBM::layerContents
 }
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-RefPtr<VideoFrame> GraphicsContextGLGBM::paintCompositedResultsToVideoFrame()
+RefPtr<VideoFrame> GraphicsContextGLGBM::surfaceBufferToVideoFrame(SurfaceBuffer)
 {
 #if USE(GSTREAMER)
     if (auto pixelBuffer = readCompositedResults())

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
@@ -51,7 +51,7 @@ public:
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    RefPtr<VideoFrame> paintCompositedResultsToVideoFrame() override;
+    RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) override;
 #endif
 #if ENABLE(VIDEO)
     bool copyTextureFromMedia(MediaPlayer&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type, bool premultiplyAlpha, bool flipY) override;

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -158,7 +158,7 @@ bool GraphicsContextGLTextureMapperANGLE::copyTextureFromMedia(MediaPlayer&, Pla
 #endif
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-RefPtr<VideoFrame> GraphicsContextGLTextureMapperANGLE::paintCompositedResultsToVideoFrame()
+RefPtr<VideoFrame> GraphicsContextGLTextureMapperANGLE::surfaceBufferToVideoFrame(SurfaceBuffer)
 {
 #if USE(GSTREAMER)
     if (auto pixelBuffer = readCompositedResults())

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -50,7 +50,7 @@ public:
     bool copyTextureFromMedia(MediaPlayer&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type, bool premultiplyAlpha, bool flipY) final;
 #endif
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    RefPtr<VideoFrame> paintCompositedResultsToVideoFrame() final;
+    RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) final;
 #endif
     RefPtr<PixelBuffer> readCompositedResults() final;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -209,30 +209,21 @@ void RemoteGraphicsContextGL::markContextChanged()
     m_context->markContextChanged();
 }
 
-void RemoteGraphicsContextGL::paintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier imageBufferIdentifier, CompletionHandler<void()>&& completionHandler)
+void RemoteGraphicsContextGL::drawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBufferIdentifier, CompletionHandler<void()>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    m_context->withDrawingBufferAsNativeImage([&](NativeImage& image) {
-        paintNativeImageToImageBuffer(image, imageBufferIdentifier);
-    });
-    completionHandler();
-}
-
-void RemoteGraphicsContextGL::paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBufferIdentifier, CompletionHandler<void()>&& completionHandler)
-{
-    assertIsCurrent(workQueue());
-    m_context->withDisplayBufferAsNativeImage([&](NativeImage& image) {
+    m_context->withBufferAsNativeImage(buffer, [&](NativeImage& image) {
         paintNativeImageToImageBuffer(image, imageBufferIdentifier);
     });
     completionHandler();
 }
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-void RemoteGraphicsContextGL::paintCompositedResultsToVideoFrame(CompletionHandler<void(std::optional<WebKit::RemoteVideoFrameProxy::Properties>&&)>&& completionHandler)
+void RemoteGraphicsContextGL::surfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer buffer, CompletionHandler<void(std::optional<WebKit::RemoteVideoFrameProxy::Properties>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     std::optional<WebKit::RemoteVideoFrameProxy::Properties> result;
-    if (auto videoFrame = m_context->paintCompositedResultsToVideoFrame())
+    if (auto videoFrame = m_context->surfaceBufferToVideoFrame(buffer))
         result = m_videoFrameObjectHeap->add(videoFrame.releaseNonNull());
     completionHandler(WTFMove(result));
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -121,10 +121,9 @@ protected:
     void prepareForDisplay(CompletionHandler<void()>&&);
 #endif
     void getErrors(CompletionHandler<void(GCGLErrorCodeSet)>&&);
-    void paintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier, CompletionHandler<void()>&&);
-    void paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier, CompletionHandler<void()>&&);
+    void drawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer, WebCore::RenderingResourceIdentifier, CompletionHandler<void()>&&);
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    void paintCompositedResultsToVideoFrame(CompletionHandler<void(std::optional<WebKit::RemoteVideoFrameProxy::Properties>&&)>&&);
+    void surfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer, CompletionHandler<void(std::optional<WebKit::RemoteVideoFrameProxy::Properties>&&)>&&);
 #endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     void copyTextureFromVideoFrame(SharedVideoFrame&&, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&&);
@@ -147,8 +146,6 @@ protected:
 #include "RemoteGraphicsContextGLFunctionsGenerated.h" // NOLINT
 
 private:
-    void paintRenderingResultsToCanvasWithQualifiedIdentifier(WebCore::RenderingResourceIdentifier);
-    void paintCompositedResultsToCanvasWithQualifiedIdentifier(WebCore::RenderingResourceIdentifier);
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
 
 protected:

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -41,15 +41,14 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void EnsureExtensionEnabled(String extension)
     void MarkContextChanged()
     void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
-    void PaintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
-    void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
+    void DrawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
+#if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
+    void SurfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer buffer) -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
+#endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle) NotStreamEncodable
-#endif
-#if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
 #endif
     void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
     void ReadPixelsInline(WebCore::IntRect rect, uint32_t format, uint32_t type) -> (std::optional<WebCore::IntSize> readArea, IPC::ArrayReference<uint8_t> data) Synchronous
@@ -329,7 +328,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void BlitFramebufferANGLE(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
-    void PaintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY arg0) -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
+    void DrawingBufferToPixelBuffer(WebCore::GraphicsContextGL::FlipY arg0) -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
     void DestroyEGLSync(uint64_t arg0) -> (bool returnValue) Synchronous
     void ClientWaitEGLSyncWithFlush(uint64_t arg0, uint64_t timeout)
     void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1492,11 +1492,11 @@
         assertIsCurrent(workQueue());
         m_context->setDrawingBufferColorSpace(arg0);
     }
-    void paintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY&& arg0, CompletionHandler<void(RefPtr<WebCore::PixelBuffer>&&)>&& completionHandler)
+    void drawingBufferToPixelBuffer(WebCore::GraphicsContextGL::FlipY&& arg0, CompletionHandler<void(RefPtr<WebCore::PixelBuffer>&&)>&& completionHandler)
     {
         RefPtr<WebCore::PixelBuffer> returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->paintRenderingResultsToPixelBuffer(arg0);
+        returnValue = m_context->drawingBufferToPixelBuffer(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void destroyEGLSync(uint64_t arg0, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -209,34 +209,12 @@ void RemoteGraphicsContextGLProxy::reshape(int width, int height)
         markContextLost();
 }
 
-void RemoteGraphicsContextGLProxy::paintRenderingResultsToCanvas(ImageBuffer& buffer)
+void RemoteGraphicsContextGLProxy::drawSurfaceBufferToImageBuffer(SurfaceBuffer buffer, ImageBuffer& imageBuffer)
 {
     if (isContextLost())
         return;
-    // FIXME: the buffer is "relatively empty" always, but for consistency, we need to ensure
-    // no pending operations are targeted for the `buffer`.
-    buffer.flushDrawingContext();
-
-    // FIXME: We cannot synchronize so that we would know no pending operations are using the `buffer`.
-
-    // FIXME: Currently RemoteImageBufferProxy::getPixelBuffer et al do not wait for the flushes of the images
-    // inside the display lists. Rather, it assumes that processing its sequence (e.g. the display list) will equal to read flush being
-    // fulfilled. For below, we cannot create a new flush id since we go through different sequence (RemoteGraphicsContextGL sequence)
-
-    // FIXME: Maybe implement IPC::Fence or something similar.
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToCanvas(buffer.renderingResourceIdentifier()));
-    if (!sendResult.succeeded()) {
-        markContextLost();
-        return;
-    }
-}
-
-void RemoteGraphicsContextGLProxy::paintCompositedResultsToCanvas(ImageBuffer& buffer)
-{
-    if (isContextLost())
-        return;
-    buffer.flushDrawingContext();
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintCompositedResultsToCanvas(buffer.renderingResourceIdentifier()));
+    imageBuffer.flushDrawingContext();
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::DrawSurfaceBufferToImageBuffer(buffer, imageBuffer.renderingResourceIdentifier()));
     if (!sendResult.succeeded()) {
         markContextLost();
         return;
@@ -244,12 +222,12 @@ void RemoteGraphicsContextGLProxy::paintCompositedResultsToCanvas(ImageBuffer& b
 }
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-RefPtr<WebCore::VideoFrame> RemoteGraphicsContextGLProxy::paintCompositedResultsToVideoFrame()
+RefPtr<WebCore::VideoFrame> RemoteGraphicsContextGLProxy::surfaceBufferToVideoFrame(SurfaceBuffer buffer)
 {
     ASSERT(isMainRunLoop());
     if (isContextLost())
         return nullptr;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintCompositedResultsToVideoFrame());
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::SurfaceBufferToVideoFrame(buffer));
     if (!sendResult.succeeded()) {
         markContextLost();
         return nullptr;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -80,10 +80,9 @@ public:
     bool supportsExtension(const String&) final;
     void ensureExtensionEnabled(const String&) final;
     bool isExtensionEnabled(const String&) final;
-    void paintRenderingResultsToCanvas(WebCore::ImageBuffer&) final;
-    void paintCompositedResultsToCanvas(WebCore::ImageBuffer&) final;
+    void drawSurfaceBufferToImageBuffer(SurfaceBuffer, WebCore::ImageBuffer&) final;
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    RefPtr<WebCore::VideoFrame> paintCompositedResultsToVideoFrame() final;
+    RefPtr<WebCore::VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) final;
 #endif
     GCGLErrorCodeSet getErrors() final;
 #if ENABLE(VIDEO)
@@ -366,7 +365,7 @@ public:
     void blitFramebufferANGLE(GCGLint srcX0, GCGLint srcY0, GCGLint srcX1, GCGLint srcY1, GCGLint dstX0, GCGLint dstY0, GCGLint dstX1, GCGLint dstY1, GCGLbitfield mask, GCGLenum filter) final;
     void getInternalformativ(GCGLenum target, GCGLenum internalformat, GCGLenum pname, std::span<GCGLint> params) final;
     void setDrawingBufferColorSpace(const WebCore::DestinationColorSpace&) final;
-    RefPtr<WebCore::PixelBuffer> paintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY) final;
+    RefPtr<WebCore::PixelBuffer> drawingBufferToPixelBuffer(WebCore::GraphicsContextGL::FlipY) final;
     bool destroyEGLSync(GCEGLSync) final;
     void clientWaitEGLSyncWithFlush(GCEGLSync, uint64_t timeout) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -3082,11 +3082,11 @@ void RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace(const WebCore::Des
     }
 }
 
-RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY arg0)
+RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::drawingBufferToPixelBuffer(WebCore::GraphicsContextGL::FlipY arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer(arg0));
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::DrawingBufferToPixelBuffer(arg0));
     if (!sendResult.succeeded()) {
         markContextLost();
         return { };

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -105,15 +105,14 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void EnsureExtensionEnabled(String extension)
     void MarkContextChanged()
     void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
-    void PaintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
-    void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
+    void DrawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
+#if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
+    void SurfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer buffer) -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
+#endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle) NotStreamEncodable
-#endif
-#if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
 #endif
     void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
     void ReadPixelsInline(WebCore::IntRect rect, uint32_t format, uint32_t type) -> (std::optional<WebCore::IntSize> readArea, IPC::ArrayReference<uint8_t> data) Synchronous


### PR DESCRIPTION
#### 3cf847f4c0b488559358f6ecdae56a59632266f8
<pre>
[WebCodecs] Poor video frame rate exporting from Construct Animate
<a href="https://bugs.webkit.org/show_bug.cgi?id=255869">https://bugs.webkit.org/show_bug.cgi?id=255869</a>
rdar://108459224

Reviewed by Dan Glastonbury.

WebCodecsVideoFrame would use HTMLCanvasElement::toVideoFrame().
Before WebCodecsVideoFrame, this function was intended to be used from
CanvasCaptureMediaStreamTrack, which would capture the composited frame
at the time of capture. Thus WebCodecsVideoFrame would read the
composited frame, not the drawing buffer.

Add functionality to read the WebGL drawing buffer.

Rename GraphicsContextGL::paintRenderingResultsToCanvas() to more
descriptive and consistent name drawSurfaceBufferToImageBuffer.

The added test will fail for premultipliedAlpha == false case. This
will be fixed in later commits.

* LayoutTests/http/wpt/webcodecs/videoFrame-webglCanvasImageSource.html: Added.
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
(WebCore::HTMLCanvasElement::toVideoFrame):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::transferToImageBitmap):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::paintRenderingResultsToCanvas):
(WebCore::WebGLRenderingContextBase::drawingBufferToPixelBuffer):
(WebCore::WebGLRenderingContextBase::surfaceBufferToVideoFrame):
(WebCore::WebGLRenderingContextBase::paintRenderingResultsToPixelBuffer): Deleted.
(WebCore::WebGLRenderingContextBase::paintCompositedResultsToVideoFrame): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::drawSurfaceBufferToImageBuffer):
(WebCore::GraphicsContextGLANGLE::withBufferAsNativeImage):
(WebCore::GraphicsContextGLANGLE::drawingBufferToPixelBuffer):
(WebCore::GraphicsContextGLANGLE::paintRenderingResultsToCanvas): Deleted.
(WebCore::GraphicsContextGLANGLE::paintCompositedResultsToCanvas): Deleted.
(WebCore::GraphicsContextGLANGLE::withDrawingBufferAsNativeImage): Deleted.
(WebCore::GraphicsContextGLANGLE::withDisplayBufferAsNativeImage): Deleted.
(WebCore::GraphicsContextGLANGLE::paintRenderingResultsToPixelBuffer): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::surfaceBuffer):
(WebCore::GraphicsContextGLCocoa::createPbufferAndAttachIOSurface):
(WebCore::GraphicsContextGLCocoa::surfaceBufferToVideoFrame):
(WebCore::GraphicsContextGLCocoa::withBufferAsNativeImage):
(WebCore::GraphicsContextGLCocoa::displayBuffer): Deleted.
(WebCore::GraphicsContextGLCocoa::drawingBuffer): Deleted.
(WebCore::GraphicsContextGLCocoa::paintCompositedResultsToVideoFrame): Deleted.
(WebCore::GraphicsContextGLCocoa::withDrawingBufferAsNativeImage): Deleted.
(WebCore::GraphicsContextGLCocoa::withDisplayBufferAsNativeImage): Deleted.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::surfaceBufferToVideoFrame):
(WebCore::GraphicsContextGLGBM::paintCompositedResultsToVideoFrame): Deleted.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::surfaceBufferToVideoFrame):
(WebCore::GraphicsContextGLTextureMapperANGLE::paintCompositedResultsToVideoFrame): Deleted.
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::drawSurfaceBufferToImageBuffer):
(WebKit::RemoteGraphicsContextGL::surfaceBufferToVideoFrame):
(WebKit::RemoteGraphicsContextGL::paintRenderingResultsToCanvas): Deleted.
(WebKit::RemoteGraphicsContextGL::paintCompositedResultsToCanvas): Deleted.
(WebKit::RemoteGraphicsContextGL::paintCompositedResultsToVideoFrame): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(drawingBufferToPixelBuffer):
(paintRenderingResultsToPixelBuffer): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::drawSurfaceBufferToImageBuffer):
(WebKit::RemoteGraphicsContextGLProxy::surfaceBufferToVideoFrame):
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToCanvas): Deleted.
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToCanvas): Deleted.
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToVideoFrame): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::drawingBufferToPixelBuffer):
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer): Deleted.
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/269757@main">https://commits.webkit.org/269757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a2a0bf924ceac1d0b1c7ab89461e20207e9dc8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24613 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21686 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24031 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26247 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21225 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21487 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18656 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21000 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5601 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->