### PR TITLE
Clarify refcounting in WKMediaSessionCoordinatorForTesting::WKMediaSessionCoordinatorForTesting()

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -617,9 +617,8 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
             : WebKit::MediaSessionCoordinatorProxyPrivate()
             , m_clientCoordinator(clientCoordinator)
         {
-            auto* delegateHelper = [[WKMediaSessionCoordinatorHelper alloc] initWithCoordinator:this];
-            [m_clientCoordinator setDelegate:delegateHelper];
-            m_coordinatorDelegate = adoptNS(delegateHelper);
+            m_coordinatorDelegate = adoptNS([[WKMediaSessionCoordinatorHelper alloc] initWithCoordinator:this]);
+            [m_clientCoordinator setDelegate:m_coordinatorDelegate.get()];
         }
 
         void seekSessionToTime(double time, CompletionHandler<void(bool)>&& callback) final


### PR DESCRIPTION
#### d2db744604a4c3523783181e8ce81d93e36c31e7
<pre>
Clarify refcounting in WKMediaSessionCoordinatorForTesting::WKMediaSessionCoordinatorForTesting()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263579">https://bugs.webkit.org/show_bug.cgi?id=263579</a>
rdar://117388768

Reviewed by Eric Carlson.

Immediately put the result of [WKMediaSessionCoordinatorHelper alloc]... into a smart pointer

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _createMediaSessionCoordinatorForTesting:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/269877@main">https://commits.webkit.org/269877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03fbfad85031e394e19b5c46df6c12686671c38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24445 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23878 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26089 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/798 "Passed tests") | | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27231 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21263 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25103 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/794 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/751 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5720 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->