### PR TITLE
[JSC] Add CallCustomAccessorGetter / CallCustomAccessorSetter DFG nodes

### DIFF
--- a/JSTests/microbenchmarks/custom-accessor-thin-air-setter.js
+++ b/JSTests/microbenchmarks/custom-accessor-thin-air-setter.js
@@ -1,0 +1,22 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function assert(b) {
+    if (!b)
+        throw new Error;
+}
+
+function test5() {
+    function set(o, value) {
+        o.customAccessor = value;
+    }
+    noInline(set);
+
+    const o = $vm.createCustomTestGetterSetter();
+
+    for (let i = 0; i < 500000; ++i) {
+        set(o, 1337);
+    }
+    for (let i = 0; i < 500000; ++i) {
+        set(o, 1337);
+    }
+}
+test5();

--- a/JSTests/stress/domjit-getter-complex-with-incorrect-object.js
+++ b/JSTests/stress/domjit-getter-complex-with-incorrect-object.js
@@ -11,7 +11,7 @@ function shouldThrow(func, errorMessage) {
     }
     if (!errorThrown)
         throw new Error('not thrown');
-    if (String(error) !== errorMessage)
+    if (!String(error).startsWith(errorMessage))
         throw new Error(`bad error: ${String(error)}`);
 }
 
@@ -26,5 +26,5 @@ noInline(access);
 for (var i = 0; i < 1e4; ++i) {
     shouldThrow(() => {
         access(object);
-    }, `TypeError: The DOMJITGetterComplex.customGetter getter can only be used on instances of DOMJITGetterComplex`);
+    }, `TypeError`);
 }

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -312,78 +312,98 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
                 // crash on null structure.
                 return GetByStatus(JSC::slowVersion(summary), stubInfo);
             }
-            
-            ComplexGetStatus complexGetStatus = ComplexGetStatus::computeFor(
-                structure, access.conditionSet(), access.uid());
-             
-            switch (complexGetStatus.kind()) {
-            case ComplexGetStatus::ShouldSkip:
-                continue;
-                 
-            case ComplexGetStatus::TakesSlowPath:
-                return GetByStatus(JSC::slowVersion(summary), stubInfo);
-                 
-            case ComplexGetStatus::Inlineable: {
-                std::unique_ptr<CallLinkStatus> callLinkStatus;
-                JSFunction* intrinsicFunction = nullptr;
-                CodePtr<CustomAccessorPtrTag> customAccessorGetter;
-                std::unique_ptr<DOMAttributeAnnotation> domAttribute;
-                bool haveDOMAttribute = false;
 
-                switch (access.type()) {
-                case AccessCase::Load:
-                case AccessCase::GetGetter:
-                case AccessCase::Miss: {
-                    break;
-                }
-                case AccessCase::IntrinsicGetter: {
-                    intrinsicFunction = access.as<IntrinsicGetterAccessCase>().intrinsicFunction();
-                    break;
-                }
-                case AccessCase::Getter: {
-                    callLinkStatus = makeUnique<CallLinkStatus>();
-                    if (CallLinkInfo* callLinkInfo = access.as<GetterSetterAccessCase>().callLinkInfo()) {
-                        *callLinkStatus = CallLinkStatus::computeFor(
-                            locker, profiledBlock, *callLinkInfo, callExitSiteData);
-                    }
-                    break;
-                }
-                case AccessCase::CustomAccessorGetter: {
-                    customAccessorGetter = access.as<GetterSetterAccessCase>().customAccessor();
-                    if (!access.as<GetterSetterAccessCase>().domAttribute())
-                        return GetByStatus(JSC::slowVersion(summary), stubInfo);
-                    domAttribute = WTF::makeUnique<DOMAttributeAnnotation>(*access.as<GetterSetterAccessCase>().domAttribute());
-                    haveDOMAttribute = true;
-                    result.m_state = Custom;
-                    break;
-                }
-                default: {
-                    // FIXME: It would be totally sweet to support more of these at some point in the
-                    // future. https://bugs.webkit.org/show_bug.cgi?id=133052
+            switch (access.type()) {
+            case AccessCase::CustomAccessorGetter: {
+                auto conditionSet = access.conditionSet();
+                if (!conditionSet.isStillValid())
+                    continue;
+
+                Structure* currStructure = access.hasAlternateBase() ? access.alternateBase()->structure() : access.structure();
+                // For now, we only support cases which JSGlobalObject is the same to the currently profiledBlock.
+                if (currStructure->globalObject() != profiledBlock->globalObject())
                     return GetByStatus(JSC::slowVersion(summary), stubInfo);
-                } }
+
+                auto customAccessorGetter = access.as<GetterSetterAccessCase>().customAccessor();
+                std::unique_ptr<DOMAttributeAnnotation> domAttribute;
+                if (access.as<GetterSetterAccessCase>().domAttribute())
+                    domAttribute = WTF::makeUnique<DOMAttributeAnnotation>(*access.as<GetterSetterAccessCase>().domAttribute());
 
                 ASSERT((AccessCase::Miss == access.type() || access.isCustom()) == (access.offset() == invalidOffset));
-                GetByVariant variant(access.identifier(), StructureSet(structure), complexGetStatus.offset(),
-                    complexGetStatus.conditionSet(), WTFMove(callLinkStatus),
-                    intrinsicFunction,
+                GetByVariant variant(access.identifier(), StructureSet(structure), invalidOffset,
+                    WTFMove(conditionSet), nullptr,
+                    nullptr,
                     customAccessorGetter,
                     WTFMove(domAttribute));
 
                 if (!result.appendVariant(variant))
                     return GetByStatus(JSC::slowVersion(summary), stubInfo);
 
-                if (haveDOMAttribute) {
+                if (domAttribute) {
                     // Give up when custom accesses are not merged into one.
                     if (result.numVariants() != 1)
                         return GetByStatus(JSC::slowVersion(summary), stubInfo);
+                    result.m_containsDOMGetter = true;
                 } else {
-                    // Give up when custom access and simple access are mixed.
-                    if (result.m_state == Custom)
+                    if (result.m_containsDOMGetter)
                         return GetByStatus(JSC::slowVersion(summary), stubInfo);
                 }
+                result.m_state = CustomAccessor;
                 break;
-            } }
+            }
+            default: {
+                ComplexGetStatus complexGetStatus = ComplexGetStatus::computeFor(structure, access.conditionSet(), access.uid());
+                switch (complexGetStatus.kind()) {
+                case ComplexGetStatus::ShouldSkip:
+                    continue;
+
+                case ComplexGetStatus::TakesSlowPath:
+                    return GetByStatus(JSC::slowVersion(summary), stubInfo);
+
+                case ComplexGetStatus::Inlineable: {
+                    std::unique_ptr<CallLinkStatus> callLinkStatus;
+                    JSFunction* intrinsicFunction = nullptr;
+                    switch (access.type()) {
+                    case AccessCase::Load:
+                    case AccessCase::GetGetter:
+                    case AccessCase::Miss: {
+                        break;
+                    }
+                    case AccessCase::IntrinsicGetter: {
+                        intrinsicFunction = access.as<IntrinsicGetterAccessCase>().intrinsicFunction();
+                        break;
+                    }
+                    case AccessCase::Getter: {
+                        callLinkStatus = makeUnique<CallLinkStatus>();
+                        if (CallLinkInfo* callLinkInfo = access.as<GetterSetterAccessCase>().callLinkInfo()) {
+                            *callLinkStatus = CallLinkStatus::computeFor(
+                                locker, profiledBlock, *callLinkInfo, callExitSiteData);
+                        }
+                        break;
+                    }
+                    default: {
+                        // FIXME: It would be totally sweet to support more of these at some point in the
+                        // future. https://bugs.webkit.org/show_bug.cgi?id=133052
+                        return GetByStatus(JSC::slowVersion(summary), stubInfo);
+                    }
+                    }
+
+                    ASSERT((AccessCase::Miss == access.type() || access.isCustom()) == (access.offset() == invalidOffset));
+                    GetByVariant variant(access.identifier(), StructureSet(structure), complexGetStatus.offset(),
+                        complexGetStatus.conditionSet(), WTFMove(callLinkStatus), intrinsicFunction);
+
+                    if (!result.appendVariant(variant))
+                        return GetByStatus(JSC::slowVersion(summary), stubInfo);
+
+                    // Give up when custom access and simple access are mixed.
+                    if (result.m_state == CustomAccessor)
+                        return GetByStatus(JSC::slowVersion(summary), stubInfo);
+                    break;
+                }
+                }
+                break;
+            }
+            }
         }
         
         result.shrinkToFit();
@@ -489,7 +509,7 @@ bool GetByStatus::makesCalls() const
     case NoInformation:
     case LikelyTakesSlowPath:
     case ObservedTakesSlowPath:
-    case Custom:
+    case CustomAccessor:
     case ModuleNamespace:
         return false;
     case Simple:
@@ -535,7 +555,7 @@ void GetByStatus::merge(const GetByStatus& other)
 
     case Megamorphic:
         if (m_state != other.m_state) {
-            if (other.m_state == Simple || other.m_state == Custom) {
+            if (other.m_state == Simple || other.m_state == CustomAccessor) {
                 *this = other;
                 return;
             }
@@ -544,7 +564,7 @@ void GetByStatus::merge(const GetByStatus& other)
         return;
         
     case Simple:
-    case Custom:
+    case CustomAccessor:
     case ProxyObject:
         if (m_state != other.m_state)
             return mergeSlow();
@@ -644,8 +664,8 @@ void GetByStatus::dump(PrintStream& out) const
     case Simple:
         out.print("Simple");
         break;
-    case Custom:
-        out.print("Custom");
+    case CustomAccessor:
+        out.print("CustomAccessor");
         break;
     case Megamorphic:
         out.print("Megamorphic");

--- a/Source/JavaScriptCore/bytecode/GetByStatus.h
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.h
@@ -57,7 +57,7 @@ public:
         // a possible structure chain and a possible specific value.
         Simple,
         // It's cached for a custom accessor with a possible structure chain.
-        Custom,
+        CustomAccessor,
         // It's cached for a megamorphic case.
         Megamorphic,
         // It's cached for an access to a module namespace object's binding.
@@ -102,7 +102,7 @@ public:
     bool isSet() const { return m_state != NoInformation; }
     explicit operator bool() const { return isSet(); }
     bool isSimple() const { return m_state == Simple; }
-    bool isCustom() const { return m_state == Custom; }
+    bool isCustomAccessor() const { return m_state == CustomAccessor; }
     bool isMegamorphic() const { return m_state == Megamorphic; }
     bool isModuleNamespace() const { return m_state == ModuleNamespace; }
     bool isProxyObject() const { return m_state == ProxyObject; }
@@ -114,7 +114,7 @@ public:
 
     bool takesSlowPath() const
     {
-        return m_state == LikelyTakesSlowPath || m_state == ObservedTakesSlowPath || m_state == MakesCalls || m_state == ObservedSlowPathAndMakesCalls || m_state == Custom || m_state == ModuleNamespace || m_state == Megamorphic;
+        return m_state == LikelyTakesSlowPath || m_state == ObservedTakesSlowPath || m_state == MakesCalls || m_state == ObservedSlowPathAndMakesCalls || m_state == CustomAccessor || m_state == ModuleNamespace || m_state == Megamorphic;
     }
     bool observedStructureStubInfoSlowPath() const { return m_state == ObservedTakesSlowPath || m_state == ObservedSlowPathAndMakesCalls; }
     bool makesCalls() const;
@@ -162,7 +162,8 @@ private:
     Vector<GetByVariant, 1> m_variants;
     Box<ModuleNamespaceData> m_moduleNamespaceData;
     State m_state;
-    bool m_wasSeenInJIT { false };
+    bool m_wasSeenInJIT : 1 { false };
+    bool m_containsDOMGetter : 1 { false };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/GetByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.cpp
@@ -130,16 +130,15 @@ bool GetByVariant::attemptToMerge(const GetByVariant& other)
     if (m_conditionSet.isEmpty() != other.m_conditionSet.isEmpty())
         return false;
     
-    ObjectPropertyConditionSet mergedConditionSet;
     if (!m_conditionSet.isEmpty()) {
-        mergedConditionSet = m_conditionSet.mergedWith(other.m_conditionSet);
+        auto mergedConditionSet = m_conditionSet.mergedWith(other.m_conditionSet);
         if (!mergedConditionSet.isValid())
             return false;
         // If this is a hit variant, one slot base should exist. If this is not a hit variant, the slot base is not necessary.
         if (!isPropertyUnset() && !mergedConditionSet.hasOneSlotBaseCondition())
             return false;
+        m_conditionSet = mergedConditionSet;
     }
-    m_conditionSet = mergedConditionSet;
     
     m_structureSet.merge(other.m_structureSet);
     

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -138,6 +138,18 @@ bool ObjectPropertyConditionSet::structuresEnsureValidity() const
     return true;
 }
 
+bool ObjectPropertyConditionSet::isStillValid() const
+{
+    if (!isValid())
+        return false;
+
+    for (const ObjectPropertyCondition& condition : *this) {
+        if (!condition.isStillValid(Concurrency::ConcurrentThread))
+            return false;
+    }
+    return true;
+}
+
 bool ObjectPropertyConditionSet::needImpurePropertyWatchpoint() const
 {
     for (const ObjectPropertyCondition& condition : *this) {

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
@@ -132,6 +132,7 @@ public:
     // invalid().
     ObjectPropertyConditionSet mergedWith(const ObjectPropertyConditionSet& other) const;
     
+    bool isStillValid() const;
     bool structuresEnsureValidity() const;
     
     bool needImpurePropertyWatchpoint() const;

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -251,7 +251,29 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
                     return PutByStatus(JSC::slowVersion(summary), *stubInfo);
                 break;
             }
-                
+
+            case AccessCase::CustomAccessorSetter: {
+                auto conditionSet = access.conditionSet();
+                if (!conditionSet.isStillValid())
+                    continue;
+
+                Structure* currStructure = access.hasAlternateBase() ? access.alternateBase()->structure() : access.structure();
+                // For now, we only support cases which JSGlobalObject is the same to the currently profiledBlock.
+                if (currStructure->globalObject() != profiledBlock->globalObject())
+                    return PutByStatus(JSC::slowVersion(summary), *stubInfo);
+
+                auto customAccessorSetter = access.as<GetterSetterAccessCase>().customAccessor();
+                std::unique_ptr<DOMAttributeAnnotation> domAttribute;
+                if (access.as<GetterSetterAccessCase>().domAttribute())
+                    domAttribute = WTF::makeUnique<DOMAttributeAnnotation>(*access.as<GetterSetterAccessCase>().domAttribute());
+                result.m_state = CustomAccessor;
+
+                auto variant = PutByVariant::customSetter(access.identifier(), access.structure(), WTFMove(conditionSet), customAccessorSetter, WTFMove(domAttribute));
+                if (!result.appendVariant(variant))
+                    return PutByStatus(JSC::slowVersion(summary), *stubInfo);
+                break;
+            }
+
             case AccessCase::Setter: {
                 Structure* structure = access.structure();
                 
@@ -260,27 +282,27 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
                 switch (complexGetStatus.kind()) {
                 case ComplexGetStatus::ShouldSkip:
                     continue;
-                    
+
                 case ComplexGetStatus::TakesSlowPath:
                     return PutByStatus(JSC::slowVersion(summary), *stubInfo);
-                    
+
                 case ComplexGetStatus::Inlineable: {
                     auto callLinkStatus = makeUnique<CallLinkStatus>();
                     if (CallLinkInfo* callLinkInfo = access.as<GetterSetterAccessCase>().callLinkInfo()) {
                         *callLinkStatus = CallLinkStatus::computeFor(
                             locker, profiledBlock, *callLinkInfo, callExitSiteData);
                     }
-                    
+
                     auto variant = PutByVariant::setter(access.identifier(), structure, complexGetStatus.offset(), complexGetStatus.conditionSet(), WTFMove(callLinkStatus));
                     if (!result.appendVariant(variant))
                         return PutByStatus(JSC::slowVersion(summary), *stubInfo);
+                    break;
                 }
                 }
                 break;
             }
-                
+
             case AccessCase::CustomValueSetter:
-            case AccessCase::CustomAccessorSetter:
                 return PutByStatus(MakesCalls);
 
             case AccessCase::ProxyObjectStore: {
@@ -455,6 +477,7 @@ bool PutByStatus::makesCalls() const
     case MakesCalls:
     case ObservedSlowPathAndMakesCalls:
     case Megamorphic:
+    case CustomAccessor:
         return true;
     case Simple: {
         for (unsigned i = m_variants.size(); i--;) {
@@ -536,7 +559,8 @@ void PutByStatus::merge(const PutByStatus& other)
         return;
         
     case Simple:
-        if (other.m_state != Simple)
+    case CustomAccessor:
+        if (other.m_state != m_state)
             return mergeSlow();
         
         for (const PutByVariant& other : other.m_variants) {
@@ -569,31 +593,34 @@ void PutByStatus::filter(const StructureSet& set)
 
 void PutByStatus::dump(PrintStream& out) const
 {
+    out.print("(");
     switch (m_state) {
     case NoInformation:
-        out.print("(NoInformation)");
+        out.print("NoInformation");
         return;
     case Simple:
-        out.print("(", listDump(m_variants), ")");
-        return;
+        out.print("Simple");
+        break;
+    case CustomAccessor:
+        out.print("CustomAccessor");
+        break;
     case Megamorphic:
         out.print("Megamorphic");
-        return;
+        break;
     case LikelyTakesSlowPath:
         out.print("LikelyTakesSlowPath");
-        return;
+        break;
     case ObservedTakesSlowPath:
         out.print("ObservedTakesSlowPath");
-        return;
+        break;
     case MakesCalls:
         out.print("MakesCalls");
-        return;
+        break;
     case ObservedSlowPathAndMakesCalls:
         out.print("ObservedSlowPathAndMakesCalls");
-        return;
+        break;
     }
-    
-    RELEASE_ASSERT_NOT_REACHED();
+    out.print(", ", listDump(m_variants), ")");
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/PutByStatus.h
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.h
@@ -53,6 +53,8 @@ public:
         NoInformation,
         // It's cached as a simple store of some kind.
         Simple,
+        // It's cached for a custom accessor with a possible structure chain.
+        CustomAccessor,
         // It's cached for a megamorphic case.
         Megamorphic,
         // It will likely take the slow path.
@@ -111,10 +113,12 @@ public:
     bool isSet() const { return m_state != NoInformation; }
     bool operator!() const { return m_state == NoInformation; }
     bool isSimple() const { return m_state == Simple; }
+    bool isCustomAccessor() const { return m_state == CustomAccessor; }
     bool isMegamorphic() const { return m_state == Megamorphic; }
     bool takesSlowPath() const
     {
         switch (m_state) {
+        case CustomAccessor:
         case Megamorphic:
         case LikelyTakesSlowPath:
         case ObservedTakesSlowPath:

--- a/Source/JavaScriptCore/bytecode/PutByVariant.h
+++ b/Source/JavaScriptCore/bytecode/PutByVariant.h
@@ -41,6 +41,7 @@ public:
         Replace,
         Transition,
         Setter,
+        CustomAccessorSetter,
         Proxy,
     };
     
@@ -61,6 +62,8 @@ public:
     
     static PutByVariant setter(CacheableIdentifier, const StructureSet&, PropertyOffset, const ObjectPropertyConditionSet&, std::unique_ptr<CallLinkStatus>);
 
+    static PutByVariant customSetter(CacheableIdentifier, const StructureSet&, const ObjectPropertyConditionSet&, CodePtr<CustomAccessorPtrTag>, std::unique_ptr<DOMAttributeAnnotation>&&);
+
     static PutByVariant proxy(CacheableIdentifier, const StructureSet&, std::unique_ptr<CallLinkStatus>);
     
     Kind kind() const { return m_kind; }
@@ -76,7 +79,7 @@ public:
     
     const StructureSet& oldStructure() const
     {
-        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter || kind() == Proxy);
+        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter || kind() == CustomAccessorSetter || kind() == Proxy);
         return m_oldStructure;
     }
     
@@ -87,7 +90,7 @@ public:
     
     StructureSet& oldStructure()
     {
-        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter || kind() == Proxy);
+        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter || kind() == CustomAccessorSetter || kind() == Proxy);
         return m_oldStructure;
     }
     
@@ -152,15 +155,20 @@ public:
         return structureSet().overlaps(other.structureSet());
     }
 
+    CodePtr<CustomAccessorPtrTag> customAccessorSetter() const { return m_customAccessorSetter; }
+    DOMAttributeAnnotation* domAttribute() const { return m_domAttribute.get(); }
+
 private:
     bool attemptToMergeTransitionWithReplace(const PutByVariant& replace);
     
     Kind m_kind;
-    PropertyOffset m_offset;
+    PropertyOffset m_offset { invalidOffset };
     StructureSet m_oldStructure;
     Structure* m_newStructure { nullptr };
     ObjectPropertyConditionSet m_conditionSet;
     std::unique_ptr<CallLinkStatus> m_callLinkStatus;
+    CodePtr<CustomAccessorPtrTag> m_customAccessorSetter;
+    std::unique_ptr<DOMAttributeAnnotation> m_domAttribute;
     CacheableIdentifier m_identifier;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4864,6 +4864,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case DirectCall:
     case DirectConstruct:
     case DirectTailCallInlinedCaller:
+    case CallCustomAccessorGetter:
+    case CallCustomAccessorSetter:
         clobberWorld();
         makeHeapTopForNode(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -768,6 +768,8 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case ConstructForwardVarargs:
     case CallDirectEval:
     case CallWasm:
+    case CallCustomAccessorGetter:
+    case CallCustomAccessorSetter:
     case ToPrimitive:
     case ToPropertyKey:
     case InByVal:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -294,6 +294,8 @@ bool doesGC(Graph& graph, Node* node)
     case DirectTailCall:
     case DirectTailCallInlinedCaller:
     case CallWasm:
+    case CallCustomAccessorGetter:
+    case CallCustomAccessorSetter:
     case ForceOSRExit:
     case FunctionToString:
     case FunctionBind:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3136,6 +3136,8 @@ private:
         case GetWebAssemblyInstanceExports:
         case NewBoundFunction:
         case MakeAtomString:
+        case CallCustomAccessorGetter:
+        case CallCustomAccessorSetter:
             break;
 #else // not ASSERT_ENABLED
         default:

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1231,6 +1231,7 @@ public:
     Bag<StackAccessData> m_stackAccessData;
     Bag<LazyJSValue> m_lazyJSValues;
     Bag<CallDOMGetterData> m_callDOMGetterData;
+    Bag<CallCustomAccessorData> m_callCustomAccessorData;
     Bag<BitVector> m_bitVectors;
     Vector<InlineVariableData, 4> m_inlineVariableData;
     HashMap<CodeBlock*, std::unique_ptr<FullBytecodeLiveness>> m_bytecodeLiveness;

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -157,6 +157,8 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case RegExpExecNonGlobalOrSticky:
     case RegExpMatchFastGlobal:
     case CallWasm:
+    case CallCustomAccessorGetter:
+    case CallCustomAccessorSetter:
     case AllocatePropertyStorage:
     case ReallocatePropertyStorage:
         result = ExitsForExceptions;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -379,6 +379,9 @@ namespace JSC { namespace DFG {
     macro(CallDirectEval, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(CallWasm, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     \
+    macro(CallCustomAccessorGetter, NodeResultJS | NodeMustGenerate) \
+    macro(CallCustomAccessorSetter, NodeMustGenerate) \
+    \
     /* Shadow Chicken */\
     macro(LogShadowChickenPrologue, NodeMustGenerate) \
     macro(LogShadowChickenTail, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1016,6 +1016,7 @@ private:
         case ConstructForwardVarargs:
         case TailCallForwardVarargsInlinedCaller:
         case CallWasm:
+        case CallCustomAccessorGetter:
         case GetGlobalVar:
         case GetGlobalLexicalVariable:
         case GetClosureVar:
@@ -1586,6 +1587,7 @@ private:
         case PutSetterByVal:
         case DefineDataProperty:
         case DefineAccessorProperty:
+        case CallCustomAccessorSetter:
         case DFG::Jump:
         case Branch:
         case Switch:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -591,6 +591,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case TailCallForwardVarargsInlinedCaller:
     case ConstructVarargs:
     case CallWasm:
+    case CallCustomAccessorGetter:
+    case CallCustomAccessorSetter:
     case VarargsLength:
     case LoadVarargs:
     case CallForwardVarargs:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1346,6 +1346,8 @@ public:
     void compileCallDOMGetter(Node*);
     void compileCallDOM(Node*);
     void compileCheckJSCast(Node*);
+    void compileCallCustomAccessorGetter(Node*);
+    void compileCallCustomAccessorSetter(Node*);
     void compileNormalizeMapKey(Node*);
     void compileGetMapBucketHead(Node*);
     void compileGetMapBucketNext(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3309,6 +3309,16 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case CallCustomAccessorGetter: {
+        compileCallCustomAccessorGetter(node);
+        break;
+    }
+
+    case CallCustomAccessorSetter: {
+        compileCallCustomAccessorSetter(node);
+        break;
+    }
+
     case TryGetById: {
         compileGetById(node, AccessType::TryGetById);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4414,6 +4414,16 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case CallCustomAccessorGetter: {
+        compileCallCustomAccessorGetter(node);
+        break;
+    }
+
+    case CallCustomAccessorSetter: {
+        compileCallCustomAccessorSetter(node);
+        break;
+    }
+
     case TryGetById: {
         compileGetById(node, AccessType::TryGetById);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -198,6 +198,8 @@ inline CapabilityLevel canCompile(Node* node)
     case TailCallForwardVarargsInlinedCaller:
     case ConstructForwardVarargs:
     case CallWasm:
+    case CallCustomAccessorGetter:
+    case CallCustomAccessorSetter:
     case VarargsLength:
     case LoadVarargs:
     case ValueToInt32:


### PR DESCRIPTION
#### 2280a97d2334cb16aa13cf8db9a01613d99366f9
<pre>
[JSC] Add CallCustomAccessorGetter / CallCustomAccessorSetter DFG nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263745">https://bugs.webkit.org/show_bug.cgi?id=263745</a>
<a href="https://rdar.apple.com/117551452">rdar://117551452</a>

Reviewed by Keith Miller.

When we see custom accessor getter and setter in DFG, we give up and use normal generic IC for this site.
We should not do that since

1. IC is costly. Its peak performance is fast, but setup is not free.
2. IC bloats more code.
3. Directly embedding IC&apos;s custom accessor getter / setter code into DFG / FTL is faster and more efficient.

This patch adds CallCustomAccessorGetter and CallCustomAccessorSetter. We appropriately start handling custom
accessor feedback from IC and starts putting these nodes instead of just putting GetById / PutById.

                                            ToT                     Patched

custom-accessor                        9.7385+-0.0277     ^      9.4625+-0.0374        ^ definitely 1.0292x faster
custom-accessor-materialized           9.8093+-0.0166     ^      9.5174+-0.0291        ^ definitely 1.0307x faster
custom-accessor-thin-air-setter        5.3423+-0.0150     ^      4.7375+-0.0205        ^ definitely 1.1277x faster
custom-accessor-thin-air              19.8702+-0.0815     ^     19.1854+-0.0327        ^ definitely 1.0357x faster

* JSTests/microbenchmarks/custom-accessor-thin-air-setter.js: Added.
(assert):
(test5.set const):
(test5.set for):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::ObjectPropertyConditionSet::isStillValid const):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h:
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForStubInfo):
(JSC::PutByStatus::makesCalls const):
(JSC::PutByStatus::merge):
(JSC::PutByStatus::dump const):
* Source/JavaScriptCore/bytecode/PutByStatus.h:
* Source/JavaScriptCore/bytecode/PutByVariant.cpp:
(JSC::PutByVariant::operator=):
(JSC::PutByVariant::customSetter):
(JSC::PutByVariant::writesStructures const):
(JSC::PutByVariant::reallocatesStorage const):
(JSC::PutByVariant::makesCalls const):
(JSC::PutByVariant::attemptToMerge):
(JSC::PutByVariant::dumpInContext const):
* Source/JavaScriptCore/bytecode/PutByVariant.h:
(JSC::PutByVariant::oldStructure const):
(JSC::PutByVariant::oldStructure):
(JSC::PutByVariant::customAccessorSetter const):
(JSC::PutByVariant::domAttribute const):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::check):
(JSC::DFG::ByteCodeParser::handleGetById):
(JSC::DFG::ByteCodeParser::handlePutById):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasCacheableIdentifier):
(JSC::DFG::Node::cacheableIdentifier):
(JSC::DFG::Node::hasHeapPrediction):
(JSC::DFG::Node::hasCallCustomAccessorData const):
(JSC::DFG::Node::callCustomAccessorData):
(JSC::DFG::Node::customAccessor):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/270028@main">https://commits.webkit.org/270028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2896ef04951a700351b3c405f164121589f93240

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22389 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4073 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/7 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24568 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/1955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27047 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21945 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21165 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22254 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23622 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1625 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/7 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31019 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/2904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6798 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2030 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30984 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3107 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1993 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6474 "Passed tests") | 
<!--EWS-Status-Bubble-End-->