### PR TITLE
[JSC] Fix the fast path of copying indexed properties for objectConstructorValues

### DIFF
--- a/JSTests/stress/object-assign-values-order.js
+++ b/JSTests/stress/object-assign-values-order.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+let obj = {
+    1: "v0",
+    20230726: "v1",
+    20230802: "v2",
+    20230809: "v3",
+    20230816: "v4",
+    20230823: "v5",
+    20230830: "v6",
+    20230906: "v7",
+    20230913: "v8",
+    20230920: "v9",
+    20230927: "v10",
+    20231004: "v11",
+    20231011: "v12",
+    20231018: "v13",
+    20231025: "v14",
+};
+
+{
+    let actual = Object.values(obj).toString();
+    let expected = "v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14";
+    shouldBe(actual, expected);
+}
+
+{
+    let actual = JSON.stringify(Object.assign({}, obj));
+    let expected = `{"1":"v0","20230726":"v1","20230802":"v2","20230809":"v3","20230816":"v4","20230823":"v5","20230830":"v6","20230906":"v7","20230913":"v8","20230920":"v9","20230927":"v10","20231004":"v11","20231011":"v12","20231018":"v13","20231025":"v14"}`;
+    shouldBe(actual, expected);
+}

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -167,7 +167,8 @@ public:
     template<typename PropertyNameType> JSValue getIfPropertyExists(JSGlobalObject*, const PropertyNameType&);
     bool noSideEffectMayHaveNonIndexProperty(VM&, PropertyName);
 
-    template<typename Functor>
+    enum class SortMode { Default, Ascending };
+    template<SortMode mode = SortMode::Default, typename Functor>
     void forEachOwnIndexedProperty(JSGlobalObject*, const Functor&);
 
 private:

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -585,7 +585,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorValues, (JSGlobalObject* globalObject,
             Structure* arrayStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
             MarkedArgumentBuffer indexedPropertyValues;
             if (target->canHaveExistingOwnIndexedProperties()) {
-                target->forEachOwnIndexedProperty(globalObject, [&](unsigned, JSValue value) {
+                target->forEachOwnIndexedProperty<JSObject::SortMode::Ascending>(globalObject, [&](unsigned, JSValue value) {
                     indexedPropertyValues.appendWithCrashOnOverflow(value);
                     return IterationStatus::Continue;
                 });

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -55,7 +55,7 @@ ALWAYS_INLINE void objectAssignIndexedPropertiesFast(JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    source->forEachOwnIndexedProperty(globalObject, [&](unsigned index, JSValue value) {
+    source->forEachOwnIndexedProperty<>(globalObject, [&](unsigned index, JSValue value) {
         target->putDirectIndex(globalObject, index, value);
         RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
         return IterationStatus::Continue;


### PR DESCRIPTION
#### ba9245ab655b2d0604e96bb386d990175a407865
<pre>
[JSC] Fix the fast path of copying indexed properties for objectConstructorValues
<a href="https://bugs.webkit.org/show_bug.cgi?id=263742">https://bugs.webkit.org/show_bug.cgi?id=263742</a>
rdar://117439508

Reviewed by Yusuke Suzuki.

The fast path of copying indexed properties for objectConstructorValues
should copy property and value pairs in ascending order by the indexed
property. See specs:

- <a href="https://tc39.es/ecma262/#sec-object.values">https://tc39.es/ecma262/#sec-object.values</a>
- <a href="https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys</a>
- <a href="https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys">https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys</a>
- <a href="https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-ownpropertykeys">https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-ownpropertykeys</a>
- <a href="https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys">https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys</a>
- <a href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">https://tc39.es/ecma262/#sec-ordinaryownpropertykeys</a>

* JSTests/stress/object-assign-values-order.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::forEachOwnIndexedProperty):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignIndexedPropertiesFast):

Canonical link: <a href="https://commits.webkit.org/269896@main">https://commits.webkit.org/269896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e7b186a0fef626bfe72ce95a0704cb9273a938e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21991 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22512 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26590 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27781 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20743 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25564 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23171 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18914 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30574 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1231 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5734 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1639 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30529 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1549 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6385 "Passed tests") | 
<!--EWS-Status-Bubble-End-->