### PR TITLE
Incorrect documentation for webkit-cookie-manager-get-cookies-finish

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
@@ -355,7 +355,7 @@ void webkit_cookie_manager_get_cookies(WebKitCookieManager* manager, const gchar
  *
  * Finish an asynchronous operation started with webkit_cookie_manager_get_cookies().
  *
- * The return value is a #GSList of #SoupCookie instances which should be released
+ * The return value is a #GList of #SoupCookie instances which should be released
  * with g_list_free_full() and soup_cookie_free().
  *
  * Returns: (element-type SoupCookie) (transfer full): A #GList of #SoupCookie instances.
@@ -606,7 +606,7 @@ void webkit_cookie_manager_get_all_cookies(WebKitCookieManager* manager, GCancel
  *
  * Finish an asynchronous operation started with webkit_cookie_manager_get_all_cookies().
  *
- * The return value is a #GSList of #SoupCookie instances which should be released
+ * The return value is a #GList of #SoupCookie instances which should be released
  * with g_list_free_full() and soup_cookie_free().
  *
  * Returns: (element-type SoupCookie) (transfer full): A #GList of #SoupCookie instances.


### PR DESCRIPTION
#### e57b85e56c4c6c0e7b6664645c18a6439eae6da6
<pre>
Incorrect documentation for webkit-cookie-manager-get-cookies-finish
<a href="https://bugs.webkit.org/show_bug.cgi?id=263967">https://bugs.webkit.org/show_bug.cgi?id=263967</a>

Reviewed by Carlos Garcia Campos.

This fixes a serious typo. GSList and GList are entirely separate,
incompatible types. This tricked the Eclipse developers and now they
have a type confusion problem because they trusted our incorrect
documentation. See also: eclipse-platform/eclipse.platform.swt#842

* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp:

Canonical link: <a href="https://commits.webkit.org/270058@main">https://commits.webkit.org/270058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e976219029966cc9cbff9957d07dcb50796b9210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22369 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22814 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1931 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21001 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27024 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1685 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28144 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22165 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22228 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 3 pre-existing failure based on results-db; Uploaded test results (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25930 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 58 api tests failed or timed out; 58 api tests failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1609 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2886 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5849 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->