### PR TITLE
Adopt more smart pointers in RenderElement

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9786,6 +9786,11 @@ CheckedRef<const Style::Scope> Document::checkedStyleScope() const
     return m_styleScope.get();
 }
 
+RefPtr<LocalFrameView> Document::protectedView() const
+{
+    return view();
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4531,16 +4531,6 @@ void FrameLoader::advanceStatePastInitialEmptyDocument()
         stateMachine().advanceTo(FrameLoaderStateMachine::CommittedFirstRealLoad);
 }
 
-void FrameLoader::incrementPtrCount() const
-{
-    m_frame.incrementPtrCount();
-}
-
-void FrameLoader::decrementPtrCount() const
-{
-    m_frame.decrementPtrCount();
-}
-
 } // namespace WebCore
 
 #undef PAGE_ID

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -98,16 +98,12 @@ WEBCORE_EXPORT bool isReload(FrameLoadType);
 
 using ContentPolicyDecisionFunction = Function<void(PolicyAction, PolicyCheckIdentifier)>;
 
-class FrameLoader final {
+class FrameLoader final : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(FrameLoader);
 public:
     FrameLoader(LocalFrame&, UniqueRef<LocalFrameLoaderClient>&&);
     ~FrameLoader();
-
-    // For use with CheckedPtr / CheckedRef. Forwards the pointer counting to the owning frame.
-    void incrementPtrCount() const;
-    void decrementPtrCount() const;
 
     WEBCORE_EXPORT void init();
     void initForSynthesizedDocument(const URL&);

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -39,6 +39,7 @@
 #include "Timer.h"
 #include <memory>
 #include <utility>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -130,7 +131,7 @@ enum class ImmediateActionStage : uint8_t {
     ActionCompleted
 };
 
-class EventHandler {
+class EventHandler : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit EventHandler(LocalFrame&);
@@ -607,7 +608,9 @@ private:
         m_isCapturingRootElementForMouseEvents = false;
     }
 
-    LocalFrame& m_frame;
+    Ref<LocalFrame> protectedFrame() const;
+
+    CheckedRef<LocalFrame> m_frame;
     RefPtr<Node> m_mousePressNode;
     Timer m_hoverTimer;
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1202,9 +1202,14 @@ LocalFrame* LocalFrame::contentFrameFromWindowOrFrameElement(JSContextRef contex
     return dynamicDowncast<LocalFrame>(downcast<HTMLFrameOwnerElement>(jsNode->wrapped()).contentFrame());
 }
 
-RefPtr<LocalFrameView> Document::protectedView() const
+CheckedRef<EventHandler> LocalFrame::checkedEventHandler()
 {
-    return view();
+    return m_eventHandler.get();
+}
+
+CheckedRef<const EventHandler> LocalFrame::checkedEventHandler() const
+{
+    return m_eventHandler.get();
 }
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -145,8 +145,12 @@ public:
 
     Editor& editor() { return document()->editor(); }
     const Editor& editor() const { return document()->editor(); }
+
     EventHandler& eventHandler() { return m_eventHandler; }
     const EventHandler& eventHandler() const { return m_eventHandler; }
+    CheckedRef<EventHandler> checkedEventHandler();
+    CheckedRef<const EventHandler> checkedEventHandler() const;
+
     const FrameLoader& loader() const { return m_loader.get(); }
     FrameLoader& loader() { return m_loader.get(); }
     CheckedRef<const FrameLoader> checkedLoader() const;

--- a/Source/WebCore/page/cocoa/EventHandlerCocoa.mm
+++ b/Source/WebCore/page/cocoa/EventHandlerCocoa.mm
@@ -37,7 +37,7 @@ namespace WebCore {
 
 VisibleSelection EventHandler::selectClosestWordFromHitTestResultBasedOnLookup(const HitTestResult& result)
 {
-    if (!m_frame.editor().behavior().shouldSelectBasedOnDictionaryLookup())
+    if (!m_frame->editor().behavior().shouldSelectBasedOnDictionaryLookup())
         return { };
 
     auto range = DictionaryLookup::rangeAtHitTestResult(result);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -179,8 +179,8 @@ RenderPtr<RenderElement> RenderElement::createFor(Element& element, RenderStyle&
     const ContentData* contentData = style.contentData();
     if (!rendererTypeOverride && contentData && isContentDataSupported(*contentData) && !element.isPseudoElement()) {
         Style::loadPendingResources(style, element.document(), &element);
-        auto& styleImage = downcast<ImageContentData>(*contentData).image();
-        auto image = createRenderer<RenderImage>(RenderObject::Type::Image, element, WTFMove(style), const_cast<StyleImage*>(&styleImage));
+        Ref styleImage = downcast<ImageContentData>(*contentData).image();
+        auto image = createRenderer<RenderImage>(RenderObject::Type::Image, element, WTFMove(style), const_cast<StyleImage*>(styleImage.ptr()));
         image->setIsGeneratedContent();
         return image;
     }
@@ -361,7 +361,7 @@ void RenderElement::updateFillImages(const FillLayer* oldLayers, const FillLayer
     };
 
     auto isRegisteredWithNewFillImages = [&]() -> bool {
-        for (auto* layer = newLayers; layer; layer = layer->next()) {
+        for (RefPtr layer = newLayers; layer; layer = layer->next()) {
             if (layer->image() && !layer->image()->hasClient(*this))
                 return false;
         }
@@ -374,13 +374,13 @@ void RenderElement::updateFillImages(const FillLayer* oldLayers, const FillLayer
         return;
 
     // Add before removing, to avoid removing all clients of an image that is in both sets.
-    for (auto* layer = newLayers; layer; layer = layer->next()) {
-        if (layer->image())
-            layer->image()->addClient(*this);
+    for (RefPtr layer = newLayers; layer; layer = layer->next()) {
+        if (RefPtr image = layer->image())
+            image->addClient(*this);
     }
-    for (auto* layer = oldLayers; layer; layer = layer->next()) {
-        if (layer->image())
-            layer->image()->removeClient(*this);
+    for (RefPtr layer = oldLayers; layer; layer = layer->next()) {
+        if (RefPtr image = layer->image())
+            image->removeClient(*this);
     }
 }
 
@@ -397,7 +397,7 @@ void RenderElement::updateImage(StyleImage* oldImage, StyleImage* newImage)
 void RenderElement::updateShapeImage(const ShapeValue* oldShapeValue, const ShapeValue* newShapeValue)
 {
     if (oldShapeValue || newShapeValue)
-        updateImage(oldShapeValue ? oldShapeValue->image() : nullptr, newShapeValue ? newShapeValue->image() : nullptr);
+        updateImage(oldShapeValue ? oldShapeValue->image() : nullptr, newShapeValue ? newShapeValue->protectedImage().get() : nullptr);
 }
 
 bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderStyle& oldStyle, const RenderStyle& newStyle)
@@ -452,8 +452,8 @@ bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderS
         }
 
         if (diff > StyleDifference::RepaintLayer && oldStyle.visibility() != newStyle.visibility()) {
-            if (auto* enclosingLayer = this->enclosingLayer()) {
-                auto rendererWillBeHidden = newStyle.visibility() != Visibility::Visible;
+            if (CheckedPtr enclosingLayer = this->enclosingLayer()) {
+                bool rendererWillBeHidden = newStyle.visibility() != Visibility::Visible;
                 if (rendererWillBeHidden && enclosingLayer->hasVisibleContent() && (this == &enclosingLayer->renderer() || enclosingLayer->renderer().style().visibility() != Visibility::Visible))
                     return RequiredRepaint::RendererOnly;
             }
@@ -464,7 +464,7 @@ bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderS
 
     if (shouldRepaintBeforeStyleChange == RequiredRepaint::RendererAndDescendantsRenderersWithLayers) {
         ASSERT(hasLayer());
-        downcast<RenderLayerModelObject>(*this).layer()->repaintIncludingDescendants();
+        downcast<RenderLayerModelObject>(*this).checkedLayer()->repaintIncludingDescendants();
         return true;
     }
 
@@ -478,7 +478,7 @@ bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderS
 
 void RenderElement::initializeStyle()
 {
-    Style::loadPendingResources(m_style, document(), element());
+    Style::loadPendingResources(m_style, protectedDocument(), protectedElement().get());
 
     styleWillChange(StyleDifference::NewStyle, style());
     m_hasInitializedStyle = true;
@@ -507,7 +507,7 @@ void RenderElement::setStyle(RenderStyle&& style, StyleDifference minimalStyleDi
 
     diff = adjustStyleDifference(diff, contextSensitiveProperties);
 
-    Style::loadPendingResources(style, document(), element());
+    Style::loadPendingResources(style, protectedDocument(), protectedElement().get());
 
     auto didRepaint = repaintBeforeStyleChange(diff, m_style, style);
     styleWillChange(diff, style);
@@ -519,8 +519,8 @@ void RenderElement::setStyle(RenderStyle&& style, StyleDifference minimalStyleDi
     styleDidChange(diff, &oldStyle);
 
     // Text renderers use their parent style. Notify them about the change.
-    for (auto& child : childrenOfType<RenderText>(*this))
-        child.styleDidChange(diff, &oldStyle);
+    for (CheckedRef child : childrenOfType<RenderText>(*this))
+        child->styleDidChange(diff, &oldStyle);
 
     // FIXME: |this| might be destroyed here. This can currently happen for a RenderTextFragment when
     // its first-letter block gets an update in RenderTextFragment::styleDidChange. For RenderTextFragment(s),
@@ -569,7 +569,7 @@ void RenderElement::didAttachChild(RenderObject& child, RenderObject*)
     // To avoid the problem alltogether, detect early if we're inside a hidden SVG subtree
     // and stop creating layers at all for these cases - they're not used anyways.
     if (child.hasLayer() && !layerCreationAllowedForSubtree())
-        downcast<RenderLayerModelObject>(child).layer()->removeOnlyThisLayer(RenderLayer::LayerChangeTiming::RenderTreeConstruction);
+        downcast<RenderLayerModelObject>(child).checkedLayer()->removeOnlyThisLayer(RenderLayer::LayerChangeTiming::RenderTreeConstruction);
 }
 
 RenderObject* RenderElement::attachRendererInternal(RenderPtr<RenderObject> child, RenderObject* beforeChild)
@@ -580,34 +580,37 @@ RenderObject* RenderElement::attachRendererInternal(RenderPtr<RenderObject> chil
         m_firstChild = child.get();
 
     if (beforeChild) {
-        auto* previousSibling = beforeChild->previousSibling();
+        CheckedPtr previousSibling = beforeChild->previousSibling();
         if (previousSibling)
             previousSibling->setNextSibling(child.get());
-        child->setPreviousSibling(previousSibling);
+        child->setPreviousSibling(previousSibling.get());
         child->setNextSibling(beforeChild);
         beforeChild->setPreviousSibling(child.get());
         return child.release();
     }
-    if (m_lastChild)
-        m_lastChild->setNextSibling(child.get());
-    child->setPreviousSibling(m_lastChild.get());
+    {
+        CheckedPtr lastChild = m_lastChild.get();
+        if (lastChild)
+            lastChild->setNextSibling(child.get());
+        child->setPreviousSibling(lastChild.get());
+    }
     m_lastChild = child.get();
     return child.release();
 }
 
 RenderPtr<RenderObject> RenderElement::detachRendererInternal(RenderObject& renderer)
 {
-    auto* parent = renderer.parent();
+    CheckedPtr parent = renderer.parent();
     ASSERT(parent);
-    auto* nextSibling = renderer.nextSibling();
+    CheckedPtr nextSibling = renderer.nextSibling();
 
-    if (renderer.previousSibling())
-        renderer.previousSibling()->setNextSibling(nextSibling);
+    if (CheckedPtr previousSibling = renderer.previousSibling())
+        previousSibling->setNextSibling(nextSibling.get());
     if (nextSibling)
         nextSibling->setPreviousSibling(renderer.previousSibling());
 
     if (parent->firstChild() == &renderer)
-        parent->m_firstChild = nextSibling;
+        parent->m_firstChild = nextSibling.get();
     if (parent->lastChild() == &renderer)
         parent->m_lastChild = renderer.previousSibling();
 
@@ -643,7 +646,7 @@ static RenderLayer* findNextLayer(const RenderElement& currRenderer, const Rende
     // Step 4: If |checkParent| is set, climb up to our parent and check its siblings that
     // follow us to see if we can locate a layer.
     if (checkParent && currRenderer.parent())
-        return findNextLayer(*currRenderer.parent(), parentLayer, &currRenderer, true);
+        return findNextLayer(*currRenderer.checkedParent(), parentLayer, &currRenderer, true);
 
     return nullptr;
 }
@@ -663,13 +666,13 @@ static RenderLayer* layerNextSiblingRespectingTopLayer(const RenderElement& rend
         return nullptr;
     }
 
-    return findNextLayer(*renderer.parent(), parentLayer, &renderer);
+    return findNextLayer(*renderer.checkedParent(), parentLayer, &renderer);
 }
 
 static void addLayers(const RenderElement& insertedRenderer, RenderElement& currentRenderer, RenderLayer& parentLayer)
 {
     if (currentRenderer.hasLayer()) {
-        auto* layerToUse = &parentLayer;
+        CheckedPtr layerToUse = &parentLayer;
         if (isInTopLayerOrBackdrop(currentRenderer.style(), currentRenderer.element())) {
             // The special handling of a toplayer/backdrop content may result in trying to insert the associated
             // layer twice as we connect subtrees.
@@ -679,28 +682,28 @@ static void addLayers(const RenderElement& insertedRenderer, RenderElement& curr
             }
             layerToUse = insertedRenderer.view().layer();
         }
-        auto* beforeChild = layerNextSiblingRespectingTopLayer(insertedRenderer, *layerToUse);
-        layerToUse->addChild(*downcast<RenderLayerModelObject>(currentRenderer).layer(), beforeChild);
+        CheckedPtr beforeChild = layerNextSiblingRespectingTopLayer(insertedRenderer, *layerToUse);
+        layerToUse->addChild(*downcast<RenderLayerModelObject>(currentRenderer).checkedLayer(), beforeChild.get());
         return;
     }
 
-    for (auto& child : childrenOfType<RenderElement>(currentRenderer))
+    for (CheckedRef child : childrenOfType<RenderElement>(currentRenderer))
         addLayers(insertedRenderer, child, parentLayer);
 }
 
 void RenderElement::removeLayers()
 {
-    RenderLayer* parentLayer = layerParent();
+    CheckedPtr parentLayer = layerParent();
     if (!parentLayer)
         return;
 
     if (hasLayer()) {
-        parentLayer->removeChild(*downcast<RenderLayerModelObject>(*this).layer());
+        parentLayer->removeChild(*downcast<RenderLayerModelObject>(*this).checkedLayer());
         return;
     }
 
-    for (auto& child : childrenOfType<RenderElement>(*this))
-        child.removeLayers();
+    for (CheckedRef child : childrenOfType<RenderElement>(*this))
+        child->removeLayers();
 }
 
 void RenderElement::moveLayers(RenderLayer& newParent)
@@ -708,23 +711,22 @@ void RenderElement::moveLayers(RenderLayer& newParent)
     if (hasLayer()) {
         if (isInTopLayerOrBackdrop(style(), element()))
             return;
-        RenderLayer* layer = downcast<RenderLayerModelObject>(*this).layer();
-        auto* layerParent = layer->parent();
-        if (layerParent)
+        CheckedPtr layer = downcast<RenderLayerModelObject>(*this).layer();
+        if (CheckedPtr layerParent = layer->parent())
             layerParent->removeChild(*layer);
         newParent.addChild(*layer);
         return;
     }
 
-    for (auto& child : childrenOfType<RenderElement>(*this))
-        child.moveLayers(newParent);
+    for (CheckedRef child : childrenOfType<RenderElement>(*this))
+        child->moveLayers(newParent);
 }
 
 RenderLayer* RenderElement::layerParent() const
 {
-    ASSERT_IMPLIES(isInTopLayerOrBackdrop(style(), element()), hasLayer());
+    ASSERT_IMPLIES(isInTopLayerOrBackdrop(style(), protectedElement().get()), hasLayer());
 
-    if (hasLayer() && isInTopLayerOrBackdrop(style(), element()))
+    if (hasLayer() && isInTopLayerOrBackdrop(style(), protectedElement().get()))
         return view().layer();
 
     return parent()->enclosingLayer();
@@ -766,33 +768,33 @@ bool RenderElement::layerCreationAllowedForSubtree() const
 void RenderElement::propagateStyleToAnonymousChildren(StylePropagationType propagationType)
 {
     // FIXME: We could save this call when the change only affected non-inherited properties.
-    for (auto& elementChild : childrenOfType<RenderElement>(*this)) {
-        if (!elementChild.isAnonymous() || elementChild.style().styleType() != PseudoId::None)
+    for (CheckedRef elementChild : childrenOfType<RenderElement>(*this)) {
+        if (!elementChild->isAnonymous() || elementChild->style().styleType() != PseudoId::None)
             continue;
 
-        if (propagationType == PropagateToBlockChildrenOnly && !is<RenderBlock>(elementChild))
+        if (propagationType == PropagateToBlockChildrenOnly && !is<RenderBlock>(elementChild.get()))
             continue;
 
         // RenderFragmentedFlows are updated through the RenderView::styleDidChange function.
-        if (is<RenderFragmentedFlow>(elementChild))
+        if (is<RenderFragmentedFlow>(elementChild.get()))
             continue;
 
-        auto newStyle = RenderStyle::createAnonymousStyleWithDisplay(style(), elementChild.style().display());
+        auto newStyle = RenderStyle::createAnonymousStyleWithDisplay(style(), elementChild->style().display());
         if (style().specifiesColumns()) {
-            if (elementChild.style().specifiesColumns())
+            if (elementChild->style().specifiesColumns())
                 newStyle.inheritColumnPropertiesFrom(style());
-            if (elementChild.style().columnSpan() == ColumnSpan::All)
+            if (elementChild->style().columnSpan() == ColumnSpan::All)
                 newStyle.setColumnSpan(ColumnSpan::All);
         }
 
         // Preserve the position style of anonymous block continuations as they can have relative or sticky position when
         // they contain block descendants of relative or sticky positioned inlines.
-        if (elementChild.isInFlowPositioned() && elementChild.isContinuation())
-            newStyle.setPosition(elementChild.style().position());
+        if (elementChild->isInFlowPositioned() && elementChild->isContinuation())
+            newStyle.setPosition(elementChild->style().position());
 
         updateAnonymousChildStyle(newStyle);
         
-        elementChild.setStyle(WTFMove(newStyle));
+        elementChild->setStyle(WTFMove(newStyle));
     }
 }
 
@@ -813,13 +815,13 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
         bool contentVisibilityChanged = oldStyle && oldStyle->contentVisibility() != newStyle.contentVisibility();
         if (contentVisibilityChanged) {
             if (oldStyle->contentVisibility() == ContentVisibility::Auto)
-                ContentVisibilityDocumentState::unobserve(*element());
+                ContentVisibilityDocumentState::unobserve(*protectedElement());
             auto wasSkippedContent = oldStyle->contentVisibility() == ContentVisibility::Hidden ? IsSkippedContent::Yes : IsSkippedContent::No;
             auto isSkippedContent = newStyle.contentVisibility() == ContentVisibility::Hidden ? IsSkippedContent::Yes : IsSkippedContent::No;
             ContentVisibilityDocumentState::updateAnimations(*element(), wasSkippedContent, isSkippedContent);
         }
         if ((contentVisibilityChanged || !oldStyle) && newStyle.contentVisibility() == ContentVisibility::Auto)
-            ContentVisibilityDocumentState::observe(*element());
+            ContentVisibilityDocumentState::observe(*protectedElement());
     };
 
     if (oldStyle) {
@@ -830,18 +832,19 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
             || m_style.hasAutoUsedZIndex() != newStyle.hasAutoUsedZIndex();
 
         if (visibilityChanged)
-            document().invalidateRenderingDependentRegions();
+            protectedDocument()->invalidateRenderingDependentRegions();
 
         if (visibilityChanged) {
-            if (AXObjectCache* cache = document().existingAXObjectCache())
-                cache->childrenChanged(parent(), this);
+            Ref document = this->document();
+            if (CheckedPtr cache = document->existingAXObjectCache())
+                cache->childrenChanged(checkedParent().get(), this);
         }
 
         // Keep layer hierarchy visibility bits up to date if visibility changes.
         bool wasVisible = m_style.visibility() == Visibility::Visible && !m_style.skippedContentReason().has_value();
         bool willBeVisible = newStyle.visibility() == Visibility::Visible && !newStyle.skippedContentReason().has_value();
         if (wasVisible != willBeVisible) {
-            if (RenderLayer* layer = enclosingLayer()) {
+            if (CheckedPtr layer = enclosingLayer()) {
                 if (willBeVisible)
                     layer->setHasVisibleContent();
                 else if (layer->hasVisibleContent() && (this == &layer->renderer() || layer->renderer().style().visibility() != Visibility::Visible))
@@ -869,7 +872,7 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
 
         if (needsInvalidateEventRegion()) {
             // Usually the event region gets updated as a result of paint invalidation. Here we need to request an update explicitly.
-            if (auto* layer = enclosingLayer())
+            if (CheckedPtr layer = enclosingLayer())
                 layer->invalidateEventRegion(RenderLayer::EventRegionInvalidationReason::Style);
         }
 
@@ -902,9 +905,9 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
     bool hasOutline = newStyle.hasOutline();
     if (hadOutline != hasOutline) {
         if (hasOutline)
-            view().incrementRendersWithOutline();
+            checkedView()->incrementRendersWithOutline();
         else
-            view().decrementRendersWithOutline();
+            checkedView()->decrementRendersWithOutline();
     }
 
     bool newStyleSlowScroll = false;
@@ -917,12 +920,12 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
 
     if (view().frameView().hasSlowRepaintObject(*this)) {
         if (!newStyleSlowScroll)
-            view().frameView().removeSlowRepaintObject(*this);
+            view().protectedFrameView()->removeSlowRepaintObject(*this);
     } else if (newStyleSlowScroll)
-        view().frameView().addSlowRepaintObject(*this);
+        view().protectedFrameView()->addSlowRepaintObject(*this);
 
     if (isDocumentElementRenderer() || isBody())
-        view().frameView().updateExtendBackgroundIfNecessary();
+        view().protectedFrameView()->updateExtendBackgroundIfNecessary();
 }
 
 inline void RenderCounter::rendererStyleChanged(RenderElement& renderer, const RenderStyle* oldStyle, const RenderStyle& newStyle)
@@ -951,11 +954,11 @@ void RenderElement::styleDidChange(StyleDifference diff, const RenderStyle* oldS
     auto registerImages = [this](auto* style, auto* oldStyle) {
         if (!style && !oldStyle)
             return;
-        updateFillImages(oldStyle ? &oldStyle->backgroundLayers() : nullptr, style ? &style->backgroundLayers() : nullptr);
-        updateFillImages(oldStyle ? &oldStyle->maskLayers() : nullptr, style ? &style->maskLayers() : nullptr);
-        updateImage(oldStyle ? oldStyle->borderImage().image() : nullptr, style ? style->borderImage().image() : nullptr);
-        updateImage(oldStyle ? oldStyle->maskBorder().image() : nullptr, style ? style->maskBorder().image() : nullptr);
-        updateShapeImage(oldStyle ? oldStyle->shapeOutside() : nullptr, style ? style->shapeOutside() : nullptr);
+        updateFillImages(oldStyle ? &oldStyle->protectedBackgroundLayers().get() : nullptr, style ? &style->protectedBackgroundLayers().get() : nullptr);
+        updateFillImages(oldStyle ? &oldStyle->protectedMaskLayers().get() : nullptr, style ? &style->protectedMaskLayers().get() : nullptr);
+        updateImage(oldStyle ? oldStyle->borderImage().protectedImage().get() : nullptr, style ? style->borderImage().protectedImage().get() : nullptr);
+        updateImage(oldStyle ? oldStyle->maskBorder().protectedImage().get() : nullptr, style ? style->maskBorder().protectedImage().get() : nullptr);
+        updateShapeImage(oldStyle ? oldStyle->protectedShapeOutside().get() : nullptr, style ? style->protectedShapeOutside().get() : nullptr);
     };
 
     registerImages(&style(), oldStyle);
@@ -997,7 +1000,7 @@ void RenderElement::styleDidChange(StyleDifference diff, const RenderStyle* oldS
 
 #if !PLATFORM(IOS_FAMILY)
     if (oldStyle && !areCursorsEqual(oldStyle, &style()))
-        frame().eventHandler().scheduleCursorUpdate();
+        protectedFrame()->checkedEventHandler()->scheduleCursorUpdate();
 #endif
 
     bool hadOutlineAuto = oldStyle && oldStyle->outlineStyleIsAuto() == OutlineIsAuto::On;
@@ -1012,18 +1015,15 @@ void RenderElement::insertedIntoTree(IsInternalMove isInternalMove)
 {
     // Keep our layer hierarchy updated. Optimize for the common case where we don't have any children
     // and don't have a layer attached to ourselves.
-    RenderLayer* parentLayer = nullptr;
     if (firstChild() || hasLayer()) {
-        if (auto* parentLayer = layerParent())
+        if (CheckedPtr parentLayer = layerParent())
             addLayers(*this, *this, *parentLayer);
     }
 
     // If |this| is visible but this object was not, tell the layer it has some visible content
     // that needs to be drawn and layer visibility optimization can't be used
     if (parent()->style().visibility() != Visibility::Visible && style().visibility() == Visibility::Visible && !hasLayer()) {
-        if (!parentLayer)
-            parentLayer = layerParent();
-        if (parentLayer)
+        if (CheckedPtr parentLayer = layerParent())
             parentLayer->dirtyVisibleContentStatus();
     }
 
@@ -1035,7 +1035,7 @@ void RenderElement::willBeRemovedFromTree(IsInternalMove isInternalMove)
     // If we remove a visible child from an invisible parent, we don't know the layer visibility any more.
     if (parent()->style().visibility() != Visibility::Visible && style().visibility() == Visibility::Visible && !hasLayer()) {
         // FIXME: should get parent layer. Necessary?
-        if (auto* enclosingLayer = parent()->enclosingLayer())
+        if (CheckedPtr enclosingLayer = parent()->enclosingLayer())
             enclosingLayer->dirtyVisibleContentStatus();
     }
     // Keep our layer hierarchy updated.
@@ -1043,7 +1043,7 @@ void RenderElement::willBeRemovedFromTree(IsInternalMove isInternalMove)
         removeLayers();
 
     if (isOutOfFlowPositioned() && parent()->childrenInline())
-        parent()->dirtyLinesFromChangedChild(*this);
+        checkedParent()->dirtyLinesFromChangedChild(*this);
 
     RenderObject::willBeRemovedFromTree(isInternalMove);
 }
@@ -1063,7 +1063,7 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
     // This indicates a failure to layout the child, which is why
     // the layout root is still set to |this|. Make sure to clear it
     // since we are getting destroyed.
-    view().frameView().layoutContext().clearSubtreeLayoutRoot();
+    view().protectedFrameView()->layoutContext().clearSubtreeLayoutRoot();
 }
 
 void RenderElement::willBeDestroyed()
@@ -1073,7 +1073,7 @@ void RenderElement::willBeDestroyed()
         document().contentChangeObserver().rendererWillBeDestroyed(*element());
 #endif
     if (m_style.hasAnyFixedBackground() && !settings().fixedBackgroundsPaintRelativeToDocument())
-        view().frameView().removeSlowRepaintObject(*this);
+        view().protectedFrameView()->removeSlowRepaintObject(*this);
 
     unregisterForVisibleInViewportCallback();
 
@@ -1091,30 +1091,30 @@ void RenderElement::willBeDestroyed()
 
     auto unregisterImages = [&](auto& style) {
         for (auto* backgroundLayer = &style.backgroundLayers(); backgroundLayer; backgroundLayer = backgroundLayer->next())
-            unregisterImage(backgroundLayer->image());
+            unregisterImage(backgroundLayer->protectedImage().get());
         for (auto* maskLayer = &style.maskLayers(); maskLayer; maskLayer = maskLayer->next())
-            unregisterImage(maskLayer->image());
-        unregisterImage(style.borderImage().image());
-        unregisterImage(style.maskBorder().image());
+            unregisterImage(maskLayer->protectedImage().get());
+        unregisterImage(style.borderImage().protectedImage().get());
+        unregisterImage(style.maskBorder().protectedImage().get());
         if (auto shapeValue = style.shapeOutside())
-            unregisterImage(shapeValue->image());
+            unregisterImage(shapeValue->protectedImage().get());
     };
 
     if (hasInitializedStyle()) {
         unregisterImages(m_style);
 
         if (style().hasOutline())
-            view().decrementRendersWithOutline();
+            checkedView()->decrementRendersWithOutline();
 
         if (auto* firstLineStyle = style().getCachedPseudoStyle(PseudoId::FirstLine))
             unregisterImages(*firstLineStyle);
     }
 
     if (m_hasPausedImageAnimations)
-        view().removeRendererWithPausedImageAnimations(*this);
+        checkedView()->removeRendererWithPausedImageAnimations(*this);
 
     if (style().contentVisibility() == ContentVisibility::Auto && element())
-        ContentVisibilityDocumentState::unobserve(*element());
+        ContentVisibilityDocumentState::unobserve(*protectedElement());
 }
 
 void RenderElement::setNeedsPositionedMovementLayout(const RenderStyle* oldStyle)
@@ -1181,7 +1181,7 @@ void RenderElement::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
-    for (auto* child = firstChild(); child; child = child->nextSibling()) {
+    for (CheckedPtr child = firstChild(); child; child = child->nextSibling()) {
         if (child->needsLayout())
             downcast<RenderElement>(*child).layout();
         ASSERT(!child->needsLayout());
@@ -1196,7 +1196,7 @@ static bool mustRepaintFillLayers(const RenderElement& renderer, const FillLayer
         return true;
 
     // Make sure we have a valid image.
-    auto* image = layer.image();
+    RefPtr image = layer.image();
     if (!image || !image->canRender(&renderer, renderer.style().effectiveZoom()))
         return false;
 
@@ -1411,14 +1411,14 @@ bool RenderElement::borderImageIsLoadedAndCanBeRendered() const
 {
     ASSERT(style().hasBorder());
 
-    StyleImage* borderImage = style().borderImage().image();
+    RefPtr borderImage = style().borderImage().image();
     return borderImage && borderImage->canRender(this, style().effectiveZoom()) && borderImage->isLoaded(this);
 }
 
 bool RenderElement::mayCauseRepaintInsideViewport(const IntRect* optionalViewportRect) const
 {
-    auto& frameView = view().frameView();
-    if (frameView.isOffscreen())
+    Ref frameView = view().frameView();
+    if (frameView->isOffscreen())
         return false;
 
     if (!hasNonVisibleOverflow()) {
@@ -1430,7 +1430,7 @@ bool RenderElement::mayCauseRepaintInsideViewport(const IntRect* optionalViewpor
     }
 
     // Compute viewport rect if it was not provided.
-    const IntRect& visibleRect = optionalViewportRect ? *optionalViewportRect : frameView.windowToContents(frameView.windowClipRect());
+    const IntRect& visibleRect = optionalViewportRect ? *optionalViewportRect : frameView->windowToContents(frameView->windowClipRect());
     return visibleRect.intersects(enclosingIntRect(absoluteClippedOverflowRectForRepaint()));
 }
 
@@ -1474,7 +1474,7 @@ void RenderElement::registerForVisibleInViewportCallback()
         return;
     m_isRegisteredForVisibleInViewportCallback = true;
 
-    view().registerForVisibleInViewportCallback(*this);
+    checkedView()->registerForVisibleInViewportCallback(*this);
 }
 
 void RenderElement::unregisterForVisibleInViewportCallback()
@@ -1483,7 +1483,7 @@ void RenderElement::unregisterForVisibleInViewportCallback()
         return;
     m_isRegisteredForVisibleInViewportCallback = false;
 
-    view().unregisterForVisibleInViewportCallback(*this);
+    checkedView()->unregisterForVisibleInViewportCallback(*this);
 }
 
 void RenderElement::setVisibleInViewportState(VisibleInViewportState state)
@@ -1501,8 +1501,8 @@ void RenderElement::visibleInViewportStateChanged()
 
 bool RenderElement::isVisibleInViewport() const
 {
-    auto& frameView = view().frameView();
-    auto visibleRect = frameView.windowToContents(frameView.windowClipRect());
+    Ref frameView = view().frameView();
+    auto visibleRect = frameView->windowToContents(frameView->windowClipRect());
     return isVisibleInDocumentRect(visibleRect);
 }
 
@@ -1511,7 +1511,7 @@ VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, Im
     bool isVisible = isVisibleInViewport();
 
     if (!isVisible && animatingState == ImageAnimatingState::Yes)
-        view().addRendererWithPausedImageAnimations(*this, image);
+        checkedView()->addRendererWithPausedImageAnimations(*this, image);
 
     // Static images should repaint even if they are outside the viewport rectangle
     // because they should be inside the TileCoverageRect.
@@ -1519,7 +1519,7 @@ VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, Im
         imageChanged(&image, changeRect);
 
     if (element() && image.image()->isBitmapImage())
-        element()->dispatchWebKitImageReadyEventForTesting();
+        protectedElement()->dispatchWebKitImageReadyEventForTesting();
 
     return isVisible ? VisibleInViewportState::Yes : VisibleInViewportState::No;
 }
@@ -1534,7 +1534,7 @@ VisibleInViewportState RenderElement::imageVisibleInViewport(const Document& doc
 
 void RenderElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
 {
-    document().cachedResourceLoader().notifyFinished(resource);
+    document().protectedCachedResourceLoader()->notifyFinished(resource);
 }
 
 bool RenderElement::allowsAnimation() const
@@ -1547,12 +1547,12 @@ bool RenderElement::allowsAnimation() const
 void RenderElement::didRemoveCachedImageClient(CachedImage& cachedImage)
 {
     if (hasPausedImageAnimations())
-        view().removeRendererWithPausedImageAnimations(*this, cachedImage);
+        checkedView()->removeRendererWithPausedImageAnimations(*this, cachedImage);
 }
 
 void RenderElement::scheduleRenderingUpdateForImage(CachedImage&)
 {
-    if (auto* page = document().page())
+    if (CheckedPtr page = document().page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::Images);
 }
 
@@ -1564,9 +1564,9 @@ bool RenderElement::repaintForPausedImageAnimationsIfNeeded(const IntRect& visib
 
     repaint();
 
-    if (auto* image = cachedImage.image()) {
-        if (is<SVGImage>(image))
-            downcast<SVGImage>(image)->scheduleStartAnimation();
+    if (RefPtr image = cachedImage.image()) {
+        if (auto* svgImage = dynamicDowncast<SVGImage>(*image))
+            svgImage->scheduleStartAnimation();
         else
             image->startAnimation();
     }
@@ -1606,13 +1606,14 @@ std::unique_ptr<RenderStyle> RenderElement::getUncachedPseudoStyle(const Style::
     if (isAnonymous())
         return nullptr;
 
-    auto& styleResolver = element()->styleResolver();
+    Ref element = *this->element();
+    auto& styleResolver = element->styleResolver();
 
-    auto resolvedStyle = styleResolver.styleForPseudoElement(*element(), pseudoElementRequest, { parentStyle });
+    auto resolvedStyle = styleResolver.styleForPseudoElement(element, pseudoElementRequest, { parentStyle });
     if (!resolvedStyle)
         return nullptr;
 
-    Style::loadPendingResources(*resolvedStyle->style, document(), element());
+    Style::loadPendingResources(*resolvedStyle->style, protectedDocument(), element.ptr());
 
     return WTFMove(resolvedStyle->style);
 }
@@ -1919,24 +1920,24 @@ void RenderElement::issueRepaintForOutlineAuto(float outlineSize)
 void RenderElement::updateOutlineAutoAncestor(bool hasOutlineAuto)
 {
     if (is<RenderMultiColumnSpannerPlaceholder>(*this)) {
-        auto* spanner = downcast<RenderMultiColumnSpannerPlaceholder>(*this).spanner();
+        CheckedPtr spanner = downcast<RenderMultiColumnSpannerPlaceholder>(*this).spanner();
         spanner->setHasOutlineAutoAncestor(hasOutlineAuto);
         spanner->updateOutlineAutoAncestor(hasOutlineAuto);
     }
 
-    for (auto& child : childrenOfType<RenderObject>(*this)) {
-        if (hasOutlineAuto == child.hasOutlineAutoAncestor())
+    for (CheckedRef child : childrenOfType<RenderObject>(*this)) {
+        if (hasOutlineAuto == child->hasOutlineAutoAncestor())
             continue;
-        child.setHasOutlineAutoAncestor(hasOutlineAuto);
-        bool childHasOutlineAuto = child.outlineStyleForRepaint().outlineStyleIsAuto() == OutlineIsAuto::On;
+        child->setHasOutlineAutoAncestor(hasOutlineAuto);
+        bool childHasOutlineAuto = child->outlineStyleForRepaint().outlineStyleIsAuto() == OutlineIsAuto::On;
         if (childHasOutlineAuto)
             continue;
-        if (!is<RenderElement>(child))
+        if (!is<RenderElement>(child.get()))
             continue;
-        downcast<RenderElement>(child).updateOutlineAutoAncestor(hasOutlineAuto);
+        downcast<RenderElement>(child.get()).updateOutlineAutoAncestor(hasOutlineAuto);
     }
     if (is<RenderBoxModelObject>(*this)) {
-        if (auto* continuation = downcast<RenderBoxModelObject>(*this).continuation())
+        if (CheckedPtr continuation = downcast<RenderBoxModelObject>(*this).continuation())
             continuation->updateOutlineAutoAncestor(hasOutlineAuto);
     }
 }
@@ -1987,14 +1988,14 @@ void RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded(con
         downcast<RenderBlock>(*this).resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants();
     else {
         // Relatively positioned inline boxes can have absolutely positioned block descendants. We need to reset them as well.
-        for (auto& descendant : descendantsOfType<RenderBlock>(*this))
-            descendant.resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants();
+        for (CheckedRef descendant : descendantsOfType<RenderBlock>(*this))
+            descendant->resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants();
     }
     
     // Adjust the flow tread state on the subtree.
     setFragmentedFlowState(RenderObject::computedFragmentedFlowState(*this));
-    for (auto& descendant : descendantsOfType<RenderObject>(*this))
-        descendant.setFragmentedFlowState(RenderObject::computedFragmentedFlowState(descendant));
+    for (CheckedRef descendant : descendantsOfType<RenderObject>(*this))
+        descendant->setFragmentedFlowState(RenderObject::computedFragmentedFlowState(descendant));
 }
 
 void RenderElement::removeFromRenderFragmentedFlow()
@@ -2014,17 +2015,17 @@ void RenderElement::removeFromRenderFragmentedFlowIncludingDescendants(bool shou
     if (isRenderFragmentedFlow())
         shouldUpdateState = false;
 
-    for (auto& child : childrenOfType<RenderObject>(*this)) {
-        if (is<RenderElement>(child)) {
-            downcast<RenderElement>(child).removeFromRenderFragmentedFlowIncludingDescendants(shouldUpdateState);
+    for (CheckedRef child : childrenOfType<RenderObject>(*this)) {
+        if (is<RenderElement>(child.get())) {
+            downcast<RenderElement>(child.get()).removeFromRenderFragmentedFlowIncludingDescendants(shouldUpdateState);
             continue;
         }
         if (shouldUpdateState)
-            child.setFragmentedFlowState(NotInsideFragmentedFlow);
+            child->setFragmentedFlowState(NotInsideFragmentedFlow);
     }
 
     // We have to ask for our containing flow thread as it may be above the removed sub-tree.
-    RenderFragmentedFlow* enclosingFragmentedFlow = this->enclosingFragmentedFlow();
+    CheckedPtr enclosingFragmentedFlow = this->enclosingFragmentedFlow();
     while (enclosingFragmentedFlow) {
         enclosingFragmentedFlow->removeFlowChildInfo(*this);
 
@@ -2047,8 +2048,8 @@ void RenderElement::resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants
     if (fragmentedFlow)
         fragmentedFlow->removeFlowChildInfo(*this);
 
-    for (auto& child : childrenOfType<RenderElement>(*this))
-        child.resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants(fragmentedFlow);
+    for (CheckedRef child : childrenOfType<RenderElement>(*this))
+        child->resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants(fragmentedFlow);
 }
 
 ReferencedSVGResources& RenderElement::ensureReferencedSVGResources()
@@ -2097,7 +2098,7 @@ static RenderObject::BlockContentHeightType includeNonFixedHeight(const RenderOb
 
 void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWidth)
 {
-    auto* document = view().frameView().frame().document();
+    RefPtr document = view().frameView().frame().document();
     if (!document)
         return;
 
@@ -2109,15 +2110,15 @@ void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWid
     // But we apply it to nodes which are located deep enough
     // (nesting depth is greater than some const) inside of a parent block
     // which has fixed height but its content overflows intentionally.
-    for (RenderObject* descendent = traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth); descendent; descendent = descendent->traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth)) {
+    for (CheckedPtr descendant = traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth); descendant; descendant = descendant->traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth)) {
         while (depthStack.size() > 0 && currentDepth <= depthStack[depthStack.size() - 1])
             depthStack.remove(depthStack.size() - 1);
         if (newFixedDepth)
             depthStack.append(newFixedDepth);
 
         int stackSize = depthStack.size();
-        if (is<RenderBlockFlow>(*descendent) && !descendent->isListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
-            downcast<RenderBlockFlow>(*descendent).adjustComputedFontSizes(size, visibleWidth);
+        if (is<RenderBlockFlow>(*descendant) && !descendant->isListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
+            downcast<RenderBlockFlow>(*descendant).adjustComputedFontSizes(size, visibleWidth);
         newFixedDepth = 0;
     }
 
@@ -2127,7 +2128,7 @@ void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWid
 
 void RenderElement::resetTextAutosizing()
 {
-    auto* document = view().frameView().frame().document();
+    RefPtr document = view().frameView().frame().document();
     if (!document)
         return;
 
@@ -2139,15 +2140,15 @@ void RenderElement::resetTextAutosizing()
     int currentDepth = 0;
     int newFixedDepth = 0;
 
-    for (RenderObject* descendent = traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth); descendent; descendent = descendent->traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth)) {
+    for (CheckedPtr descendant = traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth); descendant; descendant = descendant->traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth)) {
         while (depthStack.size() > 0 && currentDepth <= depthStack[depthStack.size() - 1])
             depthStack.remove(depthStack.size() - 1);
         if (newFixedDepth)
             depthStack.append(newFixedDepth);
 
         int stackSize = depthStack.size();
-        if (is<RenderBlockFlow>(*descendent) && !descendent->isListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
-            downcast<RenderBlockFlow>(*descendent).resetComputedFontSize();
+        if (is<RenderBlockFlow>(*descendant) && !descendant->isListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
+            downcast<RenderBlockFlow>(*descendant).resetComputedFontSize();
         newFixedDepth = 0;
     }
 }
@@ -2245,7 +2246,7 @@ FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const
     };
 
     auto determineSVGViewport = [&]() {
-        const auto* viewportElement = downcast<SVGElement>(element());
+        RefPtr viewportElement = downcast<SVGElement>(element());
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         // RenderSVGViewportContainer is the only possible anonymous renderer in the SVG tree.
@@ -2258,7 +2259,7 @@ FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const
 
         // FIXME: [LBSE] Upstream: Cache the immutable SVGLengthContext per SVGElement, to avoid the repeated RenderSVGRoot size queries in determineViewport().
         ASSERT(viewportElement);
-        auto viewportSize = SVGLengthContext(viewportElement).viewportSize().value_or(FloatSize { });
+        auto viewportSize = SVGLengthContext(viewportElement.get()).viewportSize().value_or(FloatSize { });
         return FloatRect { { }, viewportSize };
     };
 
@@ -2309,8 +2310,8 @@ bool RenderElement::hasEligibleContainmentForSizeQuery() const
 
 void RenderElement::clearNeedsLayoutForDescendants()
 {
-    for (auto& descendant : descendantsOfType<RenderObject>(*this))
-        descendant.clearNeedsLayout();
+    for (CheckedRef descendant : descendantsOfType<RenderObject>(*this))
+        descendant->clearNeedsLayout();
 }
 
 void RenderElement::layoutIfNeeded()

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -396,7 +396,7 @@ private:
     void updateReferencedSVGResources();
     void clearReferencedSVGResources();
 
-    PackedPtr<RenderObject> m_firstChild;
+    PackedCheckedPtr<RenderObject> m_firstChild;
     unsigned m_baseTypeFlags : 8;
     unsigned m_ancestorLineBoxDirty : 1;
     unsigned m_hasInitializedStyle : 1;
@@ -406,7 +406,7 @@ private:
     unsigned m_hasCounterNodeMap : 1;
     unsigned m_hasContinuationChainNode : 1;
 
-    PackedPtr<RenderObject> m_lastChild;
+    PackedCheckedPtr<RenderObject> m_lastChild;
 
     unsigned m_isContinuation : 1;
     unsigned m_isFirstLetter : 1;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -629,8 +629,10 @@ public:
     Node* generatingNode() const { return isPseudoElement() ? generatingPseudoHostElement() : node(); }
 
     Document& document() const { return m_node.get().document(); }
+    inline Ref<Document> protectedDocument() const; // Defined in RenderObjectInlines.h.
     TreeScope& treeScopeForSVGReferences() const { return m_node.get().treeScopeForSVGReferences(); }
     LocalFrame& frame() const;
+    Ref<LocalFrame> protectedFrame() const { return frame(); }
     Page& page() const;
     Settings& settings() const { return page().settings(); }
 

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "Document.h"
 #include "RenderObject.h"
 #include "RenderStyleInlines.h"
 
@@ -28,5 +29,6 @@ inline bool RenderObject::hasTransformOrPerspective() const { return hasTransfor
 inline bool RenderObject::isAtomicInlineLevelBox() const { return style().isDisplayInlineType() && !(style().display() == DisplayType::Inline && !isReplacedOrInlineBlock()); }
 inline bool RenderObject::isTransformed() const { return hasTransformRelatedProperty() && (style().affectsTransform() || hasSVGTransform()); }
 inline bool RenderObject::preservesNewline() const { return !isSVGInlineText() && style().preserveNewline(); }
+inline Ref<Document> RenderObject::protectedDocument() const { return document(); }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/FillLayer.h
+++ b/Source/WebCore/rendering/style/FillLayer.h
@@ -70,6 +70,7 @@ public:
     ~FillLayer();
 
     StyleImage* image() const { return m_image.get(); }
+    RefPtr<StyleImage> protectedImage() const { return m_image; }
     const Length& xPosition() const { return m_xPosition; }
     const Length& yPosition() const { return m_yPosition; }
     Edge backgroundXOrigin() const { return static_cast<Edge>(m_backgroundXOrigin); }

--- a/Source/WebCore/rendering/style/NinePieceImage.h
+++ b/Source/WebCore/rendering/style/NinePieceImage.h
@@ -118,6 +118,7 @@ public:
 
     bool hasImage() const { return m_data->image; }
     StyleImage* image() const { return m_data->image.get(); }
+    RefPtr<StyleImage> protectedImage() const { return image(); }
     void setImage(RefPtr<StyleImage>&& image) { m_data.access().image = WTFMove(image); }
 
     const LengthBox& imageSlices() const { return m_data->imageSlices; }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -600,7 +600,8 @@ public:
     inline FillSizeType backgroundSizeType() const;
     inline const LengthSize& backgroundSizeLength() const;
     inline FillLayer& ensureBackgroundLayers();
-    inline const FillLayer& backgroundLayers() const;
+    inline const FillLayer& backgroundLayers() const; // Defined in RenderStyleInlines.h.
+    inline Ref<const FillLayer> protectedBackgroundLayers() const; // Defined in RenderStyleInlines.h.
     inline BlendMode backgroundBlendMode() const;
 
     inline StyleImage* maskImage() const;
@@ -613,7 +614,8 @@ public:
     inline FillSizeType maskSizeType() const;
     inline const LengthSize& maskSizeLength() const;
     inline FillLayer& ensureMaskLayers();
-    inline const FillLayer& maskLayers() const;
+    inline const FillLayer& maskLayers() const; // Defined in RenderStyleInlines.h.
+    inline Ref<const FillLayer> protectedMaskLayers() const; // Defined in RenderStyleInlines.h.
     inline const NinePieceImage& maskBorder() const;
     inline StyleImage* maskBorderSource() const;
 
@@ -1655,7 +1657,8 @@ public:
     inline void setKerning(SVGLengthValue);
 
     inline void setShapeOutside(RefPtr<ShapeValue>&&);
-    inline ShapeValue* shapeOutside() const;
+    inline ShapeValue* shapeOutside() const; // Defined in RenderStyleInlines.h.
+    inline RefPtr<ShapeValue> protectedShapeOutside() const; // Defined in RenderStyleInlines.h.
     static ShapeValue* initialShapeOutside() { return nullptr; }
 
     inline const Length& shapeMargin() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -84,6 +84,7 @@ inline BlendMode RenderStyle::backgroundBlendMode() const { return backgroundLay
 inline FillBox RenderStyle::backgroundClip() const { return backgroundLayers().clip(); }
 inline const StyleColor& RenderStyle::backgroundColor() const { return m_nonInheritedData->backgroundData->color; }
 inline const FillLayer& RenderStyle::backgroundLayers() const { return m_nonInheritedData->backgroundData->background; }
+inline Ref<const FillLayer> RenderStyle::protectedBackgroundLayers() const { return backgroundLayers(); }
 inline FillBox RenderStyle::backgroundOrigin() const { return backgroundLayers().origin(); }
 inline FillRepeatXY RenderStyle::backgroundRepeat() const { return backgroundLayers().repeat(); }
 inline const LengthSize& RenderStyle::backgroundSizeLength() const { return backgroundLayers().sizeLength(); }
@@ -572,6 +573,7 @@ inline FillBox RenderStyle::maskClip() const { return maskLayers().clip(); }
 inline CompositeOperator RenderStyle::maskComposite() const { return maskLayers().composite(); }
 inline StyleImage* RenderStyle::maskImage() const { return maskLayers().image(); }
 inline const FillLayer& RenderStyle::maskLayers() const { return m_nonInheritedData->miscData->mask; }
+inline Ref<const FillLayer> RenderStyle::protectedMaskLayers() const { return maskLayers(); }
 inline FillBox RenderStyle::maskOrigin() const { return maskLayers().origin(); }
 inline FillRepeatXY RenderStyle::maskRepeat() const { return maskLayers().repeat(); }
 inline const LengthSize& RenderStyle::maskSizeLength() const { return maskLayers().sizeLength(); }
@@ -642,6 +644,7 @@ inline const StyleColor& RenderStyle::scrollbarTrackColor() const { return m_rar
 inline float RenderStyle::shapeImageThreshold() const { return m_nonInheritedData->rareData->shapeImageThreshold; }
 inline const Length& RenderStyle::shapeMargin() const { return m_nonInheritedData->rareData->shapeMargin; }
 inline ShapeValue* RenderStyle::shapeOutside() const { return m_nonInheritedData->rareData->shapeOutside.get(); }
+inline RefPtr<ShapeValue> RenderStyle::protectedShapeOutside() const { return shapeOutside(); }
 inline std::optional<ContentVisibility> RenderStyle::skippedContentReason() const
 {
     auto reason = static_cast<ContentVisibility>(m_rareInheritedData->effectiveSkippedContent);

--- a/Source/WebCore/rendering/style/ShapeValue.h
+++ b/Source/WebCore/rendering/style/ShapeValue.h
@@ -61,6 +61,7 @@ public:
     CSSBoxType cssBox() const { return m_cssBox; }
     CSSBoxType effectiveCSSBox() const;
     StyleImage* image() const { return m_image.get(); }
+    RefPtr<StyleImage> protectedImage() const { return m_image; }
     bool isImageValid() const;
 
     void setImage(Ref<StyleImage>&& image)


### PR DESCRIPTION
#### ea4f8e5ea638e3d82f8a87811aa8c9654cabf993
<pre>
Adopt more smart pointers in RenderElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=263542">https://bugs.webkit.org/show_bug.cgi?id=263542</a>

Reviewed by Ryosuke Niwa.

Adopt more smart pointers in RenderElement.

I also made some changes to EventHandler so that we can store it in
a CheckedPtr / CheckedRef. I made it forward its checked pointer count
to its associated frame since it is owned by the frame. As extra safety,
I made EventHandler::m_frame be a CheckedRef&lt;Frame&gt; which required me
to update all uses of m_frame in this file. That said, the changes in
EventHandler are NOT meant to be exhaustive.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedView const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::incrementPtrCount const):
(WebCore::EventHandler::decrementPtrCount const):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::checkedEventHandler):
(WebCore::LocalFrame::checkedEventHandler const):
(WebCore::Document::protectedView const): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::createFor):
(WebCore::RenderElement::updateFillImages):
(WebCore::RenderElement::updateShapeImage):
(WebCore::RenderElement::repaintBeforeStyleChange):
(WebCore::RenderElement::initializeStyle):
(WebCore::RenderElement::setStyle):
(WebCore::RenderElement::didAttachChild):
(WebCore::RenderElement::attachRendererInternal):
(WebCore::RenderElement::detachRendererInternal):
(WebCore::findNextLayer):
(WebCore::layerNextSiblingRespectingTopLayer):
(WebCore::addLayers):
(WebCore::RenderElement::removeLayers):
(WebCore::RenderElement::moveLayers):
(WebCore::RenderElement::layerParent const):
(WebCore::RenderElement::propagateStyleToAnonymousChildren):
(WebCore::RenderElement::styleWillChange):
(WebCore::RenderElement::styleDidChange):
(WebCore::RenderElement::insertedIntoTree):
(WebCore::RenderElement::willBeRemovedFromTree):
(WebCore::RenderElement::clearSubtreeLayoutRootIfNeeded const):
(WebCore::RenderElement::willBeDestroyed):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::protectedFrame const):
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::protectedDocument const):
* Source/WebCore/rendering/style/NinePieceImage.h:
(WebCore::NinePieceImage::protectedImage const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::protectedBackgroundLayers const):
(WebCore::RenderStyle::protectedMaskLayers const):
(WebCore::RenderStyle::protectedShapeOutside const):
* Source/WebCore/rendering/style/ShapeValue.h:
(WebCore::ShapeValue::protectedImage const):

Canonical link: <a href="https://commits.webkit.org/269712@main">https://commits.webkit.org/269712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73eae543c2aa88b7e9eab814701f04bcdebdd09d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24453 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23886 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26097 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21091 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27241 "An unexpected error occured. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25115 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18548 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1215 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2975 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->