### PR TITLE
[WebGPU] std::optional<To> convertFloat(From value) does not work for negative values

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -135,10 +135,14 @@ std::optional<To> convertInteger(From value)
 template<typename To, typename From>
 std::optional<To> convertFloat(From value)
 {
+    static_assert(std::is_floating_point<To>::value || std::is_same<To, __fp16>::value, "Result type is expected to be a floating point type: double, float, or __fp16");
     if (value > std::numeric_limits<To>::max())
         return std::nullopt;
-    if (value < std::numeric_limits<To>::min())
+    if (value < std::numeric_limits<To>::lowest())
+        return std::nullopt;
+    if (std::abs(value) < std::numeric_limits<To>::min())
         return { 0 };
+
     return { value };
 }
 


### PR DESCRIPTION
#### 5d2b2aa7ae7a9a9618ac30304b8cb5ee54222b76
<pre>
[WebGPU] std::optional&lt;To&gt; convertFloat(From value) does not work for negative values
<a href="https://bugs.webkit.org/show_bug.cgi?id=263747">https://bugs.webkit.org/show_bug.cgi?id=263747</a>
&lt;rdar://117553304&gt;

Reviewed by Dan Glastonbury.

Small fallout from <a href="https://bugs.webkit.org/show_bug.cgi?id=263675">https://bugs.webkit.org/show_bug.cgi?id=263675</a>, convertFloat
was not working with negative numbers, since std::numeric_limits&lt;float&gt;::min() returns
the smallest positive floating point number a float can represent.

* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::convertFloat):

Canonical link: <a href="https://commits.webkit.org/269835@main">https://commits.webkit.org/269835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8e1c8156544332d0d47c8de8f12ed21c6245768

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21895 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26474 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1171 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27687 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25455 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18831 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1124 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5673 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->