### PR TITLE
[iOS] Stop conforming to private UIKit ObjC protocols when "Async UIKit Interactions" is enabled

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1667,3 +1667,7 @@
 #if !PLATFORM(APPLETV) && !PLATFORM(WATCHOS) && __has_include(<UIKit/_UITextCursorDragAnimator.h>)
 #define HAVE_UI_TEXT_CURSOR_DRAG_ANIMATOR 1
 #endif
+
+#if __has_include(<UIKit/UIAsyncTextInteraction.h>)
+#define HAVE_UI_ASYNC_TEXT_INTERACTION 1
+#endif

--- a/Source/WebCore/platform/ios/WebEvent.mm
+++ b/Source/WebCore/platform/ios/WebEvent.mm
@@ -46,7 +46,7 @@ using WebCore::windowsKeyCodeForKeyCode;
 using WebCore::windowsKeyCodeForCharCode;
 
 @implementation WebEvent {
-#if HAVE(UI_ASYNC_TEXT_INPUT)
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
     RetainPtr<UIKeyEvent> _originalUIKeyEvent;
 #endif
 }
@@ -493,7 +493,7 @@ static NSString *normalizedStringWithAppKitCompatibilityMapping(NSString *charac
 
 @end
 
-#if HAVE(UI_ASYNC_TEXT_INPUT)
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
 
 @implementation WebEvent (UIAsyncTextInputSupport)
 
@@ -553,6 +553,6 @@ static inline WebEventFlags webEventModifierFlags(UIKeyModifierFlags flags)
 
 @end
 
-#endif // HAVE(UI_ASYNC_TEXT_INPUT)
+#endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/ios/WebEventPrivate.h
+++ b/Source/WebCore/platform/ios/WebEventPrivate.h
@@ -27,7 +27,7 @@
 
 #import <WebCore/WebEvent.h>
 
-#if HAVE(UI_ASYNC_TEXT_INPUT)
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
 
 @class UIKeyEvent;
 
@@ -38,4 +38,4 @@
 
 @end
 
-#endif // HAVE(UI_ASYNC_TEXT_INPUT)
+#endif // HAVE(UI_ASYNC_TEXT_INTERACTION)

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -118,7 +118,7 @@
 #import <UIKit/_UITextDragCaretView.h>
 #endif
 
-#if HAVE(UI_ASYNC_TEXT_INPUT)
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
 #import <UIKit/UIAsyncTextInput.h>
 #import <UIKit/UIKeyEventContext.h>
 #endif
@@ -713,11 +713,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 @class UIWKDocumentContext;
 
 @protocol UIWKInteractionViewProtocol
-#if HAVE(UI_WK_DOCUMENT_CONTEXT)
-- (void)adjustSelectionWithDelta:(NSRange)deltaRange completionHandler:(void (^)(void))completionHandler;
-- (void)requestDocumentContext:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
-- (void)selectPositionAtPoint:(CGPoint)point withContextRequest:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
-#endif
 
 - (void)changeSelectionWithGestureAt:(CGPoint)point withGesture:(UIWKGestureType)gestureType withState:(UIGestureRecognizerState)state;
 - (void)changeSelectionWithTouchAt:(CGPoint)point withSelectionTouch:(UIWKSelectionTouch)touch baseIsStart:(BOOL)baseIsStart withFlags:(UIWKSelectionFlags)flags;
@@ -728,8 +723,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (void)requestAutocorrectionContextWithCompletionHandler:(void (^)(UIWKAutocorrectionContext *autocorrectionContext))completionHandler;
 
 - (void)requestAutocorrectionRectsForString:(NSString *)input withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForInput))completionHandler;
-
-- (void)applyAutocorrection:(NSString *)correction toString:(NSString *)input withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForCorrection))completionHandler;
 
 - (NSString *)markedText;
 - (BOOL)hasMarkedText;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -69,14 +69,9 @@
 - (void)_focusTextInputContext:(_WKTextInputContext *)context placeCaretAt:(CGPoint)point completionHandler:(void (^)(UIResponder<UITextInput> *))completionHandler;
 - (void)_willBeginTextInteractionInTextInputContext:(_WKTextInputContext *)context;
 - (void)_didFinishTextInteractionInTextInputContext:(_WKTextInputContext *)context;
-- (void)_requestDocumentContext:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
-- (void)_adjustSelectionWithDelta:(NSRange)deltaRange completionHandler:(void (^)(void))completionHandler;
 - (void)setTimePickerValueToHour:(NSInteger)hour minute:(NSInteger)minute;
 - (double)timePickerValueHour;
 - (double)timePickerValueMinute;
-
-- (void)applyAutocorrection:(NSString *)newString toString:(NSString *)oldString withCompletionHandler:(void (^)(void))completionHandler;
-- (void)applyAutocorrection:(NSString *)newString toString:(NSString *)oldString isCandidate:(BOOL)isCandidate withCompletionHandler:(void (^)(void))completionHandler;
 
 - (NSDictionary *)_propertiesOfLayerWithID:(unsigned long long)layerID;
 - (void)_simulateElementAction:(_WKElementActionType)actionType atLocation:(CGPoint)location;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -97,24 +97,6 @@ static void dumpSeparatedLayerProperties(TextStream&, CALayer *) { }
     [_contentView _didFinishTextInteractionInTextInputContext:context];
 }
 
-- (void)_requestDocumentContext:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler
-{
-#if HAVE(UI_WK_DOCUMENT_CONTEXT)
-    [_contentView requestDocumentContext:request completionHandler:completionHandler];
-#else
-    completionHandler(nil);
-#endif
-}
-
-- (void)_adjustSelectionWithDelta:(NSRange)deltaRange completionHandler:(void (^)(void))completionHandler
-{
-#if HAVE(UI_WK_DOCUMENT_CONTEXT)
-    [_contentView adjustSelectionWithDelta:deltaRange completionHandler:completionHandler];
-#else
-    completionHandler();
-#endif
-}
-
 - (BOOL)_mayContainEditableElementsInRect:(CGRect)rect
 {
 #if ENABLE(EDITABLE_REGION)
@@ -133,21 +115,6 @@ static void dumpSeparatedLayerProperties(TextStream&, CALayer *) { }
 {
     [_contentView accessoryTab:NO];
 }
-
-- (void)applyAutocorrection:(NSString *)newString toString:(NSString *)oldString withCompletionHandler:(void (^)(void))completionHandler
-{
-    [_contentView applyAutocorrection:newString toString:oldString withCompletionHandler:[capturedCompletionHandler = makeBlockPtr(completionHandler)] (UIWKAutocorrectionRects *rects) {
-        capturedCompletionHandler();
-    }];
-}
-
-- (void)applyAutocorrection:(NSString *)newString toString:(NSString *)oldString isCandidate:(BOOL)isCandidate withCompletionHandler:(void (^)(void))completionHandler
-{
-    [_contentView applyAutocorrection:newString toString:oldString isCandidate:isCandidate withCompletionHandler:[capturedCompletionHandler = makeBlockPtr(completionHandler)] (UIWKAutocorrectionRects *rects) {
-        capturedCompletionHandler();
-    }];
-}
-
 
 - (void)dismissFormAccessoryView
 {

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -203,6 +203,9 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 
     _page = processPool.createWebPage(*_pageClient, WTFMove(configuration));
     _page->initializeWebPage();
+
+    [self _updateRuntimeProtocolConformanceIfNeeded];
+
     _page->setIntrinsicDeviceScaleFactor(WebCore::screenScaleFactor([UIScreen mainScreen]));
     _page->setUseFixedLayout(true);
     _page->setScreenIsBeingCaptured([[[self window] screen] isCaptured]);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -559,14 +559,14 @@ struct ImageAnalysisContextMenuActionData {
     WebCore::FloatRect _imageAnalysisInteractionBounds;
     std::optional<WebKit::RemoveBackgroundData> _removeBackgroundData;
 #endif
-#if HAVE(UI_ASYNC_TEXT_INPUT)
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
     __weak id<UIAsyncTextInputDelegate> _asyncSystemInputDelegate;
 #endif
 }
 
 @end
 
-@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextAutoscrolling, UITextInputMultiDocument, UITextInputPrivate, WKFormAccessoryViewDelegate, WKTouchEventsGestureRecognizerDelegate, UIWKInteractionViewProtocol, _UITextInputTranslationSupport, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
+@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextInput, WKFormAccessoryViewDelegate, WKTouchEventsGestureRecognizerDelegate, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
 #if HAVE(CONTACTSUI)
     , WKContactPickerDelegate
 #endif
@@ -574,7 +574,7 @@ struct ImageAnalysisContextMenuActionData {
     , WKShareSheetDelegate
 #endif
 #if ENABLE(DRAG_SUPPORT)
-    , UIDragInteractionDelegate, UIDropInteractionDelegate
+    , UIDropInteractionDelegate
 #endif
     , WKTouchActionGestureRecognizerDelegate
 #if HAVE(UIFINDINTERACTION)
@@ -585,6 +585,8 @@ struct ImageAnalysisContextMenuActionData {
 #endif
 #if HAVE(UI_ASYNC_DRAG_INTERACTION)
     , _UIAsyncDragInteractionDelegate
+#elif ENABLE(DRAG_SUPPORT)
+    , UIDragInteractionDelegate
 #endif
 >
 
@@ -608,6 +610,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly) CGRect tapHighlightViewRect;
 @property (nonatomic, readonly) UIGestureRecognizer *imageAnalysisGestureRecognizer;
 @property (nonatomic, readonly, getter=isKeyboardScrollingAnimationRunning) BOOL keyboardScrollingAnimationRunning;
+@property (nonatomic, readonly) UIView *unscaledView;
 
 #if ENABLE(DATALIST_ELEMENT)
 @property (nonatomic, strong) UIView <WKFormControl> *dataListTextSuggestionsInputView;
@@ -761,6 +764,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_didEnterFullscreen;
 - (void)_didExitFullscreen;
 #endif
+
+- (void)_updateRuntimeProtocolConformanceIfNeeded;
 
 - (void)_requestTextInputContextsInRect:(CGRect)rect completionHandler:(void (^)(NSArray<_WKTextInputContext *> *))completionHandler;
 - (void)_focusTextInputContext:(_WKTextInputContext *)context placeCaretAt:(CGPoint)point completionHandler:(void (^)(UIResponder<UITextInput> *))completionHandler;

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -242,6 +242,15 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (BOOL)textInteractionGesture:(UIWKGestureType)gesture shouldBeginAtPoint:(CGPoint)point;
 - (void)replaceDictatedText:(NSString *)oldText withText:(NSString *)newText;
 - (NSArray<NSTextAlternatives *> *)alternativesForSelectedText;
+
+- (void)applyAutocorrection:(NSString *)correction toString:(NSString *)input shouldUnderline:(BOOL)shouldUnderline withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForCorrection))completionHandler;
+
+#if HAVE(UI_WK_DOCUMENT_CONTEXT)
+- (void)requestDocumentContext:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
+- (void)adjustSelectionWithDelta:(NSRange)deltaRange completionHandler:(void (^)(void))completionHandler;
+- (void)selectPositionAtPoint:(CGPoint)point withContextRequest:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
+#endif
+
 @property (nonatomic, readonly) NSString *selectedText;
 
 @optional

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -150,7 +150,7 @@ static UIWKDocumentRequest *makeRequest(UIWKDocumentRequestFlags flags, UITextGr
 {
     __block bool finished = false;
     __block RetainPtr<UIWKDocumentContext> result;
-    [self _requestDocumentContext:request completionHandler:^(UIWKDocumentContext *context) {
+    [self.textInputContentView requestDocumentContext:request completionHandler:^(UIWKDocumentContext *context) {
         result = context;
         finished = true;
     }];
@@ -161,7 +161,7 @@ static UIWKDocumentRequest *makeRequest(UIWKDocumentRequestFlags flags, UITextGr
 - (void)synchronouslyAdjustSelectionWithDelta:(NSRange)range
 {
     __block bool finished = false;
-    [self _adjustSelectionWithDelta:range completionHandler:^() {
+    [self.textInputContentView adjustSelectionWithDelta:range completionHandler:^{
         finished = true;
     }];
     TestWebKitAPI::Util::run(&finished);
@@ -1568,7 +1568,7 @@ TEST(DocumentEditingContext, RequestAutocorrectedRanges)
     [webView waitForNextPresentationUpdate];
 
     __block bool appliedAutocorrection = false;
-    [webView applyAutocorrection:@"San Francisco" toString:@"sanfrancisco" isCandidate:YES withCompletionHandler:^{
+    [[webView textInputContentView] applyAutocorrection:@"San Francisco" toString:@"sanfrancisco" shouldUnderline:YES withCompletionHandler:^(UIWKAutocorrectionRects *) {
         appliedAutocorrection = true;
     }];
 
@@ -1584,7 +1584,7 @@ TEST(DocumentEditingContext, RequestAutocorrectedRanges)
     [contentView insertText:@" atfer"];
 
     appliedAutocorrection = false;
-    [webView applyAutocorrection:@"after" toString:@"atfer" isCandidate:YES withCompletionHandler:^{
+    [[webView textInputContentView] applyAutocorrection:@"after" toString:@"atfer" shouldUnderline:YES withCompletionHandler:^(UIWKAutocorrectionRects *) {
         appliedAutocorrection = true;
     }];
 

--- a/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
@@ -170,7 +170,7 @@ TEST(AutocorrectionTests, AutocorrectionIndicatorsDismissAfterNextWord)
 
     __block bool done = false;
 
-    [webView applyAutocorrection:@"different" toString:@"diferent" isCandidate:YES withCompletionHandler:^{
+    [[webView textInputContentView] applyAutocorrection:@"different" toString:@"diferent" shouldUnderline:YES withCompletionHandler:^(UIWKAutocorrectionRects *) {
         NSString *hasCorrectionIndicatorMarker = [webView stringByEvaluatingJavaScript:hasCorrectionIndicatorMarkerJavaScript];
         EXPECT_WK_STREQ("1", hasCorrectionIndicatorMarker);
         done = true;
@@ -212,7 +212,7 @@ TEST(AutocorrectionTests, AutocorrectionIndicatorsMultiWord)
 
     __block bool done = false;
 
-    [webView applyAutocorrection:@"tomorrow night" toString:@"tomorrownight" isCandidate:YES withCompletionHandler:^{
+    [[webView textInputContentView] applyAutocorrection:@"tomorrow night" toString:@"tomorrownight" shouldUnderline:YES withCompletionHandler:^(UIWKAutocorrectionRects *) {
         NSString *hasCorrectionIndicatorMarker = [webView stringByEvaluatingJavaScript:hasCorrectionIndicatorMarkerJavaScript];
         EXPECT_WK_STREQ("1", hasCorrectionIndicatorMarker);
         done = true;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -835,8 +835,8 @@ void UIScriptControllerIOS::applyAutocorrection(JSStringRef newString, JSStringR
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
-    TestRunnerWKWebView *webView = this->webView();
-    [webView applyAutocorrection:toWTFString(newString) toString:toWTFString(oldString) withCompletionHandler:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    auto contentView = static_cast<id<UIWKInteractionViewProtocol>>(platformContentView());
+    [contentView applyAutocorrection:toWTFString(newString) toString:toWTFString(oldString) shouldUnderline:NO withCompletionHandler:makeBlockPtr([this, strongThis = Ref { *this }, callbackID](UIWKAutocorrectionRects *) {
         dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
             // applyAutocorrection can call its completion handler synchronously,
             // which makes UIScriptController unhappy (see bug 172884).


### PR DESCRIPTION
#### 00b1201b3e8991387c6b3c15a660c3a29e71d7a6
<pre>
[iOS] Stop conforming to private UIKit ObjC protocols when &quot;Async UIKit Interactions&quot; is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=263813">https://bugs.webkit.org/show_bug.cgi?id=263813</a>
<a href="https://rdar.apple.com/117611037">rdar://117611037</a>

Reviewed by Aditya Keerthi.

Refactor UIKit async interaction support:

•   Rename `HAVE(UI_ASYNC_TEXT_INPUT)` to `HAVE(UI_ASYNC_TEXT_INTERACTION)`, and guard compile-time
    enablement on the availability of `UIAsyncTextInteraction.h`. This allows us to remain source-
    compatible with versions of UIKit that have slightly-older versions of `UIAsyncTextInput.h`,
    that are missing a declaration of `UITextReplacementOptions`.

•   Stop declaring conformance at compile-time to the following 5 SPI protocols, from UIKit:
      • `UIWKInteractionViewProtocol`
      • `UITextInputPrivate`
      • `UITextAutoscrolling`
      • `UITextInputMultiDocument`
      • `UITextInputTranslationSupport`
    ...and instead, conform to these protocols only when the `UseAsyncUIKitInteractions` internal
    preference is disabled.

•   Make this logic run once, immediately upon content view initialization, to limit any risk that
    any logic that depends on the content view conforming to any of these protocols might be broken
    after this refactoring.

This will put us in a position where we can easily test against versions of UIKit that have system
support for `UIAsyncTextInput`, while revealing any interactions or features that might still be
relying on the 5 protocols listed above. It also puts us in a better position to completely remove
reliance on those protocols once the `UseAsyncUIKitInteractions` preference is enabled by default,
simply by removing the logic to establish conformance at runtime.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/platform/ios/WebEvent.mm:
* Source/WebCore/platform/ios/WebEventPrivate.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _requestDocumentContext:completionHandler:]): Deleted.
(-[WKWebView _adjustSelectionWithDelta:completionHandler:]): Deleted.
(-[WKWebView applyAutocorrection:toString:withCompletionHandler:]): Deleted.
(-[WKWebView applyAutocorrection:toString:isCandidate:withCompletionHandler:]): Deleted.
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateRuntimeProtocolConformanceIfNeeded]):
(-[WKContentView setUpInteraction]):
(-[WKContentView _interpretKeyEvent:isCharEvent:]):
(-[WKContentView _ensureBinaryCompatibilityWithAsyncInteractionsIfNeeded]): Deleted.

Rename this to `-_updateRuntimeProtocolConformanceIfNeeded`, to better reflect its new role, now
that it adds protocol conformance to several legacy UIKit protocols at runtime.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::dispatchWheelEventWithoutScrolling):
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:

Move the protocol declarations out of `UIKitSPI.h`, and into `UIKitSPIForTesting.h`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(-[TestWKWebView synchronouslyRequestDocumentContext:]):
(-[TestWKWebView synchronouslyAdjustSelectionWithDelta:]):
* Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::applyAutocorrection):

Adjust some test infrastructure to stop using the deleted testing hooks, and instead just call into
`WKContentView` directly, like most of the other API tests already do.

Canonical link: <a href="https://commits.webkit.org/270027@main">https://commits.webkit.org/270027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff2b78b6db57fa5f1bb0a0be5f3c2d2c83a7cdcf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22559 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26687 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27845 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20829 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25642 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18974 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30662 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1316 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5826 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1707 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30625 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1645 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6407 "Passed tests") | 
<!--EWS-Status-Bubble-End-->