### PR TITLE
[git-webkit] Link radars in PR descriptions

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6439,7 +6439,8 @@ class UpdatePullRequest(shell.ShellCommandNewStyle, GitHubMixin, AddToLogMixin):
     @classmethod
     def escape_html(cls, message):
         message = ''.join(cls.ESCAPE_TABLE.get(c, c) for c in message)
-        return re.sub(r'(https?://[^\s<>,:;]+?)(?=[\s<>,:;]|(&gt))', r'<a href="\1">\1</a>', message)
+        message = re.sub(r'(https?://[^\s<>,:;]+?)(?=[\s<>,:;]|(&gt))', r'<a href="\1">\1</a>', message)
+        return re.sub(r'rdar://([^\s<>,:;]+?)(?=[\s<>,:;]|(&gt))', r'<a href="https://rdar.apple.com/\1">rdar://\1</a>', message)
 
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, timeout=300, **kwargs)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -8261,7 +8261,7 @@ class TestUpdatePullRequest(BuildStepMixinAdditions, unittest.TestCase):
 <pre>
 [Merge-Queue] Add http credential helper
 <a href="https://bugs.webkit.org/show_bug.cgi?id=238553">https://bugs.webkit.org/show_bug.cgi?id=238553</a>
-&lt;rdar://problem/91044821&gt;
+&lt;<a href="https://rdar.apple.com/problem/91044821">rdar://problem/91044821</a>&gt;
 
 Reviewed by NOBODY (OOPS!).
 
@@ -8427,11 +8427,11 @@ Date:   Tue Mar 29 16:04:35 2022 -0700
                 description,
                 '''#### 9140b95e718e7342366bbcdc29cb1ba0f9328422
 <pre>
-Cherry-pick 252432.1026@safari-7614-branch (2a8469e53b2f). rdar://107367418
+Cherry-pick 252432.1026@safari-7614-branch (2a8469e53b2f). <a href="https://rdar.apple.com/107367418">rdar://107367418</a>
 
     Remove inheritance of designMode attribute
     <a href="https://bugs.webkit.org/show_bug.cgi?id=248615">https://bugs.webkit.org/show_bug.cgi?id=248615</a>
-    rdar://102868995
+    <a href="https://rdar.apple.com/102868995">rdar://102868995</a>
 
     Reviewed by Wenson Hsieh and Jonathan Bedard.
 
@@ -8457,11 +8457,11 @@ Canonical link: <a href="https://commits.webkit.org/262299@main">https://commits
 ----------------------------------------------------------------------
 #### 6ec5319be307db36a27ea61d208cf68ce84abd67
 <pre>
-Cherry-pick 252432.1024@safari-7614-branch (2ea437d75522). rdar://107367090
+Cherry-pick 252432.1024@safari-7614-branch (2ea437d75522). <a href="https://rdar.apple.com/107367090">rdar://107367090</a>
 
     Use-after-free in ContactsManager::select
     <a href="https://bugs.webkit.org/show_bug.cgi?id=250351">https://bugs.webkit.org/show_bug.cgi?id=250351</a>
-    rdar://101241436
+    <a href="https://rdar.apple.com/101241436">rdar://101241436</a>
 
     Reviewed by Wenson Hsieh and Jonathan Bedard.
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -82,11 +82,12 @@ class PullRequest(object):
     @classmethod
     def escape_html(cls, message):
         message = ''.join(cls.ESCAPE_TABLE.get(c, c) for c in message)
-        return re.sub(r'(https?://[^\s<>,:;]+?)(?=[\s<>,:;]|(&gt))', r'<a href="\1">\1</a>', message)
+        message = re.sub(r'(https?://[^\s<>,:;]+?)(?=[\s<>,:;]|(&gt))', r'<a href="\1">\1</a>', message)
+        return re.sub(r'rdar://([^\s<>,:;]+?)(?=[\s<>,:;]|(&gt))', r'<a href="https://rdar.apple.com/\1">rdar://\1</a>', message)
 
     @classmethod
     def unescape_html(cls, message):
-        message = re.sub(r'<a href=".+">(https?://[^\s<>,:;]+)</a>', r'\1', message)
+        message = re.sub(r'<a href="https?://.+">([^\s<>,:;/]+://[^\s<>,:;]+)</a>', r'\1', message)
         for c, escaped in cls.ESCAPE_TABLE.items():
             message = message.replace(escaped, c)
         return message


### PR DESCRIPTION
#### e0b3ca0085ba348ffd66a34651e0e4b3d7710da5
<pre>
[git-webkit] Link radars in PR descriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=263723">https://bugs.webkit.org/show_bug.cgi?id=263723</a>
rdar://117535561

Reviewed by Dewei Zhu.

Use <a href="https://rdar.apple.com">https://rdar.apple.com</a> to link to Radars in pull-request descriptions.

* Tools/CISupport/ews-build/steps.py:
(UpdatePullRequest.escape_html): Convert references to rdar:// with <a href="https://rdar.apple.com.">https://rdar.apple.com.</a>
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.escape_html): Convert references to rdar:// with <a href="https://rdar.apple.com.">https://rdar.apple.com.</a>
(PullRequest.unescape_html): Make linkage escapes more generic to capture converted radar links.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestPullRequest.test_create_body_single_linked): Added.

Canonical link: <a href="https://commits.webkit.org/269986@main">https://commits.webkit.org/269986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e92f80ae8514e5165fd1971f2f2b0783cb275442

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21842 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22400 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26416 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23844 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27650 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25414 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18789 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/23453 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1499 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3088 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->