### PR TITLE
Fix an XML fragment parsing issue with in-scope namespace prefixes

### DIFF
--- a/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces1-expected.txt
+++ b/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces1-expected.txt
@@ -1,0 +1,3 @@
+Test of Range.createContextualFragment() with in-scope namespace prefixes on attributes. If the test succeeds you will see the word "PASS" below.
+
+PASS

--- a/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces1.html
+++ b/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces1.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<p>Test of Range.createContextualFragment() with in-scope namespace prefixes on attributes. If the test succeeds you will see the word "PASS" below.</p>
+<p id="result"></p>
+<script type="text/javascript">
+function onIframeLoad() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    var result = document.getElementById("result");
+    result.textContent = "FAIL";
+
+    var iframe = document.getElementById("iframe"),
+        doc = iframe.contentDocument,
+        range = doc.createRange(),
+        docFragment;
+
+    var defs1 = doc.getElementById("defs1");
+    range.setStart(defs1, 0);
+    docFragment = range.createContextualFragment("<linearGradient id='gradient1'/>" +
+                                                 "<linearGradient id='gradient2' XL:href='#gradient1' href='otherHref'/>");
+    var gradient2 = docFragment.lastChild;
+    if (gradient2.namespaceURI != "http://www.w3.org/2000/svg") {
+        result.textContent += " - #gradient2 has the wrong namespace URI";
+        return;
+    }
+    if (gradient2.getAttributeNS(defs1.lookupNamespaceURI("XL"), "href") != "#gradient1") {
+        result.textContent += " - wrong XL:href attribute value on #gradient2";
+        return;
+    }
+    defs1.appendChild(docFragment);
+    if (gradient2.lookupNamespaceURI("XL") != defs1.lookupNamespaceURI("XL")) {
+        result.textContent += " - #gradient2 returned the incorrect namespace URI for prefix 'XL'";
+        return;
+    }
+    gradient2 = null;
+    defs1 = null;
+
+    var defs2 = doc.getElementById("defs2");
+    range.setStart(defs2, 0);
+    docFragment = range.createContextualFragment("<linearGradient id='gradient3'/>" +
+                                                 "<linearGradient id='gradient4' xLink:href='#gradient3' href='otherHref'/>");
+    defs2.appendChild(docFragment);
+    var gradient4 = defs2.lastChild;
+    if (gradient4.namespaceURI != "http://www.w3.org/2000/svg") {
+        result.textContent += " - #gradient4 has the wrong namespace URI";
+        return;
+    }
+    if (gradient4.getAttributeNS(defs2.lookupNamespaceURI("xLink"), "href") != "#gradient3") {
+        result.textContent += " - wrong xLink:href attribute value on #gradient2";
+        return;
+    }
+    if (gradient4.lookupNamespaceURI("xLink") != defs2.lookupNamespaceURI("xLink")) {
+        result.textContent += " - #gradient2 returned the incorrect namespace URI for prefix 'xLink'";
+        return;
+    }
+
+    // Check that Range.createContextualFragment() fails if an out-of-scope namespace prefix is used.
+    var exception;
+    try {
+        range.createContextualFragment("<linearGradient id='gradient5' XL:href='#gradient3'/>");
+    } catch (e) {
+        exception = e;
+    }
+    if (exception == null) {
+        result.textContent += " - Range.createContextualFragment() did not raise an exception when attempting to use an out-of-scope namespace prefix";
+        return;
+    }
+    if (String.prototype.indexOf.call(exception.message, "invalid XML") < 0) {
+        result.textContent += " - wrong exception thrown";
+        return;
+    }
+
+    result.textContent = "PASS";
+}
+</script>
+<iframe id="iframe" src="resources/svg-document-ns1.svg" onload="onIframeLoad()"></iframe>

--- a/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces2-expected.txt
+++ b/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces2-expected.txt
@@ -1,0 +1,5 @@
+Test of Range.createContextualFragment() with in-scope namespace prefixes on elements. If the test succeeds you will see the word "PASS" below.
+
+PASS
+
+

--- a/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces2.html
+++ b/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces2.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<p>Test of Range.createContextualFragment() with in-scope namespace prefixes on elements. If the test succeeds you will see the word "PASS" below.</p>
+<p id="result"></p>
+<script type="text/javascript">
+function onIframeLoad() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    var result = document.getElementById("result");
+    result.textContent = "FAIL";
+
+    var iframe = document.getElementById("iframe"),
+        doc = iframe.contentDocument,
+        range = doc.createRange(),
+        docFragment;
+
+    var defs = doc.getElementById("defs");
+    range.setStart(defs, 0);
+    docFragment = range.createContextualFragment("<\u0108:test id='test1'/><\u015D:test id='test2'/>");
+    defs.appendChild(docFragment);
+
+    var test1 = doc.getElementById("test1");
+    if (test1.namespaceURI != "urn:x-test:U+0108") {
+        result.textContent += " - #test1 is in the wrong namespace";
+        return;
+    }
+    var test2 = doc.getElementById("test2");
+    if (test2.namespaceURI != "urn:x-test:U+015D") {
+        result.textContent += " - #test2 is in the wrong namespace";
+        return;
+    }
+
+    result.textContent = "PASS";
+}
+</script>
+<iframe id="iframe" src="resources/svg-document-ns2.svg" onload="onIframeLoad()"></iframe>

--- a/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces3-expected.txt
+++ b/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces3-expected.txt
@@ -1,0 +1,5 @@
+Test of Range.createContextualFragment() with in-scope namespace prefixes, where the XML fragment introduces additional namespace prefixes. If the test succeeds you will see the word "PASS" below.
+
+PASS
+
+

--- a/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces3.xhtml
+++ b/LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces3.xhtml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<body onload="onPageLoad()">
+<p>Test of Range.createContextualFragment() with in-scope namespace prefixes, where the XML fragment introduces additional namespace prefixes. If the test succeeds you will see the word "PASS" below.</p>
+<p id="result">Running test...</p>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <svg:defs id="defs"/>
+</svg:svg>
+<script type="text/javascript">//<![CDATA[
+function onPageLoad() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    var result = document.getElementById("result");
+
+    var defs = document.getElementById("defs"),
+        range = document.createRange(),
+        docFragment;
+
+    range.setStart(defs, 0);
+    docFragment = range.createContextualFragment("<svg:linearGradient id='gradient1'/>" +
+                                                 "<a:aTest id='aTest' xmlns:a='urn:x-test:a' xmlns:b='urn:x-test:b' a:aAttr='aValue' xlink:href='#gradient1'>" +
+                                                 "  <b:bTest id='bTest' a:aAttr='aValue2' b:bAttr='bValue'>" +
+                                                 "    <xlink:testRedefiningXlink id='testRedefiningXlink' xlink:xlinkAttr='xlinkValue' xmlns:xlink='urn:x-test:xlink'/>" +
+                                                 "    <svg:linearGradient id='gradient2' xlink:href='#gradient1'/>" +
+                                                 "  </b:bTest>" +
+                                                 "</a:aTest>");
+    defs.appendChild(docFragment);
+
+    var gradient1 = document.getElementById("gradient1");
+    if (gradient1.namespaceURI != "http://www.w3.org/2000/svg") {
+        result.textContent += ' - #gradient1 has the wrong namespaceURI';
+        return;
+    }
+
+    var aTest = document.getElementById("aTest");
+    if (aTest.namespaceURI != "urn:x-test:a") {
+        result.textContent += ' - #aTest has the wrong namespaceURI';
+        return;
+    }
+    if (aTest.getAttributeNS("urn:x-test:a", "aAttr") != "aValue") {
+        result.textContent += ' - wrong value for the a:aAttr attribute of #aTest';
+        return;
+    }
+    if (aTest.getAttributeNS("http://www.w3.org/1999/xlink", "href") != "#gradient1") {
+        result.textContent += ' - wrong value for the xlink:href attribute of #aTest';
+        return;
+    }
+
+    var bTest = document.getElementById("bTest");
+    if (bTest.namespaceURI != "urn:x-test:b") {
+        result.textContent += ' - #bTest has the wrong namespaceURI';
+        return;
+    }
+    if (bTest.getAttributeNS("urn:x-test:a", "aAttr") != "aValue2") {
+        result.textContent += ' - wrong value for the a:aAttr attribute of #bTest';
+        return;
+    }
+    if (bTest.getAttributeNS("urn:x-test:b", "bAttr") != "bValue") {
+        result.textContent += ' - wrong value for the b:bAttr attribute of #bTest';
+        return;
+    }
+
+    var testRedefiningXlink = document.getElementById("testRedefiningXlink");
+    if (testRedefiningXlink.namespaceURI != "urn:x-test:xlink") {
+        result.textContent += ' - #testRedefiningXlink has the wrong namespaceURI';
+        return;
+    }
+    if (testRedefiningXlink.getAttributeNS("urn:x-test:xlink", "xlinkAttr") != "xlinkValue") {
+        result.textContent += ' - wrong value for the xlink:xlinkAttr attribute of #testRedefiningXlink';
+        return;
+    }
+
+    var gradient2 = document.getElementById("gradient2");
+    if (gradient2.namespaceURI != "http://www.w3.org/2000/svg") {
+        result.textContent += ' - #gradient2 has the wrong namespaceURI';
+        return;
+    }
+    if (gradient2.getAttributeNS("http://www.w3.org/1999/xlink", "href") != "#gradient1") {
+        result.textContent += ' - wrong value for the xlink:href attribute of #gradient2';
+        return;
+    }
+
+    if (result.textContent === "Running test...")
+        result.textContent = "PASS";
+}
+//]]>
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/Range/resources/svg-document-ns1.svg
+++ b/LayoutTests/fast/dom/Range/resources/svg-document-ns1.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <svg xmlns:XL="http://www.w3.org/1999/xlink">
+    <defs id="defs1"></defs>
+  </svg>
+  <defs id="defs2" xmlns:xLink="http://www.w3.org/1999/xlink"></defs>
+</svg>

--- a/LayoutTests/fast/dom/Range/resources/svg-document-ns2.svg
+++ b/LayoutTests/fast/dom/Range/resources/svg-document-ns2.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:Ĉ="urn:x-test:U+0108" version="1.1">
+  <defs id="defs" xmlns:ŝ="urn:x-test:U+015D"></defs>
+</svg>

--- a/LayoutTests/fast/dom/innerHTML-namespaces-expected.txt
+++ b/LayoutTests/fast/dom/innerHTML-namespaces-expected.txt
@@ -1,0 +1,3 @@
+
+PASS set innerHTML to an XHTML fragment with in-scope namespace prefixes on attributes
+

--- a/LayoutTests/fast/dom/innerHTML-namespaces.xhtml
+++ b/LayoutTests/fast/dom/innerHTML-namespaces.xhtml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<body>
+<p id="result" xmlns:a="urn:x-test:a" style="visibility: hidden;"></p>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script type="text/javascript">//<![CDATA[
+
+test(function () {
+    var result = document.getElementById("result");
+    result.innerHTML = "<span a:test='some value via innerHTML'>Testing</span>";
+    var spanElement = result.firstChild;
+    assert_equals(spanElement.namespaceURI, "http://www.w3.org/1999/xhtml", "<span> in correct namespace");
+    assert_true(spanElement.hasAttributeNS("urn:x-test:a", "test"), "<span> has 'test' attribute in the 'urn:x-test:a' namespace");
+    assert_equals(spanElement.getAttributeNS("urn:x-test:a", "test"), "some value via innerHTML", "'test' attribute in the 'urn:x-test:a' namespace has the correct value");
+}, "set innerHTML to an XHTML fragment with in-scope namespace prefixes on attributes");
+
+//]]>
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/insertAdjacentHTML-namespaces-expected.txt
+++ b/LayoutTests/fast/dom/insertAdjacentHTML-namespaces-expected.txt
@@ -1,0 +1,3 @@
+
+PASS insert an XHTML fragment with in-scope namespace prefixes on attributes
+

--- a/LayoutTests/fast/dom/insertAdjacentHTML-namespaces.xhtml
+++ b/LayoutTests/fast/dom/insertAdjacentHTML-namespaces.xhtml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<body>
+<p id="result" xmlns:a="urn:x-test:a" style="visibility: hidden;"></p>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>//<![CDATA[
+
+test(function () {
+    var result = document.getElementById("result");
+    result.insertAdjacentHTML("beforeEnd", "<span a:test='some value via insertAdjacentHTML()'>Testing</span>");
+    var spanElement = result.lastChild;
+    assert_equals(spanElement.namespaceURI, "http://www.w3.org/1999/xhtml", "<span> in correct namespace");
+    assert_true(spanElement.hasAttributeNS("urn:x-test:a", "test"), "<span> has 'test' attribute in the 'urn:x-test:a' namespace");
+    assert_equals(spanElement.getAttributeNS("urn:x-test:a", "test"), "some value via insertAdjacentHTML()", "'test' attribute in the 'urn:x-test:a' namespace has the correct value");
+}, "insert an XHTML fragment with in-scope namespace prefixes on attributes");
+
+//]]>
+</script>
+</body>
+</html>


### PR DESCRIPTION
<pre>
Fix an XML fragment parsing issue with in-scope namespace prefixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=66424">https://bugs.webkit.org/show_bug.cgi?id=66424</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=190360">https://src.chromium.org/viewvc/blink?view=revision&revision=190360</a>

Step 2 of the XML fragment parsing algorithm specifies that the XML parser
should be fed "the string corresponding to the start tag of [the context]
element, declaring all the namespace prefixes that are in scope on that
element in the DOM, as well as declaring the default namespace (if any)
that is in scope on that element in the DOM. A namespace prefix is in
scope if the DOM lookupNamespaceURI() method on the element would return
a non-null value for that prefix."

<a href="https://html.spec.whatwg.org/#xml-fragment-parsing-algorithm">https://html.spec.whatwg.org/#xml-fragment-parsing-algorithm</a>

All of the in-scope namespace prefixes were added to the XMLDocumentParser's
m_prefixToNamespaceMap member by the XMLDocumentParser constructor. The
bug was fixed by having handleElementAttributes() resolve namespace prefixes
using the namespace URI from libxml2 if provided; otherwise, using the
m_prefixToNamespaceMap map.

Merge (for additional tests): <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=191940">https://src.chromium.org/viewvc/blink?view=revision&revision=191940</a>

* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(handleElementAttributes):
(XMLDocumentParser::startElementNs):
* LayoutTests/fast/dom/Range/resources/svg-document-ns1.svg: Add Test Support File
* LayoutTests/fast/dom/Range/resources/svg-document-ns2.svg: Ditto
* LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces1.html: Add Test Case
* LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces1-expected.txt: Add Test Case Expectation
* LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces2.html: Add Test Case
* LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces2-expected.txt: Add Test Case Expectation
* LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces3.xhtml: Add Test Case
* LayoutTests/fast/dom/Range/create-contextual-fragment-namespaces3-expected.txt: Add Test Case Expectation
* LayoutTests/fast/dom/insertAdjacentHTML-namespaces.xhtml: Add Test Case
* LayoutTests/fast/dom/insertAdjacentHTML-namespaces-expected.txt: Add Test Case Expectations
* LayoutTests/fast/dom/innerHTML-namespaces.xhtml: Add Test Case
* fast/dom/innerHTML-namespaces-expected.txt: Add Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dc83f855fccdb93f3411f8b0013adf4c4f340bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24580 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23998 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23697 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1117 "Found 1 new test failure: fast/dom/Range/create-contextual-fragment-namespaces1.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26214 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/929 "layout-tests (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21193 "Found 1 new test failure: fast/dom/Range/create-contextual-fragment-namespaces1.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27590 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21376 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21462 "Found 1 new test failure: fast/dom/Range/create-contextual-fragment-namespaces1.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25225 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/907 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18626 "Found 1 new test failure: fast/dom/Range/create-contextual-fragment-namespaces1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/870 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20970 "Exiting early after 10 failures. 19 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->