### PR TITLE
The URL move constructor doesn't invalidate the "moved-out" URL

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -73,6 +73,47 @@ public:
     {
     }
 
+    URL(const URL&) = default;
+    URL& operator=(const URL&) = default;
+
+    URL(URL&& other)
+        : m_string(WTFMove(other.m_string))
+        , m_isValid(other.m_isValid)
+        , m_protocolIsInHTTPFamily(other.m_protocolIsInHTTPFamily)
+        , m_hasOpaquePath(other.m_hasOpaquePath)
+        , m_portLength(other.m_portLength)
+        , m_schemeEnd(other.m_schemeEnd)
+        , m_userStart(other.m_userStart)
+        , m_userEnd(other.m_userEnd)
+        , m_passwordEnd(other.m_passwordEnd)
+        , m_hostEnd(other.m_hostEnd)
+        , m_pathAfterLastSlash(other.m_pathAfterLastSlash)
+        , m_pathEnd(other.m_pathEnd)
+        , m_queryEnd(other.m_queryEnd)
+    {
+        other.m_isValid = false;
+    }
+
+    URL& operator=(URL&& other)
+    {
+        m_string = WTFMove(other.m_string);
+        m_isValid = other.m_isValid;
+        other.m_isValid = false;
+        m_protocolIsInHTTPFamily = other.m_protocolIsInHTTPFamily;
+        m_hasOpaquePath = other.m_hasOpaquePath;
+        m_portLength = other.m_portLength;
+        m_schemeEnd = other.m_schemeEnd;
+        m_userStart = other.m_userStart;
+        m_userEnd = other.m_userEnd;
+        m_passwordEnd = other.m_passwordEnd;
+        m_hostEnd = other.m_hostEnd;
+        m_pathAfterLastSlash = other.m_pathAfterLastSlash;
+        m_pathEnd = other.m_pathEnd;
+        m_queryEnd = other.m_queryEnd;
+
+        return *this;
+    }
+
     WTF_EXPORT_PRIVATE static URL fakeURLWithRelativePart(StringView);
     WTF_EXPORT_PRIVATE static URL fileURLWithFileSystemPath(StringView);
 

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -653,4 +653,21 @@ TEST_F(WTF_URL, IsolatedCopy)
     EXPECT_EQ(url2Copy.string().impl(), originalStringImpl); // Should have adopted the StringImpl of url2.
 }
 
+TEST_F(WTF_URL, MoveInvalidatesURL)
+{
+    URL url1 { "http://www.apple.com"_str };
+    EXPECT_TRUE(url1.isValid());
+    URL url2 { WTFMove(url1) };
+    EXPECT_TRUE(url2.isValid());
+    EXPECT_FALSE(url1.isValid());
+
+    URL url3 { "http://www.webkit.org"_str };
+    url3 = WTFMove(url2);
+    EXPECT_TRUE(url3.isValid());
+    EXPECT_FALSE(url2.isValid());
+
+    url3 = { };
+    EXPECT_FALSE(url3.isValid());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### e68882fc2467c39df45691156138231f20b31bbc
<pre>
The URL move constructor doesn&apos;t invalidate the &quot;moved-out&quot; URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=263615">https://bugs.webkit.org/show_bug.cgi?id=263615</a>

Reviewed by Ryosuke Niwa.

The URL move constructor doesn&apos;t invalidate the &quot;moved-out&quot; URL. This can lead
WebKit code to do weird things.

For example, URLKeepingBlobAlive contains a m_url data member and is often
moved-out to pass to a lambda. The destructor of the &quot;moved-out&quot;
URLKeepingBlobAlive then runs and calls `unregisterBlobURLHandleIfNecessary()`.
`unregisterBlobURLHandleIfNecessary()` will try to use m_url after it&apos;s been
moved out to see if the URL protocol is &quot;blob&quot;. This  causes URL::protocolIs()
to try to do out-of-bound access in the underlying String (since the URL is
marked as valid, even though it&apos;s m_string was moved out and other data members
that are indexes into that string were not reset). Luckily, String&apos;s operator[]
just returns nil when doing an out of bounds access at the moment.

* Source/WTF/wtf/URL.h:
(WTF::URL::URL):
(WTF::URL::operator=):
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/269750@main">https://commits.webkit.org/269750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01483ae66e01932e6be8a6f8a668ca70faa59ae7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24566 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23989 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26203 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/909 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21185 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20398 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25207 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22794 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18628 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30181 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/861 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6228 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5599 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1309 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30133 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1165 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6122 "Passed tests") | 
<!--EWS-Status-Bubble-End-->