### PR TITLE
[ews-app] Use passwords.json instead of environment variables

### DIFF
--- a/Tools/CISupport/ews-app/ews-app/settings.py
+++ b/Tools/CISupport/ews-app/ews-app/settings.py
@@ -32,9 +32,10 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+import ews.common.util as util
 
-is_test_mode_enabled = os.getenv('EWS_PRODUCTION') is None
-is_dev_instance = (os.getenv('DEV_INSTANCE', '').lower() == 'true')
+is_test_mode_enabled = util.load_password('EWS_PRODUCTION') is None
+is_dev_instance = (util.load_password('DEV_INSTANCE', default='').lower() == 'true')
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +45,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('EWS_SECRET_KEY', 'secret')
+SECRET_KEY = util.load_password('EWS_SECRET_KEY', default='secret')
 
 DEBUG = False
 if (is_test_mode_enabled and not is_dev_instance):
@@ -111,10 +112,10 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': os.environ.get('DB_NAME', None),
-            'USER': os.environ.get('DB_USERNAME', None),
-            'PASSWORD': os.environ.get('DB_PASSWORD', None),
-            'HOST': os.environ.get('DB_URL', None),
+            'NAME': util.load_password('DB_NAME'),
+            'USER': util.load_password('DB_USERNAME'),
+            'PASSWORD': util.load_password('DB_PASSWORD'),
+            'HOST': util.load_password('DB_URL'),
         }
     }
 

--- a/Tools/CISupport/ews-app/ews/common/bugzilla.py
+++ b/Tools/CISupport/ews-app/ews/common/bugzilla.py
@@ -214,8 +214,8 @@ class BugzillaBeautifulSoup():
     browser = property(_get_browser, _set_browser)
 
     def authenticate(self):
-        username = os.getenv('BUGZILLA_USERNAME', None)
-        password = os.getenv('BUGZILLA_PASSWORD', None)
+        username = util.load_password('BUGZILLA_USERNAME')
+        password = util.load_password('BUGZILLA_PASSWORD')
         if not username or not password:
             _log.warn('Bugzilla username/password not configured in environment variables. Skipping authentication.')
             return

--- a/Tools/CISupport/ews-app/ews/common/buildbot.py
+++ b/Tools/CISupport/ews-app/ews/common/buildbot.py
@@ -168,8 +168,8 @@ class Buildbot():
             return False
 
         build_url = 'https://{}/api/v2/builders/{}/builds/{}'.format(config.BUILDBOT_SERVER_HOST, builder_id, build_number)
-        username = os.getenv('EWS_ADMIN_USERNAME')
-        password = os.getenv('EWS_ADMIN_PASSWORD')
+        username = util.load_password('EWS_ADMIN_USERNAME')
+        password = util.load_password('EWS_ADMIN_PASSWORD')
         session = requests.Session()
         response = session.head('https://{}/auth/login'.format(config.BUILDBOT_SERVER_HOST), auth=(username, password))
         if (not response) or response.status_code not in (200, 302):

--- a/Tools/CISupport/ews-app/ews/config.py
+++ b/Tools/CISupport/ews-app/ews/config.py
@@ -24,8 +24,8 @@ import os
 
 import ews.common.util as util
 
-is_test_mode_enabled = os.getenv('EWS_PRODUCTION') is None
-is_dev_instance = (os.getenv('DEV_INSTANCE', '').lower() == 'true')
+is_test_mode_enabled = util.load_password('EWS_PRODUCTION') is None
+is_dev_instance = (util.load_password('DEV_INSTANCE', default='').lower() == 'true')
 
 BUG_SERVER_HOST = 'bugs.webkit.org'
 BUG_SERVER_URL = 'https://{}/'.format(BUG_SERVER_HOST)
@@ -42,8 +42,8 @@ BUILDBOT_TRY_HOST = util.load_password('BUILDBOT_TRY_HOST', default=BUILDBOT_SER
 
 BUILDBOT_SERVER_PORT = '5555'
 COMMIT_QUEUE_PORT = '5557'
-BUILDBOT_TRY_USERNAME = os.getenv('BUILDBOT_TRY_USERNAME', 'sampleuser')
-BUILDBOT_TRY_PASSWORD = os.getenv('BUILDBOT_TRY_PASSWORD', 'samplepass')
+BUILDBOT_TRY_USERNAME = util.load_password('BUILDBOT_TRY_USERNAME', default='sampleuser')
+BUILDBOT_TRY_PASSWORD = util.load_password('BUILDBOT_TRY_PASSWORD', default='samplepass')
 
 SUCCESS = 0
 ERR_UNEXPECTED = -1

--- a/Tools/CISupport/ews-app/ews/views/results.py
+++ b/Tools/CISupport/ews-app/ews/views/results.py
@@ -36,6 +36,7 @@ from ews.config import SUCCESS
 from ews.common.github import GitHubEWS
 from ews.models.build import Build
 from ews.models.step import Step
+import ews.common.util as util
 
 _log = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class Results(View):
     def post(self, request):
         data = json.loads(request.body)
 
-        if data.get('EWS_API_KEY') != os.getenv('EWS_API_KEY', None):
+        if data.get('EWS_API_KEY') != util.load_password('EWS_API_KEY'):
             _log.error('Incorrect API Key {}. Host: {}. Ignoring data.'.format(data.get('EWS_API_KEY'), data.get('hostname')))
             return HttpResponse('Incorrect API Key received')
 


### PR DESCRIPTION
#### 81dce146552a6e7a7c62c263df83317527336394
<pre>
[ews-app] Use passwords.json instead of environment variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=263331">https://bugs.webkit.org/show_bug.cgi?id=263331</a>
rdar://117155033

Reviewed by Aakash Jain.

Use util.load_password instead of os.getenv.

* Tools/CISupport/ews-app/ews-app/settings.py:
* Tools/CISupport/ews-app/ews/common/bugzilla.py:
(BugzillaBeautifulSoup.authenticate):
* Tools/CISupport/ews-app/ews/common/buildbot.py:
(Buildbot.retry_build):
* Tools/CISupport/ews-app/ews/config.py:
* Tools/CISupport/ews-app/ews/views/results.py:
(Results.post):

Canonical link: <a href="https://commits.webkit.org/269772@main">https://commits.webkit.org/269772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdc54fc36d7121cf3cda564530e34e5c7236fb29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24595 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24013 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26229 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21208 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25245 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18640 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/887 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5614 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->