### PR TITLE
Fix layering violation in Frame::disconnectOwnerElement()

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9311,17 +9311,6 @@ void Document::detachFromFrame()
     observeFrame(nullptr);
 }
 
-void Document::frameWasDisconnectedFromOwner()
-{
-    if (!frame())
-        return;
-
-    if (RefPtr window = domWindow())
-        window->willDetachDocumentFromFrame();
-
-    detachFromFrame();
-}
-
 bool Document::hitTest(const HitTestRequest& request, HitTestResult& result)
 {
     return hitTest(request, result.hitTestLocation(), result);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1734,8 +1734,6 @@ public:
     WEBCORE_EXPORT bool isRunningUserScripts() const;
     WEBCORE_EXPORT void setAsRunningUserScripts();
 
-    void frameWasDisconnectedFromOwner();
-
     WEBCORE_EXPORT bool hitTest(const HitTestRequest&, HitTestResult&);
     bool hitTest(const HitTestRequest&, const HitTestLocation&, HitTestResult&);
 #if ASSERT_ENABLED
@@ -1841,6 +1839,8 @@ public:
 
     void invalidateDOMCookieCache();
 
+    void detachFromFrame();
+
 protected:
     enum class ConstructionFlag : uint8_t {
         Synthesized = 1 << 0,
@@ -1915,8 +1915,6 @@ private:
 
     void pendingTasksTimerFired();
     bool isCookieAverse() const;
-
-    void detachFromFrame();
 
     template<CollectionType> Ref<HTMLCollection> ensureCachedCollection();
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -26,9 +26,7 @@
 #include "config.h"
 #include "Frame.h"
 
-#include "DocumentInlines.h"
 #include "HTMLFrameOwnerElement.h"
-#include "LocalFrame.h"
 #include "NavigationScheduler.h"
 #include "Page.h"
 #include "RemoteFrame.h"
@@ -103,9 +101,7 @@ void Frame::disconnectOwnerElement()
         m_ownerElement = nullptr;
     }
 
-    // FIXME: This is a layering violation. Move this code so Frame doesn't do anything with its Document.
-    if (auto* document = is<LocalFrame>(*this) ? downcast<LocalFrame>(*this).document() : nullptr)
-        document->frameWasDisconnectedFromOwner();
+    frameWasDisconnectedFromOwner();
 }
 
 void Frame::takeWindowProxyFrom(Frame& frame)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -89,6 +89,8 @@ protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent);
     void resetWindowProxy();
 
+    virtual void frameWasDisconnectedFromOwner() const { }
+
 private:
     virtual DOMWindow* virtualWindow() const = 0;
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1232,6 +1232,17 @@ DataDetectionResultsStorage& LocalFrame::dataDetectionResults()
 
 #endif
 
+void LocalFrame::frameWasDisconnectedFromOwner() const
+{
+    if (!m_doc)
+        return;
+
+    if (RefPtr window = m_doc->domWindow())
+        window->willDetachDocumentFromFrame();
+
+    protectedDocument()->detachFromFrame();
+}
+
 } // namespace WebCore
 
 #undef FRAME_RELEASE_LOG_ERROR

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -301,6 +301,9 @@ public:
 
     void documentURLDidChange(const URL&);
 
+protected:
+    void frameWasDisconnectedFromOwner() const final;
+
 private:
     friend class NavigationDisabler;
 


### PR DESCRIPTION
#### d20a6a2130032e592e10109d6a4617f7b741e684
<pre>
Fix layering violation in Frame::disconnectOwnerElement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263948">https://bugs.webkit.org/show_bug.cgi?id=263948</a>
<a href="https://rdar.apple.com/117721204">rdar://117721204</a>

Reviewed by Pascoe.

Document should only be used from LocalFrame.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::frameWasDisconnectedFromOwner): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::disconnectOwnerElement):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::frameWasDisconnectedFromOwner const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::frameWasDisconnectedFromOwner const):
* Source/WebCore/page/LocalFrame.h:

Canonical link: <a href="https://commits.webkit.org/270042@main">https://commits.webkit.org/270042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59ace1ee57e6c8214c85688272a1f58d1afab083

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22394 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22829 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27052 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28162 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22259 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25958 "Found 2 new API test failures: /WebKitGTK/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WebKitGTK/TestLoaderClient:/webkit/WebKitURIRequest/http-headers (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1629 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2 "Found 1 new test failure: fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2908 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2035 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3111 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->