### PR TITLE
REGRESSION (UI-side compositing) Disabled scrollbars don't show in some cases

### DIFF
--- a/LayoutTests/css3/scroll-snap/nested-elements.html
+++ b/LayoutTests/css3/scroll-snap/nested-elements.html
@@ -63,11 +63,7 @@
             debug("Scroll-snap offsets for 'container': " + window.internals.scrollSnapOffsets(container));
 
             var invalidContainer = document.getElementById('invalidContainer');
-            try {
-                testFailed("Scroll-snap offsets for 'invalidContainer': " + window.internals.scrollSnapOffsets(invalidContainer));
-            } catch(ex) {
-                testPassed("Scroll-snap offsets for 'invalidContainer': UNDEFINED");
-            }
+            debug("Scroll-snap offsets for 'invalidContainer': " + window.internals.scrollSnapOffsets(invalidContainer));
 
             finishJSTest();
         }

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
@@ -4,6 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS window.internals.scrollbarsControllerTypeForNode(svgScroller) is "ScrollbarsControllerMac"
+PASS window.internals.scrollbarsControllerTypeForNode(disabledScroller) is "ScrollbarsControllerMac"
 PASS window.internals.scrollbarsControllerTypeForNode(scroller) is "RemoteScrollbarsController"
 PASS window.internals.scrollbarsControllerTypeForNode() is "RemoteScrollbarsController"
 

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <style>
@@ -22,9 +22,6 @@
     <script>
         jsTestIsAsync = true;
 
-        if (window.internals)
-            internals.setUsesOverlayScrollbars(true);
-
         async function doTest()
         {
             description('Ensure scrollbars controller state is correct for scroller type');
@@ -33,6 +30,9 @@
             await UIHelper.renderingUpdate();
             svgScroller = document.getElementById('svgScroller');
             shouldBeEqualToString('window.internals.scrollbarsControllerTypeForNode(svgScroller)', 'ScrollbarsControllerMac');
+
+            disabledScroller = document.getElementById('disabledScroller');
+            shouldBeEqualToString('window.internals.scrollbarsControllerTypeForNode(disabledScroller)', 'ScrollbarsControllerMac');
 
             scroller = document.getElementById('scroller');
             shouldBeEqualToString('window.internals.scrollbarsControllerTypeForNode(scroller)', window.internals.isUsingUISideCompositing() ? 'RemoteScrollbarsController' : 'ScrollbarsControllerMac');
@@ -60,6 +60,13 @@
             </div>
         </foreignObject>
     </svg>
+
+    <div style="height: 200px; width: 100px; overflow: scroll;" id="disabledScroller">
+        <div style="height: 100px; overflow: hidden; position: relative; background-color: green;">
+            <div style="margin-top: 100px; height: 100px; background-color: red;"></div>
+        </div>
+    </div>
+    
     <div id="console"></div>
 </body>
 </html>

--- a/LayoutTests/platform/ios/css3/scroll-snap/nested-elements-expected.txt
+++ b/LayoutTests/platform/ios/css3/scroll-snap/nested-elements-expected.txt
@@ -1,5 +1,5 @@
 Scroll-snap offsets for 'container': vertical = { 100, 215, 330, 445, 560, 675, 790, 905, 1020, 1135, 1250, 1365, 1480, 1595, 1710, 1825, 1940, 2055, 2170 }
-Scroll-snap offsets for 'invalidContainer': vertical = { 48 }
+Scroll-snap offsets for 'invalidContainer': vertical = { 50 }
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/mac-ventura-wk2/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt
@@ -4,6 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS window.internals.scrollbarsControllerTypeForNode(svgScroller) is "ScrollbarsControllerMac"
+PASS window.internals.scrollbarsControllerTypeForNode(disabledScroller) is "ScrollbarsControllerMac"
 PASS window.internals.scrollbarsControllerTypeForNode(scroller) is "ScrollbarsControllerMac"
 PASS window.internals.scrollbarsControllerTypeForNode() is "ScrollbarsControllerMac"
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3325,9 +3325,6 @@ ExceptionOr<ScrollableArea*> Internals::scrollableAreaForNode(Node* node) const
             return Exception { ExceptionCode::InvalidAccessError };
 
         auto& renderBox = *element.renderBox();
-        if (!renderBox.canBeScrolledAndHasScrollableArea())
-            return Exception { ExceptionCode::InvalidAccessError };
-
         if (is<RenderListBox>(renderBox))
             scrollableArea = &downcast<RenderListBox>(renderBox);
         else {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1200,9 +1200,9 @@ void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea&
     
     switch (page->drawingArea()->type()) {
     case DrawingAreaType::RemoteLayerTree: {
-        if (!area.usesAsyncScrolling() && (!currentScrollbarsController || is<RemoteScrollbarsController>(currentScrollbarsController)))
+        if (!area.usesCompositedScrolling() && (!currentScrollbarsController || is<RemoteScrollbarsController>(currentScrollbarsController)))
             area.setScrollbarsController(ScrollbarsController::create(area));
-        else if (area.usesAsyncScrolling() && (!currentScrollbarsController || !is<RemoteScrollbarsController>(currentScrollbarsController)))
+        else if (area.usesCompositedScrolling() && (!currentScrollbarsController || !is<RemoteScrollbarsController>(currentScrollbarsController)))
             area.setScrollbarsController(makeUnique<RemoteScrollbarsController>(area, corePage.scrollingCoordinator()));
         return;
     }


### PR DESCRIPTION
#### 5c367f97364c91adb1982fe3ede5bfd7b0fa6940
<pre>
REGRESSION (UI-side compositing) Disabled scrollbars don&apos;t show in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=261295">https://bugs.webkit.org/show_bug.cgi?id=261295</a>
<a href="https://rdar.apple.com/115137778">rdar://115137778</a>

Reviewed by Simon Fraser.

For the case where we need to show disabled scrollbars on a scroller without a layer we need
to have the scrollbars controller of type ScrollbarsControllerMac, so that we can create
a temporary NSScrollerImp in the web process to display the disabled scrollbars (similar to
what we do for svg foreign object, etc.). However, the previous fix checked usesAsyncScrolling
to determine this, but it is better to check usesCompositedScrolling (as for this case
usesAsyncScrolling returns true even when we don&apos;t have a layer). For the normal case we will
properly update the scrollbars controller type to RemoteScrollbarsController for when the layer
is made, and for this case where the layer isn&apos;t made, we will properly use ScrollbarsControllerMac.

* LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type-expected.txt:
* LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-type.html:
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore:: const):
(WebCore::Internals::scrollbarsControllerTypeForNode const):
* Source/WebCore/testing/Internals.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::ensureScrollbarsController const):

Canonical link: <a href="https://commits.webkit.org/280026@main">https://commits.webkit.org/280026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dae2946cfd9b6c38a2f30a22f5a26d816b1aee6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5888 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44655 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4029 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5118 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60032 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52084 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51549 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32776 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8186 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->