### PR TITLE
Add convenience option to enable/disable all Debug JITCode validations.

### DIFF
--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -107,6 +107,8 @@ void AssemblyHelpers::clearSamplingFlag(int32_t flag)
 #if USE(JSVALUE64)
 void AssemblyHelpers::jitAssertIsInt32(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
 #if CPU(X86_64) || CPU(ARM64)
     Jump checkInt32 = branch64(BelowOrEqual, gpr, TrustedImm64(static_cast<uintptr_t>(0xFFFFFFFFu)));
     abortWithReason(AHIsNotInt32);
@@ -118,6 +120,8 @@ void AssemblyHelpers::jitAssertIsInt32(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertIsJSInt32(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkJSInt32 = branch64(AboveOrEqual, gpr, GPRInfo::numberTagRegister);
     abortWithReason(AHIsNotJSInt32);
     checkJSInt32.link(this);
@@ -125,6 +129,8 @@ void AssemblyHelpers::jitAssertIsJSInt32(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertIsJSNumber(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkJSNumber = branchTest64(MacroAssembler::NonZero, gpr, GPRInfo::numberTagRegister);
     abortWithReason(AHIsNotJSNumber);
     checkJSNumber.link(this);
@@ -132,6 +138,8 @@ void AssemblyHelpers::jitAssertIsJSNumber(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertIsJSDouble(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkJSInt32 = branch64(AboveOrEqual, gpr, GPRInfo::numberTagRegister);
     Jump checkJSNumber = branchTest64(MacroAssembler::NonZero, gpr, GPRInfo::numberTagRegister);
     checkJSInt32.link(this);
@@ -141,6 +149,8 @@ void AssemblyHelpers::jitAssertIsJSDouble(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertIsCell(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkCell = branchTest64(MacroAssembler::Zero, gpr, GPRInfo::notCellMaskRegister);
     abortWithReason(AHIsNotCell);
     checkCell.link(this);
@@ -148,6 +158,8 @@ void AssemblyHelpers::jitAssertIsCell(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertTagsInPlace()
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump ok = branch64(Equal, GPRInfo::numberTagRegister, TrustedImm64(JSValue::NumberTag));
     abortWithReason(AHNumberTagNotInPlace);
     breakpoint();
@@ -160,11 +172,15 @@ void AssemblyHelpers::jitAssertTagsInPlace()
 #elif USE(JSVALUE32_64)
 void AssemblyHelpers::jitAssertIsInt32(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     UNUSED_PARAM(gpr);
 }
 
 void AssemblyHelpers::jitAssertIsJSInt32(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkJSInt32 = branch32(Equal, gpr, TrustedImm32(JSValue::Int32Tag));
     abortWithReason(AHIsNotJSInt32);
     checkJSInt32.link(this);
@@ -172,6 +188,8 @@ void AssemblyHelpers::jitAssertIsJSInt32(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertIsJSNumber(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkJSInt32 = branch32(Equal, gpr, TrustedImm32(JSValue::Int32Tag));
     Jump checkJSDouble = branch32(Below, gpr, TrustedImm32(JSValue::LowestTag));
     abortWithReason(AHIsNotJSNumber);
@@ -181,6 +199,8 @@ void AssemblyHelpers::jitAssertIsJSNumber(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertIsJSDouble(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkJSDouble = branch32(Below, gpr, TrustedImm32(JSValue::LowestTag));
     abortWithReason(AHIsNotJSDouble);
     checkJSDouble.link(this);
@@ -188,6 +208,8 @@ void AssemblyHelpers::jitAssertIsJSDouble(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertIsCell(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkCell = branchIfCell(gpr);
     abortWithReason(AHIsNotCell);
     checkCell.link(this);
@@ -195,11 +217,15 @@ void AssemblyHelpers::jitAssertIsCell(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertTagsInPlace()
 {
+    if (!Options::useJITAsserts())
+        return;
 }
 #endif // USE(JSVALUE32_64)
 
 void AssemblyHelpers::jitAssertHasValidCallFrame()
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkCFR = branchTestPtr(Zero, GPRInfo::callFrameRegister, TrustedImm32(7));
     abortWithReason(AHCallFrameMisaligned);
     checkCFR.link(this);
@@ -207,6 +233,8 @@ void AssemblyHelpers::jitAssertHasValidCallFrame()
 
 void AssemblyHelpers::jitAssertIsNull(GPRReg gpr)
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump checkNull = branchTestPtr(Zero, gpr);
     abortWithReason(AHIsNotNull);
     checkNull.link(this);
@@ -214,6 +242,8 @@ void AssemblyHelpers::jitAssertIsNull(GPRReg gpr)
 
 void AssemblyHelpers::jitAssertArgumentCountSane()
 {
+    if (!Options::useJITAsserts())
+        return;
     Jump ok = branch32(Below, payloadFor(CallFrameSlot::argumentCountIncludingThis), TrustedImm32(10000000));
     abortWithReason(AHInsaneArgumentCount);
     ok.link(this);
@@ -221,6 +251,8 @@ void AssemblyHelpers::jitAssertArgumentCountSane()
 
 void AssemblyHelpers::jitAssertCodeBlockOnCallFrameWithType(GPRReg scratchGPR, JITType type)
 {
+    if (!Options::useJITAsserts())
+        return;
     JIT_COMMENT(*this, "jitAssertCodeBlockOnCallFrameWithType | ", scratchGPR, " = callFrame->codeBlock->jitCode->jitType == ", type);
     emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, scratchGPR);
     loadPtr(Address(scratchGPR, CodeBlock::jitCodeOffset()), scratchGPR);
@@ -232,6 +264,8 @@ void AssemblyHelpers::jitAssertCodeBlockOnCallFrameWithType(GPRReg scratchGPR, J
 
 void AssemblyHelpers::jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame(GPRReg scratchGPR, GPRReg scratchGPR2, UnlinkedCodeBlock& block)
 {
+    if (!Options::useJITAsserts())
+        return;
     if (block.codeType() != FunctionCode)
         return;
     auto kind = block.isConstructor() ? CodeForConstruct : CodeForCall;
@@ -254,6 +288,8 @@ void AssemblyHelpers::jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame
 
 void AssemblyHelpers::jitAssertCodeBlockOnCallFrameIsOptimizingJIT(GPRReg scratchGPR)
 {
+    if (!Options::useJITAsserts())
+        return;
     emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, scratchGPR);
     loadPtr(Address(scratchGPR, CodeBlock::jitCodeOffset()), scratchGPR);
     load8(Address(scratchGPR, JITCode::offsetOfJITType()), scratchGPR);

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3938,6 +3938,17 @@ void CommandLine::parseArguments(int argc, char** argv)
             continue;
         }
 
+        static const unsigned useJITCodeValidationsStrLength = strlen("--useJITCodeValidations=");
+        if (!strncmp(arg, "--useJITCodeValidations=", useJITCodeValidationsStrLength)) {
+            const char* valueStr = argv[i] + useJITCodeValidationsStrLength;
+            bool success = Options::setAllJITCodeValidations(valueStr);
+            if (!success) {
+                hasBadJSCOptions = true;
+                dataLogLn("ERROR: invalid value for --useJITCodeValidations: ", valueStr);
+            }
+            continue;
+        }
+
         // See if the -- option is a JSC VM option.
         if (strstr(arg, "--") == arg) {
             if (!JSC::Options::setOption(&arg[2], /* verify = */ false)) {

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -586,6 +586,23 @@ static void overrideDefaults()
     }
 }
 
+bool Options::setAllJITCodeValidations(const char* valueStr)
+{
+    auto value = parse<OptionsStorage::Bool>(valueStr);
+    if (!value)
+        return false;
+    setAllJITCodeValidations(value.value());
+    return true;
+}
+
+void Options::setAllJITCodeValidations(bool value)
+{
+    Options::validateDFGClobberize() = value;
+    Options::validateDFGExceptionHandling() = value;
+    Options::validateDoesGC() = value;
+    Options::useJITAsserts() = value;
+}
+
 static inline void disableAllJITOptions()
 {
     Options::useLLInt() = true;
@@ -653,9 +670,6 @@ void Options::notifyOptionsChanged()
     if (thresholdForGlobalLexicalBindingEpoch == 0 || thresholdForGlobalLexicalBindingEpoch == 1)
         Options::thresholdForGlobalLexicalBindingEpoch() = UINT_MAX;
 
-#if !defined(NDEBUG)
-    Options::validateDFGExceptionHandling() = true;
-#endif
 #if !ENABLE(JIT)
     Options::useJIT() = false;
 #endif

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -106,6 +106,8 @@ public:
     JS_EXPORT_PRIVATE static void initialize();
     static void finalize();
 
+    JS_EXPORT_PRIVATE static bool setAllJITCodeValidations(const char* arg);
+
     // Parses a string of options where each option is of the format "--<optionName>=<value>"
     // and are separated by a space. The leading "--" is optional and will be ignored.
     JS_EXPORT_PRIVATE static bool setOptions(const char* optionsList);
@@ -151,6 +153,8 @@ private:
 #if !PLATFORM(COCOA)
     static bool overrideAliasedOptionWithHeuristic(const char* name);
 #endif
+
+    static void setAllJITCodeValidations(bool);
 
     static bool defaultTCSMValue();
     static unsigned computeNumberOfGCMarkers(unsigned maxNumberOfGCMarkers);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -166,6 +166,7 @@ bool canUseHandlerIC();
     v(Bool, verboseFTLCompilation, false, Normal, nullptr) \
     v(Bool, logCompilationChanges, false, Normal, nullptr) \
     v(Bool, printEachOSRExit, false, Normal, nullptr) \
+    v(Bool, useJITAsserts, ASSERT_ENABLED, Normal, nullptr) \
     v(Bool, validateDoesGC, ASSERT_ENABLED, Normal, nullptr) \
     v(Bool, validateGraph, false, Normal, nullptr) \
     v(Bool, validateGraphAtEachPhase, false, Normal, nullptr) \
@@ -411,7 +412,7 @@ bool canUseHandlerIC();
     v(Bool, exitOnResourceExhaustion, false, Normal, nullptr) \
     v(Bool, useExceptionFuzz, false, Normal, nullptr) \
     v(Unsigned, fireExceptionFuzzAt, 0, Normal, nullptr) \
-    v(Bool, validateDFGExceptionHandling, false, Normal, "Causes the DFG to emit code validating exception handling for each node that can exit") /* This is true by default on Debug builds */\
+    v(Bool, validateDFGExceptionHandling, ASSERT_ENABLED, Normal, "Causes the DFG to emit code validating exception handling for each node that can exit") \
     v(Bool, dumpSimulatedThrows, false, Normal, "Dumps the call stack of the last simulated throw if exception scope verification fails") \
     v(Bool, validateExceptionChecks, false, Normal, "Verifies that needed exception checks are performed.") \
     v(Unsigned, unexpectedExceptionStackTraceLimit, 100, Normal, "Stack trace limit for debugging unexpected exceptions observed in the VM") \


### PR DESCRIPTION
#### 77b974f043d5faa8e9929c7dbc4a690b2c26517c
<pre>
Add convenience option to enable/disable all Debug JITCode validations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263811">https://bugs.webkit.org/show_bug.cgi?id=263811</a>
rdar://117609282

Reviewed by Justin Michaud.

Sometimes, we just want to have the debuggability of a Debug build without all the JITCode
validations cluttering up the generated code.  Conversely, sometimes, we want all the
available validations enabled for a Release build test run.  We should have a jsc shell
convenience option to toggle all the JITCode validation options on or off.

What changed?
1. Added a Options::useJITAsserts() to allow us to disable all jitAssertXXX code emissions.
2. Changed Options::validateDFGExceptionHandling() to not be forced on for Debug builds.
3. Added a --useJITCodeValidations=&lt;bool value&gt; option to the jsc shell to enable/disable
   Options::useJITAsserts() and all JITCode validation codegen options.

* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::jitAssertIsInt32):
(JSC::AssemblyHelpers::jitAssertIsJSInt32):
(JSC::AssemblyHelpers::jitAssertIsJSNumber):
(JSC::AssemblyHelpers::jitAssertIsJSDouble):
(JSC::AssemblyHelpers::jitAssertIsCell):
(JSC::AssemblyHelpers::jitAssertTagsInPlace):
(JSC::AssemblyHelpers::jitAssertHasValidCallFrame):
(JSC::AssemblyHelpers::jitAssertIsNull):
(JSC::AssemblyHelpers::jitAssertArgumentCountSane):
(JSC::AssemblyHelpers::jitAssertCodeBlockOnCallFrameWithType):
(JSC::AssemblyHelpers::jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame):
(JSC::AssemblyHelpers::jitAssertCodeBlockOnCallFrameIsOptimizingJIT):
* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::setAllJITCodeValidations):
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/Options.h:
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/269879@main">https://commits.webkit.org/269879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58c44d0b7578836687a5060f8857719c69e7f187

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26069 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3650 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/24414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1573 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26658 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/21590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/20805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25618 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23238 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/24414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30637 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1289 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6728 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30596 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3056 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1617 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6397 "Passed tests") | 
<!--EWS-Status-Bubble-End-->