### PR TITLE
Use `_UITextCursorDragAnimator` to animate the caret view when dropping over editable content

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1664,3 +1664,7 @@
 #if !PLATFORM(WATCHOS) && __has_include(<UIKit/_UIContextMenuAsyncConfiguration.h>)
 #define HAVE_UI_CONTEXT_MENU_ASYNC_CONFIGURATION 1
 #endif
+
+#if !PLATFORM(APPLETV) && !PLATFORM(WATCHOS) && __has_include(<UIKit/_UITextCursorDragAnimator.h>)
+#define HAVE_UI_TEXT_CURSOR_DRAG_ANIMATOR 1
+#endif

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -132,6 +132,10 @@
 #import <UIKit/_UIContextMenuAsyncConfiguration.h>
 #endif
 
+#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
+#import <UIKit/_UITextCursorDragAnimator.h>
+#endif
+
 #if HAVE(UIFINDINTERACTION)
 #import <UIKit/UIFindSession_Private.h>
 #import <UIKit/_UIFindInteraction.h>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -140,6 +140,7 @@ class WebPageProxy;
 @class UIPointerRegion;
 @class UITargetedPreview;
 @class _UILookupGestureRecognizer;
+@class _UITextCursorDragAnimator;
 
 #if HAVE(PEPPER_UI_CORE)
 @class PUICQuickboardViewController;
@@ -508,6 +509,10 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<UIView> _unselectedContentSnapshot;
     RetainPtr<_UITextDragCaretView> _editDropCaretView;
     BlockPtr<void()> _actionToPerformAfterReceivingEditDragSnapshot;
+#endif
+#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
+    RetainPtr<UIView<UITextCursorView>> _editDropTextCursorView;
+    RetainPtr<_UITextCursorDragAnimator> _editDropCaretAnimator;
 #endif
 
 #if HAVE(PEPPER_UI_CORE)


### PR DESCRIPTION
#### f5b5a33d6f129ebae5acab64dfff3e0e481283b7
<pre>
Use `_UITextCursorDragAnimator` to animate the caret view when dropping over editable content
<a href="https://bugs.webkit.org/show_bug.cgi?id=263540">https://bugs.webkit.org/show_bug.cgi?id=263540</a>
rdar://114331535

Reviewed by Megan Gardner.

Adopt `_UITextCursorDragAnimator` and use it to display the &quot;drop caret&quot; when hovering over an
editable element on iOS, with an active drag session (we currently use `_UITextDragCaretView`). The
new animator works similarly, taking `UITextPosition`s that can be used to update the caret position
when the drop position changes; however, it must be initialized with a `UIView&lt;UITextCursorView&gt;`,
which we can indirectly create by

* Source/WTF/wtf/PlatformHave.h:

Add a new compile-time flag.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Import the requisite header for `_UITextCursorDragAnimator`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _shouldUseTextCursorDragAnimator]):

Use the new animator only if `UseAsyncUIKitInteractions` is set, and the animator class is available
at runtime.

(-[WKContentView cleanUpDragSourceSessionState]):
(-[WKContentView _insertDropCaret:]):
(-[WKContentView _removeDropCaret]):

Consolidate logic for tearing down the drop caret in a single method, now that it needs to take care
of both the legacy `_UITextDragCaretView` and the modern `_UITextCursorDragAnimator` /
`UIView&lt;UITextCursorView&gt;`.

(-[WKContentView _didChangeDragCaretRect:currentRect:]):

Canonical link: <a href="https://commits.webkit.org/269681@main">https://commits.webkit.org/269681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fbe6ebfb2f6a740330965c53fefc9abb5343178

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24353 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21469 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23772 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25996 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27178 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20220 "Found 1 new JSC binary failure: testapi (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21279 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22596 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/725 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29975 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/664 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5549 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1141 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29927 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/939 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6088 "Passed tests") | 
<!--EWS-Status-Bubble-End-->