### PR TITLE
Generate serialization of WebCore::ScrollingStateTree

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -44,12 +44,12 @@ class ScrollingStateTree {
     WTF_MAKE_FAST_ALLOCATED;
     friend class ScrollingStateNode;
 public:
+    WEBCORE_EXPORT static std::optional<ScrollingStateTree> createAfterReconstruction(bool, bool, RefPtr<ScrollingStateFrameScrollingNode>&&);
     WEBCORE_EXPORT ScrollingStateTree(AsyncScrollingCoordinator* = nullptr);
     WEBCORE_EXPORT ScrollingStateTree(ScrollingStateTree&&);
     WEBCORE_EXPORT ~ScrollingStateTree();
 
     WEBCORE_EXPORT RefPtr<ScrollingStateFrameScrollingNode> rootStateNode() const;
-    WEBCORE_EXPORT bool setRootStateNodeAfterReconstruction(RefPtr<ScrollingStateFrameScrollingNode>&&);
     WEBCORE_EXPORT RefPtr<ScrollingStateNode> stateNodeForID(ScrollingNodeID) const;
 
     ScrollingNodeID createUnparentedNode(ScrollingNodeType, ScrollingNodeID);
@@ -94,6 +94,8 @@ public:
     String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior>) const;
 
 private:
+    ScrollingStateTree(bool hasNewRootStateNode, bool hasChangedProperties, RefPtr<ScrollingStateFrameScrollingNode>&&);
+
     void setRootStateNode(Ref<ScrollingStateFrameScrollingNode>&&);
     void addNode(ScrollingStateNode&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -47,24 +47,9 @@
 namespace IPC {
 using namespace WebCore;
 
-template<> struct ArgumentCoder<ScrollingStateNode> {
-    static void encode(Encoder&, const ScrollingStateNode&);
-    static std::optional<Ref<ScrollingStateNode>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<ScrollingStateScrollingNode> {
-    static void encode(Encoder&, const ScrollingStateScrollingNode&);
-    static std::optional<Ref<ScrollingStateScrollingNode>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<ScrollingStateFrameHostingNode> {
     static void encode(Encoder&, const ScrollingStateFrameHostingNode&);
     static std::optional<Ref<ScrollingStateFrameHostingNode>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<ScrollingStateFrameScrollingNode> {
-    static void encode(Encoder&, const ScrollingStateFrameScrollingNode&);
-    static std::optional<Ref<ScrollingStateFrameScrollingNode>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<ScrollingStateOverflowScrollingNode> {
@@ -614,37 +599,6 @@ std::optional<Ref<ScrollingStatePositionedNode>> ArgumentCoder<ScrollingStatePos
     }
 
     return WTFMove(node);
-}
-
-void ArgumentCoder<WebCore::ScrollingStateTree>::encode(Encoder& encoder, const WebCore::ScrollingStateTree& tree)
-{
-    encoder << tree.hasNewRootStateNode();
-    encoder << tree.hasChangedProperties();
-    encoder << tree.rootStateNode();
-}
-
-std::optional<WebCore::ScrollingStateTree> ArgumentCoder<WebCore::ScrollingStateTree>::decode(Decoder& decoder)
-{
-    bool hasNewRootNode;
-    if (!decoder.decode(hasNewRootNode))
-        return std::nullopt;
-
-    bool hasChangedProperties;
-    if (!decoder.decode(hasChangedProperties))
-        return std::nullopt;
-
-    ScrollingStateTree scrollingStateTree;
-    scrollingStateTree.setHasChangedProperties(hasChangedProperties);
-
-    auto rootNode = decoder.decode<RefPtr<ScrollingStateFrameScrollingNode>>();
-    if (!rootNode)
-        return std::nullopt;
-    if (!scrollingStateTree.setRootStateNodeAfterReconstruction(WTFMove(*rootNode)))
-        return std::nullopt;
-
-    scrollingStateTree.setHasNewRootStateNode(hasNewRootNode);
-
-    return { WTFMove(scrollingStateTree) };
 }
 
 namespace WebKit {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -36,6 +36,8 @@ class Encoder;
 }
 
 namespace WebCore {
+class ScrollingStateFrameScrollingNode;
+class ScrollingStateNode;
 class ScrollingStateTree;
 }
 
@@ -71,9 +73,13 @@ private:
 } // namespace WebKit
 
 namespace IPC {
-template<> struct ArgumentCoder<WebCore::ScrollingStateTree> {
-    static void encode(Encoder&, const WebCore::ScrollingStateTree&);
-    static std::optional<WebCore::ScrollingStateTree> decode(Decoder&);
+template<> struct ArgumentCoder<WebCore::ScrollingStateNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateNode&);
+    static std::optional<Ref<WebCore::ScrollingStateNode>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::ScrollingStateFrameScrollingNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateFrameScrollingNode&);
+    static std::optional<Ref<WebCore::ScrollingStateFrameScrollingNode>> decode(Decoder&);
 };
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -26,3 +26,9 @@ class WebKit::RemoteScrollingCoordinatorTransaction {
     std::unique_ptr<WebCore::ScrollingStateTree> scrollingStateTree()
     bool clearScrollLatching()
 }
+
+[CreateUsing=createAfterReconstruction] class WebCore::ScrollingStateTree {
+    bool hasNewRootStateNode()
+    bool hasChangedProperties()
+    RefPtr<WebCore::ScrollingStateFrameScrollingNode> rootStateNode()
+}


### PR DESCRIPTION
#### 436992c4ce4856215fba08285c950dd07794e599
<pre>
Generate serialization of WebCore::ScrollingStateTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=263543">https://bugs.webkit.org/show_bug.cgi?id=263543</a>
rdar://117366227

Reviewed by Brady Eidson.

Move logic around a little, but no change in behavior

* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::createAfterReconstruction):
(WebCore::ScrollingStateTree::ScrollingStateTree):
(WebCore::ScrollingStateTree::attachDeserializedNodes):
(WebCore::ScrollingStateTree::setRootStateNodeAfterReconstruction): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;WebCore::ScrollingStateTree&gt;::encode): Deleted.
(ArgumentCoder&lt;WebCore::ScrollingStateTree&gt;::decode): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:

Canonical link: <a href="https://commits.webkit.org/269699@main">https://commits.webkit.org/269699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f57f944e8485f6f9666e4ddba2af0c3cd8cfe752

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24374 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23808 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26019 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27184 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21288 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25066 "Found 1 new API test failure: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18491 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1149 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2970 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->