### PR TITLE
MediaTime isn't usable in an Expected

### DIFF
--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -68,11 +68,6 @@ static int64_t signum(int64_t val)
 
 const uint32_t MediaTime::MaximumTimeScale = 1000000000;
 
-MediaTime::MediaTime(const MediaTime& rhs)
-{
-    *this = rhs;
-}
-
 MediaTime MediaTime::createWithFloat(float floatTime)
 {
     if (floatTime != floatTime)
@@ -157,14 +152,6 @@ double MediaTime::toDouble() const
     if (hasDoubleValue())
         return m_timeValueAsDouble;
     return static_cast<double>(m_timeValue) / m_timeScale;
-}
-
-MediaTime& MediaTime::operator=(const MediaTime& rhs)
-{
-    m_timeValue = rhs.m_timeValue;
-    m_timeScale = rhs.m_timeScale;
-    m_timeFlags = rhs.m_timeFlags;
-    return *this;
 }
 
 MediaTime MediaTime::operator+(const MediaTime& rhs) const

--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -55,7 +55,7 @@ public:
 
     constexpr MediaTime();
     constexpr MediaTime(int64_t value, uint32_t scale, uint8_t flags = Valid);
-    MediaTime(const MediaTime& rhs);
+    MediaTime(const MediaTime&) = default;
 
     static MediaTime createWithFloat(float floatTime);
     static MediaTime createWithFloat(float floatTime, uint32_t timeScale);
@@ -65,7 +65,7 @@ public:
     float toFloat() const;
     double toDouble() const;
 
-    MediaTime& operator=(const MediaTime& rhs);
+    MediaTime& operator=(const MediaTime&) = default;
     MediaTime& operator+=(const MediaTime& rhs) { return *this = *this + rhs; }
     MediaTime& operator-=(const MediaTime& rhs) { return *this = *this - rhs; }
     MediaTime operator+(const MediaTime& rhs) const;

--- a/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 
 #include <limits>
+#include <wtf/Expected.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MediaTime.h>
 
@@ -337,5 +338,12 @@ TEST(WTF, MediaTime)
     EXPECT_EQ(MediaTime::createWithFloat(-999).toTimeScale(0), MediaTime::negativeInfiniteTime());
 }
 
+TEST(WTF, MediaTimeInExpected)
+{
+    using Test = Expected<MediaTime, int>;
+    Test test1;
+    Test test2;
+    test1 = WTFMove(test2);
 }
 
+}


### PR DESCRIPTION
#### c7327fa6d918d5c5c855b34d6f6de2f178164e60
<pre>
MediaTime isn&apos;t usable in an Expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=263857">https://bugs.webkit.org/show_bug.cgi?id=263857</a>
rdar://117659224

Reviewed by Dan Glastonbury and Eric Carlson.

Expected requires the object to be trivially copyable, which isn&apos;t the case with an explicitly defined copy constructor.
So we remove the redundant code and declare is as `= default`.

* Source/WTF/wtf/MediaTime.cpp:
(WTF::MediaTime::MediaTime): Deleted.
(WTF::MediaTime::operator=): Deleted.
* Source/WTF/wtf/MediaTime.h:
* Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/269918@main">https://commits.webkit.org/269918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1902a50b78635b736254cdd0382aab49f9b1be5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24560 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26806 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27975 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20940 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22014 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25751 "Found 57 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/ephemeral, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/reload, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cookies, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-cancel, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/populate-menu, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-no-credential ... (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23386 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19083 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30780 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1433 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6760 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5748 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1822 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30744 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1765 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6433 "Passed tests") | 
<!--EWS-Status-Bubble-End-->