### PR TITLE
REGRESSION ( Sonoma?): [ Sonoma ] TestWebKitAPI.WebKit2CustomProtocolsTest.LoadInvalidScheme is a consistent timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsInvalidScheme.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsInvalidScheme.mm
@@ -33,16 +33,22 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
-static bool testFinished = false;
+static bool navigationSucceeded = false;
+static bool didCrash = false;
 
 @interface LoadInvalidSchemeDelegate : NSObject <WKNavigationDelegate>
 @end
 
 @implementation LoadInvalidSchemeDelegate
 
-- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    testFinished = true;
+    navigationSucceeded = true;
+}
+
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
+{
+    didCrash = true;
 }
 
 // This selector is needed so the URL "ht'tp://www.webkit.org" isn't given to LSAppLink
@@ -74,8 +80,10 @@ TEST(WebKit2CustomProtocolsTest, LoadInvalidScheme)
     webView.get().navigationDelegate = loadDelegate.get();
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"ht'tp://www.webkit.org"]]];
+    Util::runFor(50_ms);
     
-    Util::run(&testFinished);
+    EXPECT_FALSE(didCrash);
+    EXPECT_FALSE(navigationSucceeded);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### a4ce5c78105f46b76c346e3eddd7c41ec44ae96e
<pre>
REGRESSION ( Sonoma?): [ Sonoma ] TestWebKitAPI.WebKit2CustomProtocolsTest.LoadInvalidScheme is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=263576">https://bugs.webkit.org/show_bug.cgi?id=263576</a>
rdar://117388019

Reviewed by Brent Fulgham.

The test tries calling [WKWebView loadRequest] with a URL that has an invalid scheme to make sure
no crash occurs and the load doesn&apos;t occur. We used to call the didFailProvisionalNavigation
navigation delegate. However, on Sonoma, we fail the navigation policy decision because the
request is invalid, which means that didFailProvisionalNavigation no longer gets called but
no crash or navigation occurs. Presumably, the behavior change is on CFNetwork side where they
no longer construct a valid NSURLRequest from this invalid URL. The new behavior is not incorrect
so I am simply updating the test to check that no crash or navigation occurs, instead of expecting
didFailProvisionalNavigation to get called.

* Tools/TestWebKitAPI/Tests/WebKitObjC/CustomProtocolsInvalidScheme.mm:
(-[LoadInvalidSchemeDelegate webView:didFinishNavigation:]):
(-[LoadInvalidSchemeDelegate webViewWebContentProcessDidTerminate:]):
(TestWebKitAPI::TEST):
(-[LoadInvalidSchemeDelegate webView:didFailProvisionalNavigation:withError:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/269749@main">https://commits.webkit.org/269749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16519df413e9168bb5ac7e4512157b4c9cf26979

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24606 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24024 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26240 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21217 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21479 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/929 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/898 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5598 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->