### PR TITLE
Allow extraction of transform from inline renderer

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-transform-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-transform-expected.txt
@@ -1,6 +1,9 @@
-translate(80px, 90px) expected matrix(1, 0, 0, 1, 80, 90) : PASS
-translate(10px, 50%) expected matrix(1, 0, 0, 1, 10, 60) : PASS
-scale(1.2, 0.8) expected matrix(1.2, 0, 0, 0.8, 0, 0) : PASS
-skew(-0.7rad, 20deg) expected matrix(1, 0.36397, -0.842288, 1, 0, 0) : PASS
-rotate(45deg) expected matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0) : PASS
+div: translate(80px, 90px) expected matrix(1, 0, 0, 1, 80, 90) : PASS
+span: translate(80px, 90px) expected matrix(1, 0, 0, 1, 80, 90) : PASS
+div: scale(1.2, 0.8) expected matrix(1.2, 0, 0, 0.8, 0, 0) : PASS
+span: scale(1.2, 0.8) expected matrix(1.2, 0, 0, 0.8, 0, 0) : PASS
+div: skew(-0.7rad, 20deg) expected matrix(1, 0.36397, -0.842288, 1, 0, 0) : PASS
+span: skew(-0.7rad, 20deg) expected matrix(1, 0.36397, -0.842288, 1, 0, 0) : PASS
+div: rotate(45deg) expected matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0) : PASS
+span: rotate(45deg) expected matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0) : PASS
 

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-transform.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-transform.html
@@ -33,7 +33,6 @@
 
     var gTests = [
       { 'transform' : 'translate(80px, 90px)',  'result' : 'matrix(1, 0, 0, 1, 80, 90)' },
-      { 'transform' : 'translate(10px, 50%)',   'result' : 'matrix(1, 0, 0, 1, 10, 60)' },
       { 'transform' : 'scale(1.2, 0.8)',        'result' : 'matrix(1.2, 0, 0, 0.8, 0, 0)' },
       { 'transform' : 'skew(-0.7rad, 20deg)',   'result' : 'matrix(1, 0.36397, -0.842288, 1, 0, 0)' },
       { 'transform' : 'rotate(45deg)',          'result' : 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)' },
@@ -65,19 +64,22 @@
         // read back computed style
         var computedTransform = window.getComputedStyle(testBox).webkitTransform;
         var computedSpanTransform = window.getComputedStyle(testSpan).webkitTransform;
-        // compare expected result to computed transformation matrix
+        // compare expected result to computed transformation matrix for test-box
         var success = compareTransform(curTest.result, computedTransform);
         var result;
         if (success)
-          result = curTest.transform + ' expected <code>' + curTest.result + '</code> : PASS';
+          result = 'div: ' + curTest.transform + ' expected <code>' + curTest.result + '</code> : PASS';
         else
-          result = curTest.transform + ' expected <code>' + curTest.result + '</code>, got <code>' + computedTransform + '</code> : FAIL';
+          result = 'div: ' + curTest.transform + ' expected <code>' + curTest.result + '</code>, got <code>' + computedTransform + '</code> : FAIL';
         resultsBox.innerHTML += result + '<br>';
 
-        if (computedSpanTransform !== 'none') {
-          result = curTest.transform + ' applied to a non-box element: ' + ' expected <code>none</code> got <code>' + computedSpanTransform + '</code> : FAIL';
-          resultsBox.innerHTML += result + '<br>';
-        }
+        // compare expected result to computed transformation matrix for test-span
+        success = compareTransform(curTest.result, computedSpanTransform);
+        if (success)
+          result = 'span: ' + curTest.transform + ' expected <code>' + curTest.result + '</code> : PASS';
+        else
+          result = 'span: ' + curTest.transform + ' expected <code>' + curTest.result + '</code>, got <code>' + computedSpanTransform + '</code> : FAIL';
+        resultsBox.innerHTML += result + '<br>';
       });
       
       if (window.testRunner)

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -856,7 +856,7 @@ RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& 
 
 static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyle& style, ComputedStyleExtractor::PropertyValueType valueType)
 {
-    if (!style.hasTransform() || is<RenderInline>(renderer))
+    if (!style.hasTransform())
         return CSSPrimitiveValue::create(CSSValueNone);
 
     if (renderer) {


### PR DESCRIPTION
#### 1f695bbf944909f67885000dbbc9091b8a42e470
<pre>
Allow extraction of transform from inline renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=263699">https://bugs.webkit.org/show_bug.cgi?id=263699</a>
rdar://problem/117523629

Reviewed by Antoine Quint.

Previously, inline elements would return a null transform value
when using the getComputedStyle method. This change ensures that
getComputedStyle now provides a valid transform value for inline
elements.

Updated LayoutTests/fast/css/getComputedStyle/getComputedStyle-transform.html and rebaselined expectations:
The test below was removed because the matrix of 50% translation is dependent on
the element size and the result should not differ between div and span elements

 { &apos;transform&apos; : &apos;translate(10px, 50%)&apos;,   &apos;result&apos; : &apos;matrix(1, 0, 0, 1, 10, 60)&apos; },

* Source/WebCore/css/ComputedStyleExtractor.cpp:
 (WebCore::computedTransform):
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-transform-expected.txt:
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-transform.html:

Canonical link: <a href="https://commits.webkit.org/269920@main">https://commits.webkit.org/269920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/634fe3f572066092be92d30921817212f243759b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22170 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22646 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26794 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27965 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21938 "Found 2 new API test failures: TestWebKitAPI.ServiceWorker.WindowClientNavigate, TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22005 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25741 "Found 1 new API test failure: /WebKitGTK/TestLoaderClient:/webkit/WebKitURIRequest/http-method (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19073 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21486 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1810 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3064 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->