### PR TITLE
[GStreamer] Cannot play mp4 videos in Element: Received unexpected 200 HTTP status code for range request

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -1052,8 +1052,12 @@ void CachedResourceStreamingClient::responseReceived(PlatformMediaResource&, con
     }
 
     if (members->requestedPosition) {
-        // Seeking ... we expect a 206 == PARTIAL_CONTENT
-        if (response.httpStatusCode() != 206) {
+        // Seeking ... we expect a 206 == PARTIAL_CONTENT or...:
+        // https://tools.ietf.org/id/draft-ietf-httpbis-p5-range-09.html#header.content-range
+        // If the server ignores a byte - range - spec because it is syntactically invalid, the
+        // server SHOULD treat the request as if the invalid Range header field did not
+        // exist. Normally, this means return a 200 response containing the full entity.
+        if (response.httpStatusCode() != 206 && response.httpStatusCode() != 200) {
             // Range request completely failed.
             GST_ELEMENT_ERROR(src, RESOURCE, READ, ("R%u: Received unexpected %d HTTP status code for range request", m_requestNumber, response.httpStatusCode()), (nullptr));
             members->doesHaveEOS = true;


### PR DESCRIPTION
#### e14eade027dd52bed716a363020274b96ee7d36d
<pre>
[GStreamer] Cannot play mp4 videos in Element: Received unexpected 200 HTTP status code for range request
<a href="https://bugs.webkit.org/show_bug.cgi?id=221622">https://bugs.webkit.org/show_bug.cgi?id=221622</a>

Reviewed by NOBODY (OOPS!).

<a href="https://tools.ietf.org/id/draft-ietf-httpbis-p5-range-09.html#header.content-range">https://tools.ietf.org/id/draft-ietf-httpbis-p5-range-09.html#header.content-range</a>
If the server ignores a byte - range - spec because it is syntactically invalid, the
server SHOULD treat the request as if the invalid Range header field did not
exist. Normally, this means return a 200 response containing the full entity.

* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(CachedResourceStreamingClient::responseReceived):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e14eade027dd52bed716a363020274b96ee7d36d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26166 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22618 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24269 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1667 "Found 1 new test failure: fast/events/ios/select-all-with-existing-selection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26755 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27924 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21970 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25712 "Found 55 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/ephemeral, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/reload, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cookies, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-cancel, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/populate-menu, /WebKitGTK/TestResources:/webkit/WebKitWebResource/loading ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19037 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1382 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->