### PR TITLE
Stop using a raw pointer for Node::m_treeScope

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -292,6 +292,15 @@ inline bool is(const Ref<ArgType, PtrTraits>& source)
 }
 
 template<typename Target, typename Source, typename PtrTraits>
+inline Ref<Target> checkedDowncast(Ref<Source, PtrTraits> source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT(is<Target>(source));
+    return static_reference_cast<Target>(WTFMove(source));
+}
+
+template<typename Target, typename Source, typename PtrTraits>
 inline Ref<Target> downcast(Ref<Source, PtrTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -259,6 +259,15 @@ inline bool is(const RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
 }
 
 template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
+inline RefPtr<Target> checkedDowncast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT(!source || is<Target>(*source));
+    return static_pointer_cast<Target>(WTFMove(source));
+}
+
+template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
 inline RefPtr<Target> downcast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");

--- a/Source/WTF/wtf/TypeCasts.h
+++ b/Source/WTF/wtf/TypeCasts.h
@@ -72,6 +72,23 @@ using match_constness_t =
 
 // Safe downcasting functions.
 template<typename Target, typename Source>
+inline match_constness_t<Source, Target>& checkedDowncast(Source& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT(is<Target>(source));
+    return static_cast<match_constness_t<Source, Target>&>(source);
+}
+template<typename Target, typename Source>
+inline match_constness_t<Source, Target>* checkedDowncast(Source* source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT(!source || is<Target>(*source));
+    return static_cast<match_constness_t<Source, Target>*>(source);
+}
+
+template<typename Target, typename Source>
 inline match_constness_t<Source, Target>& downcast(Source& source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
@@ -134,5 +151,6 @@ inline bool is(const std::unique_ptr<ArgType, Deleter>& source)
 
 using WTF::TypeCastTraits;
 using WTF::is;
+using WTF::checkedDowncast;
 using WTF::downcast;
 using WTF::dynamicDowncast;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -762,7 +762,7 @@ private:
     mutable OptionSet<NodeFlag> m_nodeFlags;
 
     CheckedPtr<ContainerNode> m_parentNode;
-    TreeScope* m_treeScope { nullptr };
+    CheckedPtr<TreeScope> m_treeScope;
     CheckedPtr<Node> m_previous;
     CheckedPtr<Node> m_next;
     CompactPointerTuple<RenderObject*, uint16_t> m_rendererWithStyleFlags;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -65,6 +65,10 @@ public:
 
     virtual ~ShadowRoot();
 
+    // Resolve ambiguity for CanMakeCheckedPtr.
+    void incrementPtrCount() const { static_cast<const DocumentFragment*>(this)->incrementPtrCount(); }
+    void decrementPtrCount() const { static_cast<const DocumentFragment*>(this)->decrementPtrCount(); }
+
     using TreeScope::getElementById;
     using TreeScope::rootNode;
 

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -89,6 +89,22 @@ TreeScope::TreeScope(Document& document)
 
 TreeScope::~TreeScope() = default;
 
+void TreeScope::incrementPtrCount() const
+{
+    if (auto* document = dynamicDowncast<Document>(m_rootNode))
+        document->incrementPtrCount();
+    else
+        checkedDowncast<ShadowRoot>(m_rootNode).incrementPtrCount();
+}
+
+void TreeScope::decrementPtrCount() const
+{
+    if (auto* document = dynamicDowncast<Document>(m_rootNode))
+        document->decrementPtrCount();
+    else
+        checkedDowncast<ShadowRoot>(m_rootNode).decrementPtrCount();
+}
+
 void TreeScope::destroyTreeScopeData()
 {
     m_elementsById = nullptr;

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -68,6 +68,10 @@ public:
     TreeScope* parentTreeScope() const { return m_parentTreeScope; }
     void setParentTreeScope(TreeScope&);
 
+    // For CheckedPtr / CheckedRef use.
+    void incrementPtrCount() const;
+    void decrementPtrCount() const;
+
     Element* focusedElementInScope();
     Element* pointerLockElement() const;
 


### PR DESCRIPTION
#### 2714943f80da611b6d992d9aa457ba9c5c2f633a
<pre>
Stop using a raw pointer for Node::m_treeScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=262239">https://bugs.webkit.org/show_bug.cgi?id=262239</a>
rdar://116501041

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/Ref.h:
(WTF::checkedDowncast):
* Source/WTF/wtf/RefPtr.h:
(WTF::checkedDowncast):
* Source/WTF/wtf/TypeCasts.h:
(WTF::checkedDowncast):
Introduce checkedDowncast&lt;&gt;(), which is similar to downcast&lt;&gt;() but the
type check happens in release builds too for extra safety.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node):
(WebCore::Node::~Node):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::incrementPtrCount const):
(WebCore::TreeScope::decrementPtrCount const):
* Source/WebCore/dom/TreeScope.h:

Canonical link: <a href="https://commits.webkit.org/269692@main">https://commits.webkit.org/269692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91e0e088f1facb6f14b9439ac3a8abc278bb896e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24399 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21497 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23832 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26046 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21046 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20253 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21305 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22637 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18508 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30019 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/708 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5554 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1170 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29971 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1010 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6096 "Passed tests") | 
<!--EWS-Status-Bubble-End-->