### PR TITLE
[iOS] A scrollTo() followed by an animated scroll ends at the wrong scroll position

### DIFF
--- a/LayoutTests/fast/scrolling/ios/smooth-scroll-after-scrollTo-on-overflow-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/smooth-scroll-after-scrollTo-on-overflow-expected.txt
@@ -1,0 +1,5 @@
+PASS scrollContainer.scrollTop is 700
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/smooth-scroll-after-scrollTo-on-overflow.html
+++ b/LayoutTests/fast/scrolling/ios/smooth-scroll-after-scrollTo-on-overflow.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroll-container {
+            height: 250px;
+            width: 300px;
+            border: 1px solid black;
+            overflow: scroll;
+        }
+        
+        .contents {
+            height: 500%;
+            background-image: repeating-linear-gradient(white, silver 250px);
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        async function runTest()
+        {
+            scrollContainer = document.querySelector('.scroll-container');
+
+            if (window.eventSender)
+                await UIHelper.startMonitoringWheelEvents();
+
+            scrollContainer.scrollTo(0, 200);
+            scrollContainer.scrollBy({
+                top: 500,
+                behavior: 'smooth'
+            });
+            
+            await UIHelper.waitForScrollCompletion();
+            
+            shouldBe('scrollContainer.scrollTop', '700');
+            finishJSTest();
+        }
+    
+        window.addEventListener('load', () => {
+            setTimeout(runTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroll-container">
+        <div class="contents"></div>
+    </div>
+    <div id="console"></div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -60,9 +60,17 @@ void RequestedScrollData::merge(RequestedScrollData&& other)
     *this = WTFMove(other);
 }
 
-FloatPoint RequestedScrollData::destinationPosition(const FloatPoint& currentScrollPosition) const
+FloatPoint RequestedScrollData::destinationPosition(FloatPoint currentScrollPosition) const
 {
-    return requestType == ScrollRequestType::DeltaUpdate ? (currentScrollPosition + std::get<FloatSize>(scrollPositionOrDelta)) : std::get<FloatPoint>(scrollPositionOrDelta);
+    return computeDestinationPosition(currentScrollPosition, requestType, scrollPositionOrDelta);
+}
+
+FloatPoint RequestedScrollData::computeDestinationPosition(FloatPoint currentScrollPosition, ScrollRequestType requestType, const std::variant<FloatPoint, FloatSize>& scrollPositionOrDelta)
+{
+    if (requestType == ScrollRequestType::DeltaUpdate)
+        return currentScrollPosition + std::get<FloatSize>(scrollPositionOrDelta);
+
+    return std::get<FloatPoint>(scrollPositionOrDelta);
 }
 
 TextStream& operator<<(TextStream& ts, SynchronousScrollingReason reason)

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -115,7 +115,10 @@ struct RequestedScrollData {
     std::optional<std::tuple<ScrollRequestType, std::variant<FloatPoint, FloatSize>, ScrollType, ScrollClamping>> requestedDataBeforeAnimatedScroll { };
 
     void merge(RequestedScrollData&&);
-    WEBCORE_EXPORT FloatPoint destinationPosition(const FloatPoint&) const;
+
+    WEBCORE_EXPORT FloatPoint destinationPosition(FloatPoint currentScrollPosition) const;
+    WEBCORE_EXPORT static FloatPoint computeDestinationPosition(FloatPoint currentScrollPosition, ScrollRequestType, const std::variant<FloatPoint, FloatSize>& scrollPositionOrDelta);
+
     bool comparePositionOrDelta(const RequestedScrollData& other) const
     {
         if (requestType == ScrollRequestType::PositionUpdate)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -313,14 +313,22 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
     if (scrollingTree().scrollingTreeNodeRequestsScroll(scrollingNodeID(), requestedScrollData))
         return;
 
-    auto scrollToPosition = requestedScrollData.destinationPosition(currentScrollPosition());
+    auto currentScrollPosition = this->currentScrollPosition();
+
+    if (requestedScrollData.requestedDataBeforeAnimatedScroll) {
+        auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *requestedScrollData.requestedDataBeforeAnimatedScroll;
+        auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
+        scrollTo(intermediatePosition, scrollType, clamping);
+    }
+
+    auto destinationPosition = requestedScrollData.destinationPosition(currentScrollPosition);
 
     if (requestedScrollData.animated == ScrollIsAnimated::Yes) {
-        startAnimatedScrollToPosition(scrollToPosition);
+        startAnimatedScrollToPosition(destinationPosition);
         return;
     }
 
-    scrollTo(scrollToPosition, requestedScrollData.scrollType, requestedScrollData.clamping);
+    scrollTo(destinationPosition, requestedScrollData.scrollType, requestedScrollData.clamping);
 }
 
 FloatPoint ScrollingTreeScrollingNode::adjustedScrollPosition(const FloatPoint& scrollPosition, ScrollClamping clamping) const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -279,13 +279,13 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     // Handle requested scroll position updates from the scrolling tree transaction after didCommitLayerTree()
     // has updated the view size based on the content size.
     if (requestedScroll) {
-        auto previousScrollPosition = webPageProxy->scrollingCoordinatorProxy()->currentMainFrameScrollPosition();
+        auto currentScrollPosition = webPageProxy->scrollingCoordinatorProxy()->currentMainFrameScrollPosition();
         if (auto previousData = std::exchange(requestedScroll->requestedDataBeforeAnimatedScroll, std::nullopt)) {
-            auto& [type, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *previousData;
-            previousScrollPosition = type == ScrollRequestType::DeltaUpdate ? (webPageProxy->scrollingCoordinatorProxy()->currentMainFrameScrollPosition() + std::get<FloatSize>(positionOrDeltaBeforeAnimatedScroll)) : std::get<FloatPoint>(positionOrDeltaBeforeAnimatedScroll);
+            auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *previousData;
+            currentScrollPosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
         }
 
-        webPageProxy->requestScroll(requestedScroll->destinationPosition(previousScrollPosition), layerTreeTransaction.scrollOrigin(), requestedScroll->animated);
+        webPageProxy->requestScroll(requestedScroll->destinationPosition(currentScrollPosition), layerTreeTransaction.scrollOrigin(), requestedScroll->animated);
     }
 #endif // ENABLE(ASYNC_SCROLLING)
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -161,12 +161,15 @@ void RemoteScrollingTreeMac::startPendingScrollAnimations()
         if (!targetNode)
             continue;
 
+        auto currentScrollPosition = targetNode->currentScrollPosition();
+
         if (auto previousData = std::exchange(data.requestedDataBeforeAnimatedScroll, std::nullopt)) {
-            auto& [type, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *previousData;
-            targetNode->scrollTo(type == ScrollRequestType::DeltaUpdate ? (targetNode->currentScrollPosition() + std::get<FloatSize>(positionOrDeltaBeforeAnimatedScroll)) : std::get<FloatPoint>(positionOrDeltaBeforeAnimatedScroll), scrollType, clamping);
+            auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *previousData;
+            auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
+            targetNode->scrollTo(intermediatePosition, scrollType, clamping);
         }
 
-        targetNode->startAnimatedScrollToPosition(data.destinationPosition(targetNode->currentScrollPosition()));
+        targetNode->startAnimatedScrollToPosition(data.destinationPosition(currentScrollPosition));
     }
 
     auto nodesWithPendingKeyboardScrollAnimations = std::exchange(m_nodesWithPendingKeyboardScrollAnimations, { });


### PR DESCRIPTION
#### 9b87cf844c2f847a8222bab057eac7ba735e605e
<pre>
[iOS] A scrollTo() followed by an animated scroll ends at the wrong scroll position
<a href="https://bugs.webkit.org/show_bug.cgi?id=263808">https://bugs.webkit.org/show_bug.cgi?id=263808</a>
rdar://117608836

Reviewed by Richard Robinson.

Programmatic scroll requests (`RequestedScrollData`) are handled in three places:
1. `RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction()` for iOS main frame scrolls
2. `ScrollingTreeScrollingNode::handleScrollPositionRequest()` for non-main-frame iOS scrolls
3. `RemoteScrollingTreeMac::startPendingScrollAnimations()` for all scollers on macOS

The second failed to handle the `requestedDataBeforeAnimatedScroll` data in the request, so
a sequence like `scrollTo(x, y); scrollBy({ top: z, behavior: &apos;smooth&apos; })` would fail to
accumulate the two deltas.

Fix by having `ScrollingTreeScrollingNode::handleScrollPositionRequest()` process `requestedDataBeforeAnimatedScroll`
like the other call sites. Also reuse the &quot;position or delta&quot; logic in `RequestedScrollData::destinationPosition()`
in all these call sites for clarity.

* LayoutTests/fast/scrolling/ios/smooth-scroll-after-scrollTo-on-overflow-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/smooth-scroll-after-scrollTo-on-overflow.html: Added.
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::RequestedScrollData::destinationPosition const):
(WebCore::RequestedScrollData::computeDestinationPosition):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::startPendingScrollAnimations):

Canonical link: <a href="https://commits.webkit.org/269897@main">https://commits.webkit.org/269897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61077f0eea24ab195350780e0ce728ca69e385b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22540 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26650 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25605 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18957 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5735 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->