### PR TITLE
REGRESSION(267683@main): [ iOS ] platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html is a consistent text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4719,8 +4719,6 @@ webkit.org/b/263466 fast/mediastream/getDisplayMedia-max-constraints4.html [ Fai
 
 webkit.org/b/263471 fast/forms/ios/keydown-in-hidden-contenteditable-with-inputmode-none.html [ Pass Failure ]
 
-webkit.org/b/263479 platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html [ Pass Failure ]
-
 webkit.org/b/263396 css3/color/text.html [ Skip ]
 
 # webkit.org/b/263439 [ iOS ] Several WPTs using wheel actions are timing out after b243272

--- a/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
+++ b/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
@@ -30,6 +30,10 @@ promise_test(async () => {
         internals.beginAudioSessionInterruption();
 
     video.srcObject = null;
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    if (window.internals)
+        internals.clearAudioSessionInterruptionFlag();
 
     stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     video.srcObject = stream;

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -130,6 +130,7 @@ public:
 
     virtual void beginInterruptionForTesting() { beginInterruption(); }
     virtual void endInterruptionForTesting() { endInterruption(MayResume::Yes); }
+    virtual void clearInterruptionFlagForTesting() { }
 
     class InterruptionObserver : public CanMakeWeakPtr<InterruptionObserver> {
     public:

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4793,6 +4793,13 @@ void Internals::endAudioSessionInterruption()
 #endif
 }
 
+void Internals::clearAudioSessionInterruptionFlag()
+{
+#if USE(AUDIO_SESSION)
+    AudioSession::sharedSession().clearInterruptionFlagForTesting();
+#endif
+}
+
 void Internals::suspendAllMediaBuffering()
 {
     auto frame = this->frame();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -801,6 +801,7 @@ public:
     bool isPlayerMuted(const HTMLMediaElement&) const;
     void beginAudioSessionInterruption();
     void endAudioSessionInterruption();
+    void clearAudioSessionInterruptionFlag();
     void suspendAllMediaBuffering();
 #endif
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -871,6 +871,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=VIDEO] undefined activeAudioRouteDidChange(boolean shouldPause);
     [Conditional=VIDEO] undefined beginAudioSessionInterruption();
     [Conditional=VIDEO] undefined endAudioSessionInterruption();
+    [Conditional=VIDEO] undefined clearAudioSessionInterruptionFlag();
     [Conditional=VIDEO] undefined suspendAllMediaBuffering();
 
     [Conditional=WIRELESS_PLAYBACK_TARGET] undefined setMockMediaPlaybackTargetPickerEnabled(boolean enabled);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -99,6 +99,7 @@ private:
 
     void beginInterruptionForTesting() final;
     void endInterruptionForTesting() final;
+    void clearInterruptionFlagForTesting() final { m_isInterruptedForTesting = false; }
 
     const RemoteAudioSessionConfiguration& configuration() const;
     RemoteAudioSessionConfiguration& configuration();


### PR DESCRIPTION
#### 068189b33d98adaaa8476b2d999e60e4e90bacfb
<pre>
REGRESSION(267683@main): [ iOS ] platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html is a consistent text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263479">https://bugs.webkit.org/show_bug.cgi?id=263479</a>
rdar://problem/117282117

Reviewed by Eric Carlson.

In 267683@main, we added support for failing tryToSetActivate in case of interruption like happens in a phone call.
This broke this test which expects to end interruption in case of calling getUserMedia and phone call is ended (but we did not receive the end interruption).
To be able to test this case, we are introducing a new internals API that clears the interruption flag, which will allow tryToSetActivate to succeed.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html:
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::clearAudioSessionInterruptionFlag):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:

Canonical link: <a href="https://commits.webkit.org/269855@main">https://commits.webkit.org/269855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5845ef299bab25ac66d29e738d96276edd573829

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23804 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21952 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22478 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26546 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27744 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25527 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18880 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21262 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5693 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->