### PR TITLE
Fix WebVTT Parser to disallow negative percentages

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-regionanchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-regionanchor-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL regions, regionanchor assert_equals: Failed with region 13 expected 0 but got -0
+PASS regions, regionanchor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-viewportanchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-viewportanchor-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL regions, viewportanchor assert_equals: Failed with region 13 expected 0 but got -0
+PASS regions, viewportanchor
 

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -60,13 +60,14 @@ constexpr unsigned styleIdentifierLength = 5;
 bool WebVTTParser::parseFloatPercentageValue(VTTScanner& valueScanner, float& percentage)
 {
     float number;
-    if (!valueScanner.scanFloat(number))
+    bool isNegative = false;
+    if (!valueScanner.scanFloat(number, &isNegative))
         return false;
     // '%' must be present and at the end of the setting value.
     if (!valueScanner.scan('%'))
         return false;
 
-    if (number < 0 || number > 100)
+    if (isNegative || number > 100)
         return false;
 
     percentage = number;


### PR DESCRIPTION
#### 6c997a688fcdb3d8a2ee11ccc1118b5cb5349733
<pre>
Fix WebVTT Parser to disallow negative percentages
<a href="https://bugs.webkit.org/show_bug.cgi?id=263640">https://bugs.webkit.org/show_bug.cgi?id=263640</a>

Reviewed by Eric Carlson.

This patch addresses an issue in the WebVTT parser where it incorrectly
allowed negative percentage values for region and viewport anchors.
According to the WebVTT specification, percentage values must be in the
range of 0 to 100, and negative percentages are not valid. This patch
ensures that the parser correctly identifies negative percentages
as invalid values.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-regionanchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-viewportanchor-expected.txt:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::parseFloatPercentageValue):

Canonical link: <a href="https://commits.webkit.org/269882@main">https://commits.webkit.org/269882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a84d1d93df4667de4fc78294a1a05eaedbab6b3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25661 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22293 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26251 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21228 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25264 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18660 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/909 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5722 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1352 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->