### PR TITLE
[LBSE] Reduce SVG state in RenderLayer

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1339,11 +1339,8 @@ private:
     WeakPtr<RenderLayer> m_enclosingPaginationLayer;
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    // Pointer to the enclosing RenderSVGResourceContainer, if present.
-    WeakPtr<RenderSVGResourceContainer> m_enclosingSVGResourceContainer;
-
-    // Pointer to the enclosing RenderSVGHiddenContainer, if present.
-    WeakPtr<RenderSVGHiddenContainer> m_enclosingSVGHiddenContainer;
+    // Pointer to the enclosing RenderSVGHiddenContainer or RenderSVGResourceContainer, if present.
+    WeakPtr<RenderSVGHiddenContainer> m_enclosingSVGHiddenOrResourceContainer;
 #endif
 
     IntRect m_blockSelectionGapsBounds;


### PR DESCRIPTION
#### 0b83dfd6d194cc197ce006631772298578e6a181
<pre>
[LBSE] Reduce SVG state in RenderLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=263847">https://bugs.webkit.org/show_bug.cgi?id=263847</a>

Reviewed by Nikolas Zimmermann.

The two member variables m_enclosingSVGResourceContainer and
m_enclosingSVGHiddenContainer basically keep track of the same
information, what is the nearest hidden or resource ancestor, so
we just need one member variable and some more type checks.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateAncestorDependentState):
(WebCore::RenderLayer::setupClipPath):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::hitTestLayer):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/270012@main">https://commits.webkit.org/270012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2725491c982ef9c68d48c7959a27f600e5f60428

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26171 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26760 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27935 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25716 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19042 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1387 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5812 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->