### PR TITLE
InteractionRegions: elements with explicitly set `border-radius` should not get the default radius

### DIFF
--- a/LayoutTests/interaction-region/border-radii-expected.txt
+++ b/LayoutTests/interaction-region/border-radii-expected.txt
@@ -1,4 +1,4 @@
-uniform half pill diagonal tongue degenerate changing
+uniform half pill diagonal tongue degenerate changing default explicit
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -23,7 +23,11 @@ uniform half pill diagonal tongue degenerate changing
         (interaction (434,10) width=102 height=52)
         (borderRadius 2.00),
         (interaction (559,10) width=92 height=52)
-        (borderRadius 20.00)])
+        (borderRadius 20.00),
+        (interaction (674,10) width=77 height=52)
+        (borderRadius 8.00),
+        (interaction (10,82) width=80 height=52)
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/border-radii.html
+++ b/LayoutTests/interaction-region/border-radii.html
@@ -28,6 +28,14 @@
     .changed {
         border-radius: 20px;
     }
+
+    .default, .explicit {
+        background: transparent;
+        color: black;
+    }
+    .explicit {
+        border-radius: 0;
+    }
 </style>
 <script src="../resources/ui-helper.js"></script>
 <body>
@@ -37,6 +45,8 @@
 <div class="tongue">tongue</div>
 <div class="degenerate">degenerate</div>
 <div class="changing">changing</div>
+<div class="default">default</div>
+<div class="explicit">explicit</div>
 <pre id="results"></pre>
 <script>
 document.body.addEventListener("click", function(e) {

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -312,7 +312,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         }
     }
 
-    if (!regionRenderer.hasVisibleBoxDecorations() && !renderer.hasVisibleBoxDecorations()) {
+    if (!regionRenderer.hasVisibleBoxDecorations() && !renderer.hasVisibleBoxDecorations() && !renderer.style().hasExplicitlySetBorderRadius()) {
         // We can safely tweak the bounds and radius without causing visual mismatch.
         borderRadius = std::max<float>(borderRadius, regionRenderer.document().settings().interactionRegionMinimumCornerRadius());
         if (isInlineNonBlock)


### PR DESCRIPTION
#### e6990174db146db97fda96b568332c7271410a19
<pre>
InteractionRegions: elements with explicitly set `border-radius` should not get the default radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=263611">https://bugs.webkit.org/show_bug.cgi?id=263611</a>
&lt;rdar://116815739&gt;

Reviewed by Tim Horton.

When an element has a border radius explicitly set, even when set to 0,
avoid adding the default radius to the corresponding InteractionRegion.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Check if the RenderStyle has an explicitly set border-radius.

* LayoutTests/interaction-region/border-radii-expected.txt:
* LayoutTests/interaction-region/border-radii.html:
Add test cases covering this change.

Canonical link: <a href="https://commits.webkit.org/269755@main">https://commits.webkit.org/269755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50bb27609f7d10ed9f4b4b95adec795ab4ce3960

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24550 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23980 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26191 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21172 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25179 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18615 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5603 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->