### PR TITLE
[WebGPU] Using the stencil reference value as the stencil clear value fails when the reference value is greater than 255

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/render_pass/clear_value-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/render_pass/clear_value-expected.txt
@@ -1,1 +1,36 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :stored:
+PASS :loaded:
+PASS :srgb:
+PASS :layout:
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=0;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=0;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=1;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=1;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=255;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=255;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=258;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=258;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=65539;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="stencil8";stencilClearValue=65539;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=0;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=0;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=1;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=1;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=255;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=255;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=258;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=258;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=65539;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth24plus-stencil8";stencilClearValue=65539;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=0;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=0;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=1;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=1;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=255;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=255;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=258;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=258;applyStencilClearValueAsStencilReferenceValue=false
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=65539;applyStencilClearValueAsStencilReferenceValue=true
+PASS :stencil_clear_value:stencilFormat="depth32float-stencil8";stencilClearValue=65539;applyStencilClearValueAsStencilReferenceValue=false
+

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -320,7 +320,7 @@ void RenderPassEncoder::setScissorRect(uint32_t x, uint32_t y, uint32_t width, u
 
 void RenderPassEncoder::setStencilReference(uint32_t reference)
 {
-    [m_renderCommandEncoder setStencilReferenceValue:reference];
+    [m_renderCommandEncoder setStencilReferenceValue:(reference & 0xFF)];
 }
 
 void RenderPassEncoder::setVertexBuffer(uint32_t slot, const Buffer& buffer, uint64_t offset, uint64_t size)


### PR DESCRIPTION
#### c571e2a7ad862776ebd54bbd46a351e022526a07
<pre>
[WebGPU] Using the stencil reference value as the stencil clear value fails when the reference value is greater than 255
<a href="https://bugs.webkit.org/show_bug.cgi?id=263812">https://bugs.webkit.org/show_bug.cgi?id=263812</a>
&lt;radar://117610399&gt;

Reviewed by Tadeu Zagallo.

The stencil value is masked to the max value in the stencil buffer.

All of our stencil formats are 8 bits and that is not likely to change
as stencil formats have not changed in more than ten years, so mask with 255.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/render_pass/clear_value-expected.txt:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setStencilReference):

Canonical link: <a href="https://commits.webkit.org/269957@main">https://commits.webkit.org/269957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dcb8a11c4881bce1616e1ec48f78daf8951cece

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22046 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22546 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26659 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27822 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18961 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1290 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->