### PR TITLE
Defer to non-anonymous ancestor when determining selection background color for anonymous blocks.

### DIFF
--- a/LayoutTests/fast/selectors/selection-gap-background-color-expected.html
+++ b/LayoutTests/fast/selectors/selection-gap-background-color-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selection gap custom background color</title>
+
+<style>
+::selection {
+    background-color: #FF0000;
+}
+</style>
+
+<div>This test passes if the gap to the right of this sentence -></div>
+<p>
+Is colored with the same background color as this text.
+</p>
+
+<script>
+document.execCommand("SelectAll");
+</script>

--- a/LayoutTests/fast/selectors/selection-gap-background-color.html
+++ b/LayoutTests/fast/selectors/selection-gap-background-color.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<title>Selection gap custom background color</title>
+<meta name="assert" content="Selection gaps between blocks of different widths are colored with an ancestor's ::selection pseudo-element background color.">
+
+<body>
+
+<style>
+::selection {
+    background-color: red;
+}
+</style>
+
+This test passes if the gap to the right of this sentence ->
+<p>
+Is colored with the same background color as this text.
+</p>
+
+<script>
+window.addEventListener('load', async event => {
+	document.execCommand("SelectAll");
+});
+</script>
+
+</body>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1708,9 +1708,15 @@ Color RenderElement::selectionBackgroundColor() const
     if (frame().selection().shouldShowBlockCursor() && frame().selection().isCaret())
         return theme().transformSelectionBackgroundColor(style().visitedDependentColorWithColorFilter(CSSPropertyColor), styleColorOptions());
 
-    std::unique_ptr<RenderStyle> pseudoStyle = selectionPseudoStyle();
-    if (pseudoStyle && pseudoStyle->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor).isValid())
-        return theme().transformSelectionBackgroundColor(pseudoStyle->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor), styleColorOptions());
+    auto pseudoStyleCandidate = this;
+    if (pseudoStyleCandidate->isAnonymous())
+        pseudoStyleCandidate = pseudoStyleCandidate->firstNonAnonymousAncestor();
+
+    if (pseudoStyleCandidate) {
+        std::unique_ptr<RenderStyle> pseudoStyle = pseudoStyleCandidate->selectionPseudoStyle();
+        if (pseudoStyle && pseudoStyle->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor).isValid())
+            return theme().transformSelectionBackgroundColor(pseudoStyle->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor), styleColorOptions());
+    }
 
     if (frame().selection().isFocusedAndActive())
         return theme().activeSelectionBackgroundColor(styleColorOptions());


### PR DESCRIPTION
#### 76bb9606ee1b4724d5df8ad4b259092268af8fe0
<pre>
Defer to non-anonymous ancestor when determining selection background color for anonymous blocks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263658">https://bugs.webkit.org/show_bug.cgi?id=263658</a>

Reviewed by Ryosuke Niwa.

There is a precedent for anonymous blocks deferring to their non-anonymous
ancestors when deriving selectionBackgroundColor. For example RenderText
defers to its ancestor in order to ensure text blocks are colored correctly
when a custom color has been set with a Selection pseudo-element. This
change addresses the failure to defer to an ancestor when painting the
selection on gaps between two blocks with uneven widths. By deferring to
nonAnonymousAncestor at the RenderElement level, it should ensure a fix for
bug #263658 as well as potentially alleviating failures in other areas that
have not yet been diagnosed. Because the change is limited to anonymous nodes,
and because the selectionBackgroundColor is only consulted specifically when
managing the painting of selected ranges, I believe this is a low risk proposal
which cleanly addresses the linked bug report.

* LayoutTests/platform/mac/fast/selectors/selection-gap-background-color-expected.png: Added.
* LayoutTests/platform/mac/fast/selectors/selection-gap-background-color.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::selectionBackgroundColor const):

Canonical link: <a href="https://commits.webkit.org/271129@main">https://commits.webkit.org/271129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e275da6fe04874b9da83e3e701d0940a2707f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29671 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24918 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30307 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2559 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28498 "Found 8 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/long-expires, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6599 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->