### PR TITLE
[WebRTC] Add targets for vp8 and vp9 replay fuzzers

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/vp8_dec_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/vp8_dec_fuzzer.xcconfig
@@ -1,3 +1,26 @@
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #include "Base-libvpx.xcconfig"
 
 PRODUCT_NAME = vp8_dec_fuzzer;

--- a/Source/ThirdParty/libwebrtc/Configurations/vp8_replay_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/vp8_replay_fuzzer.xcconfig
@@ -21,8 +21,10 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "Base-libvpx.xcconfig"
+#include "Base-libwebrtc.xcconfig"
 
-PRODUCT_NAME = vp9_dec_fuzzer;
+PRODUCT_NAME = vp8_replay_fuzzer;
 
-OTHER_CFLAGS = $(inherited) -DDECODER=vp9;
+GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+
+HEADER_SEARCH_PATHS = $(inherited) Source/third_party/json/include;

--- a/Source/ThirdParty/libwebrtc/Configurations/vp9_replay_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/vp9_replay_fuzzer.xcconfig
@@ -21,8 +21,10 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "Base-libvpx.xcconfig"
+#include "Base-libwebrtc.xcconfig"
 
-PRODUCT_NAME = vp9_dec_fuzzer;
+PRODUCT_NAME = vp9_replay_fuzzer;
 
-OTHER_CFLAGS = $(inherited) -DDECODER=vp9;
+GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+
+HEADER_SEARCH_PATHS = $(inherited) Source/third_party/json/include;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/json/include/json/json.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/json/include/json/json.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Adapter for Google's jsoncpp project using json.hpp from nlohmann-json.
+// See: <rdar://117694188> Add jsoncpp project to libwebrtc
+
+#if WEBRTC_WEBKIT_BUILD
+
+#define JSON_NOEXCEPTION
+#include <nlohmann/v3.8/json.hpp>
+
+namespace Json {
+
+using String = nlohmann::json;
+using Value = nlohmann::json;
+
+class CharReader {
+public:
+    CharReader() = default;
+    ~CharReader() = default;
+
+    bool parse(char const* begin, char const* end, Value* root, String* /*error*/) {
+        if (!root)
+            return false;
+        *root = nlohmann::json::parse(begin, end);
+        return true;
+    }
+};
+
+class CharReaderBuilder {
+public:
+    CharReaderBuilder() = default;
+    ~CharReaderBuilder() = default;
+
+    CharReader* newCharReader() { return new CharReader(); }
+};
+
+} // namespace Json
+
+#endif // WEBRTC_WEBKIT_BUILD

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/call_config_utils.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/call_config_utils.cc
@@ -25,17 +25,50 @@ VideoReceiveStreamInterface::Config ParseVideoReceiveStreamJsonConfig(
   auto receive_config = VideoReceiveStreamInterface::Config(transport);
   for (const auto& decoder_json : json["decoders"]) {
     VideoReceiveStreamInterface::Decoder decoder;
+#if WEBRTC_WEBKIT_BUILD
+    decoder.video_format =
+        SdpVideoFormat(decoder_json["payload_name"].get<std::string>());
+    decoder.payload_type = decoder_json["payload_type"].get<int32_t>();
+#else
     decoder.video_format =
         SdpVideoFormat(decoder_json["payload_name"].asString());
     decoder.payload_type = decoder_json["payload_type"].asInt64();
+#endif
     for (const auto& params_json : decoder_json["codec_params"]) {
+#if WEBRTC_WEBKIT_BUILD
+      std::vector<std::string> members(params_json.size());
+      for (const auto& [key, value] : params_json.items()) {
+        members.emplace_back(key);
+      }
+      RTC_CHECK_EQ(members.size(), 1);
+      decoder.video_format.parameters[members[0]] =
+          params_json[members[0]].get<std::string>();
+#else
       std::vector<std::string> members = params_json.getMemberNames();
       RTC_CHECK_EQ(members.size(), 1);
       decoder.video_format.parameters[members[0]] =
           params_json[members[0]].asString();
+#endif
     }
     receive_config.decoders.push_back(decoder);
   }
+#if WEBRTC_WEBKIT_BUILD
+  receive_config.render_delay_ms = json["render_delay_ms"].get<int32_t>();
+  receive_config.rtp.remote_ssrc = json["rtp"]["remote_ssrc"].get<uint32_t>();
+  receive_config.rtp.local_ssrc = json["rtp"]["local_ssrc"].get<uint32_t>();
+  receive_config.rtp.rtcp_mode =
+      json["rtp"]["rtcp_mode"].get<std::string>() == "RtcpMode::kCompound"
+          ? RtcpMode::kCompound
+          : RtcpMode::kReducedSize;
+  receive_config.rtp.lntf.enabled = json["rtp"]["lntf"]["enabled"].get<bool>();
+  receive_config.rtp.nack.rtp_history_ms =
+      json["rtp"]["nack"]["rtp_history_ms"].get<int32_t>();
+  receive_config.rtp.ulpfec_payload_type =
+      json["rtp"]["ulpfec_payload_type"].get<int32_t>();
+  receive_config.rtp.red_payload_type =
+      json["rtp"]["red_payload_type"].get<int32_t>();
+  receive_config.rtp.rtx_ssrc = json["rtp"]["rtx_ssrc"].get<uint32_t>();
+#else
   receive_config.render_delay_ms = json["render_delay_ms"].asInt64();
   receive_config.rtp.remote_ssrc = json["rtp"]["remote_ssrc"].asInt64();
   receive_config.rtp.local_ssrc = json["rtp"]["local_ssrc"].asInt64();
@@ -51,13 +84,25 @@ VideoReceiveStreamInterface::Config ParseVideoReceiveStreamJsonConfig(
   receive_config.rtp.red_payload_type =
       json["rtp"]["red_payload_type"].asInt64();
   receive_config.rtp.rtx_ssrc = json["rtp"]["rtx_ssrc"].asInt64();
+#endif
 
   for (const auto& pl_json : json["rtp"]["rtx_payload_types"]) {
+#if WEBRTC_WEBKIT_BUILD
+    std::vector<std::string> members(pl_json.size());
+    for (const auto& [key, value] : pl_json.items()) {
+        members.emplace_back(key);
+    }
+    RTC_CHECK_EQ(members.size(), 1);
+    Json::Value rtx_payload_type = pl_json[members[0]];
+    receive_config.rtp.rtx_associated_payload_types[std::stoi(members[0])] =
+        rtx_payload_type.get<int32_t>();
+#else
     std::vector<std::string> members = pl_json.getMemberNames();
     RTC_CHECK_EQ(members.size(), 1);
     Json::Value rtx_payload_type = pl_json[members[0]];
     receive_config.rtp.rtx_associated_payload_types[std::stoi(members[0])] =
         rtx_payload_type.asInt64();
+#endif
   }
   return receive_config;
 }
@@ -66,18 +111,34 @@ Json::Value GenerateVideoReceiveStreamJsonConfig(
     const VideoReceiveStreamInterface::Config& config) {
   Json::Value root_json;
 
+#if WEBRTC_WEBKIT_BUILD
+  root_json["decoders"] = Json::Value("[]");
+#else
   root_json["decoders"] = Json::Value(Json::arrayValue);
+#endif
   for (const auto& decoder : config.decoders) {
     Json::Value decoder_json;
     decoder_json["payload_type"] = decoder.payload_type;
     decoder_json["payload_name"] = decoder.video_format.name;
+#if WEBRTC_WEBKIT_BUILD
+    decoder_json["codec_params"] = Json::Value("[]");
+#else
     decoder_json["codec_params"] = Json::Value(Json::arrayValue);
+#endif
     for (const auto& codec_param_entry : decoder.video_format.parameters) {
       Json::Value codec_param_json;
       codec_param_json[codec_param_entry.first] = codec_param_entry.second;
+#if WEBRTC_WEBKIT_BUILD
+      decoder_json["codec_params"].push_back(codec_param_json);
+#else
       decoder_json["codec_params"].append(codec_param_json);
+#endif
     }
+#if WEBRTC_WEBKIT_BUILD
+    root_json["decoders"].push_back(decoder_json);
+#else
     root_json["decoders"].append(decoder_json);
+#endif
   }
 
   Json::Value rtp_json;
@@ -91,12 +152,20 @@ Json::Value GenerateVideoReceiveStreamJsonConfig(
   rtp_json["ulpfec_payload_type"] = config.rtp.ulpfec_payload_type;
   rtp_json["red_payload_type"] = config.rtp.red_payload_type;
   rtp_json["rtx_ssrc"] = config.rtp.rtx_ssrc;
+#if WEBRTC_WEBKIT_BUILD
+  rtp_json["rtx_payload_types"] = Json::Value("[]");
+#else
   rtp_json["rtx_payload_types"] = Json::Value(Json::arrayValue);
+#endif
 
   for (auto& kv : config.rtp.rtx_associated_payload_types) {
     Json::Value val;
     val[std::to_string(kv.first)] = kv.second;
+#if WEBRTC_WEBKIT_BUILD
+    rtp_json["rtx_payload_types"].push_back(val);
+#else
     rtp_json["rtx_payload_types"].append(val);
+#endif
   }
 
   root_json["rtp"] = rtp_json;

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Add-targets-for-vp8-and-vp9-replay-fuzzers.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Add-targets-for-vp8-and-vp9-replay-fuzzers.patch
@@ -1,0 +1,248 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/test/call_config_utils.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/test/call_config_utils.cc
+index d93c902bbe26..21104792041e 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/call_config_utils.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/call_config_utils.cc
+@@ -25,17 +25,50 @@ VideoReceiveStreamInterface::Config ParseVideoReceiveStreamJsonConfig(
+   auto receive_config = VideoReceiveStreamInterface::Config(transport);
+   for (const auto& decoder_json : json["decoders"]) {
+     VideoReceiveStreamInterface::Decoder decoder;
++#if WEBRTC_WEBKIT_BUILD
++    decoder.video_format =
++        SdpVideoFormat(decoder_json["payload_name"].get<std::string>());
++    decoder.payload_type = decoder_json["payload_type"].get<int32_t>();
++#else
+     decoder.video_format =
+         SdpVideoFormat(decoder_json["payload_name"].asString());
+     decoder.payload_type = decoder_json["payload_type"].asInt64();
++#endif
+     for (const auto& params_json : decoder_json["codec_params"]) {
++#if WEBRTC_WEBKIT_BUILD
++      std::vector<std::string> members(params_json.size());
++      for (const auto& [key, value] : params_json.items()) {
++        members.emplace_back(key);
++      }
++      RTC_CHECK_EQ(members.size(), 1);
++      decoder.video_format.parameters[members[0]] =
++          params_json[members[0]].get<std::string>();
++#else
+       std::vector<std::string> members = params_json.getMemberNames();
+       RTC_CHECK_EQ(members.size(), 1);
+       decoder.video_format.parameters[members[0]] =
+           params_json[members[0]].asString();
++#endif
+     }
+     receive_config.decoders.push_back(decoder);
+   }
++#if WEBRTC_WEBKIT_BUILD
++  receive_config.render_delay_ms = json["render_delay_ms"].get<int32_t>();
++  receive_config.rtp.remote_ssrc = json["rtp"]["remote_ssrc"].get<uint32_t>();
++  receive_config.rtp.local_ssrc = json["rtp"]["local_ssrc"].get<uint32_t>();
++  receive_config.rtp.rtcp_mode =
++      json["rtp"]["rtcp_mode"].get<std::string>() == "RtcpMode::kCompound"
++          ? RtcpMode::kCompound
++          : RtcpMode::kReducedSize;
++  receive_config.rtp.lntf.enabled = json["rtp"]["lntf"]["enabled"].get<bool>();
++  receive_config.rtp.nack.rtp_history_ms =
++      json["rtp"]["nack"]["rtp_history_ms"].get<int32_t>();
++  receive_config.rtp.ulpfec_payload_type =
++      json["rtp"]["ulpfec_payload_type"].get<int32_t>();
++  receive_config.rtp.red_payload_type =
++      json["rtp"]["red_payload_type"].get<int32_t>();
++  receive_config.rtp.rtx_ssrc = json["rtp"]["rtx_ssrc"].get<uint32_t>();
++#else
+   receive_config.render_delay_ms = json["render_delay_ms"].asInt64();
+   receive_config.rtp.remote_ssrc = json["rtp"]["remote_ssrc"].asInt64();
+   receive_config.rtp.local_ssrc = json["rtp"]["local_ssrc"].asInt64();
+@@ -51,13 +84,25 @@ VideoReceiveStreamInterface::Config ParseVideoReceiveStreamJsonConfig(
+   receive_config.rtp.red_payload_type =
+       json["rtp"]["red_payload_type"].asInt64();
+   receive_config.rtp.rtx_ssrc = json["rtp"]["rtx_ssrc"].asInt64();
++#endif
+ 
+   for (const auto& pl_json : json["rtp"]["rtx_payload_types"]) {
++#if WEBRTC_WEBKIT_BUILD
++    std::vector<std::string> members(pl_json.size());
++    for (const auto& [key, value] : pl_json.items()) {
++        members.emplace_back(key);
++    }
++    RTC_CHECK_EQ(members.size(), 1);
++    Json::Value rtx_payload_type = pl_json[members[0]];
++    receive_config.rtp.rtx_associated_payload_types[std::stoi(members[0])] =
++        rtx_payload_type.get<int32_t>();
++#else
+     std::vector<std::string> members = pl_json.getMemberNames();
+     RTC_CHECK_EQ(members.size(), 1);
+     Json::Value rtx_payload_type = pl_json[members[0]];
+     receive_config.rtp.rtx_associated_payload_types[std::stoi(members[0])] =
+         rtx_payload_type.asInt64();
++#endif
+   }
+   return receive_config;
+ }
+@@ -66,18 +111,34 @@ Json::Value GenerateVideoReceiveStreamJsonConfig(
+     const VideoReceiveStreamInterface::Config& config) {
+   Json::Value root_json;
+ 
++#if WEBRTC_WEBKIT_BUILD
++  root_json["decoders"] = Json::Value("[]");
++#else
+   root_json["decoders"] = Json::Value(Json::arrayValue);
++#endif
+   for (const auto& decoder : config.decoders) {
+     Json::Value decoder_json;
+     decoder_json["payload_type"] = decoder.payload_type;
+     decoder_json["payload_name"] = decoder.video_format.name;
++#if WEBRTC_WEBKIT_BUILD
++    decoder_json["codec_params"] = Json::Value("[]");
++#else
+     decoder_json["codec_params"] = Json::Value(Json::arrayValue);
++#endif
+     for (const auto& codec_param_entry : decoder.video_format.parameters) {
+       Json::Value codec_param_json;
+       codec_param_json[codec_param_entry.first] = codec_param_entry.second;
++#if WEBRTC_WEBKIT_BUILD
++      decoder_json["codec_params"].push_back(codec_param_json);
++#else
+       decoder_json["codec_params"].append(codec_param_json);
++#endif
+     }
++#if WEBRTC_WEBKIT_BUILD
++    root_json["decoders"].push_back(decoder_json);
++#else
+     root_json["decoders"].append(decoder_json);
++#endif
+   }
+ 
+   Json::Value rtp_json;
+@@ -91,12 +152,20 @@ Json::Value GenerateVideoReceiveStreamJsonConfig(
+   rtp_json["ulpfec_payload_type"] = config.rtp.ulpfec_payload_type;
+   rtp_json["red_payload_type"] = config.rtp.red_payload_type;
+   rtp_json["rtx_ssrc"] = config.rtp.rtx_ssrc;
++#if WEBRTC_WEBKIT_BUILD
++  rtp_json["rtx_payload_types"] = Json::Value("[]");
++#else
+   rtp_json["rtx_payload_types"] = Json::Value(Json::arrayValue);
++#endif
+ 
+   for (auto& kv : config.rtp.rtx_associated_payload_types) {
+     Json::Value val;
+     val[std::to_string(kv.first)] = kv.second;
++#if WEBRTC_WEBKIT_BUILD
++    rtp_json["rtx_payload_types"].push_back(val);
++#else
+     rtp_json["rtx_payload_types"].append(val);
++#endif
+   }
+ 
+   root_json["rtp"] = rtp_json;
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/test/mac/video_renderer_mac.mm b/Source/ThirdParty/libwebrtc/Source/webrtc/test/mac/video_renderer_mac.mm
+index 71033753830e..e79ba72f795c 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/mac/video_renderer_mac.mm
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/mac/video_renderer_mac.mm
+@@ -17,7 +17,11 @@
+ @interface CocoaWindow : NSObject {
+  @private
+   NSWindow *window_;
++#if WEBRTC_WEBKIT_BUILD
++  NSOpenGLView *view_;
++#else
+   NSOpenGLContext *context_;
++#endif
+   NSString *title_;
+   int width_;
+   int height_;
+@@ -43,7 +47,21 @@ - (id)initWithTitle:(NSString *)title width:(int)width height:(int)height {
+   return self;
+ }
+ 
++#if WEBRTC_WEBKIT_BUILD
++- (void)dealloc {
++  @autoreleasepool {
++    [NSOpenGLContext clearCurrentContext];
++    [view_ clearGLContext];
++    [view_ removeFromSuperview];
++    [window_ orderOut:NSApp];
++  }
++}
++#endif
++
+ - (void)createWindow:(NSObject *)ignored {
++#if WEBRTC_WEBKIT_BUILD
++  @autoreleasepool {
++#endif
+   NSInteger xOrigin = nextXOrigin_;
+   NSRect screenFrame = [[NSScreen mainScreen] frame];
+   if (nextXOrigin_ + width_ < screenFrame.size.width) {
+@@ -66,16 +84,31 @@ - (void)createWindow:(NSObject *)ignored {
+                                             defer:NO];
+ 
+   NSRect viewFrame = NSMakeRect(0, 0, width_, height_);
++#if WEBRTC_WEBKIT_BUILD
++  view_ = [[NSOpenGLView alloc] initWithFrame:viewFrame pixelFormat:nil];
++
++  [[window_ contentView] addSubview:view_];
++#else
+   NSOpenGLView *view = [[NSOpenGLView alloc] initWithFrame:viewFrame pixelFormat:nil];
+   context_ = [view openGLContext];
+ 
+   [[window_ contentView] addSubview:view];
++#endif
+   [window_ setTitle:title_];
+   [window_ makeKeyAndOrderFront:NSApp];
++#if WEBRTC_WEBKIT_BUILD
++  } // @autoreleasepool
++#endif
+ }
+ 
+ - (void)makeCurrentContext {
++#if WEBRTC_WEBKIT_BUILD
++  @autoreleasepool {
++    [[view_ openGLContext] makeCurrentContext];
++  }
++#else
+   [context_ makeCurrentContext];
++#endif
+ }
+ 
+ @end
+@@ -98,10 +131,19 @@ MacRenderer::MacRenderer()
+     : window_(NULL) {}
+ 
+ MacRenderer::~MacRenderer() {
++#if WEBRTC_WEBKIT_BUILD
++  @autoreleasepool {
++#endif
+   GlRenderer::Destroy();
++#if WEBRTC_WEBKIT_BUILD
++  } // @autoreleasepool
++#endif
+ }
+ 
+ bool MacRenderer::Init(const char* window_title, int width, int height) {
++#if WEBRTC_WEBKIT_BUILD
++  @autoreleasepool {
++#endif
+   window_ = [[CocoaWindow alloc]
+       initWithTitle:[NSString stringWithUTF8String:window_title]
+                                              width:width
+@@ -116,11 +158,20 @@ bool MacRenderer::Init(const char* window_title, int width, int height) {
+   GlRenderer::Init();
+   GlRenderer::ResizeViewport(width, height);
+   return true;
++#if WEBRTC_WEBKIT_BUILD
++  } // @autoreleasepool
++#endif
+ }
+ 
+ void MacRenderer::OnFrame(const VideoFrame& frame) {
++#if WEBRTC_WEBKIT_BUILD
++  @autoreleasepool {
++#endif
+   [window_ makeCurrentContext];
+   GlRenderer::OnFrame(frame);
++#if WEBRTC_WEBKIT_BUILD
++  } // @autoreleasepool
++#endif
+ }
+ 
+ }  // test

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -18,7 +18,9 @@
 				449467BF2AE05CA800A9FED0 /* PBXTargetDependency */,
 				449CF1612ADEDE9B00F22CAF /* PBXTargetDependency */,
 				449CF1632ADEDE9D00F22CAF /* PBXTargetDependency */,
+				446359E02AEA14F000551EEE /* PBXTargetDependency */,
 				449CF1652ADEDEA000F22CAF /* PBXTargetDependency */,
+				444A6F0C2AEAE064005FE121 /* PBXTargetDependency */,
 			);
 			name = "Fuzzers (libwebrtc)";
 			productName = Fuzzers;
@@ -3137,6 +3139,30 @@
 		441380D02AE06BC200C928CB /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
 		441380D12AE06BC200C928CB /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
 		442459322ACB915400E105A1 /* quantize_ssse3.h in Headers */ = {isa = PBXBuildFile; fileRef = 442459312ACB915300E105A1 /* quantize_ssse3.h */; };
+		444A6EF42AEADFC9005FE121 /* null_transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44FD16752AEA3562003636CB /* null_transport.cc */; };
+		444A6EF52AEADFC9005FE121 /* call_config_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359CD2AEA12BB00551EEE /* call_config_utils.cc */; };
+		444A6EF62AEADFC9005FE121 /* encoder_settings.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359CF2AEA12E400551EEE /* encoder_settings.cc */; };
+		444A6EF72AEADFC9005FE121 /* fake_decoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359D32AEA12FE00551EEE /* fake_decoder.cc */; };
+		444A6EF82AEADFC9005FE121 /* video_renderer_mac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44FD167C2AEA361B003636CB /* video_renderer_mac.mm */; };
+		444A6EF92AEADFC9005FE121 /* video_renderer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44FD167A2AEA35E3003636CB /* video_renderer.cc */; };
+		444A6EFA2AEADFC9005FE121 /* rtp_file_reader.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359D52AEA132B00551EEE /* rtp_file_reader.cc */; };
+		444A6EFB2AEADFC9005FE121 /* rtp_replayer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359C92AEA11F400551EEE /* rtp_replayer.cc */; };
+		444A6EFC2AEADFC9005FE121 /* run_loop.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359D82AEA135100551EEE /* run_loop.cc */; };
+		444A6EFE2AEADFC9005FE121 /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		444A6EFF2AEADFC9005FE121 /* gl_renderer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44FD16822AEA376F003636CB /* gl_renderer.cc */; };
+		444A6F012AEADFC9005FE121 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44FD167F2AEA36BB003636CB /* AppKit.framework */; platformFilters = (macos, ); };
+		444A6F022AEADFC9005FE121 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44FD16852AEA37E6003636CB /* OpenGL.framework */; platformFilters = (macos, ); };
+		444A6F032AEADFC9005FE121 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		444A6F092AEADFD8005FE121 /* vp9_replay_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 444A6EEF2AEADFB6005FE121 /* vp9_replay_fuzzer.cc */; };
+		446359C32AEA10C900551EEE /* vp8_replay_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359C22AEA10C900551EEE /* vp8_replay_fuzzer.cc */; };
+		446359C62AEA110100551EEE /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		446359C72AEA111E00551EEE /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		446359CB2AEA11F500551EEE /* rtp_replayer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359C92AEA11F400551EEE /* rtp_replayer.cc */; };
+		446359CE2AEA12BB00551EEE /* call_config_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359CD2AEA12BB00551EEE /* call_config_utils.cc */; };
+		446359D12AEA12E400551EEE /* encoder_settings.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359CF2AEA12E400551EEE /* encoder_settings.cc */; };
+		446359D42AEA12FF00551EEE /* fake_decoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359D32AEA12FE00551EEE /* fake_decoder.cc */; };
+		446359D72AEA132C00551EEE /* rtp_file_reader.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359D52AEA132B00551EEE /* rtp_file_reader.cc */; };
+		446359DA2AEA135200551EEE /* run_loop.cc in Sources */ = {isa = PBXBuildFile; fileRef = 446359D82AEA135100551EEE /* run_loop.cc */; };
 		446CFE442AC694AB00F870D9 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
 		448D48422AB0BEBA0065014C /* vpx_dec_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */; };
 		449467B52AE05C9600A9FED0 /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
@@ -3166,6 +3192,13 @@
 		44E751B52AC73F8800828AC4 /* field_trial.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E751B32AC73F8800828AC4 /* field_trial.h */; };
 		44E751B82AC7421D00828AC4 /* fake_video_renderer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 416B09D52A3C7D450017367B /* fake_video_renderer.cc */; };
 		44E751C02AC7424000828AC4 /* fake_video_renderer.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF309F727C599E9006A526F /* fake_video_renderer.h */; };
+		44FD16742AEA1F37003636CB /* json.h in Headers */ = {isa = PBXBuildFile; fileRef = 44FD16732AEA1F36003636CB /* json.h */; };
+		44FD16772AEA3562003636CB /* null_transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44FD16752AEA3562003636CB /* null_transport.cc */; };
+		44FD167B2AEA35E4003636CB /* video_renderer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44FD167A2AEA35E3003636CB /* video_renderer.cc */; };
+		44FD167E2AEA361B003636CB /* video_renderer_mac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44FD167C2AEA361B003636CB /* video_renderer_mac.mm */; };
+		44FD16802AEA36BB003636CB /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44FD167F2AEA36BB003636CB /* AppKit.framework */; platformFilters = (macos, ); };
+		44FD16842AEA3770003636CB /* gl_renderer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44FD16822AEA376F003636CB /* gl_renderer.cc */; };
+		44FD16862AEA37E6003636CB /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44FD16852AEA37E6003636CB /* OpenGL.framework */; platformFilters = (macos, ); };
 		5C0073111E5513E70042215A /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C00730C1E5513E70042215A /* CoreMedia.framework */; };
 		5C0073121E5513E70042215A /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C00730D1E5513E70042215A /* CoreVideo.framework */; };
 		5C0073141E5514020042215A /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C0073131E5514020042215A /* VideoToolbox.framework */; };
@@ -5212,6 +5245,34 @@
 			proxyType = 1;
 			remoteGlobalIDString = 41F77D15215BE45E00E72967;
 			remoteInfo = yasm;
+		};
+		444A6EF22AEADFC9005FE121 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		444A6F0B2AEAE064005FE121 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 444A6EF02AEADFC9005FE121;
+			remoteInfo = vp9_replay_fuzzer;
+		};
+		446359C42AEA10F400551EEE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		446359DF2AEA14F000551EEE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 446359B62AEA108C00551EEE;
+			remoteInfo = vp8_replay_fuzzer;
 		};
 		448D483C2AB0BDB80065014C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -9037,6 +9098,23 @@
 		442459382ACB928500E105A1 /* ghash-ssse3-x86_64.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "ghash-ssse3-x86_64.pl"; sourceTree = "<group>"; };
 		442459392ACB933B00E105A1 /* celt_lpc_sse4_1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = celt_lpc_sse4_1.c; sourceTree = "<group>"; };
 		4424593A2ACB93B000E105A1 /* jnt_sad_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = jnt_sad_sse2.c; sourceTree = "<group>"; };
+		444A6EEF2AEADFB6005FE121 /* vp9_replay_fuzzer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = vp9_replay_fuzzer.cc; sourceTree = "<group>"; };
+		444A6F082AEADFC9005FE121 /* vp9_replay_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp9_replay_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		444A6F0A2AEAE01D005FE121 /* vp9_replay_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = vp9_replay_fuzzer.xcconfig; sourceTree = "<group>"; };
+		446359C12AEA108C00551EEE /* vp8_replay_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp8_replay_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		446359C22AEA10C900551EEE /* vp8_replay_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vp8_replay_fuzzer.cc; sourceTree = "<group>"; };
+		446359C92AEA11F400551EEE /* rtp_replayer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_replayer.cc; sourceTree = "<group>"; };
+		446359CA2AEA11F400551EEE /* rtp_replayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_replayer.h; sourceTree = "<group>"; };
+		446359CC2AEA12BB00551EEE /* call_config_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = call_config_utils.h; sourceTree = "<group>"; };
+		446359CD2AEA12BB00551EEE /* call_config_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = call_config_utils.cc; sourceTree = "<group>"; };
+		446359CF2AEA12E400551EEE /* encoder_settings.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = encoder_settings.cc; sourceTree = "<group>"; };
+		446359D02AEA12E400551EEE /* encoder_settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encoder_settings.h; sourceTree = "<group>"; };
+		446359D22AEA12FE00551EEE /* fake_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_decoder.h; sourceTree = "<group>"; };
+		446359D32AEA12FE00551EEE /* fake_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_decoder.cc; sourceTree = "<group>"; };
+		446359D52AEA132B00551EEE /* rtp_file_reader.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_file_reader.cc; sourceTree = "<group>"; };
+		446359D62AEA132B00551EEE /* rtp_file_reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_file_reader.h; sourceTree = "<group>"; };
+		446359D82AEA135100551EEE /* run_loop.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = run_loop.cc; sourceTree = "<group>"; };
+		446359D92AEA135200551EEE /* run_loop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = run_loop.h; sourceTree = "<group>"; };
 		44871D222AC69336007538BC /* Base-libwebrtc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-libwebrtc.xcconfig"; sourceTree = "<group>"; };
 		448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = h264_depacketizer_fuzzer.xcconfig; sourceTree = "<group>"; };
 		448D48342AB0BDB00065014C /* vp8_dec_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp8_dec_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -9068,6 +9146,18 @@
 		44E751A72AC73EA700828AC4 /* scoped_key_value_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scoped_key_value_config.h; sourceTree = "<group>"; };
 		44E751AB2AC73F8800828AC4 /* field_trial.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = field_trial.cc; sourceTree = "<group>"; };
 		44E751B32AC73F8800828AC4 /* field_trial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = field_trial.h; sourceTree = "<group>"; };
+		44FD166E2AEA16CC003636CB /* vp8_replay_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = vp8_replay_fuzzer.xcconfig; sourceTree = "<group>"; };
+		44FD16732AEA1F36003636CB /* json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json.h; sourceTree = "<group>"; };
+		44FD16752AEA3562003636CB /* null_transport.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = null_transport.cc; sourceTree = "<group>"; };
+		44FD16762AEA3562003636CB /* null_transport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = null_transport.h; sourceTree = "<group>"; };
+		44FD16792AEA35E3003636CB /* video_renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_renderer.h; sourceTree = "<group>"; };
+		44FD167A2AEA35E3003636CB /* video_renderer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_renderer.cc; sourceTree = "<group>"; };
+		44FD167C2AEA361B003636CB /* video_renderer_mac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = video_renderer_mac.mm; sourceTree = "<group>"; };
+		44FD167D2AEA361B003636CB /* video_renderer_mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_renderer_mac.h; sourceTree = "<group>"; };
+		44FD167F2AEA36BB003636CB /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		44FD16822AEA376F003636CB /* gl_renderer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gl_renderer.cc; sourceTree = "<group>"; };
+		44FD16832AEA376F003636CB /* gl_renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_renderer.h; sourceTree = "<group>"; };
+		44FD16852AEA37E6003636CB /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		5C0073091E5513E70042215A /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		5C00730A1E5513E70042215A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		5C00730B1E5513E70042215A /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
@@ -10741,6 +10831,26 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		444A6F002AEADFC9005FE121 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				444A6F012AEADFC9005FE121 /* AppKit.framework in Frameworks */,
+				444A6F032AEADFC9005FE121 /* libwebrtc.dylib in Frameworks */,
+				444A6F022AEADFC9005FE121 /* OpenGL.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		446359BB2AEA108C00551EEE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44FD16802AEA36BB003636CB /* AppKit.framework in Frameworks */,
+				446359C62AEA110100551EEE /* libwebrtc.dylib in Frameworks */,
+				44FD16862AEA37E6003636CB /* OpenGL.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -15899,6 +16009,15 @@
 			path = g722;
 			sourceTree = "<group>";
 		};
+		446359C82AEA114B00551EEE /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				446359C92AEA11F400551EEE /* rtp_replayer.cc */,
+				446359CA2AEA11F400551EEE /* rtp_replayer.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
 		44650D562ACBD6B40069144E /* fft */ = {
 			isa = PBXGroup;
 			children = (
@@ -15939,10 +16058,26 @@
 			isa = PBXGroup;
 			children = (
 				44ABBE862AC63DC5006B44DD /* fuzzers */,
+				44FD16812AEA3703003636CB /* gl */,
+				44FD16782AEA35D3003636CB /* mac */,
+				446359CD2AEA12BB00551EEE /* call_config_utils.cc */,
+				446359CC2AEA12BB00551EEE /* call_config_utils.h */,
+				446359CF2AEA12E400551EEE /* encoder_settings.cc */,
+				446359D02AEA12E400551EEE /* encoder_settings.h */,
+				446359D32AEA12FE00551EEE /* fake_decoder.cc */,
+				446359D22AEA12FE00551EEE /* fake_decoder.h */,
 				44E751AB2AC73F8800828AC4 /* field_trial.cc */,
 				44E751B32AC73F8800828AC4 /* field_trial.h */,
+				44FD16752AEA3562003636CB /* null_transport.cc */,
+				44FD16762AEA3562003636CB /* null_transport.h */,
+				446359D52AEA132B00551EEE /* rtp_file_reader.cc */,
+				446359D62AEA132B00551EEE /* rtp_file_reader.h */,
+				446359D82AEA135100551EEE /* run_loop.cc */,
+				446359D92AEA135200551EEE /* run_loop.h */,
 				44E7519F2AC73EA700828AC4 /* scoped_key_value_config.cc */,
 				44E751A72AC73EA700828AC4 /* scoped_key_value_config.h */,
+				44FD167A2AEA35E3003636CB /* video_renderer.cc */,
+				44FD16792AEA35E3003636CB /* video_renderer.h */,
 			);
 			path = test;
 			sourceTree = "<group>";
@@ -15950,12 +16085,15 @@
 		44ABBE862AC63DC5006B44DD /* fuzzers */ = {
 			isa = PBXGroup;
 			children = (
+				446359C82AEA114B00551EEE /* utils */,
 				441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */,
 				441380CC2AE06BC200C928CB /* fuzz_data_helper.h */,
 				44D88ACF2AF049A1005C956E /* h264_depacketizer_fuzzer.cc */,
 				449467C02AE05D6B00A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer.cc */,
 				449467D02AE05DBF00A9FED0 /* rtp_packetizer_av1_fuzzer.cc */,
 				44ABBE872AC63EF3006B44DD /* sdp_integration_fuzzer.cc */,
+				446359C22AEA10C900551EEE /* vp8_replay_fuzzer.cc */,
+				444A6EEF2AEADFB6005FE121 /* vp9_replay_fuzzer.cc */,
 				44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */,
 			);
 			path = fuzzers;
@@ -16036,6 +16174,48 @@
 				41F9BF9F2051C88500ABF0B9 /* audio_util.h */,
 			);
 			path = include;
+			sourceTree = "<group>";
+		};
+		44FD166F2AEA1DF0003636CB /* json */ = {
+			isa = PBXGroup;
+			children = (
+				44FD16712AEA1EC2003636CB /* include */,
+			);
+			path = json;
+			sourceTree = "<group>";
+		};
+		44FD16712AEA1EC2003636CB /* include */ = {
+			isa = PBXGroup;
+			children = (
+				44FD16722AEA1F13003636CB /* json */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		44FD16722AEA1F13003636CB /* json */ = {
+			isa = PBXGroup;
+			children = (
+				44FD16732AEA1F36003636CB /* json.h */,
+			);
+			path = json;
+			sourceTree = "<group>";
+		};
+		44FD16782AEA35D3003636CB /* mac */ = {
+			isa = PBXGroup;
+			children = (
+				44FD167D2AEA361B003636CB /* video_renderer_mac.h */,
+				44FD167C2AEA361B003636CB /* video_renderer_mac.mm */,
+			);
+			path = mac;
+			sourceTree = "<group>";
+		};
+		44FD16812AEA3703003636CB /* gl */ = {
+			isa = PBXGroup;
+			children = (
+				44FD16822AEA376F003636CB /* gl_renderer.cc */,
+				44FD16832AEA376F003636CB /* gl_renderer.h */,
+			);
+			path = gl;
 			sourceTree = "<group>";
 		};
 		5C0885111E4A99C200403995 /* include */ = {
@@ -16817,6 +16997,7 @@
 				413AD19E21265ACB003F7263 /* abseil-cpp */,
 				5C63FC631E4184C0002CA531 /* boringssl */,
 				41B8D9B028CB893200E5FA37 /* crc32c */,
+				44FD166F2AEA1DF0003636CB /* json */,
 				DDEBB11F24C0191800ADBD44 /* libaom */,
 				5CDD90841E43D30300621E92 /* libsrtp */,
 				4105EB64212E018C008C0C20 /* libvpx */,
@@ -17250,6 +17431,7 @@
 		5CB3048A1DE4143400D2C405 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				44FD167F2AEA36BB003636CB /* AppKit.framework */,
 				5C0073091E5513E70042215A /* AudioToolbox.framework */,
 				5C00730A1E5513E70042215A /* AVFoundation.framework */,
 				5C85C4CA1E5780DD00D097B1 /* CFNetwork.framework */,
@@ -17260,6 +17442,7 @@
 				5C00730D1E5513E70042215A /* CoreVideo.framework */,
 				5C316D8A1E66333C008BE64D /* Foundation.framework */,
 				4417F7EE2ADE112D00A7254F /* libgtest.a */,
+				44FD16852AEA37E6003636CB /* OpenGL.framework */,
 				5C0073421E552C800042215A /* Security.framework */,
 				5C0073451E552CA20042215A /* SystemConfiguration.framework */,
 				416D2F101FA8CC0400097345 /* VideoProcessing.framework */,
@@ -19176,7 +19359,9 @@
 				441380CA2AE069CB00C928CB /* rtp_packetizer_av1_fuzzer.xcconfig */,
 				44ABBE972AC641B4006B44DD /* sdp_integration_fuzzer.xcconfig */,
 				449187242AB380BE007266F2 /* vp8_dec_fuzzer.xcconfig */,
+				44FD166E2AEA16CC003636CB /* vp8_replay_fuzzer.xcconfig */,
 				449187252AB380BE007266F2 /* vp9_dec_fuzzer.xcconfig */,
+				444A6F0A2AEAE01D005FE121 /* vp9_replay_fuzzer.xcconfig */,
 				41F77D1E215BE4AD00E72967 /* yasm.xcconfig */,
 			);
 			path = Configurations;
@@ -19671,6 +19856,8 @@
 				44ABBE932AC63F0C006B44DD /* sdp_integration_fuzzer */,
 				448D48342AB0BDB00065014C /* vp8_dec_fuzzer */,
 				44C20E942AB39FA80046C6A8 /* vp9_dec_fuzzer */,
+				446359C12AEA108C00551EEE /* vp8_replay_fuzzer */,
+				444A6F082AEADFC9005FE121 /* vp9_replay_fuzzer */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -21149,6 +21336,7 @@
 				415F8878273960010047AD64 /* jsep_transport_collection.h in Headers */,
 				4131BF28234B88200028A615 /* jsep_transport_controller.h in Headers */,
 				DDF30AC427C5A355006A526F /* json.h in Headers */,
+				44FD16742AEA1F37003636CB /* json.h in Headers */,
 				DDF30A8027C59CBB006A526F /* jvm_android.h in Headers */,
 				5C0885301E4A99D200403995 /* key.h in Headers */,
 				DDF30C0727C5A6DA006A526F /* keyframe_interval_settings.h in Headers */,
@@ -22406,6 +22594,40 @@
 			productReference = 41F77D16215BE45E00E72967 /* yasm */;
 			productType = "com.apple.product-type.tool";
 		};
+		444A6EF02AEADFC9005FE121 /* vp9_replay_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 444A6F042AEADFC9005FE121 /* Build configuration list for PBXNativeTarget "vp9_replay_fuzzer" */;
+			buildPhases = (
+				444A6EF32AEADFC9005FE121 /* Sources */,
+				444A6F002AEADFC9005FE121 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				444A6EF12AEADFC9005FE121 /* PBXTargetDependency */,
+			);
+			name = vp9_replay_fuzzer;
+			productName = vp9_replay_fuzzer;
+			productReference = 444A6F082AEADFC9005FE121 /* vp9_replay_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
+		446359B62AEA108C00551EEE /* vp8_replay_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 446359BD2AEA108C00551EEE /* Build configuration list for PBXNativeTarget "vp8_replay_fuzzer" */;
+			buildPhases = (
+				446359B92AEA108C00551EEE /* Sources */,
+				446359BB2AEA108C00551EEE /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				446359C52AEA10F400551EEE /* PBXTargetDependency */,
+			);
+			name = vp8_replay_fuzzer;
+			productName = vp8_replay_fuzzer;
+			productReference = 446359C12AEA108C00551EEE /* vp8_replay_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
 		448D48332AB0BDB00065014C /* vp8_dec_fuzzer */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 448D483B2AB0BDB10065014C /* Build configuration list for PBXNativeTarget "vp8_dec_fuzzer" */;
@@ -22741,7 +22963,9 @@
 				449467A22AE05C9600A9FED0 /* rtp_packetizer_av1_fuzzer */,
 				44ABBE882AC63F0C006B44DD /* sdp_integration_fuzzer */,
 				448D48332AB0BDB00065014C /* vp8_dec_fuzzer */,
+				446359B62AEA108C00551EEE /* vp8_replay_fuzzer */,
 				44C20E892AB39FA80046C6A8 /* vp9_dec_fuzzer */,
+				444A6EF02AEADFC9005FE121 /* vp9_replay_fuzzer */,
 			);
 		};
 /* End PBXProject section */
@@ -23231,6 +23455,44 @@
 				41F77D35215BE72B00E72967 /* yasm-options.c in Sources */,
 				41F77D37215BE72B00E72967 /* yasm-plugin.c in Sources */,
 				41F77D36215BE72B00E72967 /* yasm.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		444A6EF32AEADFC9005FE121 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				444A6EF52AEADFC9005FE121 /* call_config_utils.cc in Sources */,
+				444A6EF62AEADFC9005FE121 /* encoder_settings.cc in Sources */,
+				444A6EF72AEADFC9005FE121 /* fake_decoder.cc in Sources */,
+				444A6EFF2AEADFC9005FE121 /* gl_renderer.cc in Sources */,
+				444A6EF42AEADFC9005FE121 /* null_transport.cc in Sources */,
+				444A6EFA2AEADFC9005FE121 /* rtp_file_reader.cc in Sources */,
+				444A6EFB2AEADFC9005FE121 /* rtp_replayer.cc in Sources */,
+				444A6EFC2AEADFC9005FE121 /* run_loop.cc in Sources */,
+				444A6EF92AEADFC9005FE121 /* video_renderer.cc in Sources */,
+				444A6EF82AEADFC9005FE121 /* video_renderer_mac.mm in Sources */,
+				444A6F092AEADFD8005FE121 /* vp9_replay_fuzzer.cc in Sources */,
+				444A6EFE2AEADFC9005FE121 /* webrtc_fuzzer_main.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		446359B92AEA108C00551EEE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				446359CE2AEA12BB00551EEE /* call_config_utils.cc in Sources */,
+				446359D12AEA12E400551EEE /* encoder_settings.cc in Sources */,
+				446359D42AEA12FF00551EEE /* fake_decoder.cc in Sources */,
+				44FD16842AEA3770003636CB /* gl_renderer.cc in Sources */,
+				44FD16772AEA3562003636CB /* null_transport.cc in Sources */,
+				446359D72AEA132C00551EEE /* rtp_file_reader.cc in Sources */,
+				446359CB2AEA11F500551EEE /* rtp_replayer.cc in Sources */,
+				446359DA2AEA135200551EEE /* run_loop.cc in Sources */,
+				44FD167B2AEA35E4003636CB /* video_renderer.cc in Sources */,
+				44FD167E2AEA361B003636CB /* video_renderer_mac.mm in Sources */,
+				446359C32AEA10C900551EEE /* vp8_replay_fuzzer.cc in Sources */,
+				446359C72AEA111E00551EEE /* webrtc_fuzzer_main.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -25314,6 +25576,26 @@
 			target = 41F77D15215BE45E00E72967 /* yasm */;
 			targetProxy = 41BE7173215BF42300A7B196 /* PBXContainerItemProxy */;
 		};
+		444A6EF12AEADFC9005FE121 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 444A6EF22AEADFC9005FE121 /* PBXContainerItemProxy */;
+		};
+		444A6F0C2AEAE064005FE121 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 444A6EF02AEADFC9005FE121 /* vp9_replay_fuzzer */;
+			targetProxy = 444A6F0B2AEAE064005FE121 /* PBXContainerItemProxy */;
+		};
+		446359C52AEA10F400551EEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 446359C42AEA10F400551EEE /* PBXContainerItemProxy */;
+		};
+		446359E02AEA14F000551EEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 446359B62AEA108C00551EEE /* vp8_replay_fuzzer */;
+			targetProxy = 446359DF2AEA14F000551EEE /* PBXContainerItemProxy */;
+		};
 		448D483D2AB0BDB80065014C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 4105EB69212E01D2008C0C20 /* vpx */;
@@ -25450,6 +25732,54 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 41F77D1E215BE4AD00E72967 /* yasm.xcconfig */;
 			buildSettings = {
+			};
+			name = Production;
+		};
+		444A6F052AEADFC9005FE121 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 444A6F0A2AEAE01D005FE121 /* vp9_replay_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		444A6F062AEADFC9005FE121 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 444A6F0A2AEAE01D005FE121 /* vp9_replay_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		444A6F072AEADFC9005FE121 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 444A6F0A2AEAE01D005FE121 /* vp9_replay_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		446359BE2AEA108C00551EEE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44FD166E2AEA16CC003636CB /* vp8_replay_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		446359BF2AEA108C00551EEE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44FD166E2AEA16CC003636CB /* vp8_replay_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		446359C02AEA108C00551EEE /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44FD166E2AEA16CC003636CB /* vp8_replay_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Production;
 		};
@@ -25839,6 +26169,26 @@
 				41F77D1B215BE45E00E72967 /* Debug */,
 				41F77D1C215BE45E00E72967 /* Release */,
 				41F77D1D215BE45E00E72967 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		444A6F042AEADFC9005FE121 /* Build configuration list for PBXNativeTarget "vp9_replay_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				444A6F052AEADFC9005FE121 /* Debug */,
+				444A6F062AEADFC9005FE121 /* Release */,
+				444A6F072AEADFC9005FE121 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		446359BD2AEA108C00551EEE /* Build configuration list for PBXNativeTarget "vp8_replay_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				446359BE2AEA108C00551EEE /* Debug */,
+				446359BF2AEA108C00551EEE /* Release */,
+				446359C02AEA108C00551EEE /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### 6da809348ebef718d9d6bd9ae835afc5a482be2a
<pre>
[WebRTC] Add targets for vp8 and vp9 replay fuzzers
<a href="https://bugs.webkit.org/show_bug.cgi?id=263912">https://bugs.webkit.org/show_bug.cgi?id=263912</a>
&lt;<a href="https://rdar.apple.com/116139782">rdar://116139782</a>&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Configurations/vp8_dec_fuzzer.xcconfig:
* Source/ThirdParty/libwebrtc/Configurations/vp9_dec_fuzzer.xcconfig:
- Drive-by fix to add license headers.
* Source/ThirdParty/libwebrtc/Configurations/vp8_replay_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/vp9_replay_fuzzer.xcconfig: Add.
- Add xcconfig files for each fuzzer.

* Source/ThirdParty/libwebrtc/Source/third_party/json/include/json/json.h: Add.
(Json::CharReader::parse):
(Json::CharReaderBuilder::newCharReader):
- Temporary workaround for jsoncpp project.
* Source/ThirdParty/libwebrtc/Source/webrtc/test/call_config_utils.cc:
- Temporary workaround for jsoncpp project.

* Source/ThirdParty/libwebrtc/Source/webrtc/test/mac/video_renderer_mac.mm:
(-[CocoaWindow dealloc]): Add.
(-[CocoaWindow createWindow:]):
(-[CocoaWindow makeCurrentContext]):
(webrtc::test::MacRenderer::~MacRenderer):
(webrtc::test::MacRenderer::Init):
(webrtc::test::MacRenderer::OnFrame):
- Fix leaks caused by autoreleased objects getting added to an
  autoreleasePool of last resort and by failing to tear down objects in
  the -[CocoaWindow dealloc] method.

* Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Add-targets-for-vp8-and-vp9-replay-fuzzers.patch: Add.

* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
- Add missing sources to the project for the vp{8,9}_replay_fuzzer
  targets.
- Add vp{8,9}_replay_fuzzer targets.

Canonical link: <a href="https://commits.webkit.org/270011@main">https://commits.webkit.org/270011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e597e5a4d13e5824776593706f5e46e30619e9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2409 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/25386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26433 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4048 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/24765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24543 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/1928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/25386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27023 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/25386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/25386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/24765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/2885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/25386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3103 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/1976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->