### PR TITLE
Accelerate WTF::equal using NEON intrinsics

### DIFF
--- a/Source/WTF/wtf/PlatformCPU.h
+++ b/Source/WTF/wtf/PlatformCPU.h
@@ -254,7 +254,7 @@
 #  error "Cannot use both of WTF_CPU_ARM_TRADITIONAL and WTF_CPU_ARM_THUMB2 platforms"
 #endif /* !defined(WTF_CPU_ARM_TRADITIONAL) && !defined(WTF_CPU_ARM_THUMB2) */
 
-#if defined(__ARM_NEON__) && !defined(WTF_CPU_ARM_NEON)
+#if (defined(__ARM_NEON__) || defined(__ARM_NEON)) && !defined(WTF_CPU_ARM_NEON)
 #define WTF_CPU_ARM_NEON 1
 #endif
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1458,6 +1458,10 @@ bool equal(const StringImpl* a, const LChar* b)
 
 bool equal(const StringImpl& a, const StringImpl& b)
 {
+    unsigned aHash = a.rawHash();
+    unsigned bHash = b.rawHash();
+    if (aHash != bHash && aHash && bHash)
+        return false;
     return equalCommon(a, b);
 }
 

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -197,6 +197,8 @@ class StringImpl : private StringImplShape {
     template<typename> friend struct WTF::BufferFromStaticDataTranslator;
     template<typename> friend struct WTF::HashAndCharactersTranslator;
 
+    friend WTF_EXPORT_PRIVATE bool equal(const StringImpl&, const StringImpl&);
+
 public:
     enum BufferOwnership { BufferInternal, BufferOwned, BufferSubstring, BufferExternal };
 


### PR DESCRIPTION
#### 661be0f9c16d3bdefaf9c80e29eb793428440dc7
<pre>
Accelerate WTF::equal using NEON intrinsics
<a href="https://bugs.webkit.org/show_bug.cgi?id=263734">https://bugs.webkit.org/show_bug.cgi?id=263734</a>
rdar://117541948

Reviewed by Yusuke Suzuki.

1. Adds a hash check to WTF::equal(StringImpl*, StringImpl*) to quickly rule
out matches (thanks @hyjorc1!).

2. Reworks the implementation of WTF::equal for LChar and UChar strings.
Instead of checking for leftover bytes at the end, we use overlapping loads to
reduce the amount of branching per string. And we now switch up-front on the
string length instead of falling through to other branches, reducing branching
for most small strings.

3. When CPU(ARM_NEON) is defined, use 16-byte SIMD chunks to do the comparison,
whenever strings are large enough.

4. Also adds a SIMD loop to WTF::equal(const LChar*, const UChar*, unsigned),
which is dramatically (~5x) faster than the current byte-by-byte pessimistic
implementation.

* Source/WTF/wtf/PlatformCPU.h:
* Source/WTF/wtf/text/StringCommon.h:
(WTF::equal):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::equal):
* Source/WTF/wtf/text/StringImpl.h:

Canonical link: <a href="https://commits.webkit.org/269866@main">https://commits.webkit.org/269866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ea240c26aeecdab5d7a6b52a0aa2aae3226b2fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23728 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21898 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22443 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26477 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27703 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20647 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25472 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23062 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18832 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30455 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1127 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5706 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1549 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30409 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1438 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6359 "Passed tests") | 
<!--EWS-Status-Bubble-End-->