### PR TITLE
Drop unused DOMWindow::allWindows()

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -38,25 +38,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DOMWindow);
 
-HashMap<GlobalWindowIdentifier, DOMWindow*>& DOMWindow::allWindows()
-{
-    ASSERT(isMainThread());
-    static NeverDestroyed<HashMap<GlobalWindowIdentifier, DOMWindow*>> map;
-    return map;
-}
-
 DOMWindow::DOMWindow(GlobalWindowIdentifier&& identifier)
     : m_identifier(WTFMove(identifier))
 {
-    ASSERT(!allWindows().contains(m_identifier));
-    allWindows().add(m_identifier, this);
 }
 
-DOMWindow::~DOMWindow()
-{
-    ASSERT(allWindows().contains(identifier()));
-    allWindows().remove(identifier());
-}
+DOMWindow::~DOMWindow() = default;
 
 ExceptionOr<RefPtr<SecurityOrigin>> DOMWindow::createTargetOriginForPostMessage(const String& targetOrigin, Document& sourceDocument)
 {

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -27,6 +27,7 @@
 
 #include "EventTarget.h"
 #include "GlobalWindowIdentifier.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 
@@ -44,8 +45,6 @@ class DOMWindow : public RefCounted<DOMWindow>, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(DOMWindow);
 public:
     virtual ~DOMWindow();
-
-    static HashMap<GlobalWindowIdentifier, DOMWindow*>& allWindows();
 
     const GlobalWindowIdentifier& identifier() const { return m_identifier; }
     virtual Frame* frame() const = 0;


### PR DESCRIPTION
#### b78ce3c89382c1646ed15fe062ffb48841a3dffe
<pre>
Drop unused DOMWindow::allWindows()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263973">https://bugs.webkit.org/show_bug.cgi?id=263973</a>

Reviewed by Brent Fulgham.

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::DOMWindow):
(): Deleted.
(WebCore::DOMWindow::~DOMWindow): Deleted.
* Source/WebCore/page/DOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/270021@main">https://commits.webkit.org/270021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/401d99de3f9d61f1e702bf99a0d6e4060f239b24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24744 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27004 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28127 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22214 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25920 "Found 8 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WebKitGTK/TestResources:/webkit/WebKitWebResource/active-uri, /WebKitGTK/TestResources:/webkit/WebKitWebResource/mime-type, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/origin-and-total-storage-ratio, /WebKitGTK/TestResources:/webkit/WebKitWebResource/loading, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1588 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/19249 "Build is being retried. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2866 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5823 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->