### PR TITLE
AX: comboboxes with aria-activedescendant but no aria-owns no longer work

### DIFF
--- a/LayoutTests/accessibility/aria-combobox-no-owns-expected.txt
+++ b/LayoutTests/accessibility/aria-combobox-no-owns-expected.txt
@@ -1,0 +1,12 @@
+A combobox should still support aria-activedescendant even if it doesn't use aria-owns.
+PASS: list.selectedChildrenCount === 0
+Received AXSelectedChildrenChanged for Combobox
+PASS: list.selectedChildrenCount === 1
+PASS list.selectedChildAtIndex(0) is listitem1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+item1
+item2

--- a/LayoutTests/accessibility/aria-combobox-no-owns.html
+++ b/LayoutTests/accessibility/aria-combobox-no-owns.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<input type="text" role="combobox" id="combobox" aria-label="Combobox">
+<div role="list" id="list" aria-label="List1">
+  <div role="listitem" id="item1">item1</div>
+  <div role="listitem" id="item2">item2</div>
+</div>
+
+<script>
+    var output = "A combobox should still support aria-activedescendant even if it doesn't use aria-owns.\n";
+
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+        var selectedChildrenChangeCount = 0;
+
+        window.accessibilityController.addNotificationListener(function (target, notification) {
+            if (notification == "AXSelectedChildrenChanged" || notification == "AXSelectedRowsChanged") {
+                selectedChildrenChangeCount++;
+                var targetString = platformValueForW3CName(target);
+                output += "Received " + notification + " for " + targetString + "\n";
+            }
+        });
+
+        document.getElementById("combobox").focus();
+        var list = accessibilityController.accessibleElementById("list");
+        output += expect("list.selectedChildrenCount", "0");
+        document.getElementById("combobox").setAttribute("aria-activedescendant", "item1");
+        var listitem1 = accessibilityController.accessibleElementById("item1");
+        setTimeout(async function() {
+            output += await expectAsync("list.selectedChildrenCount", "1");
+            output += list.selectedChildAtIndex(0).isEqual(listitem1)
+                ? "PASS list.selectedChildAtIndex(0) is listitem1\n"
+                  : "FAIL list.selectedChildAtIndex(0) is not listitem1\n";
+
+            debug(output);
+            accessibilityController.removeNotificationListener();
+            finishJSTest();
+        }, 0);
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/accessibility/aria-combobox-no-owns-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/aria-combobox-no-owns-expected.txt
@@ -1,0 +1,11 @@
+A combobox should still support aria-activedescendant even if it doesn't use aria-owns.
+PASS: list.selectedChildrenCount === 0
+PASS: list.selectedChildrenCount === 1
+PASS list.selectedChildAtIndex(0) is listitem1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+item1
+item2

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2277,6 +2277,8 @@ void AXObjectCache::handleActiveDescendantChange(Element& element, const AtomStr
             target = ownedObject;
         else if (auto* controlledObject = Accessibility::findRelatedObjectInAncestry(*object, AXRelationType::ControllerFor, *activeDescendant))
             target = controlledObject;
+        else
+            target = object;
 #endif
     } else {
         // Check to see if the active descendant is a child of the controlled object. Then we have to use that


### PR DESCRIPTION
#### 481028cb765bb767493e48b704e8a64f5907ae37
<pre>
AX: comboboxes with aria-activedescendant but no aria-owns no longer work
<a href="https://bugs.webkit.org/show_bug.cgi?id=263979">https://bugs.webkit.org/show_bug.cgi?id=263979</a>
<a href="https://rdar.apple.com/117747058">rdar://117747058</a>

Reviewed by Tyler Wilcock.

WebKit should fire a notification when aria-activedescendant changes on
a combobox, even when the combobox doesn&apos;t use aria-owns or aria-controls.

* LayoutTests/accessibility/aria-combobox-no-owns-expected.txt: Added.
* LayoutTests/accessibility/aria-combobox-no-owns.html: Added.
* LayoutTests/platform/glib/accessibility/aria-combobox-no-owns-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/270182@main">https://commits.webkit.org/270182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48b62d68f9f209858dddd08f33cbf8ed408a52f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23064 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27442 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28453 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26263 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/287 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5934 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->