### PR TITLE
Adopt more smart pointers in WebProcessPool

### DIFF
--- a/Source/WebKit/Shared/WebPreferencesStore.h
+++ b/Source/WebKit/Shared/WebPreferencesStore.h
@@ -27,6 +27,7 @@
 
 #include "Decoder.h"
 #include "Encoder.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/text/StringHash.h>
@@ -34,7 +35,7 @@
 
 namespace WebKit {
 
-struct WebPreferencesStore {
+struct WebPreferencesStore : public CanMakeCheckedPtr {
     WebPreferencesStore();
 
     using Value = std::variant<String, bool, uint32_t, double>;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -78,9 +78,9 @@ WebProcessPool* PageConfiguration::processPool()
     return m_data.processPool.get();
 }
 
-void PageConfiguration::setProcessPool(WebProcessPool* processPool)
+void PageConfiguration::setProcessPool(RefPtr<WebProcessPool>&& processPool)
 {
-    m_data.processPool = processPool;
+    m_data.processPool = WTFMove(processPool);
 }
 
 WebUserContentControllerProxy* PageConfiguration::userContentController()
@@ -88,9 +88,9 @@ WebUserContentControllerProxy* PageConfiguration::userContentController()
     return m_data.userContentController.get();
 }
 
-void PageConfiguration::setUserContentController(WebUserContentControllerProxy* userContentController)
+void PageConfiguration::setUserContentController(RefPtr<WebUserContentControllerProxy>&& userContentController)
 {
-    m_data.userContentController = userContentController;
+    m_data.userContentController = WTFMove(userContentController);
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -99,9 +99,9 @@ WebExtensionController* PageConfiguration::webExtensionController()
     return m_data.webExtensionController.get();
 }
 
-void PageConfiguration::setWebExtensionController(WebExtensionController* webExtensionController)
+void PageConfiguration::setWebExtensionController(RefPtr<WebExtensionController>&& webExtensionController)
 {
-    m_data.webExtensionController = webExtensionController;
+    m_data.webExtensionController = WTFMove(webExtensionController);
 }
 
 WebExtensionController* PageConfiguration::weakWebExtensionController()
@@ -120,9 +120,9 @@ WebPageGroup* PageConfiguration::pageGroup()
     return m_data.pageGroup.get();
 }
 
-void PageConfiguration::setPageGroup(WebPageGroup* pageGroup)
+void PageConfiguration::setPageGroup(RefPtr<WebPageGroup>&& pageGroup)
 {
-    m_data.pageGroup = pageGroup;
+    m_data.pageGroup = WTFMove(pageGroup);
 }
 
 WebPreferences* PageConfiguration::preferences()
@@ -130,9 +130,9 @@ WebPreferences* PageConfiguration::preferences()
     return m_data.preferences.get();
 }
 
-void PageConfiguration::setPreferences(WebPreferences* preferences)
+void PageConfiguration::setPreferences(RefPtr<WebPreferences>&& preferences)
 {
-    m_data.preferences = preferences;
+    m_data.preferences = WTFMove(preferences);
 }
 
 WebPageProxy* PageConfiguration::relatedPage() const
@@ -140,9 +140,9 @@ WebPageProxy* PageConfiguration::relatedPage() const
     return m_data.relatedPage.get();
 }
 
-void PageConfiguration::setRelatedPage(WebPageProxy* relatedPage)
+void PageConfiguration::setRelatedPage(RefPtr<WebPageProxy>&& relatedPage)
 {
-    m_data.relatedPage = relatedPage;
+    m_data.relatedPage = WTFMove(relatedPage);
 }
 
 WebKit::WebPageProxy* PageConfiguration::pageToCloneSessionStorageFrom() const
@@ -160,9 +160,9 @@ WebKit::VisitedLinkStore* PageConfiguration::visitedLinkStore()
     return m_data.visitedLinkStore.get();
 }
 
-void PageConfiguration::setVisitedLinkStore(WebKit::VisitedLinkStore* visitedLinkStore)
+void PageConfiguration::setVisitedLinkStore(RefPtr<WebKit::VisitedLinkStore>&& visitedLinkStore)
 {
-    m_data.visitedLinkStore = visitedLinkStore;
+    m_data.visitedLinkStore = WTFMove(visitedLinkStore);
 }
 
 WebKit::WebsiteDataStore* PageConfiguration::websiteDataStore()
@@ -170,9 +170,14 @@ WebKit::WebsiteDataStore* PageConfiguration::websiteDataStore()
     return m_data.websiteDataStore.get();
 }
 
-void PageConfiguration::setWebsiteDataStore(WebKit::WebsiteDataStore* websiteDataStore)
+RefPtr<WebKit::WebsiteDataStore> PageConfiguration::protectedWebsiteDataStore()
 {
-    m_data.websiteDataStore = websiteDataStore;
+    return m_data.websiteDataStore;
+}
+
+void PageConfiguration::setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&& websiteDataStore)
+{
+    m_data.websiteDataStore = WTFMove(websiteDataStore);
 }
 
 WebsitePolicies* PageConfiguration::defaultWebsitePolicies() const
@@ -180,9 +185,9 @@ WebsitePolicies* PageConfiguration::defaultWebsitePolicies() const
     return m_data.defaultWebsitePolicies.get();
 }
 
-void PageConfiguration::setDefaultWebsitePolicies(WebsitePolicies* policies)
+void PageConfiguration::setDefaultWebsitePolicies(RefPtr<WebsitePolicies>&& policies)
 {
-    m_data.defaultWebsitePolicies = policies;
+    m_data.defaultWebsitePolicies = WTFMove(policies);
 }
 
 RefPtr<WebKit::WebURLSchemeHandler> PageConfiguration::urlSchemeHandlerForURLScheme(const WTF::String& scheme)
@@ -239,9 +244,9 @@ ApplicationManifest* PageConfiguration::applicationManifest() const
     return m_data.applicationManifest.get();
 }
 
-void PageConfiguration::setApplicationManifest(ApplicationManifest* applicationManifest)
+void PageConfiguration::setApplicationManifest(RefPtr<ApplicationManifest>&& applicationManifest)
 {
-    m_data.applicationManifest = applicationManifest;
+    m_data.applicationManifest = WTFMove(applicationManifest);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -86,39 +86,40 @@ public:
     WebKit::BrowsingContextGroup& browsingContextGroup();
 
     WebKit::WebProcessPool* processPool();
-    void setProcessPool(WebKit::WebProcessPool*);
+    void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);
 
     WebKit::WebUserContentControllerProxy* userContentController();
-    void setUserContentController(WebKit::WebUserContentControllerProxy*);
+    void setUserContentController(RefPtr<WebKit::WebUserContentControllerProxy>&&);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
     WebKit::WebExtensionController* webExtensionController();
-    void setWebExtensionController(WebKit::WebExtensionController*);
+    void setWebExtensionController(RefPtr<WebKit::WebExtensionController>&&);
 
     WebKit::WebExtensionController* weakWebExtensionController();
     void setWeakWebExtensionController(WebKit::WebExtensionController*);
 #endif
 
     WebKit::WebPageGroup* pageGroup();
-    void setPageGroup(WebKit::WebPageGroup*);
+    void setPageGroup(RefPtr<WebKit::WebPageGroup>&&);
 
     WebKit::WebPreferences* preferences();
-    void setPreferences(WebKit::WebPreferences*);
+    void setPreferences(RefPtr<WebKit::WebPreferences>&&);
 
     WebKit::WebPageProxy* relatedPage() const;
-    void setRelatedPage(WebKit::WebPageProxy*);
+    void setRelatedPage(RefPtr<WebKit::WebPageProxy>&&);
 
     WebKit::WebPageProxy* pageToCloneSessionStorageFrom() const;
     void setPageToCloneSessionStorageFrom(WebKit::WebPageProxy*);
 
     WebKit::VisitedLinkStore* visitedLinkStore();
-    void setVisitedLinkStore(WebKit::VisitedLinkStore*);
+    void setVisitedLinkStore(RefPtr<WebKit::VisitedLinkStore>&&);
 
     WebKit::WebsiteDataStore* websiteDataStore();
-    void setWebsiteDataStore(WebKit::WebsiteDataStore*);
+    RefPtr<WebKit::WebsiteDataStore> protectedWebsiteDataStore();
+    void setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&&);
 
     WebsitePolicies* defaultWebsitePolicies() const;
-    void setDefaultWebsitePolicies(WebsitePolicies*);
+    void setDefaultWebsitePolicies(RefPtr<WebsitePolicies>&&);
 
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked() const { return m_data.canShowWhileLocked; }
@@ -155,7 +156,7 @@ public:
 
 #if ENABLE(APPLICATION_MANIFEST)
     ApplicationManifest* applicationManifest() const;
-    void setApplicationManifest(ApplicationManifest*);
+    void setApplicationManifest(RefPtr<ApplicationManifest>&&);
 #endif
 
     RefPtr<WebKit::WebURLSchemeHandler> urlSchemeHandlerForURLScheme(const WTF::String&);

--- a/Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp
@@ -33,6 +33,7 @@
 #include "WebInspectorUIProxy.h"
 #include "WebPageGroup.h"
 #include "WebPageProxy.h"
+#include "WebProcessPool.h"
 #include "WebView.h"
 #include <WebCore/InspectorFrontendClient.h>
 #include <WebCore/IntRect.h>

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -54,7 +54,7 @@ using LayerHostingContextID = uint32_t;
 
 enum class ShouldDelayClosingUntilFirstLayerFlush : bool { No, Yes };
 
-class SuspendedPageProxy final: public IPC::MessageReceiver, public IPC::MessageSender {
+class SuspendedPageProxy final: public IPC::MessageReceiver, public IPC::MessageSender, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, ShouldDelayClosingUntilFirstLayerFlush);

--- a/Source/WebKit/UIProcess/WebPageGroup.cpp
+++ b/Source/WebKit/UIProcess/WebPageGroup.cpp
@@ -129,7 +129,17 @@ WebPreferences& WebPageGroup::preferences() const
     return *m_preferences;
 }
 
+Ref<WebPreferences> WebPageGroup::protectedPreferences() const
+{
+    return preferences();
+}
+
 WebUserContentControllerProxy& WebPageGroup::userContentController()
+{
+    return m_userContentController;
+}
+
+Ref<WebUserContentControllerProxy> WebPageGroup::protectedUserContentController()
 {
     return m_userContentController;
 }

--- a/Source/WebKit/UIProcess/WebPageGroup.h
+++ b/Source/WebKit/UIProcess/WebPageGroup.h
@@ -59,8 +59,10 @@ public:
 
     void setPreferences(WebPreferences*);
     WebPreferences& preferences() const;
+    Ref<WebPreferences> protectedPreferences() const;
 
     WebUserContentControllerProxy& userContentController();
+    Ref<WebUserContentControllerProxy> protectedUserContentController();
 
 private:
     WebPageGroupData m_data;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3678,7 +3678,7 @@ bool WebPageProxy::handleKeyboardEvent(const NativeWebKeyboardEvent& event)
     return true;
 }
 
-WebPreferencesStore WebPageProxy::preferencesStore() const
+const WebPreferencesStore& WebPageProxy::preferencesStore() const
 {
     return m_preferences->store();
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1882,7 +1882,7 @@ public:
 
     void getTextFragmentMatch(CompletionHandler<void(const String&)>&&);
 
-    WebPreferencesStore preferencesStore() const;
+    const WebPreferencesStore& preferencesStore() const;
 
     void setDefersLoadingForTesting(bool);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -152,6 +152,7 @@ public:
     virtual ~WebProcessPool();
 
     API::ProcessPoolConfiguration& configuration() { return m_configuration.get(); }
+    Ref<API::ProcessPoolConfiguration> protectedConfiguration() { return m_configuration; }
 
     static Vector<Ref<WebProcessPool>> allProcessPools();
 
@@ -365,6 +366,7 @@ public:
     void createGPUProcessConnection(WebProcessProxy&, IPC::Connection::Handle&&, WebKit::GPUProcessConnectionParameters&&);
 
     GPUProcessProxy& ensureGPUProcess();
+    Ref<GPUProcessProxy> ensureProtectedGPUProcess();
     GPUProcessProxy* gpuProcess() const { return m_gpuProcess.get(); }
 #endif
     // Network Process Management

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -162,6 +162,7 @@ public:
     static Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies();
 
     WebConnection* webConnection() const { return m_webConnection.get(); }
+    RefPtr<WebConnection> protectedWebConnection() const { return m_webConnection; }
 
     unsigned suspendedPageCount() const { return m_suspendedPages.computeSize(); }
     void addSuspendedPageProxy(SuspendedPageProxy&);


### PR DESCRIPTION
#### 006bf284d44b8c07fa0a6a74879db09925878b11
<pre>
Adopt more smart pointers in WebProcessPool
<a href="https://bugs.webkit.org/show_bug.cgi?id=263839">https://bugs.webkit.org/show_bug.cgi?id=263839</a>

Reviewed by Brent Fulgham.

* Source/WebKit/Shared/WebPreferencesStore.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::setProcessPool):
(API::PageConfiguration::setUserContentController):
(API::PageConfiguration::setWebExtensionController):
(API::PageConfiguration::setPageGroup):
(API::PageConfiguration::setPreferences):
(API::PageConfiguration::setRelatedPage):
(API::PageConfiguration::setVisitedLinkStore):
(API::PageConfiguration::protectedWebsiteDataStore):
(API::PageConfiguration::setWebsiteDataStore):
(API::PageConfiguration::setDefaultWebsitePolicies):
(API::PageConfiguration::setApplicationManifest):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebPageGroup.cpp:
(WebKit::WebPageGroup::protectedPreferences const):
(WebKit::WebPageGroup::protectedUserContentController):
* Source/WebKit/UIProcess/WebPageGroup.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::preferencesStore const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::processPools):
(WebKit::WebProcessPool::allProcessPools):
(WebKit::WebProcessPool::~WebProcessPool):
(WebKit::WebProcessPool::setOverrideLanguages):
(WebKit::WebProcessPool::sendMemoryPressureEvent):
(WebKit::WebProcessPool::setApplicationIsActive):
(WebKit::WebProcessPool::networkProcessDidTerminate):
(WebKit::WebProcessPool::ensureGPUProcess):
(WebKit::WebProcessPool::ensureProtectedGPUProcess):
(WebKit::WebProcessPool::gpuProcessDidFinishLaunching):
(WebKit::WebProcessPool::gpuProcessExited):
(WebKit::WebProcessPool::createGPUProcessConnection):
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::windowServerConnectionStateChanged):
(WebKit::WebProcessPool::tryTakePrewarmedProcess):
(WebKit::WebProcessPool::initializeNewWebProcess):
(WebKit::WebProcessPool::enableProcessTermination):
(WebKit::WebProcessPool::processDidFinishLaunching):
(WebKit::WebProcessPool::disconnectProcess):
(WebKit::WebProcessPool::processForRegistrableDomain):
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::updateRemoteWorkerUserAgent):
(WebKit::WebProcessPool::pageEndUsingWebsiteDataStore):
(WebKit::WebProcessPool::download):
(WebKit::WebProcessPool::resumeDownload):
(WebKit::WebProcessPool::postMessageToInjectedBundle):
(WebKit::WebProcessPool::handleMemoryPressureWarning):
(WebKit::WebProcessPool::activePagesOriginsInWebProcessForTesting):
(WebKit::WebProcessPool::registerURLSchemeAsSecure):
(WebKit::WebProcessPool::registerURLSchemeAsBypassingContentSecurityPolicy):
(WebKit::WebProcessPool::registerURLSchemeAsLocal):
(WebKit::WebProcessPool::registerURLSchemeAsNoAccess):
(WebKit::WebProcessPool::registerGlobalURLSchemeAsHavingCustomProtocolHandlers):
(WebKit::WebProcessPool::unregisterGlobalURLSchemeAsHavingCustomProtocolHandlers):
(WebKit::WebProcessPool::updateBackForwardCacheCapacity):
(WebKit::WebProcessPool::setCacheModel):
(WebKit::WebProcessPool::setCacheModelSynchronouslyForTesting):
(WebKit::WebProcessPool::createDownloadProxy):
(WebKit::WebProcessPool::terminateAllWebContentProcesses):
(WebKit::WebProcessPool::terminateServiceWorkers):
(WebKit::WebProcessPool::setAutomationSession):
(WebKit::webProcessProxyFromConnection):
(WebKit::WebProcessPool::handleMessage):
(WebKit::WebProcessPool::handleSynchronousMessage):
(WebKit::WebProcessPool::startedUsingGamepads):
(WebKit::WebProcessPool::stoppedUsingGamepads):
(WebKit::WebProcessPool::gamepadConnected):
(WebKit::WebProcessPool::gamepadDisconnected):
(WebKit::WebProcessPool::updateProcessAssertions):
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
(WebKit::WebProcessPool::addMockMediaDevice):
(WebKit::WebProcessPool::clearMockMediaDevices):
(WebKit::WebProcessPool::removeMockMediaDevice):
(WebKit::WebProcessPool::setMockMediaDeviceIsEphemeral):
(WebKit::WebProcessPool::resetMockMediaDevices):
(WebKit::WebProcessPool::setDomainsWithCrossPageStorageAccess):
(WebKit::WebProcessPool::seedResourceLoadStatisticsForTesting):
(WebKit::WebProcessPool::notifyMediaStreamingActivity):
(WebKit::WebProcessPool::setUseSeparateServiceWorkerProcess):
(WebKit::WebProcessPool::forEachProcessForSession):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::protectedWebConnection const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::allDataStores):
(WebKit::WebsiteDataStore::forEachWebsiteDataStore):
(WebKit::WebsiteDataStore::existingDataStoreForIdentifier):
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
(WebKit::WebsiteDataStore::registerWithSessionIDMap):
(WebKit::WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::forwardManagedDomainsToITPIfInitialized):

Canonical link: <a href="https://commits.webkit.org/269971@main">https://commits.webkit.org/269971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8cd2534d21365a4fb0deb91ee31633133162d6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26150 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22115 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22605 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26739 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1406 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27901 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25690 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19021 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1364 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5786 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->