### PR TITLE
[WGSL] Allow pointer operators on assignment targets

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -974,6 +974,11 @@ Result<AST::Statement::Ref> Parser<Lexer>::parseStatement()
         CONSUME_TYPE(Semicolon);
         return { variableUpdatingStatement };
     }
+    case TokenType::ParenLeft:
+    case TokenType::And:
+    case TokenType::Star: {
+        return parseVariableUpdatingStatement();
+    }
     case TokenType::KeywordFor: {
         // FIXME: Handle attributes attached to statement.
         return parseForStatement();
@@ -1538,7 +1543,13 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseLHSExpression()
 {
     START_PARSE();
 
-    // FIXME: Add the possibility of a prefix
+    if (current().type == TokenType::And || current().type == TokenType::Star) {
+        auto op = toUnaryOperation(current());
+        consume();
+        PARSE(expression, LHSExpression);
+        RETURN_ARENA_NODE(UnaryExpression, WTFMove(expression), op);
+    }
+
     PARSE(base, CoreLHSExpression);
     return parsePostfixExpression(WTFMove(base), _startOfElementPosition);
 }

--- a/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
@@ -12,8 +12,15 @@ fn f2(x: ptr<private, i32>) -> i32
 
 fn f3(x: vec3<f32>) { }
 
-fn f4(p: ptr<function, vec2<i32>>) -> i32 {
+fn f4(p: ptr<function, vec2<i32>>) -> i32
+{
     return (*p).x;
+}
+
+fn f5(p: ptr<function, vec2<i32>>)
+{
+    *p = vec2(0);
+    (*p).x = 42;
 }
 
 var<private> global: i32;
@@ -64,6 +71,14 @@ fn testVectorAccessPrecedence()
     let x = f4(p);
 }
 
+fn testAssignment()
+{
+    var v = vec2(0);
+    let p = &v;
+    f5(p);
+    *&v = vec2(13);
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
@@ -83,4 +98,5 @@ fn main()
     testShadowedGlobalRewriting();
     testShadowedLocalRewriting();
     testVectorAccessPrecedence();
+    testAssignment();
 }


### PR DESCRIPTION
#### c02eeb8b9b22cd5effae9a654f36e61f24118beb
<pre>
[WGSL] Allow pointer operators on assignment targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=263547">https://bugs.webkit.org/show_bug.cgi?id=263547</a>
rdar://117369455

Reviewed by Mike Wyrzykowski.

The grammar allows for `*x` and `*x` to appear in the left-hand side of assignments,
but our parser did not support it yet.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseLHSExpression):
* Source/WebGPU/WGSL/tests/valid/pointers.wgsl:

Canonical link: <a href="https://commits.webkit.org/269677@main">https://commits.webkit.org/269677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be9ddf9fbd54c83adc51b5a54a02627e2a0257c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24371 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23804 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/920 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26016 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/679 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5542 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->