### PR TITLE
[WGSL] Add support for constant matrices

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.cpp
+++ b/Source/WebGPU/WGSL/ConstantValue.cpp
@@ -64,6 +64,17 @@ void ConstantValue::dump(PrintStream& out) const
                 out.print(element);
             }
             out.print(")");
+        },
+        [&](const ConstantMatrix& m) {
+            out.print("mat", m.columns, "x", m.rows, "(");
+            bool first = true;
+            for (const auto& element : m.elements) {
+                if (!first)
+                    out.print(", ");
+                first = false;
+                out.print(element);
+            }
+            out.print(")");
         });
 }
 

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -66,7 +66,28 @@ struct ConstantVector {
     FixedVector<ConstantValue> elements;
 };
 
-using BaseValue = std::variant<double, int64_t, bool, ConstantArray, ConstantVector>;
+struct ConstantMatrix {
+    ConstantMatrix(uint32_t columns, uint32_t rows)
+        : columns(columns)
+        , rows(rows)
+        , elements(columns * rows)
+    {
+    }
+
+    ConstantMatrix(uint32_t columns, uint32_t rows, const FixedVector<ConstantValue>& elements)
+        : columns(columns)
+        , rows(rows)
+        , elements(elements)
+    {
+        RELEASE_ASSERT(elements.size() == columns * rows);
+    }
+
+    uint32_t columns;
+    uint32_t rows;
+    FixedVector<ConstantValue> elements;
+};
+
+using BaseValue = std::variant<double, int64_t, bool, ConstantArray, ConstantVector, ConstantMatrix>;
 struct ConstantValue : BaseValue {
     ConstantValue() = default;
 
@@ -78,6 +99,7 @@ struct ConstantValue : BaseValue {
     bool isInt() const { return std::holds_alternative<int64_t>(*this); }
     bool isNumber() const { return isInt() || std::holds_alternative<double>(*this); }
     bool isVector() const { return std::holds_alternative<ConstantVector>(*this); }
+    bool isMatrix() const { return std::holds_alternative<ConstantMatrix>(*this); }
 
     bool toBool() const { return std::get<bool>(*this); }
     int64_t toInt() const
@@ -96,7 +118,6 @@ struct ConstantValue : BaseValue {
     }
     const ConstantVector& toVector() const
     {
-        ASSERT(isNumber());
         return std::get<ConstantVector>(*this);
     }
 };

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1788,9 +1788,19 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
             }
             m_stringBuilder.append("}");
         },
-        [&](const Matrix&) {
-            // Not supported yet
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Matrix& matrixType) {
+            auto& matrix = std::get<ConstantMatrix>(value);
+            m_stringBuilder.append("matrix<");
+            visit(matrixType.element);
+            m_stringBuilder.append(", ", matrixType.columns, ", ", matrixType.rows, ">(");
+            bool first = true;
+            for (auto& element : matrix.elements) {
+                if (!first)
+                    m_stringBuilder.append(", ");
+                first = false;
+                serializeConstant(matrixType.element, element);
+            }
+            m_stringBuilder.append(")");
         },
         [&](const Struct&) {
             // Not supported yet

--- a/Source/WebGPU/WGSL/tests/valid/constant-matrix.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constant-matrix.wgsl
@@ -1,0 +1,61 @@
+// RUN: %metal-compile main
+// RUN: %metal main 2>&1 | %check
+
+
+@compute @workgroup_size(1)
+fn main()
+{
+    // CHECK-L: 8680
+    let x = determinant(mat4x4(
+      15,2,34,4,
+      18,2,3,4,
+      1,72,32,4,
+      17,2,3,4,
+    ));
+
+    // CHECK-L: 8680
+    let y = determinant(mat4x4(
+        vec4(15,2,34,4),
+        vec4(18,2,3,4),
+        vec4(1,72,32,4),
+        vec4(17,2,3,4),
+    ));
+
+    const m2 = mat2x2(
+      1,2,
+      3,4,
+    );
+
+    // CHECK-L: 1., 3., 2., 4.
+    let tm2 = transpose(m2);
+
+    // CHECK-L: 1., 4., 7., 2., 5., 8., 3., 6., 9.
+    let tm3 = transpose(mat3x3(
+      1,2,3,
+      4,5,6,
+      7,8,9,
+    ));
+
+    // CHECK-L: 2., 4., 6., 8.
+    let x0 = m2 * 2;
+
+    const m2x3 = mat2x3(
+      1,2,3,
+      4,5,6
+    );
+
+    // CHECK-L: 1., 4., 2., 5., 3., 6.
+    let x1 = transpose(m2x3);
+
+    // CHECK-L: 10., 14., 18.
+    let x2 = m2x3 * vec2(2);
+
+    // CHECK-L: 12., 30.
+    let x3 = vec3(2) * m2x3;
+
+    // CHECK-L: 32
+    let x4 = dot(vec3(1,2,3), vec3(4,5,6));
+
+    // CHECK-L: 95., 128., 68., 92., 41., 56., 14., 20.
+    let x5 = mat3x2(1,2,3,4,5,6) * mat4x3(12,11,10,9,8,7,6,5,4,3,2,1);
+}


### PR DESCRIPTION
#### d041f3c6a9a1e1d9df8401b0469d24a97e3be6e8
<pre>
[WGSL] Add support for constant matrices
<a href="https://bugs.webkit.org/show_bug.cgi?id=263555">https://bugs.webkit.org/show_bug.cgi?id=263555</a>
rdar://117371722

Reviewed by Mike Wyrzykowski.

Implement ConstantMatrix as one of the variants in ConstantValue and implement
all the constant functions that depend on it.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::zeroValue):
(WGSL::constantMatrix):
(WGSL::constantAdd):
(WGSL::constantMultiply):
(WGSL::constantDeterminant):
(WGSL::constantTranspose):
* Source/WebGPU/WGSL/ConstantValue.cpp:
(WGSL::ConstantValue::dump const):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantMatrix::ConstantMatrix):
(WGSL::ConstantValue::isMatrix const):
(WGSL::ConstantValue::toVector const):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):
* Source/WebGPU/WGSL/tests/valid/constant-matrix.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/269741@main">https://commits.webkit.org/269741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a558d849db7e1d28fab620cedba1c3075d7f5214

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24544 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21632 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23972 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26185 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/893 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21353 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/844 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5596 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->