### PR TITLE
[WGSL] TypeChecker also ASSERTs on constants

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -383,11 +383,12 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
             typeError(InferBottom::No, variable.span(), "cannot initialize var of type '", *result, "' with value of type '", *initializerType, "'");
     }
 
-    if (value.has_value())
-        convertValue(variable.span(), result, *value);
-    if (variable.flavor() == AST::VariableFlavor::Const && result != m_types.bottomType())
-        ASSERT(value.has_value());
-    else
+    if (variable.flavor() == AST::VariableFlavor::Const && result != m_types.bottomType()) {
+        if (value)
+            convertValue(variable.span(), result, *value);
+        else
+            typeError(InferBottom::No, variable.span(), "INTERNAL ERROR: failed to compute constant");
+    } else
         value = std::nullopt;
 
     if (variable.flavor() == AST::VariableFlavor::Var) {


### PR DESCRIPTION
#### 8ca433aff29fe3d61a4ed6a6dd3423dbccb237a7
<pre>
[WGSL] TypeChecker also ASSERTs on constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=263981">https://bugs.webkit.org/show_bug.cgi?id=263981</a>
<a href="https://rdar.apple.com/117748362">rdar://117748362</a>

Reviewed by Mike Wyrzykowski.

This PR does 2 things:
- Fix an incorrect assert: the intention of the assertion, as the message suggests,
  is to report a constant for which we failed to compute a value. However, due to
  an oversight, the code always asserts, without actually checking if there is a value
  or not.
- We also change the ASSERTION into a type error, this allows running the CTS tests
  and getting failures instead of crashes. I do believe that an assertion is more
  correct here, but the error makes development a lot easier while we still have gaps
  in the constant evaluator.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):

Canonical link: <a href="https://commits.webkit.org/270017@main">https://commits.webkit.org/270017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/527e7c534448a49071406bbc1f43b11036229d59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22366 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24763 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27021 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22163 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22221 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/2883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5816 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2007 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/1974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->