### PR TITLE
New test (269129@main): TestWebKitAPI.WebArchive.SaveResourcesBlobURL is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
@@ -564,11 +564,12 @@ TEST(WebArchive, SaveResourcesBlobURL)
             } else {
                 // Image file from img and the second iframe element.
                 unsigned replacementPathCount = 0;
-                NSRange range = [savedMainResource rangeOfString:replacementPath];
+                NSString *savedMainResourceCopy = [NSString stringWithString:savedMainResource];
+                NSRange range = [savedMainResourceCopy rangeOfString:replacementPath];
                 while (range.location != NSNotFound) {
                     ++replacementPathCount;
-                    savedMainResource = [savedMainResource substringFromIndex:range.location + 1];
-                    range = [savedMainResource rangeOfString:replacementPath];
+                    savedMainResourceCopy = [savedMainResourceCopy substringFromIndex:range.location + 1];
+                    range = [savedMainResourceCopy rangeOfString:replacementPath];
                 }
                 EXPECT_EQ(2u, replacementPathCount);
             }


### PR DESCRIPTION
#### 5d29635a113512df8b5905d79e48ff25a339f820
<pre>
New test (269129@main): TestWebKitAPI.WebArchive.SaveResourcesBlobURL is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263607">https://bugs.webkit.org/show_bug.cgi?id=263607</a>
rdar://117431471

Reviewed by Ryosuke Niwa.

We currently edit savedMainResource string directly when searching for a target string. However, savedMainResource may
be checked later, where the test expects savedMainResource to contain the original content (i.e. not modified). To
fix this, we make a copy of savedMainResource and perform editing on the copy.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/269816@main">https://commits.webkit.org/269816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2a5e9ab4a4d8641f0cb8e9f5e8c724a4d8c3f06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21737 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22321 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26300 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21269 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25307 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18700 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/955 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5657 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->