### PR TITLE
Adopt more smart pointers in WebsiteDataStore

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -301,6 +301,7 @@ public:
     void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&);
 
     DeviceIdHashSaltStorage& deviceIdHashSaltStorage() { return m_deviceIdHashSaltStorage.get(); }
+    Ref<DeviceIdHashSaltStorage> protectedDeviceIdHashSaltStorage();
 
     WebsiteDataStoreParameters parameters();
     static Vector<WebsiteDataStoreParameters> parametersFromEachWebsiteDataStore();
@@ -502,6 +503,8 @@ private:
 
     WebsiteDataStore();
     static WorkQueue& websiteDataStoreIOQueue();
+
+    Ref<WorkQueue> protectedQueue() const;
 
     // FIXME: Only Cocoa ports respect ShouldCreateDirectory, so you cannot rely on it to create
     // directories. This is confusing.


### PR DESCRIPTION
#### e247488557e6e2b0c47c2d41c97b65a473d940a5
<pre>
Adopt more smart pointers in WebsiteDataStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=263944">https://bugs.webkit.org/show_bug.cgi?id=263944</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::~WebsiteDataStore):
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
(WebKit::WebsiteDataStore::networkProcess):
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary):
(WebKit::WebsiteDataStore::protectedQueue const):
(WebKit::WebsiteDataStore::fetchData):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::fetchDataForRegistrableDomains):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::protectedDeviceIdHashSaltStorage):
(WebKit::WebsiteDataStore::setMaxStatisticsEntries):
(WebKit::WebsiteDataStore::setPruneEntriesDownTo):
(WebKit::WebsiteDataStore::setGrandfatheringTime):
(WebKit::WebsiteDataStore::setMinimumTimeBetweenDataRecordsRemoval):
(WebKit::WebsiteDataStore::setPrevalentResource):
(WebKit::WebsiteDataStore::setPrevalentResourceForDebugMode):
(WebKit::WebsiteDataStore::setVeryPrevalentResource):
(WebKit::WebsiteDataStore::setShouldClassifyResourcesBeforeDataRecordsRemoval):
(WebKit::WebsiteDataStore::setSubframeUnderTopFrameDomain):
(WebKit::WebsiteDataStore::setSubresourceUnderTopFrameDomain):
(WebKit::WebsiteDataStore::setSubresourceUniqueRedirectTo):
(WebKit::WebsiteDataStore::getResourceLoadStatisticsDataSummary):
(WebKit::WebsiteDataStore::scheduleCookieBlockingUpdate):
(WebKit::WebsiteDataStore::scheduleStatisticsAndDataRecordsProcessing):
(WebKit::WebsiteDataStore::setLastSeen):
(WebKit::WebsiteDataStore::mergeStatisticForTesting):
(WebKit::WebsiteDataStore::insertExpiredStatisticForTesting):
(WebKit::WebsiteDataStore::setNotifyPagesWhenDataRecordsWereScanned):
(WebKit::WebsiteDataStore::setIsRunningResourceLoadStatisticsTest):
(WebKit::WebsiteDataStore::getAllStorageAccessEntries):
(WebKit::WebsiteDataStore::setTimeToLiveUserInteraction):
(WebKit::WebsiteDataStore::logUserInteraction):
(WebKit::WebsiteDataStore::clearUserInteraction):
(WebKit::WebsiteDataStore::setGrandfathered):
(WebKit::WebsiteDataStore::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::WebsiteDataStore::resetCrossSiteLoadsWithLinkDecorationForTesting):
(WebKit::WebsiteDataStore::deleteCookiesForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsShouldDowngradeReferrerForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsShouldBlockThirdPartyCookiesForTesting):
(WebKit::WebsiteDataStore::setThirdPartyCookieBlockingMode):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsShouldEnbleSameSiteStrictEnforcementForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsToSameSiteStrictCookiesForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting):
(WebKit::WebsiteDataStore::setCacheMaxAgeCapForPrevalentResources):
(WebKit::WebsiteDataStore::processPools const):
(WebKit::WebsiteDataStore::getNetworkProcessConnection):
(WebKit::WebsiteDataStore::terminateNetworkProcess):
(WebKit::WebsiteDataStore::setTrackingPreventionEnabled):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsDebugMode):
(WebKit::WebsiteDataStore::closeDatabases):
(WebKit::WebsiteDataStore::clearResourceLoadStatisticsInWebProcesses):
(WebKit::WebsiteDataStore::dispatchOnQueue):
(WebKit::WebsiteDataStore::setCacheModelSynchronouslyForTesting):
(WebKit::WebsiteDataStore::resetQuota):
(WebKit::WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::setAppBoundDomainsForITP):
(WebKit::WebsiteDataStore::forwardManagedDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::setManagedDomainsForITP):
(WebKit::WebsiteDataStore::updateBundleIdentifierInNetworkProcess):
(WebKit::WebsiteDataStore::clearBundleIdentifierInNetworkProcess):
(WebKit::WebsiteDataStore::download):
(WebKit::WebsiteDataStore::processPushMessage):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/270008@main">https://commits.webkit.org/270008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f5f89fd38440acd9fbd723097b012e5b6c15161

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22300 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22755 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26943 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1594 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28070 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22078 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22155 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25855 "Found 2 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/origin-and-total-storage-ratio (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19191 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1939 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3100 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->