### PR TITLE
Fix MSVC warnings November 2023 edition

### DIFF
--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -6391,15 +6391,21 @@ public:
         WTF::unalignedStore<int32_t>(ptr + 1, static_cast<int32_t>(distance));
     }
 
+#if COMPILER(GCC)
     // FIXME: Indirection needed to work around GCC error in Debian 11.
     static void* memcpyWrapper(void* dest, const void* src, size_t n)
     {
         return memcpy(dest, src, n);
     }
+#endif
 
     static void replaceWithNops(void* instructionStart, size_t memoryToFillWithNopsInBytes)
     {
+#if COMPILER(GCC)
         fillNops<memcpyWrapper>(instructionStart, memoryToFillWithNopsInBytes);
+#else
+        fillNops<memcpy>(instructionStart, memoryToFillWithNopsInBytes);
+#endif
     }
 
     static ptrdiff_t maxJumpReplacementSize()

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -192,7 +192,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, size_t index
             const UnlinkedHandlerInfo& unlinkedHandler = generator.m_exceptionHandlers[i];
             HandlerInfo& handler = m_exceptionHandlers[i];
             void* ptr = reinterpret_cast<void*>(unlinkedHandler.m_type == HandlerType::Catch ? ipint_catch_entry : ipint_catch_all_entry);
-            void* untagged = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr();
+            void* untagged = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).untaggedPtr();
             void* retagged = nullptr;
 #if ENABLE(JIT_CAGE)
             if (Options::useJITCage())

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -119,7 +119,7 @@ inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomString& key, const Tre
 
     // We know there's at least one node that matches; iterate to find the first one.
     Ref rootNode = scope.rootNode();
-    for (Ref element : descendantsOfType<Element>(rootNode.get())) {
+    for (Ref<Element> element : descendantsOfType<Element>(rootNode.get())) {
         if (!element->isInTreeScope())
             continue;
         if (!keyMatches(key, element))

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1542,11 +1542,11 @@ bool RenderBox::hitTestClipPath(const HitTestLocation& hitTestLocation, const La
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         if (is<RenderSVGResourceClipper>(element.renderer())) {
             CheckedRef clipper = downcast<RenderSVGResourceClipper>(*element.renderer());
-            return clipper->hitTestClipContent( { borderBoxRect() }, hitTestLocationInLocalCoordinates);
+            return clipper->hitTestClipContent( FloatRect { borderBoxRect() }, hitTestLocationInLocalCoordinates);
         }
 #endif
         CheckedRef clipper = downcast<LegacyRenderSVGResourceClipper>(*element.renderer());
-        return clipper->hitTestClipContent( { borderBoxRect() }, FloatPoint { hitTestLocationInLocalCoordinates });
+        return clipper->hitTestClipContent( FloatRect { borderBoxRect() }, FloatPoint { hitTestLocationInLocalCoordinates });
     };
 
     switch (style().clipPath()->type()) {


### PR DESCRIPTION
#### bd68a82273735df6b06124db3d44f5e0e839c4ce
<pre>
Fix MSVC warnings November 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=263689">https://bugs.webkit.org/show_bug.cgi?id=263689</a>

Reviewed by Fujii Hironori.

Fix MSVC warnings around types.

* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::replaceWithNops):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::get const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hitTestClipPath const):

Canonical link: <a href="https://commits.webkit.org/271031@main">https://commits.webkit.org/271031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be20db7e2d9c88babe5bc879305acf6712116f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24578 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3911 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4009 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29873 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23553 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30191 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26212 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28106 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5464 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33665 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6518 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4466 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7291 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->