### PR TITLE
Provide a getter for webViewConfiguration on _WKWebExtensionContext.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -67,6 +67,15 @@
 /* Extension's process name that appears in Activity Monitor where the parameter is the name of the extension */
 "%@ Web Extension" = "%@ Web Extension";
 
+/* Extension's process name for background content that appears in Activity Monitor where the parameter is the name of the extension */
+"%@ Web Extension Background Content" = "%@ Web Extension Background Content";
+
+/* Extension's process name for popups that appears in Activity Monitor where the parameter is the name of the extension */
+"%@ Web Extension Popup" = "%@ Web Extension Popup";
+
+/* Extension's process name for tabs that appears in Activity Monitor where the parameter is the name of the extension */
+"%@ Web Extension Tab" = "%@ Web Extension Tab";
+
 /* Visible name of Web Inspector's web process. The argument is the application name. */
 "%@ Web Inspector" = "%@ Web Inspector";
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -121,6 +121,7 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     LazyInitialized<RetainPtr<WKPreferences>> _preferences;
     LazyInitialized<RetainPtr<WKUserContentController>> _userContentController;
 #if ENABLE(WK_WEB_EXTENSIONS)
+    RetainPtr<NSURL> _requiredWebExtensionBaseURL;
     RetainPtr<_WKWebExtensionController> _webExtensionController;
     WeakObjCPtr<_WKWebExtensionController> _weakWebExtensionController;
 #endif
@@ -411,6 +412,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+    configuration._requiredWebExtensionBaseURL = self._requiredWebExtensionBaseURL;
+
     if (auto *controller = self->_webExtensionController.get())
         configuration._webExtensionController = controller;
 
@@ -522,6 +525,22 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)setUserContentController:(WKUserContentController *)userContentController
 {
     _userContentController.set(userContentController);
+}
+
+- (NSURL *)_requiredWebExtensionBaseURL
+{
+#if ENABLE(WK_WEB_EXTENSIONS)
+    return _requiredWebExtensionBaseURL.get();
+#else
+    return nil;
+#endif
+}
+
+- (void)_setRequiredWebExtensionBaseURL:(NSURL *)baseURL
+{
+#if ENABLE(WK_WEB_EXTENSIONS)
+    _requiredWebExtensionBaseURL = baseURL;
+#endif
 }
 
 - (_WKWebExtensionController *)_strongWebExtensionController

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -61,6 +61,10 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 @property (nonatomic, strong, setter=_setVisitedLinkStore:) _WKVisitedLinkStore *_visitedLinkStore;
 
+// Specifies the base URL that the web view must use for navigation. Navigation to URLs not matching this base URL will result in a navigation error.
+// When not set, the web view allows navigation to any URL that isn't a web extension URL. This is needed to ensure proper configuration of the web view.
+@property (nonatomic, strong, setter=_setRequiredWebExtensionBaseURL:) NSURL *_requiredWebExtensionBaseURL;
+
 @property (nonatomic, strong, readonly) _WKWebExtensionController *_strongWebExtensionController;
 @property (nonatomic, weak, setter=_setWeakWebExtensionController:) _WKWebExtensionController *_weakWebExtensionController;
 @property (nonatomic, strong, setter=_setWebExtensionController:) _WKWebExtensionController *_webExtensionController;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -31,6 +31,7 @@
 #import <WebKit/_WKWebExtensionPermission.h>
 #import <WebKit/_WKWebExtensionTab.h>
 
+@class WKWebViewConfiguration;
 @class _WKWebExtension;
 @class _WKWebExtensionAction;
 @class _WKWebExtensionController;
@@ -164,10 +165,8 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 /*!
  @abstract An unique identifier used to distinguish the extension from other extensions and target it for messages.
  @discussion The default value is a unique value that matches the host in the default base URL. The identifier can be any
- value that is unique. Setting is only allowed when the context is not loaded.
-
- This value is accessible by the extension via `browser.runtime.id` and is used for messaging the extension as the first
- argument of `browser.runtime.sendMessage(extensionId, message, options)`.
+ value that is unique. Setting is only allowed when the context is not loaded. This value is accessible by the extension via
+ `browser.runtime.id` and is used for messaging the extension via `browser.runtime.sendMessage()`.
  */
 @property (nonatomic, copy) NSString *uniqueIdentifier;
 
@@ -179,10 +178,21 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @property (nonatomic, getter=isInspectable) BOOL inspectable;
 
 /*!
+ @abstract The web view configuration to use for web views that load pages from this extension.
+ @discussion Returns a customized copy of the configuration, originally set in the web extension controller configuration, for this extension.
+ The app must use this configuration when initializing web views intended to navigate to a URL originating from this extension's base URL.
+ The app must also swap web views in tabs when navigating to and from web extension URLs. This property returns `nil` if the context isn't
+ associated with a web extension controller. The returned configuration copy can be customized prior to web view initialization.
+ @note Navigations will fail if a web view using this configuration attempts to navigate to a URL that doesn't originate from this extension's
+ base URL. Similarly, navigations will be canceled if a web view not configured with this configuration attempts to navigate to a URL that does
+ originate from this extension's base URL.
+ */
+@property (nonatomic, readonly, copy, nullable) WKWebViewConfiguration *webViewConfiguration;
+
+/*!
  @abstract The currently granted permissions and their expiration dates.
  @discussion Permissions that don't expire will have a distant future date. This will never include expired entries at time of access.
  Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
-
  Permissions in this dictionary should be explicitly granted by the user before being added. Any permissions in this collection will not be
  presented for approval again until they expire.
  @seealso setPermissionStatus:forPermission:
@@ -194,7 +204,6 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract The currently granted permission match patterns and their expiration dates.
  @discussion Match patterns that don't expire will have a distant future date. This will never include expired entries at time of access.
  Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
-
  Match patterns in this dictionary should be explicitly granted by the user before being added. Any match pattern in this collection will not be
  presented for approval again until they expire.
  @seealso setPermissionStatus:forMatchPattern:
@@ -206,7 +215,6 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract The currently denied permissions and their expiration dates.
  @discussion Permissions that don't expire will have a distant future date. This will never include expired entries at time of access.
  Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
-
  Permissions in this dictionary should be explicitly denied by the user before being added. Any match pattern in this collection will not be
  presented for approval again until they expire.
  @seealso setPermissionStatus:forPermission:
@@ -218,7 +226,6 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract The currently denied permission match patterns and their expiration dates.
  @discussion Match patterns that don't expire will have a distant future date. This will never include expired entries at time of access.
  Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
-
  Match patterns in this dictionary should be explicitly denied by the user before being added. Any match pattern in this collection will not be
  presented for approval again until they expire.
  @seealso setPermissionStatus:forMatchPattern:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -140,6 +140,11 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
     _webExtensionContext->setInspectable(inspectable);
 }
 
+- (WKWebViewConfiguration *)webViewConfiguration
+{
+    return _webExtensionContext->webViewConfiguration(WebKit::WebExtensionContext::WebViewPurpose::Tab);
+}
+
 static inline WallTime toImpl(NSDate *date)
 {
     NSCParameterAssert(!date || [date isKindOfClass:NSDate.class]);
@@ -810,6 +815,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 
 - (void)setInspectable:(BOOL)inspectable
 {
+}
+
+- (WKWebViewConfiguration *)webViewConfiguration
+{
+    return nil;
 }
 
 - (NSDictionary<_WKWebExtensionPermission, NSDate *> *)grantedPermissions

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -101,6 +101,16 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 - (nullable _WKWebExtensionContext *)extensionContextForExtension:(_WKWebExtension *)extension NS_SWIFT_NAME(extensionContext(for:));
 
 /*!
+ @abstract Returns a loaded extension context matching the specified URL.
+ @param URL The URL to lookup.
+ @result An extension context or `nil` if no match was found.
+ @discussion This method is useful for determining the extension context to use when about to navigate to an extension URL. For example,
+ you could use this method to retrieve the appropriate extension context and then use its `webViewConfiguration` property to configure a
+ web view for loading that URL.
+ */
+- (nullable _WKWebExtensionContext *)extensionContextForURL:(NSURL *)URL NS_SWIFT_NAME(extensionContext(for:));
+
+/*!
  @abstract A set of all the currently loaded extensions.
  @seealso extensionContexts
 */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -99,6 +99,15 @@
     return nil;
 }
 
+- (_WKWebExtensionContext *)extensionContextForURL:(NSURL *)url
+{
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
+
+    if (auto extensionContext = _webExtensionController->extensionContext(url))
+        return extensionContext->wrapper();
+    return nil;
+}
+
 template<typename T>
 static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
@@ -257,6 +266,11 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 }
 
 - (_WKWebExtensionContext *)extensionContextForExtension:(_WKWebExtension *)extension
+{
+    return nil;
+}
+
+- (_WKWebExtensionContext *)extensionContextForURL:(NSURL *)url
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -236,7 +236,7 @@ WKWebView *WebExtensionAction::popupWebView(LoadOnFirstAccess loadOnFirstAccess)
     if (m_popupWebView || loadOnFirstAccess == LoadOnFirstAccess::No)
         return m_popupWebView.get();
 
-    auto *webViewConfiguration = extensionContext()->webViewConfiguration();
+    auto *webViewConfiguration = extensionContext()->webViewConfiguration(WebExtensionContext::WebViewPurpose::Popup);
     webViewConfiguration.suppressesIncrementalRendering = YES;
 
     m_popupWebViewDelegate = [[_WKWebExtensionActionWebViewDelegate alloc] initWithWebExtensionAction:*this];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -637,13 +637,6 @@ NSArray *WebExtension::errors()
     return [m_errors copy] ?: @[ ];
 }
 
-NSString *WebExtension::webProcessDisplayName()
-{
-ALLOW_NONLITERAL_FORMAT_BEGIN
-    return [NSString stringWithFormat:WEB_UI_STRING("%@ Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension"), displayShortName()];
-ALLOW_NONLITERAL_FORMAT_END
-}
-
 _WKWebExtensionLocalization *WebExtension::localization()
 {
     if (!manifestParsedSuccessfully())

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -34,9 +34,11 @@
 
 #import "APIFrameInfo.h"
 #import "WKURLSchemeTaskInternal.h"
+#import "WKWebViewConfigurationPrivate.h"
 #import "WebExtension.h"
 #import "WebExtensionContext.h"
 #import "WebExtensionController.h"
+#import "WebPageProxy.h"
 #import "WebURLSchemeTask.h"
 #import "_WKWebExtensionLocalization.h"
 #import <UniformTypeIdentifiers/UTType.h>
@@ -55,7 +57,7 @@ WebExtensionURLSchemeHandler::WebExtensionURLSchemeHandler(WebExtensionControlle
 
 void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLSchemeTask& task)
 {
-    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([this, &task, protectedThis = Ref { *this }, protectedTask = Ref { task }]() {
+    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([this, &task, &page, protectedThis = Ref { *this }, protectedTask = Ref { task }, protectedPage = Ref { page }]() {
         // If a frame is loading, the frame request URL will be an empty string, since the request is actually the frame URL being loaded.
         // In this case, consider the firstPartyForCookies() to be the document including the frame. This fails for nested frames, since
         // it is always the main frame URL, not the immediate parent frame.
@@ -82,6 +84,14 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
         if (!protocolHostAndPortAreEqual(frameDocumentURL, requestURL)) {
             if (!extensionContext->extension().isAccessibleResourcePath(requestURL.path().toString(), frameDocumentURL)) {
                 task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:noPermissionErrorCode userInfo:nil]);
+                return;
+            }
+        }
+
+        if (task.frameInfo().isMainFrame() && requestURL == frameDocumentURL) {
+            auto *requiredBaseURL = page.cocoaView().get().configuration._requiredWebExtensionBaseURL;
+            if (!requiredBaseURL || !extensionContext->isURLForThisExtension(requiredBaseURL)) {
+                task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorResourceUnavailable userInfo:nil]);
                 return;
             }
         }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -147,7 +147,7 @@ public:
     Ref<API::Data> serializeManifest();
 
     double manifestVersion();
-    bool supportsManifestVersion(double version) { return manifestVersion() >= version; }
+    bool supportsManifestVersion(double version) { ASSERT(version > 2); return manifestVersion() >= version; }
 
     Ref<API::Data> serializeLocalization();
 
@@ -164,8 +164,6 @@ public:
 
     NSString *resourceStringForPath(NSString *, CacheResult = CacheResult::No);
     NSData *resourceDataForPath(NSString *, CacheResult = CacheResult::No);
-
-    NSString *webProcessDisplayName();
 
     _WKWebExtensionLocalization *localization();
     NSLocale *defaultLocale();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -170,6 +170,13 @@ public:
         BrowserUpdate,
     };
 
+    enum class WebViewPurpose : uint8_t {
+        Any,
+        Background,
+        Popup,
+        Tab,
+    };
+
     WebExtensionContextIdentifier identifier() const { return m_identifier; }
     WebExtensionContextParameters parameters() const;
 
@@ -308,7 +315,9 @@ public:
     UserStyleSheetVector& dynamicallyInjectedUserStyleSheets() { return m_dynamicallyInjectedUserStyleSheets; };
 
     WKWebView *relatedWebView();
-    WKWebViewConfiguration *webViewConfiguration();
+    NSString *processDisplayName(WebViewPurpose = WebViewPurpose::Any);
+    NSArray *corsDisablingPatterns();
+    WKWebViewConfiguration *webViewConfiguration(WebViewPurpose = WebViewPurpose::Any);
 
     void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet, CompletionHandler<void()>&&);
 


### PR DESCRIPTION
#### 82de229ab5a54e1441857befa56fa9cab65b1e8e
<pre>
Provide a getter for webViewConfiguration on _WKWebExtensionContext.
<a href="https://webkit.org/b/263533">https://webkit.org/b/263533</a>
rdar://problem/117359849

Reviewed by Brian Weinstein.

Add API for obtaining correct WKWebViewConfiguration for web extension content in tabs.
Flesh out the remaining web view configuration properties needed, and provide configurations
for distinct web view purposes with different process names in manifest v3.

To make sure the app uses the right configuration, make extension URL load fail if they are not
using the right configuration, and prevent extension configured views from loading other URLs.

* Source/WebCore/en.lproj/Localizable.strings: Updated.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration copyWithZone:]): Copy _requiredWebExtensionBaseURL.
(-[WKWebViewConfiguration _requiredWebExtensionBaseURL]): Added.
(-[WKWebViewConfiguration _setRequiredWebExtensionBaseURL:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext webViewConfiguration]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController extensionContextForURL:]): Added.
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::isUnsupportedWebExtensionNavigation): Added.
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction): Call isUnsupportedWebExtensionNavigation.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::popupWebView): Pass a WebViewPurpose for the configuration.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::webProcessDisplayName): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::relatedWebView): Return nil for v3 and later. Simplify by looking at all known pages that
have the extension URL loaded, so it catches tab pages too.
(WebKit::WebExtensionContext::processDisplayName): Added.
(WebKit::WebExtensionContext::corsDisablingPatterns): Added.
(WebKit::WebExtensionContext::webViewConfiguration): Expanded and added WebViewPurpose.
(WebKit::WebExtensionContext::loadBackgroundWebView): Pass a WebViewPurpose for the configuration.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask): Return an error when loading an extension URL in the main frame
of a improperly configured web view.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::supportsManifestVersion): Added an ASSERT to catch a mistake that I keep making where passing 2
is invalid since that will be true for all extensions.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/269669@main">https://commits.webkit.org/269669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b9bd80c3811c7bce704c40b730a4bf0f471be67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24334 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23752 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25977 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21003 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25041 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1119 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2950 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->