### PR TITLE
Strong Password button is clipped on google.com and imdb.com

### DIFF
--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment-expected.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment-expected.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+.password-box {
+    background-color: rgb(250, 255, 189);
+    border: 1px solid black;
+    padding: 1px;
+    height: 40px;
+    width: 200px;
+    font-size: 11px;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.container {
+    display: flex;
+    align-items: center;
+    height: 40px;
+}
+
+.inner-text {
+    display: inline-block;
+    text-overflow: clip;
+    white-space: nowrap;
+    overflow: hidden;
+    font-family: monospace;
+    mask-image: linear-gradient(90deg,  black 50%, transparent 100%);
+}
+
+.autofill-button {
+    flex-shrink: 0;
+    font-family: -apple-system;
+    text-align: right;
+    color: rgba(0, 0, 0, 0.8);
+    padding-left: 6px;
+    white-space: nowrap;
+}
+
+</style>
+</head>
+<body>
+    <div class="password-box">
+        <div class="container">
+            <div class="inner-text">thisisaverystrongpassword</div>
+            <div class="autofill-button">Strong Password</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    font-size: 11px;
+    background-color: white;
+    border: 1px solid black;
+    border-radius: 0px;
+    padding: 1px;
+    width: 200px;
+    height: 40px;
+}
+
+</style>
+</head>
+<body>
+    <input type="password" value="thisisaverystrongpassword">
+<script>
+if (window.internals) {
+    var input = document.querySelector("input");
+    internals.setAutoFilledAndViewable(input, true);
+    internals.setShowAutoFillButton(input, "StrongPassword");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height-expected.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+.password-box {
+    background-color: rgb(250, 255, 189);
+    border: 1px solid black;
+    padding: 1px;
+    height: 40px;
+    width: 200px;
+    font-size: 11px;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.container {
+    display: flex;
+    align-items: center;
+    height: 40px;
+}
+
+.inner-text {
+    display: inline-block;
+    text-overflow: clip;
+    white-space: nowrap;
+    overflow: hidden;
+    font-family: monospace;
+    mask-image: linear-gradient(90deg,  black 50%, transparent 100%);
+}
+
+.autofill-button {
+    flex-shrink: 0;
+    font-size: 17px;
+    font-family: -apple-system;
+    text-align: right;
+    color: rgba(0, 0, 0, 0.8);
+    padding-left: 6px;
+    white-space: nowrap;
+}
+
+</style>
+</head>
+<body>
+    <div class="password-box">
+        <div class="container">
+            <div class="inner-text">thisisaverystrongpassword</div>
+            <div class="autofill-button">Strong Password</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html
+++ b/LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    font-size: 11px;
+    background-color: white;
+    border: 1px solid black;
+    border-radius: 0px;
+    padding: 1px;
+    width: 200px;
+    height: 40px;
+}
+
+input::-webkit-strong-password-auto-fill-button {
+    font-size: 17px;
+}
+
+</style>
+</head>
+<body>
+    <input type="password" value="thisisaverystrongpassword">
+<script>
+if (window.internals) {
+    var input = document.querySelector("input");
+    internals.setAutoFilledAndViewable(input, true);
+    internals.setShowAutoFillButton(input, "StrongPassword");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2206,6 +2206,7 @@ webkit.org/b/179605 editing/execCommand/underline-selection-containing-image.htm
 webkit.org/b/179722 compositing/accelerated-layers-after-back.html [ Failure ]
 
 webkit.org/b/181662 fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html [ Missing Failure ]
+webkit.org/b/181662 fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html [ ImageOnlyFailure ]
 
 webkit.org/b/182103 fast/forms/textarea-scrolled-type.html [ Failure ]
 webkit.org/b/182103 fast/forms/focus-selection-textarea.html [ Failure ]

--- a/LayoutTests/platform/ios/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
@@ -1,88 +1,88 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x216
-  RenderBlock {HTML} at (0,0) size 800x216
-    RenderBody {BODY} at (8,16) size 784x192
+layer at (0,0) size 800x212
+  RenderBlock {HTML} at (0,0) size 800x212
+    RenderBody {BODY} at (8,16) size 784x188
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 758x19
           text run at (0,0) width 758: "This tests that the Strong Password AutoFill button renders in an auto-filled input. It can only be tested in the test tool."
-      RenderBlock {DIV} at (0,36) size 784x156
-        RenderTextControl {INPUT} at (0,15) size 153x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
-        RenderText {#text} at (153,14) size 4x19
-          text run at (153,14) width 4: " "
-        RenderTextControl {INPUT} at (157,15) size 153x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
-        RenderText {#text} at (310,14) size 4x19
-          text run at (310,14) width 4: " "
-        RenderTextControl {INPUT} at (314,15) size 313x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
-        RenderText {#text} at (627,14) size 4x19
-          text run at (627,14) width 4: " "
+      RenderBlock {DIV} at (0,36) size 784x152
+        RenderTextControl {INPUT} at (0,13) size 153x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
+        RenderText {#text} at (153,11) size 4x19
+          text run at (153,11) width 4: " "
+        RenderTextControl {INPUT} at (157,13) size 153x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
+        RenderText {#text} at (310,11) size 4x19
+          text run at (310,11) width 4: " "
+        RenderTextControl {INPUT} at (314,13) size 313x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
+        RenderText {#text} at (627,11) size 4x19
+          text run at (627,11) width 4: " "
         RenderTextControl {INPUT} at (631,0) size 33x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
         RenderText {#text} at (0,0) size 0x0
-        RenderTextControl {INPUT} at (0,49) size 153x108 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
-        RenderText {#text} at (153,92) size 4x19
-          text run at (153,92) width 4: " "
-        RenderTextControl {INPUT} at (157,34) size 33x108 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
-        RenderText {#text} at (190,92) size 4x19
-          text run at (190,92) width 4: " "
-        RenderTextControl {INPUT} at (194,93) size 153x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
-layer at (15,70) size 140x12 scrollHeight 15
-  RenderFlexibleBox {DIV} at (6,3) size 141x13
-    RenderBlock {DIV} at (45,0) size 95x15 [color=#000000CC]
+        RenderTextControl {INPUT} at (0,45) size 153x108 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
+        RenderText {#text} at (153,87) size 4x19
+          text run at (153,87) width 4: " "
+        RenderTextControl {INPUT} at (157,32) size 33x108 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
+        RenderText {#text} at (190,87) size 4x19
+          text run at (190,87) width 4: " "
+        RenderTextControl {INPUT} at (194,89) size 153x20 [bgcolor=#FAFFBD] [border: (1px solid #3C3C4399)]
+layer at (15,67) size 140x14
+  RenderFlexibleBox {DIV} at (6,2) size 141x15
+    RenderBlock {DIV} at (45,0) size 95x14 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x14
         text run at (6,0) width 89: "Strong Password"
-layer at (15,70) size 46x15 backgroundClip at (15,70) size 45x12 clip at (15,70) size 45x12
-  RenderBlock {DIV} at (0,0) size 46x15
-layer at (172,70) size 140x12 scrollHeight 15
-  RenderFlexibleBox {DIV} at (6,3) size 141x13
-    RenderBlock {DIV} at (45,0) size 95x15 [color=#000000CC]
+layer at (15,68) size 46x12 backgroundClip at (15,68) size 45x12 clip at (15,68) size 45x12
+  RenderBlock {DIV} at (0,1) size 46x12
+layer at (172,67) size 140x14
+  RenderFlexibleBox {DIV} at (6,2) size 141x15
+    RenderBlock {DIV} at (45,0) size 95x14 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x14
         text run at (6,0) width 89: "Strong Password"
-layer at (172,70) size 46x15 backgroundClip at (172,70) size 45x12 clip at (172,70) size 45x12
-  RenderBlock {DIV} at (0,0) size 46x15
-layer at (329,70) size 300x12 scrollHeight 15
-  RenderFlexibleBox {DIV} at (6,3) size 301x13
-    RenderBlock {DIV} at (205,0) size 95x15 [color=#000000CC]
+layer at (172,68) size 46x12 backgroundClip at (172,68) size 45x12 clip at (172,68) size 45x12
+  RenderBlock {DIV} at (0,1) size 46x12
+layer at (329,67) size 300x14
+  RenderFlexibleBox {DIV} at (6,2) size 301x15
+    RenderBlock {DIV} at (205,0) size 95x14 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x14
         text run at (6,0) width 89: "Strong Password"
-layer at (329,70) size 206x15 backgroundClip at (329,70) size 205x12 clip at (329,70) size 205x12
-  RenderBlock {DIV} at (0,0) size 206x15
-layer at (646,55) size 20x12 scrollWidth 94 scrollHeight 29
+layer at (329,68) size 206x12 backgroundClip at (329,68) size 205x12 clip at (329,68) size 205x12
+  RenderBlock {DIV} at (0,1) size 206x12
+layer at (646,55) size 20x12 scrollWidth 94 scrollHeight 26
   RenderFlexibleBox {DIV} at (6,3) size 21x13
-    RenderBlock {DIV} at (0,15) size 95x14 [color=#000000CC]
+    RenderBlock {DIV} at (0,12) size 95x14 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x14
         text run at (6,0) width 89: "Strong Password"
-layer at (646,55) size 20x15 backgroundClip at (646,55) size 20x12 clip at (646,55) size 20x12
-  RenderBlock {DIV} at (0,0) size 20x15
-layer at (15,148) size 140x12 scrollHeight 15
-  RenderFlexibleBox {DIV} at (6,47) size 141x13
-    RenderBlock {DIV} at (45,0) size 95x15 [color=#000000CC]
+layer at (646,55) size 20x12
+  RenderBlock {DIV} at (0,0) size 20x12
+layer at (15,143) size 140x14
+  RenderFlexibleBox {DIV} at (6,46) size 141x15
+    RenderBlock {DIV} at (45,0) size 95x14 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x14
         text run at (6,0) width 89: "Strong Password"
-layer at (15,148) size 46x15 backgroundClip at (15,148) size 45x12 clip at (15,148) size 45x12
-  RenderBlock {DIV} at (0,0) size 46x15
-layer at (172,133) size 20x12 scrollWidth 94 scrollHeight 29
+layer at (15,144) size 46x12 backgroundClip at (15,144) size 45x12 clip at (15,144) size 45x12
+  RenderBlock {DIV} at (0,1) size 46x12
+layer at (172,131) size 20x12 scrollWidth 94 scrollHeight 26
   RenderFlexibleBox {DIV} at (6,47) size 21x13
-    RenderBlock {DIV} at (0,15) size 95x14 [color=#000000CC]
+    RenderBlock {DIV} at (0,12) size 95x14 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x14
         text run at (6,0) width 89: "Strong Password"
-layer at (172,133) size 20x15 backgroundClip at (172,133) size 20x12 clip at (172,133) size 20x12
-  RenderBlock {DIV} at (0,0) size 20x15
-layer at (209,148) size 140x12 scrollHeight 15
-  RenderFlexibleBox {DIV} at (6,3) size 141x13
-    RenderBlock {DIV} at (45,0) size 95x15 [color=#000000CC]
+layer at (172,131) size 20x12
+  RenderBlock {DIV} at (0,0) size 20x12
+layer at (209,143) size 140x14
+  RenderFlexibleBox {DIV} at (6,2) size 141x15
+    RenderBlock {DIV} at (45,0) size 95x14 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x14
         text run at (6,0) width 89: "Strong Password"
-layer at (209,148) size 46x15 backgroundClip at (209,148) size 45x12 clip at (209,148) size 45x12
-  RenderBlock {DIV} at (0,0) size 46x15
-layer at (15,70) size 46x12 backgroundClip at (15,70) size 45x12 clip at (15,70) size 45x12 scrollWidth 284
+layer at (209,144) size 46x12 backgroundClip at (209,144) size 45x12 clip at (209,144) size 45x12
+  RenderBlock {DIV} at (0,1) size 46x12
+layer at (15,68) size 46x12 backgroundClip at (15,68) size 45x12 clip at (15,68) size 45x12 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 46x12 [color=#00000099]
     RenderText {#text} at (0,0) size 284x12
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (172,70) size 46x12 backgroundClip at (172,70) size 45x12 clip at (172,70) size 45x12 scrollWidth 284
+layer at (172,68) size 46x12 backgroundClip at (172,68) size 45x12 clip at (172,68) size 45x12 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 46x12 [color=#00000099]
     RenderText {#text} at (0,0) size 284x12
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (329,70) size 206x12 backgroundClip at (329,70) size 205x12 clip at (329,70) size 205x12 scrollWidth 284
+layer at (329,68) size 206x12 backgroundClip at (329,68) size 205x12 clip at (329,68) size 205x12 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 206x12 [color=#00000099]
     RenderText {#text} at (0,0) size 284x12
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
@@ -90,11 +90,11 @@ layer at (646,55) size 20x12 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 20x12 [color=#00000099]
     RenderText {#text} at (0,0) size 284x12
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (15,148) size 46x12 backgroundClip at (15,148) size 45x12 clip at (15,148) size 45x12 scrollWidth 284
+layer at (15,144) size 46x12 backgroundClip at (15,144) size 45x12 clip at (15,144) size 45x12 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 46x12 [color=#00000099]
     RenderText {#text} at (0,0) size 284x12
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (172,133) size 20x12 scrollWidth 284
+layer at (172,131) size 20x12 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 20x12 [color=#00000099]
     RenderText {#text} at (0,0) size 284x12
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."

--- a/LayoutTests/platform/mac/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
@@ -1,88 +1,88 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x213
-  RenderBlock {HTML} at (0,0) size 800x213
-    RenderBody {BODY} at (8,16) size 784x189
+layer at (0,0) size 800x209
+  RenderBlock {HTML} at (0,0) size 800x209
+    RenderBody {BODY} at (8,16) size 784x185
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 757x18
           text run at (0,0) width 757: "This tests that the Strong Password AutoFill button renders in an auto-filled input. It can only be tested in the test tool."
-      RenderBlock {DIV} at (0,34) size 784x155
-        RenderTextControl {INPUT} at (0,15) size 158x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
-        RenderText {#text} at (158,16) size 4x18
-          text run at (158,16) width 4: " "
-        RenderTextControl {INPUT} at (162,15) size 158x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
-        RenderText {#text} at (320,16) size 4x18
-          text run at (320,16) width 4: " "
-        RenderTextControl {INPUT} at (324,15) size 306x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
-        RenderText {#text} at (630,16) size 4x18
-          text run at (630,16) width 4: " "
+      RenderBlock {DIV} at (0,34) size 784x151
+        RenderTextControl {INPUT} at (0,13) size 158x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
+        RenderText {#text} at (158,13) size 4x18
+          text run at (158,13) width 4: " "
+        RenderTextControl {INPUT} at (162,13) size 158x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
+        RenderText {#text} at (320,13) size 4x18
+          text run at (320,13) width 4: " "
+        RenderTextControl {INPUT} at (324,13) size 306x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
+        RenderText {#text} at (630,13) size 4x18
+          text run at (630,13) width 4: " "
         RenderTextControl {INPUT} at (634,0) size 26x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
         RenderText {#text} at (0,0) size 0x0
-        RenderTextControl {INPUT} at (0,49) size 158x106 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
-        RenderText {#text} at (158,93) size 4x18
-          text run at (158,93) width 4: " "
-        RenderTextControl {INPUT} at (162,34) size 26x106 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
-        RenderText {#text} at (188,93) size 4x18
-          text run at (188,93) width 4: " "
-        RenderTextControl {INPUT} at (192,92) size 158x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
-layer at (11,68) size 152x13 scrollHeight 16
+        RenderTextControl {INPUT} at (0,45) size 158x106 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
+        RenderText {#text} at (158,88) size 4x18
+          text run at (158,88) width 4: " "
+        RenderTextControl {INPUT} at (162,32) size 26x106 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
+        RenderText {#text} at (188,88) size 4x18
+          text run at (188,88) width 4: " "
+        RenderTextControl {INPUT} at (192,88) size 158x19 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
+layer at (11,66) size 152x13
   RenderFlexibleBox {DIV} at (3,3) size 152x13
-    RenderBlock {DIV} at (57,1) size 95x14 [color=#000000CC]
+    RenderBlock {DIV} at (57,0) size 95x13 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x13
         text run at (6,0) width 89: "Strong Password"
-layer at (11,68) size 58x16 backgroundClip at (11,68) size 58x13 clip at (11,68) size 58x13
-  RenderBlock {DIV} at (0,0) size 58x16
-layer at (173,68) size 152x13 scrollHeight 16
+layer at (11,66) size 58x13
+  RenderBlock {DIV} at (0,0) size 58x13
+layer at (173,66) size 152x13
   RenderFlexibleBox {DIV} at (3,3) size 152x13
-    RenderBlock {DIV} at (57,1) size 95x14 [color=#000000CC]
+    RenderBlock {DIV} at (57,0) size 95x13 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x13
         text run at (6,0) width 89: "Strong Password"
-layer at (173,68) size 58x16 backgroundClip at (173,68) size 58x13 clip at (173,68) size 58x13
-  RenderBlock {DIV} at (0,0) size 58x16
-layer at (335,68) size 300x13 scrollHeight 16
+layer at (173,66) size 58x13
+  RenderBlock {DIV} at (0,0) size 58x13
+layer at (335,66) size 300x13
   RenderFlexibleBox {DIV} at (3,3) size 300x13
-    RenderBlock {DIV} at (205,1) size 95x14 [color=#000000CC]
+    RenderBlock {DIV} at (205,0) size 95x13 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x13
         text run at (6,0) width 89: "Strong Password"
-layer at (335,68) size 206x16 backgroundClip at (335,68) size 206x13 clip at (335,68) size 206x13
-  RenderBlock {DIV} at (0,0) size 206x16
-layer at (645,53) size 20x13 scrollWidth 94 scrollHeight 29
+layer at (335,66) size 206x13
+  RenderBlock {DIV} at (0,0) size 206x13
+layer at (645,53) size 20x13 scrollWidth 94 scrollHeight 26
   RenderFlexibleBox {DIV} at (3,3) size 20x13
-    RenderBlock {DIV} at (0,16) size 95x13 [color=#000000CC]
+    RenderBlock {DIV} at (0,13) size 95x13 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x13
         text run at (6,0) width 89: "Strong Password"
-layer at (645,53) size 20x16 backgroundClip at (645,53) size 20x13 clip at (645,53) size 20x13
-  RenderBlock {DIV} at (0,0) size 20x16
-layer at (11,146) size 152x13 scrollHeight 16
+layer at (645,53) size 20x13
+  RenderBlock {DIV} at (0,0) size 20x13
+layer at (11,142) size 152x13
   RenderFlexibleBox {DIV} at (3,46) size 152x14
-    RenderBlock {DIV} at (57,1) size 95x14 [color=#000000CC]
+    RenderBlock {DIV} at (57,0) size 95x13 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x13
         text run at (6,0) width 89: "Strong Password"
-layer at (11,146) size 58x16 backgroundClip at (11,146) size 58x13 clip at (11,146) size 58x13
-  RenderBlock {DIV} at (0,0) size 58x16
-layer at (173,131) size 20x13 scrollWidth 94 scrollHeight 29
+layer at (11,142) size 58x13
+  RenderBlock {DIV} at (0,0) size 58x13
+layer at (173,129) size 20x13 scrollWidth 94 scrollHeight 26
   RenderFlexibleBox {DIV} at (3,46) size 20x14
-    RenderBlock {DIV} at (0,16) size 95x13 [color=#000000CC]
+    RenderBlock {DIV} at (0,13) size 95x13 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x13
         text run at (6,0) width 89: "Strong Password"
-layer at (173,131) size 20x16 backgroundClip at (173,131) size 20x13 clip at (173,131) size 20x13
-  RenderBlock {DIV} at (0,0) size 20x16
-layer at (203,145) size 152x13 scrollHeight 16
+layer at (173,129) size 20x13
+  RenderBlock {DIV} at (0,0) size 20x13
+layer at (203,141) size 152x13
   RenderFlexibleBox {DIV} at (3,3) size 152x13
-    RenderBlock {DIV} at (57,1) size 95x14 [color=#000000CC]
+    RenderBlock {DIV} at (57,0) size 95x13 [color=#000000CC]
       RenderText {#text} at (6,0) size 89x13
         text run at (6,0) width 89: "Strong Password"
-layer at (203,145) size 58x16 backgroundClip at (203,145) size 58x13 clip at (203,145) size 58x13
-  RenderBlock {DIV} at (0,0) size 58x16
-layer at (11,68) size 58x13 scrollWidth 284
+layer at (203,141) size 58x13
+  RenderBlock {DIV} at (0,0) size 58x13
+layer at (11,66) size 58x13 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 58x13 [color=#00000099]
     RenderText {#text} at (0,0) size 284x13
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (173,68) size 58x13 scrollWidth 284
+layer at (173,66) size 58x13 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 58x13 [color=#00000099]
     RenderText {#text} at (0,0) size 284x13
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (335,68) size 206x13 scrollWidth 284
+layer at (335,66) size 206x13 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 206x13 [color=#00000099]
     RenderText {#text} at (0,0) size 284x13
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
@@ -90,11 +90,11 @@ layer at (645,53) size 20x13 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 20x13 [color=#00000099]
     RenderText {#text} at (0,0) size 284x13
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (11,146) size 58x13 scrollWidth 284
+layer at (11,142) size 58x13 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 58x13 [color=#00000099]
     RenderText {#text} at (0,0) size 284x13
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."
-layer at (173,131) size 20x13 scrollWidth 284
+layer at (173,129) size 20x13 scrollWidth 284
   RenderBlock {DIV} at (0,0) size 20x13 [color=#00000099]
     RenderText {#text} at (0,0) size 284x13
       text run at (0,0) width 284: "A quick brown fox jumped over the lazy dog."

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3336,7 +3336,7 @@ std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode
     if (style().display() == DisplayType::InlineBlock) {
         // The baseline of an 'inline-block' is the baseline of its last line box in the normal flow, unless it has either no in-flow line boxes or if its 'overflow'
         // property has a computed value other than 'visible'. see https://www.w3.org/TR/CSS22/visudet.html
-        auto shouldSynthesizeBaseline = !style().isOverflowVisible() && !is<HTMLFormControlElement>(element());
+        auto shouldSynthesizeBaseline = !style().isOverflowVisible() && !is<HTMLFormControlElement>(element()) && !isTextControlInnerBlock();
         if (shouldSynthesizeBaseline)
             return std::nullopt;
     }


### PR DESCRIPTION
#### af06b864403c001c463f12589bedb1a9865b5e8c
<pre>
Strong Password button is clipped on google.com and imdb.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=263921">https://bugs.webkit.org/show_bug.cgi?id=263921</a>
<a href="https://rdar.apple.com/113701243">rdar://113701243</a>

Reviewed by Alan Baradlay.

Descenders in the &quot;Strong Password&quot; button in autofilled fields with strong
passwords are clipped on google.com and imdb. This issue is exacerbated when
the user has a system language which has very tall descenders, such as Hindi.

There are two distinct issues contributing to the clipping, both as a
consequence of the behavior added in 200350@main, which made it so that
&quot;Strong Password&quot; is hidden in narrow inputs.

1. 200350@main began forcing the height of the text container in input
   elements to equal the height of the inner text. This was done so that
   the &quot;Strong Password&quot; button could overflow (and be hidden) on to the
   next line in narrow inputs. However, this is problematic, as in cases
   where the button does not overflow, and is taller than the inner text,
   the button is clipped to match the height of the inner text. This
   scenario commonly occurs for users with a Hindi language set, as the tall
   descenders in Hindi often result in the button being taller than the
   password text.

2. Following the changes in 232913@main to correct inline block baseline
   behavior, the inner text element receives a &quot;synthesized&quot; baseline. This
   means that the text sits on the baseline with the bottom of the inline-block
   box and not with the baseline of the last (only) line. Consequently, the
   flex item that wraps the text ends up taller than the actual text. Then, the
   &quot;Strong Password&quot; button, which is also a flex item, gets pushed lower due
   to `align-items: center` alongside the taller flex item. Finally, it gets
   clipped for the same reason as clipping in (1). If (1) were fixed, clipping
   would not occur, but the &quot;Strong Password&quot; button would still be misaligned
   with the text.

To fix (1), take the taller of the inner text and &quot;Strong Password&quot; button in
order to determine the height to use for the container. This ensures that the
container will not have a height smaller than the button&apos;s height in cases where
the button is visible.

To fix (2), simply stop synthesizing the baseline for the inner text renderer.

* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment-expected.html: Added.
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html: Added.
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height-expected.html: Added.
* LayoutTests/fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt:
* LayoutTests/platform/mac/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt:

Rebaseline the test to reflect the new positions and heights of the shadow tree
elements. Notably, all the issues described in this commit message are already
observable in this test. However, because it is a render tree dump test that
also involves additional user input, the issue was never observed.

Due to this testing flaw, additional ref tests have been added as part of this change.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::inlineBlockBaseline const):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::layout):

Canonical link: <a href="https://commits.webkit.org/270068@main">https://commits.webkit.org/270068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf6077ee772c5c4d0d3a674c45427c5aeb4d15aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24399 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/74 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22868 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24645 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2033 "Found 1 new test failure: fast/dom/focus-dialog-blur-input-type-change-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27116 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28209 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25999 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1698 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/38 "Found 2 new test failures: compositing/reflections/repaint-with-reflection.html, imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21760 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5854 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->