### PR TITLE
Use more smart pointers in GlyphData & GlyphPage

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -30,6 +30,7 @@
 #include "RenderingResourceIdentifier.h"
 #include <variant>
 #include <wtf/BitVector.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Hasher.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
@@ -74,7 +75,7 @@ bool fontHasEitherTable(CTFontRef, unsigned tableTag1, unsigned tableTag2);
 #endif
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Font);
-class Font : public RefCounted<Font>, public CanMakeWeakPtr<Font> {
+class Font : public RefCounted<Font>, public CanMakeWeakPtr<Font>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Font);
 public:
     // Used to create platform fonts.

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1223,7 +1223,7 @@ int FontCascade::emphasisMarkAscent(const AtomString& mark) const
     if (!markGlyphData)
         return 0;
 
-    const Font* markFontData = markGlyphData.value().font;
+    CheckedPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return 0;
@@ -1237,7 +1237,7 @@ int FontCascade::emphasisMarkDescent(const AtomString& mark) const
     if (!markGlyphData)
         return 0;
 
-    const Font* markFontData = markGlyphData.value().font;
+    CheckedPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return 0;
@@ -1252,7 +1252,7 @@ const Font* FontCascade::fontForEmphasisMark(const AtomString& mark) const
         return { };
 
     ASSERT(markGlyphData->font);
-    return markGlyphData->font;
+    return markGlyphData->font.get();
 }
 
 int FontCascade::emphasisMarkHeight(const AtomString& mark) const
@@ -1401,7 +1401,7 @@ void FontCascade::drawEmphasisMarks(GraphicsContext& context, const GlyphBuffer&
     if (!markGlyphData)
         return;
 
-    const Font* markFontData = markGlyphData.value().font;
+    CheckedPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return;
@@ -1557,7 +1557,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
 
     if (!baseCharacterGlyphData.glyph)
         return nullptr;
-    return baseCharacterGlyphData.font;
+    return baseCharacterGlyphData.font.get();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -50,7 +50,7 @@ public:
     {
         unsigned index = GlyphPage::indexForCodePoint(c);
         ASSERT_WITH_SECURITY_IMPLICATION(index < GlyphPage::size);
-        return { m_glyphs[index], m_fonts[index] };
+        return { m_glyphs[index], m_fonts[index].get() };
     }
 
     void setGlyphDataForCharacter(UChar32 c, GlyphData glyphData)
@@ -67,7 +67,7 @@ private:
     }
 
     Glyph m_glyphs[GlyphPage::size] { };
-    const Font* m_fonts[GlyphPage::size] { };
+    CheckedPtr<const Font> m_fonts[GlyphPage::size] { };
 };
 
 inline FontCascadeFonts::GlyphPageCacheEntry::GlyphPageCacheEntry(RefPtr<GlyphPage>&& singleFont)
@@ -338,12 +338,12 @@ static const Font* findBestFallbackFont(FontCascadeFonts& fontCascadeFonts, cons
         auto& fontRanges = fontCascadeFonts.realizeFallbackRangesAt(description, fallbackIndex);
         if (fontRanges.isNull())
             break;
-        auto* currentFont = fontRanges.glyphDataForCharacter(character, ExternalResourceDownloadPolicy::Forbid).font;
+        CheckedPtr currentFont = fontRanges.glyphDataForCharacter(character, ExternalResourceDownloadPolicy::Forbid).font;
         if (!currentFont)
             currentFont = &fontRanges.fontForFirstRange();
 
         if (!currentFont->isInterstitial())
-            return currentFont;
+            return currentFont.get();
     }
 
     return nullptr;

--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -95,7 +95,7 @@ GlyphData FontRanges::glyphDataForCharacter(UChar32 character, ExternalResourceD
                 } else {
                     auto glyphData = font->glyphDataForCharacter(character);
                     if (glyphData.font) {
-                        auto* glyphDataFont = glyphData.font;
+                        CheckedPtr glyphDataFont = glyphData.font;
                         if (glyphDataFont && glyphDataFont->visibility() == Font::Visibility::Visible && resultFont && resultFont->visibility() == Font::Visibility::Invisible)
                             return GlyphData(glyphData.glyph, &glyphDataFont->invisibleFont());
                         return glyphData;
@@ -118,7 +118,7 @@ GlyphData FontRanges::glyphDataForCharacter(UChar32 character, ExternalResourceD
 
 const Font* FontRanges::fontForCharacter(UChar32 character) const
 {
-    return glyphDataForCharacter(character, ExternalResourceDownloadPolicy::Allow).font;
+    return glyphDataForCharacter(character, ExternalResourceDownloadPolicy::Allow).font.get();
 }
 
 const Font& FontRanges::fontForFirstRange() const

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -30,16 +30,16 @@
 #ifndef GlyphPage_h
 #define GlyphPage_h
 
+#include "Font.h"
 #include "Glyph.h"
 #include "TextFlags.h"
 #include <unicode/utypes.h>
 #include <wtf/BitSet.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
-
-class Font;
 
 // Holds the glyph index and the corresponding Font information for a given
 // character.
@@ -55,7 +55,7 @@ struct GlyphData {
 
     Glyph glyph;
     ColorGlyphType colorGlyphType;
-    const Font* font;
+    CheckedPtr<const Font> font;
 };
 
 // A GlyphPage contains a fixed-size set of GlyphData mappings for a contiguous
@@ -97,7 +97,7 @@ public:
     {
         Glyph glyph = glyphForIndex(index);
         auto colorGlyphType = colorGlyphTypeForIndex(index);
-        return GlyphData(glyph, glyph ? &m_font : nullptr, colorGlyphType);
+        return GlyphData(glyph, glyph ? m_font.ptr() : nullptr, colorGlyphType);
     }
 
     Glyph glyphForIndex(unsigned index) const
@@ -122,7 +122,7 @@ public:
 
     const Font& font() const
     {
-        return m_font;
+        return m_font.get();
     }
 
     // Implemented by the platform.
@@ -135,7 +135,7 @@ private:
         ++s_count;
     }
 
-    const Font& m_font;
+    CheckedRef<const Font> m_font;
     Glyph m_glyphs[size] { };
     WTF::BitSet<size> m_isColor;
 

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -382,7 +382,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         return;
 
     const GlyphData& glyphData = m_font.glyphDataForCharacter(character, false, FontVariant::NormalVariant);
-    advanceInternalState.updateFont(glyphData.font ? glyphData.font : primaryFont.ptr());
+    advanceInternalState.updateFont(glyphData.font ? glyphData.font.get() : primaryFont.ptr());
     auto capitalizedCharacter = capitalized(character);
     if (shouldSynthesizeSmallCaps(smallCapsState.dontSynthesizeSmallCaps, advanceInternalState.font.get(), character, capitalizedCharacter, smallCapsState.fontVariantCaps, smallCapsState.engageAllSmallCapsProcessing))
         smallCapsState.setSmallCapsData(advanceInternalState.font.get(), fontDescription);
@@ -411,7 +411,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         }
 #endif
         const GlyphData& glyphData = m_font.glyphDataForCharacter(character, false, FontVariant::NormalVariant);
-        advanceInternalState.updateFont(glyphData.font ? glyphData.font : primaryFont.ptr());
+        advanceInternalState.updateFont(glyphData.font ? glyphData.font.get() : primaryFont.ptr());
         smallCapsState.shouldSynthesizeCharacter = shouldSynthesizeSmallCaps(smallCapsState.dontSynthesizeSmallCaps, advanceInternalState.font.get(), character, capitalizedCharacter, smallCapsState.fontVariantCaps, smallCapsState.engageAllSmallCapsProcessing);
         updateCharacterAndSmallCapsIfNeeded(smallCapsState, capitalizedCharacter, characterToWrite);
 
@@ -424,7 +424,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
             characterToWrite = u_charMirror(characterToWrite);
 
         Glyph glyph = glyphData.glyph;
-        if (glyphData.font != advanceInternalState.nextRangeFont || character != characterToWrite)
+        if (glyphData.font.get() != advanceInternalState.nextRangeFont || character != characterToWrite)
             glyph = advanceInternalState.nextRangeFont->glyphForCharacter(characterToWrite);
 
         if (!glyph && !characterMustDrawSomething) {

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -123,19 +123,19 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     else if (characters[length - 1] == 0xFE0F)
         preferColoredFont = true;
 
-    const Font* baseFont = glyphDataForCharacter(character, false, NormalVariant).font;
+    CheckedPtr baseFont = glyphDataForCharacter(character, false, NormalVariant).font;
     if (baseFont
         && (clusterLength == length || baseFont->canRenderCombiningCharacterSequence(normalizedString.view))
         && (!preferColoredFont || baseFont->platformData().isColorBitmapFont()))
-        return baseFont;
+        return baseFont.get();
 
     for (unsigned i = 0; !fallbackRangesAt(i).isNull(); ++i) {
-        const Font* fallbackFont = fallbackRangesAt(i).fontForCharacter(character);
+        CheckedPtr fallbackFont = fallbackRangesAt(i).fontForCharacter(character);
         if (!fallbackFont || fallbackFont == baseFont)
             continue;
 
         if (fallbackFont->canRenderCombiningCharacterSequence(normalizedString.view) && (!preferColoredFont || fallbackFont->platformData().isColorBitmapFont()))
-            return fallbackFont;
+            return fallbackFont.get();
     }
 
     const auto& originalFont = fallbackRangesAt(0).fontForFirstRange();
@@ -148,7 +148,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
             return systemFallback.get();
     }
 
-    return baseFont;
+    return baseFont.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -416,7 +416,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
         return nullptr;
 
     if (isOnlySingleCodePoint)
-        return baseCharacterGlyphData.font;
+        return baseCharacterGlyphData.font.get();
 
     bool triedBaseCharacterFont = false;
 
@@ -456,7 +456,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     }
 
     if (!triedBaseCharacterFont && baseCharacterGlyphData.font && baseCharacterGlyphData.font->canRenderCombiningCharacterSequence(stringView))
-        return baseCharacterGlyphData.font;
+        return baseCharacterGlyphData.font.get();
 
     return Font::systemFallback();
 }

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -251,7 +251,7 @@ void MathOperator::calculateDisplayStyleLargeOperator(const RenderStyle& style)
 
     // We choose the first size variant that is larger than the expected displayOperatorMinHeight and otherwise fallback to the largest variant.
     for (auto& sizeVariant : sizeVariants) {
-        GlyphData glyphData(sizeVariant, baseGlyph.font);
+        GlyphData glyphData(sizeVariant, baseGlyph.font.get());
         setSizeVariant(glyphData);
         m_maxPreferredWidth = m_width;
         m_italicCorrection = glyphData.font->mathData()->getItalicCorrection(*glyphData.font, glyphData.glyph);
@@ -385,7 +385,7 @@ void MathOperator::calculateStretchyData(const RenderStyle& style, bool calculat
         getMathVariantsWithFallback(style, isVertical, sizeVariants, assemblyParts);
         // We verify the size variants.
         for (auto& sizeVariant : sizeVariants) {
-            GlyphData glyphData(sizeVariant, baseGlyph.font);
+            GlyphData glyphData(sizeVariant, baseGlyph.font.get());
             if (calculateMaxPreferredWidth)
                 m_maxPreferredWidth = std::max(m_maxPreferredWidth, LayoutUnit(advanceWidthForGlyph(glyphData)));
             else {


### PR DESCRIPTION
#### 7b5f8e5c3b54623b2bda4b582c5a866aed2bd3d9
<pre>
Use more smart pointers in GlyphData &amp; GlyphPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=263943">https://bugs.webkit.org/show_bug.cgi?id=263943</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::emphasisMarkAscent const):
(WebCore::FontCascade::emphasisMarkDescent const):
(WebCore::FontCascade::fontForEmphasisMark const):
(WebCore::FontCascade::drawEmphasisMarks const):
(WebCore::FontCascade::fontForCombiningCharacterSequence const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::MixedFontGlyphPage::glyphDataForCharacter const):
(WebCore::findBestFallbackFont):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::primaryFont):
* Source/WebCore/platform/graphics/FontRanges.cpp:
(WebCore::FontRanges::glyphDataForCharacter const):
(WebCore::FontRanges::fontForCharacter const):
* Source/WebCore/platform/graphics/GlyphPage.h:
(WebCore::GlyphPage::glyphDataForIndex const):
(WebCore::GlyphPage::font const):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::advanceInternal):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::fontForCombiningCharacterSequence const):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::calculateDisplayStyleLargeOperator):
(WebCore::MathOperator::calculateStretchyData):

Canonical link: <a href="https://commits.webkit.org/270013@main">https://commits.webkit.org/270013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c453803593e6b6fa1450b525c4e6a1a65a83270

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24738 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26994 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28117 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25906 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1582 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19247 "Build is being retried. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2860 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5813 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->