### PR TITLE
[Cocoa] WebCodecs H264 decoder should reorder frames according presentation time

### DIFF
--- a/LayoutTests/http/tests/webcodecs/h264-reordering-expected.txt
+++ b/LayoutTests/http/tests/webcodecs/h264-reordering-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test H264 reordering
+

--- a/LayoutTests/http/tests/webcodecs/h264-reordering.html
+++ b/LayoutTests/http/tests/webcodecs/h264-reordering.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+let decoder;
+promise_test(async () => {
+     const response = await fetch("/media-resources/media-source/content/test-fragmented.mp4");
+     const buffer = await response.arrayBuffer();
+     const avcCOffset = [519, 34];
+     const frames = [
+         [41, 1995, 25120],
+         [125, 27115, 2173],
+         [83, 29288, 1348],
+         [208, 30636, 1049],
+         [166, 31685, 865],
+         [291, 32550, 930],
+         [250, 33480, 812],
+         [375, 34292, 1231],
+         [333, 35523, 803],
+         [458, 36326, 1564]
+    ];
+
+    let frameTimestamps = [];
+    decoder =  new VideoDecoder({
+        output(frame) {
+            frameTimestamps.push(frame.timestamp);
+            frame.close();
+        },
+        error(e) {
+            console.log(e);
+        }
+    });
+    decoder.configure({
+        codec: 'avc1.4d401e',
+        codedWidth: 640,
+        codedHeight: 480,
+        visibleRect: {x: 0, y: 0, width: 640, height: 480},
+        displayWidth: 640,
+        displayHeight: 480,
+        description: new Uint8Array(buffer, avcCOffset[0], avcCOffset[1])
+    });
+
+    chunks = frames.map((frame, i) => new EncodedVideoChunk({type: i == 0 ? 'key' : 'delta', timestamp: frame[0], duration: 1, data: new Uint8Array(buffer, frame[1], frame[2])}));
+
+    chunks.forEach(chunk => decoder.decode(chunk));
+    await decoder.flush();
+
+    assert_array_equals(frameTimestamps, frames.map(frame => frame[0]).sort((a,b) => a - b), "timestamps are ordered");
+}, "Test H264 reordering");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1200,6 +1200,8 @@ imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.html [ 
 imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Pass DumpJSConsoleLogInStdErr ]
 
+http/tests/webcodecs/h264-reordering.html [ Failure ]
+
 # This test is flaky crashing with the current GStreamer version of the SDK (1.22), raising a
 # critical warning in GStreamer, but the issue is not happening with GStreamer 1.23. So this test is
 # expected to pass again once we update to GStreamer 1.24.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -40,6 +40,7 @@ imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-x
 
 webkit.org/b/235072 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-repeating.html [ Skip ]
 
+http/tests/webcodecs [ Skip ]
 http/wpt/webcodecs [ Skip ]
 imported/w3c/web-platform-tests/webcodecs [ Skip ]
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -69,6 +69,7 @@ void h265DecompressionOutputCallback(void* decoderRef,
   // TODO(tkchin): Handle CVO properly.
   RTCCVPixelBuffer* frameBuffer =
       [[RTCCVPixelBuffer alloc] initWithPixelBuffer:imageBuffer];
+  // FIXME: compute reorderSize.
   RTCVideoFrame* decodedFrame = [[RTCVideoFrame alloc]
       initWithBuffer:frameBuffer
             rotation:RTCVideoRotation_0

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.cc
@@ -17,6 +17,7 @@
 
 #include "rtc_base/checks.h"
 #include "rtc_base/logging.h"
+#include "common_video/h264/sps_parser.h"
 
 namespace webrtc {
 
@@ -465,6 +466,296 @@ CMVideoFormatDescriptionRef CreateVideoFormatDescription(
     return nullptr;
   }
   return description;
+}
+
+class SpsAndVuiParser : private SpsParser {
+public:
+    struct State : SpsState {
+      explicit State(const SpsState& spsState)
+        : SpsState(spsState)
+      {
+      }
+
+      uint8_t profile_idc { 0 };
+      uint8_t level_idc { 0 };
+      bool constraint_set3_flag { false };
+      bool bitstream_restriction_flag { false };
+      uint64_t max_num_reorder_frames { 0 };
+    };
+    static absl::optional<State> Parse(const std::vector<uint8_t>& unpacked_buffer)
+    {
+      BitstreamReader reader(unpacked_buffer);
+      auto spsState = ParseSpsUpToVui(reader);
+      if (!spsState) {
+          return { };
+      }
+      State result { *spsState };
+
+      {
+        // We are restarting parsing for some values we need and that ParseSpsUpToVui is not giving us.
+        BitstreamReader reader2(unpacked_buffer);
+        result.profile_idc = reader2.Read<uint8_t>();
+        // constraint_set0_flag, constraint_set1_flag, constraint_set2_flag
+        reader2.ConsumeBits(3);
+        result.constraint_set3_flag = reader2.Read<bool>();
+        // constraint_set4_flag, constraint_set5_flag and reserved bits (2)
+        reader2.ConsumeBits(4);
+        result.level_idc = reader2.Read<uint8_t>();
+        if (!reader2.Ok()) {
+          return { };
+        }
+      }
+
+      if (!spsState->vui_params_present) {
+        return result;
+      }
+      // Based on ANNEX VUI parameters syntax.
+
+      // aspect_ratio_info_present_flag
+      if (reader.Read<bool>()) {
+        // aspect_ratio_idc
+        auto aspect_ratio_idc = reader.Read<uint8_t>();
+        // FIXME Extended_SAR
+        constexpr uint64_t extendedSar = 255;
+        if (aspect_ratio_idc == extendedSar) {
+          // sar_width
+          reader.ConsumeBits(16);
+          // sar_height
+          reader.ConsumeBits(16);
+        }
+      }
+      // overscan_info_present_flag
+      if (reader.Read<bool>()) {
+        // overscan_appropriate_flag
+        reader.ConsumeBits(1);
+      }
+      // video_signal_type_present_flag
+      if (reader.Read<bool>()) {
+        // video_format
+        reader.ConsumeBits(3);
+        // video_full_range_flag
+        reader.ConsumeBits(1);
+        // colour_description_present_flag
+        if (reader.Read<bool>()) {
+          // colour_primaries
+          reader.ConsumeBits(8);
+          // transfer_characteristics
+          reader.ConsumeBits(8);
+          // matrix_coefficients
+          reader.ConsumeBits(8);
+        }
+      }
+      // chroma_loc_info_present_flag
+      if (reader.Read<bool>()) {
+          // chroma_sample_loc_type_top_field
+          reader.ReadExponentialGolomb();
+          // chroma_sample_loc_type_bottom_field
+          reader.ReadExponentialGolomb();
+      }
+      // timing_info_present_flag
+      if (reader.Read<bool>()) {
+        // num_units_in_tick
+        reader.ConsumeBits(32);
+        // time_scale
+        reader.ConsumeBits(32);
+        // fixed_frame_rate_flag
+        reader.ConsumeBits(1);
+      }
+      // nal_hrd_parameters_present_flag
+      bool nal_hrd_parameters_present_flag = reader.Read<bool>();
+      if (nal_hrd_parameters_present_flag) {
+        // hrd_parameters
+        skipHRDParameters(reader);
+      }
+      // vcl_hrd_parameters_present_flag
+      bool vcl_hrd_parameters_present_flag = reader.Read<bool>();
+      if (vcl_hrd_parameters_present_flag) {
+        // hrd_parameters
+        skipHRDParameters(reader);
+      }
+      if (nal_hrd_parameters_present_flag || vcl_hrd_parameters_present_flag) {
+        // low_delay_hrd_flag
+        reader.ConsumeBits(1);
+      }
+      // pic_struct_present_flag
+      reader.ConsumeBits(1);
+      // bitstream_restriction_flag
+      result.bitstream_restriction_flag = reader.Read<bool>();
+      if (result.bitstream_restriction_flag) {
+        // motion_vectors_over_pic_boundaries_flag
+        reader.ConsumeBits(1);
+        // max_bytes_per_pic_denom
+        reader.ReadExponentialGolomb();
+        // max_bits_per_mb_denom
+        reader.ReadExponentialGolomb();
+        // log2_max_mv_length_horizontal
+        reader.ReadExponentialGolomb();
+        // log2_max_mv_length_vertical
+        reader.ReadExponentialGolomb();
+        // max_num_reorder_frames
+        result.max_num_reorder_frames = reader.ReadExponentialGolomb();
+        // max_dec_frame_buffering
+        reader.ReadExponentialGolomb();
+      }
+
+      if (!reader.Ok()) {
+          return { };
+      }
+      return result;
+    }
+
+    static void skipHRDParameters(BitstreamReader& reader)
+    {
+        // cpb_cnt_minus1
+        auto cpb_cnt_minus1 = reader.ReadExponentialGolomb();
+        // bit_rate_scale
+        // cpb_size_scale
+        reader.ConsumeBits(8);
+        for (size_t cptr = 0; cptr < cpb_cnt_minus1; ++cptr) {
+            // bit_rate_value_minus1
+            reader.ReadExponentialGolomb();
+            // cpb_size_value_minus1
+            reader.ReadExponentialGolomb();
+            // cbr_flag
+            reader.ConsumeBits(1);
+        }
+        // initial_cpb_removal_delay_length_minus1
+        // cpb_removal_delay_length_minus1
+        // dpb_output_delay_length_minus1
+        // time_offset_length
+        reader.ConsumeBits(20);
+    }
+};
+
+// Table A-1 of H.264 spec
+static size_t maxDpbMbsFromLevelNumber(uint8_t profile_idc, uint8_t level_idc, bool constraint_set3_flag)
+{
+  if ((profile_idc == 66 || profile_idc == 77) && level_idc == 11 && constraint_set3_flag) {
+    // level1b
+    return 396;
+  }
+  H264Level level_casted = static_cast<H264Level>(level_idc);
+
+  switch (level_casted) {
+  case H264Level::kLevel1:
+    return 396;
+  case H264Level::kLevel1_1:
+    return 900;
+  case H264Level::kLevel1_2:
+  case H264Level::kLevel1_3:
+  case H264Level::kLevel2:
+    return 2376;
+  case H264Level::kLevel2_1:
+    return 4752;
+  case H264Level::kLevel2_2:
+  case H264Level::kLevel3:
+    return 8100;
+  case H264Level::kLevel3_1:
+    return 18000;
+  case H264Level::kLevel3_2:
+    return 20480;
+  case H264Level::kLevel4:
+    return 32768;
+  case H264Level::kLevel4_1:
+    return 32768;
+  case H264Level::kLevel4_2:
+    return 34816;
+  case H264Level::kLevel5:
+    return 110400;
+  case H264Level::kLevel5_1:
+    return 184320;
+  case H264Level::kLevel5_2:
+    return 184320;
+  default:
+    RTC_LOG(LS_ERROR) << "Wrong maxDpbMbsFromLevelNumber";
+    return 0;
+  }
+}
+
+static uint8_t ComputeH264ReorderSizeFromSPS(const SpsAndVuiParser::State& state) {
+  if (state.pic_order_cnt_type == 2) {
+    return 0;
+  }
+
+  uint64_t max_dpb_mbs = maxDpbMbsFromLevelNumber(state.profile_idc, state.level_idc, state.constraint_set3_flag);
+  uint64_t max_dpb_frames_from_sps = max_dpb_mbs / ((state.width / 16) * (state.height / 16));
+  // We use a max value of 16.
+  auto max_dpb_frames = static_cast<uint8_t>(std::min(max_dpb_frames_from_sps, 16ull));
+
+  if (state.bitstream_restriction_flag) {
+    if (state.max_num_reorder_frames < max_dpb_frames) {
+      return static_cast<uint8_t>(state.max_num_reorder_frames);
+    } else {
+      return max_dpb_frames;
+    }
+  }
+  if (state.constraint_set3_flag && (state.profile_idc == 44 || state.profile_idc == 86 || state.profile_idc == 100 || state.profile_idc == 110 || state.profile_idc == 122 || state.profile_idc == 244)) {
+    return 0;
+  }
+  return max_dpb_frames;
+}
+
+uint8_t ComputeH264ReorderSizeFromAnnexB(const uint8_t* annexb_buffer, size_t annexb_buffer_size) {
+  AnnexBBufferReader reader(annexb_buffer, annexb_buffer_size);
+  if (!reader.SeekToNextNaluOfType(kSps)) {
+    return 0;
+  }
+  const uint8_t* spsData;
+  size_t spsDataSize;
+
+  if (!reader.ReadNalu(&spsData, &spsDataSize)) {
+    return 0;
+  }
+
+  std::vector<uint8_t> unpacked_buffer = H264::ParseRbsp(spsData, spsDataSize);
+  auto spsAndVui = SpsAndVuiParser::Parse(unpacked_buffer);
+  if (!spsAndVui) {
+    RTC_LOG(LS_ERROR) << "Failed to parse sps.";
+    return 0;
+  }
+
+  return ComputeH264ReorderSizeFromSPS(*spsAndVui);
+}
+
+uint8_t ComputeH264ReorderSizeFromAVC(const uint8_t* avcData, size_t avcDataSize) {
+  std::vector<uint8_t> unpacked_buffer { avcData, avcData + avcDataSize };
+  BitstreamReader reader(unpacked_buffer);
+
+  // configurationVersion
+  reader.ConsumeBits(8);
+  // AVCProfileIndication;
+  reader.ConsumeBits(8);
+  // profile_compatibility;
+  reader.ConsumeBits(8);
+  // AVCLevelIndication;
+  reader.ConsumeBits(8);
+  // bit(6) reserved = '111111'b;
+  // unsigned int(2) lengthSizeMinusOne;
+  reader.ConsumeBits(8);
+  // bit(3) reserved = '111'b;
+  // unsigned int(5) numOfSequenceParameterSets;
+  auto numOfSequenceParameterSets = 0x1F & reader.Read<uint8_t>();
+
+  if (!reader.Ok()) {
+    return 0;
+  }
+
+  size_t offset = 6;
+  if (numOfSequenceParameterSets) {
+    auto size = reader.Read<uint16_t>();
+    offset += 2;
+
+    reader.ConsumeBits(8 * (size + H264::kNaluTypeSize));
+    if (!reader.Ok()) {
+      return 0;
+    }
+
+    auto spsAndVui = SpsAndVuiParser::Parse({ avcData + offset + H264::kNaluTypeSize, avcData + offset + size });
+    if (spsAndVui) {
+      return ComputeH264ReorderSizeFromSPS(*spsAndVui);
+    }
+  }
+  return 0;
 }
 
 #ifndef DISABLE_H265

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.h
@@ -46,6 +46,9 @@ bool H264AnnexBBufferToCMSampleBuffer(const uint8_t* annexb_buffer,
                                       CMSampleBufferRef* out_sample_buffer,
                                       CMMemoryPoolRef memory_pool);
 
+uint8_t ComputeH264ReorderSizeFromAnnexB(const uint8_t* annexb_buffer, size_t annexb_buffer_size);
+uint8_t ComputeH264ReorderSizeFromAVC(const uint8_t* avcdata, size_t avcdata_size);
+
 #ifdef WEBRTC_USE_H265
 // Converts a sample buffer emitted from the VideoToolbox encoder into a buffer
 // suitable for RTP. The sample buffer is in avcc format whereas the rtp buffer


### PR DESCRIPTION
#### cf345a7967b324872fb7ff4a173307ddb93101ac
<pre>
[Cocoa] WebCodecs H264 decoder should reorder frames according presentation time
<a href="https://bugs.webkit.org/show_bug.cgi?id=263901">https://bugs.webkit.org/show_bug.cgi?id=263901</a>
<a href="https://rdar.apple.com/117692801">rdar://117692801</a>

Reviewed by Jean-Yves Avenard.

Add a SPS VUI parser to be able to extract max_num_reorder_frames.
Add an AVC parser to locate the SPS and parse it.

Compute the reorder queue size based on the parsed SPS.
Add a queue in RTCVideoDecoderH264 and reorder based on timestamp.

We will need a follow-up refactoring to pipe memory attribution of these video frames when getting them.

* LayoutTests/http/tests/webcodecs/h264-reordering-expected.txt: Added.
* LayoutTests/http/tests/webcodecs/h264-reordering.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm:
(RTCFrameDecodeParams::RTCFrameDecodeParams):
(RTCVideoFrameWithOrder::RTCVideoFrameWithOrder):
(RTCVideoFrameWithOrder::~RTCVideoFrameWithOrder):
(RTCVideoFrameWithOrder::take):
(decompressionOutputCallback):
(-[RTCVideoDecoderH264 init]):
(-[RTCVideoDecoderH264 decodeData:size:timeStamp:]):
(-[RTCVideoDecoderH264 setAVCFormat:size:width:height:]):
(-[RTCVideoDecoderH264 flush]):
(-[RTCVideoDecoderH264 processFrame:reorderSize:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm:
(h265DecompressionOutputCallback):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.h:

Canonical link: <a href="https://commits.webkit.org/271004@main">https://commits.webkit.org/271004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40ba642931d51aaa6e7832be5948238cead47022

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24417 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24329 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29945 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27851 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6499 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->