### PR TITLE
REGRESSION (269779@main): [ macOS iOS 17 ] 3 API tests in TestWGSL is a consistent failure/crash

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -660,7 +660,7 @@ Token Lexer<T>::lexNumber()
     const T* fract = nullptr;
     const T* exponent = nullptr;
 
-    while (m_code != m_codeEnd) {
+    while (true) {
         switch (state) {
         case Start:
             switch (m_current) {

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -127,10 +127,9 @@ TEST(WGSLLexerTests, SingleTokens)
     checkSingleLiteral("042e0f"_s, TokenType::FloatLiteral, 42);
     checkSingleToken("042f"_s, TokenType::Invalid);
     checkSingleLiteral("0123.f"_s, TokenType::FloatLiteral, 123);
-    checkSingleLiteral(".456f"_s, TokenType::FloatLiteral, 0.456);
+    checkSingleLiteral(".456f"_s, TokenType::FloatLiteral, 0.456f);
     checkSingleLiteral("42e-3"_s, TokenType::AbstractFloatLiteral, 42e-3);
-    checkSingleLiteral("42e-3f"_s, TokenType::FloatLiteral, 42e-3);
-    checkSingleLiteral("42e-a"_s, TokenType::IntegerLiteral, 42);
+    checkSingleLiteral("42e-3f"_s, TokenType::FloatLiteral, 42e-3f);
 }
 
 TEST(WGSLLexerTests, KeywordTokens)


### PR DESCRIPTION
#### a8ac4a4cdd3f698758df2e2d4a053fa0676ac9f5
<pre>
REGRESSION (269779@main): [ macOS iOS 17 ] 3 API tests in TestWGSL is a consistent failure/crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=263746">https://bugs.webkit.org/show_bug.cgi?id=263746</a>
rdar://117553256

Reviewed by Mike Wyrzykowski.

We had 4 test cases failing, which consisted of 3 incorrect tests and 1 edge case:
- The edge case was when we parse a floating point at the end of the input source,
  ending with a period (the test was `01.`). We have to run the state machine once
  more past the end of the file to read the EOF char and either return an error or
  terminate a valid number token.
- 2 tests were parsing numbers that had the `f` suffix in the WGSL source, but
  comparing against a double value in C++. Originally the lexer did not perform
  the narrowing to float, so the comparison passed, but it shouldn&apos;t, so I updated
  the expectations.
- The last failing test was an invalid input (`42e-4`), which now correctly
  returns an invalid token.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lexNumber):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/269856@main">https://commits.webkit.org/269856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ea4bc9382bd9030f88a2b4f5b03df58a622b0cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21944 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22471 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26538 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1220 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21483 "Failed to checkout and rebase branch from PR 19627") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27737 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18871 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1181 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5694 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->