### PR TITLE
REGRESSION(269844@main): [GStreamer] WebCodecs encoders now closing from non-main thread

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1161,12 +1161,6 @@ imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?adts_aac [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp4_aac [ Failure ]
 
-# Needs rebasing
-imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.html [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker.html [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.html [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker.html [ Pass Failure ]
-
 imported/w3c/web-platform-tests/webcodecs/audio-data-serialization.any.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-data.any.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker.html [ Pass ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -29,7 +29,7 @@ PASS Test that VideoEncoder.configure() doesn't support config: Width is too lar
 PASS Test that VideoEncoder.configure() doesn't support config: Height is too large
 PASS Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "NotSupportedError" but got "InvalidStateError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string

--- a/Source/WebCore/platform/VideoDecoder.cpp
+++ b/Source/WebCore/platform/VideoDecoder.cpp
@@ -75,8 +75,8 @@ void VideoDecoder::createLocalDecoder(const String& codecName, const Config& con
         return;
     }
 #elif USE(GSTREAMER)
-    if (GStreamerVideoDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback)))
-        return;
+    GStreamerVideoDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+    return;
 #else
     UNUSED_PARAM(codecName);
     UNUSED_PARAM(config);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
@@ -35,7 +35,7 @@ class GStreamerVideoDecoder : public ThreadSafeRefCounted<GStreamerVideoDecoder>
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    static bool create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
 
     GStreamerVideoDecoder(const String& codecName, const Config&, OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerVideoDecoder();


### PR DESCRIPTION
#### 264d86dee5244d378f73d881bce792ddb51b75e2
<pre>
REGRESSION(269844@main): [GStreamer] WebCodecs encoders now closing from non-main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=263846">https://bugs.webkit.org/show_bug.cgi?id=263846</a>

Reviewed by Youenn Fablet.

Schedule the close/reset of encoders and decoders in the script execution context. Otherwise the
resetEncoder() might attempt to trigger rejection of pending flush promises from a non main thread,
leading to ASSERTs hit in Debug builds.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::create):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerVideoEncoder::create):

Canonical link: <a href="https://commits.webkit.org/269913@main">https://commits.webkit.org/269913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbcee735af8120d65258a56dd7fa37267fd7a699

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26187 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22152 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22633 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26776 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27947 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21933 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21991 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25725 "Found 2 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/origin-and-total-storage-ratio (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1402 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5745 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->