### PR TITLE
[JSC] `yield` is not a valid BindingIdentifier for AsyncGeneratorExpression

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1154,8 +1154,6 @@ test/language/expressions/assignmenttargettype/direct-callexpression-arguments.j
   default: 'Test262: This statement should not be evaluated.'
 test/language/expressions/assignmenttargettype/parenthesized-callexpression-arguments.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/expressions/async-generator/early-errors-expression-yield-as-function-binding-identifier.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/expressions/async-generator/generator-created-after-decl-inst.js:
   default: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'
   strict mode: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'

--- a/LayoutTests/js/parser-syntax-check-expected.txt
+++ b/LayoutTests/js/parser-syntax-check-expected.txt
@@ -1315,6 +1315,8 @@ PASS Invalid: "(function () {'use strict'; ({...arguments} = {}); })()". Produce
 PASS Invalid: "function f() { (function () {'use strict'; ({...arguments} = {}); })() }". Produced the following syntax error: "SyntaxError: Cannot modify 'arguments' in strict mode."
 PASS Invalid: "async function foo () { let {...await} = {}; }". Produced the following syntax error: "SyntaxError: Cannot use 'await' as a lexical variable name in an async function."
 PASS Invalid: "function f() { async function foo () { let {...await} = {}; } }". Produced the following syntax error: "SyntaxError: Cannot use 'await' as a lexical variable name in an async function."
+PASS Invalid: "(async function* yield() {})". Produced the following syntax error: "SyntaxError: Cannot declare async generator function named 'yield'."
+PASS Invalid: "function f() { (async function* yield() {}) }". Produced the following syntax error: "SyntaxError: Cannot declare async generator function named 'yield'."
 PASS Invalid: "let {...let} = {a: 1, b: 2};". Produced the following syntax error: "SyntaxError: Unexpected keyword 'let'. Cannot use 'let' as an identifier name for a LexicalDeclaration."
 PASS Invalid: "function f() { let {...let} = {a: 1, b: 2}; }". Produced the following syntax error: "SyntaxError: Unexpected keyword 'let'. Cannot use 'let' as an identifier name for a LexicalDeclaration."
 PASS Invalid: "const {...let} = {a: 1, b: 2};". Produced the following syntax error: "SyntaxError: Unexpected keyword 'let'. Cannot use 'let' as an identifier name for a LexicalDeclaration."

--- a/LayoutTests/js/script-tests/parser-syntax-check.js
+++ b/LayoutTests/js/script-tests/parser-syntax-check.js
@@ -765,6 +765,7 @@ invalid("(function * (o) { ({ ...{ x: yield } } = o); })()");
 invalid("(function () {'use strict'; ({...eval} = {}); })()");
 invalid("(function () {'use strict'; ({...arguments} = {}); })()");
 invalid("async function foo () { let {...await} = {}; }");
+invalid("(async function* yield() {})");
 invalid("let {...let} = {a: 1, b: 2};");
 invalid("const {...let} = {a: 1, b: 2};");
 invalid("try { throw {a:2} } catch({...foo.a}) {}");

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2572,8 +2572,8 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
                     semanticFailIfTrue(functionDefinitionType == FunctionDefinitionType::Declaration || isAsyncFunctionOrAsyncGeneratorWrapperParseMode(mode), "Cannot declare function named 'await' ", isDisallowedAwaitFunctionNameReason);
                 else if (isAsyncFunctionOrAsyncGeneratorWrapperParseMode(mode) && match(AWAIT) && functionDefinitionType == FunctionDefinitionType::Expression)
                     semanticFail("Cannot declare ", stringForFunctionMode(mode), " named 'await'");
-                else if (isGeneratorWrapperParseMode(mode) && match(YIELD) && functionDefinitionType == FunctionDefinitionType::Expression)
-                    semanticFail("Cannot declare generator function named 'yield'");
+                else if (isGeneratorOrAsyncGeneratorWrapperParseMode(mode) && match(YIELD) && functionDefinitionType == FunctionDefinitionType::Expression)
+                    semanticFail("Cannot declare ", stringForFunctionMode(mode), " named 'yield'");
                 next();
                 if (!nameIsInContainingScope)
                     failIfTrueIfStrict(functionScope->declareCallee(functionInfo.name) & DeclarationResult::InvalidStrictMode, "'", functionInfo.name->impl(), "' is not a valid ", stringForFunctionMode(mode), " name in strict mode");

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -233,6 +233,15 @@ ALWAYS_INLINE bool isGeneratorOrAsyncFunctionWrapperParseMode(SourceParseMode pa
         SourceParseMode::AsyncGeneratorWrapperMethodMode).contains(parseMode);
 }
 
+ALWAYS_INLINE bool isGeneratorOrAsyncGeneratorWrapperParseMode(SourceParseMode parseMode)
+{
+    return SourceParseModeSet(
+        SourceParseMode::GeneratorWrapperFunctionMode,
+        SourceParseMode::GeneratorWrapperMethodMode,
+        SourceParseMode::AsyncGeneratorWrapperFunctionMode,
+        SourceParseMode::AsyncGeneratorWrapperMethodMode).contains(parseMode);
+}
+
 ALWAYS_INLINE bool isGeneratorParseMode(SourceParseMode parseMode)
 {
     return SourceParseModeSet(


### PR DESCRIPTION
#### d5e6b960d1d0a3498e8faaee5515a6dde2d03ced
<pre>
[JSC] `yield` is not a valid BindingIdentifier for AsyncGeneratorExpression
<a href="https://bugs.webkit.org/show_bug.cgi?id=263686">https://bugs.webkit.org/show_bug.cgi?id=263686</a>
&lt;rdar://problem/117497786&gt;

Reviewed by Justin Michaud.

Representation of AsyncGeneratorExpression [1] contains BindingIdentifier production with [Yield]
parameter, which throws an early error if it matches `yield` terminal [2].

This change implements above-mentioned error, with an error message similar to the case of `await`
idenfitier, aligning JSC with V8 and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#prod-AsyncGeneratorExpression">https://tc39.es/ecma262/#prod-AsyncGeneratorExpression</a>
[2]: <a href="https://tc39.es/ecma262/#sec-identifiers-static-semantics-early-errors">https://tc39.es/ecma262/#sec-identifiers-static-semantics-early-errors</a>

* LayoutTests/js/parser-syntax-check-expected.txt:
* LayoutTests/js/script-tests/parser-syntax-check.js:
* JSTests/test262/expectations.yaml: Mark 1 test as passing.
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
* Source/JavaScriptCore/parser/ParserModes.h:
(JSC::isGeneratorOrAsyncGeneratorWrapperParseMode): Extract a helper that will most likely be needed elsewhere.

Canonical link: <a href="https://commits.webkit.org/269801@main">https://commits.webkit.org/269801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/062fd7a0280c0a45e772f22479a458decf10d9f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/23626 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/1742 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/24747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/25785 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/3315 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/24162 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/25785 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/23869 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/3315 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/24747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/26381 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/3315 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/24747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/26381 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/20561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/3315 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/24747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/26381 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/22969 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/24162 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/30359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/1033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/24747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/30359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/30312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3028 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/1344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/30312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->