### PR TITLE
Pressing ⌘V pastes content twice in text fields on Tableau analytics dashboard

### DIFF
--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -44,9 +44,10 @@ static RefPtr<UserGestureToken>& currentToken()
     return token;
 }
 
-UserGestureToken::UserGestureToken(ProcessingUserGestureState state, UserGestureType gestureType, Document* document, std::optional<WTF::UUID> authorizationToken)
+UserGestureToken::UserGestureToken(ProcessingUserGestureState state, UserGestureType gestureType, Document* document, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
     : m_state(state)
     , m_gestureType(gestureType)
+    , m_canRequestDOMPaste(canRequestDOMPaste)
     , m_authorizationToken(authorizationToken)
 {
     if (!document || !processingUserGesture())
@@ -106,13 +107,13 @@ void UserGestureToken::forEachImpactedDocument(Function<void(Document&)>&& funct
     m_documentsImpactedByUserGesture.forEach(function);
 }
 
-UserGestureIndicator::UserGestureIndicator(std::optional<ProcessingUserGestureState> state, Document* document, UserGestureType gestureType, ProcessInteractionStyle processInteractionStyle, std::optional<WTF::UUID> authorizationToken)
+UserGestureIndicator::UserGestureIndicator(std::optional<ProcessingUserGestureState> state, Document* document, UserGestureType gestureType, ProcessInteractionStyle processInteractionStyle, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
     : m_previousToken { currentToken() }
 {
     ASSERT(isMainThread());
 
     if (state)
-        currentToken() = UserGestureToken::create(state.value(), gestureType, document, authorizationToken);
+        currentToken() = UserGestureToken::create(state.value(), gestureType, document, authorizationToken, canRequestDOMPaste);
 
     if (state && document && currentToken()->processingUserGesture()) {
         document->updateLastHandledUserGestureTimestamp(currentToken()->startTime());

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -46,7 +46,8 @@ enum ProcessingUserGestureState {
     NotProcessingUserGesture
 };
 
-enum class UserGestureType { EscapeKey, ActivationTriggering, Other };
+enum class CanRequestDOMPaste : bool { No, Yes };
+enum class UserGestureType : uint8_t { EscapeKey, ActivationTriggering, Other };
 
 class UserGestureToken : public RefCounted<UserGestureToken>, public CanMakeWeakPtr<UserGestureToken> {
 public:
@@ -54,9 +55,9 @@ public:
     static const Seconds& maximumIntervalForUserGestureForwardingForFetch();
     WEBCORE_EXPORT static void setMaximumIntervalForUserGestureForwardingForFetchForTesting(Seconds);
 
-    static Ref<UserGestureToken> create(ProcessingUserGestureState state, UserGestureType gestureType, Document* document = nullptr, std::optional<WTF::UUID> authorizationToken = std::nullopt)
+    static Ref<UserGestureToken> create(ProcessingUserGestureState state, UserGestureType gestureType, Document* document = nullptr, std::optional<WTF::UUID> authorizationToken = std::nullopt, CanRequestDOMPaste canRequestDOMPaste = CanRequestDOMPaste::Yes)
     {
-        return adoptRef(*new UserGestureToken(state, gestureType, document, authorizationToken));
+        return adoptRef(*new UserGestureToken(state, gestureType, document, authorizationToken, canRequestDOMPaste));
     }
 
     WEBCORE_EXPORT ~UserGestureToken();
@@ -106,17 +107,20 @@ public:
 
     std::optional<WTF::UUID> authorizationToken() const { return m_authorizationToken; }
 
+    bool canRequestDOMPaste() const { return m_canRequestDOMPaste == CanRequestDOMPaste::Yes; }
+
     bool isValidForDocument(const Document&) const;
 
     void forEachImpactedDocument(Function<void(Document&)>&&);
 
 private:
-    UserGestureToken(ProcessingUserGestureState, UserGestureType, Document*, std::optional<WTF::UUID> authorizationToken);
+    UserGestureToken(ProcessingUserGestureState, UserGestureType, Document*, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste);
 
     ProcessingUserGestureState m_state = NotProcessingUserGesture;
     Vector<Function<void(UserGestureToken&)>> m_destructionObservers;
     UserGestureType m_gestureType;
     WeakHashSet<Document, WeakPtrImplWithEventTargetData> m_documentsImpactedByUserGesture;
+    CanRequestDOMPaste m_canRequestDOMPaste { CanRequestDOMPaste::No };
     DOMPasteAccessPolicy m_domPasteAccessPolicy { DOMPasteAccessPolicy::NotRequestedYet };
     GestureScope m_scope { GestureScope::All };
     MonotonicTime m_startTime { MonotonicTime::now() };
@@ -135,7 +139,7 @@ public:
 
     // If a document is provided, its last known user gesture timestamp is updated.
     enum class ProcessInteractionStyle { Immediate, Delayed, Never };
-    WEBCORE_EXPORT explicit UserGestureIndicator(std::optional<ProcessingUserGestureState>, Document* = nullptr, UserGestureType = UserGestureType::ActivationTriggering, ProcessInteractionStyle = ProcessInteractionStyle::Immediate, std::optional<WTF::UUID> authorizationToken = std::nullopt);
+    WEBCORE_EXPORT explicit UserGestureIndicator(std::optional<ProcessingUserGestureState>, Document* = nullptr, UserGestureType = UserGestureType::ActivationTriggering, ProcessInteractionStyle = ProcessInteractionStyle::Immediate, std::optional<WTF::UUID> authorizationToken = std::nullopt, CanRequestDOMPaste = CanRequestDOMPaste::Yes);
     WEBCORE_EXPORT explicit UserGestureIndicator(RefPtr<UserGestureToken>, UserGestureToken::GestureScope = UserGestureToken::GestureScope::All, UserGestureToken::IsPropagatedFromFetch = UserGestureToken::IsPropagatedFromFetch::No);
     WEBCORE_EXPORT ~UserGestureIndicator();
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3782,7 +3782,8 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
 
     UserGestureType gestureType = userGestureTypeForPlatformEvent(initialKeyEvent);
 
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, frame->protectedDocument().get(), gestureType, UserGestureIndicator::ProcessInteractionStyle::Delayed);
+    auto canRequestDOMPaste = frame->protectedDocument()->quirks().needsDisableDOMPasteAccessQuirk() ? CanRequestDOMPaste::No : CanRequestDOMPaste::Yes;
+    UserGestureIndicator gestureIndicator(ProcessingUserGesture, frame->protectedDocument().get(), gestureType, UserGestureIndicator::ProcessInteractionStyle::Delayed, std::nullopt, canRequestDOMPaste);
     UserTypingGestureIndicator typingGestureIndicator(frame);
 
     // FIXME (bug 68185): this call should be made at another abstraction layer

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -593,7 +593,7 @@ bool LocalFrame::requestDOMPasteAccess(DOMPasteAccessCategory pasteAccessCategor
         return false;
 
     auto gestureToken = UserGestureIndicator::currentUserGesture();
-    if (!gestureToken || !gestureToken->processingUserGesture())
+    if (!gestureToken || !gestureToken->processingUserGesture() || !gestureToken->canRequestDOMPaste())
         return false;
 
     switch (gestureToken->domPasteAccessPolicy()) {

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1574,4 +1574,24 @@ bool Quirks::shouldDisableDataURLPaddingValidation() const
     return *m_shouldDisableDataURLPaddingValidation;
 }
 
+bool Quirks::needsDisableDOMPasteAccessQuirk() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (m_needsDisableDOMPasteAccessQuirk)
+        return *m_needsDisableDOMPasteAccessQuirk;
+
+    m_needsDisableDOMPasteAccessQuirk = [&] {
+        if (!m_document)
+            return false;
+        auto* globalObject = m_document->globalObject();
+        if (!globalObject)
+            return false;
+        auto tableauPrepProperty = JSC::Identifier::fromString(globalObject->vm(), "tableauPrep"_s);
+        return globalObject->hasProperty(globalObject, tableauPrepProperty);
+    }();
+    return *m_needsDisableDOMPasteAccessQuirk;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -174,6 +174,8 @@ public:
     bool shouldStarBeFeaturePolicyDefaultValue() const;
     bool shouldDisableDataURLPaddingValidation() const;
 
+    bool needsDisableDOMPasteAccessQuirk() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;
@@ -236,6 +238,7 @@ private:
     bool m_needsToCopyUserSelectNoneQuirk { false };
     mutable std::optional<bool> m_shouldStarBeFeaturePolicyDefaultValueQuirk;
     mutable std::optional<bool> m_shouldDisableDataURLPaddingValidation;
+    mutable std::optional<bool> m_needsDisableDOMPasteAccessQuirk;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2575438ca004115ca5cf1c3225c27a6312b7027d
<pre>
Pressing ⌘V pastes content twice in text fields on Tableau analytics dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=263590">https://bugs.webkit.org/show_bug.cgi?id=263590</a>
rdar://105750465

Reviewed by Ryosuke Niwa.

In Tableau&apos;s analytics tool, pressing ⌘V to paste in any focused editable areas pastes content
twice after showing a Paste menu item, if the user clicks &quot;Paste&quot; on this item. This is because
Tableau&apos;s script does something akin to the following:

```
textField.addEventListener(&quot;keydown&quot;, event =&gt; {
    if (event.key === &quot;v&quot; &amp;&amp; event.metaKey)
        document.execCommand(&quot;Paste&quot;);
});
```

...which triggers a programmatic paste upon `keydown`, without preventing default. This means that
if the programmatic DOM paste is accepted, we&apos;ll end up triggering two paste commands: (1) due to
the `execCommand`, and (2) due to the default behavior of ⌘V.

While this is ostensibly a website bug, it works fine in other browsers (Firefox, Chrome) because
they don&apos;t support DOM paste at all, so we just end up silently failing the programmatic paste
before performing the real paste.

For now, fix this by adding a quirk for Tableau&apos;s analytics page which disables DOM paste access
triggered by key events. Making this a quirk limits risk in the short term, since it&apos;s possible that
there are other web apps and frameworks that already assume (based on user agent/engine checks) that
Safari/WebKit will show DOM paste prompts on key events.

* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureToken::UserGestureToken):
(WebCore::UserGestureIndicator::UserGestureIndicator):
* Source/WebCore/dom/UserGestureIndicator.h:

Add a new enum flag to determine whether or not we should allow DOM paste requests under the user
gesture token.

(WebCore::UserGestureToken::create):
(WebCore::UserGestureToken::canRequestDOMPaste const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):

Pass in `CanRequestDOMPaste::No` if the quirk is enabled.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::requestDOMPasteAccess):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsDisableDOMPasteAccessQuirk const):

Add the quirk; check `window.tableauPrep` instead of a domain, to fix other (non-Apple-internal)
Tableau instances which would also encounter this same issue.

* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/269736@main">https://commits.webkit.org/269736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/412100200c0cf7bc5b5681a7d3862fc3f7b63df7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24516 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23946 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26157 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27298 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21414 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18599 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/819 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5592 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->