### PR TITLE
REGRESSION (UI-side compositing) changing between non-overlay and overlay scrollbars should adjust the size of the scrollable area

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollable-area-size-for-overlay-scrollbars-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollable-area-size-for-overlay-scrollbars-expected.txt
@@ -1,0 +1,10 @@
+Tests that scrollable area size is properly updated when toggling scrollbar style
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS preChangeSize is > window.internals.scrollableAreaWidth(document.getElementById("scroller"))
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. .

--- a/LayoutTests/fast/scrolling/mac/scrollable-area-size-for-overlay-scrollbars.html
+++ b/LayoutTests/fast/scrolling/mac/scrollable-area-size-for-overlay-scrollbars.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true MockScrollbarsEnabled=false ] -->
+<html>
+<head>
+    <style>
+        .container {
+            height: 200px;
+            width: 200px;
+            border: 1px solid black;
+            overflow-y: scroll;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+        description("Tests that scrollable area size is properly updated when toggling scrollbar style");
+        window.internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            preChangeSize = window.internals.scrollableAreaWidth(document.getElementById("scroller"));
+            window.internals.setUsesOverlayScrollbars(false);
+            shouldBeGreaterThan("preChangeSize", "window.internals.scrollableAreaWidth(document.getElementById(\"scroller\"))");
+            testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div id="scroller" class="container">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. .</p>
+
+    </div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6193,6 +6193,15 @@ void LocalFrameView::invalidateScrollAnchoringElement()
         m_scrollAnchoringController->invalidateAnchorElement();
 }
 
+void LocalFrameView::scrollbarStyleDidChange()
+{
+    if (auto scrollableAreas = this->scrollableAreas()) {
+        for (auto& scrollableArea : *scrollableAreas)
+            scrollableArea.scrollbarsController().updateScrollbarStyle();
+    }
+    scrollbarsController().updateScrollbarStyle();
+}
+
 } // namespace WebCore
 
 #undef PAGE_ID

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -719,6 +719,8 @@ public:
     void invalidateScrollAnchoringElement() final;
     ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
 
+    WEBCORE_EXPORT void scrollbarStyleDidChange();
+
 private:
     explicit LocalFrameView(LocalFrame&);
 

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -939,7 +939,7 @@ void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeI
     frameScrollingNode->setLayoutViewport(frameView.layoutViewportRect());
     frameScrollingNode->setAsyncFrameOrOverflowScrollingEnabled(settings.asyncFrameScrollingEnabled() || settings.asyncOverflowScrollingEnabled());
     frameScrollingNode->setScrollingPerformanceTestingEnabled(settings.scrollingPerformanceTestingEnabled());
-    frameScrollingNode->setOverlayScrollbarsEnabled(WebCore::DeprecatedGlobalSettings::usesOverlayScrollbars());
+    frameScrollingNode->setOverlayScrollbarsEnabled(ScrollbarTheme::theme().usesOverlayScrollbars());
     frameScrollingNode->setWheelEventGesturesBecomeNonBlocking(settings.wheelEventGesturesBecomeNonBlocking());
 
     frameScrollingNode->setMinLayoutViewportOrigin(frameView.minStableLayoutViewportOrigin());

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -547,4 +547,12 @@ int Scrollbar::minimumThumbLength() const
     return m_scrollableArea.scrollbarsController().minimumThumbLength(m_orientation);
 }
 
+void Scrollbar::updateScrollbarThickness()
+{
+    if (!isCustomScrollbar()) {
+        int thickness = ScrollbarTheme::theme().scrollbarThickness(widthStyle());
+        setFrameRect(IntRect(0, 0, thickness, thickness));
+    }
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -143,6 +143,7 @@ public:
 
     bool shouldRegisterScrollbar() const;
     int minimumThumbLength() const;
+    void updateScrollbarThickness();
 
     virtual bool isMacScrollbar() const { return false; }
 

--- a/Source/WebCore/platform/ScrollbarsController.cpp
+++ b/Source/WebCore/platform/ScrollbarsController.cpp
@@ -67,4 +67,13 @@ void ScrollbarsController::mayBeginScrollGesture()
     setScrollbarAnimationsUnsuspendedByUserInteraction(true);
 }
 
+void ScrollbarsController::updateScrollbarsThickness()
+{
+    if (auto verticalScrollbar = scrollableArea().verticalScrollbar())
+        verticalScrollbar->updateScrollbarThickness();
+
+    if (auto horizontalScrollbar = scrollableArea().horizontalScrollbar())
+        horizontalScrollbar->updateScrollbarThickness();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -29,6 +29,7 @@
 #include "FloatSize.h"
 #include "UserInterfaceLayoutDirection.h"
 #include <wtf/FastMalloc.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -101,6 +102,12 @@ public:
     WEBCORE_EXPORT virtual void setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation, int) { }
     WEBCORE_EXPORT virtual int minimumThumbLength(WebCore::ScrollbarOrientation) { return 0; }
     WEBCORE_EXPORT virtual void scrollbarLayoutDirectionChanged(UserInterfaceLayoutDirection) { }
+
+    WEBCORE_EXPORT virtual void updateScrollerStyle() { }
+
+    WEBCORE_EXPORT void updateScrollbarsThickness();
+
+    WEBCORE_EXPORT virtual void updateScrollbarStyle() { }
 
 private:
     ScrollableArea& m_scrollableArea;

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
@@ -42,7 +42,7 @@ namespace WebCore {
 
 class WheelEventTestMonitor;
 
-class ScrollbarsControllerMac : public ScrollbarsController {
+class ScrollbarsControllerMac final : public ScrollbarsController {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ScrollbarsControllerMac);
 public:
@@ -90,7 +90,7 @@ public:
 
 
     // Public to be callable from Obj-C.
-    void updateScrollerStyle();
+    void updateScrollerStyle() final;
     bool scrollbarPaintTimerIsActive() const;
     void startScrollbarPaintTimer();
     void stopScrollbarPaintTimer();

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -957,14 +957,7 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         NSScrollerImp *oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
         auto* verticalScrollbarMac = dynamicDowncast<ScrollbarMac>(verticalScrollbar);
         verticalScrollbarMac->createScrollerImp(WTFMove(oldVerticalPainter));
-
         [m_scrollerImpPair setVerticalScrollerImp:verticalScrollbarMac->scrollerImp()];
-
-        // The different scrollbar styles have different thicknesses, so we must re-set the
-        // frameRect to the new thickness, and the re-layout below will ensure the position
-        // and length are properly updated.
-        int thickness = macTheme->scrollbarThickness(verticalScrollbar->widthStyle());
-        verticalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
 
     Scrollbar* horizontalScrollbar = scrollableArea().horizontalScrollbar();
@@ -974,15 +967,13 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         NSScrollerImp *oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];
         auto* horizontalScrollbarMac = dynamicDowncast<ScrollbarMac>(horizontalScrollbar);
         horizontalScrollbarMac->createScrollerImp(WTFMove(oldHorizontalPainter));
-
         [m_scrollerImpPair setHorizontalScrollerImp:horizontalScrollbarMac->scrollerImp()];
-
-        // The different scrollbar styles have different thicknesses, so we must re-set the
-        // frameRect to the new thickness, and the re-layout below will ensure the position
-        // and length are properly updated.
-        int thickness = macTheme->scrollbarThickness(horizontalScrollbar->widthStyle());
-        horizontalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
+
+    // The different scrollbar styles have different thicknesses, so we must re-set the
+    // frameRect to the new thickness, and the re-layout below will ensure the position
+    // and length are properly updated.
+    updateScrollbarsThickness();
 
     // If m_needsScrollerStyleUpdate is true, then the page is restoring from the back/forward cache, and
     // a relayout will happen on its own. Otherwise, we must initiate a re-layout ourselves.

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -649,6 +649,7 @@ IntSize RenderLayerScrollableArea::reachableTotalContentsSize() const
 
 void RenderLayerScrollableArea::availableContentSizeChanged(AvailableSizeChangeReason reason)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << " RenderLayerScrollableArea::availableContentSizeChanged " << scrollingNodeID());
     ScrollableArea::availableContentSizeChanged(reason);
 
     auto& renderer = m_layer.renderer();
@@ -657,6 +658,7 @@ void RenderLayerScrollableArea::availableContentSizeChanged(AvailableSizeChangeR
             renderBlock->setShouldForceRelayoutChildren(true);
         renderer.setNeedsLayout();
     }
+    ALWAYS_LOG_WITH_STREAM(stream << " RenderLayerScrollableArea::availableContentSizeChanged " << m_layer.renderer().needsLayout());
 }
 
 bool RenderLayerScrollableArea::shouldSuspendScrollAnimations() const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3224,6 +3224,15 @@ ExceptionOr<Vector<uint64_t>> Internals::scrollingNodeIDForNode(Node* node)
     return returnNodeID;
 }
 
+ExceptionOr<unsigned> Internals::scrollableAreaWidth(Node& node)
+{
+    auto areaOrException = scrollableAreaForNode(&node);
+    if (areaOrException.hasException())
+        return areaOrException.releaseException();
+    auto* scrollableArea = areaOrException.releaseReturnValue();
+    return scrollableArea->contentsSize().width();
+}
+
 static OptionSet<PlatformLayerTreeAsTextFlags> toPlatformLayerTreeFlags(unsigned short flags)
 {
     OptionSet<PlatformLayerTreeAsTextFlags> platformLayerTreeFlags = { };

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -409,6 +409,7 @@ public:
 
     ExceptionOr<unsigned> wheelEventHandlerCount();
     ExceptionOr<unsigned> touchEventHandlerCount();
+    ExceptionOr<unsigned> scrollableAreaWidth(Node&);
 
     ExceptionOr<Ref<DOMRectList>> touchEventRectsForEvent(const String&);
     ExceptionOr<Ref<DOMRectList>> passiveTouchEventListenerRects();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -752,6 +752,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     unsigned long numberOfIDBTransactions();
 
+    unsigned long scrollableAreaWidth(Node node);
+
     unsigned long numberOfLiveNodes();
     unsigned long numberOfLiveDocuments();
     unsigned long referencingNodeCount(Document document);

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -34,6 +34,7 @@
 #import "EventHandler.h"
 #import "HTMLMediaElement.h"
 #import "HitTestResult.h"
+#import "LocalFrameView.h"
 #import "MediaPlayerPrivate.h"
 #import "Range.h"
 #import "SharedBuffer.h"
@@ -154,6 +155,16 @@ void Internals::setUsesOverlayScrollbars(bool enabled)
 
     NSScrollerStyle style = enabled ? NSScrollerStyleOverlay : NSScrollerStyleLegacy;
     [NSScrollerImpPair _updateAllScrollerImpPairsForNewRecommendedScrollerStyle:style];
+
+    auto* document = contextDocument();
+    if (!document || !document->frame())
+        return;
+
+    auto* localFrame = dynamicDowncast<LocalFrame>(document->frame()->mainFrame());
+    if (!localFrame)
+        return;
+
+    localFrame->view()->scrollbarStyleDidChange();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -101,6 +101,8 @@ private:
 
     bool m_usesOverlayScrollbars { false };
 
+    std::optional<WebCore::ScrollbarStyle> m_scrollbarStyle;
+
     std::optional<TransactionID> m_transactionIDAfterEndingTransientZoom;
     std::optional<double> m_transientZoomScale;
     std::optional<WebCore::FloatPoint> m_transientZoomOrigin;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -182,13 +182,15 @@ void RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree(IPC::Connection&, co
         removeTransientZoomFromLayer();
         m_transactionIDAfterEndingTransientZoom = { };
     }
-    if (m_usesOverlayScrollbars != m_webPageProxy->scrollingCoordinatorProxy()->overlayScrollbarsEnabled()) {
-        m_usesOverlayScrollbars = m_webPageProxy->scrollingCoordinatorProxy()->overlayScrollbarsEnabled();
-        WebCore::DeprecatedGlobalSettings::setUsesOverlayScrollbars(m_usesOverlayScrollbars);
+    auto usesOverlayScrollbars = m_webPageProxy->scrollingCoordinatorProxy()->overlayScrollbarsEnabled();
+    auto newScrollbarStyle = usesOverlayScrollbars ? ScrollbarStyle::Overlay : ScrollbarStyle::AlwaysVisible;
+    if (!m_scrollbarStyle || m_scrollbarStyle != newScrollbarStyle) {
+        m_scrollbarStyle = newScrollbarStyle;
+        WebCore::DeprecatedGlobalSettings::setUsesOverlayScrollbars(usesOverlayScrollbars);
         
-        ScrollerStyle::setUseOverlayScrollbars(m_usesOverlayScrollbars);
+        ScrollerStyle::setUseOverlayScrollbars(usesOverlayScrollbars);
         
-        NSScrollerStyle style = m_usesOverlayScrollbars ? NSScrollerStyleOverlay : NSScrollerStyleLegacy;
+        NSScrollerStyle style = usesOverlayScrollbars ? NSScrollerStyleOverlay : NSScrollerStyleLegacy;
         [NSScrollerImpPair _updateAllScrollerImpPairsForNewRecommendedScrollerStyle:style];
     }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -58,6 +58,8 @@ public:
     void updateScrollbarEnabledState(WebCore::Scrollbar&) final;
     void scrollbarLayoutDirectionChanged(WebCore::UserInterfaceLayoutDirection) final;
 
+    void updateScrollbarStyle() final;
+
 private:
     bool m_horizontalOverlayScrollbarIsVisible { false };
     bool m_verticalOverlayScrollbarIsVisible { false };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #include <WebCore/ScrollableArea.h>
+#include <WebCore/ScrollbarThemeMac.h>
 #include <WebCore/ScrollingCoordinator.h>
 #include <pal/spi/mac/NSScrollerImpSPI.h>
 
@@ -122,6 +123,20 @@ void RemoteScrollbarsController::updateScrollbarEnabledState(WebCore::Scrollbar&
 {
     if (auto scrollingCoordinator = m_coordinator.get())
         scrollingCoordinator->setScrollbarEnabled(scrollbar);
+}
+
+void RemoteScrollbarsController::updateScrollbarStyle()
+{
+    auto& theme = WebCore::ScrollbarTheme::theme();
+    if (theme.isMockTheme())
+        return;
+
+    // The different scrollbar styles have different thicknesses, so we must re-set the
+    // frameRect to the new thickness, and the re-layout below will ensure the position
+    // and length are properly updated.
+    updateScrollbarsThickness();
+
+    scrollableArea().scrollbarStyleChanged(theme.usesOverlayScrollbars() ? WebCore::ScrollbarStyle::Overlay : WebCore::ScrollbarStyle::AlwaysVisible, true);
 }
 
 }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1206,6 +1206,11 @@ void WebProcess::scrollerStylePreferenceChanged(bool useOverlayScrollbars)
 
     static_cast<ScrollbarThemeMac&>(theme).preferencesChanged();
     
+    for (auto& page : m_pageMap.values()) {
+        if (RefPtr frameView = page->localMainFrameView())
+            frameView->scrollbarStyleDidChange();
+    }
+
     NSScrollerStyle style = useOverlayScrollbars ? NSScrollerStyleOverlay : NSScrollerStyleLegacy;
     [NSScrollerImpPair _updateAllScrollerImpPairsForNewRecommendedScrollerStyle:style];
 }


### PR DESCRIPTION
#### 81451dabde97ba73cbed2abc4c4be64957aa20f6
<pre>
REGRESSION (UI-side compositing) changing between non-overlay and overlay scrollbars should adjust the size of the scrollable area
<a href="https://bugs.webkit.org/show_bug.cgi?id=263618">https://bugs.webkit.org/show_bug.cgi?id=263618</a>
<a href="https://rdar.apple.com/117507268">rdar://117507268</a>

Reviewed by Simon Fraser.

This patch fixes a couple bugs related to switching back and forth dynamically between
overlay and non-overlay scrollbars. First, setFrameScrollingNodeState() was not always
called when switching the default, so iterate through each page and call
LocalFrameView::overlayScrollbarDefaultDidChange to force a scrolling commit to plumb
across this state change. Second, when we get the state change on the ui-process side,
we call _updateAllScrollerImpPairsForNewRecommendedScrollerStyle, which notifies all the
scroller imp pairs in the process of the new style. On the web process side, we had code
to adjust the scrollbar thickness and force a relayout, which now doesn&apos;t work since there
are no NSScrollerImpPairs in the web process. Instead, replicate this code in
RemoteScrollbarsController and loop through the scrollable areas in the FrameView. This
takes care of updating scrollable areas with overflow, while
<a href="https://github.com/WebKit/WebKit/pull/19561">https://github.com/WebKit/WebKit/pull/19561</a> will take care of updating scrollable areas
without overflow. Also add some additional testing infrastructure to compare the size of
the scrollable area before and after toggling scrollbar style.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::usesOverlayScrollbars const):
(WebCore::LocalFrameView::overlayScrollbarDefaultDidChange):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::scrollingTreeNodeMarkScrollbarStyleChange):
(WebCore::ScrollingTree::scrollingTreeNodesWithScrollbarStyleChange):
(WebCore::ScrollingTree::clearScrollingTreeNodesWithScrollbarStyleChange):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::markHasScrollbarStyleChange):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(-[WebScrollerImpPairDelegateMac scrollerImpPair:updateScrollerStyleForNewRecommendedScrollerStyle:]):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::updateScrollbarThickness):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebCore/platform/ScrollbarsController.cpp:
(WebCore::ScrollbarsController::updateScrollbarsThickness):
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::updateScrollerStyle):
* Source/WebCore/platform/mac/ScrollbarsControllerMac.h:
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::updateScrollerStyle):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingNodesHaveScrollbarStyleChange):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeMarkScrollbarStyleChange):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::macScrollbarTheme):
(WebKit::RemoteScrollbarsController::updateScrollerStyle):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scrollingTreeNodesHaveScrollbarsWithStyleChange):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::scrollerStylePreferenceChanged):

Canonical link: <a href="https://commits.webkit.org/276439@main">https://commits.webkit.org/276439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f42aefcfdfba3a48727085a49d434acfcc773d63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44645 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21119 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38428 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39570 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2692 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16136 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38686 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9950 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->