### PR TITLE
REGRESSION (UI-side compositing) overflow:scroll inside SVG foreignObject fails to render scrollbars

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/svg-foreign-object-overlay-scrollbar-hovered-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/svg-foreign-object-overlay-scrollbar-hovered-expected.txt
@@ -1,0 +1,13 @@
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Test hover over the overlay scrollbar of a overflow: scroll in an SVG foreign object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state
+enabled
+Hovering vertical scrollbar should show expanded scrollbar
+PASS Scrollbar state: enabled,expanded,visible_track,visible_thumb
+Unhovering vertical scrollbar should hide it
+PASS Thumb and track hidden
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/svg-foreign-object-overlay-scrollbar-hovered.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/svg-foreign-object-overlay-scrollbar-hovered.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 1000px;
+        }
+        .scroller {
+            width: 100px;
+            height: 100px;
+            border: 1px solid black;
+            overflow: scroll;
+        }
+    </style>
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Test hover over the overlay scrollbar of a overflow: scroll in an SVG foreign object');
+            if (window.testRunner)
+                testRunner.waitUntilDone();
+            
+            const scroller = document.getElementById('scroller');
+            const scrollertBounds = scroller.getBoundingClientRect();
+            const x = scrollertBounds.right - 8;
+            const y = scrollertBounds.top + 10;
+
+            debug('Initial state');
+            verticalScrollbarStateForSelect = await UIHelper.verticalScrollbarState(scroller);
+            debug(verticalScrollbarStateForSelect);
+
+            debug('Hovering vertical scrollbar should show expanded scrollbar');
+            await UIHelper.mouseWheelScrollAt(x, y);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                let expanded = state.indexOf('expanded') != -1;
+                if (expanded)
+                    testPassed('Scrollbar state: ' + state);
+                return expanded;
+            });
+
+            debug('Unhovering vertical scrollbar should hide it');
+            await UIHelper.moveMouseAndWaitForFrame(x - 10, y);
+            await UIHelper.moveMouseAndWaitForFrame(x - 20, y);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                let thumbHidden = state.indexOf('visible_thumb') == -1;
+                let trackHidden = state.indexOf('visible_track') == -1;
+                if (thumbHidden && trackHidden)
+                    testPassed('Thumb and track hidden');
+                return thumbHidden && trackHidden;
+            });
+
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <svg id="hello" width="400" height="400">
+        <foreignObject x="0" y="0" width="400" height="400">
+
+            <div id="scroller" class="scroller">
+                <div class="contents">
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                </div>
+            </div>
+        </foreignObject>
+    </svg>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -908,8 +908,8 @@ window.UIHelper = class UIHelper {
         if (!this.isWebKit2() || this.isIOSFamily())
             return Promise.resolve();
 
-        if (internals.isUsingUISideCompositing() && (!scroller || scroller.nodeName != "SELECT")) {
-            var scrollingNodeID = internalFunctions.scrollingNodeIDForNode(scroller);
+        var scrollingNodeID = internalFunctions.scrollingNodeIDForNode(scroller);
+        if (internals.isUsingUISideCompositing() && (!scroller || (scroller.nodeName != "SELECT" && scrollingNodeID[0] != 0))) {
             return new Promise(resolve => {
                 testRunner.runUIScript(`(function() {
                     uiController.doAfterNextStablePresentationUpdate(function() {

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -847,9 +847,11 @@ bool RenderLayerScrollableArea::canShowNonOverlayScrollbars() const
 
 void RenderLayerScrollableArea::createScrollbarsController()
 {
-    if (auto scrollbarController = m_layer.page().chrome().client().createScrollbarsController(m_layer.page(), *this)) {
-        setScrollbarsController(WTFMove(scrollbarController));
-        return;
+    if (usesAsyncScrolling()) {
+        if (auto scrollbarController = m_layer.page().chrome().client().createScrollbarsController(m_layer.page(), *this)) {
+            setScrollbarsController(WTFMove(scrollbarController));
+            return;
+        }
     }
 
     ScrollableArea::createScrollbarsController();

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -258,6 +258,8 @@ public:
     void invalidateScrollAnchoringElement() final;
     ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
 
+    void createScrollbarsController() final;
+
 private:
     bool hasHorizontalOverflow() const;
     bool hasVerticalOverflow() const;
@@ -286,8 +288,6 @@ private:
     void registerScrollableAreaForAnimatedScroll();
 
     float deviceScaleFactor() const final;
-
-    void createScrollbarsController() final;
 
 private:
     bool m_scrollDimensionsDirty { true };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -103,7 +103,7 @@ bool RemoteScrollbarsController::shouldDrawIntoScrollbarLayer(WebCore::Scrollbar
 
 bool RemoteScrollbarsController::shouldRegisterScrollbars() const
 {
-    return scrollableArea().isListBox();
+    return !scrollableArea().usesAsyncScrolling();
 }
 
 void RemoteScrollbarsController::setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation orientation, int minimumThumbLength)


### PR DESCRIPTION
#### 4f1ded96b3967cf2de4cc260b1e49940e93822e4
<pre>
REGRESSION (UI-side compositing) overflow:scroll inside SVG foreignObject fails to render scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=261227">https://bugs.webkit.org/show_bug.cgi?id=261227</a>
<a href="https://rdar.apple.com/115075206">rdar://115075206</a>

Reviewed by Simon Fraser.

Keep NSScrollerImps in the web process for scrollers inside svg foreignObject as
they don&apos;t follow the normal code path for creating scrollbars in the UI process.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::usesOverlayScrollbars const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
* Source/WebCore/platform/mac/NSScrollerImpDetails.h:
* Source/WebCore/platform/mac/NSScrollerImpDetails.mm:
(WebCore::ScrollerStyle::usesOverlayScrollbars):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::registerScrollbarsForScrollableAreaInSVGForeignObject):
(WebCore::RenderLayer::updateAncestorDependentState):
* Source/WebCore/rendering/RenderLayer.h:
(WebCore::RenderLayer::isInsideSVGForeignObject const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::RemoteScrollbarsController::shouldRegisterScrollbars const):

Canonical link: <a href="https://commits.webkit.org/277015@main">https://commits.webkit.org/277015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af85545053aa0c6b734d576bb0c24603b885e994

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37825 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41032 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50796 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45025 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43942 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22973 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6476 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->