### PR TITLE
[WebGPU] Enable requestAdapterInfo CTS test

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/adapter/requestAdapterInfo-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/adapter/requestAdapterInfo-expected.txt
@@ -1,1 +1,4 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :adapter_info:
+PASS :adapter_info_with_hints:
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2015,6 +2015,8 @@ http/tests/webgpu/webgpu/api/operation/rendering/draw.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/sampling/filter_mode.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/sampling/lod_clamp.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/sampling/anisotropy.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/adapter/requestAdapterInfo.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/adapter/requestAdapter.html [ Pass ]
 
 webkit.org/b/263920 svg/transforms/transformed-text-fill-gradient.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
@@ -38,9 +38,9 @@ public:
         return adoptRef(*new GPUAdapterInfo(WTFMove(name)));
     }
 
-    String vendor() const { auto v = m_name.split(' '); return v.size() ? v[0] : ""_s; }
+    String vendor() const { auto v = m_name.split(' '); return v.size() ? v[0].convertToLowercaseWithoutLocale() : ""_s; }
     String architecture() const { return ""_s; }
-    String device() const { return m_name; }
+    String device() const { return vendor(); }
     String description() const { return ""_s; }
 
 private:


### PR DESCRIPTION
#### 399d66f88e336da795cf2ed2836dee80af046b19
<pre>
[WebGPU] Enable requestAdapterInfo CTS test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263526">https://bugs.webkit.org/show_bug.cgi?id=263526</a>
&lt;radar://117357155&gt;

Reviewed by Dan Glastonbury and Tadeu Zagallo.

Vendor name should be lowercase and device name should not be so
specific, e.g., &apos;apple&apos; instead of &apos;Apple M1 Pro&apos;

* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h:
(WebCore::GPUAdapterInfo::vendor const):
(WebCore::GPUAdapterInfo::device const):

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/http/tests/webgpu/webgpu/api/operation/adapter/requestAdapter-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/operation/adapter/requestAdapterInfo-expected.txt:

Canonical link: <a href="https://commits.webkit.org/270000@main">https://commits.webkit.org/270000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d88fb329b48947b98eab3195e73a24a87a14d71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24688 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26942 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28069 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25864 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19192 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2530 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5808 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->