### PR TITLE
[import-w3c-tests] Remove unused git submodule support

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -249,11 +249,6 @@ class TestImporter(object):
 
     def generate_git_submodules_description_for_all_repositories(self):
         for test_repository in self._test_downloader.test_repositories:
-            if 'generate_git_submodules_description' in test_repository['import_options']:
-                self.filesystem.maybe_make_directory(self.filesystem.join(self.destination_directory, 'resources'))
-                self._test_downloader.generate_git_submodules_description(test_repository, self.filesystem.join(self.destination_directory, 'resources', test_repository['name'] + '-modules.json'))
-            if 'generate_gitignore' in test_repository['import_options']:
-                self._test_downloader.generate_gitignore(test_repository, self.destination_directory)
             if 'generate_init_py' in test_repository['import_options']:
                 self.write_init_py(self.filesystem.join(self.destination_directory, test_repository['name'], '__init__.py'))
 

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -55,7 +55,7 @@ FAKE_REPOSITORY = {
         "revision": "dd553279c3",
         "paths_to_skip": [],
         "paths_to_import": [],
-        "import_options": ["generate_git_submodules_description", "generate_gitignore", "generate_init_py"]
+        "import_options": ["generate_init_py"]
     }
 ]
 ''',
@@ -84,7 +84,7 @@ FAKE_REPOSITORIES = {
         "revision": "dd553279c3",
         "paths_to_skip": [],
         "paths_to_import": [],
-        "import_options": ["generate_git_submodules_description", "generate_gitignore", "generate_init_py"]
+        "import_options": ["generate_init_py"]
     }
 ]
 ''',
@@ -195,20 +195,6 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html'))
         self.assertTrue('src="/resources/testharness.js"' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html'))
         self.assertTrue('src="/resources/testharness.js"' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/t/test.html'))
-
-    def test_submodules_generation(self):
-        FAKE_FILES = {
-            '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/.gitmodules': '[submodule "tools/resources"]\n	path = tools/resources\n	url = https://github.com/w3c/testharness.js.git\n  ignore = dirty\n',
-            '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/.gitmodules': '[submodule "tools/resources"]\n	path = tools/resources\n	url = https://github.com/w3c/testharness.js.git\n  ignore = dirty\n',
-        }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
-
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
-
-        self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/resources/csswg-tests-modules.json'))
-        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/resources/web-platform-tests-modules.json'))
-        # FIXME: Mock-up of git cannot use submodule command, hence the json file is empty, but still it should be created
-        #self.assertTrue('https://github.com/w3c/testharness.js/archive/db4d391a69877d4a1eaaf51d1725c99a5b8ed84.tar.gz' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/resources/web-platform-tests-modules.json'))
 
     def test_skip_test_import_download(self):
         FAKE_FILES = {
@@ -467,22 +453,6 @@ class TestImporterTest(unittest.TestCase):
         tests_options = json.loads(fs.read_text_file('/mock-checkout/LayoutTests/tests-options.json'))
         self.assertIn("imported/w3c/web-platform-tests/cssom-view/old-test.html", tests_options)
         self.assertNotIn("imported/w3c/web-platform-tests/cssom/old-test.html", tests_options)
-
-    def test_git_ignore_generation(self):
-        FAKE_FILES = {
-            '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/.gitmodules': '[submodule "tools/resources"]\n	path = tools/resources\n	url = https://github.com/w3c/testharness.js.git\n  ignore = dirty\n',
-            '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/.gitmodules': '[submodule "tools/resources"]\n	path = tools/resources\n	url = https://github.com/w3c/testharness.js.git\n  ignore = dirty\n',
-        }
-
-        FAKE_FILES.update(FAKE_REPOSITORIES)
-
-        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
-
-        self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/csswg-tests/.gitignore'))
-        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/.gitignore'))
-        # We should activate these lines but this is not working in mock systems.
-        #self.assertTrue('/tools/.resources.url' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/.gitignore'))
-        #self.assertTrue('/tools/resources/' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/.gitignore'))
 
     def test_initpy_generation(self):
         FAKE_FILES = {


### PR DESCRIPTION
#### cfec9fd37dd9
<pre>
[import-w3c-tests] Remove unused git submodule support
<a href="https://bugs.webkit.org/show_bug.cgi?id=263557">https://bugs.webkit.org/show_bug.cgi?id=263557</a>

Reviewed by NOBODY (OOPS!).

TestRepositories doesn&apos;t define &quot;generate_git_submodules_description&quot; or
&quot;generate_gitignore&quot; as &quot;import_options&quot; for any repository at this
point, so we can remove this code.

* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader.update_import_expectations):
(TestDownloader._git_submodules_description): Deleted.
(TestDownloader.generate_git_submodules_description): Deleted.
(TestDownloader.generate_gitignore): Deleted.
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.generate_git_submodules_description_for_all_repositories):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfec9fd37dd9235df29ab4d93318200336ac93f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24386 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25566 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23820 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25566 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26031 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23449 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27193 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25069 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->