### PR TITLE
Add target for h264_depacketizer_fuzzer in libwebrtc

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/h264_depacketizer_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/h264_depacketizer_fuzzer.xcconfig
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libwebrtc.xcconfig"
+
+PRODUCT_NAME = h264_depacketizer_fuzzer;

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				44D88ACE2AF0495A005C956E /* PBXTargetDependency */,
 				449467D32AE05DD200A9FED0 /* PBXTargetDependency */,
 				449467BF2AE05CA800A9FED0 /* PBXTargetDependency */,
 				449CF1612ADEDE9B00F22CAF /* PBXTargetDependency */,
@@ -3149,6 +3150,9 @@
 		44ABBE962AC64024006B44DD /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
 		44C20E8D2AB39FA80046C6A8 /* vpx_dec_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */; };
 		44C20E8F2AB39FA80046C6A8 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4105EB83212E01D2008C0C20 /* libvpx.a */; };
+		44D88AC52AF04946005C956E /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		44D88AC72AF04946005C956E /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		44D88AD02AF049A1005C956E /* h264_depacketizer_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44D88ACF2AF049A1005C956E /* h264_depacketizer_fuzzer.cc */; };
 		44E751672AC738D200828AC4 /* fake_audio_capture_module.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44E7515E2AC738D100828AC4 /* fake_audio_capture_module.cc */; };
 		44E751722AC7396300828AC4 /* fake_audio_capture_module.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E751662AC738D200828AC4 /* fake_audio_capture_module.h */; };
 		44E7517D2AC73B2000828AC4 /* integration_test_helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E751742AC73B2000828AC4 /* integration_test_helpers.h */; };
@@ -5271,6 +5275,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 4105EB69212E01D2008C0C20;
 			remoteInfo = vpx;
+		};
+		44D88ABF2AF04946005C956E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		44D88ACD2AF0495A005C956E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44D88ABD2AF04946005C956E;
+			remoteInfo = h264_depacketizer_fuzzer;
 		};
 		44E7509B2AC726A600828AC4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -9020,6 +9038,7 @@
 		442459392ACB933B00E105A1 /* celt_lpc_sse4_1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = celt_lpc_sse4_1.c; sourceTree = "<group>"; };
 		4424593A2ACB93B000E105A1 /* jnt_sad_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = jnt_sad_sse2.c; sourceTree = "<group>"; };
 		44871D222AC69336007538BC /* Base-libwebrtc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-libwebrtc.xcconfig"; sourceTree = "<group>"; };
+		448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = h264_depacketizer_fuzzer.xcconfig; sourceTree = "<group>"; };
 		448D48342AB0BDB00065014C /* vp8_dec_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp8_dec_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
 		448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vpx_dec_fuzzer.cc; sourceTree = "<group>"; };
 		449187232AB3800D007266F2 /* Base-libvpx.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-libvpx.xcconfig"; sourceTree = "<group>"; };
@@ -9036,6 +9055,8 @@
 		44ABBE972AC641B4006B44DD /* sdp_integration_fuzzer.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = sdp_integration_fuzzer.xcconfig; sourceTree = "<group>"; };
 		44C20E942AB39FA80046C6A8 /* vp9_dec_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp9_dec_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
 		44C229C12A0AF4130008308E /* libwebrtc.testing.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = libwebrtc.testing.exp; sourceTree = "<group>"; };
+		44D88ACC2AF04946005C956E /* h264_depacketizer_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = h264_depacketizer_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		44D88ACF2AF049A1005C956E /* h264_depacketizer_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h264_depacketizer_fuzzer.cc; sourceTree = "<group>"; };
 		44E7515E2AC738D100828AC4 /* fake_audio_capture_module.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_audio_capture_module.cc; sourceTree = "<group>"; };
 		44E751662AC738D200828AC4 /* fake_audio_capture_module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_audio_capture_module.h; sourceTree = "<group>"; };
 		44E751742AC73B2000828AC4 /* integration_test_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = integration_test_helpers.h; sourceTree = "<group>"; };
@@ -10760,6 +10781,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				44C20E8F2AB39FA80046C6A8 /* libvpx.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44D88AC62AF04946005C956E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44D88AC72AF04946005C956E /* libwebrtc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -15923,6 +15952,7 @@
 			children = (
 				441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */,
 				441380CC2AE06BC200C928CB /* fuzz_data_helper.h */,
+				44D88ACF2AF049A1005C956E /* h264_depacketizer_fuzzer.cc */,
 				449467C02AE05D6B00A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer.cc */,
 				449467D02AE05DBF00A9FED0 /* rtp_packetizer_av1_fuzzer.cc */,
 				44ABBE872AC63EF3006B44DD /* sdp_integration_fuzzer.cc */,
@@ -19131,6 +19161,7 @@
 				5D7C59C61208C68B001C873E /* Base.xcconfig */,
 				5C4B43B01E42877A002651C8 /* boringssl.xcconfig */,
 				5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */,
+				448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */,
 				DDF30D0B27C5C01A006A526F /* libabsl.xcconfig */,
 				DDEBB11E24C0189600ADBD44 /* libaom.xcconfig */,
 				5C0884891E4A978C00403995 /* libsrtp.xcconfig */,
@@ -19634,11 +19665,12 @@
 				CDEBB11924C0187400ADBD44 /* libwebm.a */,
 				FB39D0D11200F0E300088E69 /* libwebrtc.dylib */,
 				5C0884DE1E4A980100403995 /* libyuv.a */,
+				44D88ACC2AF04946005C956E /* h264_depacketizer_fuzzer */,
+				449467CF2AE05DA200A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer */,
+				449467BD2AE05C9600A9FED0 /* rtp_packetizer_av1_fuzzer */,
 				44ABBE932AC63F0C006B44DD /* sdp_integration_fuzzer */,
 				448D48342AB0BDB00065014C /* vp8_dec_fuzzer */,
 				44C20E942AB39FA80046C6A8 /* vp9_dec_fuzzer */,
-				449467BD2AE05C9600A9FED0 /* rtp_packetizer_av1_fuzzer */,
-				449467CF2AE05DA200A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -19810,6 +19842,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				441380CE2AE06BC200C928CB /* fuzz_data_helper.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44D88AC02AF04946005C956E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -22455,6 +22494,24 @@
 			productReference = 44C20E942AB39FA80046C6A8 /* vp9_dec_fuzzer */;
 			productType = "com.apple.product-type.tool";
 		};
+		44D88ABD2AF04946005C956E /* h264_depacketizer_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44D88AC82AF04946005C956E /* Build configuration list for PBXNativeTarget "h264_depacketizer_fuzzer" */;
+			buildPhases = (
+				44D88AC02AF04946005C956E /* Headers */,
+				44D88AC22AF04946005C956E /* Sources */,
+				44D88AC62AF04946005C956E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44D88ABE2AF04946005C956E /* PBXTargetDependency */,
+			);
+			name = h264_depacketizer_fuzzer;
+			productName = h264_depacketizer_fuzzer;
+			productReference = 44D88ACC2AF04946005C956E /* h264_depacketizer_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
 		5C08848B1E4A97E300403995 /* srtp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5C0884CD1E4A97E300403995 /* Build configuration list for PBXNativeTarget "srtp" */;
@@ -22679,6 +22736,7 @@
 				DDEBB11824C0187400ADBD44 /* aom */,
 				DDF30D0527C5C003006A526F /* absl */,
 				449CF1592ADEDE8500F22CAF /* Fuzzers (libwebrtc) */,
+				44D88ABD2AF04946005C956E /* h264_depacketizer_fuzzer */,
 				449467C22AE05DA200A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer */,
 				449467A22AE05C9600A9FED0 /* rtp_packetizer_av1_fuzzer */,
 				44ABBE882AC63F0C006B44DD /* sdp_integration_fuzzer */,
@@ -23225,6 +23283,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				44C20E8D2AB39FA80046C6A8 /* vpx_dec_fuzzer.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44D88AC22AF04946005C956E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44D88AD02AF049A1005C956E /* h264_depacketizer_fuzzer.cc in Sources */,
+				44D88AC52AF04946005C956E /* webrtc_fuzzer_main.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -25292,6 +25359,16 @@
 			target = 4105EB69212E01D2008C0C20 /* vpx */;
 			targetProxy = 44C20E8B2AB39FA80046C6A8 /* PBXContainerItemProxy */;
 		};
+		44D88ABE2AF04946005C956E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 44D88ABF2AF04946005C956E /* PBXContainerItemProxy */;
+		};
+		44D88ACE2AF0495A005C956E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44D88ABD2AF04946005C956E /* h264_depacketizer_fuzzer */;
+			targetProxy = 44D88ACD2AF0495A005C956E /* PBXContainerItemProxy */;
+		};
 		44E7509C2AC726A600828AC4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
@@ -25511,6 +25588,30 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 449187252AB380BE007266F2 /* vp9_dec_fuzzer.xcconfig */;
 			buildSettings = {
+			};
+			name = Production;
+		};
+		44D88AC92AF04946005C956E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44D88ACA2AF04946005C956E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44D88ACB2AF04946005C956E /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Production;
 		};
@@ -25798,6 +25899,16 @@
 				44C20E912AB39FA80046C6A8 /* Debug */,
 				44C20E922AB39FA80046C6A8 /* Release */,
 				44C20E932AB39FA80046C6A8 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44D88AC82AF04946005C956E /* Build configuration list for PBXNativeTarget "h264_depacketizer_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44D88AC92AF04946005C956E /* Debug */,
+				44D88ACA2AF04946005C956E /* Release */,
+				44D88ACB2AF04946005C956E /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### 5392101a28db643bea7c375134ef0dc74ec6839a
<pre>
Add target for h264_depacketizer_fuzzer in libwebrtc
<a href="https://bugs.webkit.org/show_bug.cgi?id=263922">https://bugs.webkit.org/show_bug.cgi?id=263922</a>
&lt;rdar://117704678&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Configurations/h264_depacketizer_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
- Add target for h264_depacketizer_fuzzer.
- Add h264_depacketizer_fuzzer target to &quot;Fuzzers (libwebrtc)&quot; target.
- Sort Products folder.

Canonical link: <a href="https://commits.webkit.org/270003@main">https://commits.webkit.org/270003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f40d86f80f05503880dfc0e977a8a359eb0a4fed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22259 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22723 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26894 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28042 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22104 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25819 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/image/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19158 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1798 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1897 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3095 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->