### PR TITLE
Regression(268375@main) Crash under ~Node() due to CheckedRef

### DIFF
--- a/LayoutTests/fast/dom/Node/Node-destruction-crash-expected.txt
+++ b/LayoutTests/fast/dom/Node/Node-destruction-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/dom/Node/Node-destruction-crash.html
+++ b/LayoutTests/fast/dom/Node/Node-destruction-crash.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+<style>
+    html {
+        content: "a" url();
+    }
+
+    html::before {
+        container-type: size;
+        content: url();
+        float: left;
+    }
+</style>
+</head>
+<body>
+<p>This test passes if it doesn't crash.</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -27,14 +27,18 @@
 
 #include <atomic>
 #include <wtf/Forward.h>
+#include <wtf/HashMap.h>
 #include <wtf/HashTraits.h>
 #include <wtf/RawPtrTraits.h>
+#include <wtf/StackTrace.h>
 
 #if ASSERT_ENABLED
 #include <wtf/Threading.h>
 #endif
 
 namespace WTF {
+
+#define CHECKED_POINTER_DEBUG 0
 
 template<typename T, typename PtrTraits>
 class CheckedRef {
@@ -44,39 +48,60 @@ public:
     ~CheckedRef()
     {
         unpoison(*this);
-        if (auto* ptr = PtrTraits::exchange(m_ptr, nullptr))
+        if (auto* ptr = PtrTraits::exchange(m_ptr, nullptr)) {
+#if CHECKED_POINTER_DEBUG
+            PtrTraits::unwrap(ptr)->unregisterCheckedPtr(this);
+#endif
             PtrTraits::unwrap(ptr)->decrementPtrCount();
+        }
     }
 
     CheckedRef(T& object)
         : m_ptr(&object)
     {
         PtrTraits::unwrap(m_ptr)->incrementPtrCount();
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->registerCheckedPtr(this);
+#endif
     }
 
     enum AdoptTag { Adopt };
     CheckedRef(T& object, AdoptTag)
         : m_ptr(&object)
     {
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->registerCheckedPtr(this);
+#endif
     }
 
     ALWAYS_INLINE CheckedRef(const CheckedRef& other)
         : m_ptr { PtrTraits::unwrap(other.m_ptr) }
     {
-        PtrTraits::unwrap(m_ptr)->incrementPtrCount();
+        auto* ptr = PtrTraits::unwrap(m_ptr);
+        ptr->incrementPtrCount();
+#if CHECKED_POINTER_DEBUG
+        ptr->copyCheckedPtr(&other, this);
+#endif
     }
 
     template<typename OtherType, typename OtherPtrTraits>
     CheckedRef(const CheckedRef<OtherType, OtherPtrTraits>& other)
         : m_ptr { PtrTraits::unwrap(other.m_ptr) }
     {
-        PtrTraits::unwrap(m_ptr)->incrementPtrCount();
+        auto* ptr = PtrTraits::unwrap(m_ptr);
+        ptr->incrementPtrCount();
+#if CHECKED_POINTER_DEBUG
+        ptr->copyCheckedPtr(&other, this);
+#endif
     }
 
     ALWAYS_INLINE CheckedRef(CheckedRef&& other)
         : m_ptr { other.releasePtr() }
     {
         ASSERT(m_ptr);
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->moveCheckedPtr(&other, this);
+#endif
     }
 
     template<typename OtherType, typename OtherPtrTraits>
@@ -84,6 +109,9 @@ public:
         : m_ptr { other.releasePtr() }
     {
         ASSERT(m_ptr);
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->moveCheckedPtr(&other, this);
+#endif
     }
 
     CheckedRef(HashTableDeletedValueType) : m_ptr(PtrTraits::hashTableDeletedValue()) { }
@@ -106,40 +134,60 @@ public:
     CheckedRef& operator=(T& reference)
     {
         unpoison(*this);
+        unregisterCheckedPtrIfNecessary();
         CheckedRef copy { reference };
         PtrTraits::swap(m_ptr, copy.m_ptr);
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->copyCheckedPtr(&copy, this);
+#endif
         return *this;
     }
 
     CheckedRef& operator=(const CheckedRef& other)
     {
         unpoison(*this);
+        unregisterCheckedPtrIfNecessary();
         CheckedRef copy { other };
         PtrTraits::swap(m_ptr, copy.m_ptr);
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->copyCheckedPtr(&copy, this);
+#endif
         return *this;
     }
 
     template<typename OtherType, typename OtherPtrTraits> CheckedRef& operator=(const CheckedRef<OtherType, OtherPtrTraits>& other)
     {
         unpoison(*this);
+        unregisterCheckedPtrIfNecessary();
         CheckedRef copy { other };
         PtrTraits::swap(m_ptr, copy.m_ptr);
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->copyCheckedPtr(&copy, this);
+#endif
         return *this;
     }
 
     CheckedRef& operator=(CheckedRef&& other)
     {
         unpoison(*this);
+        unregisterCheckedPtrIfNecessary();
         CheckedRef moved { WTFMove(other) };
         PtrTraits::swap(m_ptr, moved.m_ptr);
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->copyCheckedPtr(&moved, this);
+#endif
         return *this;
     }
 
     template<typename OtherType, typename OtherPtrTraits> CheckedRef& operator=(CheckedRef<OtherType, OtherPtrTraits>&& other)
     {
         unpoison(*this);
+        unregisterCheckedPtrIfNecessary();
         CheckedRef moved { WTFMove(other) };
         PtrTraits::swap(m_ptr, moved.m_ptr);
+#if CHECKED_POINTER_DEBUG
+        PtrTraits::unwrap(m_ptr)->copyCheckedPtr(&moved, this);
+#endif
         return *this;
     }
 
@@ -152,6 +200,16 @@ private:
         T* ptr = PtrTraits::exchange(m_ptr, nullptr);
         poison(*this);
         return ptr;
+    }
+
+    ALWAYS_INLINE void unregisterCheckedPtrIfNecessary()
+    {
+#if CHECKED_POINTER_DEBUG
+        if (isHashTableDeletedValue() || isHashTableEmptyValue())
+            return;
+
+        PtrTraits::unwrap(m_ptr)->unregisterCheckedPtr(this);
+#endif
     }
 
 #if ASAN_ENABLED
@@ -247,7 +305,24 @@ template<typename P> struct DefaultHash<CheckedRef<P>> : PtrHash<CheckedRef<P>> 
 
 template <typename StorageType, typename PtrCounterType> class CanMakeCheckedPtrBase {
 public:
-    ~CanMakeCheckedPtrBase() { RELEASE_ASSERT(!m_count); }
+    CanMakeCheckedPtrBase() = default;
+    CanMakeCheckedPtrBase(CanMakeCheckedPtrBase&&) { }
+    CanMakeCheckedPtrBase& operator=(CanMakeCheckedPtrBase&&) { return *this; }
+    CanMakeCheckedPtrBase(const CanMakeCheckedPtrBase&) { }
+    CanMakeCheckedPtrBase& operator=(const CanMakeCheckedPtrBase&) { return *this; }
+
+    ~CanMakeCheckedPtrBase()
+    {
+#if CHECKED_POINTER_DEBUG
+        if (m_count) {
+            for (auto& stackTrace : m_checkedPtrs.values())
+                WTFLogAlways("%s", stackTrace->toString().utf8().data());
+        }
+#endif
+        // If you hit this assertion, you can turn on CHECKED_POINTER_DEBUG to help identify
+        // which CheckedPtr / CheckedRef outlived the object.
+        RELEASE_ASSERT(!m_count);
+    }
 
     PtrCounterType ptrCount() const { return m_count; }
     void incrementPtrCount() const { ++m_count; }
@@ -255,9 +330,88 @@ public:
 
     friend bool operator==(const CanMakeCheckedPtrBase&, const CanMakeCheckedPtrBase&) { return true; }
 
+#if CHECKED_POINTER_DEBUG
+    void registerCheckedPtr(const void* pointer) const;
+
+    void copyCheckedPtr(const void* source, const void* destination) const
+    {
+        auto doCopyCheckedPtr = [&] {
+            auto stackTrace = m_checkedPtrs.get(source);
+            ASSERT(stackTrace);
+            m_checkedPtrs.add(destination, WTFMove(stackTrace));
+        };
+        if constexpr (std::is_same_v<StorageType, std::atomic<uint32_t>>) {
+            Locker locker { m_checkedPtrsLock };
+            doCopyCheckedPtr();
+        } else
+            doCopyCheckedPtr();
+    }
+
+    void moveCheckedPtr(const void* source, const void* destination) const
+    {
+        auto doMoveCheckedPtr = [&] {
+            auto stackTrace = m_checkedPtrs.take(source);
+            ASSERT(stackTrace);
+            m_checkedPtrs.add(destination, WTFMove(stackTrace));
+        };
+        if constexpr (std::is_same_v<StorageType, std::atomic<uint32_t>>) {
+            Locker locker { m_checkedPtrsLock };
+            doMoveCheckedPtr();
+        } else
+            doMoveCheckedPtr();
+    }
+
+    void unregisterCheckedPtr(const void* pointer) const
+    {
+        if constexpr (std::is_same_v<StorageType, std::atomic<uint32_t>>) {
+            Locker locker { m_checkedPtrsLock };
+            m_checkedPtrs.remove(pointer);
+        } else
+            m_checkedPtrs.remove(pointer);
+    }
+#endif // CHECKED_POINTER_DEBUG
+
 private:
+#if CHECKED_POINTER_DEBUG
+    class SharedStackTrace : public RefCounted<SharedStackTrace> {
+    public:
+        static Ref<SharedStackTrace> create()
+        {
+            return adoptRef(*new SharedStackTrace);
+        }
+
+        String toString() const { return m_trace->toString(); }
+
+    private:
+        SharedStackTrace()
+        {
+            static constexpr size_t maxFrameToCapture = 8;
+            static constexpr size_t framesToSkip = 4;
+            m_trace = StackTrace::captureStackTrace(maxFrameToCapture, framesToSkip);
+        }
+
+        std::unique_ptr<StackTrace> m_trace;
+    };
+#endif
+
     mutable StorageType m_count { 0 };
+#if CHECKED_POINTER_DEBUG
+    mutable Lock m_checkedPtrsLock;
+    mutable HashMap<const void* /* CheckedPtr or CheckedRef */, RefPtr<SharedStackTrace>> m_checkedPtrs;
+#endif
 };
+
+#if CHECKED_POINTER_DEBUG
+template <typename StorageType, typename PtrCounterType>
+void CanMakeCheckedPtrBase<StorageType, PtrCounterType>::registerCheckedPtr(const void* pointer) const
+{
+    if constexpr (std::is_same_v<StorageType, std::atomic<uint32_t>>) {
+        Locker locker { m_checkedPtrsLock };
+        m_checkedPtrs.add(pointer, SharedStackTrace::create());
+    } else
+        m_checkedPtrs.add(pointer, SharedStackTrace::create());
+}
+#endif
 
 template <typename IntegralType>
 class SingleThreadIntegralWrapper {
@@ -265,7 +419,7 @@ public:
     SingleThreadIntegralWrapper(IntegralType);
 
     operator IntegralType() const;
-    bool operator!() const;
+    explicit operator bool() const;
     SingleThreadIntegralWrapper& operator++();
     SingleThreadIntegralWrapper& operator--();
 
@@ -298,10 +452,10 @@ inline SingleThreadIntegralWrapper<IntegralType>::operator IntegralType() const
 }
 
 template <typename IntegralType>
-inline bool SingleThreadIntegralWrapper<IntegralType>::operator!() const
+inline SingleThreadIntegralWrapper<IntegralType>::operator bool() const
 {
     assertThread();
-    return !m_value;
+    return m_value;
 }
 
 template <typename IntegralType>

--- a/Source/WTF/wtf/StackTrace.cpp
+++ b/Source/WTF/wtf/StackTrace.cpp
@@ -30,6 +30,7 @@
 #include <type_traits>
 #include <wtf/Assertions.h>
 #include <wtf/PrintStream.h>
+#include <wtf/StringPrintStream.h>
 
 #if USE(LIBBACKTRACE)
 #include <string.h>
@@ -119,6 +120,13 @@ std::unique_ptr<StackTrace> StackTrace::captureStackTrace(size_t maxFrames, size
         initialFrame = framesToSkip - 2; 
     }
     return std::unique_ptr<StackTrace> { new (NotNull, storage) StackTrace(size, initialFrame) };
+}
+
+String StackTrace::toString() const
+{
+    StringPrintStream stream;
+    dump(stream);
+    return stream.toString();
 }
 
 auto StackTraceSymbolResolver::demangle(void* pc) -> std::optional<DemangleEntry>

--- a/Source/WTF/wtf/StackTrace.h
+++ b/Source/WTF/wtf/StackTrace.h
@@ -28,6 +28,7 @@
 
 #include <optional>
 #include <span>
+#include <wtf/Forward.h>
 #include <wtf/SystemFree.h>
 
 #if HAVE(BACKTRACE_SYMBOLS) || HAVE(BACKTRACE)
@@ -67,8 +68,9 @@ public:
     }
 
     void dump(PrintStream&) const;
-private:
+    WTF_EXPORT_PRIVATE String toString() const;
 
+private:
     StackTrace(size_t size, size_t initialFrame)
         : m_size(size)
         , m_initialFrame(initialFrame)

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -80,7 +80,8 @@ StyleSheetContents::StyleSheetContents(StyleRuleImport* ownerRule, const String&
 }
 
 StyleSheetContents::StyleSheetContents(const StyleSheetContents& o)
-    : m_originalURL(o.m_originalURL)
+    : CanMakeCheckedPtr()
+    , m_originalURL(o.m_originalURL)
     , m_encodingFromCharsetRule(o.m_encodingFromCharsetRule)
     , m_layerRulesBeforeImportRules(o.m_layerRulesBeforeImportRules.size())
     , m_importRules(o.m_importRules.size())

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -400,6 +400,12 @@ public:
     // Resolve ambiguity for CanMakeCheckedPtr.
     void incrementPtrCount() const { static_cast<const ContainerNode*>(this)->incrementPtrCount(); }
     void decrementPtrCount() const { static_cast<const ContainerNode*>(this)->decrementPtrCount(); }
+#if CHECKED_POINTER_DEBUG
+    void registerCheckedPtr(const void* pointer) const { static_cast<const ContainerNode*>(this)->registerCheckedPtr(pointer); }
+    void copyCheckedPtr(const void* source, const void* destination) const { static_cast<const ContainerNode*>(this)->copyCheckedPtr(source, destination); }
+    void moveCheckedPtr(const void* source, const void* destination) const { static_cast<const ContainerNode*>(this)->moveCheckedPtr(source, destination); }
+    void unregisterCheckedPtr(const void* pointer) const { static_cast<const ContainerNode*>(this)->unregisterCheckedPtr(pointer); }
+#endif // CHECKED_POINTER_DEBUG
 
     // Nodes belonging to this document increase referencingNodeCount -
     // these are enough to keep the document from being destroyed, but

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -68,6 +68,12 @@ public:
     // Resolve ambiguity for CanMakeCheckedPtr.
     void incrementPtrCount() const { static_cast<const DocumentFragment*>(this)->incrementPtrCount(); }
     void decrementPtrCount() const { static_cast<const DocumentFragment*>(this)->decrementPtrCount(); }
+#if CHECKED_POINTER_DEBUG
+    void registerCheckedPtr(const void* pointer) const { static_cast<const DocumentFragment*>(this)->registerCheckedPtr(pointer); }
+    void copyCheckedPtr(const void* source, const void* destination) const { static_cast<const DocumentFragment*>(this)->copyCheckedPtr(source, destination); }
+    void moveCheckedPtr(const void* source, const void* destination) const { static_cast<const DocumentFragment*>(this)->moveCheckedPtr(source, destination); }
+    void unregisterCheckedPtr(const void* pointer) const { static_cast<const DocumentFragment*>(this)->unregisterCheckedPtr(pointer); }
+#endif // CHECKED_POINTER_DEBUG
 
     using TreeScope::getElementById;
     using TreeScope::rootNode;

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -105,6 +105,41 @@ void TreeScope::decrementPtrCount() const
         checkedDowncast<ShadowRoot>(m_rootNode).decrementPtrCount();
 }
 
+#if CHECKED_POINTER_DEBUG
+void TreeScope::registerCheckedPtr(const void* pointer) const
+{
+    if (auto* document = dynamicDowncast<Document>(m_rootNode))
+        document->registerCheckedPtr(pointer);
+    else
+        checkedDowncast<ShadowRoot>(m_rootNode).registerCheckedPtr(pointer);
+}
+
+void TreeScope::copyCheckedPtr(const void* source, const void* destination) const
+{
+    if (auto* document = dynamicDowncast<Document>(m_rootNode))
+        document->copyCheckedPtr(source, destination);
+    else
+        checkedDowncast<ShadowRoot>(m_rootNode).copyCheckedPtr(source, destination);
+}
+
+void TreeScope::moveCheckedPtr(const void* source, const void* destination) const
+{
+    if (auto* document = dynamicDowncast<Document>(m_rootNode))
+        document->moveCheckedPtr(source, destination);
+    else
+        checkedDowncast<ShadowRoot>(m_rootNode).moveCheckedPtr(source, destination);
+}
+
+void TreeScope::unregisterCheckedPtr(const void* pointer) const
+{
+    if (auto* document = dynamicDowncast<Document>(m_rootNode))
+        document->unregisterCheckedPtr(pointer);
+    else
+        checkedDowncast<ShadowRoot>(m_rootNode).unregisterCheckedPtr(pointer);
+}
+#endif // CHECKED_POINTER_DEBUG
+
+
 void TreeScope::destroyTreeScopeData()
 {
     m_elementsById = nullptr;

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -71,6 +71,12 @@ public:
     // For CheckedPtr / CheckedRef use.
     void incrementPtrCount() const;
     void decrementPtrCount() const;
+#if CHECKED_POINTER_DEBUG
+    void registerCheckedPtr(const void*) const;
+    void copyCheckedPtr(const void* source, const void* destination) const;
+    void moveCheckedPtr(const void* source, const void* destination) const;
+    void unregisterCheckedPtr(const void*) const;
+#endif // CHECKED_POINTER_DEBUG
 
     Element* focusedElementInScope();
     Element* pointerLockElement() const;

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -67,6 +67,7 @@ HistoryItem::~HistoryItem()
 
 HistoryItem::HistoryItem(const HistoryItem& item)
     : RefCounted<HistoryItem>()
+    , CanMakeCheckedPtr()
     , m_urlString(item.m_urlString)
     , m_originalURLString(item.m_originalURLString)
     , m_referrer(item.m_referrer)

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -46,6 +46,12 @@ public:
     // Resolve ambiguity for CanMakeCheckedPtr.
     void incrementPtrCount() const { static_cast<const RenderBlockFlow*>(this)->incrementPtrCount(); }
     void decrementPtrCount() const { static_cast<const RenderBlockFlow*>(this)->decrementPtrCount(); }
+#if CHECKED_POINTER_DEBUG
+    void registerCheckedPtr(const void* pointer) const { static_cast<const RenderBlockFlow*>(this)->registerCheckedPtr(pointer); }
+    void copyCheckedPtr(const void* source, const void* destination) const { static_cast<const RenderBlockFlow*>(this)->copyCheckedPtr(source, destination); }
+    void moveCheckedPtr(const void* source, const void* destination) const { static_cast<const RenderBlockFlow*>(this)->moveCheckedPtr(source, destination); }
+    void unregisterCheckedPtr(const void* pointer) const { static_cast<const RenderBlockFlow*>(this)->unregisterCheckedPtr(pointer); }
+#endif // CHECKED_POINTER_DEBUG
 
     RenderListBox(HTMLSelectElement&, RenderStyle&&);
     virtual ~RenderListBox();

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -110,15 +110,8 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 
 #endif
 
-struct SameSizeAsRenderObject : CanMakeWeakPtr<SameSizeAsRenderObject> {
+struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedPtr {
     virtual ~SameSizeAsRenderObject() = default; // Allocate vtable pointer.
-#if ASSERT_ENABLED
-    WeakHashSet<void*> cachedResourceClientAssociatedResources; // CachedImageClient.
-#endif
-    uint32_t m_checkedPtrCount; // CanMakeCheckedPtr.
-#if ASSERT_ENABLED && !USE(WEB_THREAD)
-    Ref<Thread> m_thread; // CanMakeCheckedPtr.
-#endif
 #if ASSERT_ENABLED
     unsigned m_debugBitfields : 2;
 #endif

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -935,7 +935,7 @@ bool Scope::updateQueryContainerState(QueryContainerUpdateContext& context)
         auto it = previousStates.find(*containerElement);
         bool changed = it == previousStates.end() || sizeChanged(it->value);
         // Protect against unstable layout by invalidating only once per container.
-        if (changed && context.invalidatedContainers.add(*containerElement).isNewEntry)
+        if (changed && context.invalidatedContainers.add(containerElement).isNewEntry)
             containersToInvalidate.append(containerElement);
         m_queryContainerStates.add(*containerElement, size);
     }

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -139,7 +139,10 @@ public:
     static Scope* forOrdinal(Element&, ScopeOrdinal);
 
     struct QueryContainerUpdateContext {
-        HashSet<CheckedRef<Element>> invalidatedContainers;
+        // FIXME: Switching to a WeakHashSet causes fast/dom/Node/Node-destruction-crash.html
+        // to time out. Scope::updateQueryContainerState() seems to rely on this container
+        // containing stale pointers.
+        HashSet<Element*> invalidatedContainers;
     };
     bool updateQueryContainerState(QueryContainerUpdateContext&);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -145,6 +145,13 @@ public:
 
     using CanMakeThreadSafeCheckedPtr::incrementPtrCount;
     using CanMakeThreadSafeCheckedPtr::decrementPtrCount;
+#if CHECKED_POINTER_DEBUG
+    using CanMakeThreadSafeCheckedPtr::registerCheckedPtr;
+    using CanMakeThreadSafeCheckedPtr::copyCheckedPtr;
+    using CanMakeThreadSafeCheckedPtr::moveCheckedPtr;
+    using CanMakeThreadSafeCheckedPtr::unregisterCheckedPtr;
+#endif // CHECKED_POINTER_DEBUG
+
 
     NetworkProcess(AuxiliaryProcessInitializationParameters&&);
     ~NetworkProcess();


### PR DESCRIPTION
#### f747a6b78181b8efeb10a03e42b1fb66216082f5
<pre>
Regression(268375@main) Crash under ~Node() due to CheckedRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=263671">https://bugs.webkit.org/show_bug.cgi?id=263671</a>
rdar://117483509

Reviewed by Ryosuke Niwa.

Add code behind a CHECKED_POINTER_DEBUG compile flag (off by default) to help
debug CheckedPtr / CheckedRef crashes. I used this code to debug the crash in
this bug.

Do a partial revert of 268375@main to address the regression and add a FIXME
comment to address this better in the near future.

* LayoutTests/fast/dom/Node/Node-destruction-crash-expected.txt: Added.
* LayoutTests/fast/dom/Node/Node-destruction-crash.html: Added.
* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::~CheckedPtr):
(WTF::CheckedPtr::releaseNonNull):
(WTF::CheckedPtr::operator=):
(WTF::CheckedPtr::unregisterCheckedPtrIfNecessary):
* Source/WTF/wtf/CheckedRef.h:
(WTF::CheckedRef::~CheckedRef):
(WTF::CheckedRef::CheckedRef):
(WTF::CheckedRef::operator=):
(WTF::CheckedRef::unregisterCheckedPtrIfNecessary):
(WTF::CanMakeCheckedPtrBase::CanMakeCheckedPtrBase):
(WTF::CanMakeCheckedPtrBase::operator=):
(WTF::CanMakeCheckedPtrBase::~CanMakeCheckedPtrBase):
(WTF::CanMakeCheckedPtrBase::copyCheckedPtr const):
(WTF::CanMakeCheckedPtrBase::moveCheckedPtr const):
(WTF::CanMakeCheckedPtrBase::unregisterCheckedPtr const):
(WTF::CanMakeCheckedPtrBase::SharedStackTrace::create):
(WTF::CanMakeCheckedPtrBase::SharedStackTrace::toString const):
(WTF::CanMakeCheckedPtrBase::SharedStackTrace::SharedStackTrace):
(WTF::PtrCounterType&gt;::registerCheckedPtr const):
(WTF::bool const):
(WTF::SingleThreadIntegralWrapper&lt;IntegralType&gt;::operator const): Deleted.
* Source/WTF/wtf/StackTrace.cpp:
(WTF::StackTrace::toString const):
* Source/WTF/wtf/StackTrace.h:
* Source/WebCore/dom/Document.h:
(WebCore::Document::registerCheckedPtr const):
(WebCore::Document::copyCheckedPtr const):
(WebCore::Document::moveCheckedPtr const):
(WebCore::Document::unregisterCheckedPtr const):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::registerCheckedPtr const):
(WebCore::TreeScope::copyCheckedPtr const):
(WebCore::TreeScope::moveCheckedPtr const):
(WebCore::TreeScope::unregisterCheckedPtr const):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateQueryContainerState):
* Source/WebCore/style/StyleScope.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:

Canonical link: <a href="https://commits.webkit.org/269829@main">https://commits.webkit.org/269829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/217d581af8cfde50707ab85e7c54f43768c2f6f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24219 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26439 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23867 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27666 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20617 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25432 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23027 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1108 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18810 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30416 "Built successfully") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/23476 "Failed build.webkit.org unit tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21174 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6680 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5665 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1522 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30370 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1401 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6350 "Passed tests") | 
<!--EWS-Status-Bubble-End-->