### PR TITLE
Adopt more smart pointers in WebPageProxy

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -53,32 +53,32 @@ Navigation::Navigation(WebNavigationState& state, WebCore::ProcessIdentifier pro
 {
 }
 
-Navigation::Navigation(WebNavigationState& state, WebCore::ProcessIdentifier processID, WebBackForwardListItem* currentAndTargetItem)
+Navigation::Navigation(WebNavigationState& state, WebCore::ProcessIdentifier processID, RefPtr<WebBackForwardListItem>&& currentAndTargetItem)
     : m_navigationID(state.generateNavigationID())
     , m_processID(processID)
-    , m_reloadItem(currentAndTargetItem)
+    , m_reloadItem(WTFMove(currentAndTargetItem))
     , m_clientNavigationActivity(navigationActivityTimeout)
 {
 }
 
-Navigation::Navigation(WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& request, WebBackForwardListItem* fromItem)
+Navigation::Navigation(WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& request, RefPtr<WebBackForwardListItem>&& fromItem)
     : m_navigationID(state.generateNavigationID())
     , m_processID(processID)
     , m_originalRequest(WTFMove(request))
     , m_currentRequest(m_originalRequest)
     , m_redirectChain { m_originalRequest.url() }
-    , m_fromItem(fromItem)
+    , m_fromItem(WTFMove(fromItem))
     , m_clientNavigationActivity(navigationActivityTimeout)
 {
 }
 
-Navigation::Navigation(WebNavigationState& state, WebCore::ProcessIdentifier processID, WebBackForwardListItem& targetItem, WebBackForwardListItem* fromItem, FrameLoadType backForwardFrameLoadType)
+Navigation::Navigation(WebNavigationState& state, WebCore::ProcessIdentifier processID, Ref<WebBackForwardListItem>&& targetItem, RefPtr<WebBackForwardListItem>&& fromItem, FrameLoadType backForwardFrameLoadType)
     : m_navigationID(state.generateNavigationID())
     , m_processID(processID)
-    , m_originalRequest(targetItem.url())
+    , m_originalRequest(targetItem->url())
     , m_currentRequest(m_originalRequest)
-    , m_targetItem(&targetItem)
-    , m_fromItem(fromItem)
+    , m_targetItem(WTFMove(targetItem))
+    , m_fromItem(WTFMove(fromItem))
     , m_backForwardFrameLoadType(backForwardFrameLoadType)
     , m_clientNavigationActivity(navigationActivityTimeout)
 {
@@ -91,8 +91,8 @@ Navigation::Navigation(WebKit::WebNavigationState& state, WebCore::ProcessIdenti
     m_substituteData = WTFMove(substituteData);
 }
 
-Navigation::Navigation(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& simulatedRequest, std::unique_ptr<SubstituteData>&& substituteData, WebKit::WebBackForwardListItem* fromItem)
-    : Navigation(state, processID, WTFMove(simulatedRequest), fromItem)
+Navigation::Navigation(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& simulatedRequest, std::unique_ptr<SubstituteData>&& substituteData, RefPtr<WebKit::WebBackForwardListItem>&& fromItem)
+    : Navigation(state, processID, WTFMove(simulatedRequest), WTFMove(fromItem))
 {
     ASSERT(substituteData);
     m_substituteData = WTFMove(substituteData);

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -77,19 +77,19 @@ struct SubstituteData {
 class Navigation : public ObjectImpl<Object::Type::Navigation> {
     WTF_MAKE_NONCOPYABLE(Navigation);
 public:
-    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebKit::WebBackForwardListItem* currentAndTargetItem)
+    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, RefPtr<WebKit::WebBackForwardListItem>&& currentAndTargetItem)
     {
-        return adoptRef(*new Navigation(state, processID, currentAndTargetItem));
+        return adoptRef(*new Navigation(state, processID, WTFMove(currentAndTargetItem)));
     }
 
-    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebKit::WebBackForwardListItem& targetItem, WebKit::WebBackForwardListItem* fromItem, WebCore::FrameLoadType backForwardFrameLoadType)
+    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, Ref<WebKit::WebBackForwardListItem>&& targetItem, RefPtr<WebKit::WebBackForwardListItem>&& fromItem, WebCore::FrameLoadType backForwardFrameLoadType)
     {
-        return adoptRef(*new Navigation(state, processID, targetItem, fromItem, backForwardFrameLoadType));
+        return adoptRef(*new Navigation(state, processID, WTFMove(targetItem), WTFMove(fromItem), backForwardFrameLoadType));
     }
 
-    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& request, WebKit::WebBackForwardListItem* fromItem)
+    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& request, RefPtr<WebKit::WebBackForwardListItem>&& fromItem)
     {
-        return adoptRef(*new Navigation(state, processID, WTFMove(request), fromItem));
+        return adoptRef(*new Navigation(state, processID, WTFMove(request), WTFMove(fromItem)));
     }
 
     static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, std::unique_ptr<SubstituteData>&& substituteData)
@@ -97,9 +97,9 @@ public:
         return adoptRef(*new Navigation(state, processID, WTFMove(substituteData)));
     }
 
-    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& simulatedRequest, std::unique_ptr<SubstituteData>&& substituteData, WebKit::WebBackForwardListItem* fromItem)
+    static Ref<Navigation> create(WebKit::WebNavigationState& state, WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& simulatedRequest, std::unique_ptr<SubstituteData>&& substituteData, RefPtr<WebKit::WebBackForwardListItem>&& fromItem)
     {
-        return adoptRef(*new Navigation(state, processID, WTFMove(simulatedRequest), WTFMove(substituteData), fromItem));
+        return adoptRef(*new Navigation(state, processID, WTFMove(simulatedRequest), WTFMove(substituteData), WTFMove(fromItem)));
     }
 
     virtual ~Navigation();
@@ -167,6 +167,7 @@ public:
 
     void setWebsitePolicies(RefPtr<API::WebsitePolicies>&& policies) { m_websitePolicies = WTFMove(policies); }
     API::WebsitePolicies* websitePolicies() { return m_websitePolicies.get(); }
+    RefPtr<API::WebsitePolicies> protectedWebsitePolicies() const { return m_websitePolicies; }
 
     void setOriginatorAdvancedPrivacyProtections(OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections) { m_originatorAdvancedPrivacyProtections = advancedPrivacyProtections; }
     OptionSet<WebCore::AdvancedPrivacyProtections> originatorAdvancedPrivacyProtections() const { return m_originatorAdvancedPrivacyProtections; }
@@ -176,11 +177,11 @@ public:
 
 private:
     Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier);
-    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, WebKit::WebBackForwardListItem*);
-    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, WebKit::WebBackForwardListItem* fromItem);
-    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, WebKit::WebBackForwardListItem& targetItem, WebKit::WebBackForwardListItem* fromItem, WebCore::FrameLoadType);
+    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
+    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, RefPtr<WebKit::WebBackForwardListItem>&& fromItem);
+    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, Ref<WebKit::WebBackForwardListItem>&& targetItem, RefPtr<WebKit::WebBackForwardListItem>&& fromItem, WebCore::FrameLoadType);
     Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, std::unique_ptr<SubstituteData>&&);
-    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, std::unique_ptr<SubstituteData>&&, WebKit::WebBackForwardListItem* fromItem);
+    Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, std::unique_ptr<SubstituteData>&&, RefPtr<WebKit::WebBackForwardListItem>&& fromItem);
 
     uint64_t m_navigationID;
     WebCore::ProcessIdentifier m_processID;

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -105,6 +105,8 @@ public:
         return m_connection.get();
     }
 
+    RefPtr<IPC::Connection> protectedConnection() const { return connection(); }
+
     bool hasConnection() const
     {
         return !!m_connection;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -53,4 +53,9 @@ RefPtr<RemotePageProxy> ProvisionalFrameProxy::takeRemotePageProxy()
     return std::exchange(m_remotePageProxy, nullptr);
 }
 
+Ref<WebProcessProxy> ProvisionalFrameProxy::protectedProcess() const
+{
+    return process();
 }
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -44,7 +44,8 @@ public:
     ProvisionalFrameProxy(WebFrameProxy&, WebProcessProxy&, RefPtr<RemotePageProxy>&&);
     ~ProvisionalFrameProxy();
 
-    WebProcessProxy& process() { return m_process.get(); }
+    WebProcessProxy& process() const { return m_process.get(); }
+    Ref<WebProcessProxy> protectedProcess() const;
     RefPtr<RemotePageProxy> takeRemotePageProxy();
 
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -200,4 +200,9 @@ void RemotePageProxy::sendMouseEvent(const WebCore::FrameIdentifier& frameID, co
     });
 }
 
+Ref<WebProcessProxy> RemotePageProxy::protectedProcess() const
+{
+    return m_process;
+}
+
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -78,6 +78,7 @@ public:
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
 
     WebProcessProxy& process() { return m_process.get(); }
+    Ref<WebProcessProxy> protectedProcess() const;
     WebCore::PageIdentifier pageID() const { return m_webPageID; }
     const WebCore::RegistrableDomain& domain() const { return m_domain; }
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -234,6 +234,11 @@ WebBackForwardListItem* WebBackForwardList::currentItem() const
     return m_page && m_currentIndex ? m_entries[*m_currentIndex].ptr() : nullptr;
 }
 
+RefPtr<WebBackForwardListItem> WebBackForwardList::protectedCurrentItem() const
+{
+    return currentItem();
+}
+
 WebBackForwardListItem* WebBackForwardList::backItem() const
 {
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -60,6 +60,7 @@ public:
     void clear();
 
     WebBackForwardListItem* currentItem() const;
+    RefPtr<WebBackForwardListItem> protectedCurrentItem() const;
     WebBackForwardListItem* backItem() const;
     WebBackForwardListItem* forwardItem() const;
     WebBackForwardListItem* itemAtIndex(int) const;

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -159,7 +159,8 @@ public:
     FrameTreeCreationParameters frameTreeCreationParameters() const;
 
     WebFrameProxy* parentFrame() { return m_parentFrame.get(); }
-    WebProcessProxy& process() { return m_process.get(); }
+    WebProcessProxy& process() const { return m_process.get(); }
+    Ref<WebProcessProxy> protectedProcess() const { return process(); }
     void setProcess(WebProcessProxy& process) { m_process = process; }
     ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
     std::unique_ptr<ProvisionalFrameProxy> takeProvisionalFrame();

--- a/Source/WebKit/UIProcess/WebNavigationState.cpp
+++ b/Source/WebKit/UIProcess/WebNavigationState.cpp
@@ -41,27 +41,27 @@ WebNavigationState::~WebNavigationState()
 {
 }
 
-Ref<API::Navigation> WebNavigationState::createLoadRequestNavigation(WebCore::ProcessIdentifier processID, ResourceRequest&& request, WebBackForwardListItem* currentItem)
+Ref<API::Navigation> WebNavigationState::createLoadRequestNavigation(WebCore::ProcessIdentifier processID, ResourceRequest&& request, RefPtr<WebBackForwardListItem>&& currentItem)
 {
-    auto navigation = API::Navigation::create(*this, processID, WTFMove(request), currentItem);
+    auto navigation = API::Navigation::create(*this, processID, WTFMove(request), WTFMove(currentItem));
 
     m_navigations.set(navigation->navigationID(), navigation.ptr());
 
     return navigation;
 }
 
-Ref<API::Navigation> WebNavigationState::createBackForwardNavigation(WebCore::ProcessIdentifier processID, WebBackForwardListItem& targetItem, WebBackForwardListItem* currentItem, FrameLoadType frameLoadType)
+Ref<API::Navigation> WebNavigationState::createBackForwardNavigation(WebCore::ProcessIdentifier processID, Ref<WebBackForwardListItem>&& targetItem, RefPtr<WebBackForwardListItem>&& currentItem, FrameLoadType frameLoadType)
 {
-    auto navigation = API::Navigation::create(*this, processID, targetItem, currentItem, frameLoadType);
+    auto navigation = API::Navigation::create(*this, processID, WTFMove(targetItem), WTFMove(currentItem), frameLoadType);
 
     m_navigations.set(navigation->navigationID(), navigation.ptr());
 
     return navigation;
 }
 
-Ref<API::Navigation> WebNavigationState::createReloadNavigation(WebCore::ProcessIdentifier processID, WebBackForwardListItem* currentAndTargetItem)
+Ref<API::Navigation> WebNavigationState::createReloadNavigation(WebCore::ProcessIdentifier processID, RefPtr<WebBackForwardListItem>&& currentAndTargetItem)
 {
-    auto navigation = API::Navigation::create(*this, processID, currentAndTargetItem);
+    auto navigation = API::Navigation::create(*this, processID, WTFMove(currentAndTargetItem));
 
     m_navigations.set(navigation->navigationID(), navigation.ptr());
 
@@ -77,9 +77,9 @@ Ref<API::Navigation> WebNavigationState::createLoadDataNavigation(WebCore::Proce
     return navigation;
 }
 
-Ref<API::Navigation> WebNavigationState::createSimulatedLoadWithDataNavigation(WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& request, std::unique_ptr<API::SubstituteData>&& substituteData, WebBackForwardListItem* currentItem)
+Ref<API::Navigation> WebNavigationState::createSimulatedLoadWithDataNavigation(WebCore::ProcessIdentifier processID, WebCore::ResourceRequest&& request, std::unique_ptr<API::SubstituteData>&& substituteData, RefPtr<WebBackForwardListItem>&& currentItem)
 {
-    auto navigation = API::Navigation::create(*this, processID, WTFMove(request), WTFMove(substituteData), currentItem);
+    auto navigation = API::Navigation::create(*this, processID, WTFMove(request), WTFMove(substituteData), WTFMove(currentItem));
 
     m_navigations.set(navigation->navigationID(), navigation.ptr());
 

--- a/Source/WebKit/UIProcess/WebNavigationState.h
+++ b/Source/WebKit/UIProcess/WebNavigationState.h
@@ -52,11 +52,11 @@ public:
     explicit WebNavigationState();
     ~WebNavigationState();
 
-    Ref<API::Navigation> createBackForwardNavigation(WebCore::ProcessIdentifier, WebBackForwardListItem& targetItem, WebBackForwardListItem* currentItem, WebCore::FrameLoadType);
-    Ref<API::Navigation> createLoadRequestNavigation(WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, WebBackForwardListItem* currentItem);
-    Ref<API::Navigation> createReloadNavigation(WebCore::ProcessIdentifier, WebBackForwardListItem* currentAndTargetItem);
+    Ref<API::Navigation> createBackForwardNavigation(WebCore::ProcessIdentifier, Ref<WebBackForwardListItem>&& targetItem, RefPtr<WebBackForwardListItem>&& currentItem, WebCore::FrameLoadType);
+    Ref<API::Navigation> createLoadRequestNavigation(WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, RefPtr<WebBackForwardListItem>&& currentItem);
+    Ref<API::Navigation> createReloadNavigation(WebCore::ProcessIdentifier, RefPtr<WebBackForwardListItem>&& currentAndTargetItem);
     Ref<API::Navigation> createLoadDataNavigation(WebCore::ProcessIdentifier, std::unique_ptr<API::SubstituteData>&&);
-    Ref<API::Navigation> createSimulatedLoadWithDataNavigation(WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, std::unique_ptr<API::SubstituteData>&&, WebBackForwardListItem* currentItem);
+    Ref<API::Navigation> createSimulatedLoadWithDataNavigation(WebCore::ProcessIdentifier, WebCore::ResourceRequest&&, std::unique_ptr<API::SubstituteData>&&, RefPtr<WebBackForwardListItem>&& currentItem);
 
     bool hasNavigation(uint64_t navigationID) const { return m_navigations.contains(navigationID); }
     API::Navigation* navigation(uint64_t navigationID);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -516,6 +516,7 @@ public:
     static void forMostVisibleWebPageIfAny(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(WebPageProxy*)>&&);
 
     const API::PageConfiguration& configuration() const;
+    Ref<API::PageConfiguration> protectedConfiguration() const;
 
     using Identifier = WebPageProxyIdentifier;
 
@@ -534,6 +535,7 @@ public:
     WebNavigationState& navigationState() { return *m_navigationState; }
 
     WebsiteDataStore& websiteDataStore() { return m_websiteDataStore; }
+    Ref<WebsiteDataStore> protectedWebsiteDataStore() const;
 
     void addPreviouslyVisitedPath(const String&);
 
@@ -560,6 +562,7 @@ public:
 #endif
 
     WebBackForwardList& backForwardList() { return m_backForwardList; }
+    Ref<WebBackForwardList> protectedBackForwardList() const;
 
     bool addsVisitedLinks() const { return m_addsVisitedLinks; }
     void setAddsVisitedLinks(bool addsVisitedLinks) { m_addsVisitedLinks = addsVisitedLinks; }
@@ -573,6 +576,8 @@ public:
     bool isSuspended() const { return m_isSuspended; }
 
     WebInspectorUIProxy* inspector() const;
+    RefPtr<WebInspectorUIProxy> protectedInspector() const;
+
     GeolocationPermissionRequestManagerProxy& geolocationPermissionRequestManager();
 
     void resourceLoadDidSendRequest(ResourceLoadInfo&&, WebCore::ResourceRequest&&);
@@ -1462,9 +1467,12 @@ public:
 
     const WebPreferences& preferences() const { return m_preferences; }
     WebPreferences& preferences() { return m_preferences; }
+    Ref<WebPreferences> protectedPreferences() const;
+
     void setPreferences(WebPreferences&);
 
     WebPageGroup& pageGroup() { return m_pageGroup; }
+    Ref<WebPageGroup> protectedPageGroup() const;
 
     bool hasRunningProcess() const;
     void launchInitialProcessIfNecessary();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2138,6 +2138,11 @@ WebProcessPool& WebProcessProxy::processPool() const
     return *m_processPool.get();
 }
 
+Ref<WebProcessPool> WebProcessProxy::protectedProcessPool() const
+{
+    return processPool();
+}
+
 PAL::SessionID WebProcessProxy::sessionID() const
 {
     ASSERT(m_websiteDataStore);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -169,6 +169,7 @@ public:
 
     WebProcessPool* processPoolIfExists() const;
     WebProcessPool& processPool() const;
+    Ref<WebProcessPool> protectedProcessPool() const;
 
 #if ENABLE(GPU_PROCESS)
     const std::optional<GPUProcessPreferencesForWebProcess>& preferencesForGPUProcess() const { return m_preferencesForGPUProcess; }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -138,6 +138,7 @@ public:
     
     NetworkProcessProxy& networkProcess() const;
     NetworkProcessProxy& networkProcess();
+    Ref<NetworkProcessProxy> protectedNetworkProcess() const;
     NetworkProcessProxy* networkProcessIfExists() { return m_networkProcess.get(); }
     
     static WebsiteDataStore* existingDataStoreForSessionID(PAL::SessionID);
@@ -501,7 +502,6 @@ private:
 
     WebsiteDataStore();
     static WorkQueue& websiteDataStoreIOQueue();
-    Ref<NetworkProcessProxy> protectedNetworkProcess() const;
 
     // FIXME: Only Cocoa ports respect ShouldCreateDirectory, so you cannot rely on it to create
     // directories. This is confusing.


### PR DESCRIPTION
#### 18935a82ccd2751c4d993775014734e9f5b23fbe
<pre>
Adopt more smart pointers in WebPageProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=263739">https://bugs.webkit.org/show_bug.cgi?id=263739</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::Navigation):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::create):
(API::Navigation::protectedWebsitePolicies const):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::protectedConnection const):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::protectedProcess const):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::protectedCurrentItem const):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::protectedProcess const):
* Source/WebKit/UIProcess/WebNavigationState.cpp:
(WebKit::WebNavigationState::createLoadRequestNavigation):
(WebKit::WebNavigationState::createBackForwardNavigation):
(WebKit::WebNavigationState::createReloadNavigation):
(WebKit::WebNavigationState::createSimulatedLoadWithDataNavigation):
* Source/WebKit/UIProcess/WebNavigationState.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_browsingContextGroup):
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::addAllMessageReceivers):
(WebKit::WebPageProxy::removeAllMessageReceivers):
(WebKit::WebPageProxy::protectedConfiguration const):
(WebKit::WebPageProxy::notifyProcessPoolToPrewarm):
(WebKit::WebPageProxy::setPreferences):
(WebKit::WebPageProxy::handleSynchronousMessage):
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::finishAttachingToWebProcess):
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::tryClose):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadData):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::navigateToPDFLinkWithSimulatedClick):
(WebKit::WebPageProxy::stopLoading):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::recordAutomaticNavigationSnapshot):
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goBack):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::willGoToBackForwardListItem):
(WebKit::WebPageProxy::setControlledByAutomation):
(WebKit::WebPageProxy::setInspectable):
(WebKit::WebPageProxy::activityStateDidChange):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::performDragControllerAction):
(WebKit::WebPageProxy::handleMouseEventReply):
(WebKit::WebPageProxy::processNextQueuedMouseEvent):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::wheelEventHandlingCompleted):
(WebKit::WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary):
(WebKit::WebPageProxy::updateDisplayLinkFrequency):
(WebKit::WebPageProxy::sendKeyEvent):
(WebKit::WebPageProxy::handleKeyboardEvent):
(WebKit::WebPageProxy::handleGestureEvent):
(WebKit::WebPageProxy::handleTouchEvent):
(WebKit::WebPageProxy::disableServiceWorkerEntitlementInNetworkProcess):
(WebKit::WebPageProxy::clearServiceWorkerEntitlementOverride):
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::setUserAgent):
(WebKit::WebPageProxy::restoreFromSessionState):
(WebKit::WebPageProxy::windowScreenDidChange):
(WebKit::WebPageProxy::accessibilitySettingsDidChange):
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPageProxy::getAllFrames):
(WebKit::WebPageProxy::getAllFrameTrees):
(WebKit::WebPageProxy::saveResources):
(WebKit::WebPageProxy::forceRepaint):
(WebKit::WebPageProxy::didCreateMainFrame):
(WebKit::WebPageProxy::didCreateSubframe):
(WebKit::WebPageProxy::didDestroyFrame):
(WebKit::WebPageProxy::disconnectFramesFromPage):
(WebKit::WebPageProxy::updateRemoteFrameSize):
(WebKit::WebPageProxy::didDestroyNavigation):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrame):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didExplicitOpenForFrame):
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame):
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didChangeProvisionalURLForFrame):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrame):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFinishDocumentLoadForFrame):
(WebKit::WebPageProxy::forEachWebContentProcess):
(WebKit::WebPageProxy::createRemoteSubframesInOtherProcesses):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebPageProxy::didChangeMainDocument):
(WebKit::WebPageProxy::viewIsBecomingVisible):
(WebKit::WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame):
(WebKit::WebPageProxy::didDisplayInsecureContentForFrame):
(WebKit::WebPageProxy::didRunInsecureContentForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationActionAsync):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::logFrameNavigation):
(WebKit::WebPageProxy::decidePolicyForNavigationActionSync):
(WebKit::WebPageProxy::decidePolicyForResponse):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::WebPageProxy::willSubmitForm):
(WebKit::WebPageProxy::didNavigateWithNavigationData):
(WebKit::WebPageProxy::didNavigateWithNavigationDataShared):
(WebKit::WebPageProxy::didPerformClientRedirect):
(WebKit::WebPageProxy::didPerformClientRedirectShared):
(WebKit::WebPageProxy::didPerformServerRedirect):
(WebKit::WebPageProxy::didPerformServerRedirectShared):
(WebKit::WebPageProxy::didUpdateHistoryTitle):
(WebKit::trySOAuthorization):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::exitFullscreenImmediately):
(WebKit::WebPageProxy::runJavaScriptAlert):
(WebKit::WebPageProxy::runJavaScriptConfirm):
(WebKit::WebPageProxy::runJavaScriptPrompt):
(WebKit::WebPageProxy::mouseDidMoveOverElement):
(WebKit::WebPageProxy::runBeforeUnloadConfirmPanel):
(WebKit::WebPageProxy::runOpenPanel):
(WebKit::WebPageProxy::setMuted):
(WebKit::WebPageProxy::resumeDownload):
(WebKit::WebPageProxy::downloadRequest):
(WebKit::WebPageProxy::dataTaskWithRequest):
(WebKit::WebPageProxy::setColorPickerColor):
(WebKit::WebPageProxy::endColorPicker):
(WebKit::WebPageProxy::showDataListSuggestions):
(WebKit::WebPageProxy::handleKeydownInDataList):
(WebKit::WebPageProxy::endDataListSuggestions):
(WebKit::WebPageProxy::showDateTimePicker):
(WebKit::WebPageProxy::endDateTimePicker):
(WebKit::WebPageProxy::protectedInspector const):
(WebKit::WebPageProxy::setMockVideoPresentationModeEnabled):
(WebKit::WebPageProxy::backForwardAddItem):
(WebKit::WebPageProxy::backForwardAddItemShared):
(WebKit::WebPageProxy::backForwardGoToItem):
(WebKit::WebPageProxy::backForwardListContainsItem):
(WebKit::WebPageProxy::backForwardGoToItemShared):
(WebKit::WebPageProxy::backForwardItemAtIndex):
(WebKit::WebPageProxy::didGetImageForFindMatch):
(WebKit::WebPageProxy::sendMessage):
(WebKit::WebPageProxy::sendMessageWithAsyncReply):
(WebKit::WebPageProxy::Internals::valueChangedForPopupMenu):
(WebKit::WebPageProxy::Internals::setTextFromItemForPopupMenu):
(WebKit::WebPageProxy::postMessageToInjectedBundle):
(WebKit::WebPageProxy::Internals::failedToShowPopupMenu):
(WebKit::WebPageProxy::showPopupMenu):
(WebKit::WebPageProxy::hidePopupMenu):
(WebKit::WebPageProxy::showContextMenu):
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
(WebKit::WebPageProxy::didCancelForOpenPanel):
(WebKit::WebPageProxy::mouseEventHandlingCompleted):
(WebKit::WebPageProxy::keyEventHandlingCompleted):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::logDiagnosticMessageWithValueDictionary):
(WebKit::WebPageProxy::focusedFrameChanged):
(WebKit::WebPageProxy::currentResourceDirectoryURL const):
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::backForwardClear):
(WebKit::WebPageProxy::makeStorageSpaceRequest):
(WebKit::WebPageProxy::reachedApplicationCacheOriginQuota):
(WebKit::WebPageProxy::requestGeolocationPermissionForFrame):
(WebKit::WebPageProxy::queryPermission):
(WebKit::WebPageProxy::willStartCapture):
(WebKit::WebPageProxy::requestMediaKeySystemPermissionForFrame):
(WebKit::WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::WebPageProxy::requestNotificationPermission):
(WebKit::WebPageProxy::cancelNotification):
(WebKit::WebPageProxy::clearNotifications):
(WebKit::WebPageProxy::didDestroyNotification):
(WebKit::WebPageProxy::runModal):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
(WebKit::WebPageProxy::requestControlledElementID const):
(WebKit::WebPageProxy::handleAutoFillButtonClick):
(WebKit::WebPageProxy::didResignInputElementStrongPasswordAppearance):
(WebKit::WebPageProxy::callAfterNextPresentationUpdate):
(WebKit::WebPageProxy::startURLSchemeTask):
(WebKit::WebPageProxy::startURLSchemeTaskShared):
(WebKit::WebPageProxy::stopURLSchemeTask):
(WebKit::WebPageProxy::loadSynchronousURLSchemeTask):
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromData):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromFilePath):
(WebKit::WebPageProxy::registerAttachmentsFromSerializedData):
(WebKit::WebPageProxy::cloneAttachmentData):
(WebKit::WebPageProxy::invalidateAllAttachments):
(WebKit::WebPageProxy::serializedAttachmentDataForIdentifiers):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
(WebKit::WebPageProxy::didRemoveAttachmentWithIdentifier):
(WebKit::WebPageProxy::ensureAttachment):
(WebKit::WebPageProxy::dumpPrivateClickMeasurement):
(WebKit::WebPageProxy::clearPrivateClickMeasurement):
(WebKit::WebPageProxy::setPrivateClickMeasurementOverrideTimerForTesting):
(WebKit::WebPageProxy::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::WebPageProxy::setPrivateClickMeasurementEphemeralMeasurementForTesting):
(WebKit::WebPageProxy::simulatePrivateClickMeasurementSessionRestart):
(WebKit::WebPageProxy::setPrivateClickMeasurementTokenPublicKeyURLForTesting):
(WebKit::WebPageProxy::setPrivateClickMeasurementTokenSignatureURLForTesting):
(WebKit::WebPageProxy::setPrivateClickMeasurementAttributionReportURLsForTesting):
(WebKit::WebPageProxy::markPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::WebPageProxy::setPCMFraudPreventionValuesForTesting):
(WebKit::WebPageProxy::setPrivateClickMeasurementAppBundleIDForTesting):
(WebKit::WebPageProxy::logger):
(WebKit::WebPageProxy::setMockWebAuthenticationConfiguration):
(WebKit::WebPageProxy::setOrientationForMediaCapture):
(WebKit::WebPageProxy::createMediaSessionCoordinator):
(WebKit::WebPageProxy::appPrivacyReportTestingData):
(WebKit::WebPageProxy::clearAppPrivacyReportTestingData):
(WebKit::WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock const):
(WebKit::WebPageProxy::dispatchLoadEventToFrameOwnerElement):
(WebKit::WebPageProxy::broadcastFocusedFrameToOtherProcesses):
(WebKit::WebPageProxy::protectedPreferences const):
(WebKit::WebPageProxy::protectedPageGroup const):
(WebKit::WebPageProxy::protectedWebsiteDataStore const):
(WebKit::WebPageProxy::protectedBackForwardList const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::protectedProcessPool const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/269863@main">https://commits.webkit.org/269863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a1801674319801ec3cac1e66d1b41053b1e8fa8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23858 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21995 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24354 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26595 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25568 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1235 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5705 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->