### PR TITLE
Canvas::closePath should not iterate all segments to compute subpath existence

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -50,8 +50,10 @@ void CanvasPath::closePath()
     if (m_path.isEmpty())
         return;
 
-    FloatRect boundRect = m_path.fastBoundingRect();
-    if (boundRect.width() || boundRect.height())
+    // The closePath() method, when invoked, must do nothing if the object's path has no subpaths.
+    // Otherwise, it must mark the last subpath as closed, create a new subpath whose first point
+    // is the same as the previous subpath's first point, and finally add this new subpath to the path.
+    if (m_path.hasSubpaths())
         m_path.closeSubpath();
 }
 

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -520,6 +520,17 @@ bool Path::strokeContains(const FloatPoint& point, const Function<void(GraphicsC
     return const_cast<Path&>(*this).ensurePlatformPathImpl().strokeContains(point, strokeStyleApplier);
 }
 
+bool Path::hasSubpaths() const
+{
+    if (auto segment = asSingle())
+        return PathStream::computeHasSubpaths({ segment, 1 });
+
+    if (auto impl = asImpl())
+        return impl->hasSubpaths();
+
+    return false;
+}
+
 FloatRect Path::fastBoundingRect() const
 {
     if (auto segment = asSingle())

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -101,6 +101,7 @@ public:
 
     float length() const;
     bool isClosed() const;
+    bool hasSubpaths() const;
     FloatPoint currentPoint() const;
     PathTraversalState traversalStateAtLength(float length) const;
     FloatPoint pointAtLength(float length) const;

--- a/Source/WebCore/platform/graphics/PathImpl.cpp
+++ b/Source/WebCore/platform/graphics/PathImpl.cpp
@@ -105,4 +105,10 @@ bool PathImpl::isClosed() const
     return lastElementIsClosed;
 }
 
+bool PathImpl::hasSubpaths() const
+{
+    auto rect = fastBoundingRect();
+    return rect.height() || rect.width();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -83,6 +83,8 @@ public:
 
     virtual bool isClosed() const;
 
+    virtual bool hasSubpaths() const;
+
     virtual FloatPoint currentPoint() const = 0;
 
     virtual FloatRect fastBoundingRect() const = 0;

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -273,6 +273,30 @@ FloatRect PathStream::computeFastBoundingRect(std::span<const PathSegment> segme
     return boundingRect;
 }
 
+bool PathStream::computeHasSubpaths(std::span<const PathSegment> segments)
+{
+    FloatPoint lastMoveToPoint;
+    FloatPoint currentPoint;
+    FloatRect boundingRect = FloatRect::smallestRect();
+
+    for (auto& segment : segments) {
+        segment.extendFastBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
+        if (!boundingRect.isSmallest() && (boundingRect.height() || boundingRect.width()))
+            return true;
+        currentPoint = segment.calculateEndPoint(currentPoint, lastMoveToPoint);
+    }
+
+    if (boundingRect.isSmallest())
+        boundingRect.extend(currentPoint);
+
+    return boundingRect.height() || boundingRect.width();
+}
+
+bool PathStream::hasSubpaths() const
+{
+    return computeHasSubpaths(m_segments.span());
+}
+
 FloatRect PathStream::fastBoundingRect() const
 {
     return computeFastBoundingRect(m_segments.span());

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -67,8 +67,11 @@ public:
     FloatRect fastBoundingRect() const final;
     FloatRect boundingRect() const final;
 
+    bool hasSubpaths() const final;
+
     static FloatRect computeFastBoundingRect(std::span<const PathSegment>);
     static FloatRect computeBoundingRect(std::span<const PathSegment>);
+    static bool computeHasSubpaths(std::span<const PathSegment>);
 
 private:
     PathStream() = default;


### PR DESCRIPTION
#### 3abfea5879bc848536425a70f544846c5d281704
<pre>
Canvas::closePath should not iterate all segments to compute subpath existence
<a href="https://bugs.webkit.org/show_bug.cgi?id=263753">https://bugs.webkit.org/show_bug.cgi?id=263753</a>
rdar://117559394

Reviewed by Ryosuke Niwa.

Canvas#closePath is very hot in Speedometer3.0 and this is because it is calling fastBoundingRect
to compute bounding rect to see whether there is subpath. But we do not need to iterate all segments
since we can early return when the result gets the non-zero size, and quite likely, this gets non-zero
size just iterating one or two segments. Chart-chartjs is rendering charts via Canvas as a result its
path is very long. Iterating all segments every time we closePath is very costly.

This patch adds Path::hasSubpaths and PathImpl::hasSubpaths. PathImpl::hasSubpaths does the old generic
behavior, which takes fastBoundingRect and see whether its size is non-zero. But PathStream::hasSubpaths
has an optimization which stops iteration of segments when it starts seeing non-zero bounding rect.

* Source/WebCore/html/canvas/CanvasPath.cpp:
(WebCore::CanvasPath::closePath):
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::hasSubpaths const):
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathImpl.cpp:
(WebCore::PathImpl::hasSubpaths const):
* Source/WebCore/platform/graphics/PathImpl.h:
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::computeHasSubpaths):
(WebCore::PathStream::hasSubpaths const):
* Source/WebCore/platform/graphics/PathStream.h:

Canonical link: <a href="https://commits.webkit.org/269867@main">https://commits.webkit.org/269867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bab86da2c7b7567bf0c877cdee226d2c44525c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24344 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26585 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27775 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25557 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18909 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1632 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3051 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->