### PR TITLE
WebGLRenderingContextBase::m_needsUpdate is a redundant flag

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -725,7 +725,6 @@ void WebGLRenderingContextBase::initializeNewContext(Ref<GraphicsContextGL> cont
 void WebGLRenderingContextBase::initializeContextState()
 {
     m_errors = { };
-    m_needsUpdate = true;
     m_markedCanvasDirty = false;
     m_activeTextureUnit = 0;
     m_packParameters = { };
@@ -1099,11 +1098,6 @@ void WebGLRenderingContextBase::reshape(int width, int height)
     GCGLint maxHeight = std::min(maxSize, m_maxViewportDims[1]);
     width = std::clamp(width, 1, maxWidth);
     height = std::clamp(height, 1, maxHeight);
-
-    if (m_needsUpdate) {
-        notifyCanvasContentChanged();
-        m_needsUpdate = false;
-    }
 
     // We don't have to mark the canvas as dirty, since the newly created image buffer will also start off
     // clear (and this matches what reshape will do).

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -565,7 +565,6 @@ protected:
 
     EventLoopTimerHandle m_restoreTimer;
     GCGLErrorCodeSet m_errors;
-    bool m_needsUpdate;
     bool m_markedCanvasDirty;
 
     // List of bound VBO's. Used to maintain info about sizes for ARRAY_BUFFER and stored values for ELEMENT_ARRAY_BUFFER


### PR DESCRIPTION
#### 7b16f53a6ca333f87a4d6a38f399b18118b3413a
<pre>
WebGLRenderingContextBase::m_needsUpdate is a redundant flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=263648">https://bugs.webkit.org/show_bug.cgi?id=263648</a>
rdar://117469562

Reviewed by Dan Glastonbury.

Remove m_needsUpdate. It controlled the
`renderBox-&gt;contentChanged(CanvasChanged)` call when the context was
created during reshape, only the first time after a context creation.

Initial creation for HTMLCanvasElement will call contentChanged
explicitly.

Upon restoring lost context, this is called after successful restore.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::reshape):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/269841@main">https://commits.webkit.org/269841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb39083ce680398b1c4b6420f020182d340459da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26260 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21240 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21427 "Found 2 new API test failures: TestWebKitAPI.ServiceWorker.WindowClientNavigate, TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21504 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25283 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18670 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/917 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5679 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->