### PR TITLE
[ews-build] Reduce threshold for stopping build due to excessive logging in run-api-tests

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -70,8 +70,8 @@ DEFAULT_REMOTE = 'origin'
 LAYOUT_TESTS_URL = '{}{}/blob/{}/LayoutTests/'.format(GITHUB_URL, GITHUB_PROJECTS[0], DEFAULT_BRANCH)
 MAX_COMMITS_IN_PR_SERIES = 50
 QUEUES_WITH_PUSH_ACCESS = ('commit-queue', 'merge-queue', 'unsafe-merge-queue')
-THRESHOLD_FOR_EXCESSIVE_LOGS = 1000000
-MSG_FOR_EXCESSIVE_LOGS = f'Stopped due to excessive logging, limit: {THRESHOLD_FOR_EXCESSIVE_LOGS}'
+THRESHOLD_FOR_EXCESSIVE_LOGS_DEFAULT = 1000000
+MSG_FOR_EXCESSIVE_LOGS = f'Stopped due to excessive logging, limit: {THRESHOLD_FOR_EXCESSIVE_LOGS_DEFAULT}'
 
 
 class ParseByLineLogObserver(logobserver.LineConsumerLogObserver):
@@ -3062,7 +3062,7 @@ class BuildLogLineObserver(ParseByLineLogObserver):
 
     def parseOutputLine(self, line):
         self.line_count += 1
-        if self.line_count == THRESHOLD_FOR_EXCESSIVE_LOGS:
+        if self.line_count == THRESHOLD_FOR_EXCESSIVE_LOGS_DEFAULT:
             self.thresholdExceedCallBack()
             return
 
@@ -5068,6 +5068,8 @@ class RunAPITests(shell.TestNewStyle, AddToLogMixin):
     failedTestCount = 0
     cancelled_due_to_huge_logs = False
     line_count = 0
+    THRESHOLD_FOR_EXCESSIVE_LOGS_API_TESTS = 100000
+    MSG_FOR_EXCESSIVE_LOGS_API_TEST = f'Stopped due to excessive logging, limit: {THRESHOLD_FOR_EXCESSIVE_LOGS_API_TESTS}'
 
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, **kwargs)
@@ -5116,7 +5118,7 @@ class RunAPITests(shell.TestNewStyle, AddToLogMixin):
 
     def parseOutputLine(self, line):
         self.line_count += 1
-        if self.line_count == THRESHOLD_FOR_EXCESSIVE_LOGS:
+        if self.line_count == self.THRESHOLD_FOR_EXCESSIVE_LOGS_API_TESTS:
             self.handleExcessiveLogging()
             return
 
@@ -5126,10 +5128,10 @@ class RunAPITests(shell.TestNewStyle, AddToLogMixin):
 
     def handleExcessiveLogging(self):
         build_url = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'
-        print(f'\n{MSG_FOR_EXCESSIVE_LOGS}, {build_url}\n')
+        print(f'\n{self.MSG_FOR_EXCESSIVE_LOGS_API_TEST}, {build_url}\n')
         self.cancelled_due_to_huge_logs = True
-        self.build.stopBuild(reason=MSG_FOR_EXCESSIVE_LOGS, results=FAILURE)
-        self.build.buildFinished([MSG_FOR_EXCESSIVE_LOGS], FAILURE)
+        self.build.stopBuild(reason=self.MSG_FOR_EXCESSIVE_LOGS_API_TEST, results=FAILURE)
+        self.build.buildFinished([self.MSG_FOR_EXCESSIVE_LOGS_API_TEST], FAILURE)
 
     def getResultSummary(self):
         if self.cancelled_due_to_huge_logs:


### PR DESCRIPTION
#### 79b2911c8639b5a7e3a0ad9f8413402a498c9827
<pre>
[ews-build] Reduce threshold for stopping build due to excessive logging in run-api-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=263603">https://bugs.webkit.org/show_bug.cgi?id=263603</a>

Reviewed by Ryan Haddad.

In 269577@main we added a feature to stop builds that exceed a predefined threshold of log lines
in run-api-tests, in order to prevent overloading the server. It did work, but the limit was quite high,
and buildbot was already under too much load and took long time to actually stop the build.
We should reduce that limit. Also, I analyzed data from actual runs and most runs for api-tests are under
10k log lines. It&apos;s rare for a api test run to exceed 100k logs, and most of the time it does indicate some issue.

* Tools/CISupport/ews-build/steps.py:
(BuildLogLineObserver.parseOutputLine):
(RunAPITests):
(RunAPITests.parseOutputLine):
(RunAPITests.handleExcessiveLogging):

Canonical link: <a href="https://commits.webkit.org/269778@main">https://commits.webkit.org/269778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14cfb091d34d5d9a93a6aeea484dfde9da8638b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24522 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21615 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23951 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26163 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27295 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21415 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25168 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18603 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/23199 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1278 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3016 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->