### PR TITLE
REGRESSION (267818@main): ~6% regression on `nytimes-article` in PLT

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -173,6 +173,7 @@
 #include "NodeWithIndex.h"
 #include "NoiseInjectionPolicy.h"
 #include "NotificationController.h"
+#include "OpportunisticTaskScheduler.h"
 #include "OverflowEvent.h"
 #include "PageConsoleClient.h"
 #include "PageGroup.h"
@@ -7452,6 +7453,8 @@ int Document::requestIdleCallback(Ref<IdleRequestCallback>&& callback, Seconds t
 {
     if (!m_idleCallbackController)
         m_idleCallbackController = makeUnique<IdleCallbackController>(*this);
+    if (auto page = checkedPage())
+        page->opportunisticTaskScheduler().willQueueIdleCallback();
     return m_idleCallbackController->queueIdleCallback(WTFMove(callback), timeout);
 }
 

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -36,17 +36,30 @@ OpportunisticTaskScheduler::OpportunisticTaskScheduler(Page& page)
     , m_runLoopObserver(makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [weakThis = WeakPtr { this }] {
         if (auto strongThis = weakThis.get())
             strongThis->runLoopObserverFired();
-    }, RunLoopObserver::Type::Repeating))
+    }, RunLoopObserver::Type::OneShot))
 {
-    m_runLoopObserver->schedule();
 }
 
 OpportunisticTaskScheduler::~OpportunisticTaskScheduler() = default;
 
-void OpportunisticTaskScheduler::reschedule(MonotonicTime deadline)
+void OpportunisticTaskScheduler::rescheduleIfNeeded(MonotonicTime deadline)
 {
+    auto page = checkedPage();
+    if (page->isWaitingForLoadToFinish() || !page->isVisibleAndActive())
+        return;
+
+    if (!m_mayHavePendingIdleCallbacks && !page->settings().opportunisticSweepingAndGarbageCollectionEnabled())
+        return;
+
     m_runloopCountAfterBeingScheduled = 0;
     m_currentDeadline = deadline;
+    m_runLoopObserver->invalidate();
+    m_runLoopObserver->schedule();
+}
+
+CheckedPtr<Page> OpportunisticTaskScheduler::checkedPage() const
+{
+    return m_page.get();
 }
 
 Ref<ImminentlyScheduledWorkScope> OpportunisticTaskScheduler::makeScheduledWorkScope()
@@ -59,10 +72,10 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
     if (!m_currentDeadline)
         return;
 
-    auto page = m_page;
-    if (UNLIKELY(!page))
+    if (UNLIKELY(!m_page))
         return;
 
+    auto page = checkedPage();
     if (page->isWaitingForLoadToFinish() || !page->isVisibleAndActive())
         return;
 
@@ -88,8 +101,11 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
         return false;
     }();
 
-    if (!shouldRunTask)
+    if (!shouldRunTask) {
+        m_runLoopObserver->invalidate();
+        m_runLoopObserver->schedule();
         return;
+    }
 
     TraceScope tracingScope {
         PerformOpportunisticallyScheduledTasksStart,
@@ -98,9 +114,12 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
     };
 
     auto deadline = std::exchange(m_currentDeadline, MonotonicTime { });
-    page->opportunisticallyRunIdleCallbacks();
-    if (UNLIKELY(!page))
-        return;
+    if (std::exchange(m_mayHavePendingIdleCallbacks, false)) {
+        auto weakPage = m_page;
+        page->opportunisticallyRunIdleCallbacks();
+        if (UNLIKELY(!weakPage))
+            return;
+    }
 
     if (!page->settings().opportunisticSweepingAndGarbageCollectionEnabled())
         return;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2051,7 +2051,7 @@ void Page::renderingUpdateCompleted()
 
     if (!isUtilityPage()) {
         auto nextRenderingUpdate = m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval();
-        m_opportunisticTaskScheduler->reschedule(nextRenderingUpdate);
+        m_opportunisticTaskScheduler->rescheduleIfNeeded(nextRenderingUpdate);
     }
 }
 


### PR DESCRIPTION
#### 18a4511bc7e2df666e3a46b8032e7b2a823cea06
<pre>
REGRESSION (267818@main): ~6% regression on `nytimes-article` in PLT
<a href="https://bugs.webkit.org/show_bug.cgi?id=263727">https://bugs.webkit.org/show_bug.cgi?id=263727</a>
rdar://116463015

Reviewed by Tim Horton.

After the changes in 267818@main, the `nytimes-article` subtest in PLT is regressed by roughly 6% on
some iPhone device models. From running several A/B experiments, this is due to the fact that the
opportunistic task scheduler now installs a repeating `CFRunLoopTimer`; even if the runloop timer
callback is a no-op, the overhead alone seems to be enough to impact NYT article pages in
particular.

To fix this, we instead turn the runloop timer back into a one-shot timer, and only schedule it if
needed (i.e., only if opportunistic GC/sweeping is enabled, or if there are scheduled idle
callbacks).

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::requestIdleCallback):

Set a flag when calling into `requestIdleCallback`, to let the `OpportunisticTaskScheduler` know
that it needs to be scheduled for the purposes of firing opportunistic idle callbacks.

* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::rescheduleIfNeeded):

Implement the main fix here; see above for more details.

(WebCore::OpportunisticTaskScheduler::checkedPage const):

Add a helper to return a `CheckedPtr&lt;Page&gt;`; take this opportunity to deploy smart pointers (mostly,
`CheckedPtr` in this class as well).

(WebCore::OpportunisticTaskScheduler::isPageInactiveOrLoading const):

Pull this common logic out into a helper method to avoid duplicating the check.

(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):
(WebCore::OpportunisticTaskScheduler::reschedule): Deleted.

Rename this to `rescheduleIfNeeded` to reflect the fact that it may not reschedule the runloop timer
if there are no idle callbacks, and opportunistic GC/sweeping is disabled.

* Source/WebCore/page/OpportunisticTaskScheduler.h:
(WebCore::OpportunisticTaskScheduler::willQueueIdleCallback):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::renderingUpdateCompleted):

Canonical link: <a href="https://commits.webkit.org/269833@main">https://commits.webkit.org/269833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4f9f7e152e3c7a8a1780f7c286bb79512187b9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22418 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26448 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21417 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21687 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18814 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1099 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5668 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->