### PR TITLE
Adopt more smart pointers in LocalDOMWindow

### DIFF
--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -28,6 +28,7 @@
 #include "TaskSource.h"
 #include <optional>
 #include <wtf/ApproximateTime.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/Markable.h>
 #include <wtf/MonotonicTime.h>
@@ -152,7 +153,7 @@ private:
     mutable Markable<MonotonicTime> m_nextTimerFireTimeCache;
 };
 
-class EventLoopTaskGroup : public CanMakeWeakPtr<EventLoopTaskGroup> {
+class EventLoopTaskGroup : public CanMakeWeakPtr<EventLoopTaskGroup>, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(EventLoopTaskGroup);
     WTF_MAKE_FAST_ALLOCATED;
 

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -842,6 +842,11 @@ RefPtr<DeferredPromise> ScriptExecutionContext::takeDeferredPromise(DeferredProm
     return m_deferredPromises.take(promise);
 }
 
+CheckedRef<EventLoopTaskGroup> ScriptExecutionContext::checkedEventLoop()
+{
+    return eventLoop();
+}
+
 WebCoreOpaqueRoot root(ScriptExecutionContext* context)
 {
     return WebCoreOpaqueRoot { context };

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -111,6 +111,7 @@ public:
     virtual bool isJSExecutionForbidden() const = 0;
 
     virtual EventLoopTaskGroup& eventLoop() = 0;
+    CheckedRef<EventLoopTaskGroup> checkedEventLoop();
 
     virtual const URL& url() const = 0;
     enum class ForceUTF8 : bool { No, Yes };

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -33,6 +33,7 @@
 #include "FrameLoaderTypes.h"
 #include "LoaderMalloc.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 
@@ -47,7 +48,7 @@ class SecurityOrigin;
 
 enum class NewLoadInProgress : bool { No, Yes };
     
-class NavigationScheduler {
+class NavigationScheduler : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit NavigationScheduler(Frame&);

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -80,6 +80,11 @@ Location& DOMWindow::location()
     return *m_location;
 }
 
+RefPtr<Frame> DOMWindow::protectedFrame() const
+{
+    return frame();
+}
+
 WebCoreOpaqueRoot root(DOMWindow* window)
 {
     return WebCoreOpaqueRoot { window };

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -49,6 +49,7 @@ public:
 
     const GlobalWindowIdentifier& identifier() const { return m_identifier; }
     virtual Frame* frame() const = 0;
+    RefPtr<Frame> protectedFrame() const;
 
     virtual bool isLocalDOMWindow() const = 0;
     virtual bool isRemoteDOMWindow() const = 0;

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -30,6 +30,7 @@
 #include "LocalDOMWindow.h"
 #include "Supplementable.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashCountedSet.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ namespace WebCore {
 class DeviceClient;
 class Page;
 
-class DeviceController : public Supplement<Page> {
+class DeviceController : public Supplement<Page>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit DeviceController(DeviceClient&);

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -121,4 +121,9 @@ Ref<WindowProxy> Frame::protectedWindowProxy() const
     return m_windowProxy;
 }
 
+CheckedRef<NavigationScheduler> Frame::checkedNavigationScheduler() const
+{
+    return m_navigationScheduler.get();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -74,6 +74,7 @@ public:
 
     WEBCORE_EXPORT void disconnectOwnerElement();
     NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }
+    CheckedRef<NavigationScheduler> checkedNavigationScheduler() const;
     WEBCORE_EXPORT void takeWindowProxyFrom(Frame&);
 
     virtual void frameDetached() = 0;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -274,7 +274,7 @@ bool LocalDOMWindow::dispatchAllPendingBeforeUnloadEvents()
         if (!frame)
             continue;
 
-        if (!frame->loader().shouldClose())
+        if (!frame->checkedLoader()->shouldClose())
             return false;
 
         window->enableSuddenTermination();
@@ -327,7 +327,7 @@ void LocalDOMWindow::dispatchAllPendingUnloadEvents()
 // 5) Translate the window rect coordinates to be within the coordinate space of the screen.
 FloatRect LocalDOMWindow::adjustWindowRect(Page& page, const FloatRect& pendingChanges)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
     if (!localMainFrame)
         return FloatRect();
     FloatRect screen = screenAvailableRect(localMainFrame->view());
@@ -366,7 +366,7 @@ FloatRect LocalDOMWindow::adjustWindowRect(Page& page, const FloatRect& pendingC
 
 bool LocalDOMWindow::allowPopUp(LocalFrame& firstFrame)
 {
-    if (DocumentLoader* documentLoader = firstFrame.loader().documentLoader()) {
+    if (RefPtr documentLoader = firstFrame.loader().documentLoader()) {
         // If pop-up policy was set during navigation, use it. If not, use the global settings.
         PopUpPolicy popUpPolicy = documentLoader->popUpPolicy();
         if (popUpPolicy == PopUpPolicy::Allow)
@@ -396,13 +396,14 @@ bool LocalDOMWindow::canShowModalDialog(const LocalFrame& frame)
         }
     }
 
-    auto* page = frame.page();
+    CheckedPtr page = frame.page();
     return page && page->chrome().canRunModal();
 }
 
 static void languagesChangedCallback(void* context)
 {
-    static_cast<LocalDOMWindow*>(context)->languagesChanged();
+    Ref window = *static_cast<LocalDOMWindow*>(context);
+    window->languagesChanged();
 }
 
 void LocalDOMWindow::setCanShowModalDialogOverride(bool allow)
@@ -432,7 +433,7 @@ void LocalDOMWindow::didSecureTransitionTo(Document& document)
 
 void LocalDOMWindow::prewarmLocalStorageIfNecessary()
 {
-    auto* page = this->page();
+    CheckedPtr page = this->page();
 
     // No need to prewarm for ephemeral sessions since the data is in memory only.
     if (!page || page->usesEphemeralSession())
@@ -443,11 +444,11 @@ void LocalDOMWindow::prewarmLocalStorageIfNecessary()
     if (localStorageResult.hasException())
         return;
 
-    auto* localStorage = localStorageResult.returnValue();
+    RefPtr localStorage = localStorageResult.returnValue();
     if (!localStorage)
         return;
 
-    localStorage->area().prewarm();
+    localStorage->protectedArea()->prewarm();
 }
 
 LocalDOMWindow::~LocalDOMWindow()
@@ -480,9 +481,14 @@ Page* LocalDOMWindow::page() const
     return frame() ? frame()->page() : nullptr;
 }
 
+CheckedPtr<Page> LocalDOMWindow::checkedPage() const
+{
+    return page();
+}
+
 void LocalDOMWindow::frameDestroyed()
 {
-    Ref protectedThis(*this);
+    Ref protectedThis { *this };
 
     willDestroyDocumentInFrame();
     JSDOMWindowBase::fireFrameClearedWatchpointsForWindow(this);
@@ -519,13 +525,13 @@ void LocalDOMWindow::willDetachDocumentFromFrame()
         observer.willDetachGlobalObjectFromFrame();
     });
 
-    if (m_performance)
-        m_performance->clearResourceTimings();
+    if (RefPtr performance = m_performance)
+        performance->clearResourceTimings();
 
     windowsInterestedInStorageEvents().remove(*this);
 
     JSDOMWindowBase::fireFrameClearedWatchpointsForWindow(this);
-    InspectorInstrumentation::frameWindowDiscarded(*frame(), this);
+    InspectorInstrumentation::frameWindowDiscarded(*protectedFrame(), this);
 }
 
 #if ENABLE(GAMEPAD)
@@ -740,6 +746,11 @@ PageConsoleClient* LocalDOMWindow::console() const
     return frame->page() ? &frame->page()->console() : nullptr;
 }
 
+CheckedPtr<PageConsoleClient> LocalDOMWindow::checkedConsole() const
+{
+    return console();
+}
+
 DOMApplicationCache& LocalDOMWindow::applicationCache()
 {
     if (!m_applicationCache)
@@ -750,7 +761,7 @@ DOMApplicationCache& LocalDOMWindow::applicationCache()
 Navigator& LocalDOMWindow::navigator()
 {
     if (!m_navigator)
-        m_navigator = Navigator::create(scriptExecutionContext(), *this);
+        m_navigator = Navigator::create(protectedScriptExecutionContext().get(), *this);
     ASSERT(m_navigator->scriptExecutionContext() == document());
 
     return *m_navigator;
@@ -761,7 +772,7 @@ Performance& LocalDOMWindow::performance() const
     if (!m_performance) {
         RefPtr documentLoader = document() ? document()->loader() : nullptr;
         auto timeOrigin = documentLoader ? documentLoader->timing().timeOrigin() : MonotonicTime::now();
-        m_performance = Performance::create(document(), timeOrigin);
+        m_performance = Performance::create(protectedDocument().get(), timeOrigin);
     }
     ASSERT(m_performance->scriptExecutionContext() == document());
     return *m_performance;
@@ -802,7 +813,7 @@ bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world)
     if (!frame)
         return false;
 
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return false;
 
@@ -821,7 +832,7 @@ WebKitNamespace* LocalDOMWindow::webkitNamespace()
 {
     if (!isCurrentlyDisplayedInFrame())
         return nullptr;
-    auto* page = frame()->page();
+    CheckedPtr page = frame()->page();
     if (!page)
         return nullptr;
     if (!m_webkitNamespace)
@@ -846,11 +857,11 @@ ExceptionOr<Storage*> LocalDOMWindow::sessionStorage()
     if (m_sessionStorage)
         return m_sessionStorage.get();
 
-    auto* page = document->page();
+    CheckedPtr page = document->page();
     if (!page)
         return nullptr;
 
-    auto storageArea = page->storageNamespaceProvider().sessionStorageArea(*document);
+    Ref storageArea = page->storageNamespaceProvider().sessionStorageArea(*document);
     m_sessionStorage = Storage::create(*this, WTFMove(storageArea));
     if (hasEventListeners(eventNames().storageEvent))
         windowsInterestedInStorageEvents().add(*this);
@@ -869,7 +880,7 @@ ExceptionOr<Storage*> LocalDOMWindow::localStorage()
     if (document->canAccessResource(ScriptExecutionContext::ResourceType::LocalStorage) == ScriptExecutionContext::HasResourceAccess::No)
         return Exception { SecurityError };
 
-    auto* page = document->page();
+    CheckedPtr page = document->page();
     // FIXME: We should consider supporting access/modification to local storage
     // after calling window.close(). See <https://bugs.webkit.org/show_bug.cgi?id=135330>.
     if (!page || !page->isClosing()) {
@@ -886,7 +897,7 @@ ExceptionOr<Storage*> LocalDOMWindow::localStorage()
     if (!page->settings().localStorageEnabled())
         return nullptr;
 
-    auto storageArea = page->storageNamespaceProvider().localStorageArea(*document);
+    Ref storageArea = page->storageNamespaceProvider().localStorageArea(*document);
     m_localStorage = Storage::create(*this, WTFMove(storageArea));
     if (hasEventListeners(eventNames().storageEvent))
         windowsInterestedInStorageEvents().add(*this);
@@ -907,7 +918,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
 
     auto userGestureToForward = UserGestureIndicator::currentUserGesture();
 
-    document()->eventLoop().queueTask(TaskSource::PostedMessageQueue, [this, protectedThis = Ref { *this }, message = message, incumbentWindowProxy = WTFMove(incumbentWindowProxy), sourceOrigin = WTFMove(sourceOrigin), userGestureToForward = WTFMove(userGestureToForward), postMessageIdentifier, stackTrace = WTFMove(stackTrace), targetOrigin = WTFMove(targetOrigin)]() mutable {
+    protectedDocument()->checkedEventLoop()->queueTask(TaskSource::PostedMessageQueue, [this, protectedThis = Ref { *this }, message = message, incumbentWindowProxy = WTFMove(incumbentWindowProxy), sourceOrigin = WTFMove(sourceOrigin), userGestureToForward = WTFMove(userGestureToForward), postMessageIdentifier, stackTrace = WTFMove(stackTrace), targetOrigin = WTFMove(targetOrigin)]() mutable {
         if (!isCurrentlyDisplayedInFrame())
             return;
 
@@ -915,7 +926,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
         if (targetOrigin) {
             // Check target origin now since the target document may have changed since the timer was scheduled.
             if (!targetOrigin->isSameSchemeHostPort(document()->securityOrigin())) {
-                if (auto* pageConsole = console()) {
+                if (CheckedPtr pageConsole = console()) {
                     auto message = makeString("Unable to post message to ", targetOrigin->toString(), ". Recipient has origin ", document()->securityOrigin().toString(), ".\n");
                     if (stackTrace)
                         pageConsole->addMessage(MessageSource::Security, MessageLevel::Error, message, *stackTrace);
@@ -951,7 +962,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
         InspectorInstrumentation::didDispatchPostMessage(frame, postMessageIdentifier);
     });
 
-    InspectorInstrumentation::didPostMessage(*frame(), postMessageIdentifier, lexicalGlobalObject);
+    InspectorInstrumentation::didPostMessage(*protectedFrame(), postMessageIdentifier, lexicalGlobalObject);
 }
 
 ExceptionOr<void> LocalDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue messageValue, WindowPostMessageOptions&& options)
@@ -977,7 +988,7 @@ ExceptionOr<void> LocalDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobal
         return disentangledPorts.releaseException();
 
     // Schedule the message.
-    RefPtr<WindowProxy> incumbentWindowProxy = incumbentWindow.frame() ? &incumbentWindow.frame()->windowProxy() : nullptr;
+    RefPtr incumbentWindowProxy = incumbentWindow.frame() ? &incumbentWindow.frame()->windowProxy() : nullptr;
     MessageWithMessagePorts message { messageData.releaseReturnValue(), disentangledPorts.releaseReturnValue() };
     processPostMessage(lexicalGlobalObject, WTFMove(sourceDocument), message, WTFMove(incumbentWindowProxy), targetSecurityOrigin.releaseReturnValue());
     return { };
@@ -992,7 +1003,7 @@ void LocalDOMWindow::postMessageFromRemoteFrame(JSC::JSGlobalObject& lexicalGlob
     if (!frame())
         return;
 
-    RefPtr<WindowProxy> incumbentWindowProxy = &frame()->windowProxy();
+    RefPtr incumbentWindowProxy = &frame()->windowProxy();
 
     RefPtr<SecurityOrigin> targetOrigin;
     if (target)
@@ -1027,7 +1038,7 @@ void LocalDOMWindow::focus(LocalDOMWindow& incumbentWindow)
         if (!openerFrame || openerFrame == frame || incumbentWindow.frame() != openerFrame)
             return false;
 
-        auto* page = openerFrame->page();
+        CheckedPtr page = openerFrame->page();
         return page && page->isVisibleAndActive();
     }());
 }
@@ -1038,7 +1049,7 @@ void LocalDOMWindow::focus(bool allowFocus)
     if (!frame)
         return;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return;
 
@@ -1056,7 +1067,7 @@ void LocalDOMWindow::focus(bool allowFocus)
     if (focusedFrame && focusedFrame != frame)
         focusedFrame->document()->setFocusedElement(nullptr);
 
-    frame->eventHandler().focusDocumentView();
+    frame->checkedEventHandler()->focusDocumentView();
 }
 
 void LocalDOMWindow::blur()
@@ -1065,7 +1076,7 @@ void LocalDOMWindow::blur()
     if (!frame)
         return;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return;
 
@@ -1080,7 +1091,7 @@ void LocalDOMWindow::blur()
 
 void LocalDOMWindow::close(Document& document)
 {
-    if (!document.canNavigate(frame()))
+    if (!document.canNavigate(protectedFrame().get()))
         return;
     close();
 }
@@ -1091,7 +1102,7 @@ void LocalDOMWindow::close()
     if (!frame)
         return;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return;
 
@@ -1099,18 +1110,19 @@ void LocalDOMWindow::close()
         return;
 
     if (!(page->openedByDOM() || page->backForward().count() <= 1)) {
-        console()->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
+        checkedConsole()->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
         return;
     }
 
-    if (!frame->loader().shouldClose())
+    if (!frame->checkedLoader()->shouldClose())
         return;
 
     ResourceLoadObserver::shared().updateCentralStatisticsStore([] { });
 
     page->setIsClosing();
 
-    document()->eventLoop().queueTask(TaskSource::DOMManipulation, [this, protectedThis = Ref { *this }] {
+    protectedDocument()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [this, protectedThis = Ref { *this }] {
+        // Calling closeWindow() may destroy the page.
         if (auto* page = this->page())
             page->chrome().closeWindow();
     });
@@ -1122,7 +1134,7 @@ void LocalDOMWindow::print()
     if (!frame)
         return;
 
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return;
 
@@ -1134,7 +1146,7 @@ void LocalDOMWindow::print()
     if (page->isControlledByAutomation())
         return;
 
-    if (auto loader = frame->loader().activeDocumentLoader(); loader && loader->isLoading()) {
+    if (RefPtr loader = frame->loader().activeDocumentLoader(); loader && loader->isLoading()) {
         m_shouldPrintWhenFinishedLoading = true;
         return;
     }
@@ -1151,7 +1163,7 @@ void LocalDOMWindow::stop()
     SetForScope isStopping { m_isStopping, true };
     // We must check whether the load is complete asynchronously, because we might still be parsing
     // the document until the callstack unwinds.
-    frame->loader().stopForUserCancel(true);
+    frame->checkedLoader()->stopForUserCancel(true);
 }
 
 void LocalDOMWindow::alert(const String& message)
@@ -1166,7 +1178,7 @@ void LocalDOMWindow::alert(const String& message)
         return;
     }
 
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return;
 
@@ -1195,7 +1207,7 @@ bool LocalDOMWindow::confirmForBindings(const String& message)
         return false;
     }
 
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return false;
 
@@ -1224,7 +1236,7 @@ String LocalDOMWindow::prompt(const String& message, const String& defaultValue)
         return String();
     }
 
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return String();
 
@@ -1275,7 +1287,7 @@ int LocalDOMWindow::outerHeight() const
     if (!frame)
         return 0;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return 0;
 
@@ -1283,7 +1295,7 @@ int LocalDOMWindow::outerHeight() const
         return innerHeight();
 
 #if PLATFORM(IOS_FAMILY)
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
     if (!localFrame)
         return 0;
 
@@ -1303,7 +1315,7 @@ int LocalDOMWindow::outerWidth() const
     if (!frame)
         return 0;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return 0;
 
@@ -1311,7 +1323,7 @@ int LocalDOMWindow::outerWidth() const
         return innerWidth();
 
 #if PLATFORM(IOS_FAMILY)
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
     if (!localFrame)
         return 0;
 
@@ -1332,7 +1344,7 @@ int LocalDOMWindow::innerHeight() const
     
     // Force enough layout in the parent document to ensure that the FrameView has been resized.
     if (RefPtr ownerElement = frameElement())
-        ownerElement->document().updateLayoutIfDimensionsOutOfDate(*ownerElement, { DimensionsCheck::Height });
+        ownerElement->protectedDocument()->updateLayoutIfDimensionsOutOfDate(*ownerElement, { DimensionsCheck::Height });
 
     RefPtr frame = this->frame();
     if (!frame)
@@ -1352,7 +1364,7 @@ int LocalDOMWindow::innerWidth() const
 
     // Force enough layout in the parent document to ensure that the FrameView has been resized.
     if (RefPtr ownerElement = frameElement())
-        ownerElement->document().updateLayoutIfDimensionsOutOfDate(*ownerElement, { DimensionsCheck::Width });
+        ownerElement->protectedDocument()->updateLayoutIfDimensionsOutOfDate(*ownerElement, { DimensionsCheck::Width });
 
     RefPtr frame = this->frame();
     if (!frame)
@@ -1371,7 +1383,7 @@ int LocalDOMWindow::screenX() const
     if (!frame)
         return 0;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page || page->fingerprintingProtectionsEnabled())
         return 0;
 
@@ -1384,7 +1396,7 @@ int LocalDOMWindow::screenY() const
     if (!frame)
         return 0;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page || page->fingerprintingProtectionsEnabled())
         return 0;
 
@@ -1405,7 +1417,7 @@ int LocalDOMWindow::scrollX() const
     if (!scrollX)
         return 0;
 
-    frame->document()->updateLayoutIgnorePendingStylesheets();
+    frame->protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
     // Layout may have affected the current frame:
     RefPtr frameAfterLayout = this->frame();
@@ -1453,7 +1465,7 @@ bool LocalDOMWindow::closed() const
     if (!frame)
         return true;
 
-    auto* page = frame->page();
+    CheckedPtr page = frame->page();
     return !page || page->isClosing();
 }
 
@@ -1462,7 +1474,7 @@ unsigned LocalDOMWindow::length() const
     if (!isCurrentlyDisplayedInFrame())
         return 0;
 
-    return frame()->tree().scopedChildCount();
+    return protectedFrame()->tree().scopedChildCount();
 }
 
 AtomString LocalDOMWindow::name() const
@@ -1504,7 +1516,7 @@ WindowProxy* LocalDOMWindow::opener() const
 void LocalDOMWindow::disownOpener()
 {
     if (RefPtr frame = this->frame())
-        frame->loader().setOpener(nullptr);
+        frame->checkedLoader()->setOpener(nullptr);
 }
 
 WindowProxy* LocalDOMWindow::parent() const
@@ -1586,7 +1598,7 @@ bool LocalDOMWindow::consumeTransientActivation()
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;
-        if (auto* window = localFrame->window())
+        if (RefPtr window = localFrame->window())
             window->consumeLastActivationIfNecessary();
     }
 
@@ -1610,7 +1622,7 @@ void LocalDOMWindow::notifyActivated(MonotonicTime activationTime)
         RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor.get());
         if (!localAncestor)
             continue;
-        if (auto* window = localAncestor->window())
+        if (RefPtr window = localAncestor->window())
             window->setLastActivationTimestamp(activationTime);
     }
 
@@ -1620,10 +1632,10 @@ void LocalDOMWindow::notifyActivated(MonotonicTime activationTime)
 
     RefPtr<Frame> descendant = frame();
     while ((descendant = descendant->tree().traverseNext(frame()))) {
-        auto* localDescendant = dynamicDowncast<LocalFrame>(descendant.get());
+        RefPtr localDescendant = dynamicDowncast<LocalFrame>(descendant.get());
         if (!localDescendant)
             continue;
-        auto* descendantWindow = localDescendant->window();
+        RefPtr descendantWindow = localDescendant->window();
         if (!descendantWindow)
             continue;
 
@@ -1658,7 +1670,7 @@ RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const S
         return nullptr;
 
     RefPtr frame = this->frame();
-    frame->document()->styleScope().flushPendingUpdate();
+    frame->protectedDocument()->styleScope().flushPendingUpdate();
 
     unsigned rulesToInclude = Style::Resolver::AuthorCSSRules;
     if (!authorOnly)
@@ -1690,10 +1702,11 @@ RefPtr<WebKitPoint> LocalDOMWindow::webkitConvertPointFromNodeToPage(Node* node,
     if (!node || !p)
         return nullptr;
 
-    if (!document())
+    RefPtr document = this->document();
+    if (!document)
         return nullptr;
 
-    document()->updateLayoutIgnorePendingStylesheets();
+    document->updateLayoutIgnorePendingStylesheets();
 
     FloatPoint pagePoint(p->x(), p->y());
     pagePoint = node->convertToPage(pagePoint);
@@ -1705,10 +1718,11 @@ RefPtr<WebKitPoint> LocalDOMWindow::webkitConvertPointFromPageToNode(Node* node,
     if (!node || !p)
         return nullptr;
 
-    if (!document())
+    RefPtr document = this->document();
+    if (!document)
         return nullptr;
 
-    document()->updateLayoutIgnorePendingStylesheets();
+    document->updateLayoutIgnorePendingStylesheets();
 
     FloatPoint nodePoint(p->x(), p->y());
     nodePoint = node->convertFromPage(nodePoint);
@@ -1717,11 +1731,11 @@ RefPtr<WebKitPoint> LocalDOMWindow::webkitConvertPointFromPageToNode(Node* node,
 
 double LocalDOMWindow::devicePixelRatio() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0.0;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return 0.0;
 
@@ -1781,7 +1795,7 @@ void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping cla
     }
 
     view->cancelScheduledScrolls();
-    document()->updateLayoutIgnorePendingStylesheets();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
     IntPoint layoutPos(view->mapFromCSSToLayoutUnits(scrollToOptions.left.value()), view->mapFromCSSToLayoutUnits(scrollToOptions.top.value()));
 
@@ -1812,7 +1826,7 @@ void LocalDOMWindow::moveBy(float x, float y) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    auto* page = frame()->page();
+    CheckedPtr page = frame()->page();
     FloatRect fr = page->chrome().windowRect();
     FloatRect update = fr;
     update.move(x, y);
@@ -1824,9 +1838,9 @@ void LocalDOMWindow::moveTo(float x, float y) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    auto* page = frame()->page();
+    CheckedPtr page = frame()->page();
     FloatRect fr = page->chrome().windowRect();
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
     if (!localMainFrame)
         return;
 
@@ -1842,7 +1856,7 @@ void LocalDOMWindow::resizeBy(float x, float y) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    auto* page = frame()->page();
+    CheckedPtr page = frame()->page();
     FloatRect fr = page->chrome().windowRect();
     FloatSize dest = fr.size() + FloatSize(x, y);
     FloatRect update(fr.location(), dest);
@@ -1854,7 +1868,7 @@ void LocalDOMWindow::resizeTo(float width, float height) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    auto* page = frame()->page();
+    CheckedPtr page = frame()->page();
     FloatRect fr = page->chrome().windowRect();
     FloatSize dest = FloatSize(width, height);
     FloatRect update(fr.location(), dest);
@@ -1880,10 +1894,8 @@ ExceptionOr<int> LocalDOMWindow::setTimeout(std::unique_ptr<ScheduledAction> act
 
 void LocalDOMWindow::clearTimeout(int timeoutId)
 {
-    RefPtr context = scriptExecutionContext();
-    if (!context)
-        return;
-    DOMTimer::removeById(*context, timeoutId);
+    if (RefPtr context = scriptExecutionContext())
+        DOMTimer::removeById(*context, timeoutId);
 }
 
 ExceptionOr<int> LocalDOMWindow::setInterval(std::unique_ptr<ScheduledAction> action, int timeout, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments)
@@ -1905,25 +1917,21 @@ ExceptionOr<int> LocalDOMWindow::setInterval(std::unique_ptr<ScheduledAction> ac
 
 void LocalDOMWindow::clearInterval(int timeoutId)
 {
-    ScriptExecutionContext* context = scriptExecutionContext();
-    if (!context)
-        return;
-    DOMTimer::removeById(*context, timeoutId);
+    if (RefPtr context = scriptExecutionContext())
+        DOMTimer::removeById(*context, timeoutId);
 }
 
 int LocalDOMWindow::requestAnimationFrame(Ref<RequestAnimationFrameCallback>&& callback)
 {
     RefPtr document = this->document();
-    if (!document)
-        return 0;
-    return document->requestAnimationFrame(WTFMove(callback));
+    return document ? document->requestAnimationFrame(WTFMove(callback)) : 0;
 }
 
 int LocalDOMWindow::webkitRequestAnimationFrame(Ref<RequestAnimationFrameCallback>&& callback)
 {
     static bool firstTime = true;
     if (firstTime && document()) {
-        document()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "webkitRequestAnimationFrame() is deprecated and will be removed. Please use requestAnimationFrame() instead."_s);
+        protectedDocument()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "webkitRequestAnimationFrame() is deprecated and will be removed. Please use requestAnimationFrame() instead."_s);
         firstTime = false;
     }
     return requestAnimationFrame(WTFMove(callback));
@@ -1931,26 +1939,20 @@ int LocalDOMWindow::webkitRequestAnimationFrame(Ref<RequestAnimationFrameCallbac
 
 void LocalDOMWindow::cancelAnimationFrame(int id)
 {
-    RefPtr document = this->document();
-    if (!document)
-        return;
-    document->cancelAnimationFrame(id);
+    if (RefPtr document = this->document())
+        document->cancelAnimationFrame(id);
 }
 
 int LocalDOMWindow::requestIdleCallback(Ref<IdleRequestCallback>&& callback, const IdleRequestOptions& options)
 {
     RefPtr document = this->document();
-    if (!document)
-        return 0;
-    return document->requestIdleCallback(WTFMove(callback), Seconds::fromMilliseconds(options.timeout));
+    return document ? document->requestIdleCallback(WTFMove(callback), Seconds::fromMilliseconds(options.timeout)) : 0;
 }
 
 void LocalDOMWindow::cancelIdleCallback(int id)
 {
-    RefPtr document = this->document();
-    if (!document)
-        return;
-    return document->cancelIdleCallback(id);
+    if (RefPtr document = this->document())
+        document->cancelIdleCallback(id);
 }
 
 void LocalDOMWindow::createImageBitmap(ImageBitmap::Source&& source, ImageBitmapOptions&& options, ImageBitmap::Promise&& promise)
@@ -1976,9 +1978,7 @@ void LocalDOMWindow::createImageBitmap(ImageBitmap::Source&& source, int sx, int
 bool LocalDOMWindow::isSecureContext() const
 {
     RefPtr document = this->document();
-    if (!document)
-        return false;
-    return document->isSecureContext();
+    return document && document->isSecureContext();
 }
 
 bool LocalDOMWindow::crossOriginIsolated() const
@@ -1999,18 +1999,18 @@ static void didAddStorageEventListener(LocalDOMWindow& window)
 
 bool LocalDOMWindow::isSameSecurityOriginAsMainFrame() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame || !frame->page() || !document())
         return false;
 
     if (frame->isMainFrame())
         return true;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
     if (!localFrame)
         return false;
 
-    Document* mainFrameDocument = localFrame->document();
+    RefPtr mainFrameDocument = localFrame->document();
 
     if (mainFrameDocument && document()->securityOrigin().isSameOriginDomain(mainFrameDocument->securityOrigin()))
         return true;
@@ -2072,7 +2072,7 @@ DeviceOrientationController* LocalDOMWindow::deviceOrientationController() const
 #if PLATFORM(IOS_FAMILY)
     return document() ? &document()->deviceOrientationController() : nullptr;
 #else
-    return DeviceOrientationController::from(page());
+    return DeviceOrientationController::from(checkedPage().get());
 #endif
 }
 
@@ -2081,7 +2081,7 @@ DeviceMotionController* LocalDOMWindow::deviceMotionController() const
 #if PLATFORM(IOS_FAMILY)
     return document() ? &document()->deviceMotionController() : nullptr;
 #else
-    return DeviceMotionController::from(page());
+    return DeviceMotionController::from(checkedPage().get());
 #endif
 }
 
@@ -2157,7 +2157,7 @@ void LocalDOMWindow::startListeningForDeviceOrientationIfNecessary()
     if (!hasEventListeners(eventNames().deviceorientationEvent))
         return;
 
-    auto* deviceController = deviceOrientationController();
+    CheckedPtr deviceController = deviceOrientationController();
     if (!deviceController || deviceController->hasDeviceEventListener(*this))
         return;
 
@@ -2176,7 +2176,7 @@ void LocalDOMWindow::stopListeningForDeviceOrientationIfNecessary()
     if (hasEventListeners(eventNames().deviceorientationEvent))
         return;
 
-    if (auto* deviceController = deviceOrientationController())
+    if (CheckedPtr deviceController = deviceOrientationController())
         deviceController->removeDeviceEventListener(*this);
 }
 
@@ -2185,7 +2185,7 @@ void LocalDOMWindow::startListeningForDeviceMotionIfNecessary()
     if (!hasEventListeners(eventNames().devicemotionEvent))
         return;
 
-    auto* deviceController = deviceMotionController();
+    CheckedPtr deviceController = deviceMotionController();
     if (!deviceController || deviceController->hasDeviceEventListener(*this))
         return;
 
@@ -2205,7 +2205,7 @@ void LocalDOMWindow::stopListeningForDeviceMotionIfNecessary()
     if (hasEventListeners(eventNames().devicemotionEvent))
         return;
 
-    if (auto* deviceController = deviceMotionController())
+    if (CheckedPtr deviceController = deviceMotionController())
         deviceController->removeDeviceEventListener(*this);
 }
 
@@ -2218,7 +2218,7 @@ void LocalDOMWindow::failedToRegisterDeviceMotionEventListener()
     // FIXME: This is a quirk for chase.com on iPad (<rdar://problem/48423023>).
     if (RegistrableDomain::uncheckedCreateFromRegistrableDomainString("chase.com"_s).matches(document()->url())) {
         // Fire a fake DeviceMotionEvent with acceleration data to unblock the site's login flow.
-        document()->postTask([](auto& context) {
+        protectedDocument()->postTask([](auto& context) {
             if (RefPtr window = downcast<Document>(context).domWindow()) {
                 auto acceleration = DeviceMotionData::Acceleration::create();
                 window->dispatchEvent(DeviceMotionEvent::create(eventNames().devicemotionEvent, DeviceMotionData::create(acceleration.copyRef(), acceleration.copyRef(), DeviceMotionData::RotationRate::create(), std::nullopt).ptr()));
@@ -2237,17 +2237,17 @@ void LocalDOMWindow::incrementScrollEventListenersCount()
     RefPtr document = this->document();
     if (++m_scrollEventListenerCount == 1 && document == &document->topDocument()) {
         if (RefPtr frame = this->frame(); frame && frame->page())
-            frame->page()->chrome().client().setNeedsScrollNotifications(*frame, true);
+            frame->checkedPage()->chrome().client().setNeedsScrollNotifications(*frame, true);
     }
 }
 
 void LocalDOMWindow::decrementScrollEventListenersCount()
 {
-    Document* document = this->document();
+    RefPtr document = this->document();
     if (!--m_scrollEventListenerCount && document == &document->topDocument()) {
-        auto* frame = this->frame();
+        RefPtr frame = this->frame();
         if (frame && frame->page() && document->backForwardCacheState() == Document::NotInBackForwardCache)
-            frame->page()->chrome().client().setNeedsScrollNotifications(*frame, false);
+            frame->checkedPage()->chrome().client().setNeedsScrollNotifications(*frame, false);
     }
 }
 
@@ -2257,8 +2257,8 @@ void LocalDOMWindow::resetAllGeolocationPermission()
 {
     // FIXME: Can we remove the PLATFORM(IOS_FAMILY)-guard?
 #if ENABLE(GEOLOCATION) && PLATFORM(IOS_FAMILY)
-    if (m_navigator)
-        NavigatorGeolocation::from(*m_navigator)->resetAllGeolocationPermission();
+    if (RefPtr navigator = m_navigator)
+        NavigatorGeolocation::from(*navigator)->resetAllGeolocationPermission();
 #endif
 }
 
@@ -2328,7 +2328,7 @@ void LocalDOMWindow::dispatchLoadEvent()
     if (shouldMarkLoadEventTimes) {
         auto now = MonotonicTime::now();
         protectedLoader->timing().setLoadEventStart(now);
-        if (auto* navigationTiming = performance().navigationTiming())
+        if (RefPtr navigationTiming = performance().navigationTiming())
             navigationTiming->documentLoadTiming().setLoadEventStart(now);
     }
 
@@ -2336,7 +2336,7 @@ void LocalDOMWindow::dispatchLoadEvent()
     if (isMainFrame)
         WTFBeginSignpost(document(), "Page Load: Load Event");
 
-    dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No), document());
+    dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No), protectedDocument().get());
 
     if (isMainFrame)
         WTFEndSignpost(document(), "Page Load: Load Event");
@@ -2344,19 +2344,19 @@ void LocalDOMWindow::dispatchLoadEvent()
     if (shouldMarkLoadEventTimes) {
         auto now = MonotonicTime::now();
         protectedLoader->timing().setLoadEventEnd(now);
-        if (auto* navigationTiming = performance().navigationTiming())
+        if (RefPtr navigationTiming = performance().navigationTiming())
             navigationTiming->documentLoadTiming().setLoadEventEnd(now);
     }
 
     // Send a separate load event to the element that owns this frame.
     if (RefPtr ownerFrame = frame()) {
         if (is<RemoteFrame>(ownerFrame->tree().parent()))
-            ownerFrame->loader().client().dispatchLoadEventToOwnerElementInAnotherProcess();
+            ownerFrame->checkedLoader()->client().dispatchLoadEventToOwnerElementInAnotherProcess();
         else if (RefPtr owner = ownerFrame->ownerElement())
             owner->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
     }
 
-    InspectorInstrumentation::loadEventFired(frame());
+    InspectorInstrumentation::loadEventFired(protectedFrame().get());
 }
 
 void LocalDOMWindow::dispatchEvent(Event& event, EventTarget* target)
@@ -2426,9 +2426,9 @@ void LocalDOMWindow::removeAllEventListeners()
         document->didRemoveEventTargetNode(*document);
 #endif
 
-    if (m_performance) {
-        m_performance->removeAllEventListeners();
-        m_performance->removeAllObservers();
+    if (RefPtr performance = m_performance) {
+        performance->removeAllEventListeners();
+        performance->removeAllObservers();
     }
 
     removeAllUnloadEventListeners(this);
@@ -2449,7 +2449,7 @@ void LocalDOMWindow::finishedLoading()
 {
     if (m_shouldPrintWhenFinishedLoading) {
         m_shouldPrintWhenFinishedLoading = false;
-        if (auto loader = frame()->loader().activeDocumentLoader(); !loader || loader->mainDocumentError().isNull())
+        if (RefPtr loader = frame()->loader().activeDocumentLoader(); !loader || loader->mainDocumentError().isNull())
             print();
     }
 }
@@ -2477,7 +2477,7 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
     // We want a new history item if we are processing a user gesture.
     LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
     LockBackForwardList lockBackForwardList = (locking != SetLocationLocking::LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;
-    frame->navigationScheduler().scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(),
+    frame->checkedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(),
         // FIXME: What if activeDocument()->frame() is 0?
         completedURL, activeDocument->frame()->loader().outgoingReferrer(),
         lockHistory, lockBackForwardList);
@@ -2488,7 +2488,7 @@ void LocalDOMWindow::printErrorMessage(const String& message) const
     if (message.isEmpty())
         return;
 
-    if (PageConsoleClient* pageConsole = console())
+    if (CheckedPtr pageConsole = console())
         pageConsole->addMessage(MessageSource::JS, MessageLevel::Error, message);
 }
 
@@ -2588,7 +2588,7 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
     auto initiatedByMainFrame = activeFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
 
     ResourceRequest resourceRequest { completedURL, referrer };
-    auto* openerDocumentLoader = openerFrame.document() ? openerFrame.document()->loader() : nullptr;
+    RefPtr openerDocumentLoader = openerFrame.document() ? openerFrame.document()->loader() : nullptr;
     if (openerDocumentLoader)
         resourceRequest.setIsAppInitiated(openerDocumentLoader->lastNavigationWasAppInitiated());
     FrameLoadRequest frameLoadRequest { *activeDocument, activeDocument->securityOrigin(), WTFMove(resourceRequest), frameName, initiatedByMainFrame };
@@ -2597,32 +2597,32 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
     // We pass the opener frame for the lookupFrame in case the active frame is different from
     // the opener frame, and the name references a frame relative to the opener frame.
     bool created;
-    auto newFrame = WebCore::createWindow(*activeFrame, openerFrame, WTFMove(frameLoadRequest), windowFeatures, created);
+    RefPtr newFrame = WebCore::createWindow(*activeFrame, openerFrame, WTFMove(frameLoadRequest), windowFeatures, created);
     if (!newFrame)
         return RefPtr<LocalFrame> { nullptr };
 
     bool noopener = windowFeatures.wantsNoOpener();
     if (!noopener)
-        newFrame->loader().setOpener(&openerFrame);
+        newFrame->checkedLoader()->setOpener(&openerFrame);
 
     if (created)
-        newFrame->page()->setOpenedByDOM();
+        newFrame->checkedPage()->setOpenedByDOM();
 
     if (newFrame->document()->domWindow()->isInsecureScriptAccess(activeWindow, completedURL.string()))
         return noopener ? RefPtr<LocalFrame> { nullptr } : newFrame;
 
     if (prepareDialogFunction)
-        prepareDialogFunction(*newFrame->document()->domWindow());
+        prepareDialogFunction(*newFrame->document()->protectedWindow());
 
     if (created) {
         ResourceRequest resourceRequest { completedURL, referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
-        FrameLoader::addSameSiteInfoToRequestIfNeeded(resourceRequest, openerFrame.document());
-        FrameLoadRequest frameLoadRequest { *activeWindow.document(), activeWindow.document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
+        FrameLoader::addSameSiteInfoToRequestIfNeeded(resourceRequest, openerFrame.protectedDocument().get());
+        FrameLoadRequest frameLoadRequest { activeWindow.protectedDocument().releaseNonNull(), activeWindow.document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
         frameLoadRequest.setShouldOpenExternalURLsPolicy(activeDocument->shouldOpenExternalURLsPolicyToPropagate());
-        newFrame->loader().changeLocation(WTFMove(frameLoadRequest));
+        newFrame->checkedLoader()->changeLocation(WTFMove(frameLoadRequest));
     } else if (!urlString.isEmpty()) {
         LockHistory lockHistory = UserGestureIndicator::processingUserGesture() ? LockHistory::No : LockHistory::Yes;
-        newFrame->navigationScheduler().scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(), completedURL, referrer, lockHistory, LockBackForwardList::No);
+        newFrame->checkedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(), completedURL, referrer, lockHistory, LockBackForwardList::No);
     }
 
     // Navigating the new frame could result in it being detached from its page by a navigation policy delegate.
@@ -2650,10 +2650,10 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
         urlString = "about:blank"_s;
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    auto* page = firstFrame->page();
+    CheckedPtr page = firstFrame->page();
     RefPtr firstFrameDocument = firstFrame->document();
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(firstFrame->mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(firstFrame->mainFrame());
     if (!localFrame)
         return RefPtr<WindowProxy> { nullptr };
 
@@ -2673,7 +2673,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     if (!firstWindow.allowPopUp()) {
         // Because FrameTree::findFrameForNavigation() returns true for empty strings, we must check for empty frame names.
         // Otherwise, illegitimate window.open() calls with no name will pass right through the popup blocker.
-        if (frameName.isEmpty() || !frame->loader().findFrameForNavigation(frameName, activeDocument.get()))
+        if (frameName.isEmpty() || !frame->checkedLoader()->findFrameForNavigation(frameName, activeDocument.get()))
             return RefPtr<WindowProxy> { nullptr };
     }
 
@@ -2703,7 +2703,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
         // For whatever reason, Firefox uses the first window rather than the active window to
         // determine the outgoing referrer. We replicate that behavior here.
         LockHistory lockHistory = UserGestureIndicator::processingUserGesture() ? LockHistory::No : LockHistory::Yes;
-        targetFrame->navigationScheduler().scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(), completedURL, firstFrame->loader().outgoingReferrer(),
+        targetFrame->checkedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(), completedURL, firstFrame->loader().outgoingReferrer(),
             lockHistory, LockBackForwardList::No);
         return &targetFrame->windowProxy();
     }
@@ -2745,21 +2745,19 @@ void LocalDOMWindow::showModalDialog(const String& urlString, const String& dial
     auto dialogFrameOrException = createWindow(urlString, emptyAtom(), parseDialogFeatures(dialogFeaturesString, screenAvailableRect(frame->view())), activeWindow, *firstFrame, *frame, prepareDialogFunction);
     if (dialogFrameOrException.hasException())
         return;
-    RefPtr<LocalFrame> dialogFrame = dialogFrameOrException.releaseReturnValue();
-    if (!dialogFrame)
-        return;
-    dialogFrame->page()->chrome().runModal();
+    if (RefPtr dialogFrame = dialogFrameOrException.releaseReturnValue())
+        dialogFrame->page()->chrome().runModal();
 }
 
 void LocalDOMWindow::enableSuddenTermination()
 {
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         page->chrome().enableSuddenTermination();
 }
 
 void LocalDOMWindow::disableSuddenTermination()
 {
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         page->chrome().disableSuddenTermination();
 }
 
@@ -2767,6 +2765,11 @@ LocalFrame* LocalDOMWindow::frame() const
 {
     auto* document = this->document();
     return document ? document->frame() : nullptr;
+}
+
+RefPtr<LocalFrame> LocalDOMWindow::protectedFrame() const
+{
+    return frame();
 }
 
 void LocalDOMWindow::eventListenersDidChange()

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -143,6 +143,7 @@ public:
     void resumeFromBackForwardCache();
 
     WEBCORE_EXPORT LocalFrame* frame() const final;
+    RefPtr<LocalFrame> protectedFrame() const;
 
     RefPtr<MediaQueryList> matchMedia(const String&);
 
@@ -257,6 +258,7 @@ public:
     RefPtr<WebKitPoint> webkitConvertPointFromNodeToPage(Node*, const WebKitPoint*) const;
 
     PageConsoleClient* console() const;
+    CheckedPtr<PageConsoleClient> checkedConsole() const;
 
     void printErrorMessage(const String&) const;
 
@@ -405,6 +407,8 @@ public:
     bool mayReuseForNavigation() const { return m_mayReuseForNavigation; }
 
     Page* page() const;
+    CheckedPtr<Page> checkedPage() const;
+
     WEBCORE_EXPORT static void forEachWindowInterestedInStorageEvents(const Function<void(LocalDOMWindow&)>&);
 
     CookieStore& cookieStore();

--- a/Source/WebCore/page/PageConsoleClient.h
+++ b/Source/WebCore/page/PageConsoleClient.h
@@ -30,6 +30,7 @@
 
 #include <JavaScriptCore/ConsoleClient.h>
 #include <JavaScriptCore/ScriptCallStack.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 
 namespace Inspector {
@@ -47,7 +48,7 @@ namespace WebCore {
 class Document;
 class Page;
 
-class WEBCORE_EXPORT PageConsoleClient final : public JSC::ConsoleClient {
+class WEBCORE_EXPORT PageConsoleClient final : public JSC::ConsoleClient, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit PageConsoleClient(Page&);

--- a/Source/WebCore/storage/Storage.cpp
+++ b/Source/WebCore/storage/Storage.cpp
@@ -125,4 +125,9 @@ Vector<AtomString> Storage::supportedPropertyNames() const
     });
 }
 
+Ref<StorageArea> Storage::protectedArea() const
+{
+    return m_storageArea;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/storage/Storage.h
+++ b/Source/WebCore/storage/Storage.h
@@ -52,6 +52,7 @@ public:
     Vector<AtomString> supportedPropertyNames() const;
 
     StorageArea& area() const { return m_storageArea.get(); }
+    Ref<StorageArea> protectedArea() const;
 
 private:
     Storage(LocalDOMWindow&, Ref<StorageArea>&&);


### PR DESCRIPTION
#### 6662a4438135d1fb40c571d245f3af77db65b08d
<pre>
Adopt more smart pointers in LocalDOMWindow
<a href="https://bugs.webkit.org/show_bug.cgi?id=263855">https://bugs.webkit.org/show_bug.cgi?id=263855</a>

Reviewed by Brent Fulgham.

* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::checkedEventLoop):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::protectedFrame const):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DeviceController.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::checkedNavigationScheduler const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchAllPendingBeforeUnloadEvents):
(WebCore::LocalDOMWindow::adjustWindowRect):
(WebCore::LocalDOMWindow::allowPopUp):
(WebCore::LocalDOMWindow::canShowModalDialog):
(WebCore::languagesChangedCallback):
(WebCore::LocalDOMWindow::prewarmLocalStorageIfNecessary):
(WebCore::LocalDOMWindow::checkedPage const):
(WebCore::LocalDOMWindow::frameDestroyed):
(WebCore::LocalDOMWindow::willDetachDocumentFromFrame):
(WebCore::LocalDOMWindow::checkedConsole const):
(WebCore::LocalDOMWindow::navigator):
(WebCore::LocalDOMWindow::performance const):
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
(WebCore::LocalDOMWindow::webkitNamespace):
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::postMessage):
(WebCore::LocalDOMWindow::postMessageFromRemoteFrame):
(WebCore::LocalDOMWindow::focus):
(WebCore::LocalDOMWindow::blur):
(WebCore::LocalDOMWindow::close):
(WebCore::LocalDOMWindow::print):
(WebCore::LocalDOMWindow::stop):
(WebCore::LocalDOMWindow::alert):
(WebCore::LocalDOMWindow::confirmForBindings):
(WebCore::LocalDOMWindow::prompt):
(WebCore::LocalDOMWindow::outerHeight const):
(WebCore::LocalDOMWindow::outerWidth const):
(WebCore::LocalDOMWindow::innerHeight const):
(WebCore::LocalDOMWindow::innerWidth const):
(WebCore::LocalDOMWindow::screenX const):
(WebCore::LocalDOMWindow::screenY const):
(WebCore::LocalDOMWindow::scrollX const):
(WebCore::LocalDOMWindow::closed const):
(WebCore::LocalDOMWindow::length const):
(WebCore::LocalDOMWindow::disownOpener):
(WebCore::LocalDOMWindow::consumeTransientActivation):
(WebCore::LocalDOMWindow::notifyActivated):
(WebCore::LocalDOMWindow::getMatchedCSSRules const):
(WebCore::LocalDOMWindow::webkitConvertPointFromNodeToPage const):
(WebCore::LocalDOMWindow::webkitConvertPointFromPageToNode const):
(WebCore::LocalDOMWindow::devicePixelRatio const):
(WebCore::LocalDOMWindow::scrollTo const):
(WebCore::LocalDOMWindow::moveBy const):
(WebCore::LocalDOMWindow::moveTo const):
(WebCore::LocalDOMWindow::resizeBy const):
(WebCore::LocalDOMWindow::resizeTo const):
(WebCore::LocalDOMWindow::clearTimeout):
(WebCore::LocalDOMWindow::clearInterval):
(WebCore::LocalDOMWindow::requestAnimationFrame):
(WebCore::LocalDOMWindow::webkitRequestAnimationFrame):
(WebCore::LocalDOMWindow::cancelAnimationFrame):
(WebCore::LocalDOMWindow::requestIdleCallback):
(WebCore::LocalDOMWindow::cancelIdleCallback):
(WebCore::LocalDOMWindow::isSecureContext const):
(WebCore::LocalDOMWindow::isSameSecurityOriginAsMainFrame const):
(WebCore::LocalDOMWindow::deviceOrientationController const):
(WebCore::LocalDOMWindow::deviceMotionController const):
(WebCore::LocalDOMWindow::startListeningForDeviceOrientationIfNecessary):
(WebCore::LocalDOMWindow::stopListeningForDeviceOrientationIfNecessary):
(WebCore::LocalDOMWindow::startListeningForDeviceMotionIfNecessary):
(WebCore::LocalDOMWindow::stopListeningForDeviceMotionIfNecessary):
(WebCore::LocalDOMWindow::failedToRegisterDeviceMotionEventListener):
(WebCore::LocalDOMWindow::incrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::decrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::resetAllGeolocationPermission):
(WebCore::LocalDOMWindow::dispatchLoadEvent):
(WebCore::LocalDOMWindow::removeAllEventListeners):
(WebCore::LocalDOMWindow::finishedLoading):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::printErrorMessage const):
(WebCore::LocalDOMWindow::createWindow):
(WebCore::LocalDOMWindow::open):
(WebCore::LocalDOMWindow::showModalDialog):
(WebCore::LocalDOMWindow::enableSuddenTermination):
(WebCore::LocalDOMWindow::disableSuddenTermination):
(WebCore::LocalDOMWindow::protectedFrame const):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/PageConsoleClient.h:
* Source/WebCore/storage/Storage.cpp:
(WebCore::Storage::protectedArea const):
* Source/WebCore/storage/Storage.h:

Canonical link: <a href="https://commits.webkit.org/269964@main">https://commits.webkit.org/269964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffb30d2f73d0d90060747febfc5c9cef6842b7d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26215 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26804 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27973 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19082 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1431 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->