### PR TITLE
Add <input type=checkbox switch> internal pseudo-elements

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -282,12 +282,16 @@ PseudoId CSSSelector::pseudoId(PseudoElementType type)
     return PseudoId::None;
 }
 
-CSSSelector::PseudoElementType CSSSelector::parsePseudoElementType(StringView name)
+CSSSelector::PseudoElementType CSSSelector::parsePseudoElementType(StringView name, CSSParserMode mode)
 {
     if (name.isNull())
         return PseudoElementUnknown;
 
     auto type = parsePseudoElementString(name);
+    if (mode != UASheetMode && type == PseudoElementWebKitCustom
+        && (equalLettersIgnoringASCIICase(name, "thumb"_s) || equalLettersIgnoringASCIICase(name, "track"_s)))
+        return PseudoElementUnknown;
+
     if (type == PseudoElementUnknown) {
         if (name.startsWith("-webkit-"_s) || name.startsWith("-apple-"_s))
             type = PseudoElementWebKitCustom;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "CSSParserContext.h"
 #include "QualifiedName.h"
 #include "RenderStyleConstants.h"
 #include <wtf/EnumTraits.h>
@@ -252,7 +253,7 @@ struct PossiblyQuotedIdentifier {
             RightBottomMarginBox,
         };
 
-        static PseudoElementType parsePseudoElementType(StringView);
+        static PseudoElementType parsePseudoElementType(StringView, CSSParserMode = HTMLStandardMode);
         static PseudoId pseudoId(PseudoElementType);
 
         // Selectors are kept in an array by CSSSelectorList.

--- a/Source/WebCore/css/SelectorPseudoElementTypeMap.in
+++ b/Source/WebCore/css/SelectorPseudoElementTypeMap.in
@@ -22,3 +22,5 @@ placeholder, PseudoElementWebKitCustom
 -webkit-scrollbar-track-piece
 selection
 slotted
+thumb, PseudoElementWebKitCustom
+track, PseudoElementWebKitCustom

--- a/Source/WebCore/css/htmlSwitchControl.css
+++ b/Source/WebCore/css/htmlSwitchControl.css
@@ -27,3 +27,7 @@
 input[type="checkbox"][switch] {
     margin: initial;
 }
+
+input[type="checkbox"][switch]::thumb, input[type="checkbox"][switch]::track {
+    appearance: inherit !important;
+}

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -50,9 +50,9 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePagePseudoSelector(St
     return selector;
 }
 
-std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector(StringView pseudoTypeString)
+std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector(StringView pseudoTypeString, CSSParserMode mode)
 {
-    auto pseudoType = CSSSelector::parsePseudoElementType(pseudoTypeString);
+    auto pseudoType = CSSSelector::parsePseudoElementType(pseudoTypeString, mode);
     if (pseudoType == CSSSelector::PseudoElementUnknown)
         return nullptr;
 

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "CSSParserContext.h"
 #include "CSSSelector.h"
 #include <wtf/text/AtomStringHash.h>
 
@@ -36,7 +37,7 @@ class CSSParserSelector {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static std::unique_ptr<CSSParserSelector> parsePseudoClassSelector(StringView);
-    static std::unique_ptr<CSSParserSelector> parsePseudoElementSelector(StringView);
+    static std::unique_ptr<CSSParserSelector> parsePseudoElementSelector(StringView, CSSParserMode);
     static std::unique_ptr<CSSParserSelector> parsePagePseudoSelector(StringView);
 
     CSSParserSelector();

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -811,7 +811,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
 #endif
         }
     } else {
-        selector = CSSParserSelector::parsePseudoElementSelector(token.value());
+        selector = CSSParserSelector::parsePseudoElementSelector(token.value(), m_context.mode);
 #if ENABLE(VIDEO)
         // Treat the ident version of cue as PseudoElementWebkitCustom.
         if (token.type() == IdentToken && selector && selector->match() == CSSSelector::Match::PseudoElement && selector->pseudoElementType() == CSSSelector::PseudoElementCue)

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
@@ -51,6 +51,18 @@ const AtomString& placeholder()
     return placeholder;
 }
 
+const AtomString& thumb()
+{
+    static MainThreadNeverDestroyed<const AtomString> thumb("thumb"_s);
+    return thumb;
+}
+
+const AtomString& track()
+{
+    static MainThreadNeverDestroyed<const AtomString> track("track"_s);
+    return track;
+}
+
 const AtomString& webkitContactsAutoFillButton()
 {
     static MainThreadNeverDestroyed<const AtomString> webkitContactsAutoFillButton("-webkit-contacts-auto-fill-button"_s);

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.h
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.h
@@ -37,6 +37,9 @@ const AtomString& fileSelectorButton();
 
 const AtomString& placeholder();
 
+const AtomString& thumb();
+const AtomString& track();
+
 const AtomString& webkitContactsAutoFillButton();
 const AtomString& webkitCredentialsAutoFillButton();
 const AtomString& webkitCreditCardAutoFillButton();

--- a/Source/WebCore/html/shadow/SwitchThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.cpp
@@ -25,8 +25,8 @@
 #include "config.h"
 #include "SwitchThumbElement.h"
 
-#include "RenderStyleInlines.h"
-#include "ResolvedStyle.h"
+#include "ScriptDisallowedScope.h"
+#include "ShadowPseudoIds.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -37,24 +37,16 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SwitchThumbElement);
 
 Ref<SwitchThumbElement> SwitchThumbElement::create(Document& document)
 {
-    return adoptRef(*new SwitchThumbElement(document));
+    Ref element = adoptRef(*new SwitchThumbElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
+    element->setPseudo(ShadowPseudoIds::thumb());
+    return element;
+
 }
 
 SwitchThumbElement::SwitchThumbElement(Document& document)
     : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchThumbElement)
 {
-}
-
-std::optional<Style::ResolvedStyle> SwitchThumbElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* hostStyle)
-{
-    if (!hostStyle)
-        return std::nullopt;
-
-    auto elementStyle = resolveStyle(resolutionContext);
-    if (hostStyle->effectiveAppearance() == StyleAppearance::Auto)
-        elementStyle.style->setEffectiveAppearance(StyleAppearance::SwitchThumb);
-
-    return elementStyle;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchThumbElement.h
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.h
@@ -38,8 +38,6 @@ public:
 private:
     static constexpr auto CreateSwitchThumbElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
     explicit SwitchThumbElement(Document&);
-
-    std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle*) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchTrackElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.cpp
@@ -25,8 +25,8 @@
 #include "config.h"
 #include "SwitchTrackElement.h"
 
-#include "RenderStyleInlines.h"
-#include "ResolvedStyle.h"
+#include "ScriptDisallowedScope.h"
+#include "ShadowPseudoIds.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -37,24 +37,15 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SwitchTrackElement);
 
 Ref<SwitchTrackElement> SwitchTrackElement::create(Document& document)
 {
-    return adoptRef(*new SwitchTrackElement(document));
+    Ref element = adoptRef(*new SwitchTrackElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
+    element->setPseudo(ShadowPseudoIds::track());
+    return element;
 }
 
 SwitchTrackElement::SwitchTrackElement(Document& document)
     : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchTrackElement)
 {
-}
-
-std::optional<Style::ResolvedStyle> SwitchTrackElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* hostStyle)
-{
-    if (!hostStyle)
-        return std::nullopt;
-
-    auto elementStyle = resolveStyle(resolutionContext);
-    if (hostStyle->effectiveAppearance() == StyleAppearance::Auto)
-        elementStyle.style->setEffectiveAppearance(StyleAppearance::SwitchTrack);
-
-    return elementStyle;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchTrackElement.h
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.h
@@ -38,8 +38,6 @@ public:
 private:
     static constexpr auto CreateSwitchTrackElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
     explicit SwitchTrackElement(Document&);
-
-    std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle*) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -493,6 +493,12 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
 
         if (pseudo == ShadowPseudoIds::webkitInnerSpinButton())
             return StyleAppearance::InnerSpinButton;
+
+        if (pseudo == ShadowPseudoIds::thumb())
+            return StyleAppearance::SwitchThumb;
+
+        if (pseudo == ShadowPseudoIds::track())
+            return StyleAppearance::SwitchTrack;
     }
 
     return StyleAppearance::None;


### PR DESCRIPTION
#### dc51e7fcb906549a53e52f7c08dbb399f134334e
<pre>
Add &lt;input type=checkbox switch&gt; internal pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=263928">https://bugs.webkit.org/show_bug.cgi?id=263928</a>
<a href="https://rdar.apple.com/117708673">rdar://117708673</a>

Reviewed by Aditya Keerthi and Antti Koivisto.

Changing the internal appearance of internal shadow tree elements in
resolveCustomStyle() does not work completely as this is too late for
Adjuster::adjust() to consider it having an appearance for the purposes
of theming. In particular it does not allow us to set intrinsic sizes
for these elements.

As such, internal shadow tree elements need to have appearance:inherit
declared upon them upfront in a user agent style sheet.

As we are planning on eventually supporting pseudo-elements for the
track and thumb of switches, add those now, but only expose them
internally until we are sure they match the eventual standard. These
pseudo-elements can then be used to set appearance:inherit in the user
agent style sheet on the internal shadow tree elements.

This appearance value (when it computes to auto) means that
autoAppearanceForElement() is invoked at which point we can then map
them to the appropriate internal values for the track and thumb.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElementType):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorPseudoElementTypeMap.in:
* Source/WebCore/css/htmlSwitchControl.css:
(input[type=&quot;checkbox&quot;][switch]::thumb, input[type=&quot;checkbox&quot;][switch]::track):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePseudoElementSelector):
* Source/WebCore/css/parser/CSSParserSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumePseudo):
* Source/WebCore/html/shadow/ShadowPseudoIds.cpp:
(WebCore::ShadowPseudoIds::thumb):
(WebCore::ShadowPseudoIds::track):
* Source/WebCore/html/shadow/ShadowPseudoIds.h:
* Source/WebCore/html/shadow/SwitchThumbElement.cpp:
(WebCore::SwitchThumbElement::create):
(WebCore::SwitchThumbElement::resolveCustomStyle): Deleted.
* Source/WebCore/html/shadow/SwitchThumbElement.h:
* Source/WebCore/html/shadow/SwitchTrackElement.cpp:
(WebCore::SwitchTrackElement::create):
(WebCore::SwitchTrackElement::resolveCustomStyle): Deleted.
* Source/WebCore/html/shadow/SwitchTrackElement.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):

Canonical link: <a href="https://commits.webkit.org/270037@main">https://commits.webkit.org/270037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff46ecb88c6f746234864745a7587b6661f9e45d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26494 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4110 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/29 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24608 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/1980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27080 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21973 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/29 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/2932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5833 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->