### PR TITLE
WebGLRenderingContextBase::m_layerCleared is a redundant flag

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -744,7 +744,6 @@ void WebGLRenderingContextBase::initializeContextState()
     m_stencilFuncRefBack = 0;
     m_stencilFuncMask = 0xFFFFFFFF;
     m_stencilFuncMaskBack = 0xFFFFFFFF;
-    m_layerCleared = false;
 
     m_rasterizerDiscardEnabled = false;
 
@@ -886,7 +885,6 @@ void WebGLRenderingContextBase::markContextChanged()
 
     m_context->markContextChanged();
 
-    m_layerCleared = false;
     m_compositingResultsNeedUpdating = true;
 
     if (auto* canvas = htmlCanvas()) {
@@ -934,7 +932,7 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cal
     // `clearIfComposited()` is a function that prepares for updates. Mark the context as active.
     updateActiveOrdinal();
 
-    if (!m_context->layerComposited() || m_layerCleared || m_preventBufferClearForInspector)
+    if (!m_context->layerComposited() || m_preventBufferClearForInspector)
         return false;
 
     GCGLbitfield buffersNeedingClearing = m_context->getBuffersToAutoClear();
@@ -993,8 +991,6 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cal
     restoreStateAfterClear();
     if (m_framebufferBinding)
         m_context->bindFramebuffer(bindingPoint, m_framebufferBinding->object());
-    m_layerCleared = true;
-
     return combinedClear;
 }
 
@@ -1046,7 +1042,7 @@ void WebGLRenderingContextBase::paintRenderingResultsToCanvas()
 
     clearIfComposited(CallerTypeOther);
 
-    if (!m_markedCanvasDirty && !m_layerCleared)
+    if (!m_markedCanvasDirty && m_context->getBuffersToAutoClear())
         return;
 
     auto& base = canvasBase();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -652,7 +652,6 @@ protected:
 
     PredefinedColorSpace m_drawingBufferColorSpace { PredefinedColorSpace::SRGB };
 
-    bool m_layerCleared;
     GCGLfloat m_clearColor[4];
     bool m_scissorEnabled;
     GCGLfloat m_clearDepth;


### PR DESCRIPTION
#### 0a9d09eaf785b2d9b6027bc9b77ed67adbfb88d5
<pre>
WebGLRenderingContextBase::m_layerCleared is a redundant flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=263721">https://bugs.webkit.org/show_bug.cgi?id=263721</a>
rdar://problem/117533757

Reviewed by Dan Glastonbury.

The m_layerCleared was cleared when buffers to auto clear was reset to
the default.
The m_layerCleared was set when buffers to auto clear was cleared.

The idea of the flag is to control
a) no extra default framebuffer clears being done
b) default framebuffer draw buffer is not being accessed in
WebGLRenderingContextBase::paintRenderingResultsToCanvas without
the clear happening.

The flag has same state as multiple other flags. Just remove it to
simplify the code.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::markContextChanged):
(WebCore::WebGLRenderingContextBase::clearIfComposited):
(WebCore::WebGLRenderingContextBase::paintRenderingResultsToCanvas):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/269927@main">https://commits.webkit.org/269927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5857405a97dad3fba5f995ec2d5af367225772e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22397 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26407 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27645 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25408 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18781 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1059 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5755 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->