### PR TITLE
Generate CFBoolean coders

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -351,6 +351,7 @@ $(PROJECT_DIR)/Shared/WebsiteDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebsitePoliciesData.serialization.in
 $(PROJECT_DIR)/Shared/XR/XRSystem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CFTypes.serialization.in
+$(PROJECT_DIR)/Shared/cf/CoreIPCBoolean.serialization.in
 $(PROJECT_DIR)/Shared/ios/DynamicViewportSizeUpdate.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationRequest.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -611,6 +611,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/RemoteLayerTree/RemoteLayerTree.serialization.in \
 	Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in \
 	Shared/cf/CFTypes.serialization.in \
+	Shared/cf/CoreIPCBoolean.serialization.in \
 	Shared/mac/PDFContextMenuItem.serialization.in \
 	Shared/mac/SecItemRequestData.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -394,25 +394,6 @@ std::optional<RetainPtr<CFArrayRef>> ArgumentCoder<RetainPtr<CFArrayRef>>::decod
 }
 
 template<typename Encoder>
-void ArgumentCoder<CFBooleanRef>::encode(Encoder& encoder, CFBooleanRef boolean)
-{
-    encoder << static_cast<bool>(CFBooleanGetValue(boolean));
-}
-
-template void ArgumentCoder<CFBooleanRef>::encode<Encoder>(Encoder&, CFBooleanRef);
-template void ArgumentCoder<CFBooleanRef>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, CFBooleanRef);
-
-std::optional<RetainPtr<CFBooleanRef>> ArgumentCoder<RetainPtr<CFBooleanRef>>::decode(Decoder& decoder)
-{
-    std::optional<bool> boolean;
-    decoder >> boolean;
-    if (!boolean)
-        return std::nullopt;
-
-    return adoptCF(*boolean ? kCFBooleanTrue : kCFBooleanFalse);
-}
-
-template<typename Encoder>
 void ArgumentCoder<CFCharacterSetRef>::encode(Encoder& encoder, CFCharacterSetRef characterSet)
 {
     auto data = adoptCF(CFCharacterSetCreateBitmapRepresentation(nullptr, characterSet));

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -63,13 +63,6 @@ template<> struct ArgumentCoder<RetainPtr<CFArrayRef>> : CFRetainPtrArgumentCode
     static std::optional<RetainPtr<CFArrayRef>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<CFBooleanRef> {
-    template<typename Encoder> static void encode(Encoder&, CFBooleanRef);
-};
-template<> struct ArgumentCoder<RetainPtr<CFBooleanRef>> : CFRetainPtrArgumentCoder<CFBooleanRef> {
-    static std::optional<RetainPtr<CFBooleanRef>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<CFCharacterSetRef> {
     template<typename Encoder> static void encode(Encoder&, CFCharacterSetRef);
 };

--- a/Source/WebKit/Shared/cf/CoreIPCBoolean.h
+++ b/Source/WebKit/Shared/cf/CoreIPCBoolean.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CF)
+
+#import "DataReference.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <wtf/RetainPtr.h>
+
+namespace WebKit {
+
+class CoreIPCBoolean {
+public:
+    CoreIPCBoolean(CFBooleanRef cfBoolean)
+        : value(CFBooleanGetValue(cfBoolean))
+    {
+    }
+
+    CoreIPCBoolean(bool value)
+        : value(value)
+    {
+    }
+
+    RetainPtr<CFBooleanRef> createBoolean() const
+    {
+        return value ? kCFBooleanTrue : kCFBooleanFalse;
+    }
+
+    bool value;
+};
+
+} // namespace WebKit
+
+#endif // USE(CF)

--- a/Source/WebKit/Shared/cf/CoreIPCBoolean.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCBoolean.serialization.in
@@ -22,13 +22,10 @@
 
 #if USE(CF)
 
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createData] CFDataRef wrapped by WebKit::CoreIPCData {
+webkit_platform_headers: "CoreIPCBoolean.h"
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCBoolean {
+    bool value;
 }
 
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createCFString] CFStringRef wrapped by WTF::String {
-}
-
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createBoolean] CFBooleanRef wrapped by WebKit::CoreIPCBoolean {
-}
-
-#endif
+#endif // USE(CF)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5194,6 +5194,8 @@
 		51D130521382EAC000351EDD /* SecItemResponseData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SecItemResponseData.h; sourceTree = "<group>"; };
 		51D130571382F10500351EDD /* WebProcessProxyMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebProcessProxyMac.mm; sourceTree = "<group>"; };
 		51D194352AEC1C8200E8E475 /* CFTypes.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CFTypes.serialization.in; sourceTree = "<group>"; };
+		51D194392AEC9BC900E8E475 /* CoreIPCBoolean.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCBoolean.h; sourceTree = "<group>"; };
+		51D1943A2AEC9BC900E8E475 /* CoreIPCBoolean.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCBoolean.serialization.in; sourceTree = "<group>"; };
 		51D7E0AC2356555400A67D3A /* WKPDFConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPDFConfiguration.h; sourceTree = "<group>"; };
 		51D7E0AE2356616300A67D3A /* WKPDFConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPDFConfiguration.mm; sourceTree = "<group>"; };
 		51DAAEBF2AA198DE00DB2AA4 /* com.apple.WebKit.webpushd.relocatable.mac.sb */ = {isa = PBXFileReference; lastKnownFileType = file; path = com.apple.WebKit.webpushd.relocatable.mac.sb; sourceTree = "<group>"; };
@@ -8518,6 +8520,8 @@
 				51D194352AEC1C8200E8E475 /* CFTypes.serialization.in */,
 				5194B3861F192FB900FA4708 /* CookieStorageUtilsCF.h */,
 				5104F5A11F19D7CF004CF821 /* CookieStorageUtilsCF.mm */,
+				51D194392AEC9BC900E8E475 /* CoreIPCBoolean.h */,
+				51D1943A2AEC9BC900E8E475 /* CoreIPCBoolean.serialization.in */,
 			);
 			path = cf;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### c50b2cb698b799b3ccef14ccfa4161d71db1bd8f
<pre>
Generate CFBoolean coders
<a href="https://bugs.webkit.org/show_bug.cgi?id=263904">https://bugs.webkit.org/show_bug.cgi?id=263904</a>
rdar://117694738

Reviewed by David Kilzer.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;CFBooleanRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBooleanRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Source/WebKit/Shared/cf/CoreIPCBoolean.h: Added.
(WebKit::CoreIPCBoolean::CoreIPCBoolean):
(WebKit::CoreIPCBoolean::createBoolean const):
* Source/WebKit/Shared/cf/CoreIPCBoolean.serialization.in: Copied from Source/WebKit/Shared/cf/CFTypes.serialization.in.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/269968@main">https://commits.webkit.org/269968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30ac37055abcddbe1c052c3f5667b3073d86053e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24615 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26864 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1529 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22073 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1467 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/19135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1487 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5785 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->