### PR TITLE
Generate CGColor serialization

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1101,14 +1101,15 @@ std::optional<RetainPtr<CFFooRef>> ArgumentCoder<RetainPtr<CFFooRef>>::decode(De
     return result->toCF();
 }
 
+#if USE(CFBAR)
 void ArgumentCoder<CFBarRef>::encode(Encoder& encoder, CFBarRef instance)
 {
-    encoder << WebKit::BarWrapper { instance };
+    encoder << WebKit::BarWrapper::createFromCF(instance);
 }
 
 void ArgumentCoder<CFBarRef>::encode(StreamConnectionEncoder& encoder, CFBarRef instance)
 {
-    encoder << WebKit::BarWrapper { instance };
+    encoder << WebKit::BarWrapper::createFromCF(instance);
 }
 
 std::optional<RetainPtr<CFBarRef>> ArgumentCoder<RetainPtr<CFBarRef>>::decode(Decoder& decoder)
@@ -1116,8 +1117,10 @@ std::optional<RetainPtr<CFBarRef>> ArgumentCoder<RetainPtr<CFBarRef>>::decode(De
     auto result = decoder.decode<WebKit::BarWrapper>();
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
-    return result->createCFBar();
+    return createCFBar(*result);
 }
+
+#endif
 
 } // namespace IPC
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -73,6 +73,11 @@ namespace JSC { enum class Incredible; }
 namespace Testing { enum class StorageSize : uint8_t; }
 namespace WebCore { class ScrollingStateFrameHostingNode; }
 namespace WebCore { class ScrollingStateFrameHostingNodeWithStuffAfterTuple; }
+#if USE(CFBAR)
+#endif
+#if USE(CFBAR)
+typedef struct __CFBar * CFBarRef;
+#endif
 
 namespace IPC {
 
@@ -232,6 +237,7 @@ template<> struct ArgumentCoder<RetainPtr<CFFooRef>> {
     static std::optional<RetainPtr<CFFooRef>> decode(Decoder&);
 };
 
+#if USE(CFBAR)
 template<> struct ArgumentCoder<CFBarRef> {
     static void encode(Encoder&, CFBarRef);
     static void encode(StreamConnectionEncoder&, CFBarRef);
@@ -247,6 +253,7 @@ template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
     }
     static std::optional<RetainPtr<CFBarRef>> decode(Decoder&);
 };
+#endif
 
 } // namespace IPC
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -219,5 +219,8 @@ class WebKit::TemplateTest {
 CFFooRef wrapped by WebKit::FooWrapper {
 }
 
-[CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createCFBar] CFBarRef wrapped by WebKit::BarWrapper {
+#if USE(CFBAR)
+additional_forward_declaration: typedef struct __CFBar * CFBarRef
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder, FromCFMethod=WebKit::BarWrapper::createFromCF, ToCFMethod=createCFBar(*result)] CFBarRef wrapped by WebKit::BarWrapper {
 }
+#endif

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -699,24 +699,6 @@ std::optional<RetainPtr<CGColorSpaceRef>> ArgumentCoder<RetainPtr<CGColorSpaceRe
 }
 
 template<typename Encoder>
-void ArgumentCoder<CGColorRef>::encode(Encoder& encoder, CGColorRef color)
-{
-    encoder << WebCore::Color::createAndPreserveColorSpace(color);
-}
-
-template void ArgumentCoder<CGColorRef>::encode<Encoder>(Encoder&, CGColorRef);
-template void ArgumentCoder<CGColorRef>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, CGColorRef);
-
-std::optional<RetainPtr<CGColorRef>> ArgumentCoder<RetainPtr<CGColorRef>>::decode(Decoder& decoder)
-{
-    std::optional<WebCore::Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-    return cachedCGColor(*color);
-}
-
-template<typename Encoder>
 void ArgumentCoder<SecCertificateRef>::encode(Encoder& encoder, SecCertificateRef certificate)
 {
     encoder << adoptCF(SecCertificateCopyData(certificate));

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -105,13 +105,6 @@ template<> struct ArgumentCoder<RetainPtr<CGColorSpaceRef>> : CFRetainPtrArgumen
     static std::optional<RetainPtr<CGColorSpaceRef>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<CGColorRef> {
-    template<typename Encoder> static void encode(Encoder&, CGColorRef);
-};
-template<> struct ArgumentCoder<RetainPtr<CGColorRef>> : CFRetainPtrArgumentCoder<CGColorRef> {
-    static std::optional<RetainPtr<CGColorRef>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<SecCertificateRef> {
     template<typename Encoder> static void encode(Encoder&, SecCertificateRef);
 };

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -22,13 +22,21 @@
 
 #if USE(CF)
 
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createData] CFDataRef wrapped by WebKit::CoreIPCData {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createData()] CFDataRef wrapped by WebKit::CoreIPCData {
 }
 
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createCFString] CFStringRef wrapped by WTF::String {
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFString()] CFStringRef wrapped by WTF::String {
 }
 
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=createBoolean] CFBooleanRef wrapped by WebKit::CoreIPCBoolean {
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createBoolean()] CFBooleanRef wrapped by WebKit::CoreIPCBoolean {
+}
+
+#endif
+
+#if USE(CG)
+
+additional_forward_declaration: typedef struct CGColor *CGColorRef
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, FromCFMethod=WebCore::Color::createAndPreserveColorSpace, ToCFMethod=WebCore::cachedCGColor(*result)] CGColorRef wrapped by WebCore::Color {
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCSerialization.mm
@@ -74,7 +74,9 @@ struct CFHolderForTesting {
     typedef std::variant<
         RetainPtr<CFStringRef>,
         RetainPtr<CFURLRef>,
-        RetainPtr<CFDataRef>
+        RetainPtr<CFDataRef>,
+        RetainPtr<CFBooleanRef>,
+        RetainPtr<CGColorRef>
     > ValueType;
 
     ValueType value;
@@ -257,4 +259,12 @@ TEST(IPCSerialization, Basic)
     [dateComponents setSecond:0];
 
     runTestNS({ [[NSCalendar currentCalendar] dateFromComponents:dateComponents] });
+
+    runTestCF({ kCFBooleanTrue });
+    runTestCF({ kCFBooleanFalse });
+
+    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    constexpr CGFloat testComponents[4] = { 1, .75, .5, .25 };
+    auto cgColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), testComponents));
+    runTestCF({ cgColor.get() });
 }


### PR DESCRIPTION
#### 2491896493663e307f90dc6be53672e9ca59c4ef
<pre>
Generate CGColor serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=263932">https://bugs.webkit.org/show_bug.cgi?id=263932</a>
rdar://117709336

Reviewed by David Kilzer.

WebCore::Color is already an appropriate wrapper class for CGColorRef.

But to use it, I needed to change generate-serializers.py to allow for:
- Fully custom &quot;toCF&quot; function
- Custom &quot;fromCF&quot; function
- Add an arbitrary forward declaration to the generated header.

With those changes, the actual code changes to WebKit are pure deletion.

* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(ConditionalForwardDeclaration):
(ConditionalForwardDeclaration.__init__):
(ConditionalForwardDeclaration.__lt__):
(ConditionalForwardDeclaration.__lt__.condition_str):
(ConditionalForwardDeclaration.__eq__):
(ConditionalForwardDeclaration.__hash__):
(generate_header):
(encode_cf_type):
(decode_cf_type):
(parse_serialized_types):
(main):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;CFBarRef&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;CGColorRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CGColorRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/269987@main">https://commits.webkit.org/269987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9a5b44fc965f23d9c64be34b2ec878b52a1f951

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24187 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26321 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26910 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/24359 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21823 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22118 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/19172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/2047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5794 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->