### PR TITLE
[WebGPU] GPUShaderModule.getCompilationInfo crashes

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp
@@ -78,7 +78,7 @@ void ShaderModuleImpl::compilationInfo(CompletionHandler<void(Ref<CompilationInf
 
         for (size_t i = 0; i < compilationInfo->messageCount; ++i) {
             auto& message = compilationInfo->messages[i];
-            messages.append(CompilationMessage::create(String::fromLatin1(message.message), convertFromBacking(message.type), message.lineNum, message.linePos, message.offset, message.length));
+            messages.append(CompilationMessage::create(message.message, convertFromBacking(message.type), message.lineNum, message.linePos, message.offset, message.length));
         }
 
         callback(CompilationInfo::create(WTFMove(messages)));

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -167,7 +167,7 @@ struct Messages {
 };
 
 struct CompilationMessageData {
-    CompilationMessageData(Vector<WGPUCompilationMessage>&& compilationMessages, Vector<CString>&& messages)
+    CompilationMessageData(Vector<WGPUCompilationMessage>&& compilationMessages, Vector<String>&& messages)
         : compilationMessages(WTFMove(compilationMessages))
         , messages(WTFMove(messages))
     {
@@ -177,17 +177,17 @@ struct CompilationMessageData {
     CompilationMessageData(CompilationMessageData&&) = default;
 
     Vector<WGPUCompilationMessage> compilationMessages;
-    Vector<CString> messages;
+    Vector<String> messages;
 };
 
 static CompilationMessageData convertMessages(const Messages& messages1, const std::optional<Messages>& messages2 = std::nullopt)
 {
     Vector<WGPUCompilationMessage> flattenedCompilationMessages;
-    Vector<CString> flattenedMessages;
+    Vector<String> flattenedMessages;
 
     auto populateMessages = [&](const Messages& compilationMessages) {
         for (const auto& compilationMessage : compilationMessages.messages)
-            flattenedMessages.append(compilationMessage.message().utf8());
+            flattenedMessages.append(compilationMessage.message());
     };
 
     populateMessages(messages1);
@@ -199,7 +199,7 @@ static CompilationMessageData convertMessages(const Messages& messages1, const s
             const auto& compilationMessage = compilationMessages.messages[i];
             flattenedCompilationMessages.append({
                 .nextInChain = nullptr,
-                .message = flattenedMessages[i + base].data(),
+                .message = flattenedMessages[i + base],
                 .type = compilationMessages.type,
                 .lineNum = compilationMessage.lineNumber(),
                 .linePos = compilationMessage.lineOffset(),
@@ -228,9 +228,7 @@ void ShaderModule::getCompilationInfo(CompletionHandler<void(WGPUCompilationInfo
             static_cast<uint32_t>(compilationMessageData.compilationMessages.size()),
             compilationMessageData.compilationMessages.data(),
         };
-        m_device->instance().scheduleWork([compilationInfo = WTFMove(compilationInfo), callback = WTFMove(callback)]() mutable {
-            callback(WGPUCompilationInfoRequestStatus_Success, compilationInfo);
-        });
+        callback(WGPUCompilationInfoRequestStatus_Success, compilationInfo);
     }, [&](const WGSL::FailedCheck& failedCheck) {
         auto compilationMessageData(convertMessages(
             { failedCheck.errors, WGPUCompilationMessageType_Error },
@@ -240,9 +238,7 @@ void ShaderModule::getCompilationInfo(CompletionHandler<void(WGPUCompilationInfo
             static_cast<uint32_t>(compilationMessageData.compilationMessages.size()),
             compilationMessageData.compilationMessages.data(),
         };
-        m_device->instance().scheduleWork([compilationInfo = WTFMove(compilationInfo), callback = WTFMove(callback)]() mutable {
-            callback(WGPUCompilationInfoRequestStatus_Error, compilationInfo);
-        });
+        callback(WGPUCompilationInfoRequestStatus_Error, compilationInfo);
     }, [](std::monostate) {
         ASSERT_NOT_REACHED();
     });

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -67,6 +67,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+#include <wtf/text/WTFString.h>
+#endif
+
 #define WGPU_ARRAY_LAYER_COUNT_UNDEFINED (0xffffffffUL)
 #define WGPU_COPY_STRIDE_UNDEFINED (0xffffffffUL)
 #define WGPU_LIMIT_U32_UNDEFINED (0xffffffffUL)
@@ -822,7 +826,11 @@ typedef struct WGPUCommandEncoderDescriptor {
 
 typedef struct WGPUCompilationMessage {
     WGPUChainedStruct const * nextInChain;
+#ifdef __cplusplus
+    WTF::String message;
+#else
     WGPU_NULLABLE char const * message;
+#endif
     WGPUCompilationMessageType type;
     uint64_t lineNum;
     uint64_t linePos;


### PR DESCRIPTION
#### a59c221d09e9f89a0f3ab013e96fc9ebe33cbd80
<pre>
[WebGPU] GPUShaderModule.getCompilationInfo crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263951">https://bugs.webkit.org/show_bug.cgi?id=263951</a>
&lt;radar://117723027&gt;

Reviewed by Tadeu Zagallo.

Fix improper string lifetime usage which was resulting in crashes due to
C-types storing pointers to strings which had been deallocated.

Move types from char* to WTF::String to avoid these issues in general.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp:
(WebCore::WebGPU::ShaderModuleImpl::compilationInfo):
Type is now a String.

* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::CompilationMessageData::CompilationMessageData):
There is no need to do this asynchronously, the specification does not require that
and we weren&apos;t properly cloning the data over the async call.

(WebGPU::convertMessages):
This code was building a vector which gets returned and storing pointers, which
doesn&apos;t work in general.
(WebGPU::ShaderModule::getCompilationInfo):

* Source/WebGPU/WebGPU/WebGPU.h:
Store WTF::String instead of raw pointer to char.

Canonical link: <a href="https://commits.webkit.org/270014@main">https://commits.webkit.org/270014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e666822e04afd5cdc72f2d4256dab37226684e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24741 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26997 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21904 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25917 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1585 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19244 "Build is being retried. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 5 flakes 2 failures; Uploaded test results") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2863 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5814 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->