### PR TITLE
Generate serialization of WebCore::ScrollingStateNode

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -44,125 +44,33 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/TextStream.h>
 
-namespace IPC {
-using namespace WebCore;
-
-template<> struct ArgumentCoder<ScrollingStateFrameHostingNode> {
-    static void encode(Encoder&, const ScrollingStateFrameHostingNode&);
-    static std::optional<Ref<ScrollingStateFrameHostingNode>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<ScrollingStateOverflowScrollingNode> {
-    static void encode(Encoder&, const ScrollingStateOverflowScrollingNode&);
-    static std::optional<Ref<ScrollingStateOverflowScrollingNode>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<ScrollingStateOverflowScrollProxyNode> {
-    static void encode(Encoder&, const ScrollingStateOverflowScrollProxyNode&);
-    static std::optional<Ref<ScrollingStateOverflowScrollProxyNode>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<ScrollingStateFixedNode> {
-    static void encode(Encoder&, const ScrollingStateFixedNode&);
-    static std::optional<Ref<ScrollingStateFixedNode>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<ScrollingStateStickyNode> {
-    static void encode(Encoder&, const ScrollingStateStickyNode&);
-    static std::optional<Ref<ScrollingStateStickyNode>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<ScrollingStatePositionedNode> {
-    static void encode(Encoder&, const ScrollingStatePositionedNode&);
-    static std::optional<Ref<ScrollingStatePositionedNode>> decode(Decoder&);
-};
-
-} // namespace IPC
-
 using namespace IPC;
 
-void ArgumentCoder<ScrollingStateNode>::encode(Encoder& encoder, const ScrollingStateNode& node)
-{
-    encoder << node.nodeType();
-
-    switch (node.nodeType()) {
-    case ScrollingNodeType::MainFrame:
-    case ScrollingNodeType::Subframe:
-        encoder << downcast<ScrollingStateFrameScrollingNode>(node);
-        break;
-    case ScrollingNodeType::FrameHosting:
-        encoder << downcast<ScrollingStateFrameHostingNode>(node);
-        break;
-    case ScrollingNodeType::Overflow:
-        encoder << downcast<ScrollingStateOverflowScrollingNode>(node);
-        break;
-    case ScrollingNodeType::OverflowProxy:
-        encoder << downcast<ScrollingStateOverflowScrollProxyNode>(node);
-        break;
-    case ScrollingNodeType::Fixed:
-        encoder << downcast<ScrollingStateFixedNode>(node);
-        break;
-    case ScrollingNodeType::Sticky:
-        encoder << downcast<ScrollingStateStickyNode>(node);
-        break;
-    case ScrollingNodeType::Positioned:
-        encoder << downcast<ScrollingStatePositionedNode>(node);
-        break;
-    }
-}
-
-std::optional<Ref<ScrollingStateNode>> ArgumentCoder<ScrollingStateNode>::decode(Decoder& decoder)
-{
-    auto nodeType = decoder.decode<ScrollingNodeType>();
-    if (!nodeType)
-        return std::nullopt;
-
-    switch (*nodeType) {
-    case ScrollingNodeType::MainFrame:
-    case ScrollingNodeType::Subframe:
-        return ArgumentCoder<ScrollingStateFrameScrollingNode>::decode(decoder);
-    case ScrollingNodeType::FrameHosting:
-        return ArgumentCoder<ScrollingStateFrameHostingNode>::decode(decoder);
-    case ScrollingNodeType::Overflow:
-        return ArgumentCoder<ScrollingStateOverflowScrollingNode>::decode(decoder);
-    case ScrollingNodeType::OverflowProxy:
-        return ArgumentCoder<ScrollingStateOverflowScrollProxyNode>::decode(decoder);
-    case ScrollingNodeType::Fixed:
-        return ArgumentCoder<ScrollingStateFixedNode>::decode(decoder);
-    case ScrollingNodeType::Sticky:
-        return ArgumentCoder<ScrollingStateStickyNode>::decode(decoder);
-    case ScrollingNodeType::Positioned:
-        return ArgumentCoder<ScrollingStatePositionedNode>::decode(decoder);
-    }
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-
-static void encodeNodeShared(Encoder& encoder, const ScrollingStateNode& node)
+static void encodeNodeShared(Encoder& encoder, const WebCore::ScrollingStateNode& node)
 {
     encoder << node.changedProperties();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::Layer))
         encoder << node.layer().layerIDForEncoding();
 
     encoder << node.children();
 }
 
-static bool decodeNodeShared(Decoder& decoder, ScrollingStateNode& node)
+static bool decodeNodeShared(Decoder& decoder, WebCore::ScrollingStateNode& node)
 {
-    OptionSet<ScrollingStateNode::Property> changedProperties;
+    OptionSet<WebCore::ScrollingStateNode::Property> changedProperties;
     if (!decoder.decode(changedProperties))
         return false;
 
     node.setChangedProperties(changedProperties);
-    if (node.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::Layer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return false;
-        node.setLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node.setLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
-    std::optional<Vector<Ref<ScrollingStateNode>>> children;
+    std::optional<Vector<Ref<WebCore::ScrollingStateNode>>> children;
     decoder >> children;
     if (!children)
         return false;
@@ -171,15 +79,15 @@ static bool decodeNodeShared(Decoder& decoder, ScrollingStateNode& node)
 }
 
 #define SCROLLING_NODE_ENCODE(property, getter) \
-    if (node.hasChangedProperty(property)) \
+    if (node.hasChangedProperty(WebCore::property)) \
         encoder << node.getter();
 
 #define SCROLLING_NODE_ENCODE_ENUM(property, getter) \
-    if (node.hasChangedProperty(property)) \
+    if (node.hasChangedProperty(WebCore::property)) \
         encoder << node.getter();
 
 #define SCROLLING_NODE_DECODE(property, type, setter) \
-    if (node->hasChangedProperty(property)) { \
+    if (node->hasChangedProperty(WebCore::property)) { \
         type decodedValue; \
         if (!decoder.decode(decodedValue)) \
             return std::nullopt; \
@@ -187,7 +95,7 @@ static bool decodeNodeShared(Decoder& decoder, ScrollingStateNode& node)
     }
 
 #define SCROLLING_NODE_DECODE_ENUM(property, type, setter) \
-    if (node->hasChangedProperty(property)) { \
+    if (node->hasChangedProperty(WebCore::property)) { \
         type decodedValue; \
         if (!decoder.decode(decodedValue)) \
             return std::nullopt; \
@@ -195,14 +103,14 @@ static bool decodeNodeShared(Decoder& decoder, ScrollingStateNode& node)
     }
 
 #define SCROLLING_NODE_DECODE_REFERENCE(property, type, setter) \
-    if (node.hasChangedProperty(property)) { \
+    if (node.hasChangedProperty(WebCore::property)) { \
         type decodedValue; \
         if (!decoder.decode(decodedValue)) \
             return false; \
         node.setter(WTFMove(decodedValue)); \
     }
 
-static void encodeScrollingStateScrollingNodeShared(Encoder& encoder, const ScrollingStateScrollingNode& node)
+static void encodeScrollingStateScrollingNodeShared(Encoder& encoder, const WebCore::ScrollingStateScrollingNode& node)
 {
     encodeNodeShared(encoder, node);
 
@@ -223,38 +131,38 @@ static void encodeScrollingStateScrollingNodeShared(Encoder& encoder, const Scro
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::KeyboardScrollData, keyboardScrollData)
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::ContentAreaHoverState, mouseIsOverContentArea)
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrollContainerLayer))
         encoder << node.scrollContainerLayer().layerIDForEncoding();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrolledContentsLayer))
         encoder << node.scrolledContentsLayer().layerIDForEncoding();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::HorizontalScrollbarLayer))
         encoder << node.horizontalScrollbarLayer().layerIDForEncoding();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::VerticalScrollbarLayer))
         encoder << node.verticalScrollbarLayer().layerIDForEncoding();
-    
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollbarHoverState)) {
+
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrollbarHoverState)) {
         auto mouseIsInScrollbar = node.scrollbarHoverState();
         encoder << mouseIsInScrollbar.mouseIsOverHorizontalScrollbar;
         encoder << mouseIsInScrollbar.mouseIsOverVerticalScrollbar;
     }
-    
-    if (node.hasChangedProperty(ScrollingStateNode::Property::MouseActivityState)) {
+
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::MouseActivityState)) {
         auto mouseLocationState = node.mouseLocationState();
         encoder << mouseLocationState.locationInHorizontalScrollbar;
         encoder << mouseLocationState.locationInVerticalScrollbar;
     }
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollbarEnabledState)) {
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrollbarEnabledState)) {
         auto scrollbarEnabledState = node.scrollbarEnabledState();
         encoder << scrollbarEnabledState.horizontalScrollbarIsEnabled;
         encoder << scrollbarEnabledState.verticalScrollbarIsEnabled;
     }
 }
 
-void ArgumentCoder<ScrollingStateFrameScrollingNode>::encode(Encoder& encoder, const ScrollingStateFrameScrollingNode& node)
+void ArgumentCoder<WebCore::ScrollingStateFrameScrollingNode>::encode(Encoder& encoder, const WebCore::ScrollingStateFrameScrollingNode& node)
 {
     encoder << node.isMainFrame();
     encoder << node.scrollingNodeID();
@@ -277,94 +185,94 @@ void ArgumentCoder<ScrollingStateFrameScrollingNode>::encode(Encoder& encoder, c
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::OverrideVisualViewportSize, overrideVisualViewportSize)
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::OverlayScrollbarsEnabled, overlayScrollbarsEnabled)
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::CounterScrollingLayer))
         encoder << node.counterScrollingLayer().layerIDForEncoding();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::InsetClipLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::InsetClipLayer))
         encoder << node.insetClipLayer().layerIDForEncoding();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ContentShadowLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ContentShadowLayer))
         encoder << node.contentShadowLayer().layerIDForEncoding();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::RootContentsLayer))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::RootContentsLayer))
         encoder << node.rootContentsLayer().layerIDForEncoding();
 }
 
-void ArgumentCoder<ScrollingStateFrameHostingNode>::encode(Encoder& encoder, const ScrollingStateFrameHostingNode& node)
+void ArgumentCoder<WebCore::ScrollingStateFrameHostingNode>::encode(Encoder& encoder, const WebCore::ScrollingStateFrameHostingNode& node)
 {
     encoder << node.scrollingNodeID();
     encodeNodeShared(encoder, node);
 }
 
-void ArgumentCoder<ScrollingStateOverflowScrollingNode>::encode(Encoder& encoder, const ScrollingStateOverflowScrollingNode& node)
+void ArgumentCoder<WebCore::ScrollingStateOverflowScrollingNode>::encode(Encoder& encoder, const WebCore::ScrollingStateOverflowScrollingNode& node)
 {
     encoder << node.scrollingNodeID();
     encodeScrollingStateScrollingNodeShared(encoder, node);
 }
 
-void ArgumentCoder<ScrollingStateOverflowScrollProxyNode>::encode(Encoder& encoder, const ScrollingStateOverflowScrollProxyNode& node)
+void ArgumentCoder<WebCore::ScrollingStateOverflowScrollProxyNode>::encode(Encoder& encoder, const WebCore::ScrollingStateOverflowScrollProxyNode& node)
 {
     encoder << node.scrollingNodeID();
     encodeNodeShared(encoder, node);
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::OverflowScrollingNode, overflowScrollingNode)
 }
 
-static bool decodeScrollingStateScrollingNodeShared(Decoder& decoder, ScrollingStateScrollingNode& node)
+static bool decodeScrollingStateScrollingNodeShared(Decoder& decoder, WebCore::ScrollingStateScrollingNode& node)
 {
     if (!decodeNodeShared(decoder, node))
         return false;
 
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollableAreaSize, FloatSize, setScrollableAreaSize);
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::TotalContentsSize, FloatSize, setTotalContentsSize);
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ReachableContentsSize, FloatSize, setReachableContentsSize);
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollPosition, FloatPoint, setScrollPosition);
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollOrigin, IntPoint, setScrollOrigin);
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::SnapOffsetsInfo, FloatScrollSnapOffsetsInfo, setSnapOffsetsInfo);
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollableAreaSize, WebCore::FloatSize, setScrollableAreaSize);
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::TotalContentsSize, WebCore::FloatSize, setTotalContentsSize);
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ReachableContentsSize, WebCore::FloatSize, setReachableContentsSize);
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollPosition, WebCore::FloatPoint, setScrollPosition);
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollOrigin, WebCore::IntPoint, setScrollOrigin);
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::SnapOffsetsInfo, WebCore::FloatScrollSnapOffsetsInfo, setSnapOffsetsInfo);
     SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex, std::optional<unsigned>, setCurrentHorizontalSnapPointIndex);
     SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex, std::optional<unsigned>, setCurrentVerticalSnapPointIndex);
 #if ENABLE(SCROLLING_THREAD)
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ReasonsForSynchronousScrolling, OptionSet<SynchronousScrollingReason>, setSynchronousScrollingReasons)
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ReasonsForSynchronousScrolling, OptionSet<WebCore::SynchronousScrollingReason>, setSynchronousScrollingReasons)
 #endif
     SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::IsMonitoringWheelEvents, bool, setIsMonitoringWheelEvents);
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollableAreaParams, ScrollableAreaParameters, setScrollableAreaParameters);
-    if (node.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition)) {
-        RequestedScrollData requestedScrollData;
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ScrollableAreaParams, WebCore::ScrollableAreaParameters, setScrollableAreaParameters);
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::RequestedScrollPosition)) {
+        WebCore::RequestedScrollData requestedScrollData;
         if (!decoder.decode(requestedScrollData))
             return false;
-        node.setRequestedScrollData(WTFMove(requestedScrollData), ScrollingStateScrollingNode::CanMergeScrollData::No);
+        node.setRequestedScrollData(WTFMove(requestedScrollData), WebCore::ScrollingStateScrollingNode::CanMergeScrollData::No);
     }
-    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::KeyboardScrollData, RequestedKeyboardScrollData, setKeyboardScrollData);
+    SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::KeyboardScrollData, WebCore::RequestedKeyboardScrollData, setKeyboardScrollData);
     SCROLLING_NODE_DECODE_REFERENCE(ScrollingStateNode::Property::ContentAreaHoverState, bool, setMouseIsOverContentArea);
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrollContainerLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return false;
-        node.setScrollContainerLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node.setScrollContainerLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrolledContentsLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return false;
-        node.setScrolledContentsLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node.setScrolledContentsLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::HorizontalScrollbarLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return false;
-        node.setHorizontalScrollbarLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node.setHorizontalScrollbarLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::VerticalScrollbarLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return false;
-        node.setVerticalScrollbarLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node.setVerticalScrollbarLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
-    
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollbarHoverState)) {
+
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrollbarHoverState)) {
         bool didEnterScrollbarHorizontal;
         if (!decoder.decode(didEnterScrollbarHorizontal))
             return false;
@@ -374,19 +282,19 @@ static bool decodeScrollingStateScrollingNodeShared(Decoder& decoder, ScrollingS
             return false;
         node.setScrollbarHoverState({ didEnterScrollbarHorizontal, didEnterScrollbarVertical });
     }
-    
-    if (node.hasChangedProperty(ScrollingStateNode::Property::MouseActivityState)) {
-        IntPoint locationInHorizontalScrollbar;
+
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::MouseActivityState)) {
+        WebCore::IntPoint locationInHorizontalScrollbar;
         if (!decoder.decode(locationInHorizontalScrollbar))
             return false;
 
-        IntPoint locationInVerticalScrollbar;
+        WebCore::IntPoint locationInVerticalScrollbar;
         if (!decoder.decode(locationInVerticalScrollbar))
             return false;
         node.setMouseMovedInContentArea({ locationInHorizontalScrollbar, locationInVerticalScrollbar });
     }
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollbarEnabledState)) {
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ScrollbarEnabledState)) {
         bool horizontalScrollbarEnabled;
         if (!decoder.decode(horizontalScrollbarEnabled))
             return false;
@@ -394,30 +302,30 @@ static bool decodeScrollingStateScrollingNodeShared(Decoder& decoder, ScrollingS
         bool verticalScrollbarEnabled;
         if (!decoder.decode(verticalScrollbarEnabled))
             return false;
-        node.setScrollbarEnabledState(ScrollbarOrientation::Horizontal, horizontalScrollbarEnabled);
-        node.setScrollbarEnabledState(ScrollbarOrientation::Vertical, verticalScrollbarEnabled);
+        node.setScrollbarEnabledState(WebCore::ScrollbarOrientation::Horizontal, horizontalScrollbarEnabled);
+        node.setScrollbarEnabledState(WebCore::ScrollbarOrientation::Vertical, verticalScrollbarEnabled);
     }
 
     return true;
 }
 
-std::optional<Ref<ScrollingStateFrameScrollingNode>> ArgumentCoder<ScrollingStateFrameScrollingNode>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::ScrollingStateFrameScrollingNode>> ArgumentCoder<WebCore::ScrollingStateFrameScrollingNode>::decode(Decoder& decoder)
 {
     auto mainFrame = decoder.decode<bool>();
     if (!mainFrame)
         return std::nullopt;
 
-    auto nodeID = decoder.decode<ScrollingNodeID>();
+    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
     if (!nodeID)
         return std::nullopt;
-    auto node = ScrollingStateFrameScrollingNode::create(*mainFrame, *nodeID);
+    auto node = WebCore::ScrollingStateFrameScrollingNode::create(*mainFrame, *nodeID);
 
     if (!decodeScrollingStateScrollingNodeShared(decoder, node))
         return std::nullopt;
 
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::FrameScaleFactor, float, setFrameScaleFactor);
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::EventTrackingRegion, EventTrackingRegions, setEventTrackingRegions);
-    SCROLLING_NODE_DECODE_ENUM(ScrollingStateNode::Property::BehaviorForFixedElements, ScrollBehaviorForFixedElements, setScrollBehaviorForFixedElements);
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::EventTrackingRegion, WebCore::EventTrackingRegions, setEventTrackingRegions);
+    SCROLLING_NODE_DECODE_ENUM(ScrollingStateNode::Property::BehaviorForFixedElements, WebCore::ScrollBehaviorForFixedElements, setScrollBehaviorForFixedElements);
 
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::HeaderHeight, int, setHeaderHeight);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::FooterHeight, int, setFooterHeight);
@@ -427,49 +335,49 @@ std::optional<Ref<ScrollingStateFrameScrollingNode>> ArgumentCoder<ScrollingStat
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::VisualViewportIsSmallerThanLayoutViewport, bool, setVisualViewportIsSmallerThanLayoutViewport);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::WheelEventGesturesBecomeNonBlocking, bool, setWheelEventGesturesBecomeNonBlocking)
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ScrollingPerformanceTestingEnabled, bool, setScrollingPerformanceTestingEnabled)
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::LayoutViewport, FloatRect, setLayoutViewport)
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::MinLayoutViewportOrigin, FloatPoint, setMinLayoutViewportOrigin)
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::MaxLayoutViewportOrigin, FloatPoint, setMaxLayoutViewportOrigin)
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::OverrideVisualViewportSize, std::optional<FloatSize>, setOverrideVisualViewportSize)
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::LayoutViewport, WebCore::FloatRect, setLayoutViewport)
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::MinLayoutViewportOrigin, WebCore::FloatPoint, setMinLayoutViewportOrigin)
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::MaxLayoutViewportOrigin, WebCore::FloatPoint, setMaxLayoutViewportOrigin)
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::OverrideVisualViewportSize, std::optional<WebCore::FloatSize>, setOverrideVisualViewportSize)
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::OverlayScrollbarsEnabled, bool, setOverlayScrollbarsEnabled)
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::CounterScrollingLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return std::nullopt;
-        node->setCounterScrollingLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node->setCounterScrollingLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::InsetClipLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::InsetClipLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return std::nullopt;
-        node->setInsetClipLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node->setInsetClipLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::ContentShadowLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::ContentShadowLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return std::nullopt;
-        node->setContentShadowLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node->setContentShadowLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::RootContentsLayer)) {
-        std::optional<PlatformLayerIdentifier> layerID;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::RootContentsLayer)) {
+        std::optional<WebCore::PlatformLayerIdentifier> layerID;
         if (!decoder.decode(layerID))
             return std::nullopt;
-        node->setRootContentsLayer(layerID.value_or(PlatformLayerIdentifier { }));
+        node->setRootContentsLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
 
     return WTFMove(node);
 }
 
-std::optional<Ref<ScrollingStateFrameHostingNode>> ArgumentCoder<ScrollingStateFrameHostingNode>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> ArgumentCoder<WebCore::ScrollingStateFrameHostingNode>::decode(Decoder& decoder)
 {
-    auto nodeID = decoder.decode<ScrollingNodeID>();
+    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
     if (!nodeID)
         return std::nullopt;
-    auto node = ScrollingStateFrameHostingNode::create(*nodeID);
+    auto node = WebCore::ScrollingStateFrameHostingNode::create(*nodeID);
 
     if (!decodeNodeShared(decoder, node))
         return std::nullopt;
@@ -477,12 +385,12 @@ std::optional<Ref<ScrollingStateFrameHostingNode>> ArgumentCoder<ScrollingStateF
     return WTFMove(node);
 }
 
-std::optional<Ref<ScrollingStateOverflowScrollingNode>> ArgumentCoder<ScrollingStateOverflowScrollingNode>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::ScrollingStateOverflowScrollingNode>> ArgumentCoder<WebCore::ScrollingStateOverflowScrollingNode>::decode(Decoder& decoder)
 {
-    auto nodeID = decoder.decode<ScrollingNodeID>();
+    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
     if (!nodeID)
         return std::nullopt;
-    auto node = ScrollingStateOverflowScrollingNode::create(*nodeID);
+    auto node = WebCore::ScrollingStateOverflowScrollingNode::create(*nodeID);
 
     if (!decodeScrollingStateScrollingNodeShared(decoder, node))
         return std::nullopt;
@@ -490,41 +398,41 @@ std::optional<Ref<ScrollingStateOverflowScrollingNode>> ArgumentCoder<ScrollingS
     return WTFMove(node);
 }
 
-std::optional<Ref<ScrollingStateOverflowScrollProxyNode>> ArgumentCoder<ScrollingStateOverflowScrollProxyNode>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::ScrollingStateOverflowScrollProxyNode>> ArgumentCoder<WebCore::ScrollingStateOverflowScrollProxyNode>::decode(Decoder& decoder)
 {
-    auto nodeID = decoder.decode<ScrollingNodeID>();
+    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
     if (!nodeID)
         return std::nullopt;
-    auto node = ScrollingStateOverflowScrollProxyNode::create(*nodeID);
+    auto node = WebCore::ScrollingStateOverflowScrollProxyNode::create(*nodeID);
 
     if (!decodeNodeShared(decoder, node))
         return std::nullopt;
 
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::OverflowScrollingNode, ScrollingNodeID, setOverflowScrollingNode);
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::OverflowScrollingNode, WebCore::ScrollingNodeID, setOverflowScrollingNode);
     return WTFMove(node);
 }
 
-void ArgumentCoder<ScrollingStateFixedNode>::encode(Encoder& encoder, const ScrollingStateFixedNode& node)
+void ArgumentCoder<WebCore::ScrollingStateFixedNode>::encode(Encoder& encoder, const WebCore::ScrollingStateFixedNode& node)
 {
     encoder << node.scrollingNodeID();
     encodeNodeShared(encoder, node);
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ViewportConstraints))
         encoder << node.viewportConstraints();
 }
 
-std::optional<Ref<ScrollingStateFixedNode>> ArgumentCoder<ScrollingStateFixedNode>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::ScrollingStateFixedNode>> ArgumentCoder<WebCore::ScrollingStateFixedNode>::decode(Decoder& decoder)
 {
-    auto nodeID = decoder.decode<ScrollingNodeID>();
+    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
     if (!nodeID)
         return std::nullopt;
-    auto node = ScrollingStateFixedNode::create(*nodeID);
+    auto node = WebCore::ScrollingStateFixedNode::create(*nodeID);
 
     if (!decodeNodeShared(decoder, node))
         return std::nullopt;
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints)) {
-        FixedPositionViewportConstraints decodedValue;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::ViewportConstraints)) {
+        WebCore::FixedPositionViewportConstraints decodedValue;
         if (!decoder.decode(decodedValue))
             return std::nullopt;
         node->updateConstraints(decodedValue);
@@ -533,27 +441,27 @@ std::optional<Ref<ScrollingStateFixedNode>> ArgumentCoder<ScrollingStateFixedNod
     return WTFMove(node);
 }
 
-void ArgumentCoder<ScrollingStateStickyNode>::encode(Encoder& encoder, const ScrollingStateStickyNode& node)
+void ArgumentCoder<WebCore::ScrollingStateStickyNode>::encode(Encoder& encoder, const WebCore::ScrollingStateStickyNode& node)
 {
     encoder << node.scrollingNodeID();
     encodeNodeShared(encoder, node);
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::ViewportConstraints))
         encoder << node.viewportConstraints();
 }
 
-std::optional<Ref<ScrollingStateStickyNode>> ArgumentCoder<ScrollingStateStickyNode>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::ScrollingStateStickyNode>> ArgumentCoder<WebCore::ScrollingStateStickyNode>::decode(Decoder& decoder)
 {
-    auto nodeID = decoder.decode<ScrollingNodeID>();
+    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
     if (!nodeID)
         return std::nullopt;
-    auto node = ScrollingStateStickyNode::create(*nodeID);
+    auto node = WebCore::ScrollingStateStickyNode::create(*nodeID);
 
     if (!decodeNodeShared(decoder, node))
         return std::nullopt;
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints)) {
-        StickyPositionViewportConstraints decodedValue;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::ViewportConstraints)) {
+        WebCore::StickyPositionViewportConstraints decodedValue;
         if (!decoder.decode(decodedValue))
             return std::nullopt;
         node->updateConstraints(decodedValue);
@@ -562,37 +470,37 @@ std::optional<Ref<ScrollingStateStickyNode>> ArgumentCoder<ScrollingStateStickyN
     return WTFMove(node);
 }
 
-void ArgumentCoder<ScrollingStatePositionedNode>::encode(Encoder& encoder, const ScrollingStatePositionedNode& node)
+void ArgumentCoder<WebCore::ScrollingStatePositionedNode>::encode(Encoder& encoder, const WebCore::ScrollingStatePositionedNode& node)
 {
     encoder << node.scrollingNodeID();
     encodeNodeShared(encoder, node);
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::RelatedOverflowScrollingNodes))
         encoder << node.relatedOverflowScrollingNodes();
 
-    if (node.hasChangedProperty(ScrollingStateNode::Property::LayoutConstraintData))
+    if (node.hasChangedProperty(WebCore::ScrollingStateNode::Property::LayoutConstraintData))
         encoder << node.layoutConstraints();
 }
 
-std::optional<Ref<ScrollingStatePositionedNode>> ArgumentCoder<ScrollingStatePositionedNode>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::ScrollingStatePositionedNode>> ArgumentCoder<WebCore::ScrollingStatePositionedNode>::decode(Decoder& decoder)
 {
-    auto nodeID = decoder.decode<ScrollingNodeID>();
+    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
     if (!nodeID)
         return std::nullopt;
-    auto node = ScrollingStatePositionedNode::create(*nodeID);
+    auto node = WebCore::ScrollingStatePositionedNode::create(*nodeID);
 
     if (!decodeNodeShared(decoder, node))
         return std::nullopt;
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes)) {
-        Vector<ScrollingNodeID> decodedValue;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::RelatedOverflowScrollingNodes)) {
+        Vector<WebCore::ScrollingNodeID> decodedValue;
         if (!decoder.decode(decodedValue))
             return std::nullopt;
         node->setRelatedOverflowScrollingNodes(WTFMove(decodedValue));
     }
 
-    if (node->hasChangedProperty(ScrollingStateNode::Property::LayoutConstraintData)) {
-        AbsolutePositionConstraints decodedValue;
+    if (node->hasChangedProperty(WebCore::ScrollingStateNode::Property::LayoutConstraintData)) {
+        WebCore::AbsolutePositionConstraints decodedValue;
         if (!decoder.decode(decodedValue))
             return std::nullopt;
         node->updateConstraints(decodedValue);
@@ -602,6 +510,7 @@ std::optional<Ref<ScrollingStatePositionedNode>> ArgumentCoder<ScrollingStatePos
 }
 
 namespace WebKit {
+using namespace WebCore;
 
 RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -37,7 +37,12 @@ class Encoder;
 
 namespace WebCore {
 class ScrollingStateFrameScrollingNode;
-class ScrollingStateNode;
+class ScrollingStateFrameHostingNode;
+class ScrollingStateOverflowScrollingNode;
+class ScrollingStateOverflowScrollProxyNode;
+class ScrollingStateFixedNode;
+class ScrollingStateStickyNode;
+class ScrollingStatePositionedNode;
 class ScrollingStateTree;
 }
 
@@ -73,13 +78,33 @@ private:
 } // namespace WebKit
 
 namespace IPC {
-template<> struct ArgumentCoder<WebCore::ScrollingStateNode> {
-    static void encode(Encoder&, const WebCore::ScrollingStateNode&);
-    static std::optional<Ref<WebCore::ScrollingStateNode>> decode(Decoder&);
-};
 template<> struct ArgumentCoder<WebCore::ScrollingStateFrameScrollingNode> {
     static void encode(Encoder&, const WebCore::ScrollingStateFrameScrollingNode&);
     static std::optional<Ref<WebCore::ScrollingStateFrameScrollingNode>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::ScrollingStateFrameHostingNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateFrameHostingNode&);
+    static std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::ScrollingStateOverflowScrollingNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateOverflowScrollingNode&);
+    static std::optional<Ref<WebCore::ScrollingStateOverflowScrollingNode>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::ScrollingStateOverflowScrollProxyNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateOverflowScrollProxyNode&);
+    static std::optional<Ref<WebCore::ScrollingStateOverflowScrollProxyNode>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::ScrollingStateFixedNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateFixedNode&);
+    static std::optional<Ref<WebCore::ScrollingStateFixedNode>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::ScrollingStateStickyNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateStickyNode&);
+    static std::optional<Ref<WebCore::ScrollingStateStickyNode>> decode(Decoder&);
+};
+template<> struct ArgumentCoder<WebCore::ScrollingStatePositionedNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStatePositionedNode&);
+    static std::optional<Ref<WebCore::ScrollingStatePositionedNode>> decode(Decoder&);
 };
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -32,3 +32,21 @@ class WebKit::RemoteScrollingCoordinatorTransaction {
     bool hasChangedProperties()
     RefPtr<WebCore::ScrollingStateFrameScrollingNode> rootStateNode()
 }
+
+header: <WebCore/ScrollingStateFrameScrollingNode.h>
+header: <WebCore/ScrollingStateFrameHostingNode.h>
+header: <WebCore/ScrollingStateOverflowScrollingNode.h>
+header: <WebCore/ScrollingStateOverflowScrollProxyNode.h>
+header: <WebCore/ScrollingStateFixedNode.h>
+header: <WebCore/ScrollingStateStickyNode.h>
+header: <WebCore/ScrollingStatePositionedNode.h>
+
+[RefCounted] class WebCore::ScrollingStateNode subclasses {
+    WebCore::ScrollingStateFrameScrollingNode,
+    WebCore::ScrollingStateFrameHostingNode,
+    WebCore::ScrollingStateOverflowScrollingNode,
+    WebCore::ScrollingStateOverflowScrollProxyNode,
+    WebCore::ScrollingStateFixedNode,
+    WebCore::ScrollingStateStickyNode,
+    WebCore::ScrollingStatePositionedNode,
+}


### PR DESCRIPTION
#### ddd1cb243955971dac5b571cade9386a72c0f7ac
<pre>
Generate serialization of WebCore::ScrollingStateNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=263613">https://bugs.webkit.org/show_bug.cgi?id=263613</a>
rdar://117435861

Reviewed by Brady Eidson.

* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(encodeNodeShared):
(decodeNodeShared):
(encodeScrollingStateScrollingNodeShared):
(ArgumentCoder&lt;WebCore::ScrollingStateFrameScrollingNode&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNode&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStateOverflowScrollingNode&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStateOverflowScrollProxyNode&gt;::encode):
(decodeScrollingStateScrollingNodeShared):
(ArgumentCoder&lt;WebCore::ScrollingStateFrameScrollingNode&gt;::decode):
(ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNode&gt;::decode):
(ArgumentCoder&lt;WebCore::ScrollingStateOverflowScrollingNode&gt;::decode):
(ArgumentCoder&lt;WebCore::ScrollingStateOverflowScrollProxyNode&gt;::decode):
(ArgumentCoder&lt;WebCore::ScrollingStateFixedNode&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStateFixedNode&gt;::decode):
(ArgumentCoder&lt;WebCore::ScrollingStateStickyNode&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStateStickyNode&gt;::decode):
(ArgumentCoder&lt;WebCore::ScrollingStatePositionedNode&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStatePositionedNode&gt;::decode):
(ArgumentCoder&lt;ScrollingStateNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateNode&gt;::decode): Deleted.
(ArgumentCoder&lt;ScrollingStateFrameScrollingNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateFrameHostingNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateOverflowScrollingNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateOverflowScrollProxyNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateFrameScrollingNode&gt;::decode): Deleted.
(ArgumentCoder&lt;ScrollingStateFrameHostingNode&gt;::decode): Deleted.
(ArgumentCoder&lt;ScrollingStateOverflowScrollingNode&gt;::decode): Deleted.
(ArgumentCoder&lt;ScrollingStateOverflowScrollProxyNode&gt;::decode): Deleted.
(ArgumentCoder&lt;ScrollingStateFixedNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateFixedNode&gt;::decode): Deleted.
(ArgumentCoder&lt;ScrollingStateStickyNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateStickyNode&gt;::decode): Deleted.
(ArgumentCoder&lt;ScrollingStatePositionedNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStatePositionedNode&gt;::decode): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:

Canonical link: <a href="https://commits.webkit.org/269763@main">https://commits.webkit.org/269763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6e231285b4b9b6c42b815c594159eb0fff3631e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24563 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21644 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23985 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26199 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/904 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25193 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18619 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1304 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3008 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->