### PR TITLE
WebGLRenderingContextBase preventBufferClearForInspector is redundant

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -197,7 +197,7 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
     RefPtr<VideoFrame> videoFrame = [&]() -> RefPtr<VideoFrame> {
 #if ENABLE(WEBGL)
         if (auto* gl = dynamicDowncast<WebGLRenderingContextBase>(m_canvas->renderingContext()))
-            return gl->surfaceBufferToVideoFrame(WebGLRenderingContextBase::SurfaceBuffer::DisplayBuffer);
+            return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
 #endif
         return m_canvas->toVideoFrame();
     }();

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -107,7 +107,7 @@ AffineTransform CanvasBase::baseTransform() const
 void CanvasBase::makeRenderingResultsAvailable()
 {
     if (auto* context = renderingContext()) {
-        context->paintRenderingResultsToCanvas();
+        context->drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
         if (m_canvasNoiseHashSalt)
             m_canvasNoiseInjection.postProcessDirtyCanvasBuffer(buffer(), *m_canvasNoiseHashSalt);
     }

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -388,7 +388,7 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
             return { RefPtr<ImageBitmap> { nullptr } };
 
         auto* gc3d = webGLContext->graphicsContextGL();
-        gc3d->drawSurfaceBufferToImageBuffer(WebGLRenderingContextBase::SurfaceBuffer::DrawingBuffer, *imageBitmap->buffer());
+        gc3d->drawSurfaceBufferToImageBuffer(GraphicsContextGL::SurfaceBuffer::DrawingBuffer, *imageBitmap->buffer());
 
         // FIXME: The transfer algorithm requires that the canvas effectively
         // creates a new backing store. Since we're not doing that yet, we
@@ -467,7 +467,7 @@ Image* OffscreenCanvas::copiedImage() const
 
     if (!m_copiedImage && buffer()) {
         if (m_context)
-            m_context->paintRenderingResultsToCanvas();
+            m_context->drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
         m_copiedImage = BitmapImage::create(buffer()->copyNativeImage());
     }
     return m_copiedImage.get();
@@ -539,8 +539,9 @@ void OffscreenCanvas::commitToPlaceholderCanvas()
 
     // FIXME: Transfer texture over if we're using accelerated compositing
     if (m_context && (m_context->isWebGL() || m_context->isAccelerated())) {
-        m_context->prepareForDisplayWithPaint();
-        m_context->paintRenderingResultsToCanvas();
+        if (m_context->compositingResultsNeedUpdating())
+            m_context->prepareForDisplay();
+        m_context->drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
     }
 
     if (m_placeholderData->bufferPipeSource) {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -79,10 +79,18 @@ public:
 
     virtual void clearAccumulatedDirtyRect() { }
 
-    // Called before paintRenderingResultsToCanvas if paintRenderingResultsToCanvas is
-    // used for compositing purposes.
-    virtual void prepareForDisplayWithPaint() { }
-    virtual void paintRenderingResultsToCanvas() { }
+    // Canvas 2DContext drawing buffer is the same as display buffer.
+    // WebGL, WebGPU draws to drawing buffer. The draw buffer is then swapped to
+    // display buffer during preparation and compositor composites the display buffer.
+    // toDataURL and similar functions from JS execution reads the drawing buffer.
+    // Web Inspector and similar reads from the engine reads both.
+    enum class SurfaceBuffer : uint8_t {
+        DrawingBuffer,
+        DisplayBuffer
+    };
+
+    // Draws the source buffer to the canvasBase().buffer().
+    virtual void drawBufferToCanvas(SurfaceBuffer) { }
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
 
@@ -91,6 +99,7 @@ public:
 
     virtual bool compositingResultsNeedUpdating() const { return false; }
     virtual bool needsPreparationForDisplay() const { return false; }
+    // Swaps the current drawing buffer to display buffer.
     virtual void prepareForDisplay() { }
 
     virtual PixelFormat pixelFormat() const;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -65,8 +65,7 @@ public:
     PixelFormat pixelFormat() const override;
     void reshape(int width, int height) override;
 
-    void prepareForDisplayWithPaint() override;
-    void paintRenderingResultsToCanvas() override;
+    void drawBufferToCanvas(SurfaceBuffer) override;
     // GPUCanvasContext methods:
     CanvasType canvas() override;
     void configure(GPUCanvasConfiguration&&) override;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -176,13 +176,9 @@ void GPUCanvasContextCocoa::reshape(int width, int height)
     }
 }
 
-void GPUCanvasContextCocoa::prepareForDisplayWithPaint()
+void GPUCanvasContextCocoa::drawBufferToCanvas(SurfaceBuffer)
 {
-    prepareForDisplay();
-}
-
-void GPUCanvasContextCocoa::paintRenderingResultsToCanvas()
-{
+    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=263957): WebGPU should support obtaining drawing buffer for Web Inspector.
     auto& base = canvasBase();
     base.clearCopiedImage();
     if (auto buffer = base.buffer()) {

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -133,7 +133,6 @@ class WebGLRenderingContextBase : public GraphicsContextGL::Client, public GPUBa
     WTF_MAKE_ISO_ALLOCATED(WebGLRenderingContextBase);
 public:
     using WebGLVersion = GraphicsContextGLWebGLVersion;
-    using SurfaceBuffer = GraphicsContextGL::SurfaceBuffer;
 
     using GPUBasedCanvasRenderingContext::weakPtrFactory;
     using GPUBasedCanvasRenderingContext::WeakValueType;
@@ -243,9 +242,6 @@ public:
     bool extensionIsEnabled(const String&);
 
     bool isPreservingDrawingBuffer() const { return m_attributes.preserveDrawingBuffer; }
-
-    bool preventBufferClearForInspector() const { return m_preventBufferClearForInspector; }
-    void setPreventBufferClearForInspector(bool value) { m_preventBufferClearForInspector = value; }
 
     void hint(GCGLenum target, GCGLenum mode);
     GCGLboolean isBuffer(WebGLBuffer*);
@@ -399,8 +395,8 @@ public:
 
     void reshape(int width, int height) override;
 
-    void prepareForDisplayWithPaint() final;
-    void paintRenderingResultsToCanvas() final;
+    void drawBufferToCanvas(SurfaceBuffer) final;
+
     RefPtr<PixelBuffer> drawingBufferToPixelBuffer(GraphicsContextGL::FlipY);
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer);
@@ -564,7 +560,6 @@ protected:
 
     EventLoopTimerHandle m_restoreTimer;
     GCGLErrorCodeSet m_errors;
-    bool m_markedCanvasDirty;
 
     // List of bound VBO's. Used to maintain info about sizes for ARRAY_BUFFER and stored values for ELEMENT_ARRAY_BUFFER
     WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::ARRAY_BUFFER> m_boundArrayBuffer;
@@ -670,10 +665,8 @@ protected:
 
     int m_numGLErrorsToConsoleAllowed;
 
-    bool m_preventBufferClearForInspector { false };
-
     bool m_compositingResultsNeedUpdating { false };
-    bool m_isDisplayingWithPaint { false };
+    std::optional<SurfaceBuffer> m_canvasBufferContents;
 
     // Enabled extension objects.
     // FIXME: Move some of these to WebGLRenderingContext, the ones not needed for WebGL2


### PR DESCRIPTION
#### 27dac32ecc9c989f5d4cd702baba2db6fc23fdde
<pre>
WebGLRenderingContextBase preventBufferClearForInspector is redundant
<a href="https://bugs.webkit.org/show_bug.cgi?id=263885">https://bugs.webkit.org/show_bug.cgi?id=263885</a>
<a href="https://rdar.apple.com/117684773">rdar://117684773</a>

Reviewed by Dan Glastonbury.

WebGLRenderingContextBase::setPreventBufferClearForInspector
was intended to make sure that inspector reading the WebGL rendering
would not force the pending drawing buffer clear. The read happens
with toDataURL, which generally used to read drawing buffer, not
compositing buffer.

This was a workaround for case where the read would happen after
prepareForDisplay. However, preventing the clear is incorrect, as
there is nothing correct to be read from the uncleared back buffer.
That buffer may contain contents from two frames back or it might
be a brand new buffer.

Instead, make it explicit that the transfer to the rendering results
happens from display buffer if there is no draws in drawing
buffer. Otherwise use the drawing buffer.

Remove the redundant m_isDisplayingWithPaint, instead prepare
the display buffer during paint, if it is not already prepared. Normal
layer paint happens after document-wide preparation during rendering
update. Snapshots paint or print may happen without preparation, so
the HTMLCanvasElement::paint will prepare the display buffer.

Removes the canvas reading taint check logic from Web Inspector capture.
The capture should always work, as it is trusted. Each individual
draw commands will be captured differently, and there the result
data reflects what the target canvas receives, taint logic included.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::paint):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::commitToPlaceholderCanvas):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::prepareForDisplayWithPaint): Deleted.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::prepareForDisplayWithPaint): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::markContextChanged):
(WebCore::WebGLRenderingContextBase::clearIfComposited):
(WebCore::WebGLRenderingContextBase::paintRenderingResultsToCanvas):
(WebCore::WebGLRenderingContextBase::prepareForDisplayWithPaint): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::preventBufferClearForInspector const): Deleted.
(WebCore::WebGLRenderingContextBase::setPreventBufferClearForInspector): Deleted.
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::getContentAsDataURL):

Canonical link: <a href="https://commits.webkit.org/270046@main">https://commits.webkit.org/270046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cfec6b5e7f7d159a22898851d16812320a05f3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26556 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/214 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24671 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27142 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28228 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22345 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26021 "Found 2 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/origin-and-total-storage-ratio (failure)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/55 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5841 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2158 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->