### PR TITLE
Simplify 'normalizeAngles' function and potential assertion fix 'newStartAngle >= 0...'

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -142,21 +142,19 @@ ExceptionOr<void> CanvasPath::arcTo(float x1, float y1, float x2, float y2, floa
 
 static void normalizeAngles(float& startAngle, float& endAngle, bool anticlockwise)
 {
-    float newStartAngle = startAngle;
+    constexpr auto twoPiFloat = 2 * piFloat;
+    float newStartAngle = fmodf(startAngle, twoPiFloat);
     if (newStartAngle < 0)
-        newStartAngle = (2 * piFloat) + fmodf(newStartAngle, -(2 * piFloat));
-    else
-        newStartAngle = fmodf(newStartAngle, 2 * piFloat);
+        newStartAngle += twoPiFloat;
 
     float delta = newStartAngle - startAngle;
     startAngle = newStartAngle;
     endAngle = endAngle + delta;
-    ASSERT(newStartAngle >= 0 && (newStartAngle < 2 * piFloat || WTF::areEssentiallyEqual<float>(newStartAngle, 2 * piFloat)));
-
-    if (anticlockwise && startAngle - endAngle >= 2 * piFloat)
-        endAngle = startAngle - 2 * piFloat;
-    else if (!anticlockwise && endAngle - startAngle >= 2 * piFloat)
-        endAngle = startAngle + 2 * piFloat;
+    ASSERT(newStartAngle >= 0 && (newStartAngle < twoPiFloat || WTF::areEssentiallyEqual<float>(newStartAngle, twoPiFloat)));
+    if (anticlockwise && startAngle - endAngle >= twoPiFloat)
+        endAngle = startAngle - twoPiFloat;
+    else if (!anticlockwise && endAngle - startAngle >= twoPiFloat)
+        endAngle = startAngle + twoPiFloat;
 }
 
 ExceptionOr<void> CanvasPath::arc(float x, float y, float radius, float startAngle, float endAngle, bool anticlockwise)


### PR DESCRIPTION
#### 34e0f2e73041cd3033b218cebd696bf1f4bd2ed1
<pre>
Simplify &apos;normalizeAngles&apos; function and potential assertion fix &apos;newStartAngle &gt;= 0...&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=250384">https://bugs.webkit.org/show_bug.cgi?id=250384</a>
rdar://problem/104332195

Reviewed by Kimmo Kinnunen.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/651895c0233495405847471d42dab20deab2a0f3">https://chromium.googlesource.com/chromium/blink/+/651895c0233495405847471d42dab20deab2a0f3</a>

This PR simplify multiple &apos;2 * piFloat&apos; calls by introducing object declaration in start.
Additionally, We can calculate `newStartAngle` as follows if `startAngle` is negative value.

newStartAngle = twoPiFloat + fmodf(startAngle, -twoPiFloat);

The fmodf() is always 0 if `startAngle` is negative multiples of `twoPiFloat`.
So, `newStartAngle` will be `twoPiFloat` and it can cause assertion failure.

* Source/WebCore/html/canvas/CanvasPath.cpp:
(normalizeAngles):

Canonical link: <a href="https://commits.webkit.org/269925@main">https://commits.webkit.org/269925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a504fec063afe6317fc0721618bf41e86b56e975

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22530 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26638 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27805 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25594 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18948 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1272 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5754 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->