### PR TITLE
[WebGPU] Compiler error opening https://kishimisu.github.io/WebGPU-Fluid-Simulation/

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -602,7 +602,7 @@ void TypeChecker::visit(AST::IfStatement& statement)
     if (!unify(test, m_types.boolType()))
         typeError(statement.test().span(), "expected 'bool', found ", *test);
 
-    AST::Visitor::visit(statement.trueBody());
+    visit(statement.trueBody());
     if (statement.maybeFalseBody())
         AST::Visitor::visit(*statement.maybeFalseBody());
 }

--- a/Source/WebGPU/WGSL/tests/valid/scope.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/scope.wgsl
@@ -1,6 +1,14 @@
 // RUN: %wgslc
 
 fn testScope() {
+    var x = 1;
+    if (true) {
+        var x = 2;
+    } else if (true) {
+        var x = 2;
+    } else {
+        var x = 3;
+    }
     {
         let x : i32 = 0;
     }


### PR DESCRIPTION
#### 376fed929bfa203c14af13362ebc352d34cb3852
<pre>
[WebGPU] Compiler error opening <a href="https://kishimisu.github.io/WebGPU-Fluid-Simulation/">https://kishimisu.github.io/WebGPU-Fluid-Simulation/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=263911">https://bugs.webkit.org/show_bug.cgi?id=263911</a>
<a href="https://rdar.apple.com/117698934">rdar://117698934</a>

Reviewed by Mike Wyrzykowski.

When visiting the body of the if statement we were calling the base class&apos; visitor,
which resulted in a missing scope for that block.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/valid/scope.wgsl:

Canonical link: <a href="https://commits.webkit.org/270047@main">https://commits.webkit.org/270047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b526959e3779cbd184474ccd71686270bee532d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22361 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22807 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27016 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1680 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28142 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22156 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25923 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1601 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2878 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5842 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->