### PR TITLE
[WebGPU] RenderBundle should have option to bypass ICBs

### DIFF
--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -47,14 +47,16 @@ namespace WebGPU {
 
 class Device;
 
+class RenderBundleEncoder;
+
 // https://gpuweb.github.io/gpuweb/#gpurenderbundle
 class RenderBundle : public WGPURenderBundleImpl, public RefCounted<RenderBundle> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using ResourcesContainer = NSMapTable<id<MTLResource>, ResourceUsageAndRenderStage*>;
-    static Ref<RenderBundle> create(NSArray<RenderBundleICBWithResources*> *resources, Device& device)
+    static Ref<RenderBundle> create(NSArray<RenderBundleICBWithResources*> *resources, RefPtr<WebGPU::RenderBundleEncoder> encoder, Device& device)
     {
-        return adoptRef(*new RenderBundle(resources, device));
+        return adoptRef(*new RenderBundle(resources, encoder, device));
     }
     static Ref<RenderBundle> createInvalid(Device& device)
     {
@@ -70,11 +72,13 @@ public:
     Device& device() const { return m_device; }
     NSArray<RenderBundleICBWithResources*> *renderBundlesResources() const { return m_renderBundlesResources; }
 
+    bool replayCommands(id<MTLRenderCommandEncoder>) const;
 private:
-    RenderBundle(NSArray<RenderBundleICBWithResources*> *, Device&);
+    RenderBundle(NSArray<RenderBundleICBWithResources*> *, RefPtr<RenderBundleEncoder>, Device&);
     RenderBundle(Device&);
 
     const Ref<Device> m_device;
+    RefPtr<RenderBundleEncoder> m_renderBundleEncoder;
     NSArray<RenderBundleICBWithResources*> *m_renderBundlesResources;
 };
 

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -43,8 +43,9 @@
 
 namespace WebGPU {
 
-RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, Device& device)
+RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, RefPtr<RenderBundleEncoder> encoder, Device& device)
     : m_device(device)
+    , m_renderBundleEncoder(encoder)
 {
     m_renderBundlesResources = resources;
 }
@@ -59,6 +60,11 @@ RenderBundle::~RenderBundle() = default;
 void RenderBundle::setLabel(String&& label)
 {
     m_renderBundlesResources.firstObject.indirectCommandBuffer.label = label;
+}
+
+bool RenderBundle::replayCommands(id<MTLRenderCommandEncoder> commandEncoder) const
+{
+    return m_renderBundleEncoder ? m_renderBundleEncoder->replayCommands(commandEncoder) : false;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -92,6 +92,7 @@ public:
     Device& device() const { return m_device; }
 
     bool isValid() const { return m_indirectCommandBuffer; }
+    bool replayCommands(id<MTLRenderCommandEncoder> commmandEncoder);
 
 private:
     RenderBundleEncoder(MTLIndirectCommandBufferDescriptor*, Device&);
@@ -103,6 +104,8 @@ private:
     void makeInvalid() { m_indirectCommandBuffer = nil; }
     void executePreDrawCommands();
     void endCurrentICB();
+    void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, ResourceUsageAndRenderStage*);
+    void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages);
 
     id<MTLIndirectCommandBuffer> m_indirectCommandBuffer { nil };
     MTLIndirectCommandBufferDescriptor *m_icbDescriptor { nil };
@@ -137,6 +140,8 @@ private:
     id<MTLBuffer> m_dynamicOffsetsFragmentBuffer { nil };
     uint64_t m_vertexDynamicOffset { 0 };
     uint64_t m_fragmentDynamicOffset { 0 };
+
+    id<MTLRenderCommandEncoder> m_commandEncoder { nil };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -185,6 +185,9 @@ void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<const Rende
 {
     for (auto& bundle : bundles) {
         const auto& renderBundle = bundle.get();
+        if (renderBundle.replayCommands(m_renderCommandEncoder))
+            continue;
+
         for (RenderBundleICBWithResources* icb in renderBundle.renderBundlesResources()) {
             if (id<MTLDepthStencilState> depthStencilState = icb.depthStencilState)
                 [m_renderCommandEncoder setDepthStencilState:depthStencilState];


### PR DESCRIPTION
#### 5a936d1a301a12e76cc2de50426baf8794c3dfac
<pre>
[WebGPU] RenderBundle should have option to bypass ICBs
<a href="https://bugs.webkit.org/show_bug.cgi?id=263152">https://bugs.webkit.org/show_bug.cgi?id=263152</a>
&lt;radar://116945953&gt;

Reviewed by Tadeu Zagallo.

Add a compile time option to make debugging ICBs much
easier and possible in gputrace files.

* Source/WebGPU/WebGPU/RenderBundle.h:
(WebGPU::RenderBundle::create):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
(WebGPU::RenderBundle::replayCommands const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::currentRenderCommand):
(WebGPU::RenderBundleEncoder::addResource):
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::finish):
(WebGPU::RenderBundleEncoder::replayCommands):
(WebGPU::RenderBundleEncoder::setBindGroup):
(WebGPU::RenderBundleEncoder::setPipeline):
(WebGPU::addResource): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/269837@main">https://commits.webkit.org/269837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48ea42b3e582b27b3e3c19d35f36da29a207cc9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21924 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3472 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/24277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24016 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/1424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26516 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25499 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/24277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1158 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5675 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->