### PR TITLE
[cssom-view] Root element with `content-visibility: hidden` should be considered visible by `checkVisibility`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility-expected.txt
@@ -18,4 +18,5 @@ PASS checkVisibility on content-visibility:auto with visibility:hidden inside.
 PASS checkVisibility on nested content-visibility:auto containers reports that the content is visible.
 PASS checkVisibility on content-visibility:hidden child after forced layout update.
 PASS checkVisibility on content-visibility:hidden element after forced layout update.
+PASS checkVisibility on root element with content-visibility: hidden returns true.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
@@ -141,4 +141,10 @@ test(() => {
   cvhiddenwithupdate.getBoundingClientRect();
   assert_true(cvhiddenwithupdate.checkVisibility());
 }, 'checkVisibility on content-visibility:hidden element after forced layout update.');
+
+test(() => {
+  document.documentElement.style.contentVisibility = "hidden";
+  assert_true(document.documentElement.checkVisibility());
+  document.documentElement.style.removeProperty("content-visibility");
+}, 'checkVisibility on root element with content-visibility: hidden returns true.');
 </script>


### PR DESCRIPTION
#### 4ab7e598dff32df7c6ed36ea81cbb2945a3d966f
<pre>
[cssom-view] Root element with `content-visibility: hidden` should be considered visible by `checkVisibility`
<a href="https://bugs.webkit.org/show_bug.cgi?id=263765">https://bugs.webkit.org/show_bug.cgi?id=263765</a>
rdar://117570564

Reviewed by Simon Fraser.

An element with `content-visibility: hidden` only has its contents hidden. It is not itself hidden, since it has a size and can have a background/border.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::checkVisibility):

Canonical link: <a href="https://commits.webkit.org/269860@main">https://commits.webkit.org/269860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe3b673ac05d00f8d129f0678e90365fd73af899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25997 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24347 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26588 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21530 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21302 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5698 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->