### PR TITLE
[WGSL] frag_depth on return value does not generate depth(any) attribution

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -46,6 +46,7 @@ enum class StructureRole : uint8_t {
     UserDefinedResource,
     PackedResource,
     FragmentOutput,
+    FragmentOutputWrapper,
 };
 
 class Structure final : public Declaration {

--- a/Source/WebGPU/WGSL/tests/valid/fragment-output.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/fragment-output.wgsl
@@ -15,3 +15,11 @@ fn main() -> S {
   output.depth = 1;
   return output;
 }
+
+// RUN: %metal-compile main2
+@group(0) @binding(1) var inputTexture: texture_2d<f32>;
+@fragment fn main2(@builtin(position) fragcoord : vec4<f32>) -> @builtin(frag_depth) f32
+{
+    var depthValue : vec4<f32> = textureLoad(inputTexture, vec2<i32>(fragcoord.xy), 0);
+    return depthValue.x;
+}


### PR DESCRIPTION
#### fbd53e5fa81a503d731ab9fcfb3827de132c52d7
<pre>
[WGSL] frag_depth on return value does not generate depth(any) attribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=263393">https://bugs.webkit.org/show_bug.cgi?id=263393</a>
rdar://117221582

Reviewed by Mike Wyrzykowski.

Add support for returning builtins from fragment shaders. In order to generate
valid metal code, we need to wrap the return type in a struct, since it&apos;s not
valid to add the attributes directly to the return type.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/fragment-output.wgsl:

Canonical link: <a href="https://commits.webkit.org/269950@main">https://commits.webkit.org/269950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a7805af3365c10ea4c653f9818c35744baa19a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22211 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24589 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26835 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22044 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19111 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1462 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5766 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->