### PR TITLE
WebExtension::actionIcon needs to fallback to WebExtension::icon.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -748,7 +748,9 @@ CocoaImage *WebExtension::actionIcon(CGSize size)
     else
         localizedErrorDescription = WEB_UI_STRING("Failed to load images in `default_icon` for the `browser_action` or `page_action` manifest entry.", "WKWebExtensionErrorInvalidActionIcon description for failing to load images for browser_action or page_action");
 
-    return bestImageForIconsDictionaryManifestKey(m_actionDictionary.get(), defaultIconManifestKey, size, m_actionIcon, Error::InvalidActionIcon, localizedErrorDescription);
+    if (auto *result = bestImageForIconsDictionaryManifestKey(m_actionDictionary.get(), defaultIconManifestKey, size, m_actionIcon, Error::InvalidActionIcon, localizedErrorDescription))
+        return result;
+    return icon(size);
 }
 
 NSString *WebExtension::displayActionLabel()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "TestCocoa.h"
+#import "WebExtensionUtilities.h"
 #import <WebKit/WKFoundation.h>
 #import <WebKit/_WKWebExtensionMatchPatternPrivate.h>
 #import <WebKit/_WKWebExtensionPrivate.h>
@@ -80,7 +81,7 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NULL(testExtension.displayVersion);
     EXPECT_NULL(testExtension.version);
     EXPECT_NULL(testExtension.displayDescription);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
 
     testManifestDictionary[@"name"] = @"Test";
@@ -93,7 +94,7 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0");
     EXPECT_NS_EQUAL(testExtension.version, @"1.0");
     EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
     testManifestDictionary[@"short_name"] = @"Tst";
     testManifestDictionary[@"version_name"] = @"1.0 Final";
@@ -104,80 +105,100 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0 Final");
     EXPECT_NS_EQUAL(testExtension.version, @"1.0");
     EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 }
 
 TEST(WKWebExtension, ActionParsing)
 {
     NSDictionary *testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" };
     auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ }, @"page_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"safari_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // action should be ignored in manifest v2.
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Manifest v3 looks for the "action" key.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Manifest v3 should never find a browser_action.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Or a page action.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
+
+    auto *imageData = Util::makePNGData(CGSizeMake(16, 16), @selector(greenColor));
+
+    testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title", @"default_icon": @"test.png" } };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
+    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
+    EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
+
+    testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title", @"default_icon": @{ @"16": @"test.png" } } };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
+    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
+    EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
+
+    testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"icons": @{ @"16": @"test.png" }, @"action": @{ @"default_title": @"Button Title" } };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
+    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
+    EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 }
 
 TEST(WKWebExtension, ContentScriptsParsing)
@@ -190,21 +211,21 @@ TEST(WKWebExtension, ContentScriptsParsing)
     auto webkitURL = [NSURL URLWithString:@"https://webkit.org/"];
     auto exampleURL = [NSURL URLWithString:@"https://example.com/"];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ], @"exclude_matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
@@ -213,7 +234,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @[ ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -221,7 +242,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @{ @"invalid": @YES };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -229,7 +250,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -237,7 +258,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"run_at": @"invalid" } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -449,14 +470,14 @@ TEST(WKWebExtension, BackgroundParsing)
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
 #endif
     EXPECT_FALSE(testExtension._backgroundContentUsesModules);
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
     testManifestDictionary[@"background"] = @{ @"page": @"test.html", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
 #if TARGET_OS_IPHONE
     testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test-1.js", @"", @"test-2.js" ], @"persistent": @NO };
@@ -472,21 +493,21 @@ TEST(WKWebExtension, BackgroundParsing)
 #else
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
 #endif
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
     testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js" };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
     testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
     // Invalid cases
 
@@ -496,7 +517,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 #endif
@@ -507,7 +528,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -518,7 +539,7 @@ TEST(WKWebExtension, BackgroundParsing)
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
     EXPECT_FALSE(testExtension._backgroundContentUsesModules);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -527,7 +548,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -536,7 +557,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -545,7 +566,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -554,7 +575,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -563,7 +584,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -572,7 +593,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -581,7 +602,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -590,7 +611,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NE(testExtension.errors.count, 0ul);;
+    EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -599,14 +620,14 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension._backgroundContentUsesModules);
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 
     testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test.js", @"test2.js" ], @"type": @"module", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension._backgroundContentUsesModules);
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -55,36 +55,6 @@ static auto *actionPopupManifest = @{
     },
 };
 
-NSData *makePNGData(CGSize size, SEL colorSelector) {
-#if USE(APPKIT)
-    auto image = adoptNS([[NSImage alloc] initWithSize:size]);
-
-    [image lockFocus];
-
-    [[NSColor performSelector:colorSelector] setFill];
-    NSRectFill(NSMakeRect(0, 0, size.width, size.height));
-
-    [image unlockFocus];
-
-    auto cgImageRef = [image CGImageForProposedRect:NULL context:nil hints:nil];
-    auto newImageRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
-    newImageRep.get().size = size;
-
-    return [newImageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
-#else
-    UIGraphicsBeginImageContextWithOptions(size, NO, 1.0);
-
-    [[UIColor performSelector:colorSelector] setFill];
-    UIRectFill(CGRectMake(0, 0, size.width, size.height));
-
-    auto *image = UIGraphicsGetImageFromCurrentImageContext();
-
-    UIGraphicsEndImageContext();
-
-    return UIImagePNGRepresentation(image);
-#endif
-}
-
 TEST(WKWebExtensionAPIAction, Errors)
 {
     auto *backgroundScript = Util::constructScript(@[
@@ -163,8 +133,8 @@ TEST(WKWebExtensionAPIAction, PresentActionPopup)
         @"browser.test.yield('Test Popup Action')"
     ]);
 
-    auto *smallToolbarIcon = makePNGData(CGSizeMake(16, 16), @selector(redColor));
-    auto *largeToolbarIcon = makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    auto *smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,
@@ -222,7 +192,7 @@ TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)
         @"browser.action.openPopup()"
     ]);
 
-    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,
@@ -286,9 +256,9 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
         @"browser.action.openPopup({ windowId: currentTab.windowId })"
     ]);
 
-    auto *smallToolbarIcon = makePNGData(CGSizeMake(16, 16), @selector(redColor));
-    auto *largeToolbarIcon = makePNGData(CGSizeMake(32, 32), @selector(blueColor));
-    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,
@@ -391,8 +361,8 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
         @"browser.action.openPopup({ windowId: currentWindowId })"
     ]);
 
-    auto *defaultToolbarIcon = makePNGData(CGSizeMake(32, 32), @selector(redColor));
-    auto *windowToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(greenColor));
+    auto *defaultToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(redColor));
+    auto *windowToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(greenColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,
@@ -463,7 +433,7 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePath)
         @"browser.action.openPopup()"
     ]);
 
-    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,
@@ -492,9 +462,9 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
         @"browser.action.openPopup()"
     ]);
 
-    auto *largeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
-    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(96, 96), @selector(greenColor));
-    auto *superExtraLargeToolbarIcon = makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(96, 96), @selector(greenColor));
+    auto *superExtraLargeToolbarIcon = Util::makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,
@@ -732,7 +702,7 @@ TEST(WKWebExtensionAPIAction, BrowserAction)
         @"browser.browserAction.openPopup()"
     ]);
 
-    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,
@@ -816,7 +786,7 @@ TEST(WKWebExtensionAPIAction, PageAction)
         @"browser.pageAction.openPopup()"
     ]);
 
-    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
         @"background.js": backgroundScript,

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -136,6 +136,8 @@ namespace TestWebKitAPI::Util {
 inline NSString *constructScript(NSArray *lines) { return [lines componentsJoinedByString:@"\n"]; }
 inline NSString *constructJSArrayOfStrings(NSArray *elements) { return [NSString stringWithFormat:@"['%@']", [elements componentsJoinedByString:@"', '"]]; }
 
+NSData *makePNGData(CGSize, SEL colorSelector);
+
 #endif
 
 RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *);


### PR DESCRIPTION
#### 08528dc43d175d5c969dcfdcda6731e97f4763be
<pre>
WebExtension::actionIcon needs to fallback to WebExtension::icon.
<a href="https://webkit.org/b/263561">https://webkit.org/b/263561</a>
rdar://problem/117377423

Reviewed by Brian Weinstein and Brady Eidson.

This is the documented behavior of -[_WkWebExtension actionIconForSize:], just didn&apos;t do it.
&quot;If no matching [action] icon is available, the method will fall back to the extension&apos;s icon.&quot;

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::actionIcon):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST):
(TestWebKitAPI::makePNGData): Deleted.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(TestWebKitAPI::Util::makePNGData):

Canonical link: <a href="https://commits.webkit.org/269705@main">https://commits.webkit.org/269705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7534ad2fbfb54e8b07160cc639f810561cedf511

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24412 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23845 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26059 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27208 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21326 "Passed tests") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25082 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18517 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/721 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5562 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->