### PR TITLE
[WebGPU] setDepthBias: is never called, depth bias and related functions are not implemented

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/depth_bias-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/depth_bias-expected.txt
@@ -1,1 +1,15 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :depth_bias:quadAngle=0;bias=8388608;biasSlopeScale=0;biasClamp=0
+PASS :depth_bias:quadAngle=0;bias=8388608;biasSlopeScale=0;biasClamp=0.125
+PASS :depth_bias:quadAngle=0;bias=-8388608;biasSlopeScale=0;biasClamp=0.125
+PASS :depth_bias:quadAngle=0;bias=-8388608;biasSlopeScale=0;biasClamp=-0.125
+PASS :depth_bias:quadAngle=1;bias=0;biasSlopeScale=0;biasClamp=0
+PASS :depth_bias:quadAngle=1;bias=0;biasSlopeScale=1;biasClamp=0
+PASS :depth_bias:quadAngle=1;bias=0;biasSlopeScale=-0.5;biasClamp=0
+PASS :depth_bias_24bit_format:format="depth24plus";quadAngle=0;bias=8388608;biasSlopeScale=0;biasClamp=0
+PASS :depth_bias_24bit_format:format="depth24plus";quadAngle=0;bias=8388608;biasSlopeScale=0;biasClamp=0.1
+PASS :depth_bias_24bit_format:format="depth24plus";quadAngle=1;bias=8388608;biasSlopeScale=1;biasClamp=0
+PASS :depth_bias_24bit_format:format="depth24plus-stencil8";quadAngle=0;bias=8388608;biasSlopeScale=0;biasClamp=0
+PASS :depth_bias_24bit_format:format="depth24plus-stencil8";quadAngle=0;bias=8388608;biasSlopeScale=0;biasClamp=0.1
+PASS :depth_bias_24bit_format:format="depth24plus-stencil8";quadAngle=1;bias=8388608;biasSlopeScale=1;biasClamp=0
+

--- a/Source/WebCore/Modules/WebGPU/GPUDepthStencilState.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDepthStencilState.h
@@ -38,16 +38,16 @@ struct GPUDepthStencilState {
     WebGPU::DepthStencilState convertToBacking() const
     {
         return {
-            WebCore::convertToBacking(format),
-            depthWriteEnabled,
-            WebCore::convertToBacking(depthCompare),
-            stencilFront.convertToBacking(),
-            stencilBack.convertToBacking(),
-            stencilReadMask ? std::optional { *stencilReadMask } : std::nullopt,
-            stencilWriteMask ? std::optional { *stencilWriteMask } : std::nullopt,
-            depthBias,
-            depthBiasSlopeScale,
-            depthBiasClamp,
+            .format = WebCore::convertToBacking(format),
+            .depthWriteEnabled = depthWriteEnabled,
+            .depthCompare = WebCore::convertToBacking(depthCompare),
+            .stencilFront = stencilFront.convertToBacking(),
+            .stencilBack = stencilBack.convertToBacking(),
+            .stencilReadMask = stencilReadMask ? std::optional { *stencilReadMask } : std::nullopt,
+            .stencilWriteMask = stencilWriteMask ? std::optional { *stencilWriteMask } : std::nullopt,
+            .depthBias = depthBias,
+            .depthBiasSlopeScale = depthBiasSlopeScale,
+            .depthBiasClamp = depthBiasClamp,
         };
     }
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -394,25 +394,27 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, bool de
     });
 
     WGPUDepthStencilState depthStencilState {
-        nullptr,
-        descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->format) : WGPUTextureFormat_Undefined,
-        descriptor.depthStencil ? descriptor.depthStencil->depthWriteEnabled : false,
-        descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->depthCompare) : WGPUCompareFunction_Undefined, {
+        .nextInChain = nullptr,
+        .format = descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->format) : WGPUTextureFormat_Undefined,
+        .depthWriteEnabled = descriptor.depthStencil ? descriptor.depthStencil->depthWriteEnabled : false,
+        .depthCompare = descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->depthCompare) : WGPUCompareFunction_Undefined,
+        .stencilFront = {
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilFront.compare) : WGPUCompareFunction_Undefined,
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilFront.failOp) : WGPUStencilOperation_Keep,
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilFront.depthFailOp) : WGPUStencilOperation_Keep,
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilFront.passOp) : WGPUStencilOperation_Keep,
-        }, {
+        },
+        .stencilBack = {
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilBack.compare) : WGPUCompareFunction_Undefined,
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilBack.failOp) : WGPUStencilOperation_Keep,
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilBack.depthFailOp) : WGPUStencilOperation_Keep,
             descriptor.depthStencil ? convertToBackingContext.convertToBacking(descriptor.depthStencil->stencilBack.passOp) : WGPUStencilOperation_Keep,
         },
-        descriptor.depthStencil && descriptor.depthStencil->stencilReadMask ? *descriptor.depthStencil->stencilReadMask : 0,
-        descriptor.depthStencil && descriptor.depthStencil->stencilWriteMask ? *descriptor.depthStencil->stencilWriteMask : 0,
-        descriptor.depthStencil ? descriptor.depthStencil->depthBias : 0,
-        descriptor.depthStencil ? descriptor.depthStencil->depthBiasSlopeScale : 0,
-        descriptor.depthStencil ? descriptor.depthStencil->depthBiasClamp : 0,
+        .stencilReadMask = descriptor.depthStencil && descriptor.depthStencil->stencilReadMask ? *descriptor.depthStencil->stencilReadMask : 0,
+        .stencilWriteMask = descriptor.depthStencil && descriptor.depthStencil->stencilWriteMask ? *descriptor.depthStencil->stencilWriteMask : 0,
+        .depthBias = descriptor.depthStencil ? descriptor.depthStencil->depthBias : 0,
+        .depthBiasSlopeScale = descriptor.depthStencil ? descriptor.depthStencil->depthBiasSlopeScale : 0,
+        .depthBiasClamp = descriptor.depthStencil ? descriptor.depthStencil->depthBiasClamp : 0,
     };
 
     auto fragmentEntryPoint = descriptor.fragment ? descriptor.fragment->entryPoint.utf8() : CString("");

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -39,7 +39,7 @@ struct WGPURenderBundleEncoderImpl {
 
 @interface RenderBundleICBWithResources : NSObject
 
-- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode depthBias:(float)depthBias depthBiasSlopeScale:(float)depthBiasSlopeScale depthBiasClamp:(float)depthBiasClamp NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
 @property (readonly, nonatomic) id<MTLIndirectCommandBuffer> indirectCommandBuffer;
@@ -48,6 +48,9 @@ struct WGPURenderBundleEncoderImpl {
 @property (readonly, nonatomic) MTLCullMode cullMode;
 @property (readonly, nonatomic) MTLWinding frontFace;
 @property (readonly, nonatomic) MTLDepthClipMode depthClipMode;
+@property (readonly, nonatomic) float depthBias;
+@property (readonly, nonatomic) float depthBiasSlopeScale;
+@property (readonly, nonatomic) float depthBiasClamp;
 
 - (Vector<WebGPU::BindableResources>*)resources;
 @end
@@ -118,6 +121,9 @@ private:
     MTLCullMode m_cullMode { MTLCullModeNone };
     MTLWinding m_frontFace { MTLWindingClockwise };
     MTLDepthClipMode m_depthClipMode { MTLDepthClipModeClip };
+    float m_depthBias { 0 };
+    float m_depthBiasSlopeScale { 0 };
+    float m_depthBiasClamp { 0 };
 
     MTLPrimitiveType m_primitiveType { MTLPrimitiveTypeTriangle };
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -194,6 +194,7 @@ void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<const Rende
             [m_renderCommandEncoder setCullMode:icb.cullMode];
             [m_renderCommandEncoder setFrontFacingWinding:icb.frontFace];
             [m_renderCommandEncoder setDepthClipMode:icb.depthClipMode];
+            [m_renderCommandEncoder setDepthBias:icb.depthBias slopeScale:icb.depthBiasSlopeScale clamp:icb.depthBiasClamp];
 
             for (const auto& resource : *icb.resources) {
                 if (resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment))
@@ -310,6 +311,7 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
     [m_renderCommandEncoder setCullMode:pipeline.cullMode()];
     [m_renderCommandEncoder setFrontFacingWinding:pipeline.frontFace()];
     [m_renderCommandEncoder setDepthClipMode:pipeline.depthClipMode()];
+    [m_renderCommandEncoder setDepthBias:pipeline.depthBias() slopeScale:pipeline.depthBiasSlopeScale() clamp:pipeline.depthBiasClamp()];
 }
 
 void RenderPassEncoder::setScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height)

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -44,9 +44,9 @@ class PipelineLayout;
 class RenderPipeline : public WGPURenderPipelineImpl, public RefCounted<RenderPipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthClipMode depthClipMode, MTLDepthStencilDescriptor *depthStencilDescriptor, Ref<PipelineLayout>&& pipelineLayout, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthClipMode depthClipMode, MTLDepthStencilDescriptor *depthStencilDescriptor, Ref<PipelineLayout>&& pipelineLayout, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthClipMode, depthStencilDescriptor, WTFMove(pipelineLayout), device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthClipMode, depthStencilDescriptor, WTFMove(pipelineLayout), depthBias, depthBiasSlopeScale, depthBiasClamp, device));
     }
 
     static Ref<RenderPipeline> createInvalid(Device& device)
@@ -69,12 +69,15 @@ public:
     MTLCullMode cullMode() const { return m_cullMode; }
     MTLDepthClipMode depthClipMode() const { return m_clipMode; }
     MTLDepthStencilDescriptor *depthStencilDescriptor() const { return m_depthStencilDescriptor; }
+    float depthBias() const { return m_depthBias; }
+    float depthBiasSlopeScale() const { return m_depthBiasSlopeScale; }
+    float depthBiasClamp() const { return m_depthBiasClamp; }
 
     Device& device() const { return m_device; }
     PipelineLayout& pipelineLayout() const;
 
 private:
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthClipMode, MTLDepthStencilDescriptor *, Ref<PipelineLayout>&&, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthClipMode, MTLDepthStencilDescriptor *, Ref<PipelineLayout>&&, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, Device&);
     RenderPipeline(Device&);
 
     const id<MTLRenderPipelineState> m_renderPipelineState { nil };
@@ -85,6 +88,9 @@ private:
     MTLWinding m_frontFace;
     MTLCullMode m_cullMode;
     MTLDepthClipMode m_clipMode;
+    float m_depthBias { 0 };
+    float m_depthBiasSlopeScale { 0 };
+    float m_depthBiasClamp { 0 };
     MTLDepthStencilDescriptor *m_depthStencilDescriptor;
     id<MTLDepthStencilState> m_depthStencilState;
     Ref<PipelineLayout> m_pipelineLayout;


### PR DESCRIPTION
#### 7111a438f7c71af654f3a7d45a89820f3f503eea
<pre>
[WebGPU] setDepthBias: is never called, depth bias and related functions are not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=263906">https://bugs.webkit.org/show_bug.cgi?id=263906</a>
&lt;rdar://problem/117696050&gt;

Reviewed by Dan Glastonbury.

Call setDepthBias for regular passes and ICBs and update the test expectations.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/rendering/depth_bias-expected.txt:
* Source/WebCore/Modules/WebGPU/GPUDepthStencilState.h:
(WebCore::GPUDepthStencilState::convertToBacking const):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::convertToBacking):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(-[RenderBundleICBWithResources initWithICB:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:depthBias:depthBiasSlopeScale:depthBiasClamp:]):
(WebGPU::makeRenderBundleICBWithResources):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::icbNeedsToBeSplit):
(WebGPU::RenderBundleEncoder::setPipeline):
(-[RenderBundleICBWithResources initWithICB:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:]): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::setPipeline):
* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::create):
(WebGPU::RenderPipeline::depthBias const):
(WebGPU::RenderPipeline::depthBiasSlopeScale const):
(WebGPU::RenderPipeline::depthBiasClamp const):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::RenderPipeline):

Canonical link: <a href="https://commits.webkit.org/269995@main">https://commits.webkit.org/269995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d1aaee4c3242294a4a7bb6fdc0ab1d35beed17c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22708 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26871 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28023 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22081 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25822 "Found 55 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/ephemeral, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/reload, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cookies, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-cancel, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/populate-menu, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-no-credential ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19137 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1492 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5804 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->