### PR TITLE
Add explicit to some single argument constructors

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -118,7 +118,7 @@ public:
 #endif
 
 private:
-    constexpr static auto CreateHTMLModelElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLModelElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLModelElement(const QualifiedName&, Document&);
 
     URL selectModelSource() const;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -652,20 +652,20 @@ protected:
     void setIsParsingChildrenFinished() { setNodeFlag(NodeFlag::IsParsingChildrenFinished); }
     void clearIsParsingChildrenFinished() { clearNodeFlag(NodeFlag::IsParsingChildrenFinished); }
 
-    constexpr static auto DefaultNodeFlags = OptionSet<NodeFlag>(NodeFlag::IsParsingChildrenFinished);
-    constexpr static auto CreateOther = DefaultNodeFlags;
-    constexpr static auto CreateCharacterData = DefaultNodeFlags | NodeFlag::IsCharacterData;
-    constexpr static auto CreateText = CreateCharacterData | NodeFlag::IsText;
-    constexpr static auto CreateContainer = DefaultNodeFlags | NodeFlag::IsContainerNode;
-    constexpr static auto CreateElement = CreateContainer | NodeFlag::IsElement;
-    constexpr static auto CreatePseudoElement = CreateElement | NodeFlag::IsConnected | NodeFlag::HasCustomStyleResolveCallbacks;
-    constexpr static auto CreateDocumentFragment = CreateContainer | NodeFlag::IsDocumentFragment;
-    constexpr static auto CreateShadowRoot = CreateDocumentFragment | NodeFlag::IsShadowRoot | NodeFlag::IsInShadowTree;
-    constexpr static auto CreateHTMLElement = CreateElement | NodeFlag::IsHTMLElement;
-    constexpr static auto CreateSVGElement = CreateElement | NodeFlag::IsSVGElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    constexpr static auto CreateMathMLElement = CreateElement | NodeFlag::IsMathMLElement;
-    constexpr static auto CreateDocument = CreateContainer | NodeFlag::IsDocumentNode | NodeFlag::IsConnected;
-    constexpr static auto CreateEditingText = CreateText | NodeFlag::IsEditingText;
+    static constexpr auto DefaultNodeFlags = OptionSet<NodeFlag>(NodeFlag::IsParsingChildrenFinished);
+    static constexpr auto CreateOther = DefaultNodeFlags;
+    static constexpr auto CreateCharacterData = DefaultNodeFlags | NodeFlag::IsCharacterData;
+    static constexpr auto CreateText = CreateCharacterData | NodeFlag::IsText;
+    static constexpr auto CreateContainer = DefaultNodeFlags | NodeFlag::IsContainerNode;
+    static constexpr auto CreateElement = CreateContainer | NodeFlag::IsElement;
+    static constexpr auto CreatePseudoElement = CreateElement | NodeFlag::IsConnected | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateDocumentFragment = CreateContainer | NodeFlag::IsDocumentFragment;
+    static constexpr auto CreateShadowRoot = CreateDocumentFragment | NodeFlag::IsShadowRoot | NodeFlag::IsInShadowTree;
+    static constexpr auto CreateHTMLElement = CreateElement | NodeFlag::IsHTMLElement;
+    static constexpr auto CreateSVGElement = CreateElement | NodeFlag::IsSVGElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateMathMLElement = CreateElement | NodeFlag::IsMathMLElement;
+    static constexpr auto CreateDocument = CreateContainer | NodeFlag::IsDocumentNode | NodeFlag::IsConnected;
+    static constexpr auto CreateEditingText = CreateText | NodeFlag::IsEditingText;
     using ConstructionType = OptionSet<NodeFlag>;
     Node(Document&, ConstructionType);
 

--- a/Source/WebCore/html/HTMLDivElement.h
+++ b/Source/WebCore/html/HTMLDivElement.h
@@ -33,7 +33,7 @@ public:
     static Ref<HTMLDivElement> create(const QualifiedName&, Document&);
 
 protected:
-    constexpr static auto CreateHTMLDivElement = CreateHTMLElement;
+    static constexpr auto CreateHTMLDivElement = CreateHTMLElement;
     HTMLDivElement(const QualifiedName&, Document&, ConstructionType = CreateHTMLDivElement);
 
 private:

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -106,7 +106,7 @@ public:
     using Node::deref;
 
 protected:
-    constexpr static auto CreateHTMLFormControlElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLFormControlElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLFormControlElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -40,7 +40,7 @@ public:
     ScrollbarMode scrollingMode() const final;
 
 protected:
-    constexpr static auto CreateHTMLFrameElementBase = CreateHTMLFrameOwnerElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLFrameElementBase = CreateHTMLFrameOwnerElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLFrameElementBase(const QualifiedName&, Document&);
 
     bool canLoad() const;

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -67,7 +67,7 @@ public:
     virtual bool isLazyLoadObserverActive() const { return false; }
 
 protected:
-    constexpr static auto CreateHTMLFrameOwnerElement = CreateHTMLElement;
+    static constexpr auto CreateHTMLFrameOwnerElement = CreateHTMLElement;
     HTMLFrameOwnerElement(const QualifiedName& tagName, Document&, ConstructionType = CreateHTMLFrameOwnerElement);
     void setSandboxFlags(SandboxFlags);
     bool isProhibitedSelfReference(const URL&) const;

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -54,7 +54,7 @@ public:
     bool isSupportedPropertyName(const AtomString&);
 
 private:
-    constexpr static auto CreateHTMLFrameSetElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLFrameSetElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLFrameSetElement(const QualifiedName&, Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -178,7 +178,7 @@ public:
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&);
 
 protected:
-    constexpr static auto CreateHTMLImageElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLImageElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLImageElement(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;

--- a/Source/WebCore/html/HTMLLIElement.h
+++ b/Source/WebCore/html/HTMLLIElement.h
@@ -33,7 +33,7 @@ public:
     static Ref<HTMLLIElement> create(const QualifiedName&, Document&);
 
 private:
-    constexpr static auto CreateHTMLLIElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLLIElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLLIElement(const QualifiedName&, Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -648,7 +648,7 @@ public:
     void updateMediaState();
 
 protected:
-    constexpr static auto CreateHTMLMediaElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLMediaElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();
 

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -68,7 +68,7 @@ public:
     bool selectedWithoutUpdate() const { return m_isSelected; }
 
 private:
-    constexpr static auto CreateHTMLOptionElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLOptionElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLOptionElement(const QualifiedName&, Document&);
 
     bool isFocusable() const final;

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -75,7 +75,7 @@ public:
     WEBCORE_EXPORT bool isReplacementObscured();
 
 protected:
-    constexpr static auto CreateHTMLPlugInElement = CreateHTMLFrameOwnerElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLPlugInElement = CreateHTMLFrameOwnerElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLPlugInElement(const QualifiedName& tagName, Document&);
 
     bool canContainRangeEndPoint() const override { return false; }

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -44,7 +44,7 @@ public:
     double position() const;
 
 private:
-    constexpr static auto CreateHTMLProgressElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLProgressElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLProgressElement(const QualifiedName&, Document&);
     virtual ~HTMLProgressElement();
 

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -74,7 +74,7 @@ public:
     virtual String placeholderValue() const = 0;
 
 protected:
-    constexpr static auto CreateDateTimeFieldElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateDateTimeFieldElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
     DateTimeFieldElement(Document&, FieldOwner&);
     void initialize(const AtomString& pseudo);
     Locale& localeForOwner() const;

--- a/Source/WebCore/html/shadow/DetailsMarkerControl.h
+++ b/Source/WebCore/html/shadow/DetailsMarkerControl.h
@@ -41,7 +41,7 @@ public:
     static Ref<DetailsMarkerControl> create(Document&);
 
 private:
-    DetailsMarkerControl(Document&);
+    explicit DetailsMarkerControl(Document&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool rendererIsNeeded(const RenderStyle&) override;

--- a/Source/WebCore/html/shadow/ProgressShadowElement.h
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.h
@@ -44,7 +44,7 @@ public:
     HTMLProgressElement* progressElement() const;
 
 protected:
-    ProgressShadowElement(Document&);
+    explicit ProgressShadowElement(Document&);
 
 private:
     bool rendererIsNeeded(const RenderStyle&) override;

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -57,8 +57,8 @@ public:
     void hostDisabledStateChanged();
 
 private:
-    constexpr static auto CreateSliderThumbElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    SliderThumbElement(Document&);
+    static constexpr auto CreateSliderThumbElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit SliderThumbElement(Document&);
     bool isSliderThumbElement() const final { return true; }
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) final;
@@ -113,8 +113,8 @@ public:
     static Ref<SliderContainerElement> create(Document&);
 
 private:
-    constexpr static auto CreateSliderContainerElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    SliderContainerElement(Document&);
+    static constexpr auto CreateSliderContainerElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit SliderContainerElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool isSliderContainerElement() const final { return true; }
 };

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -68,7 +68,7 @@ public:
     void forwardEvent(Event&);
 
 private:
-    constexpr static auto CreateSpinButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSpinButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
     SpinButtonElement(Document&, SpinButtonOwner&);
 
     void willDetachRenderers() override;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.h
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.h
@@ -38,8 +38,8 @@ class TextControlInnerContainer final : public HTMLDivElement {
 public:
     static Ref<TextControlInnerContainer> create(Document&);
 private:
-    constexpr static auto CreateTextControlInnerContainer = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    TextControlInnerContainer(Document&);
+    static constexpr auto CreateTextControlInnerContainer = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit TextControlInnerContainer(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
 };
@@ -50,8 +50,8 @@ public:
     static Ref<TextControlInnerElement> create(Document&);
 
 private:
-    constexpr static auto CreateTextControlInnerElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    TextControlInnerElement(Document&);
+    static constexpr auto CreateTextControlInnerElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit TextControlInnerElement(Document&);
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
 
     bool isMouseFocusable() const override { return false; }
@@ -75,8 +75,8 @@ public:
 private:
     void updateInnerTextElementEditabilityImpl(bool isEditable, bool initialization);
 
-    constexpr static auto CreateTextControlInnerTextElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    TextControlInnerTextElement(Document&);
+    static constexpr auto CreateTextControlInnerTextElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit TextControlInnerTextElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
     bool isMouseFocusable() const override { return false; }
@@ -89,8 +89,8 @@ public:
     static Ref<TextControlPlaceholderElement> create(Document&);
 
 private:
-    constexpr static auto CreateTextControlPlaceholderElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    TextControlPlaceholderElement(Document&);
+    static constexpr auto CreateTextControlPlaceholderElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit TextControlPlaceholderElement(Document&);
     
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
 };
@@ -108,8 +108,8 @@ public:
     bool canAdjustStyleForAppearance() const { return m_canAdjustStyleForAppearance; }
 
 private:
-    constexpr static auto CreateSearchFieldResultsButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    SearchFieldResultsButtonElement(Document&);
+    static constexpr auto CreateSearchFieldResultsButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit SearchFieldResultsButtonElement(Document&);
     bool isMouseFocusable() const override { return false; }
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
     bool isSearchFieldResultsButtonElement() const override { return true; }
@@ -128,8 +128,8 @@ public:
 #endif
 
 private:
-    constexpr static auto CreateSearchFieldCancelButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    SearchFieldCancelButtonElement(Document&);
+    static constexpr auto CreateSearchFieldCancelButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit SearchFieldCancelButtonElement(Document&);
     bool isMouseFocusable() const override { return false; }
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
 };

--- a/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.h
+++ b/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.h
@@ -38,7 +38,7 @@ public:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 
 private:
-    YouTubeEmbedShadowElement(Document&);
+    explicit YouTubeEmbedShadowElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -56,7 +56,7 @@ public:
 protected:
     void initialize();
 
-    constexpr static auto CreateTextTrackCueBox = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateTextTrackCueBox = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     TextTrackCueBox(Document&, TextTrackCue&);
     ~TextTrackCueBox() { }
 

--- a/Source/WebCore/mathml/MathMLMathElement.h
+++ b/Source/WebCore/mathml/MathMLMathElement.h
@@ -39,7 +39,7 @@ public:
     static Ref<MathMLMathElement> create(const QualifiedName& tagName, Document&);
 
 private:
-    constexpr static auto CreateMathMLMathElement = CreateMathMLRowElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateMathMLMathElement = CreateMathMLRowElement | NodeFlag::HasCustomStyleResolveCallbacks;
     MathMLMathElement(const QualifiedName& tagName, Document&);
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void didAttachRenderers() final;

--- a/Source/WebCore/mathml/MathMLPresentationElement.h
+++ b/Source/WebCore/mathml/MathMLPresentationElement.h
@@ -39,7 +39,7 @@ public:
     static Ref<MathMLPresentationElement> create(const QualifiedName& tagName, Document&);
 
 protected:
-    constexpr static auto CreateMathMLPresentationElement = CreateMathMLElement;
+    static constexpr auto CreateMathMLPresentationElement = CreateMathMLElement;
     MathMLPresentationElement(const QualifiedName& tagName, Document&, ConstructionType = CreateMathMLPresentationElement);
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
 

--- a/Source/WebCore/mathml/MathMLRowElement.h
+++ b/Source/WebCore/mathml/MathMLRowElement.h
@@ -37,7 +37,7 @@ public:
     static Ref<MathMLRowElement> create(const QualifiedName& tagName, Document&);
 
 protected:
-    constexpr static auto CreateMathMLRowElement = CreateMathMLPresentationElement;
+    static constexpr auto CreateMathMLRowElement = CreateMathMLPresentationElement;
     MathMLRowElement(const QualifiedName& tagName, Document&, ConstructionType = CreateMathMLRowElement);
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/mathml/MathMLTokenElement.h
+++ b/Source/WebCore/mathml/MathMLTokenElement.h
@@ -41,7 +41,7 @@ public:
     static std::optional<UChar32> convertToSingleCodePoint(StringView);
 
 protected:
-    constexpr static auto CreateMathMLTokenElement = CreateMathMLPresentationElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateMathMLTokenElement = CreateMathMLPresentationElement | NodeFlag::HasCustomStyleResolveCallbacks;
     MathMLTokenElement(const QualifiedName& tagName, Document&);
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/svg/SVGPathSegImpl.h
+++ b/Source/WebCore/svg/SVGPathSegImpl.h
@@ -42,7 +42,7 @@ private:
 
 class SVGPathSegLinetoHorizontalAbs final : public SVGPathSegLinetoHorizontal {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegLinetoHorizontalAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoHorizontalAbs>;
 private:
     using SVGPathSegLinetoHorizontal::SVGPathSegLinetoHorizontal;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToHorizontalAbs; }
@@ -52,7 +52,7 @@ private:
 
 class SVGPathSegLinetoHorizontalRel final : public SVGPathSegLinetoHorizontal {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegLinetoHorizontalRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoHorizontalRel>;
 private:
     using SVGPathSegLinetoHorizontal::SVGPathSegLinetoHorizontal;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToHorizontalRel; }
@@ -62,7 +62,7 @@ private:
 
 class SVGPathSegLinetoVerticalAbs final : public SVGPathSegLinetoVertical {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegLinetoVerticalAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoVerticalAbs>;
 private:
     using SVGPathSegLinetoVertical::SVGPathSegLinetoVertical;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToVerticalAbs; }
@@ -72,7 +72,7 @@ private:
 
 class SVGPathSegLinetoVerticalRel final : public SVGPathSegLinetoVertical {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegLinetoVerticalRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoVerticalRel>;
 private:
     using SVGPathSegLinetoVertical::SVGPathSegLinetoVertical;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToVerticalRel; }
@@ -82,7 +82,7 @@ private:
 
 class SVGPathSegMovetoAbs final : public SVGPathSegSingleCoordinate {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegMovetoAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegMovetoAbs>;
 private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::MoveToAbs; }
@@ -92,7 +92,7 @@ private:
 
 class SVGPathSegMovetoRel final : public SVGPathSegSingleCoordinate {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegMovetoRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegMovetoRel>;
 private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::MoveToRel; }
@@ -102,7 +102,7 @@ private:
 
 class SVGPathSegLinetoAbs final : public SVGPathSegSingleCoordinate {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegLinetoAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoAbs>;
 private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToAbs; }
@@ -112,7 +112,7 @@ private:
 
 class SVGPathSegLinetoRel final : public SVGPathSegSingleCoordinate {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegLinetoRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoRel>;
 private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToRel; }
@@ -122,7 +122,7 @@ private:
 
 class SVGPathSegCurvetoQuadraticAbs final : public SVGPathSegCurvetoQuadratic {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticAbs>;
 private:
     using SVGPathSegCurvetoQuadratic::SVGPathSegCurvetoQuadratic;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToQuadraticAbs; }
@@ -132,7 +132,7 @@ private:
 
 class SVGPathSegCurvetoQuadraticRel final : public SVGPathSegCurvetoQuadratic {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticRel>;
 private:
     using SVGPathSegCurvetoQuadratic::SVGPathSegCurvetoQuadratic;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToQuadraticRel; }
@@ -142,7 +142,7 @@ private:
 
 class SVGPathSegCurvetoCubicAbs final : public SVGPathSegCurvetoCubic {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicAbs>;
 private:
     using SVGPathSegCurvetoCubic::SVGPathSegCurvetoCubic;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToCubicAbs; }
@@ -152,7 +152,7 @@ private:
 
 class SVGPathSegCurvetoCubicRel final : public SVGPathSegCurvetoCubic {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicRel>;
 private:
     using SVGPathSegCurvetoCubic::SVGPathSegCurvetoCubic;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToCubicRel; }
@@ -162,7 +162,7 @@ private:
 
 class SVGPathSegArcAbs final : public SVGPathSegArc {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegArcAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegArcAbs>;
 private:
     using SVGPathSegArc::SVGPathSegArc;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::ArcAbs; }
@@ -172,7 +172,7 @@ private:
 
 class SVGPathSegArcRel final : public SVGPathSegArc {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegArcRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegArcRel>;
 private:
     using SVGPathSegArc::SVGPathSegArc;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::ArcRel; }
@@ -182,7 +182,7 @@ private:
 
 class SVGPathSegCurvetoQuadraticSmoothAbs final : public SVGPathSegSingleCoordinate {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticSmoothAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticSmoothAbs>;
 private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToQuadraticSmoothAbs; }
@@ -192,7 +192,7 @@ private:
 
 class SVGPathSegCurvetoQuadraticSmoothRel final : public SVGPathSegSingleCoordinate {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticSmoothRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticSmoothRel>;
 private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToQuadraticSmoothRel; }
@@ -202,7 +202,7 @@ private:
 
 class SVGPathSegCurvetoCubicSmoothAbs final : public SVGPathSegCurvetoCubicSmooth {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicSmoothAbs>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicSmoothAbs>;
 private:
     using SVGPathSegCurvetoCubicSmooth::SVGPathSegCurvetoCubicSmooth;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToCubicSmoothAbs; }
@@ -212,7 +212,7 @@ private:
 
 class SVGPathSegCurvetoCubicSmoothRel final : public SVGPathSegCurvetoCubicSmooth {
 public:
-    constexpr static auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicSmoothRel>;
+    static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoCubicSmoothRel>;
 private:
     using SVGPathSegCurvetoCubicSmooth::SVGPathSegCurvetoCubicSmooth;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToCubicSmoothRel; }


### PR DESCRIPTION
#### f3216a0c25f50722c44729b09c56c5791cd9b990
<pre>
Add explicit to some single argument constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=263793">https://bugs.webkit.org/show_bug.cgi?id=263793</a>
rdar://117597310

Reviewed by Chris Dumez.

During development of
<a href="https://bugs.webkit.org/show_bug.cgi?id=263435">https://bugs.webkit.org/show_bug.cgi?id=263435</a> I copied some incorrect
prior art:

1. Single argument constructors should use explicit.
2. &quot;static constexpr&quot; should be in that order.

This change addresses 2 with the exception of third party code. It only
addresses 1 for code in Source/WebCore/html/shadow.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLDivElement.h:
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFrameElementBase.h:
* Source/WebCore/html/HTMLFrameOwnerElement.h:
* Source/WebCore/html/HTMLFrameSetElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLLIElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLPlugInElement.h:
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/shadow/DateTimeFieldElement.h:
* Source/WebCore/html/shadow/DetailsMarkerControl.h:
* Source/WebCore/html/shadow/ProgressShadowElement.h:
* Source/WebCore/html/shadow/SliderThumbElement.h:
* Source/WebCore/html/shadow/SpinButtonElement.h:
* Source/WebCore/html/shadow/TextControlInnerElements.h:
* Source/WebCore/html/shadow/YouTubeEmbedShadowElement.h:
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/mathml/MathMLMathElement.h:
* Source/WebCore/mathml/MathMLPresentationElement.h:
* Source/WebCore/mathml/MathMLRowElement.h:
* Source/WebCore/mathml/MathMLTokenElement.h:
* Source/WebCore/svg/SVGPathSegImpl.h:

Canonical link: <a href="https://commits.webkit.org/269865@main">https://commits.webkit.org/269865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b957ad595fe3f1a8616454942c78b260bcf2554

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24368 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26609 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21544 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25575 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1246 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5704 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->