### PR TITLE
[WebGPU] Enable vertex_state,correctness test

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/vertex_state/index_format-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/vertex_state/index_format-expected.txt
@@ -1,1 +1,19 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :index_format,uint16:
+PASS :index_format,uint32:
+PASS :index_format,change_pipeline_after_setIndexBuffer:setPipelineBeforeSetIndexBuffer=false
+PASS :index_format,change_pipeline_after_setIndexBuffer:setPipelineBeforeSetIndexBuffer=true
+PASS :index_format,setIndexBuffer_before_setPipeline:setIndexBufferBeforeSetPipeline=false
+PASS :index_format,setIndexBuffer_before_setPipeline:setIndexBufferBeforeSetPipeline=true
+PASS :index_format,setIndexBuffer_different_formats:
+PASS :primitive_restart:indexFormat="uint16";primitiveTopology="point-list"
+PASS :primitive_restart:indexFormat="uint16";primitiveTopology="line-list"
+PASS :primitive_restart:indexFormat="uint16";primitiveTopology="line-strip"
+PASS :primitive_restart:indexFormat="uint16";primitiveTopology="triangle-list"
+PASS :primitive_restart:indexFormat="uint16";primitiveTopology="triangle-strip"
+PASS :primitive_restart:indexFormat="uint32";primitiveTopology="point-list"
+PASS :primitive_restart:indexFormat="uint32";primitiveTopology="line-list"
+PASS :primitive_restart:indexFormat="uint32";primitiveTopology="line-strip"
+PASS :primitive_restart:indexFormat="uint32";primitiveTopology="triangle-list"
+PASS :primitive_restart:indexFormat="uint32";primitiveTopology="triangle-strip"
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2011,6 +2011,7 @@ webkit.org/b/263754 [ Sonoma+ x86_64 ] css3/filters/effect-drop-shadow-clip-absp
 # WebGPU
 http/tests/webgpu/webgpu/api/operation/rendering/stencil.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/vertex_state/index_format.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/rendering/draw.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/sampling/filter_mode.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/sampling/lod_clamp.html [ Pass ]


### PR DESCRIPTION
#### 81c7f8ee92be3fc6c4f1a3a4bfad1aad654806bf
<pre>
[WebGPU] Enable vertex_state,correctness test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263523">https://bugs.webkit.org/show_bug.cgi?id=263523</a>
&lt;rdar://problem/117352784&gt;

Reviewed by Dan Glastonbury and Tadeu Zagallo.

Handle array_stride==0 per the WGPU specification and
enable vertex_correctness.html

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::stepFunction):
(WebGPU::createVertexDescriptor):

* LayoutTests/http/tests/webgpu/webgpu/api/operation/vertex_state/index_format-expected.txt:
Add expectation

Canonical link: <a href="https://commits.webkit.org/270004@main">https://commits.webkit.org/270004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce0f8ebd28174b607c4b766ee50d443ec4f46b39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22304 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24696 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26950 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28074 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25859 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19195 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2668 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5809 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->