### PR TITLE
[Font] Fix "system-ui" font family within <canvas>

### DIFF
--- a/LayoutTests/fast/canvas/font-family-system-ui-canvas-expected-mismatch.html
+++ b/LayoutTests/fast/canvas/font-family-system-ui-canvas-expected-mismatch.html
@@ -1,0 +1,8 @@
+<canvas id="myCanvas" width="200" height="100"></canvas>
+
+<script>
+var c = document.getElementById("myCanvas");
+var ctx = c.getContext("2d");
+ctx.font = "30px serif";
+ctx.fillText("Hello World", 10, 50);
+</script>

--- a/LayoutTests/fast/canvas/font-family-system-ui-canvas.html
+++ b/LayoutTests/fast/canvas/font-family-system-ui-canvas.html
@@ -1,0 +1,8 @@
+<canvas id="myCanvas" width="200" height="100"></canvas>
+
+<script>
+var c = document.getElementById("myCanvas");
+var ctx = c.getContext("2d");
+ctx.font = "30px system-ui";
+ctx.fillText("Hello World", 10, 50);
+</script> 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2654,4 +2654,6 @@ webkit.org/b/261024 webrtc/utf8-sdp.html [ Pass Timeout ]
 
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]
 
+fast/canvas/font-family-system-ui-canvas.html [ Skip ]
+
 fast/line-grid [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1676,4 +1676,6 @@ imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-function-to-url.
 
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]
 
+fast/canvas/font-family-system-ui-canvas.html [ Skip ]
+
 fast/line-grid [ Skip ]

--- a/Source/WebCore/style/StyleResolveForFontRaw.cpp
+++ b/Source/WebCore/style/StyleResolveForFontRaw.cpp
@@ -72,9 +72,13 @@ std::optional<FontCascade> resolveForFontRaw(const FontRaw& fontRaw, FontCascade
         bool isGenericFamily = false;
         switchOn(item, [&] (CSSValueID ident) {
             isGenericFamily = ident != CSSValueWebkitBody;
-            if (isGenericFamily)
-                family = familyNamesData->at(CSSPropertyParserHelpers::genericFontFamilyIndex(ident));
-            else
+            if (isGenericFamily) {
+                // FIXME: Treat system-ui like other generic font families
+                if (ident == CSSValueSystemUi)
+                    family = nameString(CSSValueSystemUi);
+                else
+                    family = familyNamesData->at(CSSPropertyParserHelpers::genericFontFamilyIndex(ident));
+            } else
                 family = AtomString(context.settingsValues().fontGenericFamilies.standardFontFamily());
         }, [&] (const AtomString& familyString) {
             family = familyString;


### PR DESCRIPTION
#### caa9d18f36b5f59249e81102072195b4212cf8a5
<pre>
[Font] Fix &quot;system-ui&quot; font family within &lt;canvas&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=263719">https://bugs.webkit.org/show_bug.cgi?id=263719</a>
rdar://117231545

Reviewed by Tim Nguyen.

The &quot;system-ui&quot; font family is expected down the line (in /platform code)
to be a string like a user font and not the CSS prefixed keyword.

* LayoutTests/fast/canvas/font-family-system-ui-canvas-expected-mismatch.html: Added.
* LayoutTests/fast/canvas/font-family-system-ui-canvas.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/style/StyleResolveForFontRaw.cpp:
(WebCore::Style::resolveForFontRaw):

Canonical link: <a href="https://commits.webkit.org/269873@main">https://commits.webkit.org/269873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f192e4ae6cf3638b0bfefb3b7799ff82a394240

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22496 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26562 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27763 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21787 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25546 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18895 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5715 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->