### PR TITLE
Form associated ElementInternals always reports customError when using setValidity

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html
@@ -170,6 +170,11 @@ test(() => {
   assert_false(validity.valid);
   assert_equals(control.i.validationMessage, 'customError message');
 
+  control.i.setValidity({valueMissing: true, customError: false}, 'valueMissing message');
+  assert_false(validity.customError, 'customError should be false.');
+  assert_false(validity.valid);
+  assert_equals(control.i.validationMessage, 'valueMissing message');
+
   // Set multiple flags
   control.i.setValidity({badInput: true, customError: true}, 'multiple errors');
   assert_true(validity.badInput);

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -65,7 +65,8 @@ ExceptionOr<void> FormAssociatedCustomElement::setValidity(ValidityStateFlags va
         return Exception { ExceptionCode::TypeError };
 
     m_validityStateFlags = validityStateFlags;
-    setCustomValidity(validityStateFlags.isValid() ? emptyString() : WTFMove(message));
+    m_validationMessage = message.isNull() || validityStateFlags.isValid() ? emptyString() : WTFMove(message);
+    setCustomValidity(validityStateFlags.customError ? message : emptyString());
 
     if (validationAnchor && !validationAnchor->isDescendantOrShadowDescendantOf(*m_element))
         return Exception { ExceptionCode::NotFoundError };
@@ -78,7 +79,7 @@ ExceptionOr<void> FormAssociatedCustomElement::setValidity(ValidityStateFlags va
 String FormAssociatedCustomElement::validationMessage() const
 {
     ASSERT(m_element->isPrecustomizedOrDefinedCustomElement());
-    return customValidationMessage();
+    return m_validationMessage;
 }
 
 ALWAYS_INLINE static CustomElementFormValue cloneIfIsFormData(CustomElementFormValue&& value)

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -97,6 +97,7 @@ private:
 
     WeakPtr<HTMLMaybeFormAssociatedCustomElement, WeakPtrImplWithEventTargetData> m_element;
     ValidityStateFlags m_validityStateFlags;
+    String m_validationMessage;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_validationAnchor { nullptr };
     CustomElementFormValue m_submissionValue { nullptr };
     CustomElementFormValue m_state { nullptr };


### PR DESCRIPTION
#### 2b9f4fab602fcc6be627dd66f6719cd31673093c
<pre>
Form associated ElementInternals always reports customError when using setValidity
<a href="https://bugs.webkit.org/show_bug.cgi?id=261432">https://bugs.webkit.org/show_bug.cgi?id=261432</a>
&lt;<a href="https://rdar.apple.com/problem/115681066">rdar://problem/115681066</a>&gt;

Reviewed by NOBODY (OOPS!).

Initial form-associated custom elements implementation attempted to avoid adding a String field by
relying on m_customValidationMessage for both regular [1] and custom [2] validation messages,
which turned out to be incompatible with the implementation of FormListedElement::customError().

Rather than deepening the hack / micro-optimization, this change adds a field and precisely implements
all the spec steps for setValidity() [3].

[1] <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#face-validation-message">https://html.spec.whatwg.org/multipage/custom-elements.html#face-validation-message</a>
[2] <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#custom-validity-error-message">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#custom-validity-error-message</a>
[3] <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setvalidity">https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setvalidity</a>

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html:
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::setValidity):
(WebCore::FormAssociatedCustomElement::validationMessage const):
* Source/WebCore/html/FormAssociatedCustomElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b9f4fab602fcc6be627dd66f6719cd31673093c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56228 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14702 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42593 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76940 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18305 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63958 "Found 1 new test failure: imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63920 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5689 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1105 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->