### PR TITLE
[macOS] Block unused unix syscalls in the WebContent process sandbox

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1840,13 +1840,9 @@
 
 (define (syscall-unix-only-in-use-before-launch)
     (syscall-number
-        SYS_csops
-        SYS_fsgetpath
         SYS_getaudit_addr
-        SYS_getfsstat64
         SYS_kdebug_trace
-        SYS_pathconf
-        SYS_statfs64))
+        SYS_pathconf))
 
 (define (syscall-unix-in-use-after-launch)
     (syscall-number
@@ -1858,6 +1854,7 @@
         SYS_bsdthread_terminate
         SYS_close
         SYS_close_nocancel
+        SYS_csops
         SYS_csops_audittoken
         SYS_csrctl
         SYS_dup ;; Remove when <rdar://88210738> is fixed
@@ -1865,6 +1862,7 @@
         SYS_fcntl
         SYS_fcntl_nocancel
         SYS_fgetxattr
+        SYS_fsgetpath
         SYS_fstat64
         SYS_fstatfs64
         SYS_getattrlist
@@ -1872,14 +1870,18 @@
         SYS_getdirentries64
         SYS_getentropy
         SYS_geteuid
+        SYS_getfsstat64
+        SYS_getgid
         SYS_getrlimit
         SYS_getrusage
         SYS_gettimeofday
         SYS_getuid
+        SYS_getxattr
         SYS_ioctl
         SYS_issetugid
         SYS_kdebug_trace64
         SYS_kdebug_trace_string ;; Needed for performance sampling, see <rdar://problem/48829655>.
+        SYS_kdebug_typefilter
         SYS_kevent_id
         SYS_kevent_qos
         SYS_lseek
@@ -1901,11 +1903,14 @@
         SYS_psynch_mutexdrop
         SYS_psynch_mutexwait
         SYS_read
+        SYS_read_nocancel
         SYS_readlink
+        SYS_sendto
 #if ASAN_ENABLED
         SYS_sigaltstack
 #endif
         SYS_stat64
+        SYS_statfs64
         SYS_sysctl
         SYS_thread_selfid
         SYS_ulock_wait
@@ -1915,26 +1920,12 @@
         SYS_write_nocancel
         SYS_writev))
 
+#if !PLATFORM(MAC)
 (define (syscall-unix-possibly-in-use-after-launch)
     (syscall-number
-        SYS___semwait_signal
-        SYS_flock
-        SYS_fsetxattr ;; <rdar://problem/56332491>
-        SYS_ftruncate
-        SYS_getgid
-        SYS_getxattr
-#if !PLATFORM(MAC)
         SYS_memorystatus_control
+        SYS_thread_selfusage))
 #endif
-        SYS_msync
-        SYS_read_nocancel
-        SYS_rename
-        SYS_sendto
-        SYS_sigaltstack
-#if !PLATFORM(MAC)
-        SYS_thread_selfusage
-#endif
-        ))
 
 (define (syscall-unix-apple-silicon)
     (syscall-number
@@ -1944,35 +1935,16 @@
 (define (syscalls-rarely-used)
     (syscall-number
         SYS_getegid
-        SYS_kdebug_typefilter
+        SYS___semwait_signal
         SYS_write))
 
 (define (syscalls-rarely-used-blocked-in-lockdown-mode)
     (syscall-number
         SYS___pthread_kill
-        SYS___semwait_signal_nocancel
-        SYS_change_fdguard_np
-        SYS_chmod
-        SYS_fchmod
-        SYS_fsync
-        SYS_getpriority ;; rdar://81727094. Required for CoreAudio AudioOutputUnitStart call. Remove when GPU process is enabled by default.
-        SYS_guarded_close_np
-        SYS_guarded_open_np
-        SYS_guarded_pwrite_np
-        SYS_kevent ;; <rdar://89072361>
-        SYS_mlock
-        SYS_munlock
-        SYS_openat_nocancel
-        SYS_proc_rlimit_control
         SYS_psynch_rw_rdlock
 #if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED < 120000
         SYS_rmdir
 #endif
-        ;; FIXME: SYS_setsockopt can be removed when contentfiltering has moved to the Network process
-        SYS_setsockopt ;; <rdar://90249455>
-        SYS_shm_open
-        SYS_sigaction
-        SYS_unlink
 #if !PLATFORM(MAC)
         SYS_abort_with_payload
         SYS_fgetattrlist
@@ -2002,24 +1974,68 @@
     SYS_umask
     SYS_work_interval_ctl))
 
-(deny syscall-unix)
+(define (syscall-unix-downlevels)
+    (syscall-number
+        SYS_flock
+        SYS_fsetxattr ;; <rdar://problem/56332491>
+        SYS_ftruncate
+        SYS_msync
+        SYS_rename))
 
+(define (syscall-unix-downlevels-blocked-in-lockdown-mode)
+    (syscall-number
+        SYS___semwait_signal_nocancel
+        SYS_change_fdguard_np
+        SYS_chmod
+        SYS_fchmod
+        SYS_fsync
+        SYS_getpriority ;; rdar://81727094. Required for CoreAudio AudioOutputUnitStart call. Remove when GPU process is enabled by default.
+        SYS_guarded_close_np
+        SYS_guarded_open_np
+        SYS_guarded_pwrite_np
+        SYS_kevent ;; <rdar://89072361>
+        SYS_mlock
+        SYS_munlock
+        SYS_openat_nocancel
+        SYS_proc_rlimit_control
+        ;; FIXME: SYS_setsockopt can be removed when contentfiltering has moved to the Network process
+        SYS_setsockopt ;; <rdar://90249455>
+        SYS_shm_open
+        SYS_sigaction
+        SYS_unlink))
+
+(deny syscall-unix)
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))
     (allow syscall-unix (syscall-unix-only-in-use-before-launch)))
 (with-filter (webcontent-process-launched)
-    (allow syscall-unix (with report) (with telemetry) (with message "Syscall unexpectedly used after launch") (syscall-unix-only-in-use-before-launch)))
+    (deny syscall-unix (with telemetry) (with message "Syscall unexpectedly used after launch") (syscall-unix-only-in-use-before-launch)))
 (allow syscall-unix (syscall-unix-in-use-after-launch))
+#if !PLATFORM(MAC)
 (allow syscall-unix (with report) (with telemetry) (syscall-unix-possibly-in-use-after-launch))
+#endif
+(with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+    (allow syscall-unix (syscall-unix-downlevels)))
+(with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
+    (allow syscall-unix (syscall-unix-downlevels-blocked-in-lockdown-mode)))
 #else
 (allow syscall-unix
     (syscall-unix-only-in-use-before-launch)
     (syscall-unix-in-use-after-launch)
-    (syscall-unix-possibly-in-use-after-launch))
+#if !PLATFORM(MAC)
+    (syscall-unix-possibly-in-use-after-launch)
+#endif
+    (syscall-unix-downlevels))
 #endif
 
 (allow syscall-unix (with report) (with telemetry) (syscalls-rarely-used))
+
+#if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
+(allow syscall-unix (syscall-unix-downlevels))
+(with-filter (require-not (lockdown-mode))
+    (allow syscall-unix (syscall-unix-downlevels-blocked-in-lockdown-mode)))
+#endif
 
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
 (with-filter (require-not (lockdown-mode))


### PR DESCRIPTION
#### 7ebe083953bee55c1c785266641ab761a7d50abf
<pre>
[macOS] Block unused unix syscalls in the WebContent process sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=263563">https://bugs.webkit.org/show_bug.cgi?id=263563</a>
rdar://117378235

Reviewed by Chris Dumez.

Based on telemetry, block unused unix syscalls in the WebContent process on macOS.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/269812@main">https://commits.webkit.org/269812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ed0b6b8d26f1e2129c49fad486dfcda135a6b3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24565 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21647 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23988 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26202 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/955 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27584 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 27 flakes 121 failures; Uploaded test results; layout-tests (retry)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21413 "Found 2 new API test failures: TestWebKitAPI.ServiceWorker.WindowClientNavigate, TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25197 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18622 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/860 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5653 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->