### PR TITLE
Use a CheckedRef for SQLiteTransaction::m_db

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -189,9 +189,10 @@ bool SQLiteIDBCursor::createSQLiteStatement(StringView sql)
     ASSERT(!m_currentUpperKey.isNull());
     ASSERT(m_transaction->sqliteTransaction());
 
-    auto statement = m_transaction->sqliteTransaction()->database().prepareHeapStatementSlow(sql);
+    CheckedRef database = m_transaction->sqliteTransaction()->database();
+    auto statement = database->prepareHeapStatementSlow(sql);
     if (!statement) {
-        LOG_ERROR("Could not create cursor statement (prepare/id) - '%s'", m_transaction->sqliteTransaction()->database().lastErrorMsg());
+        LOG_ERROR("Could not create cursor statement (prepare/id) - '%s'", database->lastErrorMsg());
         return false;
     }
     m_statement = statement.value().moveToUniquePtr();
@@ -293,18 +294,18 @@ bool SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary()
     if (m_currentIndexRecordValue.isNull())
         return true;
 
-    auto& database = m_transaction->sqliteTransaction()->database();
+    CheckedRef database = m_transaction->sqliteTransaction()->database();
     if (!m_preIndexStatement) {
-        auto preIndexStatement = database.prepareHeapStatementSlow(buildPreIndexStatement(isDirectionNext()));
+        auto preIndexStatement = database->prepareHeapStatementSlow(buildPreIndexStatement(isDirectionNext()));
         if (!preIndexStatement) {
-            LOG_ERROR("Could not prepare pre statement - '%s'", database.lastErrorMsg());
+            LOG_ERROR("Could not prepare pre statement - '%s'", database->lastErrorMsg());
             return false;
         }
         m_preIndexStatement = preIndexStatement.value().moveToUniquePtr();
     }
 
     if (m_preIndexStatement->reset() != SQLITE_OK) {
-        LOG_ERROR("Could not reset pre statement - '%s'", database.lastErrorMsg());
+        LOG_ERROR("Could not reset pre statement - '%s'", database->lastErrorMsg());
         return false;
     }
 
@@ -477,7 +478,7 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
 
     record.record.value = { };
 
-    auto& database = m_transaction->sqliteTransaction()->database();
+    CheckedRef database = m_transaction->sqliteTransaction()->database();
     SQLiteStatement* statement = nullptr;
 
     int result;
@@ -488,7 +489,7 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
         if (result == SQLITE_ROW)
             statement = m_preIndexStatement.get();
         else if (result != SQLITE_DONE)
-            LOG_ERROR("Error advancing with pre statement - (%i) %s", result, database.lastErrorMsg());
+            LOG_ERROR("Error advancing with pre statement - (%i) %s", result, database->lastErrorMsg());
     }
     
     if (!statement) {
@@ -499,7 +500,7 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
             return FetchResult::Success;
         }
         if (result != SQLITE_ROW) {
-            LOG_ERROR("Error advancing cursor - (%i) %s", result, database.lastErrorMsg());
+            LOG_ERROR("Error advancing cursor - (%i) %s", result, database->lastErrorMsg());
             markAsErrored(record);
             return FetchResult::Failure;
         }
@@ -540,14 +541,14 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
         }
 
         if (!m_cachedObjectStoreStatement || m_cachedObjectStoreStatement->reset() != SQLITE_OK) {
-            if (auto cachedObjectStoreStatement = database.prepareHeapStatement("SELECT value FROM Records WHERE key = CAST(? AS TEXT) and objectStoreID = ?;"_s))
+            if (auto cachedObjectStoreStatement = database->prepareHeapStatement("SELECT value FROM Records WHERE key = CAST(? AS TEXT) and objectStoreID = ?;"_s))
                 m_cachedObjectStoreStatement = cachedObjectStoreStatement.value().moveToUniquePtr();
         }
 
         if (!m_cachedObjectStoreStatement
             || m_cachedObjectStoreStatement->bindBlob(1, keyData) != SQLITE_OK
             || m_cachedObjectStoreStatement->bindInt64(2, m_objectStoreID) != SQLITE_OK) {
-            LOG_ERROR("Could not create index cursor statement into object store records (%i) '%s'", database.lastError(), database.lastErrorMsg());
+            LOG_ERROR("Could not create index cursor statement into object store records (%i) '%s'", database->lastError(), database->lastErrorMsg());
             markAsErrored(record);
             return FetchResult::Failure;
         }
@@ -561,7 +562,7 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
             // Skip over it.
             return FetchResult::ShouldFetchAgain;
         } else {
-            LOG_ERROR("Could not step index cursor statement into object store records (%i) '%s'", database.lastError(), database.lastErrorMsg());
+            LOG_ERROR("Could not step index cursor statement into object store records (%i) '%s'", database->lastError(), database->lastErrorMsg());
             markAsErrored(record);
             return FetchResult::Failure;
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -28,12 +28,12 @@
 
 #include <functional>
 #include <sqlite3.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Expected.h>
 #include <wtf/Lock.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Threading.h>
 #include <wtf/UniqueRef.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
@@ -49,7 +49,7 @@ class DatabaseAuthorizer;
 class SQLiteStatement;
 class SQLiteTransaction;
 
-class SQLiteDatabase : public CanMakeWeakPtr<SQLiteDatabase> {
+class SQLiteDatabase : public CanMakeThreadSafeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(SQLiteDatabase);
     friend class SQLiteTransaction;

--- a/Source/WebCore/platform/sql/SQLiteTransaction.cpp
+++ b/Source/WebCore/platform/sql/SQLiteTransaction.cpp
@@ -48,7 +48,7 @@ SQLiteTransaction::~SQLiteTransaction()
 void SQLiteTransaction::begin()
 {
     if (!m_inProgress) {
-        ASSERT(!m_db.m_transactionInProgress);
+        ASSERT(!m_db->m_transactionInProgress);
         // Call BEGIN IMMEDIATE for a write transaction to acquire
         // a RESERVED lock on the DB file. Otherwise, another write
         // transaction (on another connection) could make changes
@@ -59,14 +59,14 @@ void SQLiteTransaction::begin()
         SQLiteDatabaseTracker::incrementTransactionInProgressCount();
         int result = SQLITE_OK;
         if (m_readOnly)
-            result = m_db.execute("BEGIN"_s);
+            result = m_db->execute("BEGIN"_s);
         else
-            result = m_db.execute("BEGIN IMMEDIATE"_s);
+            result = m_db->execute("BEGIN IMMEDIATE"_s);
         if (result == SQLITE_DONE)
             m_inProgress = true;
         else
             RELEASE_LOG_ERROR(SQLDatabase, "SQLiteTransaction::begin: Failed to begin transaction (error %d)", result);
-        m_db.m_transactionInProgress = m_inProgress;
+        m_db->m_transactionInProgress = m_inProgress;
         if (!m_inProgress)
             SQLiteDatabaseTracker::decrementTransactionInProgressCount();
     } else
@@ -76,9 +76,9 @@ void SQLiteTransaction::begin()
 void SQLiteTransaction::commit()
 {
     if (m_inProgress) {
-        ASSERT(m_db.m_transactionInProgress);
-        m_inProgress = !m_db.executeCommand("COMMIT"_s);
-        m_db.m_transactionInProgress = m_inProgress;
+        ASSERT(m_db->m_transactionInProgress);
+        m_inProgress = !m_db->executeCommand("COMMIT"_s);
+        m_db->m_transactionInProgress = m_inProgress;
         if (!m_inProgress)
             SQLiteDatabaseTracker::decrementTransactionInProgressCount();
     }
@@ -86,15 +86,15 @@ void SQLiteTransaction::commit()
 
 void SQLiteTransaction::rollback()
 {
-    // We do not use the 'm_inProgress = m_db.executeCommand("ROLLBACK")' construct here,
+    // We do not use the 'm_inProgress = m_db->executeCommand("ROLLBACK")' construct here,
     // because m_inProgress should always be set to false after a ROLLBACK, and
-    // m_db.executeCommand("ROLLBACK") can sometimes harmlessly fail, thus returning
+    // m_db->executeCommand("ROLLBACK") can sometimes harmlessly fail, thus returning
     // a non-zero/true result (http://www.sqlite.org/lang_transaction.html).
     if (m_inProgress) {
-        ASSERT(m_db.m_transactionInProgress);
-        m_db.executeCommand("ROLLBACK"_s);
+        ASSERT(m_db->m_transactionInProgress);
+        m_db->executeCommand("ROLLBACK"_s);
         m_inProgress = false;
-        m_db.m_transactionInProgress = false;
+        m_db->m_transactionInProgress = false;
         SQLiteDatabaseTracker::decrementTransactionInProgressCount();
     }
 }
@@ -103,7 +103,7 @@ void SQLiteTransaction::stop()
 {
     if (m_inProgress) {
         m_inProgress = false;
-        m_db.m_transactionInProgress = false;
+        m_db->m_transactionInProgress = false;
         SQLiteDatabaseTracker::decrementTransactionInProgressCount();
     }
 }
@@ -112,7 +112,7 @@ bool SQLiteTransaction::wasRolledBackBySqlite() const
 {
     // According to http://www.sqlite.org/c3ref/get_autocommit.html,
     // the auto-commit flag should be off in the middle of a transaction
-    return m_inProgress && m_db.isAutoCommitOn();
+    return m_inProgress && m_db->isAutoCommitOn();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/sql/SQLiteTransaction.h
+++ b/Source/WebCore/platform/sql/SQLiteTransaction.h
@@ -26,6 +26,7 @@
 #ifndef SQLiteTransaction_h
 #define SQLiteTransaction_h
 
+#include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 
@@ -47,10 +48,10 @@ public:
     bool inProgress() const { return m_inProgress; }
     WEBCORE_EXPORT bool wasRolledBackBySqlite() const;
 
-    SQLiteDatabase& database() const { return m_db; }
+    SQLiteDatabase& database() const { return m_db.get(); }
 
 private:
-    SQLiteDatabase& m_db;
+    CheckedRef<SQLiteDatabase> m_db;
     bool m_inProgress;
     bool m_readOnly;
 };


### PR DESCRIPTION
#### 9405d3e158f78bd8ac3f2ad1749dfea70623fb8d
<pre>
Use a CheckedRef for SQLiteTransaction::m_db
<a href="https://bugs.webkit.org/show_bug.cgi?id=263539">https://bugs.webkit.org/show_bug.cgi?id=263539</a>
rdar://117364281

Reviewed by Sihui Liu and Chris Dumez.

Also remove `CanMakeWeakPtr&lt;SQLiteDatabase&gt;` since it&apos;s not used.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::createSQLiteStatement):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary):
(WebCore::IDBServer::SQLiteIDBCursor::internalFetchNextRecord):
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebCore/platform/sql/SQLiteTransaction.cpp:
(WebCore::SQLiteTransaction::begin):
(WebCore::SQLiteTransaction::commit):
(WebCore::SQLiteTransaction::rollback):
(WebCore::SQLiteTransaction::stop):
(WebCore::SQLiteTransaction::wasRolledBackBySqlite const):
* Source/WebCore/platform/sql/SQLiteTransaction.h:
(WebCore::SQLiteTransaction::database const):

Canonical link: <a href="https://commits.webkit.org/269697@main">https://commits.webkit.org/269697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fc91a0db7320e4389209d15151c38f1110eb5ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24352 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21468 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23771 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25995 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27175 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21276 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25049 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18483 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1140 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2969 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->