### PR TITLE
[WGSL] Make number parsing conform to the spec

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -100,6 +100,7 @@ struct ConstantValue : BaseValue {
     bool isNumber() const { return isInt() || std::holds_alternative<double>(*this); }
     bool isVector() const { return std::holds_alternative<ConstantVector>(*this); }
     bool isMatrix() const { return std::holds_alternative<ConstantMatrix>(*this); }
+    bool isArray() const { return std::holds_alternative<ConstantArray>(*this); }
 
     bool toBool() const { return std::get<bool>(*this); }
     int64_t toInt() const
@@ -121,5 +122,24 @@ struct ConstantValue : BaseValue {
         return std::get<ConstantVector>(*this);
     }
 };
+
+template<typename To, typename From>
+std::optional<To> convertInteger(From value)
+{
+    auto result = Checked<To, RecordOverflow>(value);
+    if (UNLIKELY(result.hasOverflowed()))
+        return std::nullopt;
+    return { result.value() };
+}
+
+template<typename To, typename From>
+std::optional<To> convertFloat(From value)
+{
+    if (value > std::numeric_limits<To>::max())
+        return std::nullopt;
+    if (value < std::numeric_limits<To>::min())
+        return { 0 };
+    return { value };
+}
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -26,7 +26,10 @@
 #include "config.h"
 #include "Lexer.h"
 
+#include "ConstantValue.h"
+#include <charconv>
 #include <wtf/SortedArrayMap.h>
+#include <wtf/dtoa.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -191,26 +194,6 @@ Token Lexer<T>::nextToken()
         default:
             return makeToken(TokenType::Slash);
         }
-    case '.': {
-        shift();
-        unsigned offset = currentOffset();
-        std::optional<uint64_t> postPeriod = parseDecimalInteger();
-        if (!postPeriod)
-            return makeToken(TokenType::Period);
-        double literalValue = postPeriod.value();
-        // FIXME: verify that there is no unnaceptable precision loss
-        // It should be tested in the CTS, for now let's get something that works
-        // Also the same code appears in a few places below.
-        literalValue /= pow(10, currentOffset() - offset);
-        std::optional<int64_t> exponent = parseDecimalFloatExponent();
-        if (exponent)
-            literalValue *= pow(10, exponent.value());
-        if (m_current == 'f') {
-            shift();
-            return makeLiteralToken(TokenType::FloatLiteral, literalValue);
-        }
-        return makeLiteralToken(TokenType::AbstractFloatLiteral, literalValue);
-    }
     case '-':
         shift();
         switch (m_current) {
@@ -259,94 +242,13 @@ Token Lexer<T>::nextToken()
         default:
             return makeToken(TokenType::Or);
         }
-    case '0': {
-        shift();
-        double literalValue = 0;
-        if (m_current == 'x') {
-            // FIXME: add support for hexadecimal floating point literals
-            shift();
-            bool hexNumberIsEmpty = true;
-            while (isASCIIHexDigit(m_current)) {
-                literalValue *= 16;
-                literalValue += toASCIIHexValue(m_current);
-                shift();
-                hexNumberIsEmpty = false;
-            }
-            if (hexNumberIsEmpty)
-                break;
-            return parseIntegerLiteralSuffix(literalValue);
-        }
-
-        bool isFloatingPoint = false;
-        if (isASCIIDigit(m_current) || m_current == '.' || m_current == 'e' || m_current == 'E') {
-            std::optional<uint64_t> integerPart = parseDecimalInteger();
-            if (integerPart)
-                literalValue = integerPart.value();
-            if (m_current == '.') {
-                isFloatingPoint = true;
-                shift();
-                // FIXME: share this code with the [1-9] case
-                unsigned offset = currentOffset();
-                std::optional<uint64_t> postPeriod = parseDecimalInteger();
-                if (postPeriod) {
-                    double fractionalPart = postPeriod.value();
-                    fractionalPart /= pow(10, currentOffset() - offset);
-                    literalValue += fractionalPart;
-                }
-                if (m_current == 'f') {
-                    shift();
-                    return makeLiteralToken(TokenType::FloatLiteral, literalValue);
-                }
-            }
-            if (std::optional<int64_t> exponent = parseDecimalFloatExponent()) {
-                isFloatingPoint = true;
-                literalValue *= pow(10, exponent.value());
-            }
-            // Decimal integers are not allowed to start with 0.
-            if (!isFloatingPoint)
-                return makeToken(TokenType::Invalid);
-        }
-        if (m_current == 'f') {
-            shift();
-            return makeLiteralToken(TokenType::FloatLiteral, literalValue);
-        }
-        if (isFloatingPoint)
-            return makeLiteralToken(TokenType::AbstractFloatLiteral, literalValue);
-        return parseIntegerLiteralSuffix(literalValue);
-    }
     case '~':
         shift();
         return makeToken(TokenType::Tilde);
     default:
-        if (isASCIIDigit(m_current)) {
-            std::optional<uint64_t> value = parseDecimalInteger();
-            if (!value)
-                return makeToken(TokenType::Invalid);
-            double literalValue = value.value();
-            bool isFloatingPoint = false;
-            if (m_current == '.') {
-                isFloatingPoint = true;
-                shift();
-                unsigned offset = currentOffset();
-                std::optional<uint64_t> postPeriod = parseDecimalInteger();
-                if (postPeriod) {
-                    double fractionalPart = postPeriod.value();
-                    fractionalPart /= pow(10, currentOffset() - offset);
-                    literalValue += fractionalPart;
-                }
-            }
-            if (std::optional<int64_t> exponent = parseDecimalFloatExponent()) {
-                isFloatingPoint = true;
-                literalValue *= pow(10, exponent.value());
-            }
-            if (m_current == 'f') {
-                shift();
-                return makeLiteralToken(TokenType::FloatLiteral, literalValue);
-            }
-            if (!isFloatingPoint)
-                return parseIntegerLiteralSuffix(literalValue);
-            return makeLiteralToken(TokenType::AbstractFloatLiteral, literalValue);
-        } else if (isIdentifierStart(m_current)) {
+        if (isASCIIDigit(m_current) || m_current == '.')
+            return lexNumber();
+        if (isIdentifierStart(m_current)) {
             const T* startOfToken = m_code;
             shift();
             while (isIdentifierContinue(m_current))
@@ -633,69 +535,454 @@ bool Lexer<T>::isAtEndOfFile() const
 }
 
 template <typename T>
-std::optional<uint64_t> Lexer<T>::parseDecimalInteger()
+Token Lexer<T>::lexNumber()
 {
-    if (!isASCIIDigit(m_current))
-        return std::nullopt;
+    /* Grammar:
+    decimal_int_literal:
+    | /0[iu]?/
+    | /[1-9][0-9]*[iu]?/
 
-    CheckedUint64 value = 0;
-    while (isASCIIDigit(m_current)) {
-        value *= 10ull;
-        value += readDecimal(m_current);
+    hex_int_literal :
+    | /0[xX][0-9a-fA-F]+[iu]?/
+
+    decimal_float_literal:
+    | /0[fh]/`
+    | /[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?/
+    | /[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?/
+    | /[0-9]+[eE][+-]?[0-9]+[fh]?/
+    | /[1-9][0-9]*[fh]/
+
+    hex_float_literal:
+    | /0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9]+[fh]?)?/
+    | /0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP][+-]?[0-9]+[fh]?)?/
+    | /0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+[fh]?/
+    */
+
+    /* State machine:
+    Start -> InitZero (0)
+          -> Decimal (1-9)
+          -> FloatFractNoIntegral(.)
+
+    InitZero -> End (i, u, f, h, ∅)
+             -> Hex (x, X)
+             -> Float (0-9)
+             -> FloatFract(.)
+             -> FloatExponent(e, E)
+
+    Decimal -> End (i, u, f, h, ∅)
+            -> Decimal (0-9)
+            -> FloatFract(.)
+            -> FloatExponent(e, E)
+
+    Float -> Float (0-9)
+          -> FloatFract(.)
+          -> FloatExponent(e, E)
+
+    FloatFractNoIntegral -> FloatFract (0-9)
+                         -> End(∅)
+
+    FloatFract -> FloatFract (0-9)
+               -> FloatExponent(e, E)
+               -> End(f, h, ∅)
+
+    FloatExponent -> FloatExponentPostSign(+, -)
+                  -> FloatExponentNonEmpty(0-9)
+
+    FloatExponentPostSign -> FloatExponentNonEmpty(0-9)
+
+    FloatExponentNonEmpty -> FloatExponentNonEmpty(0-9)
+                          -> End(f, h, ∅)
+
+    Hex -> HexNonEmpty(0-9, a-f, A-F)
+        -> HexFloatFractNoIntegral(.)
+
+    HexNonEmpty -> HexNonEmpty(0-9, a-f, A-F)
+                -> End(i, u, ∅)
+                -> HexFloatFract(.)
+                -> HexFloatExponentRequireSuffix(p, P)
+
+    HexFloatFractNoIntegral -> HexFloatFract(0-9, a-f, A-F)
+
+    HexFloatFract -> HexFloatFract(0-9, a-f, A-F)
+                  -> HexFloatExponent(p, P)
+                  -> End(∅)
+
+    HexFloatExponent -> HexFloatExponentNonEmpty(0-9)
+                     -> HexFloatExponentPostSign(+, -)
+
+    HexFloatExponentPostSign -> HexFloatExponentNonEmpty(0-9)
+
+    HexFloatExponentNonEmpty -> HexFloatExponentNonEmpty(0-9)
+                             -> End(f, h, ∅)
+
+    HexFloatExponentRequireSuffix -> HexFloatExponentRequireSuffixNonEmpty(0-9)
+                                  -> HexFloatExponentRequireSuffixPostSign(+, -)
+
+    HexFloatExponentRequireSuffixPostSign -> HexFloatExponentRequireSuffixNonEmpty(0-9)
+
+    HexFloatExponentRequireSuffixNonEmpty -> HexFloatExponentRequireSuffixNonEmpty(0-9)
+                                          -> End(f, h)
+    */
+
+    enum State : uint8_t {
+        Start,
+
+        InitZero,
+        Decimal,
+
+        Float,
+        FloatFractNoIntegral,
+        FloatFract,
+        FloatExponent,
+        FloatExponentPostSign,
+        FloatExponentNonEmpty,
+
+        Hex,
+        HexNonEmpty,
+        HexFloatFractNoIntegral,
+        HexFloatFract,
+        HexFloatExponent,
+        HexFloatExponentPostSign,
+        HexFloatExponentNonEmpty,
+        HexFloatExponentRequireSuffix,
+        HexFloatExponentRequireSuffixPostSign,
+        HexFloatExponentRequireSuffixNonEmpty,
+
+        End,
+        EndNoShift,
+    };
+
+    auto state = Start;
+    char suffix = '\0';
+    char exponentSign = '\0';
+    bool isHex = false;
+    const T* integral = m_code;
+    const T* fract = nullptr;
+    const T* exponent = nullptr;
+
+    while (m_code != m_codeEnd) {
+        switch (state) {
+        case Start:
+            switch (m_current) {
+            case '0':
+                state = InitZero;
+                break;
+            case '.':
+                state = FloatFractNoIntegral;
+                break;
+            default:
+                ASSERT(isASCIIDigit(m_current));
+                state = Decimal;
+                break;
+            }
+            break;
+
+        case InitZero:
+            switch (m_current) {
+            case 'i':
+            case 'u':
+            case 'f':
+            case 'h':
+                state = End;
+                suffix = m_current;
+                break;
+
+            case 'x':
+            case 'X':
+                state = Hex;
+                break;
+
+            case '.':
+                state = FloatFract;
+                break;
+
+            case 'e':
+            case 'E':
+                state = FloatExponent;
+                break;
+
+            default:
+                if (isASCIIDigit(m_current))
+                    state = Float;
+                else
+                    state = EndNoShift;
+            }
+            break;
+
+        case Decimal:
+            switch (m_current) {
+            case 'i':
+            case 'u':
+            case 'f':
+            case 'h':
+                state = End;
+                suffix = m_current;
+                break;
+
+            case '.':
+                state = FloatFract;
+                break;
+
+            case 'e':
+            case 'E':
+                state = FloatExponent;
+                break;
+
+            default:
+                if (!isASCIIDigit(m_current))
+                    state = EndNoShift;
+            }
+            break;
+
+        case Float:
+            switch (m_current) {
+            case '.':
+                state = FloatFract;
+                break;
+
+            case 'e':
+            case 'E':
+                state = FloatExponent;
+                break;
+
+            default:
+                if (!isASCIIDigit(m_current))
+                    return makeToken(TokenType::Invalid);
+            }
+            break;
+        case FloatFractNoIntegral:
+            fract = m_code;
+            if (!isASCIIDigit(m_current))
+                return makeToken(TokenType::Period);
+            state = FloatFract;
+            break;
+        case FloatFract:
+            if (!fract)
+                fract = m_code;
+            switch (m_current) {
+            case 'f':
+            case 'h':
+                state = End;
+                suffix = m_current;
+                break;
+
+            case 'e':
+            case 'E':
+                state = FloatExponent;
+                break;
+
+            default:
+                if (!isASCIIDigit(m_current))
+                    state = EndNoShift;
+            }
+            break;
+        case FloatExponent:
+            exponent = m_code;
+            switch (m_current) {
+            case '+':
+            case '-':
+                exponentSign = m_current;
+                state = FloatExponentPostSign;
+                break;
+            default:
+                if (!isASCIIDigit(m_current))
+                    return makeToken(TokenType::Invalid);
+                state = FloatExponentNonEmpty;
+            }
+            break;
+        case FloatExponentPostSign:
+            if (exponentSign == '+')
+                exponent = m_code;
+            if (!isASCIIDigit(m_current))
+                return makeToken(TokenType::Invalid);
+            state = FloatExponentNonEmpty;
+            break;
+        case FloatExponentNonEmpty:
+            switch (m_current) {
+            case 'f':
+            case 'h':
+                state = End;
+                suffix = m_current;
+                break;
+            default:
+                if (!isASCIIDigit(m_current))
+                    state = EndNoShift;
+            }
+            break;
+        case Hex:
+            isHex = true;
+            integral = m_code;
+            if (m_current == '.')
+                state = HexFloatFractNoIntegral;
+            else if (isASCIIHexDigit(m_current))
+                state = HexNonEmpty;
+            else
+                return makeToken(TokenType::Invalid);
+            break;
+        case HexNonEmpty:
+            switch (m_current) {
+            case 'i':
+            case 'u':
+                state = End;
+                suffix = m_current;
+                break;
+
+            case 'p':
+            case 'P':
+                state = HexFloatExponentRequireSuffix;
+                break;
+
+            case '.':
+                state = HexFloatFract;
+                break;
+
+            default:
+                if (!isASCIIHexDigit(m_current))
+                    state = EndNoShift;
+            }
+            break;
+        case HexFloatFractNoIntegral:
+            fract = m_code;
+            if (!isASCIIHexDigit(m_current))
+                return makeToken(TokenType::Invalid);
+            state = HexFloatFract;
+            break;
+        case HexFloatFract:
+            if (!fract)
+                fract = m_code;
+            if (isASCIIHexDigit(m_current))
+                break;
+            if (m_current == 'p' || m_current == 'P')
+                state = HexFloatExponent;
+            else
+                state = EndNoShift;
+            break;
+        case HexFloatExponent:
+            exponent = m_code;
+            if (isASCIIDigit(m_current))
+                state = HexFloatExponentNonEmpty;
+            else if (m_current == '+' || m_current == '-') {
+                exponentSign = m_current;
+                state = HexFloatExponentPostSign;
+            } else
+                return makeToken(TokenType::Invalid);
+            break;
+        case HexFloatExponentPostSign:
+            if (exponentSign == '+')
+                exponent = m_code;
+            if (isASCIIDigit(m_current)) {
+                state = HexFloatExponentNonEmpty;
+                break;
+            }
+            return makeToken(TokenType::Invalid);
+        case HexFloatExponentNonEmpty:
+            if (isASCIIDigit(m_current))
+                state = HexFloatExponentNonEmpty;
+            else if (m_current == 'f' || m_current == 'h') {
+                state = End;
+                suffix = m_current;
+            } else
+                state = EndNoShift;
+            break;
+        case HexFloatExponentRequireSuffix:
+            exponent = m_code;
+            if (isASCIIDigit(m_current))
+                state = HexFloatExponentRequireSuffixNonEmpty;
+            else if (m_current == '+' || m_current == '-') {
+                exponentSign = m_current;
+                state = HexFloatExponentRequireSuffixPostSign;
+            } else
+                return makeToken(TokenType::Invalid);
+            break;
+        case HexFloatExponentRequireSuffixPostSign:
+            if (exponentSign == '+')
+                exponent = m_code;
+            if (isASCIIDigit(m_current)) {
+                state = HexFloatExponentRequireSuffixNonEmpty;
+                break;
+            }
+            return makeToken(TokenType::Invalid);
+        case HexFloatExponentRequireSuffixNonEmpty:
+            if (isASCIIDigit(m_current))
+                state = HexFloatExponentNonEmpty;
+            else if (m_current == 'f' || m_current == 'h') {
+                state = End;
+                suffix = m_current;
+            } else
+                return makeToken(TokenType::Invalid);
+            break;
+        case End:
+        case EndNoShift:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        if (state == EndNoShift)
+            break;
         shift();
+        if (state == End)
+            break;
     }
-    if (value.hasOverflowed())
-        return std::nullopt;
-    return { value.value() };
+
+    const auto& convert = [&](auto value) -> Token {
+        switch (suffix) {
+        case 'i': {
+            if constexpr (std::is_integral_v<decltype(value)>) {
+                if (auto result = convertInteger<int>(value))
+                    return makeLiteralToken(TokenType::IntegerLiteralSigned, *result);
+            }
+            return makeToken(TokenType::Invalid);
+        }
+        case 'u': {
+            if constexpr (std::is_integral_v<decltype(value)>) {
+                if (auto result = convertInteger<unsigned>(value))
+                    return makeLiteralToken(TokenType::IntegerLiteralUnsigned, *result);
+            }
+            break;
+        }
+        case 'f': {
+            if (auto result = convertFloat<float>(value))
+                return makeLiteralToken(TokenType::FloatLiteral, *result);
+            break;
+        }
+        case 'h':
+            // FIXME: add support for f16
+            break;
+        default:
+            if constexpr (std::is_floating_point_v<decltype(value)>) {
+                if (auto result = convertFloat<double>(value))
+                    return makeLiteralToken(TokenType::AbstractFloatLiteral, *result);
+            } else {
+                if (auto result = convertInteger<int64_t>(value))
+                    return makeLiteralToken(TokenType::IntegerLiteral, *result);
+            }
+        }
+        return makeToken(TokenType::Invalid);
+    };
+
+    auto* end = m_code - (suffix ? 1 : 0);
+    if (!fract && !exponent) {
+        int64_t result;
+        auto base = isHex ? 16 : 10;
+        // FIXME: this will not work for utf16
+        auto remaining = std::from_chars(bitwise_cast<const char*>(integral), bitwise_cast<const char*>(end), result, base);
+        ASSERT(remaining.ptr == bitwise_cast<const char*>(end));
+        if (remaining.ec == std::errc::result_out_of_range)
+            return makeToken(TokenType::Invalid);
+        return convert(result);
+    }
+
+    if (!isHex) {
+        size_t parsedLength;
+        double result = parseDouble(integral, m_code - integral, parsedLength);
+        ASSERT(integral + parsedLength == end);
+        return convert(result);
+    }
+
+    char* parseEnd;
+    double result = std::strtod(bitwise_cast<const char*>(integral) - 2, &parseEnd);
+    ASSERT(parseEnd == bitwise_cast<const char*>(end));
+    return convert(result);
 }
-
-// Parse pattern (e|E)(\+|-)?[0-9]+f? if it is present, and return the exponent
-template <typename T>
-std::optional<int64_t> Lexer<T>::parseDecimalFloatExponent()
-{
-    T char1 = peek(1);
-    T char2 = peek(2);
-    // Check for pattern (e|E)(\+|-)?[0-9]+
-    if (m_current != 'e' && m_current != 'E')
-        return std::nullopt;
-    if (char1 == '+' || char1 == '-') {
-        if (!isASCIIDigit(char2))
-            return std::nullopt;
-    } else if (!isASCIIDigit(char1))
-        return std::nullopt;
-    shift();
-
-    bool negateExponent = false;
-    if (m_current == '-') {
-        negateExponent = true;
-        shift();
-    } else if (m_current == '+')
-        shift();
-
-    std::optional<int64_t> exponent = parseDecimalInteger();
-    if (!exponent)
-        return std::nullopt;
-    CheckedInt64 exponentValue = exponent.value();
-    if (negateExponent)
-        exponentValue = - exponentValue;
-    if (exponentValue.hasOverflowed())
-        return std::nullopt;
-    return { exponentValue.value() };
-};
-
-template <typename T>
-Token Lexer<T>::parseIntegerLiteralSuffix(double literalValue)
-{
-    if (m_current == 'i') {
-        shift();
-        return makeLiteralToken(TokenType::IntegerLiteralSigned, literalValue);
-    }
-    if (m_current == 'u') {
-        shift();
-        return makeLiteralToken(TokenType::IntegerLiteralUnsigned, literalValue);
-    }
-    return makeLiteralToken(TokenType::IntegerLiteral, literalValue);
-};
 
 template class Lexer<LChar>;
 template class Lexer<UChar>;

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -55,6 +55,7 @@ public:
 
 private:
     Token nextToken();
+    Token lexNumber();
     unsigned currentOffset() const { return m_currentPosition.offset; }
     unsigned currentTokenLength() const { return currentOffset() - m_tokenStartingPosition.offset; }
 
@@ -78,20 +79,8 @@ private:
     void skipLineComment();
     bool skipWhitespaceAndComments();
 
-    // Reads [0-9]+
-    std::optional<uint64_t> parseDecimalInteger();
-    // Parse pattern (e|E)(\+|-)?[0-9]+f? if it is present, and return the exponent
-    std::optional<int64_t> parseDecimalFloatExponent();
-    // Checks whether there is an "i" or "u" coming, and return the right kind of literal token
-    Token parseIntegerLiteralSuffix(double literalValue);
-
     static bool isIdentifierStart(T character) { return isASCIIAlpha(character) || character == '_'; }
     static bool isIdentifierContinue(T character) { return isASCIIAlphanumeric(character) || character == '_'; }
-    static unsigned readDecimal(T character)
-    {
-        ASSERT(isASCIIDigit(character));
-        return character - '0';
-    }
 
     T m_current;
     const T* m_code;

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -131,7 +131,7 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
         }
         dataLogLn(message.toString());
         generateAValidationError(message.toString());
-        return ShaderModule::createInvalid(*this);
+        return ShaderModule::createInvalid(*this, failedCheck);
     }
 
     return ShaderModule::create(WTFMove(checkResult), { }, { }, nil, *this);
@@ -153,8 +153,8 @@ ShaderModule::ShaderModule(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck
 {
 }
 
-ShaderModule::ShaderModule(Device& device)
-    : m_checkResult(std::monostate { })
+ShaderModule::ShaderModule(Device& device, CheckResult&& checkResult)
+    : m_checkResult(WTFMove(checkResult))
     , m_device(device)
 {
 }


### PR DESCRIPTION
#### 09f41c245383b69d1a6bc8fb1c2ceec14ccc8282
<pre>
[WGSL] Make number parsing conform to the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=263675">https://bugs.webkit.org/show_bug.cgi?id=263675</a>
rdar://117486209

Reviewed by Mike Wyrzykowski.

Refactor how we lex numbers to unify the code and add support for hexadecimal
float literals. Some of decimal float CTS tests were also failing, so a refactor
seemed appropriate. Additionally, this patch also handles the constant narrowing
during type conversion, since that code is shared with the promoting done via
literal suffixes. With these two changes, (nearly) all number parsing CTS tests
now pass, the only exception being tests that use f16. The new version of the
lexer/parser uses a hand-written state machine derived from the grammar, so I
left the comment in there hoping it helps understand what is going on when going
back to this code.

* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantValue::isArray const):
(WGSL::convertInteger):
(WGSL::convertFloat):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::nextToken):
(WGSL::Lexer&lt;T&gt;::lexNumber):
(WGSL::Lexer&lt;T&gt;::parseDecimalInteger): Deleted.
(WGSL::Lexer&lt;T&gt;::parseDecimalFloatExponent): Deleted.
(WGSL::Lexer&lt;T&gt;::parseIntegerLiteralSuffix): Deleted.
* Source/WebGPU/WGSL/Lexer.h:
(WGSL::Lexer::isIdentifierContinue):
(WGSL::Lexer::readDecimal): Deleted.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::convertValue):
* Source/WebGPU/WebGPU/ShaderModule.h:
(WebGPU::ShaderModule::createInvalid):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):
(WebGPU::ShaderModule::ShaderModule):
(WebGPU::m_device): Deleted.

Canonical link: <a href="https://commits.webkit.org/269779@main">https://commits.webkit.org/269779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aca6612d6f1125cb61482272b8083ea9c03647b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21751 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24098 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1220 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26315 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25320 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/969 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5621 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->