### PR TITLE
Fixes for build --minimal

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
@@ -68,7 +68,7 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
 #if ENABLE(VIDEO)
             mediaIdentifierForSource(source),
 #else
-            { 0 },
+            { },
 #endif
             WebCore::convertToBacking(colorSpace),
         };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h
@@ -39,8 +39,10 @@ namespace WebCore::WebGPU {
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
 using VideoSourceIdentifier = std::variant<WebCore::MediaPlayerIdentifier, RefPtr<WebCore::VideoFrame>, RetainPtr<CVPixelBufferRef>>;
-#else
+#elif ENABLE(VIDEO)
 using VideoSourceIdentifier = std::variant<WebCore::MediaPlayerIdentifier, RefPtr<WebCore::VideoFrame>, void*>;
+#else
+using VideoSourceIdentifier = std::variant<WebCore::MediaPlayerIdentifier, void*>;
 #endif
 
 struct ExternalTextureDescriptor : public ObjectDescriptorBase {

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -29,10 +29,9 @@
 #include "JSDOMGlobalObject.h"
 #include "JSDOMWrapper.h"
 #include "JSEventTarget.h"
+#include "WorkletGlobalScope.h"
 
 namespace WebCore {
-
-class WorkletGlobalScope;
 
 class JSWorkletGlobalScopeBase : public JSDOMGlobalObject {
 public:

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "CDATASection.h"
 
+#include "Document.h"
 #include "DocumentInlines.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3682,6 +3682,7 @@ const URL& Document::urlForBindings() const
         if (preNavigationURL.isEmpty() || RegistrableDomain { preNavigationURL }.matches(securityOrigin().data()))
             return false;
 
+#if ENABLE(PUBLIC_SUFFIX_LIST)
         auto areSameSiteIgnoringPublicSuffix = [](StringView domain, StringView otherDomain) {
             auto domainString = topPrivatelyControlledDomain(domain.toStringWithoutCopying());
             auto otherDomainString = topPrivatelyControlledDomain(otherDomain.toStringWithoutCopying());
@@ -3698,6 +3699,7 @@ const URL& Document::urlForBindings() const
         auto currentHost = securityOrigin().data().host();
         if (areSameSiteIgnoringPublicSuffix(preNavigationURL.host(), currentHost))
             return false;
+#endif // ENABLE(PUBLIC_SUFFIX_LIST)
 
         if (!m_hasLoadedThirdPartyScript)
             return false;
@@ -3706,8 +3708,10 @@ const URL& Document::urlForBindings() const
             if (RegistrableDomain { sourceURL }.matches(securityOrigin().data()))
                 return false;
 
+#if ENABLE(PUBLIC_SUFFIX_LIST)
             if (areSameSiteIgnoringPublicSuffix(sourceURL.host(), currentHost))
                 return false;
+#endif // ENABLE(PUBLIC_SUFFIX_LIST)
         }
 
         return true;

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -27,8 +27,10 @@
 
 #include <memory>
 #include <wtf/CheckedPtr.h>
+#include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/NamedNodeMap.h
+++ b/Source/WebCore/dom/NamedNodeMap.h
@@ -24,13 +24,13 @@
 
 #pragma once
 
+#include "Element.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 
 namespace WebCore {
 
 class Attr;
-class Element;
 
 class NamedNodeMap final : public ScriptWrappable {
     WTF_MAKE_ISO_ALLOCATED(NamedNodeMap);

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "AnimationFrameRate.h"
+#include "Document.h"
 #include "ReducedResolutionSeconds.h"
 #include "Timer.h"
 #include <wtf/CheckedPtr.h>
@@ -37,7 +38,6 @@
 
 namespace WebCore {
 
-class Document;
 class ImminentlyScheduledWorkScope;
 class Page;
 class RequestAnimationFrameCallback;

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -27,8 +27,10 @@
 #include "config.h"
 #include "AlternativeTextController.h"
 
+#include "Document.h"
 #include "DocumentFragment.h"
 #include "DocumentInlines.h"
+#include "DocumentMarkerController.h"
 #include "Editing.h"
 #include "Editor.h"
 #include "EditorClient.h"

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -27,7 +27,9 @@
 #include "DictationCommand.h"
 
 #include "AlternativeTextController.h"
+#include "Document.h"
 #include "DocumentInlines.h"
+#include "DocumentMarkerController.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameSelection.h"
 #include "InsertParagraphSeparatorCommand.h"

--- a/Source/WebCore/editing/SpellingCorrectionCommand.h
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.h
@@ -26,10 +26,9 @@
 #pragma once
 
 #include "CompositeEditCommand.h"
+#include "DocumentFragment.h"
 
 namespace WebCore {
-
-class DocumentFragment;
 
 class SpellingCorrectionCommand : public CompositeEditCommand {
 public:

--- a/Source/WebCore/editing/SplitTextNodeCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeCommand.cpp
@@ -27,7 +27,9 @@
 #include "SplitTextNodeCommand.h"
 
 #include "CompositeEditCommand.h"
+#include "Document.h"
 #include "DocumentInlines.h"
+#include "DocumentMarkerController.h"
 #include "Text.h"
 #include <wtf/Assertions.h>
 

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "VisibleSelection.h"
 
+#include "Document.h"
 #include "DocumentInlines.h"
 #include "Editing.h"
 #include "Element.h"

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "VisibleUnits.h"
 
+#include "Document.h"
 #include "DocumentInlines.h"
 #include "Editing.h"
 #include "HTMLBRElement.h"

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -36,6 +36,7 @@
 #include "InputTypeNames.h"
 #include "KeyboardEvent.h"
 #include "LocalizedStrings.h"
+#include "RenderElement.h"
 #include "ScopedEventQueue.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"

--- a/Source/WebCore/html/HiddenInputType.cpp
+++ b/Source/WebCore/html/HiddenInputType.cpp
@@ -33,6 +33,7 @@
 #include "HiddenInputType.h"
 
 #include "DOMFormData.h"
+#include "ElementInlines.h"
 #include "FormController.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/html/SubmitInputType.cpp
+++ b/Source/WebCore/html/SubmitInputType.cpp
@@ -34,6 +34,7 @@
 
 #include "DOMFormData.h"
 #include "Document.h"
+#include "ElementInlines.h"
 #include "Event.h"
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"
@@ -41,6 +42,8 @@
 #include "LocalizedStrings.h"
 
 namespace WebCore {
+
+using namespace HTMLNames;
 
 const AtomString& SubmitInputType::formControlType() const
 {

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -35,6 +35,7 @@
 #include "Element.h"
 #include "HTMLParserIdioms.h"
 #include "ParsingUtilities.h"
+#include <wtf/ListHashSet.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -1023,8 +1023,10 @@ bool Line::Run::isContentfulOrHasDecoration(const Run& run, const InlineFormatti
         if (run.isInlineBoxEnd())
             return inlineBoxGeometry.marginEnd() || inlineBoxGeometry.borderEnd() || inlineBoxGeometry.paddingEnd().value_or(0_lu);
         if (run.isLineSpanningInlineBoxStart()) {
+#if ENABLE(CSS_BOX_DECORATION_BREAK)
             if (run.style().boxDecorationBreak() != BoxDecorationBreak::Clone)
                 return false;
+#endif // ENABLE(CSS_BOX_DECORATION_BREAK)
             return inlineBoxGeometry.borderStart() || inlineBoxGeometry.paddingStart().value_or(0_lu);
         }
     }

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -466,8 +466,10 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout(cons
         return false;
     if (rootStyle.textAlignLast() == TextAlignLast::Justify || rootStyle.textAlign() == TextAlignMode::Justify || rootBox.isRubyAnnotationBox())
         return false;
+#if ENABLE(CSS_BOX_DECORATION_BREAK)
     if (rootStyle.boxDecorationBreak() == BoxDecorationBreak::Clone)
         return false;
+#endif // ENABLE(CSS_BOX_DECORATION_BREAK)
     if (!rootStyle.hangingPunctuation().isEmpty())
         return false;
     if (rootStyle.hyphenationLimitLines() != RenderStyle::initialHyphenationLimitLines())

--- a/Source/WebCore/loader/archive/Archive.cpp
+++ b/Source/WebCore/loader/archive/Archive.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "Archive.h"
 
+#include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -649,6 +649,7 @@ bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type,
 String convertEnumerationToString(FetchOptions::Destination);
 String convertEnumerationToString(FetchOptions::Mode);
 
+#if ENABLE(PUBLIC_SUFFIX_LIST)
 static const String& convertEnumerationToString(FetchMetadataSite enumerationValue)
 {
     static NeverDestroyed<const String> none(MAKE_STATIC_STRING_IMPL("none"));
@@ -690,6 +691,7 @@ static void updateRequestFetchMetadataHeaders(ResourceRequest& request, const Re
     request.setHTTPHeaderField(HTTPHeaderName::SecFetchMode, convertEnumerationToString(options.mode));
     request.setHTTPHeaderField(HTTPHeaderName::SecFetchSite, convertEnumerationToString(site));
 }
+#endif // ENABLE(PUBLIC_SUFFIX_LIST)
 
 FetchMetadataSite CachedResourceLoader::computeFetchMetadataSite(const ResourceRequest& request, CachedResource::Type type, FetchOptions::Mode mode, const SecurityOrigin& originalOrigin, FetchMetadataSite originalSite)
 {
@@ -733,6 +735,8 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         } else
             updateRequestFetchMetadataHeaders(request, options, site);
     }
+#else
+    UNUSED_PARAM(site);
 #endif // ENABLE(PUBLIC_SUFFIX_LIST)
 
     return canRequestAfterRedirection(type, request.url(), options, preRedirectURL);

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -27,6 +27,7 @@
 #include "DOMWindow.h"
 
 #include "Document.h"
+#include "Frame.h"
 #include "HTTPParsers.h"
 #include "Location.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -53,6 +53,7 @@
 #include "DeviceOrientationAndMotionAccessController.h"
 #include "DeviceOrientationController.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "DocumentLoader.h"
 #include "Editor.h"
 #include "Element.h"

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "Navigation.h"
 
+#include <wtf/IsoMallocInlines.h>
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(Navigation);

--- a/Source/WebCore/page/NavigationDestination.cpp
+++ b/Source/WebCore/page/NavigationDestination.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "NavigationDestination.h"
 
+#include <wtf/IsoMallocInlines.h>
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationDestination);

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -27,6 +27,7 @@
 #include "NavigationHistoryEntry.h"
 
 #include "ScriptExecutionContext.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -38,6 +38,7 @@ namespace WebCore {
 // When testing changes, be sure to test with application branding enabled.
 // Otherwise, we will not notice when urlRequiresUnbrandedUserAgent is needed.
 
+#if ENABLE(PUBLIC_SUFFIX_LIST)
 // Be careful with this quirk: it's an invitation for sites to use JavaScript
 // that works in Chrome that WebKit cannot handle. Prefer other quirks instead.
 static bool urlRequiresChromeBrowser(const String& domain, const String& baseDomain)
@@ -76,6 +77,7 @@ static bool urlRequiresChromeBrowser(const String& domain, const String& baseDom
 
     return false;
 }
+#endif // ENABLE(PUBLIC_SUFFIX_LIST)
 
 // Prefer using the macOS platform quirk rather than the Firefox quirk. This
 // quirk is good for websites that do macOS-specific things we don't want on
@@ -96,6 +98,7 @@ static bool urlRequiresFirefoxBrowser(const String& domain)
     return false;
 }
 
+#if ENABLE(PUBLIC_SUFFIX_LIST)
 static bool urlRequiresMacintoshPlatform(const String& domain, const String& baseDomain)
 {
     // At least finance.yahoo.com displays a mobile version with WebKitGTK's standard user agent.
@@ -135,6 +138,7 @@ static bool urlRequiresMacintoshPlatform(const String& domain, const String& bas
 
     return false;
 }
+#endif // ENABLE(PUBLIC_SUFFIX_LIST)
 
 static bool urlRequiresUnbrandedUserAgent(const String& domain)
 {

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -27,7 +27,9 @@
 #include "MarkedText.h"
 
 #include "DeprecatedGlobalSettings.h"
+#include "Document.h"
 #include "DocumentInlines.h"
+#include "DocumentMarkerController.h"
 #include "Editor.h"
 #include "ElementRuleCollector.h"
 #include "HighlightRegistry.h"

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -31,6 +31,7 @@
 #include "InlineIteratorInlineBox.h"
 #include "LocalizedStrings.h"
 #include "PaintInfo.h"
+#include "RenderBlockInlines.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderButton.h"

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2926,6 +2926,7 @@ static inline bool shouldSuppressPaintingLayer(RenderLayer* layer)
 
 void RenderLayer::paintSVGResourceLayer(GraphicsContext& context, GraphicsContextStateSaver&, const AffineTransform& layerContentTransform)
 {
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
     bool wasPaintingSVGResourceLayer = m_isPaintingSVGResourceLayer;
     m_isPaintingSVGResourceLayer = true;
     context.concatCTM(layerContentTransform);
@@ -2945,6 +2946,10 @@ void RenderLayer::paintSVGResourceLayer(GraphicsContext& context, GraphicsContex
     paintLayer(context, paintingInfo, flags);
 
     m_isPaintingSVGResourceLayer = wasPaintingSVGResourceLayer;
+#else
+    UNUSED_PARAM(context);
+    UNUSED_PARAM(layerContentTransform);
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)
 }
 
 static inline bool paintForFixedRootBackground(const RenderLayer* layer, OptionSet<RenderLayer::PaintLayerFlag> paintFlags)
@@ -3173,6 +3178,7 @@ void RenderLayer::setupClipPath(GraphicsContext& context, GraphicsContextStateSa
 
     if (is<ReferencePathOperation>(style.clipPath())) {
         auto& referenceClipPathOperation = downcast<ReferencePathOperation>(*style.clipPath());
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
         if (auto* svgClipper = svgClipperFromStyle()) {
             auto* graphicsElement = svgClipper->shouldApplyPathClipping();
             if (!graphicsElement) {
@@ -3202,6 +3208,7 @@ void RenderLayer::setupClipPath(GraphicsContext& context, GraphicsContextStateSa
                 context.translate(-coordinateSystemOriginTranslation);
             return;
         }
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)
 
         if (auto* clipperRenderer = ReferencedSVGResources::referencedClipperRenderer(renderer().treeScopeForSVGReferences(), referenceClipPathOperation)) {
             // Use the border box as the reference box, even though this is not clearly specified: https://github.com/w3c/csswg-drafts/issues/5786.

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -462,12 +462,14 @@ void RenderLayerModelObject::updateHasSVGTransformFlags()
     setHasTransformRelatedProperty(hasSVGTransform || style().hasTransformRelatedProperty());
     setHasSVGTransform(hasSVGTransform);
 }
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)
 
 CheckedPtr<RenderLayer> RenderLayerModelObject::checkedLayer() const
 {
     return m_layer.get();
 }
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
 void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -27,6 +27,7 @@
 #include "BackgroundPainter.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DocumentInlines.h"
+#include "DocumentMarkerController.h"
 #include "ElementRuleCollector.h"
 #include "FloatRoundedRect.h"
 #include "GraphicsContext.h"
@@ -401,6 +402,8 @@ static bool isVideoWithDefaultObjectSize(const RenderReplaced* maybeVideo)
 #if ENABLE(VIDEO)
     if (auto* video = dynamicDowncast<RenderVideo>(maybeVideo))
         return video->hasDefaultObjectSize();
+#else
+    UNUSED_PARAM(maybeVideo);
 #endif
     return false;
 } 

--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -41,7 +41,6 @@
 #include "RenderStyleSetters.h"
 #include "ThemeAdwaita.h"
 #include "TimeRanges.h"
-#include "UserAgentScripts.h"
 #include "UserAgentStyleSheets.h"
 #include <wtf/text/Base64.h>
 
@@ -52,6 +51,10 @@
 #if PLATFORM(WIN)
 #include "WebCoreBundleWin.h"
 #include <wtf/FileSystem.h>
+#endif
+
+#if ENABLE(MODERN_MEDIA_CONTROLS)
+#include "UserAgentScripts.h"
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -27,6 +27,7 @@
 
 #include "CompositionHighlight.h"
 #include "DocumentInlines.h"
+#include "DocumentMarkerController.h"
 #include "Editor.h"
 #include "EventRegion.h"
 #include "GraphicsContext.h"

--- a/Source/WebCore/rendering/TransformOperationData.cpp
+++ b/Source/WebCore/rendering/TransformOperationData.cpp
@@ -36,7 +36,13 @@ TransformOperationData::TransformOperationData(FloatRect boundingBox, const Rend
 {
     if (renderer) {
         motionPathData = MotionPath::motionPathDataForRenderer(*renderer);
-        isSVGRenderer = is<RenderSVGModelObject>(renderer) || is<LegacyRenderSVGModelObject>(renderer);
+        isSVGRenderer =
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+            is<RenderSVGModelObject>(renderer)
+#else
+            false
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)
+            || is<LegacyRenderSVGModelObject>(renderer);
     }
 }
 

--- a/Source/WebCore/rendering/style/WillChangeData.cpp
+++ b/Source/WebCore/rendering/style/WillChangeData.cpp
@@ -68,6 +68,9 @@ bool WillChangeData::createsContainingBlockForAbsolutelyPositioned(bool isRootEl
 
 bool WillChangeData::createsContainingBlockForOutOfFlowPositioned(bool isRootElement) const
 {
+#if !ENABLE(FILTERS_LEVEL_2)
+    UNUSED_PARAM(isRootElement);
+#endif // !ENABLE(FILTERS_LEVEL_2)
     return containsProperty(CSSPropertyPerspective)
         // CSS transforms
         || containsProperty(CSSPropertyTransform)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "RenderSVGResourceClipper.h"
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
 #include "ElementIterator.h"
 #include "Frame.h"
 #include "FrameView.h"
@@ -232,3 +233,5 @@ FloatRect RenderSVGResourceClipper::resourceBoundingBox(const RenderObject& obje
 }
 
 }
+
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+
 #include "RenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
 
@@ -64,3 +66,5 @@ private:
 }
 
 SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceClipper, isSVGResourceClipper())
+
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "RenderSVGResourceContainer.h"
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
 #include "RenderLayer.h"
 #include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGRoot.h"
@@ -85,3 +86,5 @@ void RenderSVGResourceContainer::registerResource()
 }
 
 }
+
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+
 #include "LegacyRenderSVGResource.h"
 #include "RenderSVGHiddenContainer.h"
 
@@ -57,3 +59,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceContainer, isSVGResourceContainer())
+
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -667,6 +667,7 @@ void SVGRenderSupport::paintSVGClippingMask(const RenderLayerModelObject& render
         return;
 
     ASSERT(renderer.isSVGLayerAwareRenderer());
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
     const auto& referenceClipPathOperation = downcast<ReferencePathOperation>(*renderer.style().clipPath());
     auto* renderResource = renderer.document().lookupSVGResourceById(referenceClipPathOperation.fragment());
     if (!renderResource)
@@ -674,6 +675,7 @@ void SVGRenderSupport::paintSVGClippingMask(const RenderLayerModelObject& render
 
     if (auto clipper = dynamicDowncast<RenderSVGResourceClipper>(renderResource))
         clipper->applyMaskClipping(paintInfo, renderer, renderer.objectBoundingBox());
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)
 }
 
 }

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -232,8 +232,12 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             AtomString id(clipPath.fragment());
             if (auto* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(treeScope, id))
                 ensureResources(foundResources).setClipper(clipper);
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
             else if (!renderer.document().settings().layerBasedSVGEngineEnabled())
                 treeScope.addPendingSVGResource(id, element);
+#else
+            treeScope.addPendingSVGResource(id, element);
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)
         }
 
         if (style.hasFilter()) {

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -28,6 +28,7 @@
 #include "LegacyRenderSVGResourceClipper.h"
 #include "RenderSVGResourceClipper.h"
 #include "RenderSVGText.h"
+#include "RenderStyleInlines.h"
 #include "SVGNames.h"
 #include "StyleResolver.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -548,6 +548,8 @@ ExceptionOr<void>  InternalSettings::setShouldDeactivateAudioSession(bool should
         return Exception { InvalidAccessError };
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
     PlatformMediaSessionManager::setShouldDeactivateAudioSession(should);
+#else
+    UNUSED_PARAM(should);
 #endif
     return { };
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5013,7 +5013,11 @@ void Internals::mockMediaPlaybackTargetPickerDismissPopup()
 
 bool Internals::isMonitoringWirelessRoutes() const
 {
+#if ENABLE(VIDEO)
     return PlatformMediaSessionManager::sharedManager().isMonitoringWirelessTargets();
+#else
+    return false;
+#endif // ENABLE(VIDEO)
 }
 
 ExceptionOr<Ref<MockPageOverlay>> Internals::installMockPageOverlay(PageOverlayType type)
@@ -6516,6 +6520,8 @@ void Internals::setIsPlayingToAutomotiveHeadUnit(bool isPlaying)
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
     PlatformMediaSessionManager::sharedManager().setIsPlayingToAutomotiveHeadUnit(isPlaying);
+#else
+    UNUSED_PARAM(isPlaying);
 #endif
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -494,8 +494,12 @@ void ServiceWorkerThreadProxy::setAppBadge(std::optional<uint64_t> badge)
 void ServiceWorkerThreadProxy::setInspectable(bool inspectable)
 {
     ASSERT(isMainThread());
+#if ENABLE(REMOTE_INSPECTOR)
     m_page->setInspectable(inspectable);
     m_remoteDebuggable->setInspectable(inspectable);
+#else
+    UNUSED_PARAM(inspectable);
+#endif // ENABLE(REMOTE_INSPECTOR)
 }
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -43,6 +43,7 @@
 #include <WebCore/FetchIdentifier.h>
 #include <WebCore/MessagePortChannelRegistry.h>
 #include <WebCore/NotificationEventType.h>
+#include <WebCore/NotificationPayload.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/PushPermissionState.h>

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -44,6 +44,7 @@
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/SWServerDelegate.h>
+#include <WebCore/StoredCredentialsPolicy.h>
 #include <pal/SessionID.h>
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -27,6 +27,7 @@
 
 #include "Attachment.h"
 #include "MessageNames.h"
+#include <WebCore/PlatformExportMacros.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>

--- a/Source/WebKit/Shared/API/APICaptionUserPreferencesTestingModeToken.h
+++ b/Source/WebKit/Shared/API/APICaptionUserPreferencesTestingModeToken.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#if ENABLE(VIDEO)
 #include "APIObject.h"
 #include <WebCore/CaptionUserPreferences.h>
 #include <wtf/Ref.h>
@@ -47,3 +48,5 @@ private:
 };
 
 }
+
+#endif // ENABLE(VIDEO)

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -22,6 +22,7 @@
 
 #include "APIArray.h"
 #include "WebContextMenuItem.h"
+#include "WebKitContextMenuItem.h"
 #include "WebKitContextMenuItemPrivate.h"
 #include "WebKitContextMenuPrivate.h"
 #include <wtf/glib/GRefPtr.h>
@@ -32,8 +33,10 @@
 #include <WebCore/GUniquePtrGtk.h>
 #endif
 
+#if ENABLE(CONTEXT_MENUS)
 using namespace WebKit;
 using namespace WebCore;
+#endif // ENABLE(CONTEXT_MENUS)
 
 /**
  * WebKitContextMenu:
@@ -80,6 +83,7 @@ static void webkit_context_menu_class_init(WebKitContextMenuClass* listClass)
     gObjectClass->dispose = webkitContextMenuDispose;
 }
 
+#if ENABLE(CONTEXT_MENUS)
 void webkitContextMenuPopulate(WebKitContextMenu* menu, Vector<WebContextMenuItemData>& contextMenuItems)
 {
     for (GList* item = menu->priv->items; item; item = g_list_next(item)) {
@@ -126,6 +130,7 @@ WebKitContextMenuItem* webkitContextMenuGetParentItem(WebKitContextMenu* menu)
 {
     return menu->priv->parentItem;
 }
+#endif // ENABLE(CONTEXT_MENUS)
 
 /**
  * webkit_context_menu_new:

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuActions.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuActions.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "WebKitContextMenuActions.h"
 
+#if ENABLE(CONTEXT_MENUS)
 #include "WebKitContextMenuActionsPrivate.h"
 #include <WebCore/LocalizedStrings.h>
 #include <wtf/text/WTFString.h>
@@ -353,3 +354,5 @@ String webkitContextMenuActionGetLabel(WebKitContextMenuAction action)
 
     return String();
 }
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuActionsPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuActionsPrivate.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#if ENABLE(CONTEXT_MENUS)
 #include "WebContextMenuItemGlib.h"
 #include "WebKitContextMenuActions.h"
 
@@ -26,3 +27,5 @@ bool webkitContextMenuActionIsCheckable(WebKitContextMenuAction);
 WebCore::ContextMenuAction webkitContextMenuActionGetActionTag(WebKitContextMenuAction);
 WebKitContextMenuAction webkitContextMenuActionGetForContextMenuItem(const WebKit::WebContextMenuItemGlib&);
 String webkitContextMenuActionGetLabel(WebKitContextMenuAction);
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
@@ -33,8 +33,10 @@
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 
+#if ENABLE(CONTEXT_MENUS)
 using namespace WebKit;
 using namespace WebCore;
+#endif // ENABLE(CONTEXT_MENUS)
 
 /**
  * WebKitContextMenuItem:
@@ -50,6 +52,7 @@ using namespace WebCore;
  */
 
 struct _WebKitContextMenuItemPrivate {
+#if ENABLE(CONTEXT_MENUS)
     ~_WebKitContextMenuItemPrivate()
     {
         if (subMenu)
@@ -58,6 +61,7 @@ struct _WebKitContextMenuItemPrivate {
 
     std::unique_ptr<WebContextMenuItemGlib> menuItem;
     GRefPtr<WebKitContextMenu> subMenu;
+#endif // ENABLE(CONTEXT_MENUS)
 };
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitContextMenuItem, webkit_context_menu_item, G_TYPE_INITIALLY_UNOWNED, GInitiallyUnowned)
@@ -66,6 +70,7 @@ static void webkit_context_menu_item_class_init(WebKitContextMenuItemClass*)
 {
 }
 
+#if ENABLE(CONTEXT_MENUS)
 static bool checkAndWarnIfMenuHasParentItem(WebKitContextMenu* menu)
 {
     if (menu && webkitContextMenuGetParentItem(menu)) {
@@ -123,6 +128,7 @@ WebContextMenuItemData webkitContextMenuItemToWebContextMenuItemData(WebKitConte
 
     return WebContextMenuItemData(item->priv->menuItem->type(), item->priv->menuItem->action(), item->priv->menuItem->title(), item->priv->menuItem->enabled(), item->priv->menuItem->checked());
 }
+#endif // ENABLE(CONTEXT_MENUS)
 
 #if PLATFORM(GTK) && !USE(GTK4)
 /**
@@ -140,7 +146,9 @@ WebKitContextMenuItem* webkit_context_menu_item_new(GtkAction* action)
     g_return_val_if_fail(GTK_IS_ACTION(action), nullptr);
 
     WebKitContextMenuItem* item = WEBKIT_CONTEXT_MENU_ITEM(g_object_new(WEBKIT_TYPE_CONTEXT_MENU_ITEM, nullptr));
+#if ENABLE(CONTEXT_MENUS)
     item->priv->menuItem = makeUnique<WebContextMenuItemGlib>(action);
+#endif // ENABLE(CONTEXT_MENUS)
 
     return item;
 }
@@ -169,7 +177,9 @@ WebKitContextMenuItem* webkit_context_menu_item_new_from_gaction(GAction* action
     g_return_val_if_fail(!target || g_variant_is_of_type(target, g_action_get_parameter_type(action)), nullptr);
 
     WebKitContextMenuItem* item = WEBKIT_CONTEXT_MENU_ITEM(g_object_new(WEBKIT_TYPE_CONTEXT_MENU_ITEM, nullptr));
+#if ENABLE(CONTEXT_MENUS)
     item->priv->menuItem = makeUnique<WebContextMenuItemGlib>(action, String::fromUTF8(label), target);
+#endif // ENABLE(CONTEXT_MENUS)
 
     return item;
 }
@@ -196,8 +206,10 @@ WebKitContextMenuItem* webkit_context_menu_item_new_from_stock_action(WebKitCont
     g_return_val_if_fail(action > WEBKIT_CONTEXT_MENU_ACTION_NO_ACTION && action < WEBKIT_CONTEXT_MENU_ACTION_CUSTOM, nullptr);
 
     WebKitContextMenuItem* item = WEBKIT_CONTEXT_MENU_ITEM(g_object_new(WEBKIT_TYPE_CONTEXT_MENU_ITEM, nullptr));
+#if ENABLE(CONTEXT_MENUS)
     ContextMenuItemType type = webkitContextMenuActionIsCheckable(action) ? CheckableActionType : ActionType;
     item->priv->menuItem = makeUnique<WebContextMenuItemGlib>(type, webkitContextMenuActionGetActionTag(action), webkitContextMenuActionGetLabel(action));
+#endif // ENABLE(CONTEXT_MENUS)
 
     return item;
 }
@@ -219,8 +231,10 @@ WebKitContextMenuItem* webkit_context_menu_item_new_from_stock_action_with_label
     g_return_val_if_fail(action > WEBKIT_CONTEXT_MENU_ACTION_NO_ACTION && action < WEBKIT_CONTEXT_MENU_ACTION_CUSTOM, nullptr);
 
     WebKitContextMenuItem* item = WEBKIT_CONTEXT_MENU_ITEM(g_object_new(WEBKIT_TYPE_CONTEXT_MENU_ITEM, nullptr));
+#if ENABLE(CONTEXT_MENUS)
     ContextMenuItemType type = webkitContextMenuActionIsCheckable(action) ? CheckableActionType : ActionType;
     item->priv->menuItem = makeUnique<WebContextMenuItemGlib>(type, webkitContextMenuActionGetActionTag(action), String::fromUTF8(label));
+#endif // ENABLE(CONTEXT_MENUS)
 
     return item;
 }
@@ -239,13 +253,17 @@ WebKitContextMenuItem* webkit_context_menu_item_new_with_submenu(const gchar* la
     g_return_val_if_fail(label, nullptr);
     g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU(submenu), nullptr);
 
+#if ENABLE(CONTEXT_MENUS)
     if (checkAndWarnIfMenuHasParentItem(submenu))
         return nullptr;
+#endif // ENABLE(CONTEXT_MENUS)
 
     WebKitContextMenuItem* item = WEBKIT_CONTEXT_MENU_ITEM(g_object_new(WEBKIT_TYPE_CONTEXT_MENU_ITEM, nullptr));
+#if ENABLE(CONTEXT_MENUS)
     item->priv->menuItem = makeUnique<WebContextMenuItemGlib>(ActionType, ContextMenuItemBaseApplicationTag, String::fromUTF8(label));
     item->priv->subMenu = submenu;
     webkitContextMenuSetParentItem(submenu, item);
+#endif // ENABLE(CONTEXT_MENUS)
 
     return item;
 }
@@ -260,7 +278,9 @@ WebKitContextMenuItem* webkit_context_menu_item_new_with_submenu(const gchar* la
 WebKitContextMenuItem* webkit_context_menu_item_new_separator(void)
 {
     WebKitContextMenuItem* item = WEBKIT_CONTEXT_MENU_ITEM(g_object_new(WEBKIT_TYPE_CONTEXT_MENU_ITEM, nullptr));
+#if ENABLE(CONTEXT_MENUS)
     item->priv->menuItem = makeUnique<WebContextMenuItemGlib>(SeparatorType, ContextMenuItemTagNoAction, String());
+#endif // ENABLE(CONTEXT_MENUS)
 
     return item;
 }
@@ -281,7 +301,11 @@ GtkAction* webkit_context_menu_item_get_action(WebKitContextMenuItem* item)
 {
     g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), nullptr);
 
+#if ENABLE(CONTEXT_MENUS)
     return item->priv->menuItem->gtkAction();
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
 }
 #endif
 
@@ -300,7 +324,11 @@ GAction* webkit_context_menu_item_get_gaction(WebKitContextMenuItem* item)
 {
     g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), nullptr);
 
+#if ENABLE(CONTEXT_MENUS)
     return item->priv->menuItem->gAction();
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
 }
 
 /**
@@ -320,7 +348,11 @@ WebKitContextMenuAction webkit_context_menu_item_get_stock_action(WebKitContextM
 {
     g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), WEBKIT_CONTEXT_MENU_ACTION_NO_ACTION);
 
+#if ENABLE(CONTEXT_MENUS)
     return webkitContextMenuActionGetForContextMenuItem(*item->priv->menuItem);
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
 }
 
 /**
@@ -335,7 +367,11 @@ gboolean webkit_context_menu_item_is_separator(WebKitContextMenuItem* item)
 {
     g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), FALSE);
 
+#if ENABLE(CONTEXT_MENUS)
     return item->priv->menuItem->type() == SeparatorType;
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
 }
 
 /**
@@ -352,10 +388,12 @@ void webkit_context_menu_item_set_submenu(WebKitContextMenuItem* item, WebKitCon
 {
     g_return_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item));
 
+#if ENABLE(CONTEXT_MENUS)
     if (item->priv->subMenu == submenu)
         return;
 
     webkitContextMenuItemSetSubMenu(item, submenu);
+#endif // ENABLE(CONTEXT_MENUS)
 }
 
 /**
@@ -371,6 +409,10 @@ WebKitContextMenu* webkit_context_menu_item_get_submenu(WebKitContextMenuItem* i
 {
     g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU_ITEM(item), 0);
 
+#if ENABLE(CONTEXT_MENUS)
     return item->priv->subMenu.get();
+#else
+    g_assert_not_reached();
+#endif // ENABLE(CONTEXT_MENUS)
 }
 

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuItemPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuItemPrivate.h
@@ -19,9 +19,12 @@
 
 #pragma once
 
+#if ENABLE(CONTEXT_MENUS)
 #include "WebContextMenuItemGlib.h"
 #include "WebKitContextMenuItem.h"
 
 WebKitContextMenuItem* webkitContextMenuItemCreate(const WebKit::WebContextMenuItemData&);
 WebKit::WebContextMenuItemGlib webkitContextMenuItemToWebContextMenuItemGlib(WebKitContextMenuItem*);
 WebKit::WebContextMenuItemData webkitContextMenuItemToWebContextMenuItemData(WebKitContextMenuItem*);
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#if ENABLE(CONTEXT_MENUS)
 #include "WebContextMenuItemGlib.h"
 #include "WebKitContextMenu.h"
 
@@ -39,3 +40,4 @@ void webkitContextMenuSetEvent(WebKitContextMenu*, GRefPtr<GdkEvent>&&);
 void webkitContextMenuSetEvent(WebKitContextMenu*, GUniquePtr<GdkEvent>&&);
 #endif
 #endif
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
+++ b/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebContextMenuItemGlib.h"
 
+#if ENABLE(CONTEXT_MENUS)
 #include "APIObject.h"
 #include <gio/gio.h>
 
@@ -139,3 +140,5 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 } // namespace WebKit
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/glib/WebContextMenuItemGlib.h
+++ b/Source/WebKit/Shared/glib/WebContextMenuItemGlib.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#if ENABLE(CONTEXT_MENUS)
 #include "WebContextMenuItemData.h"
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -71,3 +72,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "WebKitContextMenuClient.h"
 
+#if ENABLE(CONTEXT_MENUS)
 #include "APIContextMenuClient.h"
 #include "APIString.h"
 #include "WebContextMenuItem.h"
@@ -59,3 +60,4 @@ void attachContextMenuClientToView(WebKitWebView* webView)
     webkitWebViewGetPage(webView).setContextMenuClient(makeUnique<ContextMenuClient>(webView));
 }
 
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.h
@@ -20,8 +20,10 @@
 #ifndef WebKitContextMenuClient_h
 #define WebKitContextMenuClient_h
 
+#if ENABLE(CONTEXT_MENUS)
 #include "WebKitWebView.h"
 
 void attachContextMenuClientToView(WebKitWebView*);
+#endif // ENABLE(CONTEXT_MENUS)
 
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp
@@ -56,6 +56,7 @@ WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
     WebKitPointerLockPermissionRequest, webkit_pointer_lock_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
+#if ENABLE(POINTER_LOCK)
 static void webkitPointerLockPermissionRequestAllow(WebKitPermissionRequest* request)
 {
     ASSERT(WEBKIT_IS_POINTER_LOCK_PERMISSION_REQUEST(request));
@@ -83,17 +84,25 @@ static void webkitPointerLockPermissionRequestDeny(WebKitPermissionRequest* requ
     webkitWebViewDenyPointerLockRequest(priv->webView.get());
     priv->madeDecision = true;
 }
+#endif // ENABLE(POINTER_LOCK)
 
 static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
 {
+#if ENABLE(POINTER_LOCK)
     iface->allow = webkitPointerLockPermissionRequestAllow;
     iface->deny = webkitPointerLockPermissionRequestDeny;
+#else
+    iface->allow = nullptr;
+    iface->deny = nullptr;
+#endif // ENABLE(POINTER_LOCK)
 }
 
 static void webkitPointerLockPermissionRequestDispose(GObject* object)
 {
     // Default behaviour when no decision has been made is allowing the request.
+#if ENABLE(POINTER_LOCK)
     webkitPointerLockPermissionRequestAllow(WEBKIT_PERMISSION_REQUEST(object));
+#endif // ENABLE(POINTER_LOCK)
     G_OBJECT_CLASS(webkit_pointer_lock_permission_request_parent_class)->dispose(object);
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -845,7 +845,9 @@ static void webkitWebViewConstructed(GObject* object)
 
     attachNavigationClientToView(webView);
     attachUIClientToView(webView);
+#if ENABLE(CONTEXT_MENUS)
     attachContextMenuClientToView(webView);
+#endif // ENABLE(CONTEXT_MENUS)
     attachFormClientToView(webView);
 
 #if PLATFORM(GTK)
@@ -2796,6 +2798,7 @@ void webkitWebViewRunFileChooserRequest(WebKitWebView* webView, WebKitFileChoose
     g_signal_emit(webView, signals[RUN_FILE_CHOOSER], 0, request, &returnValue);
 }
 
+#if ENABLE(CONTEXT_MENUS)
 #if PLATFORM(GTK)
 void webkitWebViewPopulateContextMenu(WebKitWebView* webView, const Vector<WebContextMenuItemData>& proposedMenu, const WebHitTestResultData& hitTestResultData, GVariant* userData)
 {
@@ -2844,6 +2847,7 @@ void webkitWebViewPopulateContextMenu(WebKitWebView* webView, const Vector<WebCo
         hitTestResult.get(), &returnValue);
 }
 #endif
+#endif // ENABLE(CONTEXT_MENUS)
 
 void webkitWebViewSubmitFormRequest(WebKitWebView* webView, WebKitFormSubmissionRequest* request)
 {
@@ -4633,6 +4637,7 @@ struct ViewSaveAsyncData {
 };
 WEBKIT_DEFINE_ASYNC_DATA_STRUCT(ViewSaveAsyncData)
 
+#if ENABLE(MHTML)
 static void fileReplaceContentsCallback(GObject* object, GAsyncResult* result, gpointer data)
 {
     GRefPtr<GTask> task = adoptGRef(G_TASK(data));
@@ -4667,6 +4672,7 @@ static void getContentsAsMHTMLDataCallback(API::Data* wkData, GTask* taskPtr)
 
     g_task_return_boolean(task.get(), TRUE);
 }
+#endif // ENABLE(MHTML)
 
 /**
  * webkit_web_view_save:
@@ -4693,12 +4699,14 @@ void webkit_web_view_save(WebKitWebView* webView, WebKitSaveMode saveMode, GCanc
     // We only support MHTML at the moment.
     g_return_if_fail(saveMode == WEBKIT_SAVE_MODE_MHTML);
 
+#if ENABLE(MHTML)
     GTask* task = g_task_new(webView, cancellable, callback, userData);
     g_task_set_source_tag(task, reinterpret_cast<gpointer>(webkit_web_view_save));
     g_task_set_task_data(task, createViewSaveAsyncData(), reinterpret_cast<GDestroyNotify>(destroyViewSaveAsyncData));
     getPage(webView).getContentsAsMHTMLData([task](API::Data* data) {
         getContentsAsMHTMLDataCallback(data, task);
     });
+#endif // ENABLE(MHTML)
 }
 
 /**
@@ -4757,6 +4765,7 @@ void webkit_web_view_save_to_file(WebKitWebView* webView, GFile* file, WebKitSav
     // We only support MHTML at the moment.
     g_return_if_fail(saveMode == WEBKIT_SAVE_MODE_MHTML);
 
+#if ENABLE(MHTML)
     GTask* task = g_task_new(webView, cancellable, callback, userData);
     g_task_set_source_tag(task, reinterpret_cast<gpointer>(webkit_web_view_save_to_file));
     ViewSaveAsyncData* data = createViewSaveAsyncData();
@@ -4766,6 +4775,7 @@ void webkit_web_view_save_to_file(WebKitWebView* webView, GFile* file, WebKitSav
     getPage(webView).getContentsAsMHTMLData([task](API::Data* data) {
         getContentsAsMHTMLDataCallback(data, task);
     });
+#endif // ENABLE(MHTML)
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -286,17 +286,21 @@ RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy& pag
     return WebPopupMenuProxyGtk::create(m_viewWidget, page.popupMenuClient());
 }
 
+#if ENABLE(CONTEXT_MENUS)
 Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
 {
     return WebContextMenuProxyGtk::create(m_viewWidget, page, WTFMove(context), userData);
 }
+#endif // ENABLE(CONTEXT_MENUS)
 
+#if ENABLE(INPUT_TYPE_COLOR)
 RefPtr<WebColorPicker> PageClientImpl::createColorPicker(WebPageProxy* page, const WebCore::Color& color, const WebCore::IntRect& rect, Vector<WebCore::Color>&&)
 {
     if (WEBKIT_IS_WEB_VIEW(m_viewWidget))
         return WebKitColorChooser::create(*page, color, rect);
     return WebColorPickerGtk::create(*page, color, rect);
 }
+#endif // ENABLE(INPUT_TYPE_COLOR)
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 RefPtr<WebDateTimePicker> PageClientImpl::createDateTimePicker(WebPageProxy& page)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -91,7 +91,9 @@ private:
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) override;
     void doneWithKeyEvent(const NativeWebKeyboardEvent&, bool wasEventHandled) override;
     RefPtr<WebPopupMenuProxy> createPopupMenuProxy(WebPageProxy&) override;
+#if ENABLE(CONTEXT_MENUS)
     Ref<WebContextMenuProxy> createContextMenuProxy(WebPageProxy&, ContextMenuContextData&&, const UserData&) override;
+#endif // ENABLE(CONTEXT_MENUS)
 #if ENABLE(INPUT_TYPE_COLOR)
     RefPtr<WebColorPicker> createColorPicker(WebPageProxy*, const WebCore::Color& initialColor, const WebCore::IntRect&, Vector<WebCore::Color>&&) override;
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "WebKitColorChooser.h"
 
+#if ENABLE(INPUT_TYPE_COLOR)
 #include "WebKitColorChooserRequestPrivate.h"
 #include "WebKitWebViewPrivate.h"
 #include <WebCore/Color.h>
@@ -80,3 +81,5 @@ void WebKitColorChooser::showColorPicker(const Color& color)
 }
 
 } // namespace WebKit
+
+#endif // ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#if ENABLE(INPUT_TYPE_COLOR)
 #include "WebColorPickerGtk.h"
 #include <WebCore/IntRect.h>
 #include <wtf/glib/GRefPtr.h>
@@ -52,3 +53,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
@@ -31,8 +31,10 @@
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/WTFGType.h>
 
+#if ENABLE(INPUT_TYPE_COLOR)
 using namespace WebKit;
 using namespace WebCore;
+#endif // ENABLE(INPUT_TYPE_COLOR)
 
 /**
  * WebKitColorChooserRequest:
@@ -70,7 +72,9 @@ enum {
 };
 
 struct _WebKitColorChooserRequestPrivate {
+#if ENABLE(INPUT_TYPE_COLOR)
     WebKitColorChooser* colorChooser;
+#endif // ENABLE(INPUT_TYPE_COLOR)
     GdkRGBA rgba;
     bool handled;
 };
@@ -210,7 +214,11 @@ void webkit_color_chooser_request_get_element_rectangle(WebKitColorChooserReques
     g_return_if_fail(WEBKIT_IS_COLOR_CHOOSER_REQUEST(request));
     g_return_if_fail(rect);
 
+#if ENABLE(INPUT_TYPE_COLOR)
     *rect = request->priv->colorChooser->elementRect();
+#else
+    g_assert_not_reached();
+#endif // ENABLE(INPUT_TYPE_COLOR)
 }
 
 /**
@@ -259,10 +267,13 @@ void webkit_color_chooser_request_cancel(WebKitColorChooserRequest* request)
         return;
 
     request->priv->handled = true;
+#if ENABLE(INPUT_TYPE_COLOR)
     request->priv->colorChooser->cancel();
+#endif // ENABLE(INPUT_TYPE_COLOR)
     g_signal_emit(request, signals[FINISHED], 0);
 }
 
+#if ENABLE(INPUT_TYPE_COLOR)
 WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKitColorChooser* colorChooser)
 {
     WebKitColorChooserRequest* request = WEBKIT_COLOR_CHOOSER_REQUEST(
@@ -270,3 +281,4 @@ WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKitColorChooser* c
     request->priv->colorChooser = colorChooser;
     return request;
 }
+#endif // ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequestPrivate.h
@@ -30,6 +30,8 @@
 #include "WebKitColorChooser.h"
 #include "WebKitColorChooserRequest.h"
 
+#if ENABLE(INPUT_TYPE_COLOR)
 WebKitColorChooserRequest* webkitColorChooserRequestCreate(WebKit::WebKitColorChooser*);
+#endif // ENABLE(INPUT_TYPE_COLOR)
 
 #endif // WebKitColorChooserRequestPrivate_h

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -62,8 +62,10 @@ void webkitWebViewBaseExitFullScreen(WebKitWebViewBase*);
 bool webkitWebViewBaseIsFullScreen(WebKitWebViewBase*);
 #endif
 void webkitWebViewBaseSetInspectorViewSize(WebKitWebViewBase*, unsigned size);
+#if ENABLE(CONTEXT_MENUS)
 void webkitWebViewBaseSetActiveContextMenuProxy(WebKitWebViewBase*, WebKit::WebContextMenuProxyGtk*);
 WebKit::WebContextMenuProxyGtk* webkitWebViewBaseGetActiveContextMenuProxy(WebKitWebViewBase*);
+#endif // ENABLE(CONTEXT_MENUS)
 
 #if USE(GTK4)
 GRefPtr<GdkEvent> webkitWebViewBaseTakeContextMenuEvent(WebKitWebViewBase*);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -27,6 +27,7 @@
 
 #include "AppPrivacyReport.h"
 #include "AuxiliaryProcessProxy.h"
+#include "BackgroundFetchState.h"
 #include "DataReference.h"
 #include "DataTaskIdentifier.h"
 #include "IdentifierTypes.h"

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "MessageReceiver.h"
+#include "NavigationActionData.h"
 #include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -91,9 +91,11 @@
 #include <stdio.h>
 #include <wtf/Algorithms.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakListHashSet.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -45,6 +45,7 @@
 #include <WebCore/CrossOriginMode.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/MediaProducer.h>
+#include <WebCore/MessageWithMessagePorts.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2483,10 +2483,12 @@ void WebsiteDataStore::updateServiceWorkerInspectability()
 
     bool wasInspectable = m_inspectionForServiceWorkersAllowed;
     m_inspectionForServiceWorkersAllowed = [&] {
+#if ENABLE(REMOTE_INSPECTOR)
         for (auto& page : m_pages) {
             if (page.inspectable())
                 return true;
         }
+#endif // ENABLE(REMOTE_INSPECTOR)
         return false;
     }();
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FrameInfoData.h"
 #include "NetworkSessionCreationParameters.h"
 #include "WebDeviceOrientationAndMotionAccessController.h"
 #include "WebFramePolicyListenerProxy.h"

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -877,6 +877,7 @@ WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPrefere
     return WebKit::toAPI(&API::CaptionUserPreferencesTestingModeToken::create(captionPreferences).leakRef());
 #else
     UNUSED_PARAM(page);
+    return { };
 #endif
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -357,6 +357,7 @@ private:
 };
 #endif
 
+#if ENABLE(CONTEXT_MENUS)
 class PageContextMenuClient final : public API::InjectedBundle::PageContextMenuClient {
 public:
     explicit PageContextMenuClient(WebKitWebPage* webPage)
@@ -388,6 +389,7 @@ private:
 
     WebKitWebPage* m_webPage;
 };
+#endif // ENABLE(CONTEXT_MENUS)
 
 class PageFormClient final : public API::InjectedBundle::FormClient {
 public:
@@ -601,7 +603,11 @@ static void webkit_web_page_class_init(WebKitWebPageClass* klass)
         g_signal_accumulator_true_handled, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_BOOLEAN, 2,
+#if ENABLE(CONTEXT_MENUS)
         WEBKIT_TYPE_CONTEXT_MENU,
+#else
+        G_TYPE_OBJECT,
+#endif // ENABLE(CONTEXT_MENUS)
         WEBKIT_TYPE_WEB_HIT_TEST_RESULT);
 
 #if !ENABLE(2022_GLIB_API)
@@ -797,7 +803,9 @@ WebKitWebPage* webkitWebPageCreate(WebPage* webPage)
 
     webPage->setInjectedBundleResourceLoadClient(makeUnique<PageResourceLoadClient>(page));
     webPage->setInjectedBundlePageLoaderClient(makeUnique<PageLoaderClient>(page));
+#if ENABLE(CONTEXT_MENUS)
     webPage->setInjectedBundleContextMenuClient(makeUnique<PageContextMenuClient>(page));
+#endif // ENABLE(CONTEXT_MENUS)
     webPage->setInjectedBundleFormClient(makeUnique<PageFormClient>(page));
 #if !ENABLE(2022_GLIB_API)
     webPage->setInjectedBundleUIClient(makeUnique<PageUIClient>(page));

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -191,7 +191,9 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
             page->settings().setStorageBlockingPolicy(static_cast<StorageBlockingPolicy>(m_preferencesStore->getUInt32ValueForKey(WebPreferencesKey::storageBlockingPolicyKey())));
         }
         page->setupForRemoteWorker(contextData.scriptURL, contextData.registration.key.topOrigin(), contextData.referrerPolicy);
+#if ENABLE(REMOTE_INSPECTOR)
         page->setInspectable(inspectable == ServiceWorkerIsInspectable::Yes);
+#endif // ENABLE(REMOTE_INSPECTOR)
 
         std::unique_ptr<WebCore::NotificationClient> notificationClient;
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -295,18 +295,18 @@ bool DrawingAreaCoordinatedGraphics::supportsAsyncScrolling() const
 
 void DrawingAreaCoordinatedGraphics::registerScrollingTree()
 {
-#if ENABLE(SCROLLING_THREAD)
+#if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
     if (m_supportsAsyncScrolling)
         WebProcess::singleton().eventDispatcher().addScrollingTreeForPage(m_webPage);
-#endif
+#endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
 }
 
 void DrawingAreaCoordinatedGraphics::unregisterScrollingTree()
 {
-#if ENABLE(SCROLLING_THREAD)
+#if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
     if (m_supportsAsyncScrolling)
         WebProcess::singleton().eventDispatcher().removeScrollingTreeForPage(m_webPage);
-#endif
+#endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
 }
 
 GraphicsLayerFactory* DrawingAreaCoordinatedGraphics::graphicsLayerFactory()

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -76,7 +76,7 @@ public:
 
     WorkQueue& queue() { return m_queue.get(); }
 
-#if ENABLE(SCROLLING_THREAD)
+#if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
     void addScrollingTreeForPage(WebPage&);
     void removeScrollingTreeForPage(WebPage&);
 #endif


### PR DESCRIPTION
#### cfc4a23cc201b67e7023ffd34cdb1245ac4a60b3
<pre>
Fixes for build --minimal
<a href="https://bugs.webkit.org/show_bug.cgi?id=263905">https://bugs.webkit.org/show_bug.cgi?id=263905</a>

Reviewed by Michael Catanzaro.

Header file additions:
These additions all seem to be cases where normally the header is
included
by another header, but when compiling with a certain feature turned off,
the header no longer gets pulled in, making some function or class used
in
the file undeclared.

This especially sometimes shows up as linker errors, when a
&quot;FooInlines.h&quot;
header doesn&apos;t get pulled in, and an inline function is declared in the
regular &quot;Foo.h&quot; header but its body is never included.

These all show up as compiler or linker errors when building WebKit with
--minimal.

In some cases, remove a forward declaration since we do actually need to
include its header.

Preprocessor guards:

These changes fix builds with various options set by --minimal, such as
--no-video, --no-layer-based-svg-engine, --no-context-menus, etc.

In some cases, add UNUSED_PARAM to fix a warning that only occurs with
--no-video. In other cases, these changes fix compile errors.

Note that ENABLE_MODERN_MEDIA_CONTROLS is also switched off if
ENABLE_VIDEO is off.

* Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h:
(WebCore::GPUExternalTextureDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h:
* Source/WebCore/dom/CDATASection.cpp:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::urlForBindings const):
* Source/WebCore/dom/DocumentFontLoader.cpp:
* Source/WebCore/dom/DocumentMarkerController.cpp:
* Source/WebCore/dom/IdTargetObserverRegistry.h:
* Source/WebCore/dom/NamedNodeMap.h:
* Source/WebCore/dom/PendingScript.h:
* Source/WebCore/dom/ScriptedAnimationController.h:
* Source/WebCore/editing/AlternativeTextController.cpp:
* Source/WebCore/editing/DictationCommand.cpp:
* Source/WebCore/editing/SpellingCorrectionCommand.h:
* Source/WebCore/editing/SplitTextNodeCommand.cpp:
* Source/WebCore/editing/VisibleSelection.cpp:
* Source/WebCore/editing/VisibleUnits.cpp:
* Source/WebCore/history/CachedPage.cpp:
* Source/WebCore/html/CheckboxInputType.cpp:
* Source/WebCore/html/HiddenInputType.cpp:
* Source/WebCore/html/SubmitInputType.cpp:
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
* Source/WebCore/html/parser/HTMLSrcsetParser.h:
* Source/WebCore/html/shadow/SwitchThumbElement.cpp:
* Source/WebCore/html/shadow/SwitchTrackElement.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::Run::isContentfulOrHasDecoration):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout):
* Source/WebCore/loader/archive/Archive.cpp:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::updateRequestAfterRedirection):
* Source/WebCore/page/DOMWindow.cpp:
* Source/WebCore/page/LocalDOMWindow.cpp:
* Source/WebCore/page/LocalFrame.cpp:
* Source/WebCore/page/Navigation.cpp:
* Source/WebCore/page/NavigationDestination.cpp:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
* Source/WebCore/platform/graphics/FontMetrics.h:
* Source/WebCore/rendering/LayoutRepainter.cpp:
* Source/WebCore/rendering/MarkedText.cpp:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintSVGResourceLayer):
(WebCore::RenderLayer::setupClipPath):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::isVideoWithDefaultObjectSize):
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/TransformOperationData.cpp:
(WebCore::TransformOperationData::TransformOperationData):
* Source/WebCore/rendering/style/WillChangeData.cpp:
(WebCore::WillChangeData::createsContainingBlockForOutOfFlowPositioned const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::paintSVGClippingMask):
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/svg/SVGClipPathElement.cpp:
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::setShouldDeactivateAudioSession):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isMonitoringWirelessRoutes const):
(WebCore::Internals::setIsPlayingToAutomotiveHeadUnit):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::setInspectable):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Shared/API/APICaptionUserPreferencesTestingModeToken.h:
* Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp:
* Source/WebKit/Shared/API/glib/WebKitContextMenuActions.cpp:
* Source/WebKit/Shared/API/glib/WebKitContextMenuActionsPrivate.h:
* Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp:
(webkit_context_menu_item_new):
(webkit_context_menu_item_new_from_gaction):
(webkit_context_menu_item_new_from_stock_action):
(webkit_context_menu_item_new_from_stock_action_with_label):
(webkit_context_menu_item_new_with_submenu):
(webkit_context_menu_item_new_separator):
(webkit_context_menu_item_get_action):
(webkit_context_menu_item_get_gaction):
(webkit_context_menu_item_get_stock_action):
(webkit_context_menu_item_is_separator):
(webkit_context_menu_item_set_submenu):
(webkit_context_menu_item_get_submenu):
* Source/WebKit/Shared/API/glib/WebKitContextMenuItemPrivate.h:
* Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h:
* Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp:
* Source/WebKit/Shared/glib/WebContextMenuItemGlib.h:
* Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.h:
* Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp:
(webkit_permission_request_interface_init):
(webkitPointerLockPermissionRequestDispose):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
(webkit_web_view_save):
(webkit_web_view_save_to_file):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooser.h:
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp:
(webkit_color_chooser_request_get_element_rectangle):
(webkit_color_chooser_request_cancel):
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequestPrivate.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseHandleMouseEvent):
(webkit_web_view_base_class_init):
(webkitWebViewBaseSynthesizeMouseEvent):
(webkitWebViewBaseSynthesizeKeyEvent):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::updateServiceWorkerInspectability):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageCreateCaptionUserPreferencesTestingModeToken):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
(webkit_web_page_class_init):
(webkitWebPageCreate):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::registerScrollingTree):
(WebKit::DrawingAreaCoordinatedGraphics::unregisterScrollingTree):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/270103@main">https://commits.webkit.org/270103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b1bc367bad52b542224c2613365f339bdd77b46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/545 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27271 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28330 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26123 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/153 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3138 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5886 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->