### PR TITLE
[content-visibility] Optimize lazy layout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-getboundingclientrect-on-children-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-getboundingclientrect-on-children-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Calling getBoundingClientRect on container and then children should not timeout.
+PASS Calling getBoundingClientRect on children and then container should not timeout.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-getboundingclientrect-on-children.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-getboundingclientrect-on-children.html
@@ -1,0 +1,79 @@
+<!doctype HTML>
+<html>
+<meta charset="utf8">
+<title>CSS Content Visibility: stress test getBoundingClientRect</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!--
+This test creates a container div with 10,000 non-trivial div children.
+It sets content-visibility: hidden on the container and tests performance of lazy layout through getBoundingClientRect.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=container></div>
+
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+test(() => {
+  container.innerHTML = "";
+  construct(1000);
+  for (let i = 0; i < 10; i++) {
+    assert_equals(container.getBoundingClientRect().width, 502);
+    assert_equals(container.getBoundingClientRect().height, 502);
+    Array.from(container.children).forEach((item) => { assert_equals(item.getBoundingClientRect().width, 50); assert_equals(item.getBoundingClientRect().height, 50); });
+  }
+}, "Calling getBoundingClientRect on container and then children should not timeout.");
+
+test(() => {
+  container.innerHTML = "";
+  construct(1000);
+  for (let i = 0; i < 10; i++) {
+    Array.from(container.children).forEach((item) => { assert_equals(item.getBoundingClientRect().width, 50); assert_equals(item.getBoundingClientRect().height, 50); });
+    assert_equals(container.getBoundingClientRect().width, 502);
+    assert_equals(container.getBoundingClientRect().height, 502);
+  }
+}, "Calling getBoundingClientRect on children and then container should not timeout.");
+
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2728,7 +2728,7 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
 
         if (frameView && renderView()) {
             if (context && layoutOptions.contains(LayoutOptions::ContentVisibilityForceLayout)) {
-                if (context->renderer() && context->renderer()->style().hasSkippedContent())
+                if (context->renderer() && context->renderer()->style().hasSkippedContent() && !context->renderer()->everHadSkippedContentLayout())
                     context->renderer()->setNeedsLayout();
                 else
                     context = nullptr;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -956,9 +956,8 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
 
 void RenderBlock::layoutPositionedObject(RenderBox& r, bool relayoutChildren, bool fixedPositionObjectsOnly)
 {
-    if (isSkippedContentRootForLayout()) {
-        r.clearNeedsLayoutForDescendants();
-        r.clearNeedsLayout();
+    if (isSkippedContentRoot()) {
+        r.clearNeedsLayoutForSkippedContent();
         return;
     }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -899,8 +899,7 @@ void RenderBlockFlow::layoutBlockChildren(bool relayoutChildren, LayoutUnit& max
             continue; // Skip this child, since it will be positioned by the specialized subclass (fieldsets and ruby runs).
 
         if (child.isSkippedContentForLayout()) {
-            child.clearNeedsLayoutForDescendants();
-            child.clearNeedsLayout();
+            child.clearNeedsLayoutForSkippedContent();
             continue;
         }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5806,7 +5806,7 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerWidth() const
     if (style().containIntrinsicWidthType() == ContainIntrinsicSizeType::None)
         return std::nullopt;
 
-    if (element() && style().containIntrinsicWidthHasAuto() && isSkippedContentRoot()) {
+    if (element() && style().containIntrinsicWidthHasAuto() && WebCore::isSkippedContentRoot(style(), element())) {
         if (auto width = isHorizontalWritingMode() ? element()->lastRememberedLogicalWidth() : element()->lastRememberedLogicalHeight())
             return width;
     }
@@ -5825,7 +5825,7 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerHeight() const
     if (style().containIntrinsicHeightType() == ContainIntrinsicSizeType::None)
         return std::nullopt;
 
-    if (element() && style().containIntrinsicHeightHasAuto() && isSkippedContentRoot()) {
+    if (element() && style().containIntrinsicHeightHasAuto() && WebCore::isSkippedContentRoot(style(), element())) {
         if (auto height = isHorizontalWritingMode() ? element()->lastRememberedLogicalHeight() : element()->lastRememberedLogicalWidth())
             return height;
     }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2414,11 +2414,6 @@ FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const
 
 bool RenderElement::isSkippedContentRoot() const
 {
-    return WebCore::isSkippedContentRoot(style(), element());
-}
-
-bool RenderElement::isSkippedContentRootForLayout() const
-{
     return WebCore::isSkippedContentRoot(style(), element()) && !view().frameView().layoutContext().needsSkippedContentLayout();
 }
 
@@ -2439,10 +2434,11 @@ bool RenderElement::hasEligibleContainmentForSizeQuery() const
     return false;
 }
 
-void RenderElement::clearNeedsLayoutForDescendants()
+void RenderElement::clearNeedsLayoutForSkippedContent()
 {
     for (CheckedRef descendant : descendantsOfType<RenderObject>(*this))
-        descendant->clearNeedsLayout();
+        descendant->clearNeedsLayout(EverHadSkippedContentLayout::No);
+    clearNeedsLayout(EverHadSkippedContentLayout::No);
 }
 
 void RenderElement::layoutIfNeeded()
@@ -2450,8 +2446,7 @@ void RenderElement::layoutIfNeeded()
     if (!needsLayout())
         return;
     if (isSkippedContentForLayout()) {
-        clearNeedsLayoutForDescendants();
-        clearNeedsLayout();
+        clearNeedsLayoutForSkippedContent();
         return;
     }
     layout();

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -289,9 +289,8 @@ public:
     bool createsNewFormattingContext() const;
 
     bool isSkippedContentRoot() const;
-    bool isSkippedContentRootForLayout() const;
 
-    void clearNeedsLayoutForDescendants();
+    void clearNeedsLayoutForSkippedContent();
 
 protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -75,7 +75,7 @@ inline bool RenderElement::shouldApplyAnyContainment() const
 
 inline bool RenderElement::shouldApplyInlineSizeContainment() const
 {
-    return isSkippedContentRoot() || shouldApplySizeOrStyleContainment(style().containsInlineSize());
+    return WebCore::isSkippedContentRoot(style(), element()) || shouldApplySizeOrStyleContainment(style().containsInlineSize());
 }
 
 inline bool RenderElement::shouldApplyLayoutContainment() const
@@ -100,12 +100,12 @@ inline bool RenderElement::shouldApplyPaintContainment() const
 
 inline bool RenderElement::shouldApplySizeContainment() const
 {
-    return isSkippedContentRoot() || shouldApplySizeOrStyleContainment(style().containsSize());
+    return WebCore::isSkippedContentRoot(style(), element()) || shouldApplySizeOrStyleContainment(style().containsSize());
 }
 
 inline bool RenderElement::shouldApplySizeOrInlineSizeContainment() const
 {
-    return isSkippedContentRoot() || shouldApplySizeOrStyleContainment(style().containsSizeOrInlineSize());
+    return WebCore::isSkippedContentRoot(style(), element()) || shouldApplySizeOrStyleContainment(style().containsSizeOrInlineSize());
 }
 
 // FIXME: try to avoid duplication with isSkippedContentRoot.

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1437,9 +1437,8 @@ bool RenderGrid::hasStaticPositionForChild(const RenderBox& child, GridTrackSizi
 
 void RenderGrid::layoutPositionedObject(RenderBox& child, bool relayoutChildren, bool fixedPositionObjectsOnly)
 {
-    if (isSkippedContentRootForLayout()) {
-        child.clearNeedsLayoutForDescendants();
-        child.clearNeedsLayout();
+    if (isSkippedContentRoot()) {
+        child.clearNeedsLayoutForSkippedContent();
         return;
     }
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -553,10 +553,11 @@ static inline bool objectIsRelayoutBoundary(const RenderElement* object)
     return true;
 }
 
-void RenderObject::clearNeedsLayout()
+void RenderObject::clearNeedsLayout(EverHadSkippedContentLayout everHadSkippedContentLayout)
 {
     m_stateBitfields.clearFlag(StateFlag::NeedsLayout);
     setEverHadLayout();
+    setEverHadSkippedContentLayout(everHadSkippedContentLayout == EverHadSkippedContentLayout::Yes);
     setPosChildNeedsLayoutBit(false);
     setNeedsSimplifiedNormalFlowLayoutBit(false);
     setNormalChildNeedsLayoutBit(false);

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -510,6 +510,8 @@ public:
 
     static ScrollAnchoringController* searchParentChainForScrollAnchoringController(const RenderObject&);
 
+    bool everHadSkippedContentLayout() const { return m_stateBitfields.hasFlag(StateFlag::EverHadSkippedContentLayout); }
+
     bool childrenInline() const { return m_stateBitfields.hasFlag(StateFlag::ChildrenInline); }
     virtual void setChildrenInline(bool b) { m_stateBitfields.setFlag(StateFlag::ChildrenInline, b); }
 
@@ -757,7 +759,8 @@ public:
 
     void markContainingBlocksForLayout(ScheduleRelayout = ScheduleRelayout::Yes, RenderElement* newRoot = nullptr);
     void setNeedsLayout(MarkingBehavior = MarkContainingBlockChain);
-    void clearNeedsLayout();
+    enum class EverHadSkippedContentLayout { Yes, No };
+    void clearNeedsLayout(EverHadSkippedContentLayout = EverHadSkippedContentLayout::Yes);
     void setPreferredLogicalWidthsDirty(bool, MarkingBehavior = MarkContainingBlockChain);
     void invalidateContainerPreferredLogicalWidths();
     
@@ -1174,6 +1177,8 @@ private:
 
     void setEverHadLayout() { m_stateBitfields.setFlag(StateFlag::EverHadLayout); }
 
+    void setEverHadSkippedContentLayout(bool b) { m_stateBitfields.setFlag(StateFlag::EverHadSkippedContentLayout, b); }
+
     bool hasRareData() const { return m_stateBitfields.hasFlag(StateFlag::HasRareData); }
 
 #if ASSERT_ENABLED
@@ -1207,6 +1212,7 @@ private:
         ChildrenInline = 1 << 17,
         PaintContainmentApplies = 1 << 18,
         HasSVGTransform = 1 << 19,
+        EverHadSkippedContentLayout = 1 << 20,
     };
 
     class StateBitfields {
@@ -1218,12 +1224,12 @@ private:
         };
 
     private:
-        uint32_t m_flags : 20 { 0 };
+        uint32_t m_flags : 21 { 0 };
         uint32_t m_positionedState : 2 { IsStaticallyPositioned }; // PositionedState
         uint32_t m_selectionState : 3 { enumToUnderlyingType(HighlightState::None) }; // HighlightState
         uint32_t m_fragmentedFlowState : 1 { enumToUnderlyingType(FragmentedFlowState::NotInsideFlow) }; // FragmentedFlowState
         uint32_t m_boxDecorationState : 2 { enumToUnderlyingType(BoxDecorationState::None) }; // BoxDecorationState
-        // 4 bits free
+        // 3 bits free
 
     public:
         OptionSet<StateFlag> flags() const { return OptionSet<StateFlag>::fromRaw(m_flags); }


### PR DESCRIPTION
#### 58d4460957a8b92c7109bddc65c5972a556aceb2
<pre>
[content-visibility] Optimize lazy layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=263327">https://bugs.webkit.org/show_bug.cgi?id=263327</a>

Reviewed by Alan Baradlay.

Keep track of whether a hidden content-visibility subtree has been laid out using a dedicated bit
named everHadSkippedContentLayout, and only force layout if everHadSkippedContentLayout is false.
In order to make clearNeedsLayoutForSkippedContent work correctly the everHadSkippedContentLayout
bit is cleared for the whole content-visibility subtree.

This patch also merges isSkippedContentRootForLayout and isSkippedContentRoot since it was not
always clear which one to call and was a source of bugs. The new behaviour is now to always take layout into
account, but for size containment related code the static WebCore::isSkippedContentRoot is used
that does not take layout into account since size containment determination should be invariant to (forced) layout.

The test content-visibility-getboundingclientrect-on-children.html is added to verify layout is forced
only once for subtrees.

Canonical link: <a href="https://commits.webkit.org/274490@main">https://commits.webkit.org/274490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b3eb956ff60fdd174456066120f11e74bf67e5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36815 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34898 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31545 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8783 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->