### PR TITLE
[macOS] Block unused mach syscalls in the WebContent process sandbox

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2257,33 +2257,45 @@
     MSC_mk_timer_destroy
     MSC_semaphore_signal_trap
     MSC_semaphore_timedwait_trap
+    MSC_semaphore_wait_trap
     MSC_syscall_thread_switch
+    MSC_task_name_for_pid
     MSC_thread_get_special_reply_port))
 
-(define (syscall-mach-possibly-in-use) (machtrap-number
+(define (syscall-mach-downlevels) (machtrap-number
     MSC__kernelrpc_mach_port_get_attributes_trap
 #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
     MSC_iokit_user_client_trap
 #endif
-    MSC_pid_for_task
-    MSC_semaphore_wait_trap
-    MSC_task_name_for_pid))
+    MSC_pid_for_task))
 
 (define (syscall-mach-blocked-in-lockdown-mode) (machtrap-number
+    MSC_thread_self_trap))
+
+(define (syscall-mach-downlevels-blocked-in-lockdown-mode) (machtrap-number
     MSC_host_create_mach_voucher_trap
     MSC_mach_msg_trap
     MSC_mach_reply_port
     MSC_mach_voucher_extract_attr_recipe_trap
-    MSC_swtch_pri
-    MSC_thread_self_trap))
+    MSC_swtch_pri))
 
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
     (deny syscall-mach)
     (allow syscall-mach (syscall-mach-in-use))
-    (allow syscall-mach (with report) (with telemetry) (syscall-mach-possibly-in-use))
+#if HAVE(SANDBOX_STATE_FLAGS)
+    (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+        (allow syscall-mach (syscall-mach-downlevels)))
+    (with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
+        (allow syscall-unix (syscall-mach-downlevels-blocked-in-lockdown-mode)))
+#endif
+#if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
+    (allow syscall-mach (syscall-mach-downlevels))
+    (with-filter (require-not (lockdown-mode))
+        (allow syscall-mach (syscall-mach-downlevels-blocked-in-lockdown-mode)))
+#endif
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
     (with-filter (require-not (lockdown-mode))
-        (allow syscall-mach (with report) (with telemetry) (syscall-mach-blocked-in-lockdown-mode)))
+        (allow syscall-mach (syscall-mach-blocked-in-lockdown-mode)))
     (with-filter (lockdown-mode)
         (deny syscall-mach (with telemetry) (syscall-mach-blocked-in-lockdown-mode)))
 #else


### PR DESCRIPTION
#### 601d619de658a1b58daab350a5742b4a4e690fda
<pre>
[macOS] Block unused mach syscalls in the WebContent process sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=263633">https://bugs.webkit.org/show_bug.cgi?id=263633</a>
rdar://117450710

Reviewed by Brent Fulgham.

Based on telemetry, block unused mach syscalls in the WebContent process sandbox on macOS.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/269814@main">https://commits.webkit.org/269814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f0774ff88337c2a4dccb904d8979674b5d8aa6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21754 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22337 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26318 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1027 "Passed tests") | | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25324 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18714 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/972 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5654 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->