### PR TITLE
GraphicsContextGLANGLE subclasses duplicate context state initialization

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1561,7 +1561,7 @@ public:
     // Has no other side-effects.
     virtual bool isExtensionEnabled(const String&) = 0;
 
-    virtual bool enableRequiredWebXRExtensions() { return true; }
+    virtual bool enableRequiredWebXRExtensions() { return false; }
 
     // GL_ANGLE_translated_shader_source
     virtual String getTranslatedShaderSourceANGLE(PlatformGLObject) = 0;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -85,22 +85,75 @@ bool GraphicsContextGLANGLE::initialize()
         return false;
     if (!platformInitializeContext())
         return false;
+
     String extensionsString = String::fromLatin1(reinterpret_cast<const char*>(GL_GetString(GL_EXTENSIONS)));
     for (auto& extension : extensionsString.split(' '))
         m_availableExtensions.add(extension);
     extensionsString = String::fromLatin1(reinterpret_cast<const char*>(GL_GetString(GL_REQUESTABLE_EXTENSIONS_ANGLE)));
     for (auto& extension : extensionsString.split(' '))
         m_requestableExtensions.add(extension);
-    return platformInitialize();
-}
 
-bool GraphicsContextGLANGLE::platformInitializeContext()
-{
-    return true;
-}
+    validateAttributes();
+    auto attributes = contextAttributes(); // They may have changed during validation.
 
-bool GraphicsContextGLANGLE::platformInitialize()
-{
+    if (m_isForWebGL2) {
+        if (!enableExtension("GL_EXT_occlusion_query_boolean"_s))
+            return false;
+        if (!enableExtension("GL_ANGLE_framebuffer_multisample"_s))
+            return false;
+    }
+
+    if (!platformInitializeExtensions())
+        return false;
+
+    if (m_isForWebGL2)
+        GL_Enable(GraphicsContextGL::PRIMITIVE_RESTART_FIXED_INDEX);
+
+    // Create the texture that will be used for the framebuffer.
+    GLenum textureTarget = drawingBufferTextureTarget();
+
+    GL_GenTextures(1, &m_texture);
+    GL_BindTexture(textureTarget, m_texture);
+    GL_TexParameteri(textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GL_TexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    GL_BindTexture(textureTarget, 0);
+
+    GL_GenFramebuffers(1, &m_fbo);
+    GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+    m_state.boundDrawFBO = m_state.boundReadFBO = m_fbo;
+
+    if (!attributes.antialias && (attributes.stencil || attributes.depth))
+        GL_GenRenderbuffers(1, &m_depthStencilBuffer);
+
+    // If necessary, create another framebuffer for the multisample results.
+    if (attributes.antialias) {
+        GL_GenFramebuffers(1, &m_multisampleFBO);
+        GL_BindFramebuffer(GL_FRAMEBUFFER, m_multisampleFBO);
+        m_state.boundDrawFBO = m_state.boundReadFBO = m_multisampleFBO;
+        GL_GenRenderbuffers(1, &m_multisampleColorBuffer);
+        if (attributes.stencil || attributes.depth)
+            GL_GenRenderbuffers(1, &m_multisampleDepthStencilBuffer);
+    } else if (attributes.preserveDrawingBuffer) {
+        // If necessary, create another texture to handle preserveDrawingBuffer:true without
+        // antialiasing.
+        GL_GenTextures(1, &m_preserveDrawingBufferTexture);
+        GL_BindTexture(GL_TEXTURE_2D, m_preserveDrawingBufferTexture);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        GL_BindTexture(GL_TEXTURE_2D, 0);
+        // Create an FBO with which to perform BlitFramebuffer from one texture to the other.
+        GL_GenFramebuffers(1, &m_preserveDrawingBufferFBO);
+    }
+
+    GL_ClearColor(0, 0, 0, 0);
+
+    if (!platformInitialize())
+        return false;
+
     // EGL resources are only ever released if we run in process mode where EGL is used on host app threads, e.g. WK1
     // mode.
     static bool tracksUsedDisplays = !(isInWebProcess() || isInGPUProcess());
@@ -109,6 +162,18 @@ bool GraphicsContextGLANGLE::platformInitialize()
         ASSERT(m_displayObj);
         usedDisplays().add(m_displayObj);
     }
+    ASSERT(GL_GetError() == NO_ERROR);
+
+    return true;
+}
+
+bool GraphicsContextGLANGLE::platformInitializeExtensions()
+{
+    return true;
+}
+
+bool GraphicsContextGLANGLE::platformInitialize()
+{
     return true;
 }
 
@@ -564,7 +629,6 @@ void GraphicsContextGLANGLE::prepareTexture()
     if (contextAttributes().antialias)
         resolveMultisamplingIfNecessary();
 
-#if PLATFORM(COCOA)
     if (m_preserveDrawingBufferTexture) {
         // Blit m_preserveDrawingBufferTexture into m_texture.
         ScopedGLCapability scopedScissor(GL_SCISSOR_TEST, GL_FALSE);
@@ -573,20 +637,12 @@ void GraphicsContextGLANGLE::prepareTexture()
         GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, m_fbo);
         GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
-        // Note: it's been observed that BlitFramebuffer may destroy the alpha channel of the
-        // destination texture if it's an RGB texture bound to an IOSurface. This wasn't observable
-        // through the WebGL conformance tests, but it may be necessary to save and restore the
-        // color mask and clear color, and use the color mask to clear the alpha channel of the
-        // destination texture to 1.0.
-
-        // Restore user's framebuffer bindings.
         if (m_isForWebGL2) {
             GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER, m_state.boundDrawFBO);
             GL_BindFramebuffer(GL_READ_FRAMEBUFFER, m_state.boundReadFBO);
         } else
             GL_BindFramebuffer(GL_FRAMEBUFFER, m_state.boundDrawFBO);
     }
-#endif
 }
 
 RefPtr<PixelBuffer> GraphicsContextGLANGLE::readRenderingResults()
@@ -2892,13 +2948,7 @@ void GraphicsContextGLANGLE::ensureExtensionEnabled(const String& name)
     if (m_requestableExtensions.contains(name) && !m_enabledExtensions.contains(name)) {
         if (!makeContextCurrent())
             return;
-        GL_RequestExtensionANGLE(name.ascii().data());
-        m_enabledExtensions.add(name);
-
-        if (name == "GL_CHROMIUM_color_buffer_float_rgba"_s)
-            m_webglColorBufferFloatRGBA = true;
-        else if (name == "GL_CHROMIUM_color_buffer_float_rgb"_s)
-            m_webglColorBufferFloatRGB = true;
+        requestExtension(name);
     }
 }
 
@@ -3253,6 +3303,26 @@ void GraphicsContextGLANGLE::setPackParameters(GCGLint alignment, GCGLint rowLen
         GL_PixelStorei(GL_PACK_ROW_LENGTH, rowLength);
         m_packRowLength = rowLength;
     }
+}
+
+bool GraphicsContextGLANGLE::enableExtension(const String& name)
+{
+    if (m_availableExtensions.contains(name) || m_enabledExtensions.contains(name))
+        return true;
+    if (!m_requestableExtensions.contains(name))
+        return false;
+    requestExtension(name);
+    return true;
+}
+
+void GraphicsContextGLANGLE::requestExtension(const String& name)
+{
+    GL_RequestExtensionANGLE(name.ascii().data());
+    m_enabledExtensions.add(name);
+    if (name == "GL_CHROMIUM_color_buffer_float_rgba"_s)
+        m_webglColorBufferFloatRGBA = true;
+    else if (name == "GL_CHROMIUM_color_buffer_float_rgb"_s)
+        m_webglColorBufferFloatRGB = true;
 }
 
 }

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -368,8 +368,10 @@ protected:
     bool initialize();
     // Called first by initialize(). Subclasses should override to instantiate the platform specific bits of EGLContext.
     // FIXME: Currently platforms do not share the context creation. They should.
-    virtual bool platformInitializeContext();
-    // Called last by initialize(). Subclasses should override to instantiate platform specific state that depend on
+    virtual bool platformInitializeContext() = 0;
+    // Called by initialize(). Subclasses should override to enable platform specific extensions.
+    virtual bool platformInitializeExtensions();
+    // Called by initialize(). Subclasses should override to instantiate platform specific state that depend on
     // the shared state.
     virtual bool platformInitialize();
 
@@ -390,7 +392,7 @@ protected:
     RefPtr<PixelBuffer> readPixelsForPaintResults();
 
     bool reshapeFBOs(const IntSize&);
-    virtual void prepareTexture();
+    void prepareTexture();
     void resolveMultisamplingIfNecessary(const IntRect& = IntRect());
     void attachDepthAndStencilBufferIfNeeded(GCGLuint internalDepthStencilFormat, int width, int height);
 #if PLATFORM(COCOA)
@@ -401,6 +403,8 @@ protected:
     static void platformReleaseThreadResources();
 
     virtual void invalidateKnownTextureContent(GCGLuint);
+    bool enableExtension(const String&) WARN_UNUSED_RETURN;
+    void requestExtension(const String&);
 
     // Only for non-WebGL 2.0 contexts.
     GCGLenum adjustWebGL1TextureInternalFormat(GCGLenum internalformat, GCGLenum format, GCGLenum type);
@@ -441,9 +445,9 @@ protected:
 };
 
 
-inline GCGLDisplay GraphicsContextGLANGLE::platformDisplay() const 
+inline GCGLDisplay GraphicsContextGLANGLE::platformDisplay() const
 {
-    return m_displayObj; 
+    return m_displayObj;
 }
 
 inline GCGLConfig GraphicsContextGLANGLE::platformConfig() const

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -109,6 +109,7 @@ protected:
 
     // GraphicsContextGLANGLE overrides.
     bool platformInitializeContext() final;
+    bool platformInitializeExtensions() final;
     bool platformInitialize() final;
     void invalidateKnownTextureContent(GCGLuint) final;
     bool reshapeDrawingBuffer() final;
@@ -130,6 +131,10 @@ protected:
     // Inserts new fence that will invoke `signal` from a background thread when completed.
     // If not possible, calls the `signal`.
     void insertFinishedSignalOrInvoke(Function<void()> signal);
+#if ENABLE(WEBXR)
+    bool enableRequiredWebXRExtensionsImpl();
+#endif
+
 
     ProcessIdentity m_resourceOwner;
     DestinationColorSpace m_drawingBufferColorSpace;

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
@@ -64,9 +64,8 @@ public:
 
     // GraphicsContextGLANGLE overrides
     bool platformInitializeContext() override;
-    bool platformInitialize() override;
+    bool platformInitializeExtensions() override;
 
-    void prepareTexture() override;
     bool reshapeDrawingBuffer() override;
 
     struct Swapchain {

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -268,9 +268,6 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
 
 bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
 {
-    if (m_isForWebGL2)
-        GL_Enable(GraphicsContextGL::PRIMITIVE_RESTART_FIXED_INDEX);
-
 #if USE(NICOSIA)
     m_nicosiaLayer = makeUnique<Nicosia::GCGLANGLELayer>(*this);
     m_layerContentsDisplayDelegate = PlatformLayerDisplayDelegate::create(&m_nicosiaLayer->contentLayer());
@@ -279,36 +276,9 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
     m_layerContentsDisplayDelegate = PlatformLayerDisplayDelegate::create(m_texmapLayer.get());
 #endif
 
-    bool success = makeContextCurrent();
-    ASSERT_UNUSED(success, success);
-
-    Vector<ASCIILiteral, 4> requiredExtensions;
-    if (m_isForWebGL2) {
-        // For WebGL 2.0 occlusion queries to work.
-        requiredExtensions.append("GL_EXT_occlusion_query_boolean"_s);
-        requiredExtensions.append("GL_ANGLE_framebuffer_multisample"_s);
-    }
-
-    for (auto& extension : requiredExtensions) {
-        if (!supportsExtension(extension)) {
-            LOG(WebGL, "Missing required extension. %s", extension.characters());
-            return false;
-        }
-        ensureExtensionEnabled(extension);
-    }
-
-    validateAttributes();
-    auto attributes = contextAttributes(); // They may have changed during validation.
-
     GLenum textureTarget = drawingBufferTextureTarget();
-    // Create a texture to render into.
-    GL_GenTextures(1, &m_texture);
-    GL_BindTexture(textureTarget, m_texture);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 #if USE(NICOSIA)
+    GL_BindTexture(textureTarget, m_texture);
     m_textureID = setupCurrentTexture();
 #endif
 
@@ -321,69 +291,13 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
 #if USE(NICOSIA)
     m_compositorTextureID = setupCurrentTexture();
 #endif
-
     GL_BindTexture(textureTarget, 0);
 
-    // Create an FBO.
-    GL_GenFramebuffers(1, &m_fbo);
-
-    ASSERT(m_state.boundReadFBO == m_state.boundDrawFBO);
-    if (attributes.antialias) {
-        // Create a multisample FBO.
-        GL_GenFramebuffers(1, &m_multisampleFBO);
-        GL_BindFramebuffer(GL_FRAMEBUFFER, m_multisampleFBO);
-        m_state.boundDrawFBO = m_state.boundReadFBO = m_multisampleFBO;
-        GL_GenRenderbuffers(1, &m_multisampleColorBuffer);
-        if (attributes.stencil || attributes.depth)
-            GL_GenRenderbuffers(1, &m_multisampleDepthStencilBuffer);
-    } else {
-        // Bind canvas FBO.
-        GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-        m_state.boundDrawFBO = m_state.boundReadFBO = m_fbo;
-
-        if (attributes.stencil || attributes.depth)
-            GL_GenRenderbuffers(1, &m_depthStencilBuffer);
-
-        if (attributes.preserveDrawingBuffer) {
-            // Create another texture to handle preserveDrawingBuffer:true without antialiasing.
-            GL_GenTextures(1, &m_preserveDrawingBufferTexture);
-            GL_BindTexture(GL_TEXTURE_2D, m_preserveDrawingBufferTexture);
-            GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-            GL_BindTexture(GL_TEXTURE_2D, 0);
-            // Create an FBO with which to perform BlitFramebuffer from one texture to the other.
-            GL_GenFramebuffers(1, &m_preserveDrawingBufferFBO);
-        }
-    }
-
-    GL_ClearColor(0, 0, 0, 0);
-    return GraphicsContextGLANGLE::platformInitialize();
+    return true;
 }
 
-void GraphicsContextGLTextureMapperANGLE::prepareTexture()
+void GraphicsContextGLTextureMapperANGLE::swapCompositorTexture()
 {
-    ASSERT(!m_layerComposited);
-
-    if (contextAttributes().antialias)
-        resolveMultisamplingIfNecessary();
-
-    if (m_preserveDrawingBufferTexture) {
-        // Blit m_preserveDrawingBufferTexture into m_texture.
-        ScopedGLCapability scopedScissor(GL_SCISSOR_TEST, GL_FALSE);
-        ScopedGLCapability scopedDither(GL_DITHER, GL_FALSE);
-        GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
-        GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, m_fbo);
-        GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-
-        if (m_isForWebGL2) {
-            GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER, m_state.boundDrawFBO);
-            GL_BindFramebuffer(GL_READ_FRAMEBUFFER, m_state.boundReadFBO);
-        } else
-            GL_BindFramebuffer(GL_FRAMEBUFFER, m_state.boundDrawFBO);
-    }
-
     std::swap(m_texture, m_compositorTexture);
 #if USE(NICOSIA)
     std::swap(m_textureID, m_compositorTextureID);
@@ -437,6 +351,7 @@ void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
         return;
 
     prepareTexture();
+    swapCompositorTexture();
     markLayerComposited();
 }
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -64,7 +64,7 @@ private:
     bool platformInitializeContext() final;
     bool platformInitialize() final;
 
-    void prepareTexture() final;
+    void swapCompositorTexture();
 
 #if USE(NICOSIA)
     GCGLuint setupCurrentTexture();

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -402,6 +402,7 @@ TEST_P(AnyContextAttributeTest, PrepareFailureWorks)
     auto context = createTestContext({ 20, 20 });
     ASSERT_NE(context, nullptr);
     context->setClient(&client);
+    EXPECT_TRUE(context->getErrors().isEmpty());
     ASSERT_TRUE(changeContextContents(*context, 0));
     EXPECT_TRUE(context->getErrors().isEmpty());
     context->simulateEventForTesting(WebCore::GraphicsContextGLSimulatedEventForTesting::DisplayBufferAllocationFailure);


### PR DESCRIPTION
#### 6c5d9dcd77c99b8a3efbdbaa4be8271b3a60fd2f
<pre>
GraphicsContextGLANGLE subclasses duplicate context state initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=263585">https://bugs.webkit.org/show_bug.cgi?id=263585</a>
rdar://117410801

Reviewed by Dan Glastonbury.

Move the context state initialization to common
GraphicsContextGLANGLE::initialize().

Adjust GraphicsContextGLANGLE::prepareTexture(), so that it too is
common code.

This way the code stays in sync for all the ports.

This is work towards fixing premultipliedAlpha == false compositing.

* Source/WebCore/platform/graphics/GraphicsContextGL.h:
(WebCore::GraphicsContextGL::enableRequiredWebXRExtensions):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize):
(WebCore::GraphicsContextGLANGLE::prepareTexture):
(WebCore::GraphicsContextGLANGLE::ensureExtensionEnabled):
(WebCore::GraphicsContextGLANGLE::enableExtension):
(WebCore::GraphicsContextGLANGLE::requestExtension):
(WebCore::GraphicsContextGLANGLE::platformInitializeContext): Deleted.
(WebCore::GraphicsContextGLANGLE::platformInitialize): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::platformInitialize):
(WebCore::GraphicsContextGLCocoa::enableRequiredWebXRExtensions):
(WebCore::GraphicsContextGLCocoa::enableRequiredWebXRExtensionsImpl):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::prepareForDisplay):
(WebCore::GraphicsContextGLGBM::platformInitialize):
(WebCore::GraphicsContextGLGBM::prepareTexture): Deleted.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitialize):
(WebCore::GraphicsContextGLTextureMapperANGLE::swapCompositorTexture):
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareForDisplay):
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareTexture): Deleted.
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:

Canonical link: <a href="https://commits.webkit.org/269758@main">https://commits.webkit.org/269758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91c0f99926a725f9261f011e2090b2e7c0d5f08f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24620 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24038 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26254 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21232 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21495 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18664 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/912 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5606 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->