### PR TITLE
Refactor Color IPC types to not be nested

### DIFF
--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -49,7 +49,7 @@ Color::Color(Color&& other)
     *this = WTFMove(other);
 }
 
-Color::Color(std::optional<Color::ColorDataForIPC>&& colorData)
+Color::Color(std::optional<ColorDataForIPC>&& colorData)
 {
     if (colorData) {
         OptionSet<FlagsIncludingPrivate> flags;
@@ -60,14 +60,14 @@ Color::Color(std::optional<Color::ColorDataForIPC>&& colorData)
 
         WTF::switchOn(colorData->data,
             [&] (const PackedColor::RGBA& d) { setColor(asSRGBA(d), flags); },
-            [&] (const ColorDataForIPC::OutOfLineColorData& d) {
+            [&] (const OutOfLineColorDataForIPC& d) {
                 setOutOfLineComponents(OutOfLineComponents::create({ d.c1, d.c2, d.c3, d.alpha }), d.colorSpace, flags);
             }
         );
     }
 }
 
-std::optional<Color::ColorDataForIPC> Color::data() const
+std::optional<ColorDataForIPC> Color::data() const
 {
     if (!isValid())
         return std::nullopt;
@@ -76,7 +76,7 @@ std::optional<Color::ColorDataForIPC> Color::data() const
         auto& outOfLineComponents = asOutOfLine();
         auto [c1, c2, c3, alpha] = outOfLineComponents.unresolvedComponents();
 
-        Color::ColorDataForIPC::OutOfLineColorData oolcd = {
+        OutOfLineColorDataForIPC oolcd = {
             .colorSpace = colorSpace(),
             .c1 = c1,
             .c2 = c2,

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -48,6 +48,20 @@ typedef struct _GdkRGBA GdkRGBA;
 
 namespace WebCore {
 
+struct OutOfLineColorDataForIPC {
+    ColorSpace colorSpace;
+    float c1;
+    float c2;
+    float c3;
+    float alpha;
+};
+
+struct ColorDataForIPC {
+    bool isSemantic;
+    bool usesFunctionSerialization;
+    std::variant<PackedColor::RGBA, OutOfLineColorDataForIPC> data;
+};
+
 // Able to represent:
 //    - Special "invalid color" state, treated as transparent black but distinguishable
 //    - 4x 8-bit (0-255) sRGBA, stored inline, no allocation
@@ -59,19 +73,6 @@ public:
     enum class Flags {
         Semantic                        = 1 << 0,
         UseColorFunctionSerialization   = 1 << 1,
-    };
-
-    struct ColorDataForIPC {
-        struct OutOfLineColorData {
-            ColorSpace colorSpace;
-            float c1;
-            float c2;
-            float c3;
-            float alpha;
-        };
-        bool isSemantic;
-        bool usesFunctionSerialization;
-        std::variant<PackedColor::RGBA, OutOfLineColorData> data;
     };
 
     Color() = default;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2052,7 +2052,7 @@ header: <WebCore/ColorTypes.h>
 }
 
 header: <WebCore/Color.h>
-[Nested, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Color::ColorDataForIPC::OutOfLineColorData {
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::OutOfLineColorDataForIPC {
     WebCore::ColorSpace colorSpace;
     float c1;
     float c2;
@@ -2060,14 +2060,14 @@ header: <WebCore/Color.h>
     float alpha;
 }
 
-[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Color::ColorDataForIPC {
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorDataForIPC {
     bool isSemantic;
     bool usesFunctionSerialization;
-    std::variant<WebCore::PackedColor::RGBA, WebCore::Color::ColorDataForIPC::OutOfLineColorData> data;
+    std::variant<WebCore::PackedColor::RGBA, WebCore::OutOfLineColorDataForIPC> data;
 }
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::Color {
-    std::optional<WebCore::Color::ColorDataForIPC> data();
+    std::optional<WebCore::ColorDataForIPC> data();
 }
 
 struct WebCore::MediaCapabilitiesInfo {


### PR DESCRIPTION
#### 8a46e65b9cb7ac45212995d32d30048801b268fc
<pre>
Refactor Color IPC types to not be nested
<a href="https://bugs.webkit.org/show_bug.cgi?id=263688">https://bugs.webkit.org/show_bug.cgi?id=263688</a>
rdar://117499465

Reviewed by Alex Christensen.

This is necessary for upcoming work.

* Source/WebCore/platform/graphics/Color.cpp:
(WebCore::Color::Color):
(WebCore::Color::data const):
* Source/WebCore/platform/graphics/Color.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/269793@main">https://commits.webkit.org/269793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a72534a1a5266706c321ba9b0006b0ac607b8c93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25752 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24132 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1255 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26348 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27598 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1026 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1000 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->