### PR TITLE
Adopt more smart pointers in Source/WebCore/dom/messageports

### DIFF
--- a/Source/WebCore/dom/messageports/MessagePortChannel.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.cpp
@@ -52,12 +52,12 @@ MessagePortChannel::MessagePortChannel(MessagePortChannelRegistry& registry, con
     m_processes[1] = port2.processIdentifier;
     m_entangledToProcessProtectors[1] = this;
 
-    m_registry.messagePortChannelCreated(*this);
+    m_registry->messagePortChannelCreated(*this);
 }
 
 MessagePortChannel::~MessagePortChannel()
 {
-    m_registry.messagePortChannelDestroyed(*this);
+    m_registry->messagePortChannelDestroyed(*this);
 }
 
 std::optional<ProcessIdentifier> MessagePortChannel::processForPort(const MessagePortIdentifier& port)

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -29,6 +29,7 @@
 #include "MessagePortIdentifier.h"
 #include "MessageWithMessagePorts.h"
 #include "ProcessIdentifier.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -37,7 +38,7 @@ namespace WebCore {
 
 class MessagePortChannelRegistry;
 
-class MessagePortChannel : public RefCounted<MessagePortChannel> {
+class MessagePortChannel : public RefCounted<MessagePortChannel>, public CanMakeCheckedPtr {
 public:
     static Ref<MessagePortChannel> create(MessagePortChannelRegistry&, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
 
@@ -75,7 +76,7 @@ private:
     RefPtr<MessagePortChannel> m_pendingMessageProtectors[2];
     uint64_t m_messageBatchesInFlight { 0 };
 
-    MessagePortChannelRegistry& m_registry;
+    CheckedRef<MessagePortChannelRegistry> m_registry;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -29,11 +29,13 @@
 #include "MessagePortChannelProvider.h"
 #include "MessagePortIdentifier.h"
 #include "ProcessIdentifier.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
 
-class MessagePortChannelRegistry {
+class MessagePortChannelRegistry : public CanMakeCheckedPtr {
 public:
     WEBCORE_EXPORT MessagePortChannelRegistry();
 
@@ -52,7 +54,7 @@ public:
     WEBCORE_EXPORT void messagePortChannelDestroyed(MessagePortChannel&);
 
 private:
-    HashMap<MessagePortIdentifier, MessagePortChannel*> m_openChannels;
+    HashMap<MessagePortIdentifier, CheckedRef<MessagePortChannel>> m_openChannels;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 72f8ce4e37464d6c09e8eeeacf35a46fd656ea48
<pre>
Adopt more smart pointers in Source/WebCore/dom/messageports
<a href="https://bugs.webkit.org/show_bug.cgi?id=263837">https://bugs.webkit.org/show_bug.cgi?id=263837</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/messageports/MessagePortChannel.cpp:
(WebCore::MessagePortChannel::MessagePortChannel):
(WebCore::MessagePortChannel::~MessagePortChannel):
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp:
(WebCore::MessagePortChannelRegistry::messagePortChannelCreated):
(WebCore::MessagePortChannelRegistry::didEntangleLocalToRemote):
(WebCore::MessagePortChannelRegistry::didDisentangleMessagePort):
(WebCore::MessagePortChannelRegistry::didCloseMessagePort):
(WebCore::MessagePortChannelRegistry::didPostMessageToRemote):
(WebCore::MessagePortChannelRegistry::takeAllMessagesForPort):
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:

Canonical link: <a href="https://commits.webkit.org/269911@main">https://commits.webkit.org/269911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/579c11566473ec94a1109928919b261fe385063c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26778 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21701 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21989 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19057 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1404 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5742 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1794 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->