### PR TITLE
Re-import invokers WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
@@ -1,3 +1,20 @@
 
-FAIL idl_test setup promise_test: Unhandled rejection with value: object "Error fetching /interfaces/invokers.tentative.idl."
+PASS idl_test setup
+PASS idl_test validation
+PASS Element includes ParentNode: member names are unique
+PASS Element includes NonDocumentTypeChildNode: member names are unique
+PASS Element includes ChildNode: member names are unique
+PASS Element includes Slottable: member names are unique
+FAIL InvokeEvent interface: existence and properties of interface object assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent interface object length assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent interface object name assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent interface: existence and properties of interface prototype object assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent interface: attribute invoker assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent interface: attribute action assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
+FAIL InvokeEvent must be primary interface of new InvokeEvent("invoke") assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
+FAIL Stringification of new InvokeEvent("invoke") assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
+FAIL InvokeEvent interface: new InvokeEvent("invoke") must inherit property "invoker" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
+FAIL InvokeEvent interface: new InvokeEvent("invoke") must inherit property "action" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
@@ -9,7 +9,7 @@ FAIL invokeTargetElement throws error on assignment of non Element assert_throws
       }" did not throw
 FAIL invokeAction reflects 'auto' when attribute not present assert_equals: expected (string) "auto" but got (undefined) undefined
 FAIL invokeAction reflects 'auto' when attribute empty assert_equals: expected (string) "auto" but got (undefined) undefined
-PASS invokeAction reflects same casing
+FAIL invokeAction reflects same casing assert_equals: expected "fooBarBaz" but got ""
 FAIL invokeAction reflects 'auto' when attribute empty 2 assert_equals: expected "auto" but got ""
 FAIL invokeAction reflects tostring value assert_equals: expected "1,2,3" but got ""
 FAIL invokeAction reflects 'auto' when attribute set to [] assert_equals: expected (string) "auto" but got (object) []

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
@@ -17,8 +17,8 @@
     const div = document.body.appendChild(document.createElement("div"));
     invoker.invokeTargetElement = div;
     assert_equals(invoker.invokeTargetElement, div);
-    assert_equals(invoker.getAttribute('invoketarget'), '');
-    assert_false(invoker.hasAttribute('invokeaction'));
+    assert_equals(invoker.getAttribute("invoketarget"), "");
+    assert_false(invoker.hasAttribute("invokeaction"));
   }, "invokeTargetElement reflects set value");
 
   test(function () {
@@ -27,8 +27,8 @@
     const button = shadow.appendChild(document.createElement("button"));
     button.invokeTargetElement = invokee;
     assert_equals(button.invokeTargetElement, invokee);
-    assert_equals(invoker.getAttribute('invoketarget'), '');
-    assert_false(invoker.hasAttribute('invokeaction'));
+    assert_equals(invoker.getAttribute("invoketarget"), "");
+    assert_false(invoker.hasAttribute("invokeaction"));
   }, "invokeTargetElement reflects set value across shadow root into light dom");
 
   test(function () {
@@ -37,8 +37,8 @@
     const div = shadow.appendChild(document.createElement("div"));
     invoker.invokeTargetElement = div;
     assert_equals(invoker.invokeTargetElement, null);
-    assert_equals(invoker.getAttribute('invoketarget'), '');
-    assert_false(invoker.hasAttribute('invokeaction'));
+    assert_equals(invoker.getAttribute("invoketarget"), "");
+    assert_false(invoker.hasAttribute("invokeaction"));
   }, "invokeTargetElement does not reflect set value inside shadowroot");
 
   test(function () {
@@ -52,7 +52,7 @@
   }, "invokeTargetElement throws error on assignment of non Element");
 
   test(function () {
-    assert_false(invoker.hasAttribute('invokeaction'));
+    assert_false(invoker.hasAttribute("invokeaction"));
     assert_equals(invoker.invokeAction, "auto");
   }, "invokeAction reflects 'auto' when attribute not present");
 
@@ -64,6 +64,7 @@
 
   test(function () {
     invoker.invokeAction = "fooBarBaz";
+    assert_equals(invoker.getAttribute("invokeaction"), "fooBarBaz");
     assert_equals(invoker.invokeAction, "fooBarBaz");
   }, "invokeAction reflects same casing");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
@@ -6,12 +6,13 @@ FAIL action reflects initialized attribute Can't find variable: InvokeEvent
 FAIL action set to undefined Can't find variable: InvokeEvent
 FAIL action set to null Can't find variable: InvokeEvent
 FAIL action set to false Can't find variable: InvokeEvent
+FAIL action explicitly set to empty string Can't find variable: InvokeEvent
 FAIL action set to true Can't find variable: InvokeEvent
 FAIL action set to a number Can't find variable: InvokeEvent
 FAIL action set to [] Can't find variable: InvokeEvent
 FAIL action set to [1, 2, 3] Can't find variable: InvokeEvent
 FAIL action set to an object Can't find variable: InvokeEvent
-FAIL action set to an object with a valueOf function Can't find variable: InvokeEvent
+FAIL action set to an object with a toString function Can't find variable: InvokeEvent
 FAIL InvokeEventInit properties set value Can't find variable: InvokeEvent
 FAIL InvokeEventInit properties set value 2 Can't find variable: InvokeEvent
 FAIL InvokeEventInit properties set value 3 Can't find variable: InvokeEvent

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
@@ -46,6 +46,11 @@
   }, "action set to false");
 
   test(function () {
+    const event = new InvokeEvent("test", { action: "" });
+    assert_equals(event.action, "");
+  }, "action explicitly set to empty string");
+
+  test(function () {
     const event = new InvokeEvent("test", { action: true });
     assert_equals(event.action, "true");
   }, "action set to true");
@@ -57,7 +62,7 @@
 
   test(function () {
     const event = new InvokeEvent("test", { action: [] });
-    assert_equals(event.action, "auto");
+    assert_equals(event.action, "");
   }, "action set to []");
 
   test(function () {
@@ -73,13 +78,13 @@
   test(function () {
     const event = new InvokeEvent("test", {
       action: {
-        valueOf: function () {
+        toString() {
           return "sample";
         },
       },
     });
-    assert_equals(event.action, "[object Object]");
-  }, "action set to an object with a valueOf function");
+    assert_equals(event.action, "sample");
+  }, "action set to an object with a toString function");
 
   test(function () {
     const eventInit = { action: "sample", invoker: document.body };

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
@@ -1,0 +1,20 @@
+
+
+FAIL invoking (as auto) closed popover opens assert_true: expected true got false
+PASS invoking (as auto) closed popover with preventDefault does not open
+FAIL invoking (as auto) open popover closes assert_false: expected false got true
+PASS invoking (as auto) open popover with preventDefault does not close
+FAIL invoking (as togglepopover) closed popover opens assert_true: expected true got false
+FAIL invoking (as togglepopover - case insensitive) closed popover opens assert_true: expected true got false
+PASS invoking (as togglepopover) closed popover with preventDefault does not open
+FAIL invoking (as togglepopover) open popover closes assert_false: expected false got true
+PASS invoking (as togglepopover) open popover with preventDefault does not close
+FAIL invoking (as showpopover) closed popover opens assert_true: expected true got false
+FAIL invoking (as showpopover - case insensitive) closed popover opens assert_true: expected true got false
+FAIL invoking (as showpopover) open popover is noop assert_true: expected true got false
+PASS invoking (as showpopover) closed popover with preventDefault does not open
+PASS invoking (as hidepopover) closed popover is noop
+FAIL invoking (as hidepopover) open popover closes assert_false: expected false got true
+FAIL invoking (as hidepopover - case insensitive) open popover closes assert_false: expected false got true
+PASS invoking (as hidepopover) open popover with preventDefault does not close
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="invokee" popover>
+  <button id="invokerbutton2" invoketarget="invokee"></button>
+</div>
+<button id="invokerbutton" invoketarget="invokee"></button>
+
+<script>
+  // auto
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as auto) closed popover opens");
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches(":popover-open"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as auto) closed popover with preventDefault does not open");
+
+  promise_test(async function (t) {
+    invokee.showPopover();
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as auto) open popover closes");
+
+  promise_test(async function (t) {
+    invokee.showPopover();
+    t.add_cleanup(() => invokee.hidePopover());
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as auto) open popover with preventDefault does not close");
+
+  // togglepopover
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches(":popover-open"));
+    invokerbutton.setAttribute("invokeaction", "togglepopover");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as togglepopover) closed popover opens");
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches(":popover-open"));
+    invokerbutton.setAttribute("invokeaction", "tOgGlEpOpOvEr");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as togglepopover - case insensitive) closed popover opens");
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches(":popover-open"));
+    invokerbutton.setAttribute("invokeaction", "togglepopover");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as togglepopover) closed popover with preventDefault does not open");
+
+  promise_test(async function (t) {
+    invokee.showPopover();
+    invokerbutton2.setAttribute("invokeaction", "togglepopover");
+    t.add_cleanup(() => invokerbutton2.removeAttribute("invokeaction"));
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as togglepopover) open popover closes");
+
+  promise_test(async function (t) {
+    invokee.showPopover();
+    t.add_cleanup(() => invokee.hidePopover());
+    invokerbutton2.setAttribute("invokeaction", "togglepopover");
+    t.add_cleanup(() => invokerbutton2.removeAttribute("invokeaction"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as togglepopover) open popover with preventDefault does not close");
+
+  // showpopover
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "showpopover");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as showpopover) closed popover opens");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "sHoWpOpOvEr");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as showpopover - case insensitive) closed popover opens");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "showpopover");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.showPopover();
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as showpopover) open popover is noop");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "showpopover");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches(":popover-open"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as showpopover) closed popover with preventDefault does not open");
+
+  // hidepopover
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "hidepopover");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as hidepopover) closed popover is noop");
+
+  promise_test(async function (t) {
+    invokerbutton2.setAttribute("invokeaction", "hidepopover");
+    t.add_cleanup(() => invokerbutton2.removeAttribute("invokeaction"));
+    invokee.showPopover();
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as hidepopover) open popover closes");
+
+  promise_test(async function (t) {
+    invokerbutton2.setAttribute("invokeaction", "hIdEpOpOvEr");
+    t.add_cleanup(() => invokerbutton2.removeAttribute("invokeaction"));
+    invokee.showPopover();
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as hidepopover - case insensitive) open popover closes");
+
+  promise_test(async function (t) {
+    invokerbutton2.setAttribute("invokeaction", "hidepopover");
+    t.add_cleanup(() => invokerbutton2.removeAttribute("invokeaction"));
+    invokee.showPopover();
+    t.add_cleanup(() => invokee.hidePopover());
+    assert_true(invokee.matches(":popover-open"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton2);
+    assert_true(invokee.matches(":popover-open"));
+  }, "invoking (as hidepopover) open popover with preventDefault does not close");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl
@@ -1,0 +1,15 @@
+interface mixin InvokerElement {
+  [CEReactions,Reflect=invoketarget] attribute Element? invokeTargetElement;
+  [CEReactions,Reflect,ReflectMissing="auto",ReflectEmpty="auto"] attribute DOMString invokeAction;
+};
+
+interface InvokeEvent : Event {
+    constructor(DOMString type, optional InvokeEventInit eventInitDict = {});
+    readonly attribute Element? invoker;
+    readonly attribute DOMString action;
+};
+
+dictionary InvokeEventInit : EventInit {
+    Element? invoker = null;
+    DOMString action = "auto";
+};


### PR DESCRIPTION
#### fe9e1839d774a9bb53ebad99f45e99f36db90c2f
<pre>
Re-import invokers WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=263443">https://bugs.webkit.org/show_bug.cgi?id=263443</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3702380c5cb2bd384d147707382487f5cce257f0">https://github.com/web-platform-tests/wpt/commit/3702380c5cb2bd384d147707382487f5cce257f0</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl: Added.

Canonical link: <a href="https://commits.webkit.org/269907@main">https://commits.webkit.org/269907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd65870d4356e7b50feb697989a4a400a5a1cf89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22130 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22617 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24268 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1666 "Exiting early after 10 failures. 30 tests run. 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26754 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1423 "8 flakes 5 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27923 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21968 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25711 "Found 51 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/ephemeral, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/reload, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cookies, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-cancel, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/populate-menu, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-no-credential ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19036 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->