### PR TITLE
[macOS WKTR] Enable async overflow scrolling by default for WPTs

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -602,6 +602,20 @@ webkit.org/b/151709 [ Release ] http/tests/xmlhttprequest/workers/methods.html [
 
 webkit.org/b/231372 [ BigSur arm64 Debug ] http/tests/xmlhttprequest/access-control-response-with-body.html [ Pass Crash ]
 
+# webkit.org/b/263955 Twelve css WPTs are failing with async overflow scrolling enabled on macOS
+imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-scroll.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-scrollbar-vertical-lr-001.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-scrollbar-vertical-rl-001.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-masking/clip/clip-rect-scroll.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-003.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-position/position-fixed-scroll-nested-fixed.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-scrollbars/textarea-scrollbar-width-none.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-ui/outline-negative-offset-composited-scroll.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/snap-inline-block.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Failure ]
+imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.html [ Failure ]
+
 ### END OF (1) Classified failures with bug reports
 ########################################
 

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -27,6 +27,7 @@
 #include "TestFeatures.h"
 
 #include "TestCommand.h"
+#include "WPTFunctions.h"
 #include <fstream>
 #include <string>
 #include <wtf/StdFilesystem.h>
@@ -107,28 +108,19 @@ static std::optional<double> overrideDeviceScaleFactorForTest(const std::string&
 
 static bool shouldDumpJSConsoleLogInStdErr(const std::string& pathOrURL)
 {
-    auto url = URL({ }, String::fromUTF8(pathOrURL.c_str()));
-    if (!url.isValid())
-        return false;
-
-    auto host = url.host();
-    if (host != "localhost"_s && host != "web-platform.test"_s)
-        return false;
-
-    auto port = url.port().value_or(0);
-    if (port != 8800 && port != 9443)
-        return false;
-
-    auto path = url.path();
-    return path.startsWith("/beacon"_s)
-        || path.startsWith("/cors"_s)
-        || path.startsWith("/fetch"_s)
-        || path.startsWith("/service-workers"_s)
-        || path.startsWith("/streams/writable-streams"_s)
-        || path.startsWith("/streams/piping"_s)
-        || path.startsWith("/xhr"_s)
-        || path.startsWith("/webrtc"_s)
-        || path.startsWith("/websockets"_s);
+    if (auto url = URL { { }, String::fromUTF8(pathOrURL.c_str()) }; isWebPlatformTestURL(url)) {
+        auto path = url.path();
+        return path.startsWith("/beacon"_s)
+            || path.startsWith("/cors"_s)
+            || path.startsWith("/fetch"_s)
+            || path.startsWith("/service-workers"_s)
+            || path.startsWith("/streams/writable-streams"_s)
+            || path.startsWith("/streams/piping"_s)
+            || path.startsWith("/xhr"_s)
+            || path.startsWith("/webrtc"_s)
+            || path.startsWith("/websockets"_s);
+    }
+    return false;
 }
 
 static bool shouldEnableWebGPU(const std::string& pathOrURL)

--- a/Tools/TestRunnerShared/WPTFunctions.h
+++ b/Tools/TestRunnerShared/WPTFunctions.h
@@ -27,9 +27,14 @@
 
 typedef struct OpaqueJSContext* JSGlobalContextRef;
 
+namespace WTF {
+class URL;
+}
+
 namespace WTR {
 
 void sendTestRenderedEvent(JSGlobalContextRef);
 bool hasTestWaitAttribute(JSGlobalContextRef);
+bool isWebPlatformTestURL(const WTF::URL&);
 
 }

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -100,6 +100,8 @@
 		2E63EDA61891BDC0002A7AFC /* TestRunner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCC9981711D3F51E0017BCA2 /* TestRunner.cpp */; };
 		2E749BF21891EBFA007FC175 /* EventSenderProxyIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E63ED7A1891ACE9002A7AFC /* EventSenderProxyIOS.mm */; };
 		31DA8A3D1E7205CC00E1DF2F /* IOSLayoutTestCommunication.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3148A0531E6F85B600D3B316 /* IOSLayoutTestCommunication.cpp */; };
+		33558B2D2AF1BF600041E63F /* WPTFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C7881F250C69E400C0AA24 /* WPTFunctions.cpp */; };
+		33558B2E2AF1C22B0041E63F /* WPTFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C7881F250C69E400C0AA24 /* WPTFunctions.cpp */; };
 		41C5378E21F13414008B1FAD /* TestWebsiteDataStoreDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41C5378D21F1333C008B1FAD /* TestWebsiteDataStoreDelegate.mm */; };
 		41D5B62622DD9D36000F4C4A /* FakeHelvetica-SingleExtendedCharacter.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D5B62522DD9D36000F4C4A /* FakeHelvetica-SingleExtendedCharacter.ttf */; };
 		4430AE191F82C4FD0099915A /* GeneratedTouchesDebugWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4430AE171F82C4EE0099915A /* GeneratedTouchesDebugWindow.mm */; };
@@ -1263,6 +1265,7 @@
 				E132AA3D17CE776F00611DF0 /* WebKitTestRunnerEvent.mm in Sources */,
 				E1C642C617CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm in Sources */,
 				9376417A210D737200A3DAAE /* WebKitTestRunnerWindow.mm in Sources */,
+				33558B2D2AF1BF600041E63F /* WPTFunctions.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1304,6 +1307,7 @@
 				A18510431B9AE14500744AEB /* WebNotificationProvider.cpp in Sources */,
 				51998A082810FBD1009D68EB /* WebNotificationProviderCocoa.mm in Sources */,
 				A18510441B9AE14A00744AEB /* WorkQueueManager.cpp in Sources */,
+				33558B2E2AF1C22B0041E63F /* WPTFunctions.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -29,8 +29,10 @@
 #import "LayoutTestSpellChecker.h"
 #import "PlatformWebView.h"
 #import "PoseAsClass.h"
+#import "TestCommand.h"
 #import "TestInvocation.h"
 #import "TestRunnerWKWebView.h"
+#import "WPTFunctions.h"
 #import "WebKitTestRunnerPasteboard.h"
 #import <WebKit/WKContextPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
@@ -186,10 +188,17 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
     return true;
 }
 
-TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCommand&) const
+static bool shouldEnableAsyncOverflowScrolling(const std::string& pathOrURL)
+{
+    return isWebPlatformTestURL({ { }, String::fromUTF8(pathOrURL.c_str()) });
+}
+
+TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCommand& command) const
 {
     TestFeatures features;
     features.boolTestRunnerFeatures.insert({ "useThreadedScrolling", true });
+    if (shouldEnableAsyncOverflowScrolling(command.pathOrURL))
+        features.boolWebPreferenceFeatures.insert({ "AsyncOverflowScrollingEnabled", true });
     return features;
 }
 


### PR DESCRIPTION
#### 6e655dfb81542a121845a4f664aaa0698bb307eb
<pre>
[macOS WKTR] Enable async overflow scrolling by default for WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=263810">https://bugs.webkit.org/show_bug.cgi?id=263810</a>
<a href="https://rdar.apple.com/problem/117609234">rdar://problem/117609234</a>

Reviewed by Tim Nguyen.

This commit enables async overflow scrolling by default for WPTs on
macOS by hardcoding enablement of the `AsyncOverflowScrollingEnabled` web
preference within `TestControllerMac` when the test runner is running
WPTs.

The heuristic for determining whether the test running is a WPT is
simply the fact that the test path is a URL and is on the ports/hosts
specified in imported/w3c/resources/config.json, as prior art from
`shouldDumpJSConsoleLogInStdErr` shows.

We keep the concept of a valid WPT URL in a separate
`isWebPlatformTestURL` helper method in WPTFunctions.h that both
`shouldDumpJSConsoleLogInStdErr` and `shouldEnableAsyncOverflowScrolling`
can consult. To get all the definitions in the right place and satisfy
the linker, this commit also touches some of target membership for WKTR.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::shouldDumpJSConsoleLogInStdErr):
* Tools/TestRunnerShared/WPTFunctions.cpp:
(WTR::isWebPlatformTestURL):
* Tools/TestRunnerShared/WPTFunctions.h:
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::shouldEnableAsyncOverflowScrolling):
(WTR::TestController::platformSpecificFeatureDefaultsForTest const):

Canonical link: <a href="https://commits.webkit.org/270071@main">https://commits.webkit.org/270071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54d4fa583bcfae81598a0904c605687e9090f49e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22880 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27137 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28223 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22261 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26014 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/64 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3009 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5859 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->