### PR TITLE
Make it possible to immediately wrap a retained out param in a smart pointer

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
@@ -181,4 +181,18 @@ TEST(RetainPtr, RetainPtrCF)
     EXPECT_EQ(1, CFGetRetainCount(object2.get()));
 }
 
+static void functionWithRetainedCFOutParam(CFNumberRef* __nonnull CF_RETURNS_RETAINED retainedOutParam)
+{
+    float value = 3.1415926535;
+    CFNumberRef number = CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &value);
+    *retainedOutParam = number;
+}
+
+TEST(RetainPtr, RetainedOutParams)
+{
+    RetainPtr<CFNumberRef> value;
+    functionWithRetainedCFOutParam(adoptOutParam(value));
+    EXPECT_EQ(1, CFGetRetainCount(value.get()));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6c71e6d2fb7deaaabefad4c9adeb36c33b70dba8
<pre>
Make it possible to immediately wrap a retained out param in a smart pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=263538">https://bugs.webkit.org/show_bug.cgi?id=263538</a>
rdar://117382839

Reviewed by NOBODY (OOPS!).

Make it possible to write code like:

    RetainPtr&lt;CFNumberRef&gt; value;
    functionWithRetainedCFOutParam(adoptOutParam(value));

to avoid raw CFTypeRefs in the code which are later adopted via adoptCF(), which is hard to
write a style checker rule for.

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtrGetterRetains::RetainPtrGetterRetains):
(WTF::RetainPtrGetterRetains::operator T*):
(WTF::adoptOutParam):
* Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp:
(TestWebKitAPI::functionWithRetainedCFOutParam):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c71e6d2fb7deaaabefad4c9adeb36c33b70dba8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24423 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23856 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26070 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21064 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27217 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20276 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21242 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21323 "Passed tests") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25090 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22661 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18525 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30043 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/732 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6208 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1191 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29995 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1034 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6101 "Passed tests") | 
<!--EWS-Status-Bubble-End-->