### PR TITLE
Update the GB18030 table for ICU 74.1

### DIFF
--- a/Source/WebCore/PAL/pal/text/EncodingTables.cpp
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.cpp
@@ -8626,9 +8626,11 @@ const std::array<UChar, 23940>& gb18030()
             (*array)[pointer] = icuOutput;
         }
         
+#if U_ICU_VERSION_MAJOR_NUM < 74
         // This is a difference between ICU and the encoding specification.
         ASSERT((*array)[6555] == 0xe5e5);
         (*array)[6555] = 0x3000;
+#endif
 
 #if !HAVE(GB_18030_2022)
         static std::array<std::pair<size_t, UChar>, 18> gb18030_2022Differences { {


### PR DESCRIPTION
#### 5a759283ec61057c92782099301d61db2da105ef
<pre>
Update the GB18030 table for ICU 74.1
<a href="https://bugs.webkit.org/show_bug.cgi?id=263953">https://bugs.webkit.org/show_bug.cgi?id=263953</a>

Reviewed by Don Olmstead.

An assertion was failing with ICU 74.1.

&gt; ASSERTION FAILED: (*array)[6555] == 0xe5e5
&gt; WebCore\PAL\pal\text\EncodingTables.cpp(8630) : operator()

ICU 74.1 fixed the problem.

  [ICU-22420] Align GB18030 decoders with the WHATWG decoding specification
  &lt;<a href="https://unicode-org.atlassian.net/browse/ICU-22420">https://unicode-org.atlassian.net/browse/ICU-22420</a>&gt;

* Source/WebCore/PAL/pal/text/EncodingTables.cpp:
Conditioned out the code if ICU &gt;= 74.

Canonical link: <a href="https://commits.webkit.org/270019@main">https://commits.webkit.org/270019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/755da1ce14328183ed3929aa3e0ed3ec1f6d846a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22766 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26975 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28093 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25881 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19213 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2844 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5820 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->