### PR TITLE
run-jsc may kill the whole process group on some unix platforms

### DIFF
--- a/Tools/Scripts/run-jsc
+++ b/Tools/Scripts/run-jsc
@@ -34,6 +34,7 @@ use File::Spec;
 use FindBin;
 use lib $FindBin::Bin;
 use Getopt::Long;
+use POSIX qw( WEXITSTATUS WIFSIGNALED WTERMSIG );
 use webkitdirs;
 Getopt::Long::Configure("no_auto_abbrev", "pass_through");
 
@@ -47,6 +48,7 @@ my $debugger = 0;
 GetOptions("count|c=i" => \$count);
 GetOptions("debugger" => \$debugger);
 
+prohibitUnknownPort(); # To avoid confusing errors on Unix systems.
 setConfiguration();
 
 my $dyld = jscProductDir();
@@ -68,13 +70,16 @@ if (isWindows()) {
 
 while ($count--) {
     system("$jsc");
-    my $signal = $? & 0x7f;
-    my $status = ($? >> 8) & 0xff;
-    if ($signal != 0) {
-        system("kill -" . $signal . " " . $PID); # We kill ourselves with the same signal that the `jsc` process was killed with to make it look like `jsc` was directly invoked.
-    }
-    if ($status != 0) {
-        print STDERR "\njsc exited with non-zero status: $status\n";
-        exit $status;
+    if ($? == -1) {
+        print STDERR "\njsc failed to execute: $!\n";
+        exit 1;
+    } elsif (WIFSIGNALED($?)) {
+        kill(WTERMSIG($?), $PID); # We kill ourselves with the same signal that the `jsc` process was killed with to make it look like `jsc` was directly invoked.
+    } else {
+        my $status = WEXITSTATUS($?);
+        if ($status) {
+            print STDERR "\njsc exited with non-zero status: $status\n";
+            exit $status;
+        }
     }
 }


### PR DESCRIPTION
#### 03f59460b1334611bbb47d83fd26e2910a6c151c
<pre>
run-jsc may kill the whole process group on some unix platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=263792">https://bugs.webkit.org/show_bug.cgi?id=263792</a>

Reviewed by Jonathan Bedard.

Add `prohibitUnknownPort` for better UX for unix users.

Also changes how the status result from running JSC is handled. When JSC fails
to start at all, it should be handled separately to avoid sending bogus
signals. Also use Perl `kill` to add an extra layer of checks to avoid sending
a bogus signal.

* Tools/Scripts/run-jsc:

Canonical link: <a href="https://commits.webkit.org/269947@main">https://commits.webkit.org/269947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b16fcc63f4bfa9cc9f0330a3ffb65d2a6ae29e53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22523 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26627 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27800 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20778 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25589 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23208 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18940 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30609 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1261 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5765 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1663 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30566 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1583 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6391 "Found 1 new JSC stress test failure: microbenchmarks/array-from-object-func.js.lockdown (failure)") | 
<!--EWS-Status-Bubble-End-->