### PR TITLE
wasm.yaml/wasm/lowExecutableMemory/imports-oom.js.default-wasm is a flaky failure

### DIFF
--- a/JSTests/wasm/lowExecutableMemory/exports-oom.js
+++ b/JSTests/wasm/lowExecutableMemory/exports-oom.js
@@ -1,6 +1,5 @@
 // FIXME: Consider making jump islands work with Options::jitMemoryReservationSize
 // https://bugs.webkit.org/show_bug.cgi?id=209037
-//@ skip
 
 import * as assert from '../assert.js'
 import Builder from '../Builder.js'

--- a/JSTests/wasm/lowExecutableMemory/imports-oom.js
+++ b/JSTests/wasm/lowExecutableMemory/imports-oom.js
@@ -1,6 +1,5 @@
 // FIXME: Consider making jump islands work with Options::jitMemoryReservationSize
 // https://bugs.webkit.org/show_bug.cgi?id=209037
-//@ skip
 
 import * as assert from '../assert.js'
 import Builder from '../Builder.js'

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -76,6 +76,11 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     RefPtr<CalleeGroup> protectedThis = this;
     if (Options::useWasmLLInt()) {
         m_plan = adoptRef(*new LLIntPlan(vm, moduleInformation, m_llintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
+            if (!m_plan) {
+                m_errorMessage = makeString("Out of memory while creating LLInt CalleeGroup"_s);
+                setCompilationFinished();
+                return;
+            }
             Locker locker { m_lock };
             if (m_plan->failed()) {
                 m_errorMessage = m_plan->errorMessage();


### PR DESCRIPTION
#### 551c2ebfb07ae634e4e893c2fa4ecefda920bbc9
<pre>
wasm.yaml/wasm/lowExecutableMemory/imports-oom.js.default-wasm is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244122">https://bugs.webkit.org/show_bug.cgi?id=244122</a>
rdar://98882300

Reviewed by Justin Michaud.

Fixed two issues.
1) If we run out of memory when creating a LLIntPlan in the CalleeGroup constructor, we now error out.
2) If we run out of memory when compiling / linking the JS to Wasm IC callee, we error out instead of
   creating a JSToWasmICCallee that doesn&apos;t have and entrypoint.

Re-enabled exports-oom.js and imports-oom.js tests.

* JSTests/wasm/lowExecutableMemory/exports-oom.js:
* JSTests/wasm/lowExecutableMemory/imports-oom.js:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):

Canonical link: <a href="https://commits.webkit.org/269682@main">https://commits.webkit.org/269682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4299f28c3b8b7d8cd26b925b5f29ee4e47ce49b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24377 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23811 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23490 "Failed to checkout and rebase branch from PR 19433") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26022 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21029 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20233 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21287 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22611 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29991 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/685 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6198 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5548 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29943 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/986 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6092 "Found 1 new JSC stress test failure: microbenchmarks/array-from-object-func.js.lockdown (failure)") | 
<!--EWS-Status-Bubble-End-->