### PR TITLE
[macOS] Block MIG syscalls in the WebContent process sandbox

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2138,12 +2138,16 @@
     io_service_get_matching_service_bin
     io_service_get_matching_services_bin
     io_service_open_extended
+    mach_exception_raise
     mach_memory_entry_ownership
+    mach_port_extract_right
+    mach_port_get_context_from_user
     mach_port_get_refs
     mach_port_request_notification
     mach_port_set_attributes
     mach_vm_copy
     mach_vm_map_external
+    mach_vm_region
     mach_vm_region_recurse
     mach_vm_remap_external
     semaphore_create
@@ -2157,12 +2161,8 @@
     thread_resume
     thread_suspend))
 
-(define (kernel-mig-routines-possibly-in-use) (kernel-mig-routine
-    io_registry_entry_get_property_bytes
-    mach_exception_raise
-    mach_port_extract_right
-    mach_port_get_context_from_user
-    mach_vm_region))
+(define (kernel-mig-routines-downlevels) (kernel-mig-routine
+    io_registry_entry_get_property_bytes))
 
 (define (kernel-mig-routines-iokit) (kernel-mig-routine
     io_connect_add_client
@@ -2172,6 +2172,11 @@
     io_connect_set_notification_port_64))
 
 (define (kernel-mig-routines-blocked-in-lockdown-mode) (kernel-mig-routine
+    task_threads_from_user
+    thread_policy
+    thread_policy_set))
+
+(define (kernel-mig-routines-downlevels-blocked-in-lockdown-mode) (kernel-mig-routine
     clock_get_time
     host_request_notification
     io_connect_map_memory_into_task
@@ -2181,10 +2186,7 @@
     io_registry_entry_get_name_in_plane
     io_registry_entry_get_properties_bin_buf
     io_registry_get_root_entry
-    io_service_close
-    task_threads_from_user
-    thread_policy
-    thread_policy_set))
+    io_service_close))
 
 (define (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry) (kernel-mig-routine
     thread_info
@@ -2196,7 +2198,7 @@
             (deny mach-message-send)
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
             (with-filter (require-not (lockdown-mode))
-                (allow mach-message-send (with report) (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))
+                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
                 (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry)))
             (with-filter (lockdown-mode)
                 (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))
@@ -2207,14 +2209,20 @@
 #endif
 
             (allow mach-message-send (kernel-mig-routines-in-use))
+#if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
+            (allow mach-message-send (kernel-mig-routines-downlevels))
+            (with-filter (require-not (lockdown-mode))
+                (allow mach-message-send (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))
+#endif
 #if HAVE(SANDBOX_STATE_FLAGS)
             (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+                (allow mach-message-send (kernel-mig-routines-downlevels))
                 (allow mach-message-send (kernel-mig-routines-iokit)))
+            (with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
+                (allow mach-message-send (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))
 #else
             (allow mach-message-send (kernel-mig-routines-iokit))
 #endif
-            (allow mach-message-send (with report) (with telemetry) (kernel-mig-routines-possibly-in-use))
-                
 #if HAVE(SANDBOX_STATE_FLAGS) && HAVE(MACH_RANGE_CREATE)
             ;; <rdar://105161083>
             (with-filter (require-not (webcontent-process-launched))


### PR DESCRIPTION
#### 3a0472d22a282b9d2542854ad6b21773c8646b7c
<pre>
[macOS] Block MIG syscalls in the WebContent process sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=263659">https://bugs.webkit.org/show_bug.cgi?id=263659</a>
rdar://117475500

Reviewed by Brent Fulgham.

Based on telemetry, block MIG syscalls in the WebContent process sandbox on macOS.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/269813@main">https://commits.webkit.org/269813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90cfecd15ed2e1f5a38fcfb38029a4dc17245ce5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21718 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22308 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26279 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/987 "Passed tests") | | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21444 "Found 2 new API test failures: TestWebKitAPI.ServiceWorker.WindowClientNavigate, TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25289 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18685 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/936 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->