### PR TITLE
Add generation of CF serializers

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -350,6 +350,7 @@ $(PROJECT_DIR)/Shared/WebsiteData/WebsiteDataType.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebsitePoliciesData.serialization.in
 $(PROJECT_DIR)/Shared/XR/XRSystem.serialization.in
+$(PROJECT_DIR)/Shared/cf/CFTypes.serialization.in
 $(PROJECT_DIR)/Shared/ios/DynamicViewportSizeUpdate.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationRequest.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -610,6 +610,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Databases/IndexedDB/WebIDBResult.serialization.in \
 	Shared/RemoteLayerTree/RemoteLayerTree.serialization.in \
 	Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in \
+	Shared/cf/CFTypes.serialization.in \
 	Shared/mac/PDFContextMenuItem.serialization.in \
 	Shared/mac/SecItemRequestData.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -33,6 +33,7 @@
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
+#include "FooWrapper.h"
 #include "HeaderWithoutCondition"
 #include "LayerProperties.h"
 #if ENABLE(TEST_FEATURE)
@@ -1085,6 +1086,37 @@ std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> A
             WTFMove(*memberAfterTuple)
         )
     };
+}
+
+void ArgumentCoder<CFFooRef>::encode(Encoder& encoder, CFFooRef instance)
+{
+    encoder << WebKit::FooWrapper { instance };
+}
+
+std::optional<RetainPtr<CFFooRef>> ArgumentCoder<RetainPtr<CFFooRef>>::decode(Decoder& decoder)
+{
+    auto result = decoder.decode<WebKit::FooWrapper>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return result->toCF();
+}
+
+void ArgumentCoder<CFBarRef>::encode(Encoder& encoder, CFBarRef instance)
+{
+    encoder << WebKit::BarWrapper { instance };
+}
+
+void ArgumentCoder<CFBarRef>::encode(StreamConnectionEncoder& encoder, CFBarRef instance)
+{
+    encoder << WebKit::BarWrapper { instance };
+}
+
+std::optional<RetainPtr<CFBarRef>> ArgumentCoder<RetainPtr<CFBarRef>>::decode(Decoder& decoder)
+{
+    auto result = decoder.decode<WebKit::BarWrapper>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return result->createCFBar();
 }
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -27,6 +27,7 @@
 #include <wtf/ArgumentCoder.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
+#include <wtf/RetainPtr.h>
 
 #if ENABLE(BOOL_ENUM)
 namespace EnumNamespace { enum class BoolEnumType : bool; }
@@ -218,6 +219,33 @@ template<> struct ArgumentCoder<WebCore::ScrollingStateFrameHostingNode> {
 template<> struct ArgumentCoder<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple> {
     static void encode(Encoder&, const WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple&);
     static std::optional<Ref<WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<CFFooRef> {
+    static void encode(Encoder&, CFFooRef);
+};
+template<> struct ArgumentCoder<RetainPtr<CFFooRef>> {
+    static void encode(Encoder& encoder, const RetainPtr<CFFooRef>& retainPtr)
+    {
+        ArgumentCoder<CFFooRef>::encode(encoder, retainPtr.get());
+    }
+    static std::optional<RetainPtr<CFFooRef>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<CFBarRef> {
+    static void encode(Encoder&, CFBarRef);
+    static void encode(StreamConnectionEncoder&, CFBarRef);
+};
+template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
+    static void encode(Encoder& encoder, const RetainPtr<CFBarRef>& retainPtr)
+    {
+        ArgumentCoder<CFBarRef>::encode(encoder, retainPtr.get());
+    }
+    static void encode(StreamConnectionEncoder& encoder, const RetainPtr<CFBarRef>& retainPtr)
+    {
+        ArgumentCoder<CFBarRef>::encode(encoder, retainPtr.get());
+    }
+    static std::optional<RetainPtr<CFBarRef>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -33,6 +33,7 @@
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
+#include "FooWrapper.h"
 #include "HeaderWithoutCondition"
 #include "LayerProperties.h"
 #include "PlatformClass.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -215,3 +215,9 @@ class WebKit::TemplateTest {
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Other] bool otherMember
     int memberAfterTuple
 }
+
+CFFooRef wrapped by WebKit::FooWrapper {
+}
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createCFBar] CFBarRef wrapped by WebKit::BarWrapper {
+}

--- a/Source/WebKit/Shared/Cocoa/CoreIPCData.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCData.h
@@ -36,6 +36,12 @@ namespace WebKit {
 
 class CoreIPCData {
 public:
+    CoreIPCData(CFDataRef cfData)
+        : m_cfData(cfData)
+        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    {
+    }
+
     CoreIPCData(const IPC::DataReference& data)
         : m_reference(data)
     {
@@ -52,6 +58,7 @@ public:
     }
 
 private:
+    RetainPtr<CFDataRef> m_cfData;
     IPC::DataReference m_reference;
 };
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -22,7 +22,7 @@
 
 webkit_platform_headers: "StreamConnectionEncoder.h"
 
-[WebKitPlatform] class WTF::URL {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::URL {
     String string()
 }
 

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -77,13 +77,6 @@ template<> struct ArgumentCoder<RetainPtr<CFCharacterSetRef>> : CFRetainPtrArgum
     static std::optional<RetainPtr<CFCharacterSetRef>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<CFDataRef> {
-    template<typename Encoder> static void encode(Encoder&, CFDataRef);
-};
-template<> struct ArgumentCoder<RetainPtr<CFDataRef>> : CFRetainPtrArgumentCoder<CFDataRef> {
-    template<typename Decoder> static std::optional<RetainPtr<CFDataRef>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<CFDateRef> {
     template<typename Encoder> static void encode(Encoder&, CFDateRef);
 };
@@ -103,13 +96,6 @@ template<> struct ArgumentCoder<CFNumberRef> {
 };
 template<> struct ArgumentCoder<RetainPtr<CFNumberRef>> : CFRetainPtrArgumentCoder<CFNumberRef> {
     static std::optional<RetainPtr<CFNumberRef>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<CFStringRef> {
-    template<typename Encoder> static void encode(Encoder&, CFStringRef);
-};
-template<> struct ArgumentCoder<RetainPtr<CFStringRef>> : CFRetainPtrArgumentCoder<CFStringRef> {
-    static std::optional<RetainPtr<CFStringRef>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<CFURLRef> {

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -22,10 +22,10 @@
 
 #if USE(CF)
 
-webkit_platform_headers: "CoreIPCData.h"
-
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCData {
-    IPC::DataReference get();
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createData] CFDataRef wrapped by WebKit::CoreIPCData {
 }
 
-#endif // USE(CF)
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createCFString] CFStringRef wrapped by WTF::String {
+}
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5193,6 +5193,7 @@
 		51D130511382EAC000351EDD /* SecItemResponseData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SecItemResponseData.serialization.in; sourceTree = "<group>"; };
 		51D130521382EAC000351EDD /* SecItemResponseData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SecItemResponseData.h; sourceTree = "<group>"; };
 		51D130571382F10500351EDD /* WebProcessProxyMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebProcessProxyMac.mm; sourceTree = "<group>"; };
+		51D194352AEC1C8200E8E475 /* CFTypes.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CFTypes.serialization.in; sourceTree = "<group>"; };
 		51D7E0AC2356555400A67D3A /* WKPDFConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPDFConfiguration.h; sourceTree = "<group>"; };
 		51D7E0AE2356616300A67D3A /* WKPDFConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPDFConfiguration.mm; sourceTree = "<group>"; };
 		51DAAEBF2AA198DE00DB2AA4 /* com.apple.WebKit.webpushd.relocatable.mac.sb */ = {isa = PBXFileReference; lastKnownFileType = file; path = com.apple.WebKit.webpushd.relocatable.mac.sb; sourceTree = "<group>"; };
@@ -8514,6 +8515,7 @@
 			children = (
 				1AAF0C4912B16334008E49E2 /* ArgumentCodersCF.cpp */,
 				1AAF0C4812B16334008E49E2 /* ArgumentCodersCF.h */,
+				51D194352AEC1C8200E8E475 /* CFTypes.serialization.in */,
 				5194B3861F192FB900FA4708 /* CookieStorageUtilsCF.h */,
 				5104F5A11F19D7CF004CF821 /* CookieStorageUtilsCF.mm */,
 			);


### PR DESCRIPTION
#### b96d6e41056bce05390a67eaa3075b311a5aa59b
<pre>
Add generation of CF serializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=263800">https://bugs.webkit.org/show_bug.cgi?id=263800</a>

Reviewed by David Kilzer.

A decent chunk of remaining handwritten coders are in ArgumentCodersCF.

The strategy is to add a C++ class to wrap each of the CFTypes we serialize,
and that C++ class&apos;s coders are also generated.

CoreIPCData is a prime candidate of this, in that it can easily wrap a CFDataRef.

This patch teachers the generator to look for types that end in &quot;Ref&quot; and are
followed by a &quot;wrapped by&quot; clause.
It then generates the encode/decode methods for that CF type in terms of the wrapper.

CFDataRef and CFStringRef, and already have suitable wrappers, so we&apos;ll start with them.
This can also be extended to NS* types in the future.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.namespace_and_name):
(SerializedType.cf_wrapper_type):
(one_argument_coder_declaration_cf):
(one_argument_coder_declaration):
(generate_header):
(check_type_members):
(encode_cf_type):
(encode_type):
(decode_cf_type):
(decode_type):
(generate_one_impl):
(generate_serialized_type_info):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;CFFooRef&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;CFBarRef&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::encode):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCData.h:
(WebKit::CoreIPCData::CoreIPCData):
* Source/WebKit/Shared/Cocoa/CoreIPCData.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;CFDataRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFDataRef&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;CFStringRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in: Copied from Source/WebKit/Shared/Cocoa/CoreIPCData.serialization.in.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/269951@main">https://commits.webkit.org/269951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6d379755c128c18a1f87acedf8a60c59edcb00d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22121 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22610 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26745 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/24189 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1416 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27911 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21962 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25700 "Found 3 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/origin-and-total-storage-ratio, /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/ephemeral (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19029 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1371 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5770 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1762 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->