### PR TITLE
jsc_fuz/wktr: null ptr deref in WebCore::ShareDataReader::start(WebCore::Document*, WebCore::ShareDataWithParsedURL&&) + 240 (ShareDataReader.cpp:53)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5153,6 +5153,8 @@ imported/w3c/web-platform-tests/webxr/webxr_availability.http.sub.html [ DumpJSC
 
 http/tests/local/blob/navigate-blob.html [ DumpJSConsoleLogInStdErr ]
 
+http/tests/webshare/navigator-share-files-fail-access-control-checks-crash.html [ DumpJSConsoleLogInStdErr ]
+
 # "Opacity on an inline element should apply on float child".
 webkit.org/b/234690 imported/w3c/web-platform-tests/css/css-color/inline-opacity-float-child.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/http/tests/webshare/navigator-share-files-fail-access-control-checks-crash-expected.txt
+++ b/LayoutTests/http/tests/webshare/navigator-share-files-fail-access-control-checks-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/http/tests/webshare/navigator-share-files-fail-access-control-checks-crash.html
+++ b/LayoutTests/http/tests/webshare/navigator-share-files-fail-access-control-checks-crash.html
@@ -1,0 +1,17 @@
+<p>This test passes if it doesn't crash.</p>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  onload = async () => {
+    internals.withUserGesture(() => { });
+    document.createElement('audio').src = 'data:';
+    location.href = "data:dummy"
+    try {
+      await navigator.serviceWorker.register('x');
+    } catch (e) {
+      $vm.print(e);
+    }
+    navigator.share({ files: [new File([], 'a'), new File([], 'b')] });
+  };
+</script>

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -54,6 +54,10 @@ void ShareDataReader::start(Document* document, ShareDataWithParsedURL&& shareDa
             this->didFinishLoading(count, fileName);
         }));
         m_pendingFileLoads.last()->start(*blob, document, FileReaderLoader::ReadAsArrayBuffer);
+        if (m_pendingFileLoads.isEmpty()) {
+            // The previous load failed synchronously and cancel() was called. We should not attempt to do any further loads.
+            break;
+        }
         ++count;
     }
 }


### PR DESCRIPTION
#### 577579c2ca9159d22ec96469cd168b843222b8fb
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::ShareDataReader::start(WebCore::Document*, WebCore::ShareDataWithParsedURL&amp;&amp;) + 240 (ShareDataReader.cpp:53)
<a href="https://bugs.webkit.org/show_bug.cgi\?id\=263643">https://bugs.webkit.org/show_bug.cgi\?id\=263643</a>
rdar://115059534

Reviewed by Chris Dumez.

Adding empty check for m_pendingFileLoads in case reader has canceled during loop due to error and accessing null ptr.

* LayoutTests/TestExpectations: Exclude console message as this test logging blob url which contains unique UUID generated from each run.
* LayoutTests/http/tests/webshare/navigator-share-files-fail-access-control-checks-crash-expected.txt: Added.
* LayoutTests/http/tests/webshare/navigator-share-files-fail-access-control-checks-crash.html: Added.
* Source/WebCore/page/ShareDataReader.cpp:
(WebCore::ShareDataReader::start):

Canonical link: <a href="https://commits.webkit.org/269885@main">https://commits.webkit.org/269885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6e0c00f67dd25295a8eba2a8b12807ae4bf5556

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26082 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26671 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27832 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25643 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18967 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21373 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5726 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->