### PR TITLE
Adopt more smart pointers in HTMLElement

### DIFF
--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -28,6 +28,7 @@
 #include "CustomElementFormValue.h"
 #include "GCReachableRef.h"
 #include "QualifiedName.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
@@ -113,7 +114,7 @@ private:
     bool m_invoking { false };
 };
 
-class CustomElementReactionQueue {
+class CustomElementReactionQueue : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(CustomElementReactionQueue);
 public:

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -194,7 +194,7 @@ protected:
     void updateTextDirectionalityAfterInputTypeChange();
     void updateEffectiveDirectionalityOfDirAuto();
 
-    using EventHandlerNameMap = HashMap<AtomStringImpl*, AtomString>;
+    using EventHandlerNameMap = HashMap<AtomString, AtomString>;
     static const AtomString& eventNameForEventHandlerAttribute(const QualifiedName& attributeName, const EventHandlerNameMap&);
 
 private:


### PR DESCRIPTION
#### 61892486015d7f5e7808bdedfd92d614eebc09c0
<pre>
Adopt more smart pointers in HTMLElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=263841">https://bugs.webkit.org/show_bug.cgi?id=263841</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::eventNameForEventHandlerAttribute):
(WebCore::HTMLElement::attributeChanged):
(WebCore::textToFragment):
(WebCore::HTMLElement::setInnerText):
(WebCore::HTMLElement::setOuterText):
(WebCore::setHasDirAutoFlagRecursively):
(WebCore::HTMLElement::computeDirectionalityFromText const):
(WebCore::HTMLElement::dirAttributeChanged):
(WebCore::HTMLElement::updateEffectiveDirectionality):
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildAttributeChanged):
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildrenChanged):
(WebCore::HTMLElement::attachInternals):
(WebCore::runPopoverFocusingSteps):
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::hidePopoverInternal):
* Source/WebCore/html/HTMLElement.h:

Canonical link: <a href="https://commits.webkit.org/269910@main">https://commits.webkit.org/269910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bb73caf845ad01543457769cbdc7c5201f3726d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22611 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26746 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27913 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21963 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25701 "Found 3 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/origin-and-total-storage-ratio (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19030 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1372 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5741 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->