### PR TITLE
Adopt more smart pointers in RadioButtonGroups

### DIFF
--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -23,7 +23,7 @@
 
 #include "HTMLInputElement.h"
 #include "Range.h"
-#include <wtf/WeakHashSet.h>
+#include <wtf/HashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -31,7 +31,7 @@ namespace WebCore {
 class RadioButtonGroup {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    bool isEmpty() const { return m_members.isEmptyIgnoringNullReferences(); }
+    bool isEmpty() const { return m_members.isEmpty(); }
     bool isRequired() const { return m_requiredCount; }
     RefPtr<HTMLInputElement> checkedButton() const { return m_checkedButton.get(); }
     void add(HTMLInputElement&);
@@ -47,8 +47,8 @@ private:
     bool isValid() const;
     void setCheckedButton(HTMLInputElement*);
 
-    WeakHashSet<HTMLInputElement, WeakPtrImplWithEventTargetData> m_members;
-    WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_checkedButton;
+    HashSet<CheckedRef<HTMLInputElement>> m_members;
+    CheckedPtr<HTMLInputElement> m_checkedButton;
     size_t m_requiredCount { 0 };
 };
 
@@ -59,7 +59,9 @@ inline bool RadioButtonGroup::isValid() const
 
 Vector<Ref<HTMLInputElement>> RadioButtonGroup::members() const
 {
-    auto sortedMembers = copyToVectorOf<Ref<HTMLInputElement>>(m_members);
+    auto sortedMembers = WTF::map(m_members, [](auto& element) -> Ref<HTMLInputElement> {
+        return element.get();
+    });
     std::sort(sortedMembers.begin(), sortedMembers.end(), [](auto& a, auto& b) {
         return is_lt(treeOrder<ComposedTree>(a, b));
     });
@@ -68,7 +70,7 @@ Vector<Ref<HTMLInputElement>> RadioButtonGroup::members() const
 
 void RadioButtonGroup::setCheckedButton(HTMLInputElement* button)
 {
-    RefPtr<HTMLInputElement> oldCheckedButton = m_checkedButton.get();
+    RefPtr oldCheckedButton = m_checkedButton.get();
     if (oldCheckedButton == button)
         return;
 
@@ -153,7 +155,7 @@ void RadioButtonGroup::remove(HTMLInputElement& button)
         }
     }
 
-    if (m_members.isEmptyIgnoringNullReferences()) {
+    if (m_members.isEmpty()) {
         ASSERT(!m_requiredCount);
         ASSERT(!m_checkedButton);
     } else if (wasValid != isValid())
@@ -167,17 +169,19 @@ void RadioButtonGroup::remove(HTMLInputElement& button)
 
 void RadioButtonGroup::setNeedsStyleRecalcForAllButtons()
 {
-    for (auto& button : m_members) {
-        ASSERT(button.isRadioButton());
-        button.invalidateStyleForSubtree();
+    for (auto& checkedButton : m_members) {
+        Ref button = checkedButton.get();
+        ASSERT(button->isRadioButton());
+        button->invalidateStyleForSubtree();
     }
 }
 
 void RadioButtonGroup::updateValidityForAllButtons()
 {
-    for (auto& button : m_members) {
-        ASSERT(button.isRadioButton());
-        button.updateValidity();
+    for (auto& checkedButton : m_members) {
+        Ref button = checkedButton.get();
+        ASSERT(button->isRadioButton());
+        button->updateValidity();
     }
 }
 
@@ -211,14 +215,12 @@ Vector<Ref<HTMLInputElement>> RadioButtonGroups::groupMembers(const HTMLInputEle
     if (!element.isRadioButton())
         return { };
 
-    auto* name = element.name().impl();
-    if (!name)
+    auto& name = element.name();
+    if (name.isNull())
         return { };
 
     auto* group = m_nameToGroupMap.get(name);
-    if (!group)
-        return { };
-    return group->members();
+    return group ? group->members() : Vector<Ref<HTMLInputElement>> { };
 }
 
 void RadioButtonGroups::updateCheckedState(HTMLInputElement& element)
@@ -226,7 +228,7 @@ void RadioButtonGroups::updateCheckedState(HTMLInputElement& element)
     ASSERT(element.isRadioButton());
     if (element.name().isEmpty())
         return;
-    if (auto* group = m_nameToGroupMap.get(element.name().impl()))
+    if (auto* group = m_nameToGroupMap.get(element.name()))
         group->updateCheckedState(element);
 }
 
@@ -235,29 +237,26 @@ void RadioButtonGroups::requiredStateChanged(HTMLInputElement& element)
     ASSERT(element.isRadioButton());
     if (element.name().isEmpty())
         return;
-    auto* group = m_nameToGroupMap.get(element.name().impl());
-    if (!group)
-        return;
-    group->requiredStateChanged(element);
+    if (auto* group = m_nameToGroupMap.get(element.name()))
+        group->requiredStateChanged(element);
 }
 
 RefPtr<HTMLInputElement> RadioButtonGroups::checkedButtonForGroup(const AtomString& name) const
 {
     m_nameToGroupMap.checkConsistency();
-    RadioButtonGroup* group = m_nameToGroupMap.get(name.impl());
+    auto* group = m_nameToGroupMap.get(name.impl());
     return group ? group->checkedButton() : nullptr;
 }
 
 bool RadioButtonGroups::hasCheckedButton(const HTMLInputElement& element) const
 {
     ASSERT(element.isRadioButton());
-    const AtomString& name = element.name();
+    auto& name = element.name();
     if (name.isEmpty())
         return element.checked();
     auto* group = m_nameToGroupMap.get(name.impl());
-    if (!group)
-        return false; // FIXME: Update the radio button group before author script had a chance to run in didFinishInsertingNode().
-    return group->checkedButton();
+    // FIXME: Update the radio button group before author script had a chance to run in didFinishInsertingNode().
+    return group && group->checkedButton();
 }
 
 bool RadioButtonGroups::isInRequiredGroup(HTMLInputElement& element) const
@@ -265,7 +264,7 @@ bool RadioButtonGroups::isInRequiredGroup(HTMLInputElement& element) const
     ASSERT(element.isRadioButton());
     if (element.name().isEmpty())
         return false;
-    auto* group = m_nameToGroupMap.get(element.name().impl());
+    auto* group = m_nameToGroupMap.get(element.name());
     return group && group->isRequired() && group->contains(element);
 }
 
@@ -276,7 +275,7 @@ void RadioButtonGroups::removeButton(HTMLInputElement& element)
         return;
 
     m_nameToGroupMap.checkConsistency();
-    auto it = m_nameToGroupMap.find(element.name().impl());
+    auto it = m_nameToGroupMap.find(element.name());
     if (it == m_nameToGroupMap.end())
         return;
     it->value->remove(element);


### PR DESCRIPTION
#### 4fdfc1517dbe4fc4d25caf4070de1280dcbb9843
<pre>
Adopt more smart pointers in RadioButtonGroups
<a href="https://bugs.webkit.org/show_bug.cgi?id=263528">https://bugs.webkit.org/show_bug.cgi?id=263528</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroup::isEmpty const):
(WebCore::RadioButtonGroup::members const):
(WebCore::RadioButtonGroup::setCheckedButton):
(WebCore::RadioButtonGroup::remove):
(WebCore::RadioButtonGroup::setNeedsStyleRecalcForAllButtons):
(WebCore::RadioButtonGroup::updateValidityForAllButtons):
(WebCore::RadioButtonGroups::groupMembers const):
(WebCore::RadioButtonGroups::updateCheckedState):
(WebCore::RadioButtonGroups::requiredStateChanged):
(WebCore::RadioButtonGroups::checkedButtonForGroup const):
(WebCore::RadioButtonGroups::hasCheckedButton const):
(WebCore::RadioButtonGroups::isInRequiredGroup const):
(WebCore::RadioButtonGroups::removeButton):

Canonical link: <a href="https://commits.webkit.org/269672@main">https://commits.webkit.org/269672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c3e84944f4fbcab4740e575194be84c67c163df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24322 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23739 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25963 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27157 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25032 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/697 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18461 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.* (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/632 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5546 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->