### PR TITLE
[iOS] Fullscreen video becomes unresponsive after repeated PiP operations

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h
@@ -71,6 +71,7 @@ public:
     bool isPlayingVideoInEnhancedFullscreen() const { return false; }
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return std::nullopt; }
     bool changingStandbyOnly() { return false; }
+    bool returningToStandby() const { return false; }
 
     // VideoPresentationModelClient
     void hasVideoChanged(bool) final { }

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1570,11 +1570,15 @@ void VideoFullscreenInterfaceAVKit::enterFullscreenHandler(BOOL success, NSError
     }
 
     LOG(Fullscreen, "VideoFullscreenInterfaceAVKit::enterFullscreenStandard - lambda(%p)", this);
-    if (!m_standby) {
+    if (!m_standby)
         setMode(HTMLMediaElementEnums::VideoFullscreenModeStandard, !nextActions.contains(NextAction::NeedsEnterFullScreen));
-        [m_playerViewController setShowsPlaybackControls:YES];
-    } else
-        [m_playerViewController setShowsPlaybackControls:NO];
+
+    // NOTE: During a "returnToStandby" operation, this will cause the AVKit controls
+    // to be visible if the user taps on the fullscreen presentation before the Element
+    // Fullscreen presentation is fully restored. This is intentional; in the case that
+    // the Element Fullscreen presentation fails for any reason, this gives the user
+    // the ability to dismiss AVKit fullscreen.
+    [m_playerViewController setShowsPlaybackControls:YES];
 
     if (nextActions.contains(NextAction::NeedsEnterFullScreen))
         doEnterFullscreen();

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -186,6 +186,7 @@ public:
     void requestBitmapImageForCurrentTime(PlaybackSessionContextIdentifier, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&&);
 
 #if PLATFORM(IOS_FAMILY)
+    WebCore::PlatformVideoFullscreenInterface* returningToStandbyInterface() const;
     AVPlayerViewController *playerViewController(PlaybackSessionContextIdentifier) const;
     RetainPtr<WKVideoView> createViewWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& nativeSize, float hostingScaleFactor);
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -723,6 +723,19 @@ RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWit
 }
 
 #if PLATFORM(IOS_FAMILY)
+PlatformVideoFullscreenInterface* VideoPresentationManagerProxy::returningToStandbyInterface() const
+{
+    if (m_contextMap.isEmpty())
+        return nullptr;
+
+    for (auto& value : copyToVector(m_contextMap.values())) {
+        auto& interface = std::get<1>(value);
+        if (interface && interface->returningToStandby())
+            return interface.get();
+    }
+    return nullptr;
+}
+
 RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& nativeSize, float hostingDeviceScaleFactor)
 {
     auto& [model, interface] = ensureModelAndInterface(contextId);

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1036,7 +1036,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
                     });
                     videoPresentationManager->addVideoInPictureInPictureDidChangeObserver(*_pipObserver);
                 }
-                if (auto* videoFullscreenInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr) {
+                if (auto* videoFullscreenInterface = videoPresentationManager ? videoPresentationManager->returningToStandbyInterface() : nullptr) {
                     if (_returnToFullscreenFromPictureInPicture)
                         videoFullscreenInterface->preparedToReturnToStandby();
                     else if (videoFullscreenInterface->inPictureInPicture()) {
@@ -1288,7 +1288,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 - (void)didExitPictureInPicture
 {
     if (!_enterFullscreenNeedsExitPictureInPicture && _shouldReturnToFullscreenFromPictureInPicture) {
-        auto* videoFullscreenInterface = self._videoPresentationManager ? self._videoPresentationManager->controlsManagerInterface() : nullptr;
+        auto* videoFullscreenInterface = self._videoPresentationManager ? self._videoPresentationManager->returningToStandbyInterface() : nullptr;
         if (videoFullscreenInterface && videoFullscreenInterface->returningToStandby()) {
             OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, "returning to standby");
             if (!_exitingFullScreen) {


### PR DESCRIPTION
#### 0be7e2dbbc9c1f2387649d188a61056e0d692cd5
<pre>
[iOS] Fullscreen video becomes unresponsive after repeated PiP operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=263656">https://bugs.webkit.org/show_bug.cgi?id=263656</a>
rdar://117099076

Reviewed by Eric Carlson.

Entering and exiting PiP and element fullscreen can cause confusion when restoring
the element fullscreen presentation, e.g. when the user choses the &quot;restore&quot; button
in the iOS picture-in-picture window. This is because the &quot;controls manager&quot; interface
(i.e., the interface that represents the &quot;now playing&quot; video element) may be different
than the interface currently being restored.

Add a new method to VideoPresentationManagerProxy, returningToStandbyInterface(), which
returns the interface which is currently awaiting confirmation that the element fullscreen
restoration process has completed.

Separately, do not disable AVKit controls during the AVKit fullscreen portion of this
process. This has the effect of allowing the user to tap on the AVKit fullscreen presentation
and see AVKit provided controls before the element fullscreen presentation completes,
but it also allows the user to dismiss the AVKit fullscreen presentation if the element
fullscreen presentation fails for any reason.

* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::enterFullscreenHandler):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::returningToStandbyInterface const):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController didExitPictureInPicture]):

Canonical link: <a href="https://commits.webkit.org/269842@main">https://commits.webkit.org/269842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/433a7f6d689c43e776890033d5249bd0c22c5540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22436 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26479 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27690 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25458 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18834 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1128 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5680 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->