### PR TITLE
[WGSL] Add more information to type declarations

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTCallExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallExpression.h
@@ -27,7 +27,10 @@
 
 #include "ASTExpression.h"
 
-namespace WGSL::AST {
+namespace WGSL {
+class TypeChecker;
+
+namespace AST {
 
 // A CallExpression expresses a "function" call, which consists of a target to be called,
 // and a list of arguments. The target does not necesserily have to be a function identifier,
@@ -35,12 +38,17 @@ namespace WGSL::AST {
 // kind of expression can only be resolved during semantic analysis.
 class CallExpression final : public Expression {
     WGSL_AST_BUILDER_NODE(CallExpression);
+
+    friend TypeChecker;
+
 public:
     using Ref = std::reference_wrapper<CallExpression>;
 
     NodeKind kind() const override;
     Expression& target() { return m_target.get(); }
     Expression::List& arguments() { return m_arguments; }
+
+    bool isConstructor() const { return m_isConstructor; }
 
 private:
     CallExpression(SourceSpan span, Expression::Ref&& target, Expression::List&& arguments)
@@ -55,8 +63,11 @@ private:
     //   * Identifier that refers to a function.
     Expression::Ref m_target;
     Expression::List m_arguments;
+
+    bool m_isConstructor { false };
 };
 
-} // namespace WGSL::AST
+} // namespace AST
+} // namespace WGSL
 
 SPECIALIZE_TYPE_TRAITS_WGSL_AST(CallExpression)

--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -101,7 +101,6 @@ static ConstantValue constantAdd(const Type*, const FixedVector<ConstantValue>& 
     auto& rhs = arguments[1];
 
     // FIXME: handle constant matrices
-
     return scalarOrVector([&](const auto& left, auto& right) -> ConstantValue {
         if (left.isInt() && right.isInt())
             return left.toInt() + right.toInt();
@@ -242,17 +241,17 @@ static ConstantValue constantVector(const Type* resultType, const FixedVector<Co
     return { result };
 }
 
-static ConstantValue constantVector2(const Type* resultType, const FixedVector<ConstantValue>& arguments)
+static ConstantValue constantVec2(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     return constantVector(resultType, arguments, 2);
 }
 
-static ConstantValue constantVector3(const Type* resultType, const FixedVector<ConstantValue>& arguments)
+static ConstantValue constantVec3(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     return constantVector(resultType, arguments, 3);
 }
 
-static ConstantValue constantVector4(const Type* resultType, const FixedVector<ConstantValue>& arguments)
+static ConstantValue constantVec4(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     return constantVector(resultType, arguments, 4);
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1351,70 +1351,20 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             return;
         }
 
-        static constexpr std::pair<ComparableASCIILiteral, ASCIILiteral> baseTypesMappings[] {
+        static constexpr std::pair<ComparableASCIILiteral, ASCIILiteral> directMappings[] {
             { "dpdx", "dfdx"_s },
             { "dpdxCoarse", "dfdx"_s },
             { "dpdxFine", "dfdx"_s },
             { "dpdy", "dfdy"_s },
             { "dpdyCoarse", "dfdy"_s },
             { "dpdyFine", "dfdy"_s },
-            { "f32", "float"_s },
             { "fwidthCoarse", "fwidth"_s },
             { "fwidthFine", "fwidth"_s },
-            { "i32", "int"_s },
-            { "mat2x2f", "float2x2"_s },
-            { "mat2x3f", "float2x3"_s },
-            { "mat2x4f", "float2x4"_s },
-            { "mat3x2f", "float3x2"_s },
-            { "mat3x3f", "float3x3"_s },
-            { "mat3x4f", "float3x4"_s },
-            { "mat4x2f", "float4x2"_s },
-            { "mat4x3f", "float4x3"_s },
-            { "mat4x4f", "float4x4"_s },
-            { "u32", "uint"_s },
-            { "vec2f", "float2"_s },
-            { "vec2i", "int2"_s },
-            { "vec2u", "uint2"_s },
-            { "vec3f", "float3"_s },
-            { "vec3i", "int3"_s },
-            { "vec3u", "uint3"_s },
-            { "vec4f", "float4"_s },
-            { "vec4i", "int4"_s },
-            { "vec4u", "uint4"_s }
         };
-        static constexpr SortedArrayMap baseTypes { baseTypesMappings };
-
-        // FIXME: in order to remove this hack we need to distinguish in the declarations
-        // file between functions and value constructors
-        static constexpr ComparableASCIILiteral constructorNames[] {
-            "mat2x2",
-            "mat2x3",
-            "mat2x4",
-            "mat3x2",
-            "mat3x3",
-            "mat3x4",
-            "mat4x2",
-            "mat4x3",
-            "mat4x4",
-            "texture_1d",
-            "texture_2d",
-            "texture_2d_array",
-            "texture_3d",
-            "texture_cube",
-            "texture_cube_array",
-            "texture_multisampled_2d",
-            "texturetorage_1d",
-            "texturetorage_2d",
-            "texturetorage_2d_array",
-            "texturetorage_3d",
-            "vec2",
-            "vec3",
-            "vec4",
-        };
-        static constexpr SortedArraySet constructors { constructorNames };
-        if (constructors.contains(targetName)) {
+        static constexpr SortedArrayMap mappedNames { directMappings };
+        if (call.isConstructor()) {
             visit(type);
-        } else if (auto mappedName = baseTypes.get(targetName))
+        } else if (auto mappedName = mappedNames.get(targetName))
             m_stringBuilder.append(mappedName);
         else
             m_stringBuilder.append(targetName);

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -27,6 +27,7 @@
 
 #include "Constraints.h"
 #include "TypeStore.h"
+#include "WGSL.h"
 
 namespace WGSL {
 
@@ -119,6 +120,21 @@ struct OverloadCandidate {
     Vector<ValueVariable, 2> valueVariables;
     Vector<AbstractType, 2> parameters;
     AbstractType result;
+};
+
+struct OverloadedDeclaration {
+    enum Kind : uint8_t {
+        Operator,
+        Constructor,
+        Function,
+    };
+
+    Kind kind;
+    bool mustUse;
+
+    ConstantValue (*constantFunction)(const Type*, const FixedVector<ConstantValue>&);
+    OptionSet<ShaderStage> visibility;
+    Vector<OverloadCandidate> overloads;
 };
 
 struct SelectedOverload {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -158,8 +158,7 @@ private:
 
     TypeStore& m_types;
     Vector<Error> m_errors;
-    HashMap<String, Vector<OverloadCandidate>> m_overloadedOperations;
-    HashMap<String, ConstantFunction> m_constantFunctions;
+    HashMap<String, OverloadedDeclaration> m_overloadedOperations;
 };
 
 TypeChecker::TypeChecker(ShaderModule& shaderModule)
@@ -309,24 +308,6 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
 
     // This file contains the declarations generated from `TypeDeclarations.rb`
 #include "TypeDeclarations.h" // NOLINT
-
-    m_constantFunctions.add("pow"_s, constantPow);
-    m_constantFunctions.add("-"_s, constantMinus);
-    m_constantFunctions.add("+"_s, constantAdd);
-    m_constantFunctions.add("*"_s, constantMultiply);
-    m_constantFunctions.add("/"_s, constantDivide);
-    m_constantFunctions.add("vec2"_s, constantVector2);
-    m_constantFunctions.add("vec2f"_s, constantVector2);
-    m_constantFunctions.add("vec2i"_s, constantVector2);
-    m_constantFunctions.add("vec2u"_s, constantVector2);
-    m_constantFunctions.add("vec3i"_s, constantVector3);
-    m_constantFunctions.add("vec3"_s, constantVector3);
-    m_constantFunctions.add("vec3f"_s, constantVector3);
-    m_constantFunctions.add("vec3u"_s, constantVector3);
-    m_constantFunctions.add("vec4u"_s, constantVector4);
-    m_constantFunctions.add("vec4"_s, constantVector4);
-    m_constantFunctions.add("vec4f"_s, constantVector4);
-    m_constantFunctions.add("vec4i"_s, constantVector4);
 }
 
 std::optional<FailedCheck> TypeChecker::check()
@@ -1272,15 +1253,19 @@ const Type* TypeChecker::chooseOverload(const char* kind, AST::Expression& expre
         valueArguments.append(type);
     }
 
-    auto overload = resolveOverloads(m_types, it->value, valueArguments, typeArguments);
+    auto overload = resolveOverloads(m_types, it->value.overloads, valueArguments, typeArguments);
     if (overload.has_value()) {
         ASSERT(overload->parameters.size() == callArguments.size());
         for (unsigned i = 0; i < callArguments.size(); ++i)
             callArguments[i].m_inferredType = overload->parameters[i];
         inferred(overload->result);
 
-        auto it = m_constantFunctions.find(target);
-        if (it != m_constantFunctions.end()) {
+        if (it->value.kind == OverloadedDeclaration::Constructor && is<AST::CallExpression>(expression)) {
+            auto& call = downcast<AST::CallExpression>(expression);
+            call.m_isConstructor = true;
+        }
+
+        if (auto constantFunction = it->value.constantFunction) {
             unsigned argumentCount = callArguments.size();
             FixedVector<ConstantValue> arguments(argumentCount);
             for (unsigned i = 0; i < argumentCount; ++i) {
@@ -1289,7 +1274,7 @@ const Type* TypeChecker::chooseOverload(const char* kind, AST::Expression& expre
                     return overload->result;
                 arguments[i] = *value;
             }
-            setConstantValue(expression, it->value(overload->result, WTFMove(arguments)));
+            setConstantValue(expression, constantFunction(overload->result, WTFMove(arguments)));
         }
 
         return overload->result;

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -19,6 +19,9 @@ suffixes = {
 end
 
 operator :+, {
+    must_use: true,
+    const: "constantAdd",
+
     [T < Number].(T, T) => T,
 
     # vector addition
@@ -31,6 +34,9 @@ operator :+, {
 }
 
 operator :-, {
+    must_use: true,
+    const: "constantMinus",
+
     # unary
     [T < SignedNumber].(T) => T,
     [T < SignedNumber, N].(vec[N][T]) => vec[N][T],
@@ -43,7 +49,11 @@ operator :-, {
 }
 
 operator :*, {
+    must_use: true,
+    const: "constantMultiply",
+
     # unary
+    # FIXME: move this out of here
     [AS, T, AM].(ptr[AS, T, AM]) => ref[AS, T, AM],
 
     # binary
@@ -67,6 +77,9 @@ operator :*, {
 }
 
 operator :/, {
+    must_use: true,
+    const: "constantDivide",
+
     [T < Number].(T, T) => T,
 
     # vector scaling
@@ -87,6 +100,9 @@ operator :%, {
 # Comparison operations
 ["==", "!="].each do |op|
     operator :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [T < Scalar].(T, T) => bool,
         [T < Scalar, N].(vec[N][T], vec[N][T]) => vec[N][bool],
     }
@@ -94,6 +110,9 @@ end
 
 ["<", "<=", ">", ">="].each do |op|
     operator :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [T < Number].(T, T) => bool,
         [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][bool],
     }
@@ -102,25 +121,41 @@ end
 # 8.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
 
 operator :!, {
+    must_use: true,
+    #FIXME: add constant function
+
     [].(bool) => bool,
     [N].(vec[N][bool]) => vec[N][bool],
 }
 
 operator :'||', {
+    must_use: true,
+    #FIXME: add constant function
+
     [].(bool, bool) => bool,
 }
 
 operator :'&&', {
+    must_use: true,
+    #FIXME: add constant function
+
     [].(bool, bool) => bool,
 }
 
 operator :'|', {
+    must_use: true,
+    #FIXME: add constant function
+
     [].(bool, bool) => bool,
     [N].(vec[N][bool], vec[N][bool]) => vec[N][bool],
 }
 
 operator :'&', {
+    must_use: true,
+    #FIXME: add constant function
+
     # unary
+    # FIXME: move this out of here
     [AS, T, AM].(ref[AS, T, AM]) => ptr[AS, T, AM],
 
     # binary
@@ -131,12 +166,18 @@ operator :'&', {
 # 8.9. Bit Expressions (https://www.w3.org/TR/WGSL/#bit-expr)
 
 operator :~, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Integer].(T) => T,
     [T < Integer, N].(vec[N][T]) => vec[N][T]
 }
 
 ["|", "&", "^", "<<", ">>"].each do |op|
     operator :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [T < Integer].(T, T) => T,
         [T < Integer, N].(vec[N][T], vec[N][T]) => vec[N][T]
     }
@@ -145,30 +186,61 @@ end
 # 16.1. Constructor Built-in Functions
 
 # 16.1.1. Zero Value Built-in Functions
-operator :bool, {
+constructor :bool, {
+    must_use: true,
+    #FIXME: add constant function
+
     [].() => bool,
 }
-operator :i32, {
+
+constructor :i32, {
+    must_use: true,
+    #FIXME: add constant function
+
     [].() => i32,
 }
-operator :u32, {
+
+constructor :u32, {
+    must_use: true,
+    #FIXME: add constant function
+
     [].() => u32,
 }
-operator :f32, {
+
+constructor :f32, {
+    must_use: true,
+    #FIXME: add constant function
+
     [].() => f32,
 }
-operator :vec2, {
+
+constructor :vec2, {
+    must_use: true,
+    const: true,
+
     [T < ConcreteScalar].() => vec2[T],
 }
-operator :vec3, {
+
+constructor :vec3, {
+    must_use: true,
+    const: true,
+
     [T < ConcreteScalar].() => vec3[T],
 }
-operator :vec4, {
+
+constructor :vec4, {
+    must_use: true,
+    const: true,
+
     [T < ConcreteScalar].() => vec4[T],
 }
+
 (2..4).each do |columns|
     (2..4).each do |rows|
-        operator :"mat#{columns}x#{rows}", {
+        constructor :"mat#{columns}x#{rows}", {
+            must_use: true,
+            #FIXME: add constant function
+
             [T < ConcreteFloat].() => mat[columns,rows][T],
         }
     end
@@ -180,7 +252,10 @@ end
 # Implemented inline in the type checker
 
 # 16.1.2.2.
-operator :bool, {
+constructor :bool, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteScalar].(T) => bool,
 }
 
@@ -188,19 +263,28 @@ operator :bool, {
 # FIXME: add support for f16
 
 # 16.1.2.4.
-operator :f32, {
+constructor :f32, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteScalar].(T) => f32,
 }
 
 # 16.1.2.5.
-operator :i32, {
+constructor :i32, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteScalar].(T) => i32,
 }
 
 # 16.1.2.6 - 14: matCxR
 (2..4).each do |columns|
     (2..4).each do |rows|
-        operator :"mat#{columns}x#{rows}", {
+        constructor :"mat#{columns}x#{rows}", {
+            must_use: true,
+            #FIXME: add constant function
+
             [T < ConcreteFloat, S < Float].(mat[columns,rows][S]) => mat[columns,rows][T],
             [T < Float].(mat[columns,rows][T]) => mat[columns,rows][T],
             [T < Float].(*([T] * columns * rows)) => mat[columns,rows][T],
@@ -213,12 +297,18 @@ end
 # Implemented inline in the type checker
 
 # 16.1.2.16.
-operator :u32, {
+constructor :u32, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteScalar].(T) => u32,
 }
 
 # 16.1.2.17.
-operator :vec2, {
+constructor :vec2, {
+    must_use: true,
+    const: true,
+
     [T < Scalar].(T) => vec2[T],
     [T < ConcreteScalar, S < Scalar].(vec2[S]) => vec2[T],
     [S < Scalar].(vec2[S]) => vec2[S],
@@ -227,7 +317,10 @@ operator :vec2, {
 }
 
 # 16.1.2.18.
-operator :vec3, {
+constructor :vec3, {
+    must_use: true,
+    const: true,
+
     [T < Scalar].(T) => vec3[T],
     [T < ConcreteScalar, S < Scalar].(vec3[S]) => vec3[T],
     [S < Scalar].(vec3[S]) => vec3[S],
@@ -238,7 +331,10 @@ operator :vec3, {
 }
 
 # 16.1.2.19.
-operator :vec4, {
+constructor :vec4, {
+    must_use: true,
+    const: true,
+
     [T < Scalar].(T) => vec4[T],
     [T < ConcreteScalar, S < Scalar].(vec4[S]) => vec4[T],
     [S < Scalar].(vec4[S]) => vec4[S],
@@ -263,14 +359,20 @@ operator :vec4, {
 
 # 17.3.1 & 17.3.2
 ["all", "any"].each do |op|
-    operator :"#{op}", {
+    function :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [N].(vec[N][bool]) => bool,
         [N].(bool) => bool,
     }
 end
 
 # 17.3.3
-operator :select, {
+function :select, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Scalar].(T, T, bool) => T,
     [T < Scalar, N].(vec[N][T], vec[N][T], bool) => vec[N][T],
     [T < Scalar, N].(vec[N][T], vec[N][T], vec[N][bool]) => vec[N][T],
@@ -279,9 +381,12 @@ operator :select, {
 # 16.4. Array Built-in Functions
 
 # 16.4.1.
-operator :arrayLength, {
-  [T].(ptr[storage, array[T], read]) => u32,
-  [T].(ptr[storage, array[T], read_write]) => u32,
+function :arrayLength, {
+    must_use: true,
+    #FIXME: add constant function
+
+    [T].(ptr[storage, array[T], read]) => u32,
+    [T].(ptr[storage, array[T], read_write]) => u32,
 }
 
 # 17.5. Numeric Built-in Functions (https://www.w3.org/TR/WGSL/#numeric-builtin-functions)
@@ -289,14 +394,20 @@ operator :arrayLength, {
 # Trigonometric
 ["acos", "asin", "atan", "cos", "sin", "tan",
  "acosh", "asinh", "atanh", "cosh", "sinh", "tanh"].each do |op|
-    operator :"#{op}", {
+    function :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [T < Float].(T) => T,
         [T < Float, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.1
-operator :abs, {
+function :abs, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Number].(T) => T,
     [T < Number, N].(vec[N][T]) => vec[N][T],
 }
@@ -310,19 +421,28 @@ operator :abs, {
 # Defined in [Trigonometric]
 
 # 17.5.8
-operator :atan2, {
+function :atan2, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T, T) => T,
     [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.9
-operator :ceil, {
+function :ceil, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.10
-operator :clamp, {
+function :clamp, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Number].(T, T, T) => T,
     [T < Number, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
@@ -333,49 +453,73 @@ operator :clamp, {
 
 # 17.5.13-15 (Bit counting)
 ["countLeadingZeros", "countOneBits", "countTrailingZeros"].each do |op|
-    operator :"#{op}", {
+    function :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [T < ConcreteInteger].(T) => T,
         [T < ConcreteInteger, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.16
-operator :cross, {
+function :cross, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(vec3[T], vec3[T]) => vec3[T],
 }
 
 # 17.5.17
-operator :degrees, {
+function :degrees, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.18
-operator :determinant, {
+function :determinant, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float, C].(mat[C,C][T]) => T,
 }
 
 # 17.5.19
-operator :distance, {
+function :distance, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T, T) => T,
     [T < Float, N].(vec[N][T], vec[N][T]) => T,
 }
 
 # 17.5.20
-operator :dot, {
+function :dot, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Number, N].(vec[N][T], vec[N][T]) => T
 }
 
 # 17.5.21 & 17.5.22
 ["exp", "exp2"].each do |op|
-    operator :"#{op}", {
+    function :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [T < Float].(T) => T,
         [T < Float, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.23 & 17.5.24
-operator :extractBits, {
+function :extractBits, {
+    must_use: true,
+    #FIXME: add constant function
+
     # signed
     [].(i32, u32, u32) => i32,
     [N].(vec[N][i32], u32, u32) => vec[N][i32],
@@ -386,12 +530,18 @@ operator :extractBits, {
 }
 
 # 17.5.25
-operator :faceForward, {
+function :faceForward, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.26 & 17.5.27
-operator :firstLeadingBit, {
+function :firstLeadingBit, {
+    must_use: true,
+    #FIXME: add constant function
+
     # signed
     [].(i32) => i32,
     [N].(vec[N][i32]) => vec[N][i32],
@@ -402,48 +552,72 @@ operator :firstLeadingBit, {
 }
 
 # 17.5.28
-operator :firstTrailingBit, {
+function :firstTrailingBit, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteInteger].(T) => T,
     [T < ConcreteInteger, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.29
-operator :floor, {
+function :floor, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.30
-operator :fma, {
+function :fma, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T, T, T) => T,
     [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.31
-operator :fract, {
+function :fract, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.32
-operator :frexp, {
+function :frexp, {
+    must_use: true,
+    #FIXME: add constant function
+
     # FIXME: this needs the special return types __frexp_result_*
 }
 
 # 17.5.33
-operator :insertBits, {
+function :insertBits, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteInteger].(T, T, u32, u32) => T,
     [T < ConcreteInteger, N].(vec[N][T], vec[N][T], u32, u32) => vec[N][T],
 }
 
 # 17.5.34
-operator :inverseSqrt, {
+function :inverseSqrt, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.35
-operator :ldexp, {
+function :ldexp, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteFloat].(T, i32) => T,
     [].(abstract_float, abstract_int) => abstract_float,
     [T < ConcreteFloat, N].(vec[N][T], vec[N][i32]) => vec[N][T],
@@ -451,96 +625,144 @@ operator :ldexp, {
 }
 
 # 17.5.36
-operator :length, {
+function :length, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => T,
 }
 
 # 17.5.37 & 17.5.38
 ["log", "log2"].each do |op|
-    operator :"#{op}", {
+    function :"#{op}", {
+        must_use: true,
+        #FIXME: add constant function
+
         [T < Float].(T) => T,
         [T < Float, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.39
-operator :max, {
+function :max, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Number].(T, T) => T,
     [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.40
-operator :min, {
+function :min, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Number].(T, T) => T,
     [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.41
-operator :mix, {
+function :mix, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T, T, T) => T,
     [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
     [T < Float, N].(vec[N][T], vec[N][T], T) => vec[N][T],
 }
 
 # 17.5.42
-operator :modf, {
+function :modf, {
+    must_use: true,
+    #FIXME: add constant function
+
     # FIXME: this needs the special return types __modf_result_*
 }
 
 # 17.5.43
-operator :normalize, {
+function :normalize, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.44
-operator :pow, {
+function :pow, {
+    must_use: true,
+    const: true,
+
     [T < Float].(T, T) => T,
     [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.45
-operator :quantizeToF16, {
+function :quantizeToF16, {
+    must_use: true,
+    #FIXME: add constant function
+
     [].(f32) => f32,
     [N].(vec[N][f32]) => vec[N][f32],
 }
 
 # 17.5.46
-operator :radians, {
+function :radians, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.47
-operator :reflect, {
+function :reflect, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.48
-operator :refract, {
+function :refract, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float, N].(vec[N][T], vec[N][T], T) => vec[N][T],
 }
 
 # 17.5.49
-operator :reverseBits, {
+function :reverseBits, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < ConcreteInteger].(T) => T,
     [T < ConcreteInteger, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.50
-operator :round, {
+function :round, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.51
-operator :saturate, {
+function :saturate, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.52
-operator :sign, {
+function :sign, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < SignedNumber].(T) => T,
     [T < SignedNumber, N].(vec[N][T]) => vec[N][T],
 }
@@ -550,19 +772,28 @@ operator :sign, {
 # Defined in [Trigonometric]
 
 # 17.5.55
-operator :smoothstep, {
+function :smoothstep, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T, T, T) => T,
     [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.56
-operator :sqrt, {
+function :sqrt, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.57
-operator :step, {
+function :step, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T, T) => T,
     [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
@@ -572,12 +803,18 @@ operator :step, {
 # Defined in [Trigonometric]
 
 # 17.5.60
-operator :transpose, {
+function :transpose, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float, C, R].(mat[C,R][T]) => mat[R,C][T],
 }
 
 # 17.5.61
-operator :trunc, {
+function :trunc, {
+    must_use: true,
+    #FIXME: add constant function
+
     [T < Float].(T) => T,
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
@@ -603,7 +840,10 @@ operator :trunc, {
     # 16.6.9
     :fwidthFine,
 ]. each do |op|
-    operator op, {
+    function op, {
+        must_use: true,
+        stage: :fragment,
+
         [].(f32) => f32,
         [N].(vec[N][f32]) => vec[N][f32],
     }
@@ -612,7 +852,9 @@ end
 # 16.7. Texture Built-in Functions (https://gpuweb.github.io/gpuweb/wgsl/#texture-builtin-functions)
 
 # 16.7.1
-operator :textureDimensions, {
+function :textureDimensions, {
+    must_use: true,
+
     # ST is i32, u32, or f32
     # F is a texel format
     # A is an access mode
@@ -675,7 +917,9 @@ operator :textureDimensions, {
 }
 
 # 16.7.2
-operator :textureGather, {
+function :textureGather, {
+    must_use: true,
+
     [T < ConcreteInteger, S < Concrete32BitNumber].(T, texture_2d[S], sampler, vec2[f32]) => vec4[S],
 
     [T < ConcreteInteger, S < Concrete32BitNumber].(T, texture_2d[S], sampler, vec2[f32], vec2[i32]) => vec4[S],
@@ -711,7 +955,9 @@ operator :textureGather, {
 }
 
 # 16.7.3
-operator :textureGatherCompare, {
+function :textureGatherCompare, {
+    must_use: true,
+
     # @must_use fn textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> vec4<f32>
     [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => vec4[f32],
 
@@ -735,7 +981,9 @@ operator :textureGatherCompare, {
 }
 
 # 16.7.4
-operator :textureLoad, {
+function :textureLoad, {
+    must_use: true,
+
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_1d[S], T, U) => vec4[S],
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_2d[S], vec2[T], U) => vec4[S],
     [T < ConcreteInteger, V < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_2d_array[S], vec2[T], V, U) => vec4[S],
@@ -763,7 +1011,9 @@ operator :textureLoad, {
 }
 
 # 16.7.5
-operator :textureNumLayers, {
+function :textureNumLayers, {
+    must_use: true,
+
     # F is a texel format
     # A is an access mode
     # ST is i32, u32, or f32
@@ -777,7 +1027,9 @@ operator :textureNumLayers, {
 }
 
 # 16.7.6
-operator :textureNumLevels, {
+function :textureNumLevels, {
+    must_use: true,
+
     # ST is i32, u32, or f32
     # T is texture_1d<ST>, texture_2d<ST>, texture_2d_array<ST>, texture_3d<ST>, texture_cube<ST>, texture_cube_array<ST>, texture_depth_2d, texture_depth_2d_array, texture_depth_cube, or texture_depth_cube_array
     # @must_use fn textureNumLevels(t: T) -> u32
@@ -794,7 +1046,9 @@ operator :textureNumLevels, {
 }
 
 # 16.7.7
-operator :textureNumSamples, {
+function :textureNumSamples, {
+    must_use: true,
+
     # ST is i32, u32, or f32
     # T is texture_multisampled_2d<ST> or texture_depth_multisampled_2d
     # @must_use fn textureNumSamples(t: T) -> u32
@@ -803,7 +1057,10 @@ operator :textureNumSamples, {
 }
 
 # 16.7.8
-operator :textureSample, {
+function :textureSample, {
+    must_use: true,
+    stage: :fragment,
+
     [].(texture_1d[f32], sampler, f32) => vec4[f32],
 
     [].(texture_2d[f32], sampler, vec2[f32]) => vec4[f32],
@@ -844,7 +1101,10 @@ operator :textureSample, {
 }
 
 # 16.7.9
-operator :textureSampleBias, {
+function :textureSampleBias, {
+    must_use: true,
+    stage: :fragment,
+
     [].(texture_2d[f32], sampler, vec2[f32], f32) => vec4[f32],
 
     [].(texture_2d[f32], sampler, vec2[f32], f32, vec2[i32]) => vec4[f32],
@@ -862,7 +1122,10 @@ operator :textureSampleBias, {
 }
 
 # 16.7.10
-operator :textureSampleCompare, {
+function :textureSampleCompare, {
+    must_use: true,
+    stage: :fragment,
+
     # @must_use fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
     [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,
 
@@ -886,7 +1149,9 @@ operator :textureSampleCompare, {
 }
 
 # 16.7.11
-operator :textureSampleCompareLevel, {
+function :textureSampleCompareLevel, {
+    must_use: true,
+
     # @must_use fn textureSampleCompareLevel(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
     [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,
 
@@ -910,7 +1175,9 @@ operator :textureSampleCompareLevel, {
 }
 
 # 16.7.12
-operator :textureSampleGrad, {
+function :textureSampleGrad, {
+    must_use: true,
+
     [].(texture_2d[f32], sampler, vec2[f32], vec2[f32], vec2[f32]) => vec4[f32],
 
     [].(texture_2d[f32], sampler, vec2[f32], vec2[f32], vec2[f32], vec2[i32]) => vec4[f32],
@@ -928,7 +1195,9 @@ operator :textureSampleGrad, {
 }
 
 # 16.7.13
-operator :textureSampleLevel, {
+function :textureSampleLevel, {
+    must_use: true,
+
     [].(texture_2d[f32], sampler, vec2[f32], f32) => vec4[f32],
 
     [].(texture_2d[f32], sampler, vec2[f32], f32, vec2[i32]) => vec4[f32],
@@ -973,13 +1242,15 @@ operator :textureSampleLevel, {
 }
 
 # 16.7.14
-operator :textureSampleBaseClampToEdge, {
+function :textureSampleBaseClampToEdge, {
+    must_use: true,
+
     [].(texture_external, sampler, vec2[f32]) => vec4[f32],
     [].(texture_2d[f32], sampler, vec2[f32]) => vec4[f32],
 }
 
 # 16.7.15 textureStore
-operator :textureStore, {
+function :textureStore, {
     # F is a texel format
     # C is i32, or u32
     # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
@@ -1009,14 +1280,18 @@ operator :textureStore, {
 # 16.8. Atomic Built-in Functions (https://www.w3.org/TR/WGSL/#atomic-builtin-functions)
 
 # 16.8.1
-operator :atomicLoad, {
+function :atomicLoad, {
+    stage: [:fragment, :compute],
+
     # fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
     [AS, T].(ptr[AS, atomic[T], read_write]) => T,
 }
 
 
 # 16.8.2
-operator :atomicStore, {
+function :atomicStore, {
+    stage: [:fragment, :compute],
+
     # fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
     [AS, T].(ptr[AS, atomic[T], read_write], T) => void,
 }
@@ -1031,7 +1306,9 @@ operator :atomicStore, {
     :atomicXor,
     :atomicExchange,
 ].each do |op|
-    operator op, {
+    function op, {
+        stage: [:fragment, :compute],
+
         # fn #{op}(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
         [AS, T].(ptr[AS, atomic[T], read_write], T) => T,
     }
@@ -1043,19 +1320,26 @@ end
 # 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
 
 # 16.11.1.
-operator :storageBarrier, {
+function :storageBarrier, {
+    stage: :compute,
+
     # fn storageBarrier()
     [].() => void,
 }
 
 # 16.11.2.
-operator :workgroupBarrier, {
+function :workgroupBarrier, {
+    stage: :compute,
+
     # fn workgroupBarrier()
     [].() => void,
 }
 
 # 16.11.3.
-operator :workgroupUniformLoad, {
+function :workgroupUniformLoad, {
+    must_use: true,
+    stage: :compute,
+
     # @must_use fn workgroupUniformLoad(p : ptr<workgroup, T>) -> T
     [T].(ptr[workgroup, T]) => void,
 }


### PR DESCRIPTION
#### 454ec9e1ec8c89ed1977b3e149f0533ec77c6097
<pre>
[WGSL] Add more information to type declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=263550">https://bugs.webkit.org/show_bug.cgi?id=263550</a>
rdar://117370085

Reviewed by Mike Wyrzykowski.

This patch adds 4 bits of information to the declarations in TypeDeclarations.rb:
- it makes a distinction between constructors, regular functions and operators
- whether the function is const, and moves the pointer to the constant functions
  into the overload entry, so that it no longer needs to be looked up in a separate
  hash map
- the stages in which the declaration is available
- whether the function specifies `@must_use` or not

* Source/WebGPU/WGSL/AST/ASTCallExpression.h:
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantAdd):
(WGSL::constantVec2):
(WGSL::constantVec3):
(WGSL::constantVec4):
(WGSL::constantVector2): Deleted.
(WGSL::constantVector3): Deleted.
(WGSL::constantVector4): Deleted.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:

Canonical link: <a href="https://commits.webkit.org/269673@main">https://commits.webkit.org/269673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d72efa74c51da2afa4561d5ee8f3da7903da0b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24378 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23812 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23491 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26023 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/686 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5544 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->