### PR TITLE
[WebGPU] Opening https://www.babylonjs.com/demos/webgpu/forestwebgpu results in a compilation error

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -1213,8 +1213,10 @@ Vector<unsigned> RewriteGlobalVariables::insertStructs(const PipelineLayout& lay
             }
         }
 
-        if (entries.isEmpty())
+        if (entries.isEmpty()) {
+            ++group;
             continue;
+        }
 
         groups.append(group);
         finalizeArgumentBufferStruct(group++, entries);


### PR DESCRIPTION
#### c7659f4a59ccae8d9c19f6f7e18f0e08536dbc99
<pre>
[WebGPU] Opening <a href="https://www.babylonjs.com/demos/webgpu/forestwebgpu">https://www.babylonjs.com/demos/webgpu/forestwebgpu</a> results in a compilation error
<a href="https://bugs.webkit.org/show_bug.cgi?id=263690">https://bugs.webkit.org/show_bug.cgi?id=263690</a>
rdar://117501463

Reviewed by Mike Wyrzykowski.

When generating argument buffers from bind groups, I added a short circuit to skip
generating structs and parameters for empty bind groups, but I forgot to increment
the bind group id if the group was empty. This caused groups that come after an
empty bind group to have wrong id, which resulted in the compilation error.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):

Canonical link: <a href="https://commits.webkit.org/269930@main">https://commits.webkit.org/269930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cad0d216de2bd4fd2e7950d4463cb4d63a490ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21951 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3513 "Hash 3cad0d21 for PR 19630 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22477 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24046 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/3513 "Hash 3cad0d21 for PR 19630 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26545 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/3513 "Hash 3cad0d21 for PR 19630 does not build (failure)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27743 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/3513 "Hash 3cad0d21 for PR 19630 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25526 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18878 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1188 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5757 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->