### PR TITLE
[Cocoa] Make WebContextMenuProxy::copySubjectResult return a `RetainPtr`

### DIFF
--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -55,7 +55,7 @@ public:
 #endif // PLATFORM(COCOA)
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    virtual CGImageRef copySubjectResult() const { return nullptr; }
+    virtual RetainPtr<CGImageRef> imageForCopySubject() const { return { }; }
 #endif
 
 protected:

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -59,7 +59,7 @@ public:
     NSWindow *window() const;
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    CGImageRef copySubjectResult() const final { return m_copySubjectResult.get(); }
+    RetainPtr<CGImageRef> imageForCopySubject() const final { return m_copySubjectResult; }
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -808,7 +808,7 @@ void WebPageProxy::handleContextMenuCopySubject(const String& preferredMIMEType)
     if (!m_activeContextMenu)
         return;
 
-    RetainPtr image = m_activeContextMenu->copySubjectResult();
+    auto image = m_activeContextMenu->imageForCopySubject();
     if (!image)
         return;
 


### PR DESCRIPTION
#### 21a5d7f6e5b2c3d4fc502f6f1969461856260a43
<pre>
[Cocoa] Make WebContextMenuProxy::copySubjectResult return a `RetainPtr`
<a href="https://bugs.webkit.org/show_bug.cgi?id=263567">https://bugs.webkit.org/show_bug.cgi?id=263567</a>

Reviewed by Tim Horton.

Clarify the ownership model around this method by returning a `RetainPtr`, and additionally rename
the method so that it doesn&apos;t read like it copies the result.

* Source/WebKit/UIProcess/WebContextMenuProxy.h:
(WebKit::WebContextMenuProxy::imageForCopySubject const):
(WebKit::WebContextMenuProxy::copySubjectResult const): Deleted.
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::handleContextMenuCopySubject):

Canonical link: <a href="https://commits.webkit.org/269695@main">https://commits.webkit.org/269695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63a801d5bd468ff6d7bd0f1ba5df52d016ccf9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24414 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23847 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26061 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21315 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/769 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/723 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5559 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->