### PR TITLE
[GTK][WPE] PlatformDisplay should not use EGL_EXTERNAL_CONTEXT_SAVE_STATE_ANGLE

### DIFF
--- a/Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp
@@ -99,7 +99,6 @@ EGLContext PlatformDisplay::angleSharingGLContext()
     EGLint contextAttributes[] = {
         EGL_CONTEXT_CLIENT_VERSION, 2,
         EGL_EXTERNAL_CONTEXT_ANGLE, EGL_TRUE,
-        EGL_EXTERNAL_CONTEXT_SAVE_STATE_ANGLE, EGL_TRUE,
         EGL_NONE
     };
     m_angleSharingGLContext = EGL_CreateContext(m_angleEGLDisplay, config, EGL_NO_CONTEXT, contextAttributes);


### PR DESCRIPTION
#### 24ec7c56a453365e144d30266c5a61be8a782115
<pre>
[GTK][WPE] PlatformDisplay should not use EGL_EXTERNAL_CONTEXT_SAVE_STATE_ANGLE
<a href="https://bugs.webkit.org/show_bug.cgi?id=263646">https://bugs.webkit.org/show_bug.cgi?id=263646</a>

Reviewed by Kimmo Kinnunen.

It is removed in upstream ANGLE and it&apos;s not actually needed.

* Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp:
(WebCore::PlatformDisplay::angleSharingGLContext):

Canonical link: <a href="https://commits.webkit.org/269804@main">https://commits.webkit.org/269804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17c2e8fc1e3966c484126972a50d1da036ae0e14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22295 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26258 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21237 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25272 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18668 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/915 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->