### PR TITLE
Unsupported codecs should trigger WebCodecs to close encoders/decoders asynchronously

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js
@@ -135,20 +135,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new AudioDecoder({
           output: t.unreached_func('unexpected output'),
           error: t.step_func_done(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js
@@ -213,20 +213,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new AudioEncoder({
           output: t.unreached_func('unexpected output'),
           error: t.step_func_done(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
@@ -96,20 +96,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new VideoDecoder({
           output: t.unreached_func('unexpected output'),
-          error: t.step_func_done(e => {
+          error: t.step_func(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
@@ -189,20 +189,23 @@ validButUnsupportedConfigs.forEach(entry => {
 });
 
 validButUnsupportedConfigs.forEach(entry => {
-  async_test(
+  promise_test(
       t => {
+        let isErrorCallbackCalled = false;
         let codec = new VideoEncoder({
           output: t.unreached_func('unexpected output'),
           error: t.step_func_done(e => {
+            isErrorCallbackCalled = true;
             assert_true(e instanceof DOMException);
             assert_equals(e.name, 'NotSupportedError');
             assert_equals(codec.state, 'closed', 'state');
           })
         });
         codec.configure(entry.config);
-        codec.flush()
+        return codec.flush()
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
+              assert_true(isErrorCallbackCalled, "isErrorCallbackCalled");
               assert_true(e instanceof DOMException);
               assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1161,6 +1161,12 @@ imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?adts_aac [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp4_aac [ Failure ]
 
+# Needs rebasing
+imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker.html [ Pass Failure ]
+
 imported/w3c/web-platform-tests/webcodecs/audio-data-serialization.any.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-data.any.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker.html [ Pass ]


### PR DESCRIPTION
#### d686d8cda3e314c96462325828985ba322c9bf25
<pre>
Unsupported codecs should trigger WebCodecs to close encoders/decoders asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=263584">https://bugs.webkit.org/show_bug.cgi?id=263584</a>
rdar://117234338

Reviewed by Eric Carlson.

We were correctly asyncrhnously failing encoders and decoders when configuring for supported codecs with unsupported versions.
We were still synchronously failing encoders and decoders with unknown names.

We fix this by ensuring we queue a task whenever closing the codec in the configure step.
We also make sure to keep the message queue blocked in that code path to ensure we do not process additional tasks with null internal codec.

We make consistent audio and video encoder in where they set the config as base config for consistency.

We update WPT tests that were not really testing this code path by:
- transforming async_test in promise_test
- making sure the flush promise rejects before the test ends.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):

Canonical link: <a href="https://commits.webkit.org/269844@main">https://commits.webkit.org/269844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddab5834e69d5ca5d0838be37ec7a8d26e63b7b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22385 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26394 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27633 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25396 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18770 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1046 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5683 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->