### PR TITLE
Add quirk to youtube.com to have element fullscreen controls respect iPhone safe area

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1041,6 +1041,18 @@ bool Quirks::shouldAvoidPastingImagesAsWebContent() const
 #endif
 }
 
+// youtube.com rdar://117304719
+bool Quirks::shouldInjectYouTubeFullscreenStyles() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_shouldInjectYouTubeFullscreenStyles)
+        m_shouldInjectYouTubeFullscreenStyles = m_document->url().host() == "youtube.com"_s || m_document->url().host().endsWith(".youtube.com"_s);
+
+    return *m_shouldInjectYouTubeFullscreenStyles;
+}
+
 #if ENABLE(TRACKING_PREVENTION)
 // kinja.com and related sites rdar://60601895
 static bool isKinjaLoginAvatarElement(const Element& element)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -102,6 +102,8 @@ public:
     WEBCORE_EXPORT bool shouldAvoidUsingIOS13ForGmail() const;
     WEBCORE_EXPORT bool shouldAvoidUsingIOS17UserAgentForFacebook() const;
 
+    WEBCORE_EXPORT bool shouldInjectYouTubeFullscreenStyles() const;
+
     bool needsGMailOverflowScrollQuirk() const;
     bool needsYouTubeOverflowScrollQuirk() const;
     bool needsFullscreenDisplayNoneQuirk() const;
@@ -241,6 +243,7 @@ private:
     mutable std::optional<bool> m_shouldDisableDataURLPaddingValidation;
     mutable std::optional<bool> m_needsDisableDOMPasteAccessQuirk;
     mutable std::optional<bool> m_shouldAvoidUsingIOS17UserAgentForFacebook;
+    mutable std::optional<bool> m_shouldInjectYouTubeFullscreenStyles;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -904,6 +904,22 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         }
     }
 #endif
+#if PLATFORM(IOS)
+    if (m_element->document().quirks().shouldInjectYouTubeFullscreenStyles()) {
+        auto* page = m_element->document().page();
+        if (page && is<HTMLDivElement>(m_element) && m_element->document().fullscreenManager().isFullscreen() && m_element->isDescendantOrShadowDescendantOf(m_element->document().fullscreenManager().fullscreenElement())) {
+            static MainThreadNeverDestroyed<const AtomString> ytpChromeTop("ytp-chrome-top"_s);
+            static MainThreadNeverDestroyed<const AtomString> ytpChromeBottom("ytp-chrome-bottom"_s);
+
+            auto& div = downcast<HTMLDivElement>(*m_element);
+
+            if (div.hasClass() && div.classNames().contains(ytpChromeTop))
+                style.setTop({ page->fullscreenInsets().top(), LengthType::Fixed });
+            if (div.hasClass() && div.classNames().contains(ytpChromeBottom))
+                style.setBottom({ page->fullscreenInsets().bottom(), LengthType::Fixed });
+        }
+    }
+#endif
 }
 
 void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& update, const Document& document)


### PR DESCRIPTION
#### 61ee61149c39a7707c1801826edf1636f0961640
<pre>
Add quirk to youtube.com to have element fullscreen controls respect iPhone safe area
<a href="https://bugs.webkit.org/show_bug.cgi?id=263749">https://bugs.webkit.org/show_bug.cgi?id=263749</a>
rdar://117304719

Reviewed by NOBODY (OOPS!).

Embedded YouTube videos when put in fullscreen on iPhone have their controls outside
the iPhone safe zone. This patch adds a quirk on iOS that sets YouTube&apos;s fullscreen
top and bottom controls to respect the safe area.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldInjectYouTubeFullscreenStyles const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61ee61149c39a7707c1801826edf1636f0961640

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22507 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26593 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27777 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18916 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->