### PR TITLE
Invalidate table columns when a column span changes

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -4862,6 +4862,7 @@
         "web-platform-tests/css/css-tables/min-max-size-table-content-box-ref.html",
         "web-platform-tests/css/css-tables/paint/col-paint-htb-rtl-ref.html",
         "web-platform-tests/css/css-tables/paint/col-paint-vrl-rtl-ref.html",
+        "web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-ref.html",
         "web-platform-tests/css/css-tables/row-group-margin-border-padding-ref.html",
         "web-platform-tests/css/css-tables/row-group-order-ref.html",
         "web-platform-tests/css/css-tables/row-margin-border-padding-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<link rel="author" title="Andreu Botella" href="abotella@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#drawing-cell-backgrounds">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
+<meta name=assert content="Changing the span of a table column element will invalidate column backgrounds">
+<style>
+table {
+  width: 100px;
+  height: 100px;
+  border-spacing: 0;
+}
+.green {
+  background: green;
+}
+.red {
+  background: red;
+}
+</style>
+<title>CSS table column span invalidation</title>
+<script>
+waitForAtLeastOneFrame().then(() => {
+  const changeSpanCol = document.getElementById("changeSpan");
+  changeSpanCol.setAttribute("span", "2");
+  takeScreenshot();
+});
+</script>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table>
+  <col id="changeSpan" class="green">
+  <col class="green">
+  <col class="red">
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<link rel="author" title="Andreu Botella" href="abotella@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#drawing-cell-backgrounds">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
+<meta name=assert content="Changing the span of a table column element will invalidate column backgrounds, even if previously any columns with backgrounds spanned no cells">
+<style>
+table {
+  width: 100px;
+  height: 100px;
+  border-spacing: 0;
+  background: linear-gradient(to right, green 67%, red 67%);
+}
+.green {
+  background: green;
+}
+</style>
+<title>CSS table column span invalidation</title>
+<script>
+waitForAtLeastOneFrame().then(() => {
+  const changeSpanCol = document.getElementById("changeSpan");
+  changeSpanCol.removeAttribute("span");
+  takeScreenshot();
+});
+</script>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table>
+  <col id="changeSpan" span="2">
+  <col>
+  <col class="green">
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<style>
+tr { background-color: rgb(255, 0, 0); }
+td:not(#remove) { background-color: green; }
+</style>
+<title>CSS Test Reference</title>
+<p>Test passes if you see three green cells and no red below.</p>
+<table>
+    <tr>
+        <td>A1</td>
+        <td>A2</td>
+    </tr>
+    <tr>
+        <td>B1</td>
+    </tr>
+</table>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<style>
+tr { background-color: rgb(255, 0, 0); }
+td:not(#remove) { background-color: green; }
+</style>
+<title>CSS Test Reference</title>
+<p>Test passes if you see three green cells and no red below.</p>
+<table>
+    <tr>
+        <td>A1</td>
+        <td>A2</td>
+    </tr>
+    <tr>
+        <td>B1</td>
+    </tr>
+</table>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<link rel="author" title="Chenguang Shao" href="chenguangshao1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#drawing-cell-backgrounds">
+<link rel="match" href="row-background-paint-remove-last-cell-ref.html">
+<style>
+tr { background-color: rgb(255, 0, 0); }
+td:not(#remove) { background-color: green; }
+</style>
+<title>CSS Table Module Test: table-row repaint after removing last cell</title>
+<script>
+waitForAtLeastOneFrame().then(() => {
+    const remove = document.getElementById('remove');
+    remove.remove();
+    takeScreenshot();
+});
+</script>
+<p>Test passes if you see three green cells and no red below.</p>
+<table>
+    <tr>
+        <td>A1</td>
+        <td>A2</td>
+    </tr>
+    <tr>
+        <td>B1</td>
+        <td id="remove"> B2 </td>
+    </tr>
+</table>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/w3c-import.log
@@ -14,9 +14,16 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-paint-htb-rtl-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-paint-htb-rtl-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-paint-htb-rtl.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-paint-vrl-rtl-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-paint-vrl-rtl-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-paint-vrl-rtl.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell.html

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -102,8 +102,12 @@ void RenderTableCol::updateFromElement()
         m_span = tc.span();
     } else
         m_span = 1;
-    if (m_span != oldSpan && hasInitializedStyle() && parent())
-        setNeedsLayoutAndPrefWidthsRecalc();
+    if (m_span != oldSpan && parent()) {
+        if (hasInitializedStyle())
+            setNeedsLayoutAndPrefWidthsRecalc();
+        if (RenderTable* table = this->table())
+            table->invalidateColumns();
+    }
 }
 
 void RenderTableCol::insertedIntoTree()


### PR DESCRIPTION
#### 4f29c3293f6e87e0b6fb0f8ceb91ce7005cd109c
<pre>
Invalidate table columns when a column span changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=246321">https://bugs.webkit.org/show_bug.cgi?id=246321</a>

Reviewed by Alan Baradlay.

A table column element (`RenderTableCol`) spans a number of actual
table columns, and that set of spanned columns can change when its
span attribute changes. However, when this happens, the table columns
are not currently being invalidated, which can result in the
background of the table columns not changing when it should.

This patch fixes that by invalidating the table columns when some
column&apos;s span changes, which will trigger a relayout and repaint of
the table.

This patch also incorporates the
`css/css-tables/paint/col-change-span-bg-invalidation-{001,002}.html`
WPT tests, which test that the column background is correctly updated.

Combined changes:
* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/col-change-span-bg-invalidation-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/row-background-paint-remove-last-cell.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/paint/w3c-import.log:
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::updateFromElement):

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/b2528beea2a54778f7314768d2352ccee8b7993f">https://github.com/web-platform-tests/wpt/commit/b2528beea2a54778f7314768d2352ccee8b7993f</a>
Canonical link: <a href="https://commits.webkit.org/282969@main">https://commits.webkit.org/282969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48890b9c264a206ed5c239cf0695e33dc40315d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25124 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24922 "Passed tests") | [⏳ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24558 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30309 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30537 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14295 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4423 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5889 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->