### PR TITLE
[WebGPU] WGPU_COPY_STRIDE_UNDEFINED is not handled in WGPUVertexBufferLayout

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -245,13 +245,13 @@ static MTLVertexFormat vertexFormat(WGPUVertexFormat vertexFormat)
 {
     switch (vertexFormat) {
     case WGPUVertexFormat_Uint8x2:
-        return MTLVertexFormatUInt2;
+        return MTLVertexFormatUChar2;
     case WGPUVertexFormat_Uint8x4:
-        return MTLVertexFormatUInt4;
+        return MTLVertexFormatUChar4;
     case WGPUVertexFormat_Sint8x2:
-        return MTLVertexFormatInt2;
+        return MTLVertexFormatChar2;
     case WGPUVertexFormat_Sint8x4:
-        return MTLVertexFormatInt4;
+        return MTLVertexFormatChar4;
     case WGPUVertexFormat_Unorm8x2:
         return MTLVertexFormatUChar2Normalized;
     case WGPUVertexFormat_Unorm8x4:
@@ -334,6 +334,9 @@ static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState)
 
     for (size_t bufferIndex = 0; bufferIndex < vertexState.bufferCount; ++bufferIndex) {
         auto& buffer = vertexState.buffers[bufferIndex];
+        if (buffer.arrayStride == WGPU_COPY_STRIDE_UNDEFINED)
+            continue;
+
         vertexDescriptor.layouts[bufferIndex].stride = buffer.arrayStride;
         vertexDescriptor.layouts[bufferIndex].stepFunction = stepFunction(buffer.stepMode);
         // FIXME: need to assign stepRate with per-instance data?


### PR DESCRIPTION
#### 53375e8efea77e409e62077ef412844bc974a637
<pre>
[WebGPU] WGPU_COPY_STRIDE_UNDEFINED is not handled in WGPUVertexBufferLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=263484">https://bugs.webkit.org/show_bug.cgi?id=263484</a>
&lt;radar://117285397&gt;

Reviewed by Tadeu Zagallo.

WGPU_COPY_STRIDE_UNDEFINED should be handled since the buffers can be
null per the idl file, but the only reason we failed to create a buffer
in this CTS test was due to the switch statement values being incorrect.

So this patch also corrects the switch statement values to avoid the null
buffer creation.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::vertexFormat):
(WebGPU::createVertexDescriptor):

Canonical link: <a href="https://commits.webkit.org/269665@main">https://commits.webkit.org/269665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4f082d7894e23bf7927ab1a028a7f25f50ff44a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22280 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23423 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25945 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27167 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25017 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/681 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/615 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5539 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->