### PR TITLE
[WebGPU] GPUDevice::createComputePipeline does not handle missing optional layout field

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl
@@ -29,5 +29,5 @@
     EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
-    (GPUPipelineLayout or GPUAutoLayoutMode) layout;
+    required (GPUPipelineLayout or GPUAutoLayoutMode) layout;
 };


### PR DESCRIPTION
#### 693c11af53e288069cc59ebc10eaf12d6ea3d03e
<pre>
[WebGPU] GPUDevice::createComputePipeline does not handle missing optional layout field
<a href="https://bugs.webkit.org/show_bug.cgi?id=263784">https://bugs.webkit.org/show_bug.cgi?id=263784</a>
&lt;radar://117589263&gt;

Reviewed by Tadeu Zagallo.

The field is required according to the specification.

* Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl:

Canonical link: <a href="https://commits.webkit.org/269953@main">https://commits.webkit.org/269953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddb923fdba072de2317ad0ae9946277f34702fcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21983 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22502 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26582 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27771 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1223 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5772 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->