### PR TITLE
GraphicsContextGL::m_layerComposited is a redundant flag

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -932,7 +932,7 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cal
     // `clearIfComposited()` is a function that prepares for updates. Mark the context as active.
     updateActiveOrdinal();
 
-    if (!m_context->layerComposited() || m_preventBufferClearForInspector)
+    if (m_preventBufferClearForInspector)
         return false;
 
     GCGLbitfield buffersNeedingClearing = m_context->getBuffersToAutoClear();
@@ -5971,6 +5971,7 @@ void WebGLRenderingContextBase::prepareForDisplay()
 {
     if (!m_context)
         return;
+    ASSERT(m_compositingResultsNeedUpdating);
 
     m_context->prepareForDisplay();
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -577,12 +577,6 @@ void GraphicsContextGL::setDrawingBufferColorSpace(const DestinationColorSpace&)
 
 void GraphicsContextGL::markContextChanged()
 {
-    m_layerComposited = false;
-}
-
-bool GraphicsContextGL::layerComposited() const
-{
-    return m_layerComposited;
 }
 
 void GraphicsContextGL::setBuffersToAutoClear(GCGLbitfield buffers)
@@ -598,7 +592,6 @@ GCGLbitfield GraphicsContextGL::getBuffersToAutoClear() const
 
 void GraphicsContextGL::markLayerComposited()
 {
-    m_layerComposited = true;
     auto attrs = contextAttributes();
     if (!attrs.preserveDrawingBuffer) {
         m_buffersToAutoClear = GraphicsContextGL::COLOR_BUFFER_BIT;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1640,7 +1640,6 @@ public:
     // FIXME: these should be removed, caller is interested in buffer clear status and
     // should track that in a variable that the caller holds. Caller should receive
     // the value from reshape().
-    bool layerComposited() const;
     void setBuffersToAutoClear(GCGLbitfield);
     GCGLbitfield getBuffersToAutoClear() const;
 
@@ -1734,7 +1733,6 @@ protected:
     // GL_DEPTH_BUFFER_BIT, GL_STENCIL_BUFFER_BIT) which need to be
     // auto-cleared.
     GCGLbitfield m_buffersToAutoClear { 0 };
-    bool m_layerComposited { false };
     bool m_contextLost { false };
 
 private:

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -770,15 +770,10 @@ void GraphicsContextGLCocoa::prepareForDisplayWithFinishedSignal(Function<void()
         finishedSignal();
         return;
     }
-    if (m_layerComposited) {
-        // FIXME: It makes no sense that this happens. Tracking this state should be moved to caller, WebGLRendenderingContextBase.
-        // https://bugs.webkit.org/show_bug.cgi?id=219342
-        insertFinishedSignalOrInvoke(WTFMove(finishedSignal));
-        waitUntilWorkScheduled();
+    if (!drawingBuffer()) {
+        finishedSignal();
         return;
     }
-    if (!drawingBuffer())
-        return;
     prepareTexture();
     // The fence inserted by this will be scheduled because next BindTexImage will wait until scheduled.
     insertFinishedSignalOrInvoke(WTFMove(finishedSignal));

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -99,7 +99,7 @@ void GraphicsContextGLGBM::setContextVisibility(bool)
 
 void GraphicsContextGLGBM::prepareForDisplay()
 {
-    if (m_layerComposited || !makeContextCurrent())
+    if (!makeContextCurrent())
         return;
 
     prepareTexture();

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -347,7 +347,7 @@ bool GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer()
 
 void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
 {
-    if (m_layerComposited || !makeContextCurrent())
+    if (!makeContextCurrent())
         return;
 
     prepareTexture();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -132,15 +132,12 @@ void RemoteGraphicsContextGLProxy::setContextVisibility(bool)
 
 void RemoteGraphicsContextGLProxy::markContextChanged()
 {
-    // FIXME: The caller should track this state.
-    if (m_layerComposited) {
-        GraphicsContextGL::markContextChanged();
-        if (isContextLost())
-            return;
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MarkContextChanged());
-        if (sendResult != IPC::Error::NoError)
-            markContextLost();
-    }
+    GraphicsContextGL::markContextChanged();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::MarkContextChanged());
+    if (sendResult != IPC::Error::NoError)
+        markContextLost();
 }
 
 bool RemoteGraphicsContextGLProxy::supportsExtension(const String& name)


### PR DESCRIPTION
#### db1581387a571d91b0fd3420285f19c974ecae23
<pre>
GraphicsContextGL::m_layerComposited is a redundant flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=263772">https://bugs.webkit.org/show_bug.cgi?id=263772</a>
rdar://117582088

Reviewed by Don Olmstead.

The flag would be queried by
WebGLRenderingContextBase::clearIfComposited to understand if the
backbuffer needs to be cleared after prepareForDisplay before next draw
call. This is already taken care of by buffersToAutoClear variable which
tracks this state and is reset in same location, at prepareForDisplay.

The flag would be queried by GraphicsContextGL prepareForDisplay
implementations. This is taken care of by the caller, e.g. the caller
only schedules a prepare when draw has happened.

Work towards simplifying the default framebuffer implementation, in
order to implement premultipliedAlpha compositing.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::clearIfComposited):
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::markContextChanged):
(WebCore::GraphicsContextGL::markLayerComposited):
(WebCore::GraphicsContextGL::layerComposited const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::prepareForDisplayWithFinishedSignal):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::prepareForDisplay):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::markContextChanged):

Canonical link: <a href="https://commits.webkit.org/269939@main">https://commits.webkit.org/269939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c201ccc26d6d6380ef8d61b438b4d0a3af30ead

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24580 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26826 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27990 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25767 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19102 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1453 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5763 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->