### PR TITLE
Regression(244527@main): SVG lightning filter for ARM-NEON

### DIFF
--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeArithmeticNEON.h
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeArithmeticNEON.h
@@ -29,14 +29,14 @@
 
 #if HAVE(ARM_NEON_INTRINSICS)
 
-#include "FEComposite.h"
+#include "FECompositeSoftwareApplier.h"
 #include "NEONHelpers.h"
 #include <arm_neon.h>
 
 namespace WebCore {
 
 template <int b1, int b4>
-inline void FEComposite::computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
+inline void FECompositeSoftwareApplier::computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
 {
     float32x4_t k1x4 = vdupq_n_f32(k1 / 255);
     float32x4_t k2x4 = vdupq_n_f32(k2);
@@ -67,7 +67,7 @@ inline void FEComposite::computeArithmeticPixelsNeon(const uint8_t* source, uint
     }
 }
 
-inline void FEComposite::platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
+inline void FECompositeSoftwareApplier::platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4)
 {
     if (!k4) {
         if (!k1) {

--- a/Source/WebCore/platform/graphics/filters/FEComposite.h
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.h
@@ -74,13 +74,6 @@ private:
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;
 
-#if HAVE(ARM_NEON_INTRINSICS)
-    template <int b1, int b4>
-    static inline void computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
-
-    static inline void platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
-#endif
-
     CompositeOperationType m_type;
     float m_k1;
     float m_k2;

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -26,6 +26,7 @@
 #include "FECompositeSoftwareApplier.h"
 
 #include "FEComposite.h"
+#include "FECompositeArithmeticNEON.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
 #include "PixelBuffer.h"
@@ -140,13 +141,15 @@ bool FECompositeSoftwareApplier::applyArithmetic(FilterImage& input, FilterImage
     IntRect effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     input2.copyPixelBuffer(*destinationPixelBuffer, effectBDrawingRect);
 
-#if !HAVE(ARM_NEON_INTRINSICS)
     auto* sourcePixelBytes = sourcePixelBuffer->bytes();
     auto* destinationPixelBytes = destinationPixelBuffer->bytes();
 
     auto length = sourcePixelBuffer->sizeInBytes();
     ASSERT(length == destinationPixelBuffer->sizeInBytes());
+#if !HAVE(ARM_NEON_INTRINSICS)
     applyPlatformArithmetic(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
+#else
+    platformArithmeticNeon(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
 #endif
     return true;
 }

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.h
@@ -50,6 +50,12 @@ private:
 
     bool applyArithmetic(FilterImage& input, FilterImage& input2, FilterImage& result) const;
     bool applyNonArithmetic(FilterImage& input, FilterImage& input2, FilterImage& result) const;
+#if HAVE(ARM_NEON_INTRINSICS)
+    template <int b1, int b4>
+    static inline void computeArithmeticPixelsNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
+
+    static inline void platformArithmeticNeon(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 11f666470407de6625899c2729e829423f596431
<pre>
Regression(244527@main): SVG lightning filter for ARM-NEON
<a href="https://bugs.webkit.org/show_bug.cgi?id=263874">https://bugs.webkit.org/show_bug.cgi?id=263874</a>

Reviewed by NOBODY (OOPS!).

Without this fix the arithmetic computation of pixels in composite filter and for
ARM-NEON platform is not called at all.
This fix brings back calling a special computation for ARM-NEON platform after
regression from 244527@main.

* Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeArithmeticNEON.h:
(WebCore::FECompositeSoftwareApplier::computeArithmeticPixelsNeon):
(WebCore::FECompositeSoftwareApplier::platformArithmeticNeon):
(WebCore::FEComposite::computeArithmeticPixelsNeon): Deleted.
(WebCore::FEComposite::platformArithmeticNeon): Deleted.
* Source/WebCore/platform/graphics/filters/FEComposite.h:
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp:
(WebCore::FECompositeSoftwareApplier::applyArithmetic const):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11f666470407de6625899c2729e829423f596431

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26367 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22759 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26956 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28081 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25867 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19201 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->