### PR TITLE
REGRESSION ( Sonoma?): [ Sonoma ] Two TestWebKitAPI.WebKit.SlowBeforeUnloadPrompt tests are flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm
@@ -171,16 +171,15 @@ static bool didRespondToPrompt = false;
 TEST(WebKit, SlowBeforeUnloadPromptReject)
 {
     auto slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView setUIDelegate:slowBeforeUnloadPromptUIDelegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"beforeunload"];
-
-    TestWebKitAPI::Util::spinRunLoop(10);
+    [webView waitForNextPresentationUpdate];
 
     // Need a user gesture on the page before being allowed to show the beforeunload prompt.
-    [webView sendClicksAtPoint:NSMakePoint(5, 5) numberOfClicks:1];
-
-    TestWebKitAPI::Util::spinRunLoop(10);
+    [webView sendClicksAtPoint:NSMakePoint(50, 50) numberOfClicks:1];
+    [webView waitForPendingMouseEvents];
 
     shouldRejectClosingViaPrompt = true;
     [webView _tryClose];
@@ -195,16 +194,15 @@ TEST(WebKit, SlowBeforeUnloadPromptReject)
 TEST(WebKit, SlowBeforeUnloadPromptAllow)
 {
     auto slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView setUIDelegate:slowBeforeUnloadPromptUIDelegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"beforeunload"];
-
-    TestWebKitAPI::Util::spinRunLoop(10);
+    [webView waitForNextPresentationUpdate];
 
     // Need a user gesture on the page before being allowed to show the beforeunload prompt.
-    [webView sendClicksAtPoint:NSMakePoint(5, 5) numberOfClicks:1];
-
-    TestWebKitAPI::Util::spinRunLoop(10);
+    [webView sendClicksAtPoint:NSMakePoint(50, 50) numberOfClicks:1];
+    [webView waitForPendingMouseEvents];
 
     shouldRejectClosingViaPrompt = false;
     [webView _tryClose];


### PR DESCRIPTION
#### 92f5e68fd049d22e10f2e272a15ffc007b035167
<pre>
REGRESSION ( Sonoma?): [ Sonoma ] Two TestWebKitAPI.WebKit.SlowBeforeUnloadPrompt tests are flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=263570">https://bugs.webkit.org/show_bug.cgi?id=263570</a>
rdar://117382535

Reviewed by Wenson Hsieh.

Speculative fix for test flakiness on the bots:
1. Make sure we add the WebView to a window
2. Wait for first presentation update to make sure thing have settled
   before issuing the click.
3. Issue the click at (50, 50) instead of (5, 5) so that it is not so
   close to the edge.
4. Wait for the mouse event to be processed before trying to close the
   WKWebView.

The fix is speculative since it doesn&apos;t reproduce locally, only on this
bot.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ModalAlerts.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/269732@main">https://commits.webkit.org/269732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d6bc8373c3c4e7e5a2b52bc014c06e0fe601879

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24497 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23927 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26139 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27281 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25152 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18586 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/801 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5583 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->