### PR TITLE
Adopt more smart pointers in WidthIterator's AdvanceInternalState & SmallCapsState

### DIFF
--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -35,6 +35,7 @@
 #include "GlyphBufferMembers.h"
 #include <climits>
 #include <limits>
+#include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
 
 class Font;
 
-class GlyphBuffer {
+class GlyphBuffer : public CanMakeCheckedPtr {
 public:
     bool isEmpty() const { return m_fonts.isEmpty(); }
     unsigned size() const { return m_fonts.size(); }


### PR DESCRIPTION
#### 62b32c741b5a41decc45e9454ca68ab8999751b0
<pre>
Adopt more smart pointers in WidthIterator&apos;s AdvanceInternalState &amp; SmallCapsState
<a href="https://bugs.webkit.org/show_bug.cgi?id=263933">https://bugs.webkit.org/show_bug.cgi?id=263933</a>

Reviewed by Ryosuke Niwa.

AdvanceInternalState &amp; SmallCapsState are stack objects so we can use RefPtrs to Font
objects without risk of introducing reference cycles.

* Source/WebCore/platform/graphics/GlyphBuffer.h:
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::AdvanceInternalState::AdvanceInternalState):
(WebCore::AdvanceInternalState::updateFont):
(WebCore::WidthIterator::commitCurrentFontRange):
(WebCore::fontForRange):
(WebCore::WidthIterator::startNewFontRangeIfNeeded):
(WebCore::resetFontRangeIfNeeded):
(WebCore::WidthIterator::advanceInternal):

Canonical link: <a href="https://commits.webkit.org/270009@main">https://commits.webkit.org/270009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61be69f212b5a1270fd845a0fccbbefd01ced9f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22743 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26930 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28064 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1522 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19183 "Found 1 new test failure: fast/media/media-query-dynamic-with-font-face.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1928 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3099 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->