### PR TITLE
[WebGPU] Correct webgpu:api,operation,labels:* test failures

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -102,7 +102,9 @@ void RemoteAdapterProxy::requestDevice(const WebCore::WebGPU::DeviceDescriptor& 
         supportedLimits.maxComputeWorkgroupSizeZ,
         supportedLimits.maxComputeWorkgroupsPerDimension
     );
-    callback(RemoteDeviceProxy::create(WTFMove(resultSupportedFeatures), WTFMove(resultSupportedLimits), *this, m_convertToBackingContext, identifier, queueIdentifier));
+    auto result = RemoteDeviceProxy::create(WTFMove(resultSupportedFeatures), WTFMove(resultSupportedLimits), *this, m_convertToBackingContext, identifier, queueIdentifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    callback(WTFMove(result));
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -61,7 +61,9 @@ Ref<WebCore::WebGPU::RenderPassEncoder> RemoteCommandEncoderProxy::beginRenderPa
     auto sendResult = send(Messages::RemoteCommandEncoder::BeginRenderPass(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteRenderPassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteRenderPassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return WTFMove(result);
 }
 
 Ref<WebCore::WebGPU::ComputePassEncoder> RemoteCommandEncoderProxy::beginComputePass(const std::optional<WebCore::WebGPU::ComputePassDescriptor>& descriptor)
@@ -79,7 +81,9 @@ Ref<WebCore::WebGPU::ComputePassEncoder> RemoteCommandEncoderProxy::beginCompute
     auto sendResult = send(Messages::RemoteCommandEncoder::BeginComputePass(convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteComputePassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteComputePassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return WTFMove(result);
 }
 
 void RemoteCommandEncoderProxy::copyBufferToBuffer(

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -87,7 +87,9 @@ Ref<WebCore::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const WebCore::WebG
     auto sendResult = send(Messages::RemoteDevice::CreateBuffer(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteBufferProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteBufferProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::Texture> RemoteDeviceProxy::createTexture(const WebCore::WebGPU::TextureDescriptor& descriptor)
@@ -102,7 +104,9 @@ Ref<WebCore::WebGPU::Texture> RemoteDeviceProxy::createTexture(const WebCore::We
     auto sendResult = send(Messages::RemoteDevice::CreateTexture(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
+    auto result = RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const WebCore::WebGPU::SamplerDescriptor& descriptor)
@@ -117,7 +121,9 @@ Ref<WebCore::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const WebCore::We
     auto sendResult = send(Messages::RemoteDevice::CreateSampler(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteSamplerProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteSamplerProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTexture(const WebCore::WebGPU::ExternalTextureDescriptor& descriptor)
@@ -148,7 +154,9 @@ Ref<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTexture(c
     UNUSED_VARIABLE(sendResult);
 #endif
 
-    return RemoteExternalTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteExternalTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::BindGroupLayout> RemoteDeviceProxy::createBindGroupLayout(const WebCore::WebGPU::BindGroupLayoutDescriptor& descriptor)
@@ -163,7 +171,9 @@ Ref<WebCore::WebGPU::BindGroupLayout> RemoteDeviceProxy::createBindGroupLayout(c
     auto sendResult = send(Messages::RemoteDevice::CreateBindGroupLayout(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteBindGroupLayoutProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteBindGroupLayoutProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::PipelineLayout> RemoteDeviceProxy::createPipelineLayout(const WebCore::WebGPU::PipelineLayoutDescriptor& descriptor)
@@ -178,7 +188,9 @@ Ref<WebCore::WebGPU::PipelineLayout> RemoteDeviceProxy::createPipelineLayout(con
     auto sendResult = send(Messages::RemoteDevice::CreatePipelineLayout(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemotePipelineLayoutProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemotePipelineLayoutProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::BindGroup> RemoteDeviceProxy::createBindGroup(const WebCore::WebGPU::BindGroupDescriptor& descriptor)
@@ -193,7 +205,9 @@ Ref<WebCore::WebGPU::BindGroup> RemoteDeviceProxy::createBindGroup(const WebCore
     auto sendResult = send(Messages::RemoteDevice::CreateBindGroup(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteBindGroupProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteBindGroupProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::ShaderModule> RemoteDeviceProxy::createShaderModule(const WebCore::WebGPU::ShaderModuleDescriptor& descriptor)
@@ -208,7 +222,9 @@ Ref<WebCore::WebGPU::ShaderModule> RemoteDeviceProxy::createShaderModule(const W
     auto sendResult = send(Messages::RemoteDevice::CreateShaderModule(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteShaderModuleProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteShaderModuleProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::ComputePipeline> RemoteDeviceProxy::createComputePipeline(const WebCore::WebGPU::ComputePipelineDescriptor& descriptor)
@@ -223,7 +239,9 @@ Ref<WebCore::WebGPU::ComputePipeline> RemoteDeviceProxy::createComputePipeline(c
     auto sendResult = send(Messages::RemoteDevice::CreateComputePipeline(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteComputePipelineProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteComputePipelineProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::RenderPipeline> RemoteDeviceProxy::createRenderPipeline(const WebCore::WebGPU::RenderPipelineDescriptor& descriptor)
@@ -238,7 +256,9 @@ Ref<WebCore::WebGPU::RenderPipeline> RemoteDeviceProxy::createRenderPipeline(con
     auto sendResult = send(Messages::RemoteDevice::CreateRenderPipeline(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteRenderPipelineProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteRenderPipelineProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 void RemoteDeviceProxy::createComputePipelineAsync(const WebCore::WebGPU::ComputePipelineDescriptor& descriptor, CompletionHandler<void(RefPtr<WebCore::WebGPU::ComputePipeline>&&)>&& callback)
@@ -251,13 +271,15 @@ void RemoteDeviceProxy::createComputePipelineAsync(const WebCore::WebGPU::Comput
     }
 
     auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateComputePipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), strongThis = Ref { *this }](auto result) mutable {
+    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateComputePipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), strongThis = Ref { *this }, label = WTFMove(convertedDescriptor->label)](auto result) mutable {
         if (!result) {
             callback(nullptr);
             return;
         }
 
-        callback(RemoteComputePipelineProxy::create(strongThis, strongThis->m_convertToBackingContext, identifier));
+        auto computePipelineResult = RemoteComputePipelineProxy::create(strongThis, strongThis->m_convertToBackingContext, identifier);
+        computePipelineResult->setLabel(WTFMove(label));
+        callback(WTFMove(computePipelineResult));
     });
     UNUSED_PARAM(sendResult);
 }
@@ -270,13 +292,15 @@ void RemoteDeviceProxy::createRenderPipelineAsync(const WebCore::WebGPU::RenderP
         return;
 
     auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateRenderPipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), strongThis = Ref { *this }](auto result) mutable {
+    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateRenderPipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), strongThis = Ref { *this }, label = WTFMove(convertedDescriptor->label)](auto result) mutable {
         if (!result) {
             callback(nullptr);
             return;
         }
 
-        callback(RemoteRenderPipelineProxy::create(strongThis, strongThis->m_convertToBackingContext, identifier));
+        auto renderPipelineResult = RemoteRenderPipelineProxy::create(strongThis, strongThis->m_convertToBackingContext, identifier);
+        renderPipelineResult->setLabel(WTFMove(label));
+        callback(WTFMove(renderPipelineResult));
     });
     UNUSED_PARAM(sendResult);
 }
@@ -296,7 +320,9 @@ Ref<WebCore::WebGPU::CommandEncoder> RemoteDeviceProxy::createCommandEncoder(con
     auto sendResult = send(Messages::RemoteDevice::CreateCommandEncoder(WTFMove(convertedDescriptor), identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteCommandEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteCommandEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::RenderBundleEncoder> RemoteDeviceProxy::createRenderBundleEncoder(const WebCore::WebGPU::RenderBundleEncoderDescriptor& descriptor)
@@ -311,7 +337,9 @@ Ref<WebCore::WebGPU::RenderBundleEncoder> RemoteDeviceProxy::createRenderBundleE
     auto sendResult = send(Messages::RemoteDevice::CreateRenderBundleEncoder(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteRenderBundleEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteRenderBundleEncoderProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 Ref<WebCore::WebGPU::QuerySet> RemoteDeviceProxy::createQuerySet(const WebCore::WebGPU::QuerySetDescriptor& descriptor)
@@ -326,7 +354,9 @@ Ref<WebCore::WebGPU::QuerySet> RemoteDeviceProxy::createQuerySet(const WebCore::
     auto sendResult = send(Messages::RemoteDevice::CreateQuerySet(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteQuerySetProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteQuerySetProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 void RemoteDeviceProxy::pushErrorScope(WebCore::WebGPU::ErrorFilter errorFilter)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -63,7 +63,9 @@ Ref<WebCore::WebGPU::TextureView> RemoteTextureProxy::createView(const std::opti
     auto sendResult = send(Messages::RemoteTexture::CreateView(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureViewProxy::create(*this, m_convertToBackingContext, identifier);
+    auto result = RemoteTextureViewProxy::create(*this, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 void RemoteTextureProxy::destroy()


### PR DESCRIPTION
#### 00d4a6ebe7fa29c762e38cb0a0e87f63b26fc5a7
<pre>
[WebGPU] Correct webgpu:api,operation,labels:* test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=263566">https://bugs.webkit.org/show_bug.cgi?id=263566</a>
&lt;radar://117379755&gt;

Reviewed by Dan Glastonbury.

setLabel was not called on the proxy object, so that object contained
an empty label.

* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
(WebKit::WebGPU::RemoteAdapterProxy::requestDevice):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
(WebKit::WebGPU::RemoteCommandEncoderProxy::beginRenderPass):
(WebKit::WebGPU::RemoteCommandEncoderProxy::beginComputePass):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createBuffer):
(WebKit::WebGPU::RemoteDeviceProxy::createTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createSampler):
(WebKit::WebGPU::RemoteDeviceProxy::importExternalTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createBindGroupLayout):
(WebKit::WebGPU::RemoteDeviceProxy::createPipelineLayout):
(WebKit::WebGPU::RemoteDeviceProxy::createBindGroup):
(WebKit::WebGPU::RemoteDeviceProxy::createShaderModule):
(WebKit::WebGPU::RemoteDeviceProxy::createComputePipeline):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderPipeline):
(WebKit::WebGPU::RemoteDeviceProxy::createComputePipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderPipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::createCommandEncoder):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderBundleEncoder):
(WebKit::WebGPU::RemoteDeviceProxy::createQuerySet):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::createView):

Canonical link: <a href="https://commits.webkit.org/269701@main">https://commits.webkit.org/269701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c55acf683fdafe00c06f611e17a4de2233366d1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24421 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23854 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26068 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/771 "Passed tests") | | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27225 "An unexpected error occured. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21321 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/730 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5561 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1189 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->