### PR TITLE
Unreviewed, fix iOS engineering builds after 269802@main

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
@@ -96,9 +96,16 @@ WK_WEBCORE_LDFLAGS_iphonesimulator = -framework WebCore
 WK_WEBCORE_LDFLAGS_watchos = -framework WebCore
 WK_WEBCORE_LDFLAGS_watchsimulator = -framework WebCore
 
+WK_IMAGEIO_LDFLAGS = $(WK_IMAGEIO_LDFLAGS_$(WK_PLATFORM_NAME))
+WK_IMAGEIO_LDFLAGS_iphoneos = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_iphonesimulator = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_maccatalyst = -framework ImageIO
+WK_IMAGEIO_LDFLAGS_macosx = $(WK_IMAGEIO_LDFLAGS$(WK_MACOS_1300));
+WK_IMAGEIO_LDFLAGS_MACOS_SINCE_1300 = -framework ImageIO;
+
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
 
-OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices $(WK_HID_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
 OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
 
 // FIXME: This should not be built on iOS. Instead we should create and use a TestWebKitAPI application.


### PR DESCRIPTION
#### bc8b248df94aae5c73029e5ad03fff6ee99a1431
<pre>
Unreviewed, fix iOS engineering builds after 269802@main

Fix the following build error:

```
TestWebKitAPI Ld TestWebKitAPI
Undefined symbols for architecture arm64e:
  &quot;_CGImageDestinationAddImage&quot;, referenced from:
      WebKit::transcode(CGImage*, __CFString const*) in libWebKitPlatform.a(PlatformUnifiedSource1-mm.o)
  &quot;_CGImageDestinationCreateWithData&quot;, referenced from:
      WebKit::transcode(CGImage*, __CFString const*) in libWebKitPlatform.a(PlatformUnifiedSource1-mm.o)
  &quot;_CGImageDestinationFinalize&quot;, referenced from:
      WebKit::transcode(CGImage*, __CFString const*) in libWebKitPlatform.a(PlatformUnifiedSource1-mm.o)
  &quot;_CGImageSourceCreateImageAtIndex&quot;, referenced from:
      WebKit::requestBackgroundRemoval(CGImage*, WTF::CompletionHandler&lt;void (CGImage*)&gt;&amp;&amp;) in libWebKitPlatform.a(PlatformUnifiedSource1-mm.o)
  &quot;_CGImageSourceCreateWithData&quot;, referenced from:
      WebKit::requestBackgroundRemoval(CGImage*, WTF::CompletionHandler&lt;void (CGImage*)&gt;&amp;&amp;) in libWebKitPlatform.a(PlatformUnifiedSource1-mm.o)
ld: symbol(s) not found for architecture arm64e
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

...by linking against ImageIO in configurations where `ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)` is set.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig:

Canonical link: <a href="https://commits.webkit.org/269862@main">https://commits.webkit.org/269862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a8245cbd980207e2093897218f0e8b203efd500

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24331 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26572 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21515 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21795 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25550 "Found 3 new API test failures: /TestWTF:WTF_ParkingLot.UnparkOneOneFast, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18899 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1214 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->