### PR TITLE
[Cocoa] YouTube videos sometimes do not resize properly in fullscreen

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -289,7 +289,7 @@ void VideoPresentationModelVideoElement::setVideoDimensions(const FloatSize& vid
     if (m_videoDimensions == videoDimensions)
         return;
 
-    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoDimensions);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoDimensions, ", clients=", m_clients.size());
     m_videoDimensions = videoDimensions;
 
     for (auto& client : copyToVector(m_clients))

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -127,14 +127,14 @@ private:
         model->removeClient(*_presentationModelClient);
 
     _presentationModel = presentationModel;
+#if !RELEASE_LOG_DISABLED
+    _logIdentifier = presentationModel ? presentationModel->nextChildIdentifier() : nullptr;
+#endif
 
     if (presentationModel)
         presentationModel->addClient(*_presentationModelClient);
 
     self.videoDimensions = presentationModel ? presentationModel->videoDimensions() : CGSizeZero;
-#if !RELEASE_LOG_DISABLED
-    _logIdentifier = presentationModel ? presentationModel->nextChildIdentifier() : nullptr;
-#endif
 }
 
 - (AVPlayerController *)playerController
@@ -168,6 +168,7 @@ private:
     if (CGSizeEqualToSize(_videoDimensions, videoDimensions))
         return;
 
+    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, FloatSize { videoDimensions });
     _videoDimensions = videoDimensions;
     [self setNeedsLayout];
 }

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -222,7 +222,7 @@ void VideoPresentationModelContext::setVideoDimensions(const WebCore::FloatSize&
         return;
 
     m_videoDimensions = videoDimensions;
-    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoDimensions);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoDimensions, ", clients=", m_clients.computeSize());
     m_clients.forEach([&](auto& client) {
         client.videoDimensionsChanged(videoDimensions);
     });
@@ -695,6 +695,9 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
         [playerLayer layoutIfNeeded];
     }
 
+    if (m_page)
+        m_page->send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize));
+
     return model->playerLayer();
 }
 
@@ -768,6 +771,9 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
         model->setPlayerView(playerView.get());
         model->setVideoView(videoView.get());
     }
+
+    if (m_page)
+        m_page->send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize));
 
     return model->videoView();
 }

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -189,6 +189,7 @@ protected:
     void fullscreenModeChanged(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void fullscreenMayReturnToInline(PlaybackSessionContextIdentifier, bool isPageVisible);
     void requestRouteSharingPolicyAndContextUID(PlaybackSessionContextIdentifier, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&&);
+    void ensureUpdatedVideoDimensions(PlaybackSessionContextIdentifier, WebCore::FloatSize existingVideoDimensions);
 
     void setCurrentlyInFullscreen(VideoPresentationInterfaceContext&, bool);
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
@@ -39,5 +39,6 @@ messages -> VideoPresentationManager {
     FullscreenModeChanged(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode)
     FullscreenMayReturnToInline(WebKit::PlaybackSessionContextIdentifier contextId, bool isPageVisible)
     RequestRouteSharingPolicyAndContextUID(WebKit::PlaybackSessionContextIdentifier contextId) -> (enum:uint8_t WebCore::RouteSharingPolicy routeSharingPolicy, String routingContextUID)
+    EnsureUpdatedVideoDimensions(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatSize existingVideoDimensions)
 }
 #endif

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -732,6 +732,24 @@ void VideoPresentationManager::requestRouteSharingPolicyAndContextUID(PlaybackSe
     ensureModel(contextId).requestRouteSharingPolicyAndContextUID(WTFMove(reply));
 }
 
+void VideoPresentationManager::ensureUpdatedVideoDimensions(PlaybackSessionContextIdentifier contextId, WebCore::FloatSize existingVideoDimensions)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    auto model = std::get<0>(m_contextMap.get(contextId));
+    if (!model)
+        return;
+
+    auto videoDimensions = model->videoDimensions();
+    if (videoDimensions == existingVideoDimensions)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, "existingVideoDimensions=", existingVideoDimensions, ", videoDimensions=", videoDimensions);
+    page->send(Messages::VideoPresentationManagerProxy::SetVideoDimensions(contextId, videoDimensions));
+}
+
 void VideoPresentationManager::setCurrentlyInFullscreen(VideoPresentationInterfaceContext& interface, bool currentlyInFullscreen)
 {
     interface.setTargetIsFullscreen(currentlyInFullscreen);


### PR DESCRIPTION
#### 3a73162c6129502c6f02cfd71672801267956c05
<pre>
[Cocoa] YouTube videos sometimes do not resize properly in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=263889">https://bugs.webkit.org/show_bug.cgi?id=263889</a>
<a href="https://rdar.apple.com/114570133">rdar://114570133</a>

Reviewed by Jer Noble.

When a MediaPlayer&apos;s metadata becomes available its video dimensions (a.k.a. natural size) are
cached in VideoPresentationModels stored in maps in the WebContent and UI processs, keyed off of the
media element&apos;s identifier. This value is used to properly lay out the video&apos;s WebAVPlayerLayer.

When a media element needs a compositing layer during layout, a VideoElementData struct is
constructed that stores the current video dimensions. Later, when the newly-created layer is
committed, these dimensions are cached in the UI process&apos; VideoPresentationModel and passed to the
newly-created WebAVPlayerLayer.

Sometimes, committing a layer tree transaction destroys then creates a compositing layer for the
same video element. When the old layer is destroyed, the element&apos;s VideoPresentationModel is also
removed from the UI process&apos; map. Then, when the new layer is created, a new VideoPresentationModel
is created with video dimensions from the VideoElementData.

Since layer tree transactions are committed asynchronously after the VideoElementData is
constructed, this creates a race. If video metadata happens to become available after the
VideoElementData was constructed during layout but before the layer tree transaction is committed,
and the transaction involves both destroying and creating the video layer, then the
VideoPresentationModel containing the up-to-date video dimensions will be removed and replaced by a
stale value computed before video metadata became available. This results in the WebAVPlayerLayer
laying out with a false understanding of the video&apos;s dimensions (often thinking it is 0x0).

To address this, added a new VideoPresentationManager::EnsureUpdatedVideoDimensions message that is
sent after the UI process creates the new WebAVPlayerLayer. If the video dimensions known to the UI
process no longer match VideoPresentationManager&apos;s current dimensions for the element, a new
VideoPresentationManagerProxy::SetVideoDimensions message is sent to the UI process.

* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::setVideoDimensions):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setPresentationModel:]):
(-[WebAVPlayerLayer setVideoDimensions:]):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::setVideoDimensions):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::ensureUpdatedVideoDimensions):

Canonical link: <a href="https://commits.webkit.org/270061@main">https://commits.webkit.org/270061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ed8a75f2e2110106dd3542ca4ae5c44d1071d0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22821 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27037 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28153 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22175 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25949 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2895 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5850 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->