### PR TITLE
[WebGPU] Enable webgpu:api,operation,labels:* CTS test

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/labels-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/labels-expected.txt
@@ -1,0 +1,22 @@
+
+PASS :object_has_descriptor_label:name="createBuffer"
+PASS :object_has_descriptor_label:name="requestDevice"
+PASS :object_has_descriptor_label:name="createTexture"
+PASS :object_has_descriptor_label:name="createSampler"
+PASS :object_has_descriptor_label:name="createBindGroupLayout"
+PASS :object_has_descriptor_label:name="createPipelineLayout"
+PASS :object_has_descriptor_label:name="createBindGroup"
+PASS :object_has_descriptor_label:name="createShaderModule"
+PASS :object_has_descriptor_label:name="createComputePipeline"
+PASS :object_has_descriptor_label:name="createRenderPipeline"
+PASS :object_has_descriptor_label:name="createComputePipelineAsync"
+PASS :object_has_descriptor_label:name="createRenderPipelineAsync"
+PASS :object_has_descriptor_label:name="createCommandEncoder"
+PASS :object_has_descriptor_label:name="createRenderBundleEncoder"
+PASS :object_has_descriptor_label:name="createQuerySet"
+PASS :object_has_descriptor_label:name="beginRenderPass"
+PASS :object_has_descriptor_label:name="beginComputePass"
+PASS :object_has_descriptor_label:name="finish"
+PASS :object_has_descriptor_label:name="createView"
+PASS :wrappers_do_not_share_labels:
+

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -231,7 +231,9 @@ Ref<WebCore::WebGPU::CommandBuffer> RemoteCommandEncoderProxy::finish(const WebC
     auto sendResult = send(Messages::RemoteCommandEncoder::Finish(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteCommandBufferProxy::create(m_parent, m_convertToBackingContext, identifier);
+    auto result = RemoteCommandBufferProxy::create(m_parent, m_convertToBackingContext, identifier);
+    result->setLabel(WTFMove(convertedDescriptor->label));
+    return result;
 }
 
 void RemoteCommandEncoderProxy::setLabelInternal(const String& label)


### PR DESCRIPTION
#### db35a79de68c938c5c81302a228b04922a65f668
<pre>
[WebGPU] Enable webgpu:api,operation,labels:* CTS test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263805">https://bugs.webkit.org/show_bug.cgi?id=263805</a>
&lt;radar://117607715&gt;

Reviewed by Tadeu Zagallo.

One location of setLabel was missed.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/labels-expected.txt: Added.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
(WebKit::WebGPU::RemoteCommandEncoderProxy::finish):

Canonical link: <a href="https://commits.webkit.org/269959@main">https://commits.webkit.org/269959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13dce19bcf02ecef921d542558b9c64f5d28a62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22038 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22538 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26648 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27814 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25603 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18954 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1281 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5775 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->