### PR TITLE
REGRESSSION (iOS 17 Beta): Outgoing video and incoming audio do not recover if iOS User receives PSTN/FaceTime call in the middle of the WebRTC call and decline/accepts it from the notification

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session-expected.txt
+++ b/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session-expected.txt
@@ -1,0 +1,3 @@
+
+PASS AudioSession category should staty to PlayAndRecord when interrupted, not when muted by user
+

--- a/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
+++ b/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Capture source interruption and AudioSession category</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+ </head>
+<body>
+    <script>
+    var context = new AudioContext();
+    promise_test(async (test) => {
+        const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+        if (!window.internals)
+            return;
+        assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test1");
+
+        // Muting capture should trigger change of category.
+        const onMutePromise1 = new Promise(resolve => stream.getAudioTracks()[0].onmute = resolve);
+        if (window.internals)
+            internals.setPageMuted("capturedevices");
+        await onMutePromise1;
+        // We clone the capture stream to trigger an audio session category recomputation.
+        let clone = stream.clone();
+        assert_equals(internals.audioSessionCategory(), "AmbientSound", "test2");
+
+        const onUnmutePromise1 = new Promise(resolve => stream.getAudioTracks()[0].onunmute = resolve);
+        if (window.internals)
+            internals.setPageMuted("");
+        await onUnmutePromise1;
+        clone = stream.clone();
+        assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test3");
+
+        // PlayAndRecord should stick even with capture interruption.
+        const onMutePromise2 = new Promise(resolve => stream.getAudioTracks()[0].onmute = resolve);
+        if (window.internals)
+            internals.beginAudioSessionInterruption();
+        await onMutePromise2;
+        clone = stream.clone();
+        assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test4");
+
+        const onUnmutePromise2 = new Promise(resolve => stream.getAudioTracks()[0].onunmute = resolve);
+        if (window.internals)
+            internals.endAudioSessionInterruption();
+        await onUnmutePromise2;
+        clone = stream.clone();
+        assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "test5");
+    }, "AudioSession category should staty to PlayAndRecord when interrupted, not when muted by user");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1823,6 +1823,9 @@ fast/mediastream/video-rotation.html [ Skip ]
 webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
 webrtc/video-rotation-black.html [ Crash Failure Pass Timeout ]
 
+# No AudioSession category handling in WPE/GTK ports.
+fast/mediastream/microphone-interruption-and-audio-session.html [ Skip ]
+
 webkit.org/b/261329 webrtc/video-clone-track.html [ Failure ]
 
 webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -693,6 +693,12 @@ bool MediaStreamTrack::isCapturingAudio() const
     return !ended() && !muted();
 }
 
+bool MediaStreamTrack::wantsToCaptureAudio() const
+{
+    ASSERT(isCaptureTrack() && m_private->isAudio());
+    return !ended() && (!muted() || m_private->interrupted());
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStreamTrack::logChannel() const
 {

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -194,6 +194,7 @@ private:
 
     // PlatformMediaSession::AudioCaptureSource
     bool isCapturingAudio() const final;
+    bool wantsToCaptureAudio() const final;
 
     void updateVideoCaptureAccordingMicrophoneInterruption(Document&, bool);
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -208,6 +208,7 @@ public:
     public:
         virtual ~AudioCaptureSource() = default;
         virtual bool isCapturingAudio() const = 0;
+        virtual bool wantsToCaptureAudio() const = 0;
     };
 
     virtual std::optional<NowPlayingInfo> nowPlayingInfo() const;

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -160,7 +160,7 @@ int PlatformMediaSessionManager::countActiveAudioCaptureSources()
 {
     int count = 0;
     for (const auto& source : m_audioCaptureSources) {
-        if (source.isCapturingAudio())
+        if (source.wantsToCaptureAudio())
             ++count;
     }
     return count;

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -117,6 +117,11 @@ bool MediaStreamTrackPrivate::muted() const
     return m_source->muted();
 }
 
+bool MediaStreamTrackPrivate::interrupted() const
+{
+    return m_source->interrupted();
+}
+
 bool MediaStreamTrackPrivate::isCaptureTrack() const
 {
     return m_source->isCaptureSource();

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -84,6 +84,7 @@ public:
 
     bool muted() const;
     void setMuted(bool muted) { m_source->setMuted(muted); }
+    bool interrupted() const;
 
     void setIsInBackground(bool value) { m_source->setIsInBackground(value); }
 


### PR DESCRIPTION
#### 130f20449a4b9edfb76e6b51b93aedecb1bb3f0a
<pre>
REGRESSSION (iOS 17 Beta): Outgoing video and incoming audio do not recover if iOS User receives PSTN/FaceTime call in the middle of the WebRTC call and decline/accepts it from the notification
<a href="https://bugs.webkit.org/show_bug.cgi?id=259884">https://bugs.webkit.org/show_bug.cgi?id=259884</a>
rdar://113534779

Reviewed by Eric Carlson.

When we are interrupted by a phone call, we were sometimes changing the AudioSession Category from PlayAndRecord to Media.
In that case, we might try to activate the AudioSession with Media category and it will succeed given category is Media.
Capture will still fail as setting the category to PlayAndRecord before restarting capture will fail.
In that case, we stay muted but we will not be able to recover properly when getting uninterrupted.

To fix this, we are now sticking to PlayAndRecord when a process has microphone sources which are muted due to interruption.
When we will try to activate the audio session while being interrupted, activation will fail as it is lower priority compared to a phone call,
and we will wait for end of interruption signal.

Covered by added test.

* LayoutTests/fast/mediastream/microphone-interruption-and-audio-session-expected.txt: Added.
* LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html: Added.
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::wantsToCaptureAudio const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/platform/audio/PlatformMediaSession.h:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::countActiveAudioCaptureSources):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::interrupted const):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:

Canonical link: <a href="https://commits.webkit.org/269809@main">https://commits.webkit.org/269809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f3b886f9a2e6b702d1f67aa7812961b04da12f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24174 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26393 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27632 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25395 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18769 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21132 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5651 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->