### PR TITLE
Adopt more smart pointers in DOM code

### DIFF
--- a/Source/WebCore/dom/ChildNodeList.h
+++ b/Source/WebCore/dom/ChildNodeList.h
@@ -25,6 +25,7 @@
 
 #include "CollectionIndexCache.h"
 #include "NodeList.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/Ref.h>
 
@@ -32,7 +33,7 @@ namespace WebCore {
 
 class ContainerNode;
 
-class EmptyNodeList final : public NodeList {
+class EmptyNodeList final : public NodeList, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(EmptyNodeList);
 public:
     static Ref<EmptyNodeList> create(Node& owner)
@@ -55,7 +56,7 @@ private:
     Ref<Node> m_owner;
 };
 
-class ChildNodeList final : public NodeList {
+class ChildNodeList final : public NodeList, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(ChildNodeList);
 public:
     static Ref<ChildNodeList> create(ContainerNode& parent)

--- a/Source/WebCore/dom/LiveNodeList.h
+++ b/Source/WebCore/dom/LiveNodeList.h
@@ -47,6 +47,7 @@ public:
 
     NodeListInvalidationType invalidationType() const { return m_invalidationType; }
     ContainerNode& ownerNode() const { return m_ownerNode; }
+    Ref<ContainerNode> protectedOwnerNode() const { return m_ownerNode; }
     void invalidateCacheForAttribute(const QualifiedName& attributeName) const;
     virtual void invalidateCacheForDocument(Document&) const = 0;
     void invalidateCache() const { invalidateCacheForDocument(document()); }

--- a/Source/WebCore/dom/NameNodeList.cpp
+++ b/Source/WebCore/dom/NameNodeList.cpp
@@ -47,7 +47,7 @@ Ref<NameNodeList> NameNodeList::create(ContainerNode& rootNode, const AtomString
 
 NameNodeList::~NameNodeList()
 {
-    ownerNode().nodeLists()->removeCacheWithAtomName(*this, m_name);
+    protectedOwnerNode()->nodeLists()->removeCacheWithAtomName(*this, m_name);
 }
 
 bool NameNodeList::elementMatches(Element& element) const

--- a/Source/WebCore/dom/NativeNodeFilter.cpp
+++ b/Source/WebCore/dom/NativeNodeFilter.cpp
@@ -41,7 +41,7 @@ bool NativeNodeFilter::hasCallback() const
 
 CallbackResult<unsigned short> NativeNodeFilter::acceptNode(Node& node)
 {
-    return m_condition->acceptNode(node);
+    return Ref { m_condition }->acceptNode(node);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -60,7 +60,7 @@ public:
         ASSERT(!m_emptyChildNodeList);
         if (m_childNodeList)
             return *m_childNodeList;
-        auto list = ChildNodeList::create(node);
+        Ref list = ChildNodeList::create(node);
         m_childNodeList = list.ptr();
         return list;
     }
@@ -78,7 +78,7 @@ public:
         ASSERT(!m_childNodeList);
         if (m_emptyChildNodeList)
             return *m_emptyChildNodeList;
-        auto list = EmptyNodeList::create(node);
+        Ref list = EmptyNodeList::create(node);
         m_emptyChildNodeList = list.ptr();
         return list;
     }
@@ -111,8 +111,8 @@ public:
         if (!result.isNewEntry)
             return static_cast<T&>(*result.iterator->value);
 
-        auto list = T::create(container, name);
-        result.iterator->value = &list.get();
+        Ref list = T::create(container, name);
+        result.iterator->value = list.ptr();
         return list;
     }
 
@@ -122,7 +122,7 @@ public:
         if (!result.isNewEntry)
             return *result.iterator->value;
 
-        auto list = TagCollectionNS::create(node, namespaceURI, localName);
+        Ref list = TagCollectionNS::create(node, namespaceURI, localName);
         result.iterator->value = list.ptr();
         return list;
     }
@@ -134,8 +134,8 @@ public:
         if (!result.isNewEntry)
             return static_cast<T&>(*result.iterator->value);
 
-        auto list = T::create(container, collectionType, name);
-        result.iterator->value = &list.get();
+        Ref list = T::create(container, collectionType, name);
+        result.iterator->value = list.ptr();
         return list;
     }
 
@@ -146,8 +146,8 @@ public:
         if (!result.isNewEntry)
             return static_cast<T&>(*result.iterator->value);
 
-        auto list = T::create(container, collectionType);
-        result.iterator->value = &list.get();
+        Ref list = T::create(container, collectionType);
+        result.iterator->value = list.ptr();
         return list;
     }
 
@@ -161,7 +161,7 @@ public:
     void removeCacheWithAtomName(NodeListType& list, const AtomString& name)
     {
         ASSERT(&list == m_atomNameCaches.get(namedNodeListKey<NodeListType>(name)));
-        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(list.ownerNode()))
+        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(list.protectedOwnerNode()))
             return;
         m_atomNameCaches.remove(namedNodeListKey<NodeListType>(name));
     }
@@ -170,7 +170,7 @@ public:
     {
         QualifiedName name(nullAtom(), localName, namespaceURI);
         ASSERT(&collection == m_tagCollectionNSCache.get(name));
-        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection.ownerNode()))
+        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection.protectedOwnerNode()))
             return;
         m_tagCollectionNSCache.remove(name);
     }
@@ -202,8 +202,8 @@ private:
     bool deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(Node&);
 
     // These two are currently mutually exclusive and could be unioned. Not very important as this class is large anyway.
-    ChildNodeList* m_childNodeList { nullptr };
-    EmptyNodeList* m_emptyChildNodeList { nullptr };
+    CheckedPtr<ChildNodeList> m_childNodeList;
+    CheckedPtr<EmptyNodeList> m_emptyChildNodeList;
 
     NodeListCacheMap m_atomNameCaches;
     TagCollectionNSCache m_tagCollectionNSCache;

--- a/Source/WebCore/dom/PendingScript.cpp
+++ b/Source/WebCore/dom/PendingScript.cpp
@@ -59,8 +59,8 @@ PendingScript::PendingScript(ScriptElement& element, LoadableScript& loadableScr
 
 PendingScript::~PendingScript()
 {
-    if (m_loadableScript)
-        m_loadableScript->removeClient(*this);
+    if (RefPtr loadableScript = m_loadableScript)
+        loadableScript->removeClient(*this);
 }
 
 void PendingScript::notifyClientFinished()

--- a/Source/WebCore/dom/PendingScript.h
+++ b/Source/WebCore/dom/PendingScript.h
@@ -76,7 +76,7 @@ private:
     Ref<ScriptElement> m_element;
     TextPosition m_startingPosition; // Only used for inline script tags.
     RefPtr<LoadableScript> m_loadableScript;
-    PendingScriptClient* m_client { nullptr };
+    CheckedPtr<PendingScriptClient> m_client;
 };
 
 inline LoadableScript* PendingScript::loadableScript() const

--- a/Source/WebCore/dom/PendingScriptClient.h
+++ b/Source/WebCore/dom/PendingScriptClient.h
@@ -25,11 +25,13 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
+
 namespace WebCore {
 
 class PendingScript;
 
-class PendingScriptClient {
+class PendingScriptClient : public CanMakeCheckedPtr {
 public:
     virtual ~PendingScriptClient() = default;
 

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -85,7 +85,7 @@ static bool hasInlineRun(RenderObject& renderer)
 static Node* nextRenderedEditable(Node* node)
 {
     while ((node = nextLeafNode(node))) {
-        RenderObject* renderer = node->renderer();
+        CheckedPtr renderer = node->renderer();
         if (!renderer || !node->hasEditableStyle())
             continue;
         if (hasInlineRun(*renderer))
@@ -97,7 +97,7 @@ static Node* nextRenderedEditable(Node* node)
 static Node* previousRenderedEditable(Node* node)
 {
     while ((node = previousLeafNode(node))) {
-        RenderObject* renderer = node->renderer();
+        CheckedPtr renderer = node->renderer();
         if (!renderer || !node->hasEditableStyle())
             continue;
         if (hasInlineRun(*renderer))
@@ -240,7 +240,7 @@ int Position::offsetForPositionAfterAnchor() const
 {
     ASSERT(m_anchorType == PositionIsAfterAnchor || m_anchorType == PositionIsAfterChildren);
     ASSERT(!m_isLegacyEditingPosition);
-    auto anchorNode = protectedAnchorNode();
+    RefPtr anchorNode = this->anchorNode();
     ASSERT(anchorNode);
     return anchorNode ? lastOffsetForEditing(*anchorNode) : 0;
 }
@@ -249,7 +249,7 @@ int Position::offsetForPositionAfterAnchor() const
 // fixed up before handing them off to the Range object.
 Position Position::parentAnchoredEquivalent() const
 {
-    auto anchorNode = protectedAnchorNode();
+    RefPtr anchorNode = this->anchorNode();
     if (!anchorNode)
         return { };
     

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -38,7 +38,7 @@ class Document;
 class ScriptElement;
 class LoadableScript;
 
-class ScriptRunner : private PendingScriptClient, public CanMakeCheckedPtr {
+class ScriptRunner : public PendingScriptClient {
     WTF_MAKE_NONCOPYABLE(ScriptRunner); WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ScriptRunner(Document&);

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -152,8 +152,8 @@ inline Element* SelectorDataList::selectorClosest(const SelectorData& selectorDa
 
 bool SelectorDataList::matches(Element& targetElement) const
 {
-    for (auto& selctor : m_selectors) {
-        if (selectorMatches(selctor, targetElement, targetElement))
+    for (auto& selector : m_selectors) {
+        if (selectorMatches(selector, targetElement, targetElement))
             return true;
     }
     return false;

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -94,8 +94,8 @@ ShadowRoot::~ShadowRoot()
     if (isConnected())
         document().didRemoveInDocumentShadowRoot(*this);
 
-    if (m_styleSheetList)
-        m_styleSheetList->detach();
+    if (RefPtr styleSheetList = m_styleSheetList)
+        styleSheetList->detach();
 
     // We cannot let ContainerNode destructor call willBeDeletedFrom()
     // for this ShadowRoot instance because TreeScope destructor
@@ -118,8 +118,13 @@ Node::InsertedIntoAncestorResult ShadowRoot::insertedIntoAncestor(InsertionType 
     if (insertionType.connectedToDocument)
         protectedDocument()->didInsertInDocumentShadowRoot(*this);
     if (!adoptedStyleSheets().empty() && document().frame())
-        styleScope().didChangeActiveStyleSheetCandidates();
+        checkedStyleScope()->didChangeActiveStyleSheetCandidates();
     return InsertedIntoAncestorResult::Done;
+}
+
+CheckedRef<Style::Scope> ShadowRoot::checkedStyleScope() const
+{
+    return *m_styleScope;
 }
 
 void ShadowRoot::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -79,6 +79,7 @@ public:
     using TreeScope::rootNode;
 
     Style::Scope& styleScope() { return *m_styleScope; }
+    CheckedRef<Style::Scope> checkedStyleScope() const;
     StyleSheetList& styleSheets();
 
     bool delegatesFocus() const { return m_delegatesFocus; }


### PR DESCRIPTION
#### 02f9dd1869da489a1d8ccc25e7e9b8a86aadef58
<pre>
Adopt more smart pointers in DOM code
<a href="https://bugs.webkit.org/show_bug.cgi?id=263787">https://bugs.webkit.org/show_bug.cgi?id=263787</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/ChildNodeList.h:
* Source/WebCore/dom/LiveNodeList.h:
(WebCore::LiveNodeList::protectedOwnerNode const):
* Source/WebCore/dom/NameNodeList.cpp:
(WebCore::NameNodeList::~NameNodeList):
* Source/WebCore/dom/NativeNodeFilter.cpp:
(WebCore::NativeNodeFilter::acceptNode):
* Source/WebCore/dom/NodeIterator.cpp:
(WebCore::NodeIterator::NodePointer::moveToNext):
(WebCore::NodeIterator::NodePointer::moveToPrevious):
(WebCore::NodeIterator::NodeIterator):
(WebCore::NodeIterator::nextNode):
(WebCore::NodeIterator::previousNode):
(WebCore::NodeIterator::updateForNodeRemoval const):
* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeListsNodeData::ensureChildNodeList):
(WebCore::NodeListsNodeData::ensureEmptyChildNodeList):
(WebCore::NodeListsNodeData::addCacheWithAtomName):
(WebCore::NodeListsNodeData::addCachedTagCollectionNS):
(WebCore::NodeListsNodeData::addCachedCollection):
(WebCore::NodeListsNodeData::removeCacheWithAtomName):
(WebCore::NodeListsNodeData::removeCachedTagCollectionNS):
* Source/WebCore/dom/PendingScript.cpp:
(WebCore::PendingScript::~PendingScript):
* Source/WebCore/dom/PendingScript.h:
* Source/WebCore/dom/PendingScriptClient.h:
* Source/WebCore/dom/Position.cpp:
(WebCore::nextRenderedEditable):
(WebCore::previousRenderedEditable):
(WebCore::Position::offsetForPositionAfterAnchor const):
(WebCore::Position::parentAnchoredEquivalent const):
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::matches const):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::~ShadowRoot):
(WebCore::ShadowRoot::insertedIntoAncestor):
(WebCore::ShadowRoot::checkedStyleScope const):
* Source/WebCore/dom/ShadowRoot.h:

Canonical link: <a href="https://commits.webkit.org/269876@main">https://commits.webkit.org/269876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b861e06bd983c93d637b7ef961ac436b4f6ee47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26066 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3647 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/24413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24168 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/1576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26655 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/21586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/24413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1287 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5719 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->