### PR TITLE
Minor refactoring of assertion code, v2

### DIFF
--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -32,6 +32,8 @@ void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
 {
     // This could use ReasonSPI.h, but currently does not as the SPI is blocked by the sandbox.
     // See https://bugs.webkit.org/show_bug.cgi?id=224499 rdar://76396241
+    if (!connection)
+        return;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     xpc_connection_kill(connection, SIGKILL);
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -320,7 +320,7 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher*, IPC::Connection
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
     m_lifetimeActivity = throttler().foregroundActivity("Lifetime Activity"_s).moveToUniquePtr();
-    m_boostedJetsamAssertion = ProcessAssertion::create(xpc_connection_get_pid(connectionIdentifier.xpcConnection.get()), "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
+    m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
 #endif
 
     RefPtr connection = IPC::Connection::createServerConnection(connectionIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -70,7 +70,7 @@ void AuxiliaryProcessProxy::platformStartConnectionTerminationWatchdog()
     // Deploy a watchdog in the UI process, since the child process may be suspended.
     // If 30s is insufficient for any outstanding activity to complete cleanly, then it will be killed.
     ASSERT(m_connection && m_connection->xpcConnection());
-    XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog(m_connection->xpcConnection(), 30_s);
+    XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog(*this, 30_s);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -36,6 +36,7 @@
 
 namespace WebKit {
 
+class AuxiliaryProcessProxy;
 class ProcessAndUIAssertion;
 
 // ConnectionTerminationWatchdog does two things:
@@ -44,13 +45,13 @@ class ProcessAndUIAssertion;
 //    to ensure it has a chance to terminate cleanly.
 class XPCConnectionTerminationWatchdog {
 public:
-    static void startConnectionTerminationWatchdog(OSObjectPtr<xpc_connection_t>, Seconds interval);
+    static void startConnectionTerminationWatchdog(AuxiliaryProcessProxy&, Seconds interval);
 
 private:
-    XPCConnectionTerminationWatchdog(OSObjectPtr<xpc_connection_t>&&, Seconds interval);
+    XPCConnectionTerminationWatchdog(AuxiliaryProcessProxy&, Seconds interval);
     void watchdogTimerFired();
 
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+    WeakPtr<AuxiliaryProcessProxy> m_process;
     RunLoop::Timer m_watchdogTimer;
     Ref<ProcessAndUIAssertion> m_assertion;
 };

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -542,12 +542,7 @@ void GPUProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
     }
     
 #if USE(RUNNINGBOARD)
-#if USE(EXTENSIONKIT_ASSERTIONS)
-    m_throttler.didConnectToProcess(extensionProcess());
-#else
-    if (xpc_connection_t connection = this->connection()->xpcConnection())
-        m_throttler.didConnectToProcess(xpc_connection_get_pid(connection));
-#endif
+    m_throttler.didConnectToProcess(*this);
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -563,12 +563,7 @@ void NetworkProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Con
     }
     
 #if USE(RUNNINGBOARD)
-#if USE(EXTENSIONKIT_ASSERTIONS)
-    m_throttler.didConnectToProcess(extensionProcess());
-#else
-    if (xpc_connection_t connection = this->connection()->xpcConnection())
-        m_throttler.didConnectToProcess(xpc_connection_get_pid(connection));
-#endif
+    m_throttler.didConnectToProcess(*this);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -116,8 +116,8 @@ void ProcessAssertion::acquireSync()
 {
 }
 
-ProcessAndUIAssertion::ProcessAndUIAssertion(ProcessID pid, const String& reason, ProcessAssertionType assertionType, const String& environmentIdentifier)
-    : ProcessAssertion(pid, reason, assertionType, environmentIdentifier)
+ProcessAndUIAssertion::ProcessAndUIAssertion(AuxiliaryProcessProxy& process, const String& reason, ProcessAssertionType assertionType)
+    : ProcessAssertion(process, reason, assertionType)
 {
 }
 

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -34,16 +34,13 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
-#if USE(EXTENSIONKIT)
-OBJC_CLASS _SEExtensionProcess;
-#endif
-
 namespace WTF {
 class TextStream;
 }
 
 namespace WebKit {
-    
+
+class AuxiliaryProcessProxy;
 class ProcessThrottler;
 class ProcessThrottlerClient;
 
@@ -132,17 +129,13 @@ public:
 
     using TimedActivity = ProcessThrottlerTimedActivity;
 
-#if USE(EXTENSIONKIT_ASSERTIONS)
-    void didConnectToProcess(RetainPtr<_SEExtensionProcess>);
-#else
-    void didConnectToProcess(ProcessID);
-#endif
+    void didConnectToProcess(AuxiliaryProcessProxy&);
     void didDisconnectFromProcess();
     bool shouldBeRunnable() const { return !m_foregroundActivities.isEmptyIgnoringNullReferences() || !m_backgroundActivities.isEmptyIgnoringNullReferences(); }
     void setAllowsActivities(bool);
     void setShouldDropNearSuspendedAssertionAfterDelay(bool);
     void setShouldTakeNearSuspendedAssertion(bool);
-    bool isSuspended() const { return m_processID && !m_assertion; }
+    bool isSuspended() const;
     ProcessThrottleState currentState() const { return m_state; }
     bool isHoldingNearSuspendedAssertion() const { return m_assertion && m_assertion->type() == ProcessAssertionType::NearSuspended; }
 
@@ -180,11 +173,7 @@ private:
 
     UniqueRef<ProcessAssertionCache> m_assertionCache;
     ProcessThrottlerClient& m_process;
-#if USE(EXTENSIONKIT_ASSERTIONS)
-    RetainPtr<_SEExtensionProcess> m_process;
-#else
-    ProcessID m_processID { 0 };
-#endif
+    WeakPtr<AuxiliaryProcessProxy> m_processProxy;
     RefPtr<ProcessAssertion> m_assertion;
     RefPtr<ProcessAssertion> m_assertionToClearAfterPrepareToDropLastAssertion;
     RunLoop::Timer m_prepareToSuspendTimeoutTimer;
@@ -200,37 +189,6 @@ private:
     bool m_shouldTakeNearSuspendedAssertion { true };
     bool m_allowsActivities { true };
 };
-
-#define PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG(msg, ...) RELEASE_LOG(ProcessSuspension, "%p - [PID=%d, throttler=%p] ProcessThrottler::Activity::" msg, this, m_throttler->m_processID, m_throttler.get(), ##__VA_ARGS__)
-
-inline ProcessThrottlerActivity::ProcessThrottlerActivity(ProcessThrottler& throttler, ASCIILiteral name, ProcessThrottlerActivityType type)
-    : m_throttler(&throttler)
-    , m_name(name)
-    , m_type(type)
-{
-    ASSERT(isMainRunLoop());
-    if (!throttler.addActivity(*this)) {
-        m_throttler = nullptr;
-        return;
-    }
-    if (!isQuietActivity()) {
-        PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG("Activity: Starting %" PUBLIC_LOG_STRING " activity / '%" PUBLIC_LOG_STRING "'",
-            type == ProcessThrottlerActivityType::Foreground ? "foreground" : "background", m_name.characters());
-    }
-}
-
-inline void ProcessThrottlerActivity::invalidate()
-{
-    ASSERT(isValid());
-    if (!isQuietActivity()) {
-        PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG("invalidate: Ending %" PUBLIC_LOG_STRING " activity / '%" PUBLIC_LOG_STRING "'",
-            m_type == ProcessThrottlerActivityType::Foreground ? "foreground" : "background", m_name.characters());
-    }
-    m_throttler->removeActivity(*this);
-    m_throttler = nullptr;
-}
-
-#undef PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG
 
 inline auto ProcessThrottler::foregroundActivity(ASCIILiteral name) -> UniqueRef<Activity>
 {

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2158,7 +2158,7 @@ void WebProcessPool::updateAudibleMediaAssertions()
     m_audibleMediaActivity = AudibleMediaActivity {
         ProcessAssertion::create(getCurrentProcessID(), "WebKit Media Playback"_s, ProcessAssertionType::MediaPlayback)
 #if ENABLE(GPU_PROCESS)
-        , gpuProcess() ? RefPtr<ProcessAssertion> { ProcessAssertion::create(gpuProcess()->processID(), "WebKit Media Playback"_s, ProcessAssertionType::MediaPlayback) } : nullptr
+        , gpuProcess() ? RefPtr<ProcessAssertion> { ProcessAssertion::create(*gpuProcess(), "WebKit Media Playback"_s, ProcessAssertionType::MediaPlayback) } : nullptr
 #endif
     };
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1275,14 +1275,7 @@ void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 #endif
 
 #if USE(RUNNINGBOARD)
-#if USE(EXTENSIONKIT_ASSERTIONS)
-    m_throttler.didConnectToProcess(extensionProcess());
-#else
-    if (connection()) {
-        if (xpc_connection_t xpcConnection = connection()->xpcConnection())
-            m_throttler.didConnectToProcess(xpc_connection_get_pid(xpcConnection));
-    }
-#endif // USE(EXTENSIONKIT_ASSERTIONS)
+    m_throttler.didConnectToProcess(*this);
 #if PLATFORM(MAC)
     for (Ref page : pages()) {
         if (page->preferences().backgroundWebContentRunningBoardThrottlingEnabled())
@@ -1821,7 +1814,7 @@ void WebProcessProxy::updateAudibleMediaAssertions()
     if (hasAudibleWebPage) {
         WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "updateAudibleMediaAssertions: Taking MediaPlayback assertion for WebProcess");
         m_audibleMediaActivity = AudibleMediaActivity {
-            ProcessAssertion::create(processID(), "WebKit Media Playback"_s, ProcessAssertionType::MediaPlayback),
+            ProcessAssertion::create(*this, "WebKit Media Playback"_s, ProcessAssertionType::MediaPlayback),
             processPool().webProcessWithAudibleMediaToken()
         };
     } else {


### PR DESCRIPTION
#### 5d6df46811480fb26abf29a0e34dc90ef720927e
<pre>
Minor refactoring of assertion code, v2
<a href="https://bugs.webkit.org/show_bug.cgi?id=263797">https://bugs.webkit.org/show_bug.cgi?id=263797</a>
<a href="https://rdar.apple.com/117600174">rdar://117600174</a>

Reviewed by Brent Fulgham.

This patch contains some minor refactoring of assertions code:

1) Let ProcessAndUIAssertion create method take an AuxiliaryProcessProxy reference, instead of a PID.
2) Let XPCConnectionTerminationWatchdog hold on to a weak AuxiliaryProcessProxy pointer, instead of an XPC connection.
3) Let ProcessThrottler::didConnectToProcess take an AuxiliaryProcessProxy reference, instead of a PID.

* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::terminateWithReason):
* Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::platformStartConnectionTerminationWatchdog):
(WebKit::AuxiliaryProcessProxy::extensionProcess const):
(WebKit::AuxiliaryProcessProxy::extensionProcess): Deleted.
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAndUIAssertion::ProcessAndUIAssertion):
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm:
(WebKit::XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog):
(WebKit::XPCConnectionTerminationWatchdog::XPCConnectionTerminationWatchdog):
(WebKit::XPCConnectionTerminationWatchdog::watchdogTimerFired):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::updateThrottleStateIfNeeded):
(WebKit::ProcessThrottler::didConnectToProcess):
(WebKit::ProcessThrottler::didDisconnectFromProcess):
(WebKit::ProcessThrottler::sendPrepareToSuspendIPC):
(WebKit::ProcessThrottler::setShouldTakeNearSuspendedAssertion):
(WebKit::ProcessThrottler::isSuspended const):
(WebKit::ProcessThrottlerActivity::ProcessThrottlerActivity):
(WebKit::ProcessThrottlerActivity::invalidate):
* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottler::isSuspended const): Deleted.
(WebKit::ProcessThrottlerActivity::ProcessThrottlerActivity): Deleted.
(WebKit::ProcessThrottlerActivity::invalidate): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::updateAudibleMediaAssertions):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didFinishLaunching):
(WebKit::WebProcessProxy::updateAudibleMediaAssertions):

Canonical link: <a href="https://commits.webkit.org/270212@main">https://commits.webkit.org/270212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f8231b00c8aea04f652d608718d1c66c3e18618

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22794 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/815 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27532 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2123 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26341 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/371 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3350 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5957 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->