### PR TITLE
[WebGPU] Enable webgpu:api,operation,rendering,indirect_draw:*

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw-expected.txt
@@ -1,1 +1,4 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :basics:isIndexed=true
+PASS :basics:isIndexed=false
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2016,7 +2016,7 @@ webkit.org/b/263575 [ Sonoma+ Debug ] fast/text/glyph-display-lists/glyph-displa
 
 # WebGPU
 http/tests/webgpu/webgpu/api/operation/rendering/stencil.html [ Pass ]
-
+http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/rendering/draw.html [ Pass ]
 
 webkit.org/b/263738 fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 71b872759d268b2f893106e626c1f12e5cace990
<pre>
[WebGPU] Enable webgpu:api,operation,rendering,indirect_draw:*
<a href="https://bugs.webkit.org/show_bug.cgi?id=263535">https://bugs.webkit.org/show_bug.cgi?id=263535</a>
&lt;radar://117359104&gt;

Reviewed by Dan Glastonbury.

Enable this test which is passing.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw-expected.txt:

Canonical link: <a href="https://commits.webkit.org/269846@main">https://commits.webkit.org/269846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db6e0428bd1b6c7f6f7b694a6924faf8f33973ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21929 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24282 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26522 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27720 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25501 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18860 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1164 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5687 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->