### PR TITLE
[WebGPU] WGPUTextureFormat_BC2RGBAUnorm and WGPUTextureFormat_BC2RGBAUnormSrgb have the wrong block size in Texture::blockSize

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -1638,7 +1638,7 @@ uint32_t Texture::texelBlockSize(WGPUTextureFormat format) // Bytes
         return 8;
     case WGPUTextureFormat_BC2RGBAUnorm:
     case WGPUTextureFormat_BC2RGBAUnormSrgb:
-        return 8;
+        return 16;
     case WGPUTextureFormat_BC3RGBAUnorm:
     case WGPUTextureFormat_BC3RGBAUnormSrgb:
         return 16;
@@ -1658,12 +1658,12 @@ uint32_t Texture::texelBlockSize(WGPUTextureFormat format) // Bytes
     case WGPUTextureFormat_ETC2RGB8UnormSrgb:
     case WGPUTextureFormat_ETC2RGB8A1Unorm:
     case WGPUTextureFormat_ETC2RGB8A1UnormSrgb:
-    case WGPUTextureFormat_ETC2RGBA8Unorm:
-    case WGPUTextureFormat_ETC2RGBA8UnormSrgb:
         return 8;
     case WGPUTextureFormat_EACR11Unorm:
     case WGPUTextureFormat_EACR11Snorm:
         return 8;
+    case WGPUTextureFormat_ETC2RGBA8Unorm:
+    case WGPUTextureFormat_ETC2RGBA8UnormSrgb:
     case WGPUTextureFormat_EACRG11Unorm:
     case WGPUTextureFormat_EACRG11Snorm:
         return 16;


### PR DESCRIPTION
#### 9444546bdb0be60326bc23af49a738aa82170745
<pre>
[WebGPU] WGPUTextureFormat_BC2RGBAUnorm and WGPUTextureFormat_BC2RGBAUnormSrgb have the wrong block size in Texture::blockSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=263672">https://bugs.webkit.org/show_bug.cgi?id=263672</a>
&lt;radar://117483503&gt;

Reviewed by Tadeu Zagallo.

WGPUTextureFormat_BC2RGBAUnorm* block size was wrong along with
WGPUTextureFormat_BC2RGBAUnorm* as well.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::texelBlockSize):

Canonical link: <a href="https://commits.webkit.org/269775@main">https://commits.webkit.org/269775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/166815febb3e5f5093e1b2f0badc25930070c799

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21742 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24088 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26305 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/988 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/960 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5616 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->