### PR TITLE
Adopt smart pointers in FrameLoader

### DIFF
--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -207,4 +207,9 @@ bool CachedPage::hasExpired() const
     return MonotonicTime::now() > m_expirationTime;
 }
 
+RefPtr<DocumentLoader> CachedPage::protectedDocumentLoader() const
+{
+    return documentLoader();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CachedFrame.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 
 namespace WebCore {
@@ -34,7 +35,7 @@ class Document;
 class DocumentLoader;
 class Page;
 
-class CachedPage {
+class CachedPage : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit CachedPage(Page&);
@@ -46,6 +47,7 @@ public:
     Page& page() const { return m_page; }
     Document* document() const { return m_cachedMainFrame->document(); }
     DocumentLoader* documentLoader() const { return m_cachedMainFrame->documentLoader(); }
+    RefPtr<DocumentLoader> protectedDocumentLoader() const;
 
     bool hasExpired() const;
     

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -278,7 +278,7 @@ void HTMLFormElement::submitIfPossible(Event* event, HTMLFormControlElement* sub
         return;
     }
 
-    auto targetFrame = frame->loader().findFrameForNavigation(effectiveTarget(event, submitter), &document());
+    RefPtr targetFrame = frame->loader().findFrameForNavigation(effectiveTarget(event, submitter), &document());
     if (!targetFrame)
         targetFrame = frame.get();
     auto formState = FormState::create(*this, textFieldValues(), document(), NotSubmittedByJavaScript);

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -112,6 +112,11 @@ inline HTMLFrameOwnerElement* Frame::ownerElement() const
     return m_ownerElement.get();
 }
 
+inline RefPtr<HTMLFrameOwnerElement> Frame::protectedOwnerElement() const
+{
+    return m_ownerElement.get();
+}
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFrameOwnerElement)

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -282,11 +282,11 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPageController->inspectedPage().mainFrame());
     if (!localMainFrame)
         return;
-    LocalFrame& mainFrame = *localMainFrame;
+    Ref mainFrame = *localMainFrame;
 
-    UserGestureIndicator indicator { ProcessingUserGesture, mainFrame.document() };
+    UserGestureIndicator indicator { ProcessingUserGesture, mainFrame->document() };
 
-    FrameLoadRequest frameLoadRequest { *mainFrame.document(), mainFrame.document()->securityOrigin(), { }, blankTargetFrameName(), InitiatedByMainFrame::Unknown };
+    FrameLoadRequest frameLoadRequest { *mainFrame->document(), mainFrame->document()->securityOrigin(), { }, blankTargetFrameName(), InitiatedByMainFrame::Unknown };
 
     bool created;
     WindowFeatures features;
@@ -294,12 +294,12 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
     if (!frame)
         return;
 
-    frame->loader().setOpener(&mainFrame);
+    frame->loader().setOpener(mainFrame.copyRef());
     frame->page()->setOpenedByDOM();
 
     // FIXME: Why do we compute the absolute URL with respect to |frame| instead of |mainFrame|?
     ResourceRequest resourceRequest { frame->document()->completeURL(url) };
-    FrameLoadRequest frameLoadRequest2 { *mainFrame.document(), mainFrame.document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
+    FrameLoadRequest frameLoadRequest2 { mainFrame->protectedDocument().releaseNonNull(), mainFrame->document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
     frame->loader().changeLocation(WTFMove(frameLoadRequest2));
 }
 

--- a/Source/WebCore/loader/FormState.cpp
+++ b/Source/WebCore/loader/FormState.cpp
@@ -58,4 +58,9 @@ void FormState::willDetachPage()
     RELEASE_ASSERT(hasOneRef());
 }
 
+Ref<Document> FormState::protectedSourceDocument() const
+{
+    return m_sourceDocument;
+}
+
 }

--- a/Source/WebCore/loader/FormState.h
+++ b/Source/WebCore/loader/FormState.h
@@ -49,6 +49,8 @@ public:
     HTMLFormElement& form() const { return m_form; }
     const StringPairVector& textFieldValues() const { return m_textFieldValues; }
     Document& sourceDocument() const { return m_sourceDocument; }
+    Ref<Document> protectedSourceDocument() const;
+
     FormSubmissionTrigger formSubmissionTrigger() const { return m_formSubmissionTrigger; }
 
 private:

--- a/Source/WebCore/loader/FrameLoadRequest.cpp
+++ b/Source/WebCore/loader/FrameLoadRequest.cpp
@@ -37,8 +37,8 @@
 
 namespace WebCore {
 
-FrameLoadRequest::FrameLoadRequest(Document& requester, SecurityOrigin& requesterSecurityOrigin, ResourceRequest&& resourceRequest, const AtomString& frameName, InitiatedByMainFrame initiatedByMainFrame, const AtomString& downloadAttribute)
-    : m_requester { requester }
+FrameLoadRequest::FrameLoadRequest(Ref<Document>&& requester, SecurityOrigin& requesterSecurityOrigin, ResourceRequest&& resourceRequest, const AtomString& frameName, InitiatedByMainFrame initiatedByMainFrame, const AtomString& downloadAttribute)
+    : m_requester { WTFMove(requester) }
     , m_requesterSecurityOrigin { requesterSecurityOrigin }
     , m_resourceRequest { WTFMove(resourceRequest) }
     , m_frameName { frameName }

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -41,7 +41,7 @@ class SecurityOrigin;
 
 class FrameLoadRequest {
 public:
-    WEBCORE_EXPORT FrameLoadRequest(Document&, SecurityOrigin&, ResourceRequest&&, const AtomString& frameName, InitiatedByMainFrame, const AtomString& downloadAttribute = { });
+    WEBCORE_EXPORT FrameLoadRequest(Ref<Document>&&, SecurityOrigin&, ResourceRequest&&, const AtomString& frameName, InitiatedByMainFrame, const AtomString& downloadAttribute = { });
     WEBCORE_EXPORT FrameLoadRequest(LocalFrame&, const ResourceRequest&, const SubstituteData& = SubstituteData());
 
     WEBCORE_EXPORT ~FrameLoadRequest();

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -108,7 +108,8 @@ public:
     WEBCORE_EXPORT void init();
     void initForSynthesizedDocument(const URL&);
 
-    LocalFrame& frame() const { return m_frame; }
+    WEBCORE_EXPORT LocalFrame& frame() const;
+    WEBCORE_EXPORT Ref<LocalFrame> protectedFrame() const;
 
     class PolicyChecker;
     PolicyChecker& policyChecker() const { return *m_policyChecker; }
@@ -172,8 +173,10 @@ public:
 
     WEBCORE_EXPORT DocumentLoader* activeDocumentLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
+    RefPtr<DocumentLoader> protectedDocumentLoader() const;
     DocumentLoader* policyDocumentLoader() const { return m_policyDocumentLoader.get(); }
     DocumentLoader* provisionalDocumentLoader() const { return m_provisionalDocumentLoader.get(); }
+    RefPtr<DocumentLoader> protectedProvisionalDocumentLoader() const;
     FrameState state() const { return m_state; }
 
     bool shouldReportResourceTimingToParentFrame() const { return m_shouldReportResourceTimingToParentFrame; };
@@ -252,7 +255,7 @@ public:
 
     WEBCORE_EXPORT Frame* opener();
     WEBCORE_EXPORT const Frame* opener() const;
-    WEBCORE_EXPORT void setOpener(Frame*);
+    WEBCORE_EXPORT void setOpener(RefPtr<Frame>&&);
     WEBCORE_EXPORT void detachFromAllOpenedFrames();
 
     void resetMultipleFormSubmissionProtection();
@@ -281,8 +284,7 @@ public:
 
     void advanceStatePastInitialEmptyDocument();
 
-    // FIXME: should return RefPtr.
-    WEBCORE_EXPORT LocalFrame* findFrameForNavigation(const AtomString& name, Document* activeDocument = nullptr);
+    WEBCORE_EXPORT RefPtr<LocalFrame> findFrameForNavigation(const AtomString& name, Document* activeDocument = nullptr);
 
     void applyUserAgentIfNeeded(ResourceRequest&);
 
@@ -383,9 +385,9 @@ private:
     void checkLoadCompleteForThisFrame();
     void handleLoadFailureRecovery(DocumentLoader&, const ResourceError&, bool);
 
-    void setDocumentLoader(DocumentLoader*);
-    void setPolicyDocumentLoader(DocumentLoader*);
-    void setProvisionalDocumentLoader(DocumentLoader*);
+    void setDocumentLoader(RefPtr<DocumentLoader>&&);
+    void setPolicyDocumentLoader(RefPtr<DocumentLoader>&&);
+    void setProvisionalDocumentLoader(RefPtr<DocumentLoader>&&);
 
     void setState(FrameState);
 
@@ -444,7 +446,7 @@ private:
     void clearProvisionalLoadForPolicyCheck();
     bool hasOpenedFrames() const;
 
-    LocalFrame& m_frame;
+    CheckedRef<LocalFrame> m_frame;
     UniqueRef<LocalFrameLoaderClient> m_client;
 
     const std::unique_ptr<PolicyChecker> m_policyChecker;

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -944,4 +944,14 @@ void FrameLoader::HistoryController::replaceCurrentItem(HistoryItem* item)
         m_currentItem = item;
 }
 
+RefPtr<HistoryItem> FrameLoader::HistoryController::protectedCurrentItem() const
+{
+    return m_currentItem;
+}
+
+RefPtr<HistoryItem> FrameLoader::HistoryController::protectedProvisionalItem() const
+{
+    return m_provisionalItem;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -73,6 +73,7 @@ public:
     void updateForFrameLoadCompleted();
 
     HistoryItem* currentItem() const { return m_currentItem.get(); }
+    RefPtr<HistoryItem> protectedCurrentItem() const;
     WEBCORE_EXPORT void setCurrentItem(HistoryItem&);
     void setCurrentItemTitle(const StringWithDirection&);
     bool currentItemShouldBeReplaced() const;
@@ -82,6 +83,7 @@ public:
     void clearPreviousItem();
 
     HistoryItem* provisionalItem() const { return m_provisionalItem.get(); }
+    RefPtr<HistoryItem> protectedProvisionalItem() const;
     void setProvisionalItem(HistoryItem*);
 
     void pushState(RefPtr<SerializedScriptValue>&&, const String& title, const String& url);

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -28,6 +28,7 @@
 #include "Page.h"
 #include "ResourceLoaderIdentifier.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
@@ -41,7 +42,7 @@ class ResourceResponse;
 class ProgressTrackerClient;
 struct ProgressItem;
 
-class ProgressTracker {
+class ProgressTracker : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(ProgressTracker);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -116,4 +116,9 @@ void Frame::takeWindowProxyFrom(Frame& frame)
     m_windowProxy->replaceFrame(*this);
 }
 
+Ref<WindowProxy> Frame::protectedWindowProxy() const
+{
+    return m_windowProxy;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -54,6 +54,8 @@ public:
 
     WindowProxy& windowProxy() { return m_windowProxy; }
     const WindowProxy& windowProxy() const { return m_windowProxy; }
+    Ref<WindowProxy> protectedWindowProxy() const;
+
     DOMWindow* window() const { return virtualWindow(); }
     FrameTree& tree() const { return m_treeNode; }
     FrameIdentifier frameID() const { return m_frameID; }
@@ -66,7 +68,10 @@ public:
     WEBCORE_EXPORT bool isRootFrame() const;
 
     WEBCORE_EXPORT void detachFromPage();
+
     inline HTMLFrameOwnerElement* ownerElement() const; // Defined in HTMLFrameOwnerElement.h.
+    inline RefPtr<HTMLFrameOwnerElement> protectedOwnerElement() const; // Defined in HTMLFrameOwnerElement.h.
+
     WEBCORE_EXPORT void disconnectOwnerElement();
     NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }
     WEBCORE_EXPORT void takeWindowProxyFrom(Frame&);

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -155,6 +155,7 @@ public:
     FrameLoader& loader() { return m_loader.get(); }
     CheckedRef<const FrameLoader> checkedLoader() const;
     CheckedRef<FrameLoader> checkedLoader();
+
     FrameSelection& selection() { return document()->selection(); }
     const FrameSelection& selection() const { return document()->selection(); }
     ScriptController& script() { return m_script; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4567,6 +4567,16 @@ void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
     commonVM().performOpportunisticallyScheduledTasks(deadline, options);
 }
 
+CheckedRef<ProgressTracker> Page::checkedProgress()
+{
+    return m_progress.get();
+}
+
+CheckedRef<const ProgressTracker> Page::checkedProgress() const
+{
+    return m_progress.get();
+}
+
 String Page::sceneIdentifier() const
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -408,8 +408,12 @@ public:
     WEBCORE_EXPORT void settingsDidChange();
 
     Settings& settings() const { return *m_settings; }
+
     ProgressTracker& progress() { return m_progress.get(); }
     const ProgressTracker& progress() const { return m_progress.get(); }
+    CheckedRef<ProgressTracker> checkedProgress();
+    CheckedRef<const ProgressTracker> checkedProgress() const;
+
     void progressEstimateChanged(LocalFrame&) const;
     void progressFinished(LocalFrame&) const;
     BackForwardController& backForward() { return m_backForwardController.get(); }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -149,7 +149,7 @@ void WKBundleFrameClearOpener(WKBundleFrameRef frameRef)
 {
     auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (coreFrame)
-        coreFrame->loader().setOpener(0);
+        coreFrame->loader().setOpener(nullptr);
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -823,8 +823,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     }
 
     if (parameters.isProcessSwap && parameters.openerFrameIdentifier) {
-        if (auto* openerFrame = WebProcess::singleton().webFrame(*parameters.openerFrameIdentifier)) {
-            if (auto* coreMainFrame = m_mainFrame->coreLocalFrame())
+        if (RefPtr openerFrame = WebProcess::singleton().webFrame(*parameters.openerFrameIdentifier)) {
+            if (RefPtr coreMainFrame = m_mainFrame->coreLocalFrame())
                 coreMainFrame->loader().setOpener(openerFrame->coreRemoteFrame());
             else
                 ASSERT_NOT_REACHED();

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2214,7 +2214,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     auto coreFrame = _private->coreFrame;
     if (coreFrame)
-        coreFrame->loader().setOpener(0);
+        coreFrame->loader().setOpener(nullptr);
 }
 
 - (BOOL)hasRichlyEditableDragCaret


### PR DESCRIPTION
#### af1e21c6dbceb40a1b3c4b55578e614bbf28ed22
<pre>
Adopt smart pointers in FrameLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=263796">https://bugs.webkit.org/show_bug.cgi?id=263796</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitIfPossible):
* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::Frame::protectedOwnerElement const):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::openURLExternally):
* Source/WebCore/loader/FormState.cpp:
(WebCore::FormState::protectedSourceDocument const):
* Source/WebCore/loader/FormState.h:
* Source/WebCore/loader/FrameLoadRequest.cpp:
(WebCore::FrameLoadRequest::FrameLoadRequest):
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::FrameLoadRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::ForbidPromptsScope::ForbidPromptsScope):
(WebCore::ForbidPromptsScope::~ForbidPromptsScope):
(WebCore::ForbidSynchronousLoadsScope::ForbidSynchronousLoadsScope):
(WebCore::ForbidSynchronousLoadsScope::~ForbidSynchronousLoadsScope):
(WebCore::FrameLoader::FrameProgressTracker::FrameProgressTracker):
(WebCore::FrameLoader::FrameProgressTracker::~FrameProgressTracker):
(WebCore::FrameLoader::FrameProgressTracker::progressStarted):
(WebCore::FrameLoader::FrameProgressTracker::progressCompleted):
(WebCore::FrameLoader::frame const):
(WebCore::FrameLoader::protectedFrame const):
(WebCore::FrameLoader::detachFromAllOpenedFrames):
(WebCore::FrameLoader::init):
(WebCore::FrameLoader::initForSynthesizedDocument):
(WebCore::FrameLoader::pageID const):
(WebCore::FrameLoader::frameID const):
(WebCore::FrameLoader::setDefersLoading):
(WebCore::FrameLoader::shouldUpgradeRequestforHTTPSOnly const):
(WebCore::FrameLoader::changeLocation):
(WebCore::FrameLoader::submitForm):
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::stop):
(WebCore::FrameLoader::closeURL):
(WebCore::FrameLoader::didOpenURL):
(WebCore::FrameLoader::didExplicitOpen):
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::receivedFirstData):
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::finishedParsing):
(WebCore::FrameLoader::allChildrenAreComplete const):
(WebCore::FrameLoader::allAncestorsAreComplete const):
(WebCore::FrameLoader::checkCompleted):
(WebCore::FrameLoader::checkCompletenessNow):
(WebCore::FrameLoader::checkCallImplicitClose):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::loadArchive):
(WebCore::FrameLoader::outgoingReferrer const):
(WebCore::FrameLoader::outgoingOrigin const):
(WebCore::FrameLoader::checkIfFormActionAllowedByCSP const):
(WebCore::FrameLoader::setOpener):
(WebCore::FrameLoader::provisionalLoadStarted):
(WebCore::FrameLoader::updateFirstPartyForCookies):
(WebCore::FrameLoader::setFirstPartyForCookies):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::completed):
(WebCore::FrameLoader::started):
(WebCore::FrameLoader::prepareForLoadStart):
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::isNavigationAllowed const):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::defaultSubstituteDataForURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::reloadWithOverrideEncoding):
(WebCore::FrameLoader::reload):
(WebCore::FrameLoader::stopAllLoaders):
(WebCore::FrameLoader::stopForBackForwardCache):
(WebCore::FrameLoader::stopForUserCancel):
(WebCore::FrameLoader::setDocumentLoader):
(WebCore::FrameLoader::setPolicyDocumentLoader):
(WebCore::FrameLoader::setProvisionalDocumentLoader):
(WebCore::FrameLoader::setState):
(WebCore::FrameLoader::provisionalLoadFailedInAnotherProcess):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::transitionToCommitted):
(WebCore::FrameLoader::closeOldDataSources):
(WebCore::FrameLoader::willRestoreFromCachedPage):
(WebCore::FrameLoader::open):
(WebCore::FrameLoader::subframeIsLoading const):
(WebCore::FrameLoader::subresourceCachePolicy const):
(WebCore::FrameLoader::handleLoadFailureRecovery):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::setOriginalURLForDownloadRequest):
(WebCore::FrameLoader::didReachLayoutMilestone):
(WebCore::FrameLoader::didFirstLayout):
(WebCore::FrameLoader::restoreScrollPositionAndViewStateSoon):
(WebCore::FrameLoader::didReachVisuallyNonEmptyState):
(WebCore::FrameLoader::detachChildren):
(WebCore::FrameLoader::closeAndRemoveChild):
(WebCore::FrameLoader::checkLoadComplete):
(WebCore::FrameLoader::numPendingOrLoadingRequests const):
(WebCore::FrameLoader::userAgent const):
(WebCore::FrameLoader::navigatorPlatform const):
(WebCore::FrameLoader::frameDetached):
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::scheduleRefreshIfNeeded):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::receivedMainResourceError):
(WebCore::FrameLoader::continueFragmentScrollAfterNavigationPolicy):
(WebCore::FrameLoader::shouldPerformFragmentNavigation):
(WebCore::FrameLoader::scrollToFragmentWithParentBoundary):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::dispatchUnloadEvents):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::executeJavaScriptURL):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::FrameLoader::loadedResourceFromMemoryCache):
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::shouldTreatURLAsSameAsCurrent const):
(WebCore::FrameLoader::shouldTreatURLAsSrcdocDocument const):
(WebCore::FrameLoader::findFrameForNavigation):
(WebCore::FrameLoader::loadSameDocumentItem):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::effectiveReferrerPolicy const):
(WebCore::FrameLoader::dispatchDidClearWindowObjectsInAllWorlds):
(WebCore::FrameLoader::dispatchDidClearWindowObjectInWorld):
(WebCore::FrameLoader::effectiveSandboxFlags const):
(WebCore::FrameLoader::didChangeTitle):
(WebCore::FrameLoader::dispatchDidCommitLoad):
(WebCore::FrameLoader::tellClientAboutPastMemoryCacheLoads):
(WebCore::FrameLoader::loadProgressingStatusChanged):
(WebCore::createWindow):
(WebCore::FrameLoader::switchBrowsingContextsGroup):
(WebCore::FrameLoader::shouldSuppressTextInputFromEditing const):
(WebCore::FrameLoader::protectedProvisionalDocumentLoader const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::protectedWindowProxy const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::checkedProgress):
(WebCore::Page::checkedProgress const):
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameClearOpener):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _clearOpener]):

Canonical link: <a href="https://commits.webkit.org/269901@main">https://commits.webkit.org/269901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d70adb3f4ee776f9d0c34eb6178a106a88dda2e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22599 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26733 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27895 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25686 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19018 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1750 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3060 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->