### PR TITLE
Lyrics jump around in Spotify

### DIFF
--- a/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-expected.txt
+++ b/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-expected.txt
@@ -1,0 +1,9 @@
+When canceling an animated scroll, we should not trigger a scroll from zero.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-overflow-expected.txt
+++ b/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-overflow-expected.txt
@@ -1,0 +1,9 @@
+When canceling an animated scroll, we should not trigger a scroll from zero.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-overflow.html
+++ b/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-overflow.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 300px;
+            height: 300px;
+            overflow: scroll;
+            border: 1px solid black;
+        }
+        
+        .content {
+            height: 2000px;
+            background-image: repeating-linear-gradient(transparent, silver 200px);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        description('When canceling an animated scroll, we should not trigger a scroll from zero.');
+        window.addEventListener('load', async () => {
+            let scroller = document.getElementsByClassName('scroller')[0];
+
+            const startingScrollOffset = 400;
+            scroller.scrollTo(0, startingScrollOffset);
+
+            scroller.addEventListener('scroll', () => {
+                if (scroller.scrollTop < startingScrollOffset)
+                    testFailed(`We should never see a scroll offset less than ${startingScrollOffset} - saw ${scroller.scrollTop}`);
+            }, false);
+
+            setTimeout(() => {
+                scroller.scrollTo({ top: 500, behavior: 'smooth' });
+            }, 10);
+
+            await UIHelper.startMonitoringWheelEvents();
+            
+            setTimeout(() => {
+                scroller.scrollTo({ top: 520, behavior: 'smooth' });
+            }, 60);
+
+            await UIHelper.waitForScrollCompletion();
+            finishJSTest();
+
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="content"></div>
+    </div>
+    <div id="console"></div>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero.html
+++ b/LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+            background-image: repeating-linear-gradient(transparent, silver 500px);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        description('When canceling an animated scroll, we should not trigger a scroll from zero.');
+        window.addEventListener('load', async () => {
+            const startingScrollOffset = 400;
+            window.scrollTo(0, startingScrollOffset);
+
+            window.addEventListener('scroll', () => {
+                if (window.scrollTop < startingScrollOffset)
+                    testFailed(`We should never see a scroll offset less than ${startingScrollOffset} - saw ${window.scrollTop}`);
+            }, false);
+
+            setTimeout(() => {
+                window.scrollTo({ top: 500, behavior: 'smooth' });
+            }, 10);
+
+            await UIHelper.startMonitoringWheelEvents();
+            
+            setTimeout(() => {
+                window.scrollTo({ top: 520, behavior: 'smooth' });
+            }, 60);
+
+            await UIHelper.waitForScrollCompletion();
+            finishJSTest();
+
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="content"></div>
+    </div>
+    <div id="console"></div>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -317,8 +317,18 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
 
     if (requestedScrollData.requestedDataBeforeAnimatedScroll) {
         auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *requestedScrollData.requestedDataBeforeAnimatedScroll;
-        auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
-        scrollTo(intermediatePosition, scrollType, clamping);
+
+        switch (requestType) {
+        case ScrollRequestType::PositionUpdate:
+        case ScrollRequestType::DeltaUpdate: {
+            auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
+            scrollTo(intermediatePosition, scrollType, clamping);
+            break;
+        }
+        case ScrollRequestType::CancelAnimatedScroll:
+            stopAnimatedScroll();
+            break;
+        }
     }
 
     auto destinationPosition = requestedScrollData.destinationPosition(currentScrollPosition);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -282,7 +282,8 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         auto currentScrollPosition = webPageProxy->scrollingCoordinatorProxy()->currentMainFrameScrollPosition();
         if (auto previousData = std::exchange(requestedScroll->requestedDataBeforeAnimatedScroll, std::nullopt)) {
             auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *previousData;
-            currentScrollPosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
+            if (requestType != ScrollRequestType::CancelAnimatedScroll)
+                currentScrollPosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
         }
 
         webPageProxy->requestScroll(requestedScroll->destinationPosition(currentScrollPosition), layerTreeTransaction.scrollOrigin(), requestedScroll->animated);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -165,8 +165,18 @@ void RemoteScrollingTreeMac::startPendingScrollAnimations()
 
         if (auto previousData = std::exchange(data.requestedDataBeforeAnimatedScroll, std::nullopt)) {
             auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *previousData;
-            auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
-            targetNode->scrollTo(intermediatePosition, scrollType, clamping);
+
+            switch (requestType) {
+            case ScrollRequestType::PositionUpdate:
+            case ScrollRequestType::DeltaUpdate: {
+                auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
+                targetNode->scrollTo(intermediatePosition, scrollType, clamping);
+                break;
+            }
+            case ScrollRequestType::CancelAnimatedScroll:
+                targetNode->stopAnimatedScroll();
+                break;
+            }
         }
 
         targetNode->startAnimatedScrollToPosition(data.destinationPosition(currentScrollPosition));


### PR DESCRIPTION
#### c2314679be38e362cb9f6fbe7ad9c21aabfecbc1
<pre>
Lyrics jump around in Spotify
<a href="https://bugs.webkit.org/show_bug.cgi?id=263946">https://bugs.webkit.org/show_bug.cgi?id=263946</a>
<a href="https://rdar.apple.com/116843612">rdar://116843612</a>

Reviewed by Tim Horton.

The `RequestedScrollData` that&apos;s processed on the scrolling thread or in the UI process for a programmatic
scroll can contain secondary data that says what to do before starting an animated scroll, in
`requestedDataBeforeAnimatedScroll`.

The three places that process this data were failing to take into account the `ScrollRequestType::CancelAnimatedScroll`
request type, which resulted in using `positionOrDeltaBeforeAnimatedScroll` to do an initial non-animated
scroll, which would always end up as 0,0 thus triggering the scroll to top behavior.

* LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-expected.txt: Added.
* LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-overflow-expected.txt: Added.
* LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero-overflow.html: Added.
* LayoutTests/fast/scrolling/cancel-animated-scroll-should-not-scroll-from-zero.html: Added.
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::startPendingScrollAnimations):

Canonical link: <a href="https://commits.webkit.org/270077@main">https://commits.webkit.org/270077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f637bcd4807b51a42cd6ca075ffb2aa98a9f19c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26644 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/503 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27231 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/22112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/26098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/21863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5868 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->