### PR TITLE
[WebGPU] ShaderModuleImpl::compilationInfo is not implemented

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp
@@ -28,8 +28,13 @@
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
 
+#include "WebGPUCompilationInfo.h"
+#include "WebGPUCompilationMessage.h"
+#include "WebGPUCompilationMessageType.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebGPU/WebGPUExt.h>
+
+#include <wtf/BlockPtr.h>
 
 namespace WebCore::WebGPU {
 
@@ -41,9 +46,45 @@ ShaderModuleImpl::ShaderModuleImpl(WebGPUPtr<WGPUShaderModule>&& shaderModule, C
 
 ShaderModuleImpl::~ShaderModuleImpl() = default;
 
-void ShaderModuleImpl::compilationInfo(CompletionHandler<void(Ref<CompilationInfo>&&)>&&)
+static CompilationMessageType convertFromBacking(WGPUCompilationMessageType type)
 {
-    // FIXME: Implement this.
+    switch (type) {
+    case WGPUCompilationMessageType_Error:
+        return CompilationMessageType::Error;
+    case WGPUCompilationMessageType_Warning:
+        return CompilationMessageType::Warning;
+    case WGPUCompilationMessageType_Info:
+        return CompilationMessageType::Info;
+    case WGPUCompilationMessageType_Force32:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+static void compilationInfoCallback(WGPUCompilationInfoRequestStatus status, const WGPUCompilationInfo* compilationInfo, void* userdata)
+{
+    auto block = reinterpret_cast<void(^)(WGPUCompilationInfoRequestStatus, const WGPUCompilationInfo*)>(userdata);
+    block(status, compilationInfo);
+    Block_release(block); // Block_release is matched with Block_copy below in AdapterImpl::requestDevice().
+}
+
+void ShaderModuleImpl::compilationInfo(CompletionHandler<void(Ref<CompilationInfo>&&)>&& callback)
+{
+    auto blockPtr = makeBlockPtr([callback = WTFMove(callback)](WGPUCompilationInfoRequestStatus, const WGPUCompilationInfo* compilationInfo) mutable {
+        Vector<Ref<CompilationMessage>> messages;
+        if (!compilationInfo || !compilationInfo->messageCount) {
+            callback(CompilationInfo::create(WTFMove(messages)));
+            return;
+        }
+
+        for (size_t i = 0; i < compilationInfo->messageCount; ++i) {
+            auto& message = compilationInfo->messages[i];
+            messages.append(CompilationMessage::create(String::fromLatin1(message.message), convertFromBacking(message.type), message.lineNum, message.linePos, message.offset, message.length));
+        }
+
+        callback(CompilationInfo::create(WTFMove(messages)));
+    });
+
+    wgpuShaderModuleGetCompilationInfo(m_backing.get(), &compilationInfoCallback, Block_copy(blockPtr.get()));
 }
 
 void ShaderModuleImpl::setLabelInternal(const String& label)


### PR DESCRIPTION
#### ff9c8f8718f3dd2e230c967049865dec1663835a
<pre>
[WebGPU] ShaderModuleImpl::compilationInfo is not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=263598">https://bugs.webkit.org/show_bug.cgi?id=263598</a>
&lt;radar://117424136&gt;

Reviewed by Tadeu Zagallo.

Implement getCompilationInfo from WebCore.framework -&gt; WebGPU.framework.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp:
(WebCore::WebGPU::convertFromBacking):
(WebCore::WebGPU::compilationInfoCallback):
(WebCore::WebGPU::ShaderModuleImpl::compilationInfo):

Canonical link: <a href="https://commits.webkit.org/269725@main">https://commits.webkit.org/269725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72548b5113c08089c2d5a09c1fd6757220dd11a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24520 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23949 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26161 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21147 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21408 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/822 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5580 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->