### PR TITLE
screenrant.com: webcontent blank for several seconds upon resume

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -153,7 +153,6 @@ private:
         TransactionID lastVisibleTransactionID;
 #endif
         TransactionID transactionIDForPendingCACommit;
-        TransactionID transactionIDForUnhidingContent;
         ActivityStateChangeID activityStateChangeID { ActivityStateChangeAsynchronous };
     };
 
@@ -172,7 +171,9 @@ private:
     std::unique_ptr<RemoteLayerTreeHost> m_debugIndicatorLayerTreeHost;
     RetainPtr<CALayer> m_tileMapHostLayer;
     RetainPtr<CALayer> m_exposedRectIndicatorLayer;
-    
+
+    IPC::AsyncReplyID m_replyForUnhidingContent;
+
     unsigned m_countOfTransactionsWithNonEmptyLayerChanges { 0 };
 };
 


### PR DESCRIPTION
#### 359bfd90327f3b91f80398c53404a03e6a19eecd
<pre>
screenrant.com: webcontent blank for several seconds upon resume
<a href="https://bugs.webkit.org/show_bug.cgi?id=263614">https://bugs.webkit.org/show_bug.cgi?id=263614</a>
&lt;rdar://116530284&gt;

Reviewed by Tim Horton.

The existing code for hideContentUntilPendingUpdate waited for `nextLayerTreeTransactionID()`, which is usually the
next layer tree transaction to come from the WebProcess (and may already be in the incoming message queue).
The exception is when we&apos;ve already received the `willCommitLayerTree` message, but not the `commitLayerTree` one
(probably because it&apos;s still working on buffer flushing). In that case it&apos;s the second layer tree transaction after
the current point.

In some cases that means we hide the layer tree, only to immediately show it again.

This changes the code to use a DispatchAfterEnsuringDrawing() IPC message, so that we show the content on the
next presentation update after the current set of IPC messages being sent to the WebProcess have been received.

It tracks the AsyncReplyID of any request in flight, so that if we get a second we can cancel the existing one and
replace it, thus extending the hidden state to the new deadline.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate):

Canonical link: <a href="https://commits.webkit.org/269776@main">https://commits.webkit.org/269776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a34789d578caac872c2a3bea90ce2a455da7b7aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24564 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23987 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26201 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/906 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25196 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18620 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/859 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5620 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->