### PR TITLE
REGRESSION ( Sonoma?): [ Sonoma ] TestWebKitAPI.WebKit.FirstResponderSuppression is a consistent failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/FirstResponderSuppression.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FirstResponderSuppression.mm
@@ -28,6 +28,7 @@
 #if PLATFORM(MAC)
 
 #import "PlatformUtilities.h"
+#import "TestWKWebView.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
@@ -47,12 +48,12 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, FirstResponderSuppression)
 {
-    RetainPtr<NSWindow> window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600) styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600) styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
     [window makeKeyAndOrderFront:nil];
 
-    RetainPtr<FirstResponderNavigationDelegate> delegate = adoptNS([[FirstResponderNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[FirstResponderNavigationDelegate alloc] init]);
 
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView _setShouldSuppressFirstResponderChanges:YES];
     [webView setNavigationDelegate:delegate.get()];
     [[window contentView] addSubview:webView.get()];
@@ -73,6 +74,9 @@ TEST(WebKit, FirstResponderSuppression)
     // Ensure having an autofocused input field does steal focus.
     [webView loadHTMLString:testHTML baseURL:nil];
     TestWebKitAPI::Util::run(&finishedLoad);
+
+    [webView waitForNextPresentationUpdate];
+
     EXPECT_NE([window firstResponder], [window contentView]);
 }
 


### PR DESCRIPTION
#### 9047e5a1beb51ccacc362bc9f24dc0419ab9cba2
<pre>
REGRESSION ( Sonoma?): [ Sonoma ] TestWebKitAPI.WebKit.FirstResponderSuppression is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263449">https://bugs.webkit.org/show_bug.cgi?id=263449</a>
rdar://117267482

Reviewed by Wenson Hsieh.

There is some delay until the focus changes to make the test more robust to
deal with that.

* Tools/TestWebKitAPI/Tests/mac/FirstResponderSuppression.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/269820@main">https://commits.webkit.org/269820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a29e2e3ff8e9c3f2bbe32ae3765add2ed5269847

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23932 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/3379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24199 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26418 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1118 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21382 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27652 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25417 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18790 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1068 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5660 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->