### PR TITLE
Sync 'VideoPlaybackQuality.idl' with web specification and add partial interface to 'HTMLVideoElement.idl'

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -351,6 +351,7 @@
     "web-platform-tests/mathml": "import",
     "web-platform-tests/media": "import",
     "web-platform-tests/media-capabilities": "import",
+    "web-platform-tests/media-playback-quality": "import",
     "web-platform-tests/media-source": "import",
     "web-platform-tests/mediacapture-image": "skip",
     "web-platform-tests/mediacapture-record": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/META.yml
@@ -1,0 +1,3 @@
+spec: https://w3c.github.io/media-playback-quality/
+suggested_reviewers:
+  - mounirlamouri

--- a/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window-expected.txt
@@ -1,0 +1,32 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface HTMLVideoElement: original interface defined
+PASS Partial interface HTMLVideoElement: member names are unique
+PASS HTMLElement includes GlobalEventHandlers: member names are unique
+PASS HTMLElement includes DocumentAndElementEventHandlers: member names are unique
+PASS HTMLElement includes ElementContentEditable: member names are unique
+PASS HTMLElement includes HTMLOrSVGElement: member names are unique
+PASS Element includes ParentNode: member names are unique
+PASS Element includes NonDocumentTypeChildNode: member names are unique
+PASS Element includes ChildNode: member names are unique
+PASS Element includes Slottable: member names are unique
+PASS VideoPlaybackQuality interface: existence and properties of interface object
+PASS VideoPlaybackQuality interface object length
+PASS VideoPlaybackQuality interface object name
+PASS VideoPlaybackQuality interface: existence and properties of interface prototype object
+PASS VideoPlaybackQuality interface: existence and properties of interface prototype object's "constructor" property
+PASS VideoPlaybackQuality interface: existence and properties of interface prototype object's @@unscopables property
+PASS VideoPlaybackQuality interface: attribute creationTime
+PASS VideoPlaybackQuality interface: attribute droppedVideoFrames
+PASS VideoPlaybackQuality interface: attribute totalVideoFrames
+PASS VideoPlaybackQuality interface: attribute corruptedVideoFrames
+PASS VideoPlaybackQuality must be primary interface of videoPlaybackQuality
+PASS Stringification of videoPlaybackQuality
+PASS VideoPlaybackQuality interface: videoPlaybackQuality must inherit property "creationTime" with the proper type
+PASS VideoPlaybackQuality interface: videoPlaybackQuality must inherit property "droppedVideoFrames" with the proper type
+PASS VideoPlaybackQuality interface: videoPlaybackQuality must inherit property "totalVideoFrames" with the proper type
+PASS VideoPlaybackQuality interface: videoPlaybackQuality must inherit property "corruptedVideoFrames" with the proper type
+PASS HTMLVideoElement interface: operation getVideoPlaybackQuality()
+PASS HTMLVideoElement interface: video must inherit property "getVideoPlaybackQuality()" with the proper type
+

--- a/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window.js
@@ -1,0 +1,20 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://w3c.github.io/media-playback-quality/
+
+'use strict';
+
+idl_test(
+  ['media-playback-quality'],
+  ['html', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      HTMLVideoElement: ['video'],
+      VideoPlaybackQuality: ['videoPlaybackQuality']
+    });
+
+    self.video = document.createElement('video');
+    self.videoPlaybackQuality = video.getVideoPlaybackQuality();
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window.js

--- a/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.idl
+++ b/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,16 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://w3c.github.io/media-playback-quality/#idl-def-videoplaybackquality
-// FIXME: This is not specified as "LegacyNoInterfaceObject". It should have an interface object.
+// https://w3c.github.io/media-playback-quality/#videoplaybackquality-interface
+
+typedef double DOMHighResTimeStamp;
+
 [
     Conditional=VIDEO,
-    LegacyNoInterfaceObject,
+    Exposed=Window
 ] interface VideoPlaybackQuality {
-    readonly attribute unrestricted double creationTime;
-    readonly attribute unsigned long totalVideoFrames;
+    readonly attribute DOMHighResTimeStamp creationTime;
     readonly attribute unsigned long droppedVideoFrames;
+    readonly attribute unsigned long totalVideoFrames;
+
+    // Deprecated!
     readonly attribute unsigned long corruptedVideoFrames;
+
     [EnabledBySetting=videoQualityIncludesDisplayCompositingEnabled] readonly attribute unsigned long displayCompositedVideoFrames;
     readonly attribute unrestricted double totalFrameDelay;
 };

--- a/Source/WebCore/html/HTMLVideoElement.idl
+++ b/Source/WebCore/html/HTMLVideoElement.idl
@@ -58,6 +58,9 @@
     // The number of decoded frames that have been dropped by the player for performance reasons during playback.
     [Conditional=MEDIA_STATISTICS] readonly attribute unsigned long webkitDroppedFrameCount;
 
+    // https://w3c.github.io/media-playback-quality/#extension-to-the-htmlvideoelement-interface
+    VideoPlaybackQuality getVideoPlaybackQuality();
+
     [Conditional=VIDEO_PRESENTATION_MODE, EnabledBySetting=VideoPresentationModeAPIEnabled] boolean webkitSupportsPresentationMode(VideoPresentationMode mode);
     [Conditional=VIDEO_PRESENTATION_MODE, EnabledBySetting=VideoPresentationModeAPIEnabled] readonly attribute VideoPresentationMode webkitPresentationMode;
     [Conditional=VIDEO_PRESENTATION_MODE, EnabledBySetting=VideoPresentationModeAPIEnabled] undefined webkitSetPresentationMode(VideoPresentationMode mode);


### PR DESCRIPTION
#### b5ffcfbc6d163e0f3f4762d0038051646c13f544
<pre>
Sync &apos;VideoPlaybackQuality.idl&apos; with web specification and add partial interface to &apos;HTMLVideoElement.idl&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=125474">https://bugs.webkit.org/show_bug.cgi?id=125474</a>
rdar://problem/99826631

Reviewed by Eric Carlson.

This patch aligns WebKit with Web Specification [1] &amp; [2].

[1] <a href="https://w3c.github.io/media-playback-quality/#videoplaybackquality-interface">https://w3c.github.io/media-playback-quality/#videoplaybackquality-interface</a>
[2] <a href="https://w3c.github.io/media-playback-quality/#extension-to-the-htmlvideoelement-interface">https://w3c.github.io/media-playback-quality/#extension-to-the-htmlvideoelement-interface</a>

In this PR, we removed &apos;FIXME&apos; about &apos;LegacyNoInterfaceObject&apos; as well as implementation
and also added missing &apos;Exposed=Window&apos;. Additionally, we updated &apos;HTMLVideoElement.idl&apos;
to have partial interface for &apos;getVideoPlaybackQuality&apos;.

Additionally, we synced WPT tests from upstream:

Upstream Hash: 9f24a7061dc47c00ffe3f0f6dda5822a9b15c2a5

* Source/WebCore/Modules/mediasource/VideoPlaybackQuality.idl:
* Source/WebCore/html/HTMLVideoElement.idl:
* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window.js:
* LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window.html:
* LayoutTests/imported/w3c/web-platform-tests/media-playback-quality/idlharness.window-expected.txt:

Canonical link: <a href="https://commits.webkit.org/269893@main">https://commits.webkit.org/269893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b06fd3ab501e7b4019563348dfb3d2c5ccb89e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26106 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22567 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26695 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27854 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25651 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5732 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->