### PR TITLE
[WPE] `install-dependencies` fails to install `libwpewebkit-1.0-dev` on Ubuntu 23.10

### DIFF
--- a/Tools/wpe/dependencies/apt
+++ b/Tools/wpe/dependencies/apt
@@ -13,9 +13,11 @@ PACKAGES+=(
     libharfbuzz-dev
     libicu-dev
     $(aptIfExists libopenxr-dev)
-    libwpewebkit-1.0-dev
     libxml2-dev
     pkg-config
+    qtbase5-dev
+    qtbase5-private-dev
+    qtdeclarative5-dev
     unifdef
     wayland-protocols
     zlib1g-dev


### PR DESCRIPTION
#### a97613031bcde98bfc90b75306e4a73ca1746a0d
<pre>
[WPE] `install-dependencies` fails to install `libwpewebkit-1.0-dev` on Ubuntu 23.10
<a href="https://bugs.webkit.org/show_bug.cgi?id=263586">https://bugs.webkit.org/show_bug.cgi?id=263586</a>

Reviewed by Michael Catanzaro.

Ubuntu stopped packaging `libwpewebkit` since 22.10:
<a href="https://packages.ubuntu.com/search?suite=all&amp">https://packages.ubuntu.com/search?suite=all&amp</a>;section=all&amp;arch=any&amp;keywords=libwpewebkit&amp;searchon=names

Since `libwpewebkit-1.0-dev` is just a meta-package, we can remove it
and add all the missing dependencies directly.

* Tools/wpe/dependencies/apt:

Canonical link: <a href="https://commits.webkit.org/269735@main">https://commits.webkit.org/269735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/427863e8c21ad056a83be155e53024009756e321

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24478 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23910 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26121 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27268 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21378 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25137 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18570 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/783 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5591 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->