### PR TITLE
Wrappers of r-value Ref/RefPtr should be RetainPtr instead of autorelease

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -76,12 +76,12 @@ template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::Wrapp
     return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(Ref<ObjectClass>&& object)
+template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(Ref<ObjectClass>&& object)
 {
-    return adoptNS(wrapper(object.leakRef())).autorelease();
+    return wrapper(object.get());
 }
 
-template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(RefPtr<ObjectClass>&& object)
+template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(RefPtr<ObjectClass>&& object)
 {
     return object ? wrapper(object.releaseNonNull()) : nil;
 }

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -137,12 +137,12 @@ bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url)
 WKNavigation *WKPageLoadURLRequestReturningNavigation(WKPageRef pageRef, WKURLRequestRef urlRequestRef)
 {
     auto resourceRequest = WebKit::toImpl(urlRequestRef)->resourceRequest();
-    return WebKit::wrapper(WebKit::toImpl(pageRef)->loadRequest(WTFMove(resourceRequest)));
+    return WebKit::wrapper(WebKit::toImpl(pageRef)->loadRequest(WTFMove(resourceRequest))).autorelease();
 }
 
 WKNavigation *WKPageLoadFileReturningNavigation(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL)
 {
-    return WebKit::wrapper(WebKit::toImpl(pageRef)->loadFile(WebKit::toWTFString(fileURL), WebKit::toWTFString(resourceDirectoryURL)));
+    return WebKit::wrapper(WebKit::toImpl(pageRef)->loadFile(WebKit::toWTFString(fileURL), WebKit::toWTFString(resourceDirectoryURL))).autorelease();
 }
 
 WKWebView *WKPageGetWebView(WKPageRef page)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -66,12 +66,12 @@
 
 - (NSArray *)backList
 {
-    return WebKit::wrapper(_list->backList());
+    return WebKit::wrapper(_list->backList()).autorelease();
 }
 
 - (NSArray *)forwardList
 {
-    return WebKit::wrapper(_list->forwardList());
+    return WebKit::wrapper(_list->forwardList()).autorelease();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -78,7 +78,7 @@ static WKErrorCode toWKErrorCode(const std::error_code& error)
 + (instancetype)storeWithURL:(NSURL *)url
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return wrapper(API::ContentRuleListStore::storeWithPath(url.absoluteURL.path));
+    return wrapper(API::ContentRuleListStore::storeWithPath(url.absoluteURL.path)).autorelease();
 #else
     return nil;
 #endif
@@ -198,7 +198,7 @@ static WKErrorCode toWKErrorCode(const std::error_code& error)
 + (instancetype)storeWithURLAndLegacyFilename:(NSURL *)url
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return wrapper(API::ContentRuleListStore::storeWithPath(url.absoluteURL.path));
+    return wrapper(API::ContentRuleListStore::storeWithPath(url.absoluteURL.path)).autorelease();
 #else
     return nil;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -43,7 +43,7 @@
 
 + (WKContentWorld *)worldWithName:(NSString *)name
 {
-    return wrapper(API::ContentWorld::sharedWorldWithName(name));
+    return wrapper(API::ContentWorld::sharedWorldWithName(name)).autorelease();
 }
 
 - (void)dealloc

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -91,12 +91,12 @@
 
 - (_WKFrameHandle *)_handle
 {
-    return retainPtr(wrapper(_frameInfo->handle())).autorelease();
+    return wrapper(_frameInfo->handle()).autorelease();
 }
 
 - (_WKFrameHandle *)_parentFrameHandle
 {
-    return retainPtr(wrapper(_frameInfo->parentFrameHandle())).autorelease();
+    return wrapper(_frameInfo->parentFrameHandle()).autorelease();
 }
 
 - (pid_t)_processIdentifier

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm
@@ -56,17 +56,17 @@
 
 - (NSArray<NSString *> *)_acceptedMIMETypes
 {
-    return wrapper(_openPanelParameters->acceptMIMETypes());
+    return wrapper(_openPanelParameters->acceptMIMETypes()).autorelease();
 }
 
 - (NSArray<NSString *> *)_acceptedFileExtensions
 {
-    return wrapper(_openPanelParameters->acceptFileExtensions());
+    return wrapper(_openPanelParameters->acceptFileExtensions()).autorelease();
 }
 
 - (NSArray<NSString *> *)_allowedFileExtensions
 {
-    return wrapper(_openPanelParameters->allowedFileExtensions());
+    return wrapper(_openPanelParameters->allowedFileExtensions()).autorelease();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -555,13 +555,13 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 + (NSArray<_WKFeature *> *)_features
 {
     auto features = WebKit::WebPreferences::features();
-    return wrapper(API::Array::create(WTFMove(features)));
+    return wrapper(API::Array::create(WTFMove(features))).autorelease();
 }
 
 + (NSArray<_WKFeature *> *)_internalDebugFeatures
 {
     auto features = WebKit::WebPreferences::internalDebugFeatures();
-    return wrapper(API::Array::create(WTFMove(features)));
+    return wrapper(API::Array::create(WTFMove(features))).autorelease();
 }
 
 - (BOOL)_isEnabledForInternalDebugFeature:(_WKFeature *)feature
@@ -577,7 +577,7 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 + (NSArray<_WKExperimentalFeature *> *)_experimentalFeatures
 {
     auto features = WebKit::WebPreferences::experimentalFeatures();
-    return wrapper(API::Array::create(WTFMove(features)));
+    return wrapper(API::Array::create(WTFMove(features))).autorelease();
 }
 
 - (BOOL)_isEnabledForFeature:(_WKFeature *)feature

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -140,7 +140,7 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
 
 - (_WKProcessPoolConfiguration *)_configuration
 {
-    return wrapper(_processPool->configuration().copy());
+    return wrapper(_processPool->configuration().copy()).autorelease();
 }
 
 - (API::Object&)_apiObject
@@ -542,12 +542,12 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
 
 - (_WKDownload *)_downloadURLRequest:(NSURLRequest *)request websiteDataStore:(WKWebsiteDataStore *)dataStore originatingWebView:(WKWebView *)webView
 {
-    return [_WKDownload downloadWithDownload:wrapper(_processPool->download(*dataStore->_websiteDataStore, [webView _page], request))];
+    return [_WKDownload downloadWithDownload:wrapper(_processPool->download(*dataStore->_websiteDataStore, [webView _page], request)).get()];
 }
 
 - (_WKDownload *)_resumeDownloadFromData:(NSData *)resumeData websiteDataStore:(WKWebsiteDataStore *)dataStore  path:(NSString *)path originatingWebView:(WKWebView *)webView
 {
-    return [_WKDownload downloadWithDownload:wrapper(_processPool->resumeDownload(*dataStore->_websiteDataStore, [webView _page], API::Data::createWithoutCopying(resumeData).get(), path, WebKit::CallDownloadDidStart::No))];
+    return [_WKDownload downloadWithDownload:wrapper(_processPool->resumeDownload(*dataStore->_websiteDataStore, [webView _page], API::Data::createWithoutCopying(resumeData).get(), path, WebKit::CallDownloadDidStart::No)).get()];
 }
 
 - (void)_getActivePagesOriginsInWebProcessForTesting:(pid_t)pid completionHandler:(void(^)(NSArray<NSString *> *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -288,12 +288,12 @@ private:
 
 + (WKWebsiteDataStore *)defaultDataStore
 {
-    return wrapper(WebKit::WebsiteDataStore::defaultDataStore());
+    return wrapper(WebKit::WebsiteDataStore::defaultDataStore()).autorelease();
 }
 
 + (WKWebsiteDataStore *)nonPersistentDataStore
 {
-    return wrapper(WebKit::WebsiteDataStore::createNonPersistent());
+    return wrapper(WebKit::WebsiteDataStore::createNonPersistent()).autorelease();
 }
 
 - (instancetype)init
@@ -415,7 +415,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     if (!uuid || !uuid->isValid())
         [NSException raise:NSInvalidArgumentException format:@"Identifier (%s) is invalid for data store", String([identifier UUIDString]).utf8().data()];
 
-    return wrapper(WebKit::WebsiteDataStore::dataStoreForIdentifier(*uuid));
+    return wrapper(WebKit::WebsiteDataStore::dataStoreForIdentifier(*uuid)).autorelease();
 }
 
 + (void)removeDataStoreForIdentifier:(NSUUID *)identifier completionHandler:(void(^)(NSError *))completionHandler
@@ -552,7 +552,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
             return API::WebsiteDataRecord::create(WTFMove(websiteDataRecord));
         });
 
-        completionHandlerCopy(wrapper(API::Array::create(WTFMove(elements))));
+        completionHandlerCopy(wrapper(API::Array::create(WTFMove(elements))).get());
     });
 }
 
@@ -682,7 +682,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         Vector<RefPtr<API::Object>> apiDomains = WTF::map(loadedSubresourceDomains, [](auto& domain) {
             return RefPtr<API::Object>(API::String::create(String(domain.string())));
         });
-        completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))));
+        completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))).get());
     });
 #else
     completionHandler(nil);
@@ -722,7 +722,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         auto apiDomains = WTF::map(domains, [](auto& domain) -> RefPtr<API::Object> {
             return API::String::create(domain);
         });
-        completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))));
+        completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))).get());
     });
 #else
     completionHandler({ });
@@ -909,7 +909,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 
 - (_WKWebsiteDataStoreConfiguration *)_configuration
 {
-    return wrapper(_websiteDataStore->configuration().copy());
+    return wrapper(_websiteDataStore->configuration().copy()).autorelease();
 }
 
 + (WKNotificationManagerRef)_sharedServiceWorkerNotificationManager
@@ -939,7 +939,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         auto apiDomains = WTF::map(domains, [](auto& domain) -> RefPtr<API::Object> {
             return API::String::create(domain.string());
         });
-        completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))));
+        completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))).get());
     });
 #else
     completionHandler({ });
@@ -953,7 +953,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         auto apiSchemes = WTF::map(schemes, [](auto& scheme) -> RefPtr<API::Object> {
             return API::String::create(scheme);
         });
-        completionHandler(wrapper(API::Array::create(WTFMove(apiSchemes))));
+        completionHandler(wrapper(API::Array::create(WTFMove(apiSchemes))).get());
     });
 #else
     completionHandler({ });

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -330,7 +330,7 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 + (_WKApplicationManifest *)applicationManifestFromJSON:(NSString *)json manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
 {
     auto manifest = WebCore::ApplicationManifestParser::parse(WTF::String(json), URL(manifestURL), URL(documentURL));
-    return wrapper(API::ApplicationManifest::create(manifest));
+    return wrapper(API::ApplicationManifest::create(manifest)).autorelease();
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
@@ -46,7 +46,7 @@
 
 - (WKFrameInfo *)info
 {
-    return wrapper(API::FrameInfo::create(WebKit::FrameInfoData(_node->info()), &_node->page()));
+    return wrapper(API::FrameInfo::create(WebKit::FrameInfoData(_node->info()), &_node->page())).autorelease();
 }
 
 - (NSArray<_WKFrameTreeNode *> *)childFrames

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPosition.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPosition.mm
@@ -38,7 +38,7 @@
     if (!location)
         return nil;
 
-    return wrapper(WebKit::WebGeolocationPosition::create(WebCore::GeolocationPositionData { location }));
+    return wrapper(WebKit::WebGeolocationPosition::create(WebCore::GeolocationPositionData { location })).autorelease();
 }
 
 - (void)dealloc

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm
@@ -92,14 +92,14 @@ static _WKResourceLoadInfoResourceType toWKResourceLoadInfoResourceType(WebKit::
 - (_WKFrameHandle *)frame
 {
     if (auto frameID = _info->frameID())
-        return wrapper(API::FrameHandle::create(*frameID));
+        return wrapper(API::FrameHandle::create(*frameID)).autorelease();
     return nil;
 }
 
 - (_WKFrameHandle *)parentFrame
 {
     if (auto parentFrameID = _info->parentFrameID())
-        return wrapper(API::FrameHandle::create(*parentFrameID));
+        return wrapper(API::FrameHandle::create(*parentFrameID)).autorelease();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
@@ -55,7 +55,7 @@
 
 - (NSData *)userHandle
 {
-    return wrapper(_response->userHandle());
+    return wrapper(_response->userHandle()).autorelease();
 }
 
 - (BOOL)synchronizable
@@ -70,7 +70,7 @@
 
 - (NSData *)credentialID
 {
-    return wrapper(_response->credentialID());
+    return wrapper(_response->credentialID()).autorelease();
 }
 
 - (NSString *)accessGroup

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -77,19 +77,19 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 
 + (instancetype)allURLsMatchPattern
 {
-    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::allURLsMatchPattern());
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::allURLsMatchPattern()).autorelease();
 }
 
 + (instancetype)allHostsAndSchemesMatchPattern
 {
-    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::allHostsAndSchemesMatchPattern());
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::allHostsAndSchemesMatchPattern()).autorelease();
 }
 
 + (instancetype)matchPatternWithString:(NSString *)patternString
 {
     NSParameterAssert([patternString isKindOfClass:NSString.class]);
 
-    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(patternString));
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(patternString)).autorelease();
 }
 
 + (instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
@@ -98,7 +98,7 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
     NSParameterAssert([host isKindOfClass:NSString.class]);
     NSParameterAssert([path isKindOfClass:NSString.class]);
 
-    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path));
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path)).autorelease();
 }
 
 - (instancetype)initWithString:(NSString *)string error:(NSError **)error
@@ -110,7 +110,7 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
         API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self);
 
         // Use the pattern cache instead for better performance, since an error isn't needed.
-        return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(string));
+        return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(string)).autorelease();
     }
 
     API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self, string, error);
@@ -129,7 +129,7 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
         API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self);
 
         // Use the pattern cache instead for better performance, since an error isn't needed.
-        return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path));
+        return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path)).autorelease();
     }
 
     API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self, scheme, host, path, error);

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -486,10 +486,10 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
                 return;
             }
 
-            NSURLRequest *nsURLRequest = wrapper(API::URLRequest::create(navigationAction->request()));
-            if ([NSURLConnection canHandleRequest:nsURLRequest]
-                || webPage->urlSchemeHandlerForScheme([nsURLRequest URL].scheme)
-                || [nsURLRequest.URL.scheme isEqualToString:@"blob"]) {
+            auto nsURLRequest = wrapper(API::URLRequest::create(navigationAction->request()));
+            if ([NSURLConnection canHandleRequest:nsURLRequest.get()]
+                || webPage->urlSchemeHandlerForScheme(nsURLRequest.get().URL.scheme)
+                || [nsURLRequest.get().URL.scheme isEqualToString:@"blob"]) {
                 if (navigationAction->shouldPerformDownload())
                     listener->download();
                 else
@@ -711,7 +711,7 @@ void NavigationState::NavigationClient::didStartProvisionalLoadForFrame(WebPageP
         return;
 
     if (m_navigationState->m_navigationDelegateMethods.webViewDidStartProvisionalLoadWithRequestInFrame)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didStartProvisionalLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page))];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didStartProvisionalLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get()];
 }
 
 void NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation(WebPageProxy& page, API::Navigation* navigation, API::Object*)
@@ -819,7 +819,7 @@ void NavigationState::NavigationClient::didFailProvisionalNavigationWithError(We
             [navigationDelegate webView:m_navigationState->webView().get() didFailProvisionalNavigation:wrapper(navigation) withError:errorWithRecoveryAttempter.get()];
     } else {
         if (m_navigationState->m_navigationDelegateMethods.webViewNavigationDidFailProvisionalLoadInSubframeWithError)
-            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() navigation:nil didFailProvisionalLoadInSubframe:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) withError:errorWithRecoveryAttempter.get()];
+            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() navigation:nil didFailProvisionalLoadInSubframe:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() withError:errorWithRecoveryAttempter.get()];
     }
 }
 
@@ -835,7 +835,7 @@ void NavigationState::NavigationClient::didFailProvisionalLoadWithErrorForFrame(
     auto errorWithRecoveryAttempter = createErrorWithRecoveryAttempter(m_navigationState->webView().get(), frameInfo, error);
 
     if (m_navigationState->m_navigationDelegateMethods.webViewDidFailProvisionalLoadWithRequestInFrameWithError)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didFailProvisionalLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) withError:errorWithRecoveryAttempter.get()];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didFailProvisionalLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() withError:errorWithRecoveryAttempter.get()];
 }
 
 void NavigationState::NavigationClient::didCommitNavigation(WebPageProxy& page, API::Navigation* navigation, API::Object*)
@@ -862,7 +862,7 @@ void NavigationState::NavigationClient::didCommitLoadForFrame(WebKit::WebPagePro
         return;
 
     if (m_navigationState->m_navigationDelegateMethods.webViewDidCommitLoadWithRequestInFrame)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didCommitLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page))];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didCommitLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get()];
 }
 
 void NavigationState::NavigationClient::didFinishDocumentLoad(WebPageProxy& page, API::Navigation* navigation, API::Object*)
@@ -906,7 +906,7 @@ void NavigationState::NavigationClient::didFinishLoadForFrame(WebPageProxy& page
         return;
 
     if (m_navigationState->m_navigationDelegateMethods.webViewDidFinishLoadWithRequestInFrame)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didFinishLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page))];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didFinishLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get()];
 }
 
 void NavigationState::NavigationClient::didBlockLoadToKnownTracker(WebPageProxy& page, const URL& url)
@@ -965,7 +965,7 @@ void NavigationState::NavigationClient::didFailLoadWithErrorForFrame(WebPageProx
     auto errorWithRecoveryAttempter = createErrorWithRecoveryAttempter(m_navigationState->webView().get(), frameInfo, error);
 
     if (m_navigationState->m_navigationDelegateMethods.webViewDidFailLoadWithRequestInFrameWithError)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didFailLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) withError:errorWithRecoveryAttempter.get()];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:m_navigationState->webView().get() didFailLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() withError:errorWithRecoveryAttempter.get()];
 }
 
 void NavigationState::NavigationClient::didSameDocumentNavigation(WebPageProxy&, API::Navigation* navigation, SameDocumentNavigationType navigationType, API::Object*)
@@ -1349,7 +1349,7 @@ void NavigationState::HistoryClient::didNavigateWithNavigationData(WebPageProxy&
     if (!historyDelegate)
         return;
 
-    [historyDelegate _webView:m_navigationState->webView().get() didNavigateWithNavigationData:wrapper(API::NavigationData::create(navigationDataStore))];
+    [historyDelegate _webView:m_navigationState->webView().get() didNavigateWithNavigationData:wrapper(API::NavigationData::create(navigationDataStore)).get()];
 }
 
 void NavigationState::HistoryClient::didPerformClientRedirect(WebPageProxy&, const WTF::String& sourceURL, const WTF::String& destinationURL)

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -367,7 +367,7 @@ void UIDelegate::UIClient::runJavaScriptAlert(WebPageProxy& page, const WTF::Str
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:));
-    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptAlertPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] {
+    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptAlertPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler();
@@ -394,7 +394,7 @@ void UIDelegate::UIClient::runJavaScriptConfirm(WebPageProxy& page, const WTF::S
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:));
-    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -421,7 +421,7 @@ void UIDelegate::UIClient::runJavaScriptPrompt(WebPageProxy& page, const WTF::St
     page.makeViewBlankIfUnpaintedSinceLastLoadCommit();
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:));
-    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptTextInputPanelWithPrompt:message defaultText:defaultValue initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSString *result) mutable {
+    [delegate webView:m_uiDelegate->m_webView.get().get() runJavaScriptTextInputPanelWithPrompt:message defaultText:defaultValue initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSString *result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -496,12 +496,12 @@ void UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest(WebKit::W
                 break;
             }
         });
-        [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestGeolocationPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())) initiatedByFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)) decisionHandler:decisionHandler.get()];
+        [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestGeolocationPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())).get() initiatedByFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)).get() decisionHandler:decisionHandler.get()];
         return;
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestGeolocationPermissionForFrame:decisionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestGeolocationPermissionForFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)) decisionHandler:makeBlockPtr([completionHandler = std::exchange(completionHandler, nullptr), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() requestGeolocationPermissionForFrame:wrapper(API::FrameInfo::create(FrameInfoData { frameInfo }, &page)).get() decisionHandler:makeBlockPtr([completionHandler = std::exchange(completionHandler, nullptr), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -548,7 +548,7 @@ void UIDelegate::UIClient::runBeforeUnloadConfirmPanel(WebPageProxy& page, const
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:completionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() runBeforeUnloadConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() runBeforeUnloadConfirmPanelWithMessage:message initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         completionHandler(result);
@@ -1152,7 +1152,7 @@ void UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess(WebKit::W
             break;
         }
     });
-    [delegate webView:m_uiDelegate->m_webView.get().get() requestDeviceOrientationAndMotionPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())) initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) decisionHandler:decisionHandler.get()];
+    [delegate webView:m_uiDelegate->m_webView.get().get() requestDeviceOrientationAndMotionPermissionForOrigin:wrapper(API::SecurityOrigin::create(securityOrigin.get())).get() initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() decisionHandler:decisionHandler.get()];
 }
 #endif
 
@@ -1691,7 +1691,7 @@ void UIDelegate::UIClient::confirmPDFOpening(WebPageProxy& page, const WTF::URL&
         return completionHandler(true);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:shouldAllowPDFAtURL:toOpenFromFrame:completionHandler:));
-    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() shouldAllowPDFAtURL:fileURL toOpenFromFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
+    [static_cast<id<WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() shouldAllowPDFAtURL:fileURL toOpenFromFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1732,7 +1732,7 @@ void UIDelegate::UIClient::runWebAuthenticationPanel(WebPageProxy& page, API::We
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:runWebAuthenticationPanel:initiatedByFrame:completionHandler:));
-    [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() runWebAuthenticationPanel:wrapper(panel) initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKWebAuthenticationPanelResult result) mutable {
+    [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() runWebAuthenticationPanel:wrapper(panel) initiatedByFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)).get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (_WKWebAuthenticationPanelResult result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -74,7 +74,7 @@ void InspectorExtensionDelegate::InspectorExtensionClient::didShowExtensionTab(c
     if (!delegate)
         return;
 
-    [delegate inspectorExtension:m_inspectorExtensionDelegate.m_inspectorExtension.get().get() didShowTabWithIdentifier:extensionTabID withFrameHandle:wrapper(API::FrameHandle::create(frameID))];
+    [delegate inspectorExtension:m_inspectorExtensionDelegate.m_inspectorExtension.get().get() didShowTabWithIdentifier:extensionTabID withFrameHandle:wrapper(API::FrameHandle::create(frameID)).get()];
 }
 
 void InspectorExtensionDelegate::InspectorExtensionClient::didHideExtensionTab(const Inspector::ExtensionTabID& extensionTabID)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -171,7 +171,7 @@ void WebAuthenticationPanelClient::selectAssertionResponse(Vector<Ref<WebCore::A
         return API::WebAuthenticationAssertionResponse::create(response.copyRef());
     });
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(panel:selectAssertionResponse:source:completionHandler:));
-    [delegate panel:m_panel selectAssertionResponse:wrapper(API::Array::create(WTFMove(apiResponses))) source:wkWebAuthenticationSource(source) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](_WKWebAuthenticationAssertionResponse *response) mutable {
+    [delegate panel:m_panel selectAssertionResponse:wrapper(API::Array::create(WTFMove(apiResponses))).get() source:wkWebAuthenticationSource(source) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)](_WKWebAuthenticationAssertionResponse *response) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8419,7 +8419,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
     auto webView = _webView.get();
     id <WKUIDelegatePrivate> uiDelegate = static_cast<id <WKUIDelegatePrivate>>([webView UIDelegate]);
     return [uiDelegate respondsToSelector:@selector(_webView:fileUploadPanelContentIsManagedWithInitiatingFrame:)]
-        && [uiDelegate _webView:webView.get() fileUploadPanelContentIsManagedWithInitiatingFrame:wrapper(API::FrameInfo::create(WTFMove(_frameInfoForFileUploadPanel), _page.get()))];
+        && [uiDelegate _webView:webView.get() fileUploadPanelContentIsManagedWithInitiatingFrame:wrapper(API::FrameInfo::create(WTFMove(_frameInfoForFileUploadPanel), _page.get())).get()];
 }
 
 - (void)_showShareSheet:(const WebCore::ShareDataWithParsedURL&)data inRect:(std::optional<WebCore::FloatRect>)rect completionHandler:(CompletionHandler<void(bool)>&&)completionHandler

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
@@ -45,7 +45,7 @@
 {
     JSContextRef contextRef = [context JSGlobalContextRef];
     JSObjectRef objectRef = JSValueToObject(contextRef, [value JSValueRef], nullptr);
-    return wrapper(WebKit::InjectedBundleCSSStyleDeclarationHandle::getOrCreate(contextRef, objectRef));
+    return wrapper(WebKit::InjectedBundleCSSStyleDeclarationHandle::getOrCreate(contextRef, objectRef)).autorelease();
 }
 
 - (WebKit::InjectedBundleCSSStyleDeclarationHandle&)_cssStyleDeclarationHandle

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -56,12 +56,12 @@
 
 + (instancetype)lookUpFrameFromJSContext:(JSContext *)context
 {
-    return wrapper(WebKit::WebFrame::frameForContext(context.JSGlobalContextRef));
+    return wrapper(WebKit::WebFrame::frameForContext(context.JSGlobalContextRef)).autorelease();
 }
 
 + (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value
 {
-    return wrapper(WebKit::WebFrame::contentFrameForWindowOrFrameElement(value.context.JSGlobalContextRef, value.JSValueRef));
+    return wrapper(WebKit::WebFrame::contentFrameForWindowOrFrameElement(value.context.JSGlobalContextRef, value.JSValueRef)).autorelease();
 }
 
 - (void)dealloc
@@ -86,7 +86,7 @@
 
 - (WKWebProcessPlugInHitTestResult *)hitTest:(CGPoint)point
 {
-    return wrapper(_frame->hitTest(WebCore::IntPoint(point)));
+    return wrapper(_frame->hitTest(WebCore::IntPoint(point))).autorelease();
 }
 
 - (WKWebProcessPlugInHitTestResult *)hitTest:(CGPoint)point options:(WKHitTestOptions)options
@@ -94,7 +94,7 @@
     auto types = WebKit::WebFrame::defaultHitTestRequestTypes();
     if (options & WKHitTestOptionAllowUserAgentShadowRootContent)
         types.remove(WebCore::HitTestRequest::Type::DisallowUserAgentShadowContent);
-    return wrapper(_frame->hitTest(WebCore::IntPoint(point), types));
+    return wrapper(_frame->hitTest(WebCore::IntPoint(point), types)).autorelease();
 }
 
 - (JSValue *)jsCSSStyleDeclarationForCSSStyleDeclarationHandle:(WKWebProcessPlugInCSSStyleDeclarationHandle *)cssStyleDeclarationHandle inWorld:(WKWebProcessPlugInScriptWorld *)world
@@ -127,7 +127,7 @@
 
 - (NSArray *)childFrames
 {
-    return WebKit::wrapper(_frame->childFrames());
+    return WebKit::wrapper(_frame->childFrames()).autorelease();
 }
 
 - (BOOL)containsAnyFormElements
@@ -142,7 +142,7 @@
 
 - (_WKFrameHandle *)handle
 {
-    return wrapper(API::FrameHandle::create(_frame->frameID()));
+    return wrapper(API::FrameHandle::create(_frame->frameID())).autorelease();
 }
 
 - (NSString *)_securityOrigin
@@ -177,7 +177,7 @@ static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<Web
 
 - (WKWebProcessPlugInFrame *)_parentFrame
 {
-    return wrapper(_frame->parentFrame());
+    return wrapper(_frame->parentFrame()).autorelease();
 }
 
 - (BOOL)_hasCustomContentProvider

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
@@ -43,7 +43,7 @@
 
 - (WKWebProcessPlugInNodeHandle *)nodeHandle
 {
-    return WebKit::wrapper(_hitTestResult->nodeHandle());
+    return WebKit::wrapper(_hitTestResult->nodeHandle()).autorelease();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
@@ -51,12 +51,12 @@
 {
     JSContextRef contextRef = [context JSGlobalContextRef];
     JSObjectRef objectRef = JSValueToObject(contextRef, [value JSValueRef], nullptr);
-    return WebKit::wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(contextRef, objectRef));
+    return WebKit::wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(contextRef, objectRef)).autorelease();
 }
 
 - (WKWebProcessPlugInFrame *)htmlIFrameElementContentFrame
 {
-    return WebKit::wrapper(_nodeHandle->htmlIFrameElementContentFrame());
+    return WebKit::wrapper(_nodeHandle->htmlIFrameElementContentFrame()).autorelease();
 }
 
 - (CocoaImage *)renderedImageWithOptions:(WKSnapshotOptions)options
@@ -208,12 +208,12 @@ static _WKAutoFillButtonType toWKAutoFillButtonType(WebCore::AutoFillButtonType 
 
 - (WKWebProcessPlugInNodeHandle *)HTMLTableCellElementCellAbove
 {
-    return WebKit::wrapper(_nodeHandle->htmlTableCellElementCellAbove());
+    return WebKit::wrapper(_nodeHandle->htmlTableCellElementCellAbove()).autorelease();
 }
 
 - (WKWebProcessPlugInFrame *)frame
 {
-    return WebKit::wrapper(_nodeHandle->document()->documentFrame());
+    return WebKit::wrapper(_nodeHandle->document()->documentFrame()).autorelease();
 }
 
 - (WebKit::InjectedBundleNodeHandle&)_nodeHandle

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
@@ -52,12 +52,12 @@
 {
     JSContextRef contextRef = [context JSGlobalContextRef];
     JSObjectRef objectRef = JSValueToObject(contextRef, [value JSValueRef], nullptr);
-    return wrapper(WebKit::InjectedBundleRangeHandle::getOrCreate(contextRef, objectRef));
+    return wrapper(WebKit::InjectedBundleRangeHandle::getOrCreate(contextRef, objectRef)).autorelease();
 }
 
 - (WKWebProcessPlugInFrame *)frame
 {
-    return wrapper(_rangeHandle->document()->documentFrame());
+    return wrapper(_rangeHandle->document()->documentFrame()).autorelease();
 }
 
 - (NSString *)text

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
@@ -34,7 +34,7 @@
 
 + (WKWebProcessPlugInScriptWorld *)world
 {
-    return WebKit::wrapper(WebKit::InjectedBundleScriptWorld::create());
+    return WebKit::wrapper(WebKit::InjectedBundleScriptWorld::create()).autorelease();
 }
 
 + (WKWebProcessPlugInScriptWorld *)normalWorld

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -475,7 +475,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:didFocusTextField:inFrame:)])
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() didFocusTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)) inFrame:wrapper(*frame)];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() didFocusTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:wrapper(*frame)];
         }
 
         void willSendSubmitEvent(WebKit::WebPage*, WebCore::HTMLFormElement* formElement, WebKit::WebFrame* targetFrame, WebKit::WebFrame* sourceFrame, const Vector<std::pair<String, String>>& values) final
@@ -517,7 +517,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:textDidChangeInTextField:inFrame:initiatedByUserTyping:)])
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() textDidChangeInTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)) inFrame:wrapper(*frame) initiatedByUserTyping:initiatedByUserTyping];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() textDidChangeInTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:wrapper(*frame) initiatedByUserTyping:initiatedByUserTyping];
         }
 
         void willBeginInputSession(WebKit::WebPage*, WebCore::Element* element, WebKit::WebFrame* frame, bool userIsInteracting, RefPtr<API::Object>& userData) final


### PR DESCRIPTION
#### b06c5b6e37bf5af6279d85e1e9a9de34e4848a38
<pre>
Wrappers of r-value Ref/RefPtr should be RetainPtr instead of autorelease
<a href="https://bugs.webkit.org/show_bug.cgi?id=263548">https://bugs.webkit.org/show_bug.cgi?id=263548</a>
rdar://117369554

Reviewed by Simon Fraser.

It turns out they don&apos;t all need to go into the autoreleasepool.  Some of them can just use
RetainPtr::get and then deallocate the object immediately if it is not retained by the called
function.  Also, having adoptNS leakRef and autorelease on the same line is hard to tell a
regex how to reason about, so this makes our style easier to enforce.

* Source/WebKit/Shared/Cocoa/WKObject.h:
(WebKit::wrapper):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(WKPageLoadURLRequestReturningNavigation):
(WKPageLoadFileReturningNavigation):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
(-[WKBackForwardList backList]):
(-[WKBackForwardList forwardList]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(+[WKContentRuleListStore storeWithURL:]):
(+[WKContentRuleListStore storeWithURLAndLegacyFilename:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(+[WKContentWorld worldWithName:]):
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _handle]):
(-[WKFrameInfo _parentFrameHandle]):
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.mm:
(-[WKOpenPanelParameters _acceptedMIMETypes]):
(-[WKOpenPanelParameters _acceptedFileExtensions]):
(-[WKOpenPanelParameters _allowedFileExtensions]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(+[WKPreferences _features]):
(+[WKPreferences _internalDebugFeatures]):
(+[WKPreferences _experimentalFeatures]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _configuration]):
(-[WKProcessPool _downloadURLRequest:websiteDataStore:originatingWebView:]):
(-[WKProcessPool _resumeDownloadFromData:websiteDataStore:path:originatingWebView:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView loadRequest:]):
(-[WKWebView loadFileURL:allowingReadAccessToURL:]):
(-[WKWebView loadData:MIMEType:characterEncodingName:baseURL:]):
(-[WKWebView goToBackForwardListItem:]):
(-[WKWebView goBack]):
(-[WKWebView goForward]):
(-[WKWebView reload]):
(-[WKWebView reloadFromOrigin]):
(-[WKWebView loadSimulatedRequest:response:responseData:]):
(-[WKWebView loadFileRequest:allowingReadAccessToURL:]):
(-[WKWebView _mainFrame]):
(-[WKWebView _frames:]):
(-[WKWebView _frameTrees:]):
(-[WKWebView _loadData:MIMEType:characterEncodingName:baseURL:userData:]):
(-[WKWebView _loadRequest:shouldOpenExternalURLsPolicy:]):
(-[WKWebView _reloadWithoutContentBlockers]):
(-[WKWebView _reloadExpiredOnly]):
(-[WKWebView _sessionStateData]):
(-[WKWebView _restoreSessionState:andNavigate:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore defaultDataStore]):
(+[WKWebsiteDataStore nonPersistentDataStore]):
(+[WKWebsiteDataStore dataStoreForIdentifier:]):
(-[WKWebsiteDataStore _fetchDataRecordsOfTypes:withOptions:completionHandler:]):
(-[WKWebsiteDataStore _loadedSubresourceDomainsFor:completionHandler:]):
(-[WKWebsiteDataStore _getAllStorageAccessEntriesFor:completionHandler:]):
(-[WKWebsiteDataStore _configuration]):
(-[WKWebsiteDataStore _appBoundDomains:]):
(-[WKWebsiteDataStore _appBoundSchemes:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(+[_WKApplicationManifest applicationManifestFromJSON:manifestURL:documentURL:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm:
(-[_WKFrameTreeNode info]):
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfo.mm:
(-[_WKResourceLoadInfo frame]):
(-[_WKResourceLoadInfo parentFrame]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm:
(-[_WKWebAuthenticationAssertionResponse userHandle]):
(-[_WKWebAuthenticationAssertionResponse credentialID]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm:
(+[_WKWebExtensionMatchPattern allURLsMatchPattern]):
(+[_WKWebExtensionMatchPattern allHostsAndSchemesMatchPattern]):
(+[_WKWebExtensionMatchPattern matchPatternWithString:]):
(+[_WKWebExtensionMatchPattern matchPatternWithScheme:host:path:]):
(-[_WKWebExtensionMatchPattern initWithString:error:]):
(-[_WKWebExtensionMatchPattern initWithScheme:host:path:error:]):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::didStartProvisionalLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailProvisionalLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didCommitLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFinishLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFailLoadWithErrorForFrame):
(WebKit::NavigationState::HistoryClient::didNavigateWithNavigationData):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::runJavaScriptAlert):
(WebKit::UIDelegate::UIClient::runJavaScriptConfirm):
(WebKit::UIDelegate::UIClient::runJavaScriptPrompt):
(WebKit::UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest):
(WebKit::UIDelegate::UIClient::runBeforeUnloadConfirmPanel):
(WebKit::UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::UIDelegate::UIClient::confirmPDFOpening):
(WebKit::UIDelegate::UIClient::runWebAuthenticationPanel):
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm:
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::didShowExtensionTab):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::WebAuthenticationPanelClient::selectAssertionResponse const):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm:
(+[WKWebProcessPlugInCSSStyleDeclarationHandle cssStyleDeclarationHandleWithJSValue:inContext:]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(+[WKWebProcessPlugInFrame lookUpFrameFromJSContext:]):
(+[WKWebProcessPlugInFrame lookUpContentFrameFromWindowOrFrameElement:]):
(-[WKWebProcessPlugInFrame hitTest:]):
(-[WKWebProcessPlugInFrame hitTest:options:]):
(-[WKWebProcessPlugInFrame childFrames]):
(-[WKWebProcessPlugInFrame handle]):
(-[WKWebProcessPlugInFrame _parentFrame]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm:
(-[WKWebProcessPlugInHitTestResult nodeHandle]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm:
(+[WKWebProcessPlugInNodeHandle nodeHandleWithJSValue:inContext:]):
(-[WKWebProcessPlugInNodeHandle htmlIFrameElementContentFrame]):
(-[WKWebProcessPlugInNodeHandle HTMLTableCellElementCellAbove]):
(-[WKWebProcessPlugInNodeHandle frame]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm:
(+[WKWebProcessPlugInRangeHandle rangeHandleWithJSValue:inContext:]):
(-[WKWebProcessPlugInRangeHandle frame]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm:
(+[WKWebProcessPlugInScriptWorld world]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(-[WKWebProcessPlugInBrowserContextController _setFormDelegate:]):

Canonical link: <a href="https://commits.webkit.org/269686@main">https://commits.webkit.org/269686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3d08bf808bde38294e2b31ded2a4ec0b8011153

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24389 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23823 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26034 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21296 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/747 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/697 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2963 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->