### PR TITLE
Generate serialization for ScrollingStateFrameHostingNode

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp
@@ -38,13 +38,13 @@ Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(Scrol
     return adoptRef(*new ScrollingStateFrameHostingNode(stateTree, nodeID));
 }
 
-Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(ScrollingNodeID nodeID)
+Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(ScrollingNodeID nodeID, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, Vector<Ref<ScrollingStateNode>>&& children)
 {
-    return adoptRef(*new ScrollingStateFrameHostingNode(nodeID));
+    return adoptRef(*new ScrollingStateFrameHostingNode(nodeID, changedProperties, layerID, WTFMove(children)));
 }
 
-ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(ScrollingNodeID nodeID)
-    : ScrollingStateNode(ScrollingNodeType::FrameHosting, nullptr, nodeID)
+ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(ScrollingNodeID nodeID, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, Vector<Ref<ScrollingStateNode>>&& children)
+    : ScrollingStateNode(ScrollingNodeType::FrameHosting, nodeID, changedProperties, layerID, WTFMove(children))
 {
     ASSERT(isFrameHostingNode());
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h
@@ -36,7 +36,7 @@ class Scrollbar;
 class ScrollingStateFrameHostingNode final : public ScrollingStateNode {
 public:
     WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingStateTree&, ScrollingNodeID);
-    WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingNodeID);
+    WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingNodeID, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, Vector<Ref<ScrollingStateNode>>&&);
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
 
     virtual ~ScrollingStateFrameHostingNode();
@@ -44,7 +44,7 @@ public:
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
 private:
-    ScrollingStateFrameHostingNode(ScrollingNodeID);
+    ScrollingStateFrameHostingNode(ScrollingNodeID, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, Vector<Ref<ScrollingStateNode>>&&);
     ScrollingStateFrameHostingNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateFrameHostingNode(const ScrollingStateFrameHostingNode&, ScrollingStateTree&);
 };

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -57,6 +57,20 @@ ScrollingStateNode::ScrollingStateNode(const ScrollingStateNode& stateNode, Scro
     scrollingStateTree().addNode(*this);
 }
 
+ScrollingStateNode::ScrollingStateNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, Vector<Ref<ScrollingStateNode>>&& children)
+    : m_nodeType(nodeType)
+    , m_nodeID(nodeID)
+    , m_changedProperties(changedProperties)
+    , m_children(WTFMove(children))
+    , m_layer(layerID.value_or(PlatformLayerIdentifier { }))
+{
+    for (auto& child : m_children) {
+        ASSERT(!child->parent());
+        child->setParent(this);
+    }
+    ASSERT(parentPointersAreCorrect());
+}
+
 ScrollingStateNode::~ScrollingStateNode() = default;
 
 void ScrollingStateNode::attachAfterDeserialization(ScrollingStateTree& tree)

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -335,7 +335,8 @@ public:
 
 protected:
     ScrollingStateNode(const ScrollingStateNode&, ScrollingStateTree&);
-    ScrollingStateNode(ScrollingNodeType, ScrollingStateTree*, ScrollingNodeID);
+    ScrollingStateNode(ScrollingNodeType, ScrollingStateTree*, ScrollingNodeID); // FIXME: This ScrollingStateTree* should be ScrollingStateTree& once all subclasses have generated serialization.
+    ScrollingStateNode(ScrollingNodeType, ScrollingNodeID, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, Vector<Ref<ScrollingStateNode>>&&);
 
     void setPropertyChangedInternal(Property property) { m_changedProperties.add(property); }
     void setPropertiesChangedInternal(OptionSet<Property> properties) { m_changedProperties.add(properties); }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,6 +50,8 @@
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
 #include <WebCore/MoveOnlyDerivedClass.h>
+#include <WebCore/ScrollingStateFrameHostingNode.h>
+#include <WebCore/ScrollingStateFrameHostingNodeWithStuffAfterTuple.h>
 #include <WebCore/TimingFunction.h>
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
@@ -115,6 +117,7 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder
 #endif
         , offsetof(Namespace::Subnamespace::StructName, nullableTestMember)
     >::value);
+
     encoder << instance.firstMemberName;
 #if ENABLE(SECOND_MEMBER)
     encoder << instance.secondMemberName;
@@ -144,6 +147,7 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& en
 #endif
         , offsetof(Namespace::Subnamespace::StructName, nullableTestMember)
     >::value);
+
     encoder << instance.firstMemberName;
 #if ENABLE(SECOND_MEMBER)
     encoder << instance.secondMemberName;
@@ -188,6 +192,7 @@ void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namesp
         , offsetof(Namespace::OtherClass, a)
         , offsetof(Namespace::OtherClass, dataDetectorResults)
     >::value);
+
     encoder << instance.a;
     encoder << instance.b;
     encoder << instance.dataDetectorResults;
@@ -214,6 +219,7 @@ void ArgumentCoder<Namespace::ReturnRefClass>::encode(Encoder& encoder, const Na
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.functionCall().member1)>, double>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.functionCall().member2)>, double>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.uniqueMember)>, std::unique_ptr<int>>);
+
     encoder << instance.functionCall().member1;
     encoder << instance.functionCall().member2;
     encoder << instance.uniqueMember;
@@ -248,6 +254,7 @@ void ArgumentCoder<Namespace::EmptyConstructorStruct>::encode(Encoder& encoder, 
         , offsetof(Namespace::EmptyConstructorStruct, m_int)
         , offsetof(Namespace::EmptyConstructorStruct, m_double)
     >::value);
+
     encoder << instance.m_int;
     encoder << instance.m_double;
 }
@@ -289,6 +296,7 @@ void ArgumentCoder<Namespace::EmptyConstructorWithIf>::encode(Encoder& encoder, 
         , offsetof(Namespace::EmptyConstructorWithIf, m_value)
 #endif
     >::value);
+
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     encoder << instance.m_type;
 #endif
@@ -327,6 +335,7 @@ void ArgumentCoder<WithoutNamespace>::encode(Encoder& encoder, const WithoutName
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespace, a)
     >::value);
+
     encoder << instance.a;
 }
 
@@ -352,6 +361,7 @@ void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(Encoder& encoder, con
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespaceWithAttributes, a)
     >::value);
+
     encoder << instance.a;
 }
 
@@ -365,6 +375,7 @@ void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(OtherEncoder& encoder
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespaceWithAttributes, a)
     >::value);
+
     encoder << instance.a;
 }
 
@@ -386,10 +397,12 @@ void ArgumentCoder<WebCore::InheritsFrom>::encode(Encoder& encoder, const WebCor
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespace, a)
     >::value);
+
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, float>);
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebCore::InheritsFrom, b)
     >::value);
+
     encoder << instance.a;
     encoder << instance.b;
 }
@@ -416,14 +429,17 @@ void ArgumentCoder<WebCore::InheritanceGrandchild>::encode(Encoder& encoder, con
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespace, a)
     >::value);
+
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, float>);
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebCore::InheritsFrom, b)
     >::value);
+
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.c)>, double>);
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebCore::InheritanceGrandchild, c)
     >::value);
+
     encoder << instance.a;
     encoder << instance.b;
     encoder << instance.c;
@@ -452,6 +468,7 @@ std::optional<WebCore::InheritanceGrandchild> ArgumentCoder<WebCore::Inheritance
 void ArgumentCoder<WTF::Seconds>::encode(Encoder& encoder, const WTF::Seconds& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value())>, double>);
+
     encoder << instance.value();
 }
 
@@ -477,6 +494,7 @@ void ArgumentCoder<WTF::CreateUsingClass>::encode(Encoder& encoder, const WTF::C
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WTF::CreateUsingClass, value)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -498,6 +516,7 @@ void ArgumentCoder<WebCore::FloatBoxExtent>::encode(Encoder& encoder, const WebC
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.right())>, float>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.bottom())>, float>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.left())>, float>);
+
     encoder << instance.top();
     encoder << instance.right();
     encoder << instance.bottom();
@@ -535,6 +554,7 @@ void ArgumentCoder<SoftLinkedMember>::encode(Encoder& encoder, const SoftLinkedM
         , offsetof(SoftLinkedMember, firstMember)
         , offsetof(SoftLinkedMember, secondMember)
     >::value);
+
     encoder << instance.firstMember;
     encoder << instance.secondMember;
 }
@@ -630,6 +650,7 @@ void ArgumentCoder<Namespace::ConditionalCommonClass>::encode(Encoder& encoder, 
     static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::ConditionalCommonClass, value)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -657,6 +678,7 @@ void ArgumentCoder<Namespace::CommonClass>::encode(Encoder& encoder, const Names
     static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::CommonClass, value)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -685,6 +707,7 @@ void ArgumentCoder<Namespace::AnotherCommonClass>::encode(Encoder& encoder, cons
         , offsetof(Namespace::AnotherCommonClass, value)
         , offsetof(Namespace::AnotherCommonClass, notSerialized)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -743,6 +766,7 @@ void ArgumentCoder<WebCore::MoveOnlyDerivedClass>::encode(Encoder& encoder, WebC
         , offsetof(WebCore::MoveOnlyDerivedClass, firstMember)
         , offsetof(WebCore::MoveOnlyDerivedClass, secondMember)
     >::value);
+
     encoder << WTFMove(instance.firstMember);
     encoder << WTFMove(instance.secondMember);
 }
@@ -808,6 +832,7 @@ void ArgumentCoder<WebKit::LayerProperties>::encode(Encoder& encoder, const WebK
 #endif
         , static_cast<uint64_t>(WebKit::LayerChange::FeatureEnabledMember)
     >::value);
+
     encoder << instance.changedProperties;
     if (instance.changedProperties & WebKit::LayerChange::NameChanged)
         encoder << instance.name;
@@ -822,34 +847,32 @@ void ArgumentCoder<WebKit::LayerProperties>::encode(Encoder& encoder, const WebK
 std::optional<WebKit::LayerProperties> ArgumentCoder<WebKit::LayerProperties>::decode(Decoder& decoder)
 {
     WebKit::LayerProperties result;
-    auto bits = decoder.decode<OptionSet<WebKit::LayerChange>>();
-    if (!bits)
+    auto changedProperties = decoder.decode<OptionSet<WebKit::LayerChange>>();
+    if (!changedProperties)
         return std::nullopt;
-    result.changedProperties = *bits;
-
-    if (*bits & WebKit::LayerChange::NameChanged) {
+    result.changedProperties = *changedProperties;
+    if (*changedProperties & WebKit::LayerChange::NameChanged) {
         if (auto deserialized = decoder.decode<String>())
             result.name = WTFMove(*deserialized);
         else
             return std::nullopt;
     }
-
 #if ENABLE(FEATURE)
-    if (*bits & WebKit::LayerChange::TransformChanged) {
+    if (*changedProperties & WebKit::LayerChange::TransformChanged) {
         if (auto deserialized = decoder.decode<std::unique_ptr<WebCore::TransformationMatrix>>())
             result.featureEnabledMember = WTFMove(*deserialized);
         else
             return std::nullopt;
     }
 #endif
-
-    if (*bits & WebKit::LayerChange::FeatureEnabledMember) {
+    if (*changedProperties & WebKit::LayerChange::FeatureEnabledMember) {
         if (auto deserialized = decoder.decode<bool>())
             result.bitFieldMember = WTFMove(*deserialized);
         else
             return std::nullopt;
     }
-
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
     return { WTFMove(result) };
 }
 
@@ -863,6 +886,7 @@ void ArgumentCoder<WebKit::TemplateTest<WebKit::Fabulous>>::encode(Encoder& enco
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebKit::TemplateTest, value)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -888,6 +912,7 @@ void ArgumentCoder<WebKit::TemplateTest<WebCore::Amazing>>::encode(Encoder& enco
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebKit::TemplateTest, value)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -913,6 +938,7 @@ void ArgumentCoder<WebKit::TemplateTest<JSC::Incredible>>::encode(Encoder& encod
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebKit::TemplateTest, value)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -938,6 +964,7 @@ void ArgumentCoder<WebKit::TemplateTest<Testing::StorageSize>>::encode(Encoder& 
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebKit::TemplateTest, value)
     >::value);
+
     encoder << instance.value;
 }
 
@@ -950,6 +977,113 @@ std::optional<WebKit::TemplateTest<Testing::StorageSize>> ArgumentCoder<WebKit::
         WebKit::TemplateTest<Testing::StorageSize> {
             WTFMove(*value)
         }
+    };
+}
+
+void ArgumentCoder<WebCore::ScrollingStateFrameHostingNode>::encode(Encoder& encoder, const WebCore::ScrollingStateFrameHostingNode& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.scrollingNodeID())>, WebCore::ScrollingNodeID>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.children())>, Vector<Ref<WebCore::ScrollingStateNode>>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.changedProperties())>, OptionSet<WebCore::ScrollingStateNodeProperty>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.layer().layerIDForEncoding())>, std::optional<WebCore::PlatformLayerIdentifier>>);
+    static_assert(static_cast<uint64_t>(WebCore::ScrollingStateNode::Property::Layer) == 1);
+    static_assert(BitsInIncreasingOrder<
+        , static_cast<uint64_t>(WebCore::ScrollingStateNode::Property::Layer)
+    >::value);
+
+    encoder << instance.scrollingNodeID();
+    encoder << instance.children();
+    encoder << instance.changedProperties();
+    if (instance.changedProperties() & WebCore::ScrollingStateNode::Property::Layer)
+        encoder << instance.layer().layerIDForEncoding();
+}
+
+std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> ArgumentCoder<WebCore::ScrollingStateFrameHostingNode>::decode(Decoder& decoder)
+{
+    auto scrollingNodeID = decoder.decode<WebCore::ScrollingNodeID>();
+    auto children = decoder.decode<Vector<Ref<WebCore::ScrollingStateNode>>>();
+    auto changedProperties = decoder.decode<OptionSet<WebCore::ScrollingStateNodeProperty>>();
+    if (!changedProperties)
+        return std::nullopt;
+
+    std::optional<WebCore::PlatformLayerIdentifier> layerlayerIDForEncoding { };
+    if (*changedProperties & WebCore::ScrollingStateNode::Property::Layer) {
+        if (auto deserialized = decoder.decode<std::optional<WebCore::PlatformLayerIdentifier>>())
+            changedProperties = WTFMove(*deserialized);
+        else
+            return std::nullopt;
+    }
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebCore::ScrollingStateFrameHostingNode::create(
+            WTFMove(*scrollingNodeID),
+            WTFMove(*children),
+            WTFMove(*changedProperties),
+            WTFMove(*layerlayerIDForEncoding)
+        )
+    };
+}
+
+void ArgumentCoder<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>::encode(Encoder& encoder, const WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.scrollingNodeID())>, WebCore::ScrollingNodeID>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.children())>, Vector<Ref<WebCore::ScrollingStateNode>>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.changedProperties())>, OptionSet<WebCore::ScrollingStateNodeProperty>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.layer().layerIDForEncoding())>, std::optional<WebCore::PlatformLayerIdentifier>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.otherMember)>, bool>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.memberAfterTuple)>, int>);
+    static_assert(static_cast<uint64_t>(WebCore::ScrollingStateNode::Property::Layer) == 1);
+    static_assert(BitsInIncreasingOrder<
+        , static_cast<uint64_t>(WebCore::ScrollingStateNode::Property::Layer)
+        , static_cast<uint64_t>(WebCore::ScrollingStateNode::Property::Other)
+    >::value);
+
+    encoder << instance.scrollingNodeID();
+    encoder << instance.children();
+    encoder << instance.changedProperties();
+    if (instance.changedProperties() & WebCore::ScrollingStateNode::Property::Layer)
+        encoder << instance.layer().layerIDForEncoding();
+    if (instance.changedProperties() & WebCore::ScrollingStateNode::Property::Other)
+        encoder << instance.otherMember;
+    encoder << instance.memberAfterTuple;
+}
+
+std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> ArgumentCoder<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>::decode(Decoder& decoder)
+{
+    auto scrollingNodeID = decoder.decode<WebCore::ScrollingNodeID>();
+    auto children = decoder.decode<Vector<Ref<WebCore::ScrollingStateNode>>>();
+    auto changedProperties = decoder.decode<OptionSet<WebCore::ScrollingStateNodeProperty>>();
+    if (!changedProperties)
+        return std::nullopt;
+
+    std::optional<WebCore::PlatformLayerIdentifier> layerlayerIDForEncoding { };
+    if (*changedProperties & WebCore::ScrollingStateNode::Property::Layer) {
+        if (auto deserialized = decoder.decode<std::optional<WebCore::PlatformLayerIdentifier>>())
+            changedProperties = WTFMove(*deserialized);
+        else
+            return std::nullopt;
+    }
+
+    bool otherMember { };
+    if (*changedProperties & WebCore::ScrollingStateNode::Property::Other) {
+        if (auto deserialized = decoder.decode<bool>())
+            changedProperties = WTFMove(*deserialized);
+        else
+            return std::nullopt;
+    }
+    auto memberAfterTuple = decoder.decode<int>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple::create(
+            WTFMove(*scrollingNodeID),
+            WTFMove(*children),
+            WTFMove(*changedProperties),
+            WTFMove(*layerlayerIDForEncoding),
+            WTFMove(*otherMember),
+            WTFMove(*memberAfterTuple)
+        )
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,6 +70,8 @@ namespace WebKit { class Fabulous; }
 namespace WebCore { struct Amazing; }
 namespace JSC { enum class Incredible; }
 namespace Testing { enum class StorageSize : uint8_t; }
+namespace WebCore { class ScrollingStateFrameHostingNode; }
+namespace WebCore { class ScrollingStateFrameHostingNodeWithStuffAfterTuple; }
 
 namespace IPC {
 
@@ -206,6 +208,16 @@ template<> struct ArgumentCoder<WebKit::TemplateTest<JSC::Incredible>> {
 template<> struct ArgumentCoder<WebKit::TemplateTest<Testing::StorageSize>> {
     static void encode(Encoder&, const WebKit::TemplateTest<Testing::StorageSize>&);
     static std::optional<WebKit::TemplateTest<Testing::StorageSize>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::ScrollingStateFrameHostingNode> {
+    static void encode(Encoder&, const WebCore::ScrollingStateFrameHostingNode&);
+    static std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple> {
+    static void encode(Encoder&, const WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple&);
+    static std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
 #include <WebCore/MoveOnlyDerivedClass.h>
+#include <WebCore/ScrollingStateFrameHostingNode.h>
+#include <WebCore/ScrollingStateFrameHostingNodeWithStuffAfterTuple.h>
 #include <WebCore/TimingFunction.h>
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
@@ -256,6 +258,43 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "bool"_s,
                 "value"_s
+            },
+        } },
+        { "WebCore::ScrollingStateFrameHostingNode"_s, {
+            {
+                "WebCore::ScrollingNodeID"_s,
+                "scrollingNodeID()"_s
+            },
+            {
+                "Vector<Ref<WebCore::ScrollingStateNode>>"_s,
+                "children()"_s
+            },
+            {
+                "OptionalTuple<"
+                    "std::optional<WebCore::PlatformLayerIdentifier>"
+                ">"_s,
+                "optionalTuple"_s
+            },
+        } },
+        { "WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple"_s, {
+            {
+                "WebCore::ScrollingNodeID"_s,
+                "scrollingNodeID()"_s
+            },
+            {
+                "Vector<Ref<WebCore::ScrollingStateNode>>"_s,
+                "children()"_s
+            },
+            {
+                "OptionalTuple<"
+                    "std::optional<WebCore::PlatformLayerIdentifier>"
+                    ", bool"
+                ">"_s,
+                "optionalTuple"_s
+            },
+            {
+                "int"_s,
+                "memberAfterTuple"_s
             },
         } },
         { "WebCore::SharedStringHash"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -176,7 +176,7 @@ webkit_platform_headers: "PlatformClass.h"
   int value;
 };
 
-class WebKit::LayerProperties {
+[LegacyPopulateFromEmptyConstructor] class WebKit::LayerProperties {
     [OptionalTupleBits] OptionSet<WebKit::LayerChange> changedProperties
     [NotSerialized] int nonSerializedMember
     [OptionalTupleBit=WebKit::LayerChange::NameChanged] String name;
@@ -198,4 +198,20 @@ template: enum class JSC::Incredible
 template: enum class Testing::StorageSize : uint8_t
 class WebKit::TemplateTest {
   bool value;
+}
+
+[RefCounted] class WebCore::ScrollingStateFrameHostingNode {
+    WebCore::ScrollingNodeID scrollingNodeID()
+    Vector<Ref<WebCore::ScrollingStateNode>> children()
+    [OptionalTupleBits] OptionSet<WebCore::ScrollingStateNodeProperty> changedProperties()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Layer] std::optional<WebCore::PlatformLayerIdentifier> layer().layerIDForEncoding()
+}
+
+[RefCounted] class WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple {
+    WebCore::ScrollingNodeID scrollingNodeID()
+    Vector<Ref<WebCore::ScrollingStateNode>> children()
+    [OptionalTupleBits] OptionSet<WebCore::ScrollingStateNodeProperty> changedProperties()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Layer] std::optional<WebCore::PlatformLayerIdentifier> layer().layerIDForEncoding()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Other] bool otherMember
+    int memberAfterTuple
 }

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -69,6 +69,7 @@ void ArgumentCoder<WebKit::PlatformClass>::encode(Encoder& encoder, const WebKit
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebKit::PlatformClass, value)
     >::value);
+
     encoder << instance.value;
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -189,7 +189,7 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
     std::unique_ptr<WebKit::RemoteLayerBackingStoreProperties> properties;
 };
 
-struct WebKit::LayerProperties {
+[LegacyPopulateFromEmptyConstructor] struct WebKit::LayerProperties {
     [OptionalTupleBits] OptionSet<WebKit::LayerChange> changedProperties;
     [NotSerialized] OptionSet<WebKit::LayerChange> everChangedProperties;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -198,12 +198,6 @@ void ArgumentCoder<WebCore::ScrollingStateFrameScrollingNode>::encode(Encoder& e
         encoder << node.rootContentsLayer().layerIDForEncoding();
 }
 
-void ArgumentCoder<WebCore::ScrollingStateFrameHostingNode>::encode(Encoder& encoder, const WebCore::ScrollingStateFrameHostingNode& node)
-{
-    encoder << node.scrollingNodeID();
-    encodeNodeShared(encoder, node);
-}
-
 void ArgumentCoder<WebCore::ScrollingStateOverflowScrollingNode>::encode(Encoder& encoder, const WebCore::ScrollingStateOverflowScrollingNode& node)
 {
     encoder << node.scrollingNodeID();
@@ -368,19 +362,6 @@ std::optional<Ref<WebCore::ScrollingStateFrameScrollingNode>> ArgumentCoder<WebC
             return std::nullopt;
         node->setRootContentsLayer(layerID.value_or(WebCore::PlatformLayerIdentifier { }));
     }
-
-    return WTFMove(node);
-}
-
-std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> ArgumentCoder<WebCore::ScrollingStateFrameHostingNode>::decode(Decoder& decoder)
-{
-    auto nodeID = decoder.decode<WebCore::ScrollingNodeID>();
-    if (!nodeID)
-        return std::nullopt;
-    auto node = WebCore::ScrollingStateFrameHostingNode::create(*nodeID);
-
-    if (!decodeNodeShared(decoder, node))
-        return std::nullopt;
 
     return WTFMove(node);
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -37,7 +37,6 @@ class Encoder;
 
 namespace WebCore {
 class ScrollingStateFrameScrollingNode;
-class ScrollingStateFrameHostingNode;
 class ScrollingStateOverflowScrollingNode;
 class ScrollingStateOverflowScrollProxyNode;
 class ScrollingStateFixedNode;
@@ -81,10 +80,6 @@ namespace IPC {
 template<> struct ArgumentCoder<WebCore::ScrollingStateFrameScrollingNode> {
     static void encode(Encoder&, const WebCore::ScrollingStateFrameScrollingNode&);
     static std::optional<Ref<WebCore::ScrollingStateFrameScrollingNode>> decode(Decoder&);
-};
-template<> struct ArgumentCoder<WebCore::ScrollingStateFrameHostingNode> {
-    static void encode(Encoder&, const WebCore::ScrollingStateFrameHostingNode&);
-    static std::optional<Ref<WebCore::ScrollingStateFrameHostingNode>> decode(Decoder&);
 };
 template<> struct ArgumentCoder<WebCore::ScrollingStateOverflowScrollingNode> {
     static void encode(Encoder&, const WebCore::ScrollingStateOverflowScrollingNode&);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -34,7 +34,6 @@ class WebKit::RemoteScrollingCoordinatorTransaction {
 }
 
 header: <WebCore/ScrollingStateFrameScrollingNode.h>
-header: <WebCore/ScrollingStateFrameHostingNode.h>
 header: <WebCore/ScrollingStateOverflowScrollingNode.h>
 header: <WebCore/ScrollingStateOverflowScrollProxyNode.h>
 header: <WebCore/ScrollingStateFixedNode.h>
@@ -50,3 +49,11 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     WebCore::ScrollingStateStickyNode,
     WebCore::ScrollingStatePositionedNode,
 }
+
+[RefCounted] class WebCore::ScrollingStateFrameHostingNode {
+    WebCore::ScrollingNodeID scrollingNodeID()
+    OptionSet<WebCore::ScrollingStateNodeProperty> changedProperties()
+    std::optional<WebCore::PlatformLayerIdentifier> layer().layerIDForEncoding()
+    Vector<Ref<WebCore::ScrollingStateNode>> children()
+}
+


### PR DESCRIPTION
#### 887ac88a0cce09a36aa033be0cef3998f9067ff2
<pre>
Generate serialization for ScrollingStateFrameHostingNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=263704">https://bugs.webkit.org/show_bug.cgi?id=263704</a>
rdar://117513008

Reviewed by Brady Eidson.

This required some new constructors, but the interesting part was teaching the
code generator how to handle types with OptionalTupleBits and non-OptionalTuple members.

* Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp:
(WebCore::ScrollingStateFrameHostingNode::create):
(WebCore::ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::ScrollingStateNode):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.has_optional_tuple_bits):
(check_type_members):
(encode_type):
(decode_type):
(generate_one_impl):
(generate_serialized_type_info):
(encode_optional_tuple): Deleted.
(decode_optional_tuple): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorStruct&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorWithIf&gt;::encode):
(IPC::ArgumentCoder&lt;WithoutNamespace&gt;::encode):
(IPC::ArgumentCoder&lt;WithoutNamespaceWithAttributes&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::InheritsFrom&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::InheritanceGrandchild&gt;::encode):
(IPC::ArgumentCoder&lt;WTF::Seconds&gt;::encode):
(IPC::ArgumentCoder&lt;WTF::CreateUsingClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FloatBoxExtent&gt;::encode):
(IPC::ArgumentCoder&lt;SoftLinkedMember&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ConditionalCommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::CommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::AnotherCommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyDerivedClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::LayerProperties&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::LayerProperties&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebKit::Fabulous&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebCore::Amazing&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;JSC::Incredible&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;Testing::StorageSize&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNode&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNode&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebKit::PlatformClass&gt;::encode):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNode&gt;::encode): Deleted.
(ArgumentCoder&lt;WebCore::ScrollingStateFrameHostingNode&gt;::decode): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:

Canonical link: <a href="https://commits.webkit.org/269811@main">https://commits.webkit.org/269811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c797d7ec9637ee5221d14262699a60921734748a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23622 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22374 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26377 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23805 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27621 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25382 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1464 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3030 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->