### PR TITLE
[WGSL] texture1d.read(coord, level): level must be zero

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2339,22 +2339,26 @@ fn testTextureGatherCompare()
 @compute @workgroup_size(1)
 fn testTextureLoad()
 {
+    let x: i32 = 0;
     // [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture1d], T, U) => Vector[S, 4],
     {
         {
             _ = textureLoad(t1d, 0, 0);
             _ = textureLoad(t1d, 0i, 0u);
             _ = textureLoad(t1d, 0u, 0i);
+            _ = textureLoad(t1d, 0u, x);
         }
         {
             _ = textureLoad(t1di, 0, 0);
             _ = textureLoad(t1di, 0i, 0u);
             _ = textureLoad(t1di, 0u, 0i);
+            _ = textureLoad(t1di, 0u, x);
         }
         {
             _ = textureLoad(t1du, 0, 0);
             _ = textureLoad(t1du, 0i, 0u);
             _ = textureLoad(t1du, 0u, 0i);
+            _ = textureLoad(t1du, 0u, x);
         }
     }
 
@@ -2364,16 +2368,19 @@ fn testTextureLoad()
             _ = textureLoad(t2d, vec2(0), 0);
             _ = textureLoad(t2d, vec2(0i), 0u);
             _ = textureLoad(t2d, vec2(0u), 0i);
+            _ = textureLoad(t2d, vec2(0u), x);
         }
         {
             _ = textureLoad(t2di, vec2(0), 0);
             _ = textureLoad(t2di, vec2(0i), 0u);
             _ = textureLoad(t2di, vec2(0u), 0i);
+            _ = textureLoad(t2di, vec2(0u), x);
         }
         {
             _ = textureLoad(t2du, vec2(0), 0);
             _ = textureLoad(t2du, vec2(0i), 0u);
             _ = textureLoad(t2du, vec2(0u), 0i);
+            _ = textureLoad(t2du, vec2(0u), x);
         }
     }
 
@@ -2383,16 +2390,19 @@ fn testTextureLoad()
             _ = textureLoad(t2da, vec2(0), 0, 0);
             _ = textureLoad(t2da, vec2(0i), 0u, 0i);
             _ = textureLoad(t2da, vec2(0u), 0i, 0u);
+            _ = textureLoad(t2da, vec2(0u), x, x);
         }
         {
             _ = textureLoad(t2dai, vec2(0), 0, 0);
             _ = textureLoad(t2dai, vec2(0i), 0u, 0i);
             _ = textureLoad(t2dai, vec2(0u), 0i, 0u);
+            _ = textureLoad(t2dau, vec2(0u), x, x);
         }
         {
             _ = textureLoad(t2dau, vec2(0), 0, 0);
             _ = textureLoad(t2dau, vec2(0i), 0u, 0i);
             _ = textureLoad(t2dau, vec2(0u), 0i, 0u);
+            _ = textureLoad(t2dau, vec2(0u), x, x);
         }
     }
 
@@ -2421,16 +2431,19 @@ fn testTextureLoad()
             _ = textureLoad(tm2d, vec2(0), 0);
             _ = textureLoad(tm2d, vec2(0i), 0u);
             _ = textureLoad(tm2d, vec2(0u), 0i);
+            _ = textureLoad(tm2d, vec2(0u), x);
         }
         {
             _ = textureLoad(tm2di, vec2(0), 0);
             _ = textureLoad(tm2di, vec2(0i), 0u);
             _ = textureLoad(tm2di, vec2(0u), 0i);
+            _ = textureLoad(tm2di, vec2(0u), x);
         }
         {
             _ = textureLoad(tm2du, vec2(0), 0);
             _ = textureLoad(tm2du, vec2(0i), 0u);
             _ = textureLoad(tm2du, vec2(0u), 0i);
+            _ = textureLoad(tm2du, vec2(0u), x);
         }
     }
 
@@ -2446,6 +2459,7 @@ fn testTextureLoad()
         _ = textureLoad(td2d, vec2(0), 0);
         _ = textureLoad(td2d, vec2(0i), 0i);
         _ = textureLoad(td2d, vec2(0u), 0u);
+        _ = textureLoad(td2d, vec2(0u), x);
     }
 
     // [T < ConcreteInteger, S < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d_array, Vector[T, 2], S, U) => F32,
@@ -2453,6 +2467,7 @@ fn testTextureLoad()
         _ = textureLoad(td2da, vec2(0), 0, 0);
         _ = textureLoad(td2da, vec2(0i), 0i, 0i);
         _ = textureLoad(td2da, vec2(0u), 0u, 0u);
+        _ = textureLoad(td2da, vec2(0u), x, x);
     }
 
     // [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_multisampled_2d, Vector[T, 2], U) => F32,
@@ -2460,6 +2475,7 @@ fn testTextureLoad()
         _ = textureLoad(tdms2d, vec2(0), 0);
         _ = textureLoad(tdms2d, vec2(0i), 0i);
         _ = textureLoad(tdms2d, vec2(0u), 0u);
+        _ = textureLoad(tdms2d, vec2(0u), x);
     }
 }
 


### PR DESCRIPTION
#### f6aecdc2aadb2854a3e2e6b5bc74246589ff1f0e
<pre>
[WGSL] texture1d.read(coord, level): level must be zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=263481">https://bugs.webkit.org/show_bug.cgi?id=263481</a>
rdar://117283953

Reviewed by Mike Wyrzykowski.

The MSL spec requires that the level argument be a compile time constant, and that
the value must be zero. Since that is the default value, we just skip serializing
the argument instead.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitTextureLoad):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/269931@main">https://commits.webkit.org/269931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fba6454dd1b781ebe190942b9fd0d5a6c90caf41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21963 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22486 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26557 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1247 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27753 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18888 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1200 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5759 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->