### PR TITLE
Non-unified build fixes, Halloween 2023 edition

### DIFF
--- a/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
+++ b/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(SERVICE_WORKER)
 
 #include "PushManager.h"
+#include "ScriptExecutionContext.h"
 #include "ServiceWorkerRegistration.h"
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
@@ -26,6 +26,7 @@
 #include "WebLockRegistry.h"
 
 #include "Exception.h"
+#include "ScriptExecutionContext.h"
 #include "WebLockManager.h"
 #include "WebLockManagerSnapshot.h"
 #include <wtf/CompletionHandler.h>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -32,6 +32,7 @@
 #include "AXLogger.h"
 #include "AXObjectCache.h"
 #include "AXTextMarker.h"
+#include "AccessibilityMockObject.h"
 #include "AccessibilityRenderObject.h"
 #include "AccessibilityScrollView.h"
 #include "AccessibilityTable.h"

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -30,6 +30,7 @@
 #include "CommonAtomStrings.h"
 #include "FillMode.h"
 #include "JSComputedEffectTiming.h"
+#include "ScriptExecutionContext.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/animation/AnimationEventBase.cpp
+++ b/Source/WebCore/animation/AnimationEventBase.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AnimationEventBase.h"
 
+#include "ScriptExecutionContext.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/animation/CustomEffect.cpp
+++ b/Source/WebCore/animation/CustomEffect.cpp
@@ -27,6 +27,7 @@
 #include "CustomEffect.h"
 
 #include "CustomEffectCallback.h"
+#include "ScriptExecutionContext.h"
 #include <JavaScriptCore/Exception.h>
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/animation/ElementAnimationRareData.cpp
+++ b/Source/WebCore/animation/ElementAnimationRareData.cpp
@@ -30,6 +30,7 @@
 #include "CSSTransition.h"
 #include "KeyframeEffectStack.h"
 #include "RenderStyle.h"
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ElementAnimationRareData);

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -39,6 +39,7 @@
 #include "DeclarativeAnimation.h"
 #include "Element.h"
 #include "KeyframeEffectStack.h"
+#include "ScriptExecutionContext.h"
 #include "WebAnimation.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSFileSystemEntryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSFileSystemEntryCustom.cpp
@@ -31,7 +31,7 @@
 #include "JSDOMBinding.h"
 #include "JSFileSystemDirectoryEntry.h"
 #include "JSFileSystemFileEntry.h"
-
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSFileSystemHandleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSFileSystemHandleCustom.cpp
@@ -31,6 +31,7 @@
 #include "JSDOMBinding.h"
 #include "JSFileSystemDirectoryHandle.h"
 #include "JSFileSystemFileHandle.h"
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp
@@ -30,7 +30,7 @@
 
 #include "JSDOMBinding.h"
 #include "JSIDBObjectStore.h"
-
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -93,6 +93,7 @@
 #include "RenderStyleConstants.h"
 #include "SVGPathByteStream.h"
 #include "SVGPathUtilities.h"
+#include "ScriptExecutionContext.h"
 #include "StyleColor.h"
 #include "TimingFunction.h"
 #include "WebKitFontFamilyNames.h"

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -22,7 +22,7 @@
 #include "config.h"
 #include "CDATASection.h"
 
-#include "Document.h"
+#include "DocumentInlines.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -28,8 +28,8 @@
 
 #include "ContentVisibilityAutoStateChangeEvent.h"
 #include "DeclarativeAnimation.h"
+#include "DocumentInlines.h"
 #include "DocumentTimeline.h"
-#include "Element.h"
 #include "EventNames.h"
 #include "FrameSelection.h"
 #include "IntersectionObserverCallback.h"

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ContextDestructionObserver.h"
+#include "EventTarget.h"
 #include "QualifiedName.h"
 #include <wtf/Lock.h>
 #include <wtf/RobinHoodHashMap.h>

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -33,6 +33,7 @@
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
 #include "CachedResourceRequestInitiatorTypes.h"
+#include "DocumentInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "LocalFrame.h"

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -24,10 +24,10 @@
  */
 
 #include "config.h"
-
-#if ENABLE(FULLSCREEN_API)
 #include "DocumentFullscreen.h"
 
+#if ENABLE(FULLSCREEN_API)
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "EventLoop.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -29,6 +29,7 @@
 
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "DocumentInlines.h"
 #include "LocalFrame.h"
 #include "NodeTraversal.h"
 #include "Page.h"

--- a/Source/WebCore/dom/DocumentType.cpp
+++ b/Source/WebCore/dom/DocumentType.cpp
@@ -24,6 +24,7 @@
 #include "DocumentType.h"
 
 #include "Document.h"
+#include "Element.h"
 #include "NamedNodeMap.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -27,10 +27,9 @@
 
 #include <memory>
 #include <wtf/CheckedPtr.h>
-#include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
-#include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/PendingScript.h
+++ b/Source/WebCore/dom/PendingScript.h
@@ -27,6 +27,7 @@
 
 #include "LoadableScript.h"
 #include "LoadableScriptClient.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/TextPosition.h>

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -34,7 +34,6 @@
 #include "RequestAnimationFrameCallback.h"
 #include "Settings.h"
 #include "UserGestureIndicator.h"
-#include <wtf/Ref.h>
 #include <wtf/SystemTracing.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -29,6 +29,7 @@
 #include "AnimationFrameRate.h"
 #include "ReducedResolutionSeconds.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -27,8 +27,8 @@
 #include "config.h"
 #include "AlternativeTextController.h"
 
-#include "Document.h"
-#include "DocumentMarkerController.h"
+#include "DocumentFragment.h"
+#include "DocumentInlines.h"
 #include "Editing.h"
 #include "Editor.h"
 #include "EditorClient.h"

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -27,8 +27,7 @@
 #include "DictationCommand.h"
 
 #include "AlternativeTextController.h"
-#include "Document.h"
-#include "DocumentMarkerController.h"
+#include "DocumentInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameSelection.h"
 #include "InsertParagraphSeparatorCommand.h"

--- a/Source/WebCore/editing/SplitTextNodeCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeCommand.cpp
@@ -27,8 +27,7 @@
 #include "SplitTextNodeCommand.h"
 
 #include "CompositeEditCommand.h"
-#include "Document.h"
-#include "DocumentMarkerController.h"
+#include "DocumentInlines.h"
 #include "Text.h"
 #include <wtf/Assertions.h>
 

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "VisibleSelection.h"
 
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "Editing.h"
 #include "Element.h"
 #include "HTMLInputElement.h"

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -27,7 +27,7 @@
 #include "config.h"
 #include "VisibleUnits.h"
 
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "Editing.h"
 #include "HTMLBRElement.h"
 #include "HTMLElement.h"

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -27,6 +27,7 @@
 #include "CachedPage.h"
 
 #include "Document.h"
+#include "DocumentLoader.h"
 #include "Element.h"
 #include "FocusController.h"
 #include "FrameLoader.h"

--- a/Source/WebCore/html/SubmitInputType.cpp
+++ b/Source/WebCore/html/SubmitInputType.cpp
@@ -53,7 +53,7 @@ bool SubmitInputType::appendFormData(DOMFormData& formData) const
     if (!element()->isActivatedSubmit())
         return false;
     formData.append(element()->name(), element()->valueWithDefault());
-    if (auto& dirname = element()->attributeWithoutSynchronization(dirnameAttr); !dirname.isNull())
+    if (auto& dirname = element()->attributeWithoutSynchronization(HTMLNames::dirnameAttr); !dirname.isNull())
         formData.append(dirname, element()->directionForFormData());
     return true;
 }

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -32,8 +32,11 @@
 #include "config.h"
 #include "HTMLSrcsetParser.h"
 
+#include "Element.h"
 #include "HTMLParserIdioms.h"
 #include "ParsingUtilities.h"
+#include <wtf/URL.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.h
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <wtf/ListHashSet.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/shadow/SwitchThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.cpp
@@ -25,7 +25,9 @@
 #include "config.h"
 #include "SwitchThumbElement.h"
 
+#include "RenderStyleInlines.h"
 #include "ResolvedStyle.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/shadow/SwitchTrackElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.cpp
@@ -25,7 +25,9 @@
 #include "config.h"
 #include "SwitchTrackElement.h"
 
+#include "RenderStyleInlines.h"
 #include "ResolvedStyle.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -39,6 +39,7 @@
 #include "AudioTrackList.h"
 #include "AudioTrackPrivate.h"
 #include "CommonAtomStrings.h"
+#include "ScriptExecutionContext.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -24,12 +24,12 @@
  */
 
 #include "config.h"
+#include "AudioTrackList.h"
 
 #if ENABLE(VIDEO)
 
-#include "AudioTrackList.h"
-
 #include "AudioTrack.h"
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -35,6 +35,7 @@
 #if ENABLE(VIDEO)
 
 #include "CommonAtomStrings.h"
+#include "ScriptExecutionContext.h"
 #include "VideoTrackClient.h"
 #include "VideoTrackConfiguration.h"
 #include "VideoTrackList.h"

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -24,11 +24,11 @@
  */
 
 #include "config.h"
+#include "VideoTrackList.h"
 
 #if ENABLE(VIDEO)
 
-#include "VideoTrackList.h"
-
+#include "ScriptExecutionContext.h"
 #include "VideoTrack.h"
 
 namespace WebCore {

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -77,6 +77,7 @@
 #include "NodeTraversal.h"
 #include "Page.h"
 #include "ProcessWarming.h"
+#include "RemoteFrame.h"
 #include "RenderLayerCompositor.h"
 #include "RenderTableCell.h"
 #include "RenderText.h"

--- a/Source/WebCore/platform/graphics/FontMetrics.h
+++ b/Source/WebCore/platform/graphics/FontMetrics.h
@@ -21,6 +21,7 @@
 #define FontMetrics_h
 
 #include "FontBaseline.h"
+#include <optional>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/LayoutRepainter.cpp
+++ b/Source/WebCore/rendering/LayoutRepainter.cpp
@@ -27,6 +27,7 @@
 #include "LayoutRepainter.h"
 
 #include "RenderElement.h"
+#include "RenderLayerModelObject.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -27,8 +27,7 @@
 #include "MarkedText.h"
 
 #include "DeprecatedGlobalSettings.h"
-#include "Document.h"
-#include "DocumentMarkerController.h"
+#include "DocumentInlines.h"
 #include "Editor.h"
 #include "ElementRuleCollector.h"
 #include "HighlightRegistry.h"

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -26,7 +26,7 @@
 
 #include "BackgroundPainter.h"
 #include "DeprecatedGlobalSettings.h"
-#include "DocumentMarkerController.h"
+#include "DocumentInlines.h"
 #include "ElementRuleCollector.h"
 #include "FloatRoundedRect.h"
 #include "GraphicsContext.h"

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -26,7 +26,7 @@
 #include "TextBoxPainter.h"
 
 #include "CompositionHighlight.h"
-#include "DocumentMarkerController.h"
+#include "DocumentInlines.h"
 #include "Editor.h"
 #include "EventRegion.h"
 #include "GraphicsContext.h"

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -43,6 +43,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGNames.h"
 #include "SVGPathData.h"
+#include "SVGRenderStyle.h"
 #include "SVGRenderingContext.h"
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -22,6 +22,7 @@
 #include "RenderSVGResourceContainer.h"
 
 #include "RenderLayer.h"
+#include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGRoot.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGResourcesCache.h"

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
@@ -32,6 +32,7 @@
 #include "WKBundleAPICast.h"
 #include "WebFrame.h"
 #include "WebImage.h"
+#include <WebCore/ScriptExecutionContext.h>
 
 WKTypeID WKBundleHitTestResultGetTypeID()
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
@@ -30,7 +30,6 @@
 
 #include "GeolocationPermissionRequestManager.h"
 #include "WebGeolocationManager.h"
-#include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/Geolocation.h>
 #include <WebCore/GeolocationPositionData.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
@@ -25,12 +25,11 @@
 
 #pragma once
 
+#include "WebPage.h"
 #include <WebCore/GeolocationClient.h>
 #include <wtf/CheckedRef.h>
 
 namespace WebKit {
-
-class WebPage;
 
 class WebGeolocationClient final : public WebCore::GeolocationClient {
     WTF_MAKE_FAST_ALLOCATED;


### PR DESCRIPTION
#### 5e757ac6671257c48e961235785ff22e8aeef792
<pre>
Non-unified build fixes, Halloween 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=263942">https://bugs.webkit.org/show_bug.cgi?id=263942</a>

Unreviewed non-unified build fix.

Run non-unified PlayStation Release build and add missing includes.

* Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp:
* Source/WebCore/Modules/web-locks/WebLockRegistry.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/animation/AnimationEffect.cpp:
* Source/WebCore/animation/AnimationEventBase.cpp:
* Source/WebCore/animation/CustomEffect.cpp:
* Source/WebCore/animation/ElementAnimationRareData.cpp:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
* Source/WebCore/bindings/js/JSFileSystemEntryCustom.cpp:
* Source/WebCore/bindings/js/JSFileSystemHandleCustom.cpp:
* Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/dom/CDATASection.cpp:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/DocumentFontLoader.cpp:
* Source/WebCore/dom/DocumentFullscreen.cpp:
* Source/WebCore/dom/DocumentMarkerController.cpp:
* Source/WebCore/dom/DocumentType.cpp:
* Source/WebCore/dom/IdTargetObserverRegistry.h:
* Source/WebCore/dom/PendingScript.h:
* Source/WebCore/dom/ScriptedAnimationController.cpp:
* Source/WebCore/dom/ScriptedAnimationController.h:
* Source/WebCore/editing/AlternativeTextController.cpp:
* Source/WebCore/editing/DictationCommand.cpp:
* Source/WebCore/editing/SplitTextNodeCommand.cpp:
* Source/WebCore/editing/VisibleSelection.cpp:
* Source/WebCore/editing/VisibleUnits.cpp:
* Source/WebCore/history/CachedPage.cpp:
* Source/WebCore/html/SubmitInputType.cpp:
(WebCore::SubmitInputType::appendFormData const):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
* Source/WebCore/html/parser/HTMLSrcsetParser.h:
* Source/WebCore/html/shadow/SwitchThumbElement.cpp:
* Source/WebCore/html/shadow/SwitchTrackElement.cpp:
* Source/WebCore/html/track/AudioTrack.cpp:
* Source/WebCore/html/track/AudioTrackList.cpp:
* Source/WebCore/html/track/VideoTrack.cpp:
* Source/WebCore/html/track/VideoTrackList.cpp:
* Source/WebCore/page/LocalFrame.cpp:
* Source/WebCore/platform/graphics/FontMetrics.h:
* Source/WebCore/rendering/LayoutRepainter.cpp:
* Source/WebCore/rendering/MarkedText.cpp:
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:

Canonical link: <a href="https://commits.webkit.org/269992@main">https://commits.webkit.org/269992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c388c7ad7c47f655823d96443b169b886f933935

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26339 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26928 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21840 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22137 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/19181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/2283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5803 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->