### PR TITLE
[WebGPU] Remove logging to WebSocket

### DIFF
--- a/LayoutTests/http/tests/webgpu/common/internal/websocket_logger.js
+++ b/LayoutTests/http/tests/webgpu/common/internal/websocket_logger.js
@@ -1,52 +1,7 @@
 /**
- * AUTO-GENERATED - DO NOT EDIT. Source: https://github.com/gpuweb/cts
- **/ /**
- * - 'uninitialized' means we haven't tried to connect yet
- * - Promise means it's pending
- * - 'failed' means it failed (this is the most common case, where the logger isn't running)
- * - WebSocket means it succeeded
- */ let connection = 'uninitialized';
-
-/**
- * Log a string to a websocket at `localhost:59497`. See `tools/websocket-logger`.
- *
- * This does nothing if a connection couldn't be established on the first call.
+ * MANUALLY-GENERATED - DO NOT OVERWRITE with the webgpu-cts-import script.
  */
+
 export function logToWebsocket(msg) {
-  if (connection === 'failed') {
-    return;
-  }
-
-  if (connection === 'uninitialized') {
-    connection = new Promise(resolve => {
-      if (typeof WebSocket === 'undefined') {
-        resolve('failed');
-        return;
-      }
-
-      const ws = new WebSocket('ws://localhost:59497/optional_cts_websocket_logger');
-      ws.onopen = () => {
-        resolve(ws);
-      };
-      ws.onerror = () => {
-        connection = 'failed';
-        resolve('failed');
-      };
-      ws.onclose = () => {
-        connection = 'failed';
-        resolve('failed');
-      };
-    });
-    void connection.then(resolved => {
-      connection = resolved;
-    });
-  }
-
-  void (async () => {
-    // connection may be a promise or a value here. Either is OK to await.
-    const ws = await connection;
-    if (ws !== 'failed') {
-      ws.send(msg);
-    }
-  })();
+  return;
 }

--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/draw-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/draw-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: WebSocket connection to 'ws://localhost:59497/optional_cts_websocket_logger' failed: Could not connect to the server.
 
 PASS :arguments:first=0;count=0;first_instance=0;instance_count=0;indexed=false;indirect=false;vertex_buffer_offset=0;index_buffer_offset="_undef_";base_vertex="_undef_"
 PASS :arguments:first=0;count=0;first_instance=0;instance_count=0;indexed=false;indirect=false;vertex_buffer_offset=32;index_buffer_offset="_undef_";base_vertex="_undef_"

--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/stencil-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/stencil-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: WebSocket connection to 'ws://localhost:59497/optional_cts_websocket_logger' failed: Could not connect to the server.
 
 PASS :stencil_compare_func:format="stencil8";stencilCompare="always";stencilRefValue=0
 PASS :stencil_compare_func:format="stencil8";stencilCompare="always";stencilRefValue=1

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2016,7 +2016,7 @@ webkit.org/b/263738 fast/clip/overflow-hidden-with-border-radius-overflow-clippi
 
 webkit.org/b/263754 [ Sonoma+ x86_64 ] css3/filters/effect-drop-shadow-clip-abspos.html [ ImageOnlyFailure ]
 
-# webkit.org/b/263801 [ macOS Debug ] http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw.html
-http/tests/webgpu/webgpu/api/operation/rendering/stencil.html [ Skip ]
-http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw.html [ Skip ]
-http/tests/webgpu/webgpu/api/operation/rendering/draw.html [ Skip ]
+# WebGPU
+http/tests/webgpu/webgpu/api/operation/rendering/stencil.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/rendering/draw.html [ Pass ]


### PR DESCRIPTION
#### 85e40ad30a15e2dfcda4ebad64ed7f41292908a4
<pre>
[WebGPU] Remove logging to WebSocket
<a href="https://bugs.webkit.org/show_bug.cgi?id=263803">https://bugs.webkit.org/show_bug.cgi?id=263803</a>
&lt;radar://117603746&gt;

Reviewed by Ryan Haddad.

The automatically imported WebGPU CTS attempts to write to a web socket,
but this often fails resulting in flaky failures which the only difference
is a console log indicating the web socket failed to open.

Remove this web socket logging as it is not needed.

* LayoutTests/http/tests/webgpu/common/internal/websocket_logger.js:
(export.logToWebsocket):
* LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/draw-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/stencil-expected.txt:

* LayoutTests/platform/mac-wk2/TestExpectations
Re-enable tests that the logging is removed

Canonical link: <a href="https://commits.webkit.org/269884@main">https://commits.webkit.org/269884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a7b9a8b8bfdcebcf9d9d5ffc7ec4846383e3170

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22532 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26642 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27808 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25597 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1276 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5724 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->