### PR TITLE
Rebaseline fast/invalid/008.html (layout-tests)

### DIFF
--- a/LayoutTests/platform/ios/fast/invalid/008-expected.txt
+++ b/LayoutTests/platform/ios/fast/invalid/008-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x577
       RenderBlock {P} at (0,0) size 784x20
-        RenderText {#text} at (0,0) size 32x20
-          text run at (0,0) width 32: "Test"
+        RenderText {#text} at (0,0) size 31x20
+          text run at (0,0) width 31: "Test"
 layer at (250,50) size 247x64
   RenderBlock (positioned) {DIV} at (250,50) size 248x64 [border: (2px solid #008000)]
     RenderText {#text} at (22,22) size 204x19

--- a/LayoutTests/platform/mac/fast/invalid/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/invalid/008-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x577
       RenderBlock {P} at (0,0) size 784x18
-        RenderText {#text} at (0,0) size 32x18
-          text run at (0,0) width 32: "Test"
+        RenderText {#text} at (0,0) size 31x18
+          text run at (0,0) width 31: "Test"
 layer at (250,50) size 247x62
   RenderBlock (positioned) {DIV} at (250,50) size 248x62 [border: (2px solid #008000)]
     RenderText {#text} at (22,22) size 204x18


### PR DESCRIPTION
#### c7a38017fffdc5391715f8af6abed6a1abb288c0
<pre>
Rebaseline fast/invalid/008.html (layout-tests)
<a href="https://bugs.webkit.org/show_bug.cgi?id=263696">https://bugs.webkit.org/show_bug.cgi?id=263696</a>
rdar://116421409

Reviewed by NOBODY (OOPS!).

* LayoutTests/platform/ios/fast/invalid/008-expected.txt:
* LayoutTests/platform/mac/fast/invalid/008-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7a38017fffdc5391715f8af6abed6a1abb288c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21788 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22362 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23847 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1260 "Found 1 new test failure: fast/invalid/008.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26359 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27602 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25359 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1035 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18743 "Found 2 new test failures: fast/invalid/008.html, fast/media/media-query-dynamic-with-font-face.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1011 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->