### PR TITLE
[WGSL] Fix struct size and alignment calculation

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructureMember.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructureMember.h
@@ -51,11 +51,15 @@ public:
     Attribute::List& attributes() { return m_attributes; }
 
     bool invariant() const { return m_invariant; }
-    std::optional<unsigned> alignment() const { return m_alignment; }
-    std::optional<unsigned> size() const { return m_size; }
     std::optional<Builtin> builtin() const { return m_builtin; }
     std::optional<unsigned> location() const { return m_location; }
     std::optional<Interpolation> interpolation() const { return m_interpolation; }
+
+    unsigned offset() const { return m_offset; }
+    unsigned padding() const { return m_padding; }
+
+    unsigned alignment() const { return *m_alignment; }
+    unsigned size() const { return *m_size; }
 
 private:
     StructureMember(SourceSpan span, Identifier&& name, Expression::Ref&& type, Attribute::List&& attributes)
@@ -68,6 +72,10 @@ private:
     Identifier m_name;
     Attribute::List m_attributes;
     Expression::Ref m_type;
+
+    // Compute
+    unsigned m_offset { 0 };
+    unsigned m_padding { 0 };
 
     // Attributes
     bool m_invariant { false };

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -701,7 +701,7 @@ const Type* RewriteGlobalVariables::packStructType(const Types::Struct* structTy
         if (packType(member.type().inferredType()))
             packedAnyMember = true;
     }
-    if (!packedAnyMember)
+    if (!packedAnyMember && !structType->structure.hasSizeOrAlignmentAttributes())
         return nullptr;
 
     ASSERT(structType->structure.role() == AST::StructureRole::UserDefined);

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -283,16 +283,7 @@ unsigned Type::size() const
             return array.size.value_or(1) * WTF::roundUpToMultipleOf(array.element->alignment(), array.element->size());
         },
         [&](const Struct& structure) -> unsigned {
-            unsigned alignment = 0;
-            unsigned size = 0;
-            for (auto& member : structure.structure.members()) {
-                auto* type = member.type().inferredType();
-                auto fieldAlignment = type->alignment();
-                alignment = std::max(alignment, fieldAlignment);
-                size = WTF::roundUpToMultipleOf(fieldAlignment, size);
-                size += type->size();
-            }
-            return WTF::roundUpToMultipleOf(alignment, size);
+            return structure.structure.size();
         },
         [&](const Function&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
@@ -362,10 +353,7 @@ unsigned Type::alignment() const
             return array.element->alignment();
         },
         [&](const Struct& structure) -> unsigned {
-            unsigned alignment = 0;
-            for (auto& [_, field] : structure.fields)
-                alignment = std::max(alignment, field->alignment());
-            return alignment;
+            return structure.structure.alignment();
         },
         [&](const Function&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### df5c532cb405673cfeaabc482c8b79916c26057f
<pre>
[WGSL] Fix struct size and alignment calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=263767">https://bugs.webkit.org/show_bug.cgi?id=263767</a>
rdar://117572287

Reviewed by Mike Wyrzykowski.

The computation was duplicated between the Struct type and code generation, but
the type version was incorrect since it didn&apos;t take into account @size and @align
attributes. Instead, move it into AttributeValidator, immediately after we validate
@size and @align attributes for all of the struct&apos;s members. This patch also keeps
track of whether or not the struct contains any members with size/align attributes
and uses this information when deciding if a struct needs to be packed. This fixes
a large number of CTS tests that were failing due to structs not being packed, which
caused them not respecting the size and alignment required by the attributes.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/AST/ASTStructureMember.h:
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::packStructType):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::size const):
(WGSL::Type::alignment const):

Canonical link: <a href="https://commits.webkit.org/269928@main">https://commits.webkit.org/269928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3da6d2f5b7a21ea30c8e7399f8a3277c46d814b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21964 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26558 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1245 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27754 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25537 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1201 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5756 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->