### PR TITLE
REGRESSION(261180@main?): [ Sonoma ] TestWebKitAPI.GetDisplayMediaTest.SystemCanPrompt is constantly failing.

### DIFF
--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
@@ -50,7 +50,10 @@ public:
     void promptForGetDisplayMedia(UserMediaPermissionRequestProxy::UserMediaDisplayCapturePromptType, WebPageProxy&, const WebCore::SecurityOriginData&, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
     bool canRequestDisplayCapturePermission();
     void setIndexOfDeviceSelectedForTesting(std::optional<unsigned> index) { m_indexOfDeviceSelectedForTesting = index; }
-    void setSystemCanPromptForTesting(bool canPrompt) { m_systemCanPromptForTesting = canPrompt; }
+
+    enum class PromptOverride { Default, CanPrompt, CanNotPrompt };
+    void setSystemCanPromptForTesting(bool canPrompt) { m_systemCanPromptForTesting = canPrompt ? PromptOverride::CanPrompt : PromptOverride::CanNotPrompt; }
+    bool overrideCanRequestDisplayCapturePermissionForTesting() const { return useMockCaptureDevices() && m_systemCanPromptForTesting != PromptOverride::Default; }
 
 private:
 
@@ -65,7 +68,7 @@ private:
     bool useMockCaptureDevices() const;
 
     std::optional<unsigned> m_indexOfDeviceSelectedForTesting;
-    bool m_systemCanPromptForTesting { false };
+    PromptOverride m_systemCanPromptForTesting { PromptOverride::Default };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -166,7 +166,7 @@ DisplayCaptureSessionManager::~DisplayCaptureSessionManager()
 bool DisplayCaptureSessionManager::canRequestDisplayCapturePermission()
 {
     if (useMockCaptureDevices())
-        return m_systemCanPromptForTesting;
+        return m_systemCanPromptForTesting == PromptOverride::CanPrompt;
 
 #if HAVE(SCREEN_CAPTURE_KIT)
     return WebCore::ScreenCaptureKitSharingSessionManager::useSCContentSharingPicker();

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
@@ -71,7 +71,8 @@ void UserMediaPermissionRequestProxyMac::promptForGetDisplayMedia(UserMediaDispl
 bool UserMediaPermissionRequestProxyMac::canRequestDisplayCapturePermission()
 {
 #if ENABLE(MEDIA_STREAM)
-    if (!manager() || manager()->page().preferences().requireUAGetDisplayMediaPrompt())
+    auto overridePreference = DisplayCaptureSessionManager::singleton().overrideCanRequestDisplayCapturePermissionForTesting();
+    if (!manager() || (!overridePreference && manager()->page().preferences().requireUAGetDisplayMediaPrompt()))
         return false;
 
     return DisplayCaptureSessionManager::singleton().canRequestDisplayCapturePermission();


### PR DESCRIPTION
#### c4121dd7d23a83ebdaf9592cb4e6ce0d6c6564cc
<pre>
REGRESSION(261180@main?): [ Sonoma ] TestWebKitAPI.GetDisplayMediaTest.SystemCanPrompt is constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263098">https://bugs.webkit.org/show_bug.cgi?id=263098</a>
rdar://116893261

Reviewed by Jean-Yves Avenard.

The `systemCanPromptForTesting` setting should override the `requireUAGetDisplayMediaPrompt`
preference.

* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h:
(WebKit::DisplayCaptureSessionManager::overrideCanRequestDisplayCapturePermissionForTesting const):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::canRequestDisplayCapturePermission):
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm:
(WebKit::UserMediaPermissionRequestProxyMac::canRequestDisplayCapturePermission):

Canonical link: <a href="https://commits.webkit.org/269789@main">https://commits.webkit.org/269789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d02bfa4ddee9e48fc52d922c71d925ad24d96b1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25745 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21773 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24126 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1243 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26341 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25348 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/994 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5634 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->