### PR TITLE
[GStreamer][WebCodecs] Propagate audio decoder create/configure errors to the script execution context

### DIFF
--- a/Source/WebCore/platform/AudioDecoder.cpp
+++ b/Source/WebCore/platform/AudioDecoder.cpp
@@ -62,8 +62,8 @@ bool AudioDecoder::isCodecSupported(const StringView& codec)
 void AudioDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
 {
 #if USE(GSTREAMER)
-    if (GStreamerAudioDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback)))
-        return;
+    GStreamerAudioDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+    return;
 #else
     UNUSED_PARAM(codecName);
     UNUSED_PARAM(config);

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
@@ -34,7 +34,7 @@ class GStreamerAudioDecoder : public ThreadSafeRefCounted<GStreamerAudioDecoder>
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    static bool create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
 
     GStreamerAudioDecoder(const String& codecName, const Config&, OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerAudioDecoder();


### PR DESCRIPTION
#### 22965f369e432bd5d1b3653caa5d7ae2d4158c1e
<pre>
[GStreamer][WebCodecs] Propagate audio decoder create/configure errors to the script execution context
<a href="https://bugs.webkit.org/show_bug.cgi?id=263851">https://bugs.webkit.org/show_bug.cgi?id=263851</a>

Reviewed by Xabier Rodriguez-Calvar.

Without this patch the pending flush promises rejections might trigger ASSERTs in Debug builds
because they would be called from a non-main thread.

* Source/WebCore/platform/AudioDecoder.cpp:
(WebCore::AudioDecoder::create):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerAudioDecoder::create):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/270005@main">https://commits.webkit.org/270005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7efbd118a5d5f4c70bbb2210dede4feb2ba78067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26188 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22630 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26777 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27948 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21993 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25726 "Found 2 new API test failures: /WebKitGTK/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WebKitGTK/TestLoaderClient:/webkit/WebKitURIRequest/http-headers (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19058 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1403 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5810 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->