### PR TITLE
[css-grid] Use synthesizedBaseline to synthesize the correct baseline of grid items in the column axis.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
@@ -7,34 +7,14 @@
 
 PASS .item 1
 PASS .item 2
-FAIL .item 3 assert_equals:
-<div data-offset-x="387" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 387 but got 382
+PASS .item 3
 PASS .item 4
-FAIL .item 5 assert_equals:
-<div data-offset-x="242" class="item first">
-      <span></span><br><span></span>
-    </div>
-offsetLeft expected 242 but got 232
+PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div data-offset-x="534" class="item small first"></div>
-offsetLeft expected 534 but got 549
-FAIL .item 8 assert_equals:
-<div data-offset-x="465" class="item small last"></div>
-offsetLeft expected 465 but got 480
-FAIL .item 9 assert_equals:
-<div data-offset-x="407" class="item small first"></div>
-offsetLeft expected 407 but got 417
-FAIL .item 10 assert_equals:
-<div data-offset-x="332" class="item small last"></div>
-offsetLeft expected 332 but got 347
-FAIL .item 11 assert_equals:
-<div data-offset-x="262" class="item small first"></div>
-offsetLeft expected 262 but got 267
-FAIL .item 12 assert_equals:
-<div data-offset-x="190" class="item small last"></div>
-offsetLeft expected 190 but got 205
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
@@ -5,48 +5,16 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div data-offset-x="514" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 514 but got 512
-FAIL .item 2 assert_equals:
-<div data-offset-x="428" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 428 but got 429
-FAIL .item 3 assert_equals:
-<div data-offset-x="325" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 325 but got 326
-FAIL .item 4 assert_equals:
-<div data-offset-x="234" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 234 but got 243
-FAIL .item 5 assert_equals:
-<div data-offset-x="131" class="item first">
-      <span></span><br><span></span>
-    </div>
-offsetLeft expected 131 but got 123
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div data-offset-x="524" class="item small first"></div>
-offsetLeft expected 524 but got 547
-FAIL .item 8 assert_equals:
-<div data-offset-x="393" class="item small last"></div>
-offsetLeft expected 393 but got 444
-FAIL .item 9 assert_equals:
-<div data-offset-x="335" class="item small first"></div>
-offsetLeft expected 335 but got 361
-FAIL .item 10 assert_equals:
-<div data-offset-x="199" class="item small last"></div>
-offsetLeft expected 199 but got 258
-FAIL .item 11 assert_equals:
-<div data-offset-x="141" class="item small first"></div>
-offsetLeft expected 141 but got 158
-FAIL .item 12 assert_equals:
-<div data-offset-x="5" class="item small last"></div>
-offsetLeft expected 5 but got 55
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 


### PR DESCRIPTION
#### 2688e1f33c192b78b77f2a49f787171cce7f6db1
<pre>
[css-grid] Use synthesizedBaseline to synthesize the correct baseline of grid items in the column axis.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263600">https://bugs.webkit.org/show_bug.cgi?id=263600</a>
rdar://problem/117424263

Reviewed by Alan Baradlay.

Currently GridBaselineAlignment::ascentForChild does not correctly
syntheisze the central baseline in certain situations. It appears that
the current code attempts to only synthesize the alphabetic baseline.
Accoring to the spec, alignment-baseline: baseline, which is the initial
value, refers to the box&apos;s parent&apos;s dominant-baseline, which is the
initial value of &quot;auto,&quot; since we do not implement it yet either.
The description for &quot;dominant-baseline: auto,&quot; says:

Equivalent to alphabetic in horizontal writing modes and in vertical
writing modes when text-orientation is sideways. Equivalent to central
in vertical writing modes when text-orientation is mixed or upright.

Instead of attempting to synthesize the baseline within grid layout
code, we can use synthesizedBaseline in RenderBox which synthesizes
a baseline value depending on the arguments it is given. This function
will compute the central baseline of the box in the scenarios that are
described above in the property value&apos;s description. We perform this
logic only when we are aligning in the column axis and fallback to
the old behavior for the row axis. Attempting to change this logic for
both at this time causes regressions so a closer look will be needed in
order to address that case in a separate patch.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt:
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::ascentForChild const):

Canonical link: <a href="https://commits.webkit.org/269857@main">https://commits.webkit.org/269857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbd17d940133276dc4c748685d63f9bae538e202

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26424 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27655 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25421 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1074 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5696 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->