### PR TITLE
[GTK] Fix Debian stable build after 269760@main

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
@@ -42,7 +42,7 @@ static inline struct gbm_bo* gbm_bo_create_with_modifiers2(struct gbm_device* gb
 #endif
 
 #if !HAVE(GBM_BO_GET_FD_FOR_PLANE)
-static inline int gbm_bo_get_fd_for_plane2(struct gbm_bo* bo, int plane)
+static inline int gbm_bo_get_fd_for_plane(struct gbm_bo* bo, int plane)
 {
     auto handle = gbm_bo_get_handle_for_plane(bo, plane);
     if (handle.s32 == -1)


### PR DESCRIPTION
#### 97784c5749810fa6596c8365a35d3dd524b3b69b
<pre>
[GTK] Fix Debian stable build after 269760@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=263634">https://bugs.webkit.org/show_bug.cgi?id=263634</a>

Reviewed by Carlos Garcia Campos.

Rename &apos;gbm_bo_get_fd_for_plane2&apos; to &apos;gbm_bo_get_fd_for_plane&apos;.

* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):

Canonical link: <a href="https://commits.webkit.org/269949@main">https://commits.webkit.org/269949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/835c2a3eaa4762bf36ee5154f3fc0eee66fec3ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22205 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24583 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26829 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21749 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22038 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19106 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1456 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5767 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->