### PR TITLE
_WKHitTestResult should expose a frameInfo property

### DIFF
--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -183,6 +183,14 @@ LocalFrame* HitTestResult::innerNodeFrame() const
     return 0;
 }
 
+LocalFrame* HitTestResult::frame() const
+{
+    if (m_innerNonSharedNode)
+        return m_innerNonSharedNode->document().frame();
+
+    return nullptr;
+}
+
 LocalFrame* HitTestResult::targetFrame() const
 {
     if (!m_innerURLElement)

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -92,6 +92,7 @@ public:
 
     const HitTestLocation& hitTestLocation() const { return m_hitTestLocation; }
 
+    WEBCORE_EXPORT LocalFrame* frame() const;
     WEBCORE_EXPORT LocalFrame* targetFrame() const;
     WEBCORE_EXPORT bool isSelected() const;
     WEBCORE_EXPORT String selectedText() const;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -29,6 +29,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class WKFrameInfo;
+
 typedef NS_ENUM(NSInteger, _WKHitTestResultElementType) {
     _WKHitTestResultElementTypeNone,
     _WKHitTestResultElementTypeAudio,
@@ -53,6 +55,8 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 @property (nonatomic, readonly) CGRect elementBoundingBox;
 
 @property (nonatomic, readonly) _WKHitTestResultElementType elementType WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+@property (nonatomic, readonly) WKFrameInfo *frameInfo WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -26,6 +26,9 @@
 #import "config.h"
 #import "_WKHitTestResultInternal.h"
 
+#import "WKFrameInfoInternal.h"
+#import "WebPageProxy.h"
+
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
 
 #import <WebCore/WebCoreObjCExtras.h>
@@ -110,6 +113,13 @@ static NSURL *URLFromString(const WTF::String& urlString)
 
     ASSERT_NOT_REACHED();
     return _WKHitTestResultElementTypeNone;
+}
+
+- (WKFrameInfo *)frameInfo
+{
+    if (auto frameInfo = _hitTestResult->frameInfo())
+        return wrapper(API::FrameInfo::create(WTFMove(*frameInfo), &_hitTestResult->page())).autorelease();
+    return nil;
 }
 
 - (id)copyWithZone:(NSZone *)zone

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include "FrameInfoData.h"
 #include "ShareableBitmap.h"
 #include "SharedMemory.h"
 #include <WebCore/DictionaryPopupInfo.h>
@@ -86,6 +87,7 @@ struct WebHitTestResultData {
     bool isDownloadableMedia;
     enum class ElementType : uint8_t { None, Audio, Video };
     ElementType elementType;
+    std::optional<FrameInfoData> frameInfo;
 
     String lookupText;
     String toolTipText;
@@ -109,7 +111,7 @@ struct WebHitTestResultData {
     WebHitTestResultData& operator=(const WebHitTestResultData&) = default;
     WebHitTestResultData(const WebCore::HitTestResult&, const String& toolTipText);
     WebHitTestResultData(const WebCore::HitTestResult&, bool includeImage);
-    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, const WebKit::WebHitTestResultData::ElementType&, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebKit::SharedMemory::Handle>&& imageHandle, const RefPtr<WebKit::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType,
+    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebKit::SharedMemory::Handle>&& imageHandle, const RefPtr<WebKit::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType,
 #if PLATFORM(MAC)
         const WebHitTestResultPlatformData&,
 #endif
@@ -117,6 +119,8 @@ struct WebHitTestResultData {
     ~WebHitTestResultData();
 
     WebCore::IntRect elementBoundingBoxInWindowCoordinates(const WebCore::HitTestResult&);
+
+    static std::optional<FrameInfoData> frameInfoDataFromHitTestResult(const WebCore::HitTestResult&);
 
     std::optional<WebKit::SharedMemory::Handle> getImageSharedMemoryHandle() const;
 

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -50,6 +50,7 @@ struct WebKit::WebHitTestResultData {
     bool isOverTextInsideFormControlElement;
     bool isDownloadableMedia;
     WebKit::WebHitTestResultData::ElementType elementType;
+    std::optional<WebKit::FrameInfoData> frameInfo;
     String lookupText;
     String toolTipText;
     String imageText;

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
@@ -31,6 +31,10 @@
 #include "ContextMenuContextData.h"
 #include "WebHitTestResultData.h"
 
+namespace WebKit {
+class WebPageProxy;
+}
+
 namespace API {
 
 class ContextMenuElementInfoMac final : public ObjectImpl<Object::Type::ContextMenuElementInfoMac> {
@@ -41,16 +45,19 @@ public:
     }
 
     const WebKit::WebHitTestResultData& hitTestResultData() const { return m_hitTestResultData; }
+    WebKit::WebPageProxy& page() { return m_page.get(); }
     const WTF::String& qrCodePayloadString() const { return m_qrCodePayloadString; }
     bool hasEntireImage() const { return m_hasEntireImage; }
 
 private:
-    ContextMenuElementInfoMac(const WebKit::ContextMenuContextData& data)
+    ContextMenuElementInfoMac(const WebKit::ContextMenuContextData& data, WebKit::WebPageProxy& page)
         : m_hitTestResultData(data.webHitTestResultData().value())
+        , m_page(page)
         , m_qrCodePayloadString(data.qrCodePayloadString())
         , m_hasEntireImage(data.hasEntireImage()) { }
 
     WebKit::WebHitTestResultData m_hitTestResultData;
+    Ref<WebKit::WebPageProxy> m_page;
     WTF::String m_qrCodePayloadString;
     bool m_hasEntireImage { false };
 };

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.cpp
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.cpp
@@ -22,9 +22,9 @@
 
 namespace API {
 
-Ref<HitTestResult> HitTestResult::create(const WebKit::WebHitTestResultData& hitTestResultData)
+Ref<HitTestResult> HitTestResult::create(const WebKit::WebHitTestResultData& hitTestResultData, WebKit::WebPageProxy& page)
 {
-    return adoptRef(*new HitTestResult(hitTestResultData));
+    return adoptRef(*new HitTestResult(hitTestResultData, page));
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -22,6 +22,7 @@
 #include "APIObject.h"
 #include "SharedMemory.h"
 #include "WebHitTestResultData.h"
+#include "WebPageProxy.h"
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/IntRect.h>
@@ -45,7 +46,7 @@ class WebFrame;
 
 class HitTestResult : public API::ObjectImpl<API::Object::Type::HitTestResult> {
 public:
-    static Ref<HitTestResult> create(const WebKit::WebHitTestResultData&);
+    static Ref<HitTestResult> create(const WebKit::WebHitTestResultData&, WebKit::WebPageProxy&);
 
     WTF::String absoluteImageURL() const { return m_data.absoluteImageURL; }
     WTF::String absolutePDFURL() const { return m_data.absolutePDFURL; }
@@ -72,13 +73,19 @@ public:
 
     WebKit::WebHitTestResultData::ElementType elementType() const { return m_data.elementType; }
 
+    WebKit::WebPageProxy& page() { return m_page.get(); }
+
+    const std::optional<WebKit::FrameInfoData>& frameInfo() const { return m_data.frameInfo; }
+
 private:
-    explicit HitTestResult(const WebKit::WebHitTestResultData& hitTestResultData)
+    explicit HitTestResult(const WebKit::WebHitTestResultData& hitTestResultData, WebKit::WebPageProxy& page)
         : m_data(hitTestResultData)
+        , m_page(page)
     {
     }
 
     WebKit::WebHitTestResultData m_data;
+    Ref<WebKit::WebPageProxy> m_page;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -980,7 +980,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
         {
             if (m_client.base.version >= 4 && m_client.getContextMenuFromProposedMenuAsync) {
                 auto proposedMenuItems = toAPIObjectVector(proposedMenuVector);
-                auto webHitTestResult = API::HitTestResult::create(hitTestResultData);
+                Ref webHitTestResult = API::HitTestResult::create(hitTestResultData, page);
                 m_client.getContextMenuFromProposedMenuAsync(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), toAPI(&contextMenuListener), toAPI(webHitTestResult.ptr()), toAPI(userData), m_client.base.clientInfo);
                 return;
             }
@@ -999,7 +999,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
 
             WKArrayRef newMenu = nullptr;
             if (m_client.base.version >= 2) {
-                auto webHitTestResult = API::HitTestResult::create(hitTestResultData);
+                Ref webHitTestResult = API::HitTestResult::create(hitTestResultData, page);
                 m_client.getContextMenuFromProposedMenu(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), &newMenu, toAPI(webHitTestResult.ptr()), toAPI(userData), m_client.base.clientInfo);
             } else
                 m_client.getContextMenuFromProposedMenu_deprecatedForUseWithV0(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), &newMenu, toAPI(userData), m_client.base.clientInfo);
@@ -1805,7 +1805,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                 return;
             }
 
-            auto apiHitTestResult = API::HitTestResult::create(data);
+            Ref apiHitTestResult = API::HitTestResult::create(data, page);
             m_client.mouseDidMoveOverElement(toAPI(&page), toAPI(apiHitTestResult.ptr()), toAPI(modifiers), toAPI(userData), m_client.base.clientInfo);
         }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -246,8 +246,14 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
     auto& webHitTestResultData = _navigationAction->webHitTestResultData();
     if (!webHitTestResultData)
         return nil;
+    RefPtr sourceFrame = _navigationAction->sourceFrame();
+    if (!sourceFrame)
+        return nil;
+    RefPtr page = sourceFrame->page();
+    if (!page)
+        return nil;
 
-    auto apiHitTestResult = API::HitTestResult::create(webHitTestResultData.value());
+    auto apiHitTestResult = API::HitTestResult::create(webHitTestResultData.value(), *page);
     return retainPtr(wrapper(apiHitTestResult)).autorelease();
 #else
     return nil;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
@@ -53,7 +53,7 @@
 - (_WKHitTestResult *)hitTestResult
 {
     auto& hitTestResultData = _contextMenuElementInfoMac->hitTestResultData();
-    auto apiHitTestResult = API::HitTestResult::create(hitTestResultData);
+    auto apiHitTestResult = API::HitTestResult::create(hitTestResultData, _contextMenuElementInfoMac->page());
     return retainPtr(wrapper(apiHitTestResult)).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -234,7 +234,7 @@ UIDelegate::ContextMenuClient::~ContextMenuClient()
 {
 }
 
-void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy&, NSMenu *menu, const ContextMenuContextData& data, API::Object* userInfo, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler)
+void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy& page, NSMenu *menu, const ContextMenuContextData& data, API::Object* userInfo, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler)
 {
     if (!m_uiDelegate)
         return completionHandler(menu);
@@ -248,7 +248,7 @@ void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy&, NSMenu *
     if (!delegate)
         return completionHandler(menu);
 
-    auto contextMenuElementInfo = API::ContextMenuElementInfoMac::create(data);
+    auto contextMenuElementInfo = API::ContextMenuElementInfoMac::create(data, page);
     if (m_uiDelegate->m_delegateMethods.webViewGetContextMenuFromProposedMenuForElementUserInfoCompletionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:));
         [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() getContextMenuFromProposedMenu:menu forElement:wrapper(contextMenuElementInfo.get()) userInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSMenu *menu) mutable {
@@ -279,7 +279,7 @@ UIDelegate::UIClient::~UIClient()
 }
 
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
-void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers, API::Object* userInfo)
+void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy& page, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers, API::Object* userInfo)
 {
     if (!m_uiDelegate)
         return;
@@ -291,7 +291,7 @@ void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy&, const WebHitTe
     if (!delegate)
         return;
 
-    auto apiHitTestResult = API::HitTestResult::create(data);
+    auto apiHitTestResult = API::HitTestResult::create(data, page);
 #if PLATFORM(MAC)
     auto modifierFlags = WebEventFactory::toNSEventModifierFlags(modifiers);
 #else

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7304,7 +7304,7 @@ void WebPageProxy::setStatusText(const String& text)
 
 void WebPageProxy::mouseDidMoveOverElement(WebHitTestResultData&& hitTestResultData, OptionSet<WebEventModifier> modifiers, UserData&& userData)
 {
-    m_lastMouseMoveHitTestResult = API::HitTestResult::create(hitTestResultData);
+    m_lastMouseMoveHitTestResult = API::HitTestResult::create(hitTestResultData, *this);
     m_uiClient->mouseDidMoveOverElement(*this, hitTestResultData, modifiers, protectedProcess()->transformHandlesToObjects(userData.protectedObject().get()).get());
     setToolTip(hitTestResultData.toolTipText);
 }

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -252,7 +252,7 @@
 {
     RefPtr<API::HitTestResult> hitTestResult;
     if (_state == WebKit::ImmediateActionState::Ready)
-        hitTestResult = API::HitTestResult::create(_hitTestResultData);
+        hitTestResult = API::HitTestResult::create(_hitTestResultData, *_page);
     else
         hitTestResult = CheckedPtr { _page }->lastMouseMoveHitTestResult();
 

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -593,6 +593,36 @@ TEST(ContextMenuTests, HitTestResultWithNoElementSelected)
     Util::run(&gotProposedMenu);
 }
 
+TEST(ContextMenuTests, HitTestResultWhenClickingInSubframe)
+{
+    // This is the escaped version of "data:text/html,<body>Hello from a frame!</body>" since that's what -[NSURL absoluteString] returns.
+    NSString *subframeContentsString = @"data:text/html,%3Cbody%3EHello%20from%20a%20frame!%3C/body%3E";
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        _WKHitTestResult *hitTestResult = elementInfo.hitTestResult;
+        EXPECT_NOT_NULL(elementInfo.hitTestResult);
+
+        WKFrameInfo *frameInfo = hitTestResult.frameInfo;
+        EXPECT_NOT_NULL(frameInfo);
+        EXPECT_FALSE(frameInfo.isMainFrame);
+        EXPECT_TRUE([subframeContentsString isEqualToString:frameInfo.request.URL.absoluteString]);
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate.get()];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<iframe width='400' height='400' src='%@'</iframe>", subframeContentsString]];
+    [webView waitForNextPresentationUpdate];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 9c20db5a05181f63b0989b73da5faf057f0c2445
<pre>
_WKHitTestResult should expose a frameInfo property
<a href="https://bugs.webkit.org/show_bug.cgi?id=263729">https://bugs.webkit.org/show_bug.cgi?id=263729</a>
<a href="https://rdar.apple.com/116254673">rdar://116254673</a>

Reviewed by Chris Dumez and Alex Christensen.

Add a frameInfo property to _WKHitTestResult and the plumbing to support it.

* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::frame const):
Added, this is the same frame returned by WKBundleHitTestResultGetFrame().

* Source/WebCore/rendering/HitTestResult.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult frameInfo]):
Added. Note that we need the page in order to create the WKFrameInfo.

* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
(WebKit::WebHitTestResultData::frameInfoDataFromHitTestResult):
Added. Creates a WebFrame from a LocalFrame and uses it to get the FrameInfoData.

* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
* Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h:
ContextMenuElementInfoMac now keeps track of the page.

* Source/WebKit/UIProcess/API/APIHitTestResult.cpp:
(API::HitTestResult::create):
API::HitTestResult now keeps track of the page.

* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::page):
(API::HitTestResult::frameInfo const):
(API::HitTestResult::HitTestResult):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageContextMenuClient):
(WKPageSetPageUIClient):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction _hitTestResult]):
We require a page to create an API::HitTestResult.

* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm:
(-[_WKContextMenuElementInfo hitTestResult]):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::ContextMenuClient::menuFromProposedMenu):
(WebKit::UIDelegate::UIClient::mouseDidMoveOverElement):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::mouseDidMoveOverElement):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _webHitTestResult]):
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):&apos;
Added a new HitTestResultWhenClickingInSubframe test. Verifies that right-clicking in an iframe
correctly sets frameInfo in _WKHitTestResult.

Canonical link: <a href="https://commits.webkit.org/270308@main">https://commits.webkit.org/270308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec27ea8d8f56318500c8551beb68e44146083a15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27211 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23291 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27790 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28726 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26538 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/611 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3656 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6019 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2749 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2645 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->