### PR TITLE
Use 'auto' when calling a function that returns a RetainPtr<>

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -85,7 +85,7 @@ void CompositorIntegrationImpl::withDisplayBufferAsNativeImage(uint32_t bufferIn
 
     // Use the IOSurface backed image directly
     auto& renderBuffer = m_renderBuffers[bufferIndex];
-    RetainPtr<CGContextRef> cgContext = renderBuffer->createPlatformContext();
+    auto cgContext = renderBuffer->createPlatformContext();
     if (cgContext)
         displayImage = NativeImage::create(renderBuffer->createImage(cgContext.get()));
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -292,7 +292,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const URL&, FragmentedSharedBu
 
     Ref<LegacyWebArchive> archive = create();
 
-    RetainPtr<CFDataRef> cfData = data.makeContiguous()->createCFData();
+    auto cfData = data.makeContiguous()->createCFData();
     if (!cfData)
         return nullptr;
 

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -145,14 +145,14 @@ NSArray *LocalFrame::wordsInCurrentParagraph() const
                 if (deprecatedIsSpaceOrNewline(text[i]) || text[i] == noBreakSpace) {
                     int wordLength = i - startOfWordBoundary;
                     if (wordLength > 0) {
-                        RetainPtr<NSString> chunk = text.substring(startOfWordBoundary, wordLength).createNSString();
+                        auto chunk = text.substring(startOfWordBoundary, wordLength).createNSString();
                         [words addObject:chunk.get()];
                     }
                     startOfWordBoundary += wordLength + 1;
                 }
             }
             if (startOfWordBoundary < length) {
-                RetainPtr<NSString> chunk = text.substring(startOfWordBoundary, length - startOfWordBoundary).createNSString();
+                auto chunk = text.substring(startOfWordBoundary, length - startOfWordBoundary).createNSString();
                 [words addObject:chunk.get()];
             }
         }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -957,7 +957,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession(LicenseType license
             return;
         }
 
-        RetainPtr<NSData> appIdentifier = certificate->makeContiguous()->createNSData();
+        auto appIdentifier = certificate->makeContiguous()->createNSData();
         KeyStatusVector changedKeys;
         for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
@@ -1022,7 +1022,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData(const String&
             return;
         }
 
-        RetainPtr<NSData> appIdentifier = certificate->makeContiguous()->createNSData();
+        auto appIdentifier = certificate->makeContiguous()->createNSData();
         RetainPtr<NSMutableArray> expiredSessionsArray = adoptNS([[NSMutableArray alloc] init]);
         KeyStatusVector changedKeys;
         for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
@@ -1124,7 +1124,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequest(AVContentKeyR
         return;
     }
 
-    RetainPtr<NSData> contentIdentifier = keyIDs.first()->makeContiguous()->createNSData();
+    auto contentIdentifier = keyIDs.first()->makeContiguous()->createNSData();
     @try {
         [request makeStreamingContentKeyRequestDataForApp:appIdentifier.get() contentIdentifier:contentIdentifier.get() options:nil completionHandler:[this, weakThis = WeakPtr { *this }] (NSData *contentKeyRequestData, NSError *error) mutable {
             callOnMainThread([this, weakThis = WTFMove(weakThis), error = retainPtr(error), contentKeyRequestData = retainPtr(contentKeyRequestData)] {
@@ -1286,7 +1286,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest(AVCon
         appIdentifier = certificate->makeContiguous()->createNSData();
     auto keyIDs = keyIDsForRequest(m_currentRequest.value());
 
-    RetainPtr<NSData> contentIdentifier = keyIDs.first()->makeContiguous()->createNSData();
+    auto contentIdentifier = keyIDs.first()->makeContiguous()->createNSData();
     @try {
         [request makeStreamingContentKeyRequestDataForApp:appIdentifier.get() contentIdentifier:contentIdentifier.get() options:nil completionHandler:[this, weakThis = WeakPtr { *this }] (NSData *contentKeyRequestData, NSError *error) mutable {
             callOnMainThread([this, weakThis = WTFMove(weakThis), error = retainPtr(error), contentKeyRequestData = retainPtr(contentKeyRequestData)] {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -745,7 +745,7 @@ void MediaPlayerPrivateAVFoundationObjC::synchronizeTextTrackState()
         RetainPtr<AVMediaSelectionOption> currentOption = trackPrivate->mediaSelectionOption();
 
         for (auto& track : outOfBandTrackSources) {
-            RetainPtr<CFStringRef> uniqueID = String::number(track->uniqueId()).createCFString();
+            auto uniqueID = String::number(track->uniqueId()).createCFString();
 
             if (![[currentOption outOfBandIdentifier] isEqual:(__bridge NSString *)uniqueID.get()])
                 continue;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1469,7 +1469,7 @@ void GraphicsContextCG::drawLinesForText(const FloatPoint& point, float thicknes
 
 void GraphicsContextCG::setURLForRect(const URL& link, const FloatRect& destRect)
 {
-    RetainPtr<CFURLRef> urlRef = link.createCFURL();
+    auto urlRef = link.createCFURL();
     if (!urlRef)
         return;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create
     if (!surface)
         return nullptr;
 
-    RetainPtr<CGContextRef> cgContext = surface->createPlatformContext(creationContext.displayID);
+    auto cgContext = surface->createPlatformContext(creationContext.displayID);
     if (!cgContext)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -91,7 +91,7 @@ static RetainPtr<CFMutableDictionaryRef> createImageSourceMetadataOptions()
     
 static RetainPtr<CFMutableDictionaryRef> createImageSourceThumbnailOptions()
 {
-    RetainPtr<CFMutableDictionaryRef> options = createImageSourceOptions();
+    auto options = createImageSourceOptions();
     CFDictionarySetValue(options.get(), kCGImageSourceShouldCacheImmediately, kCFBooleanTrue);
     CFDictionarySetValue(options.get(), kCGImageSourceCreateThumbnailFromImageAlways, kCFBooleanTrue);
     return options;

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -542,7 +542,7 @@ RefPtr<Font> Font::createFontWithoutSynthesizableFeatures() const
 {
     float size = m_platformData.size();
     CTFontSymbolicTraits fontTraits = CTFontGetSymbolicTraits(m_platformData.font());
-    RetainPtr<CTFontRef> ctFont = createCTFontWithoutSynthesizableFeatures(m_platformData.font());
+    auto ctFont = createCTFontWithoutSynthesizableFeatures(m_platformData.font());
     return createDerivativeFont(ctFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.customPlatformData());
 }
 

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -62,7 +62,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
 
 RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String& itemInCollection)
 {
-    RetainPtr<CFDataRef> bufferData = buffer.createCFData();
+    auto bufferData = buffer.createCFData();
 
     FPFontRef font = nullptr;
     auto array = adoptCF(FPFontCreateFontsFromData(bufferData.get()));

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -57,11 +57,11 @@ void DNSResolveQueueCFNet::updateIsUsingProxy()
         return;
     }
 
-    RetainPtr<CFURLRef> httpCFURL = URL({ }, "http://example.com/"_s).createCFURL();
-    RetainPtr<CFURLRef> httpsCFURL = URL({ }, "https://example.com/"_s).createCFURL();
+    auto httpCFURL = URL({ }, "http://example.com/"_s).createCFURL();
+    auto httpsCFURL = URL({ }, "https://example.com/"_s).createCFURL();
 
-    RetainPtr<CFArrayRef> httpProxyArray = adoptCF(CFNetworkCopyProxiesForURL(httpCFURL.get(), proxySettings.get()));
-    RetainPtr<CFArrayRef> httpsProxyArray = adoptCF(CFNetworkCopyProxiesForURL(httpsCFURL.get(), proxySettings.get()));
+    auto httpProxyArray = adoptCF(CFNetworkCopyProxiesForURL(httpCFURL.get(), proxySettings.get()));
+    auto httpsProxyArray = adoptCF(CFNetworkCopyProxiesForURL(httpsCFURL.get(), proxySettings.get()));
 
     CFIndex httpProxyCount = CFArrayGetCount(httpProxyArray.get());
     CFIndex httpsProxyCount = CFArrayGetCount(httpsProxyArray.get());

--- a/Source/WebCore/platform/text/cf/HyphenationCF.cpp
+++ b/Source/WebCore/platform/text/cf/HyphenationCF.cpp
@@ -53,13 +53,13 @@ public:
     {
         // CF hyphenation functions use locale (regional formats) language, which doesn't necessarily match primary UI language,
         // so we can't use default locale here. See <rdar://problem/14897664>.
-        RetainPtr<CFLocaleRef> locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, defaultLanguage().createCFString().get()));
+        auto locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, defaultLanguage().createCFString().get()));
         return CFStringIsHyphenationAvailableForLocale(locale.get()) ? locale : nullptr;
     }
 
     static RetainPtr<CFLocaleRef> createValueForKey(const AtomString& localeIdentifier)
     {
-        RetainPtr<CFLocaleRef> locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, localeIdentifier.string().createCFString().get()));
+        auto locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, localeIdentifier.string().createCFString().get()));
 
         return CFStringIsHyphenationAvailableForLocale(locale.get()) ? locale : nullptr;
     }
@@ -77,7 +77,7 @@ bool canHyphenate(const AtomString& localeIdentifier)
 
 size_t lastHyphenLocation(StringView text, size_t beforeIndex, const AtomString& localeIdentifier)
 {
-    RetainPtr<CFLocaleRef> locale = TinyLRUCachePolicy<AtomString, RetainPtr<CFLocaleRef>>::cache().get(localeIdentifier);
+    auto locale = TinyLRUCachePolicy<AtomString, RetainPtr<CFLocaleRef>>::cache().get(localeIdentifier);
 
     CFOptionFlags searchAcrossWordBoundaries = 1;
     CFIndex result = CFStringGetHyphenationLocationBeforeIndex(text.createCFStringWithoutCopying().get(), beforeIndex, CFRangeMake(0, text.length()), searchAcrossWordBoundaries, locale.get(), nullptr);

--- a/Source/WebCore/platform/text/mac/TextBoundaries.mm
+++ b/Source/WebCore/platform/text/mac/TextBoundaries.mm
@@ -153,7 +153,7 @@ static void findSimpleWordBoundary(StringView text, int position, int* start, in
 // Complex case: use CFStringTokenizer to find word boundary.
 static void findComplexWordBoundary(StringView text, int position, int* start, int* end)
 {
-    RetainPtr<CFStringRef> charString = text.createCFStringWithoutCopying();
+    auto charString = text.createCFStringWithoutCopying();
 
     CFStringTokenizerRef tokenizer = tokenizerForString(charString.get());
     if (!tokenizer) {

--- a/Source/WebKit/Shared/APIWebArchiveResource.mm
+++ b/Source/WebKit/Shared/APIWebArchiveResource.mm
@@ -68,7 +68,7 @@ static void releaseWebArchiveResourceData(unsigned char*, const void* data)
 
 Ref<API::Data> WebArchiveResource::data()
 {
-    RetainPtr<CFDataRef> cfData = m_archiveResource->data().makeContiguous()->createCFData();
+    auto cfData = m_archiveResource->data().makeContiguous()->createCFData();
 
     // Balanced by CFRelease in releaseWebArchiveResourceData.
     CFRetain(cfData.get());

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -674,7 +674,7 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
     if (model->videoDimensions().isEmpty() && !nativeSize.isEmpty())
         model->setVideoDimensions(nativeSize);
 
-    RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
+    auto view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 
     if (!model->playerLayer()) {
         ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayer, initialSize: ", initialSize, ", nativeSize: ", nativeSize);
@@ -728,7 +728,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
     auto& [model, interface] = ensureModelAndInterface(contextId);
     addClientForContext(contextId);
 
-    RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
+    auto view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 
     if (!model->videoView()) {
         ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayerView");
@@ -791,7 +791,7 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
         return;
     }
 
-    RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
+    auto view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 
 #if PLATFORM(IOS_FAMILY)
     auto* rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*m_page->drawingArea()).remoteLayerTreeHost().rootNode();

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -843,7 +843,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 bool WebProcessPool::isURLKnownHSTSHost(const String& urlString) const
 {
-    RetainPtr<CFURLRef> url = URL { urlString }.createCFURL();
+    auto url = URL { urlString }.createCFURL();
 
     return _CFNetworkIsKnownHSTSHostWithSession(url.get(), nullptr);
 }

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -385,7 +385,7 @@ void PageClientImpl::positionInformationDidChange(const InteractionInformationAt
 
 void PageClientImpl::saveImageToLibrary(Ref<SharedBuffer>&& imageBuffer)
 {
-    RetainPtr<NSData> imageData = imageBuffer->createNSData();
+    auto imageData = imageBuffer->createNSData();
     UIImageDataWriteToSavedPhotosAlbum(imageData.get(), nil, NULL, NULL);
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13246,8 +13246,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         RetainPtr<NSURL> alternateURL = targetURL;
         RetainPtr<NSDictionary> imageInfo;
-        RetainPtr<CGImageRef> cgImage = _positionInformation.image->makeCGImageCopy();
-        RetainPtr<UIImage> uiImage = adoptNS([[UIImage alloc] initWithCGImage:cgImage.get()]);
+        auto cgImage = _positionInformation.image->makeCGImageCopy();
+        auto uiImage = adoptNS([[UIImage alloc] initWithCGImage:cgImage.get()]);
         if ([uiDelegate respondsToSelector:@selector(_webView:alternateURLFromImage:userInfo:)]) {
             NSDictionary *userInfo;
             alternateURL = [uiDelegate _webView:self.webView alternateURLFromImage:uiImage.get() userInfo:&userInfo];

--- a/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
+++ b/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
@@ -331,7 +331,7 @@ Vector<TextCheckingResult> TextChecker::checkTextOfParagraph(SpellDocumentTag sp
 {
     Vector<TextCheckingResult> results;
 
-    RetainPtr<NSString> textString = text.createNSStringWithoutCopying();
+    auto textString = text.createNSStringWithoutCopying();
     NSDictionary *options = @{
         NSTextCheckingInsertionPointKey : @(insertionPoint),
         NSTextCheckingSuppressInitialCapitalizationKey : @(!initialCapitalizationEnabled)

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -213,7 +213,7 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     size_t bytesPerRow = CGImageGetBytesPerRow(sourceImage);
     CGColorSpaceRef colorSpace = CGImageGetColorSpace(sourceImage);
     CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(sourceImage);
-    RetainPtr<CGDataProviderRef> provider = createImageProviderWithCopiedData(CGImageGetDataProvider(sourceImage));
+    auto provider = createImageProviderWithCopiedData(CGImageGetDataProvider(sourceImage));
     bool shouldInterpolate = CGImageGetShouldInterpolate(sourceImage);
     CGColorRenderingIntent intent = CGImageGetRenderingIntent(sourceImage);
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4365,7 +4365,7 @@ void WebViewImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAcc
     [pasteMenuItem setTarget:m_domPasteMenuDelegate.get()];
 
     auto window = [m_view window];
-    RetainPtr event = m_page->createSyntheticEventForContextMenu([window convertPointFromScreen:NSEvent.mouseLocation]);
+    auto event = m_page->createSyntheticEventForContextMenu([window convertPointFromScreen:NSEvent.mouseLocation]);
     [NSMenu popUpContextMenu:m_domPasteMenu.get() withEvent:event.get() forView:window.contentView];
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareable
     if (creationContext.resourceOwner)
         surface->setOwnershipIdentity(creationContext.resourceOwner);
 
-    RetainPtr<CGContextRef> cgContext = surface->createPlatformContext();
+    auto cgContext = surface->createPlatformContext();
     if (!cgContext)
         return nullptr;
 


### PR DESCRIPTION
#### 1c47d20bfbc1ff7538a22caa4ad4f713a7259de6
<pre>
Use &apos;auto&apos; when calling a function that returns a RetainPtr&lt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=263580">https://bugs.webkit.org/show_bug.cgi?id=263580</a>
rdar://117389828

Reviewed by NOBODY (OOPS!).

When the style checker (with future changes) sees `RetainPtr&lt;Foo&gt; = someFunction()` it doesn&apos;t know
what the return value of `someFunction() is, so it can&apos;t guess about whether this over-retains.

If we use `auto` on the left-hand side here we can avoid this problem, when `someFunction()` returns
a `RetainPtr&lt;&gt;`.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::withDisplayBufferAsNativeImage):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::wordsInCurrentParagraph const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequest):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::synchronizeTextTrackState):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setURLForRect):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::create):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::createImageSourceThumbnailOptions):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::createFontWithoutSynthesizableFeatures const):
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::createFontCustomPlatformData):
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::DNSResolveQueueCFNet::updateIsUsingProxy):
* Source/WebCore/platform/text/cf/HyphenationCF.cpp:
(WebCore::lastHyphenLocation):
* Source/WebCore/platform/text/mac/TextBoundaries.mm:
(WebCore::findComplexWordBoundary):
* Source/WebKit/Shared/APIWebArchiveResource.mm:
(API::WebArchiveResource::data):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::isURLKnownHSTSHost const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::saveImageToLibrary):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _presentedViewControllerForPreviewItemController:]):
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::TextChecker::checkTextOfParagraph):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(createImageWithCopiedData):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::requestDOMPasteAccess):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBackend::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c47d20bfbc1ff7538a22caa4ad4f713a7259de6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24448 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23881 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26092 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21086 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27234 "An unexpected error occured. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25109 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->