### PR TITLE
REGRESSION(269608@main): 32-bit shifts are used to zero out upper 32-bits after all.

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1378,7 +1378,6 @@
 		86ADD1460FDDEA980006EEC2 /* MacroAssemblerARMv7.h in Headers */ = {isa = PBXBuildFile; fileRef = 86ADD1440FDDEA980006EEC2 /* MacroAssemblerARMv7.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86B8690124B89EA400487C95 /* PrivateFieldPutKind.h in Headers */ = {isa = PBXBuildFile; fileRef = 86B8690024B89EA400487C95 /* PrivateFieldPutKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86C36EEA0EE1289D00B3DF59 /* MacroAssembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C36EE90EE1289D00B3DF59 /* MacroAssembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		86C568E111A213EE0007F7F0 /* MacroAssemblerMIPS.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C568DE11A213EE0007F7F0 /* MacroAssemblerMIPS.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86C568E211A213EE0007F7F0 /* MIPSAssembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C568DF11A213EE0007F7F0 /* MIPSAssembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86C568E211A213EE0007F7FF /* MIPSRegisters.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C568DF11A213EE0007F7FF /* MIPSRegisters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86CC85A10EE79A4700288682 /* JITInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 86CC85A00EE79A4700288682 /* JITInlines.h */; };
@@ -5969,6 +5968,11 @@
 		FEC5797423105F4200BCA83F /* Integrity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Integrity.cpp; sourceTree = "<group>"; };
 		FEC5797523105F4300BCA83F /* Integrity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Integrity.h; sourceTree = "<group>"; };
 		FEC579772310954B00BCA83F /* IntegrityInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegrityInlines.h; sourceTree = "<group>"; };
+		FEC60FE92AE971FD003B7B31 /* MacroAssemblerRISCV64.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MacroAssemblerRISCV64.cpp; sourceTree = "<group>"; };
+		FEC60FEC2AE9722C003B7B31 /* MacroAssemblerRISCV64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MacroAssemblerRISCV64.h; sourceTree = "<group>"; };
+		FEC60FED2AE97245003B7B31 /* MacroAssemblerMIPS.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MacroAssemblerMIPS.cpp; sourceTree = "<group>"; };
+		FEC60FEE2AE9726E003B7B31 /* RISCV64Registers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RISCV64Registers.h; sourceTree = "<group>"; };
+		FEC60FEF2AE9726E003B7B31 /* RISCV64Assembler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RISCV64Assembler.h; sourceTree = "<group>"; };
 		FECB8B251D25BB6E006F2463 /* FunctionOverridesTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FunctionOverridesTest.cpp; path = API/tests/FunctionOverridesTest.cpp; sourceTree = "<group>"; };
 		FECB8B261D25BB6E006F2463 /* FunctionOverridesTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FunctionOverridesTest.h; path = API/tests/FunctionOverridesTest.h; sourceTree = "<group>"; };
 		FECB8B291D25CABB006F2463 /* testapi-function-overrides.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "testapi-function-overrides.js"; path = "API/tests/testapi-function-overrides.js"; sourceTree = "<group>"; };
@@ -9272,9 +9276,12 @@
 				0F6DB7EB1D617D0F00CDBF8E /* MacroAssemblerCodeRef.cpp */,
 				863B23DF0FC60E6200703AA4 /* MacroAssemblerCodeRef.h */,
 				E380A76B1DCD7195000F89E6 /* MacroAssemblerHelpers.h */,
+				FEC60FED2AE97245003B7B31 /* MacroAssemblerMIPS.cpp */,
 				86C568DE11A213EE0007F7F0 /* MacroAssemblerMIPS.h */,
 				FE68C6351B90DDD90042BCB3 /* MacroAssemblerPrinter.cpp */,
 				FE68C6361B90DDD90042BCB3 /* MacroAssemblerPrinter.h */,
+				FEC60FE92AE971FD003B7B31 /* MacroAssemblerRISCV64.cpp */,
+				FEC60FEC2AE9722C003B7B31 /* MacroAssemblerRISCV64.h */,
 				860161E10F3A83C100F84710 /* MacroAssemblerX86_64.h */,
 				A7A4AE0717973B26005612B1 /* MacroAssemblerX86Common.cpp */,
 				860161E20F3A83C100F84710 /* MacroAssemblerX86Common.h */,
@@ -9292,6 +9299,8 @@
 				FE10AAE91F44D510009DEDC5 /* ProbeStack.cpp */,
 				FE10AAEA1F44D512009DEDC5 /* ProbeStack.h */,
 				9688CB140ED12B4E001D6499 /* RegisterInfo.h */,
+				FEC60FEF2AE9726E003B7B31 /* RISCV64Assembler.h */,
+				FEC60FEE2AE9726E003B7B31 /* RISCV64Registers.h */,
 				52CAEC732790B8F600DDBAAF /* SecureARM64EHashPins.cpp */,
 				52CAEC742790B8F600DDBAAF /* SecureARM64EHashPins.h */,
 				52CAEC722790B8F600DDBAAF /* SecureARM64EHashPinsInlines.h */,
@@ -11316,7 +11325,6 @@
 				86ADD1460FDDEA980006EEC2 /* MacroAssemblerARMv7.h in Headers */,
 				863B23E00FC6118900703AA4 /* MacroAssemblerCodeRef.h in Headers */,
 				E32AB2441DCD75F400D7533A /* MacroAssemblerHelpers.h in Headers */,
-				86C568E111A213EE0007F7F0 /* MacroAssemblerMIPS.h in Headers */,
 				FE68C6371B90DE040042BCB3 /* MacroAssemblerPrinter.h in Headers */,
 				860161E50F3A83C100F84710 /* MacroAssemblerX86_64.h in Headers */,
 				860161E60F3A83C100F84710 /* MacroAssemblerX86Common.h in Headers */,

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -879,8 +879,6 @@ public:
 
     void lshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.lsl<32>(dest, src, imm.m_value & 0x1f);
     }
 
@@ -1219,8 +1217,6 @@ public:
 
     void rotateRight32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.ror<32>(dest, src, imm.m_value & 31);
     }
 
@@ -1258,8 +1254,6 @@ public:
 
     void rshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.asr<32>(dest, src, imm.m_value & 0x1f);
     }
 
@@ -1424,8 +1418,6 @@ public:
     
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.lsr<32>(dest, src, imm.m_value & 0x1f);
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
@@ -434,15 +434,11 @@ public:
 
     void lshift32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.sll(dest, dest, imm.m_value);
     }
 
     void lshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.sll(dest, src, imm.m_value);
     }
 
@@ -669,15 +665,11 @@ public:
 
     void rshift32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.sra(dest, dest, imm.m_value);
     }
 
     void rshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.sra(dest, src, imm.m_value);
     }
 
@@ -693,15 +685,11 @@ public:
 
     void urshift32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.srl(dest, dest, imm.m_value);
     }
 
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.srl(dest, src, imm.m_value);
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -650,8 +650,6 @@ public:
 
     void lshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.slliwInsn(dest, src, uint32_t(imm.m_value & ((1 << 5) - 1)));
         m_assembler.maskRegister<32>(dest);
     }
@@ -710,8 +708,6 @@ public:
 
     void rshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.sraiwInsn(dest, src, uint32_t(imm.m_value & ((1 << 5) - 1)));
         m_assembler.maskRegister<32>(dest);
     }
@@ -756,8 +752,6 @@ public:
 
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return move(src, dest);
         m_assembler.srliwInsn(dest, src, uint32_t(imm.m_value & ((1 << 5) - 1)));
         m_assembler.maskRegister<32>(dest);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -471,8 +471,6 @@ public:
 
     void lshift32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.shll_i8r(imm.m_value, dest);
     }
     
@@ -768,8 +766,6 @@ public:
 
     void rshift32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.sarl_i8r(imm.m_value, dest);
     }
     
@@ -805,8 +801,6 @@ public:
 
     void urshift32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.shrl_i8r(imm.m_value, dest);
     }
     
@@ -818,8 +812,6 @@ public:
 
     void rotateRight32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.rorl_i8r(imm.m_value, dest);
     }
 
@@ -853,8 +845,6 @@ public:
 
     void rotateLeft32(TrustedImm32 imm, RegisterID dest)
     {
-        if (UNLIKELY(!imm.m_value))
-            return;
         m_assembler.roll_i8r(imm.m_value, dest);
     }
 


### PR DESCRIPTION
#### 748f4d4620ab6f3e533219ec3d365d648aca2ff0
<pre>
REGRESSION(269608@main): 32-bit shifts are used to zero out upper 32-bits after all.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263660">https://bugs.webkit.org/show_bug.cgi?id=263660</a>
rdar://117475957

Reviewed by Yusuke Suzuki.

In <a href="https://commits.webkit.org/269608@main">https://commits.webkit.org/269608@main</a>, we added a peephole optimization to reduce shifts
to moves if the shift amount is 0.  However, this is only correct if shift instructions are
never used indirectly to zero out the upper 32-bits of the register.  It turns out that the
JIT backends do rely on 32-bit shifts to zero out the upper 32-bits.

Changes made:
1. Revert 269608@main 32-bit shift changes.
4. Add some MIPS and RISCV64 files to the Xcode project to make it easier to work with them
   in Xcode.  Also ensure that while they are added to the project, they aren&apos;t included as
   part of any build.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::lshift32):
(JSC::MacroAssemblerARM64::rotateRight32):
(JSC::MacroAssemblerARM64::rshift32):
(JSC::MacroAssemblerARM64::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h:
(JSC::MacroAssemblerMIPS::lshift32):
(JSC::MacroAssemblerMIPS::rshift32):
(JSC::MacroAssemblerMIPS::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::lshift32):
(JSC::MacroAssemblerRISCV64::rshift32):
(JSC::MacroAssemblerRISCV64::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::lshift32):
(JSC::MacroAssemblerX86Common::rshift32):
(JSC::MacroAssemblerX86Common::urshift32):
(JSC::MacroAssemblerX86Common::rotateRight32):
(JSC::MacroAssemblerX86Common::rotateLeft32):

Canonical link: <a href="https://commits.webkit.org/269785@main">https://commits.webkit.org/269785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccb0a2953a382be4c5fd8c7c584329dd57c85a16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21752 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26316 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21285 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20507 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25322 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22907 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/998 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30296 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/970 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6251 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1411 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30248 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3021 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1278 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6145 "Passed tests") | 
<!--EWS-Status-Bubble-End-->