### PR TITLE
Make `TransformOperationData` constructors explicit

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -164,7 +164,7 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         if (!offsetAnchor.x().isAuto())
             anchor = floatPointForLengthPoint(offsetAnchor, borderBoxRect.size()) + borderBoxRect.location();
 
-        auto path = offsetPath->getPath(FloatRect(borderBoxRect));
+        auto path = offsetPath->getPath(TransformOperationData(FloatRect(borderBoxRect)));
         offsetDistance = { path ? path->length() : 0.0f, LengthType:: Fixed };
     }
 

--- a/Source/WebCore/rendering/TransformOperationData.h
+++ b/Source/WebCore/rendering/TransformOperationData.h
@@ -33,8 +33,8 @@ namespace WebCore {
 class RenderElement;
 
 struct TransformOperationData {
-    TransformOperationData(FloatRect boundingBox, const RenderElement* renderer = nullptr);
-    TransformOperationData(FloatRect boundingBox, std::optional<MotionPathData> motionPathData, bool isSVGRenderer)
+    explicit TransformOperationData(FloatRect boundingBox, const RenderElement* renderer = nullptr);
+    explicit TransformOperationData(FloatRect boundingBox, std::optional<MotionPathData> motionPathData, bool isSVGRenderer)
         : boundingBox(boundingBox)
         , motionPathData(motionPathData)
         , isSVGRenderer(isSVGRenderer)


### PR DESCRIPTION
#### 00756ec4a27caa537682bf6e18005d7745ee26d1
<pre>
Make `TransformOperationData` constructors explicit
<a href="https://bugs.webkit.org/show_bug.cgi?id=263524">https://bugs.webkit.org/show_bug.cgi?id=263524</a>
rdar://117352958

Unreviewed, address Darin Adler&apos;s review comment.

* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/rendering/TransformOperationData.h:
(WebCore::TransformOperationData::TransformOperationData):

Canonical link: <a href="https://commits.webkit.org/269655@main">https://commits.webkit.org/269655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63b16a98c92d239a4b131a92e9d405dcdd1270f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23727 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25951 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27151 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21250 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25024 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/621 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5528 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1098 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->