### PR TITLE
[WGSL] ConstantValue should be more precise

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -104,7 +104,7 @@ void AttributeValidator::visit(AST::Function& function)
                 auto value = dimension->constantValue();
                 if (!value.has_value())
                     return;
-                if (value->toInt() < 1)
+                if (value->integerValue() < 1)
                     error(dimension->span(), "@workgroup_size argument must be at least 1");
             };
             check(workgroupSize.x);
@@ -189,7 +189,7 @@ void AttributeValidator::visit(AST::Variable& variable)
         if (is<AST::BindingAttribute>(attribute)) {
             if (!isResource)
                 error(attribute.span(), "@binding attribute must only be applied to resource variables");
-            auto bindingValue = downcast<AST::BindingAttribute>(attribute).binding().constantValue()->toInt();
+            auto bindingValue = downcast<AST::BindingAttribute>(attribute).binding().constantValue()->integerValue();
             if (bindingValue < 0)
                 error(attribute.span(), "@binding value must be non-negative");
             else
@@ -200,7 +200,7 @@ void AttributeValidator::visit(AST::Variable& variable)
         if (is<AST::GroupAttribute>(attribute)) {
             if (!isResource)
                 error(attribute.span(), "@group attribute must only be applied to resource variables");
-            auto groupValue = downcast<AST::GroupAttribute>(attribute).group().constantValue()->toInt();
+            auto groupValue = downcast<AST::GroupAttribute>(attribute).group().constantValue()->integerValue();
             if (groupValue < 0)
                 error(attribute.span(), "@group value must be non-negative");
             else
@@ -212,7 +212,7 @@ void AttributeValidator::visit(AST::Variable& variable)
             auto& idExpression = downcast<AST::IdAttribute>(attribute).value();
             if (variable.flavor() != AST::VariableFlavor::Override || !satisfies(variable.storeType(), Constraints::Scalar))
                 error(attribute.span(), "@id attribute must only be applied to override variables of scalar type");
-            auto idValue = idExpression.constantValue()->toInt();
+            auto idValue = idExpression.constantValue()->integerValue();
             if (idValue < 0)
                 error(attribute.span(), "@id value must be non-negative");
             else
@@ -291,7 +291,7 @@ void AttributeValidator::visit(AST::StructureMember& member)
         if (is<AST::SizeAttribute>(attribute)) {
             // FIXME: check that the member type must have creation-fixed footprint.
             m_hasSizeOrAlignmentAttributes = true;
-            auto sizeValue = downcast<AST::SizeAttribute>(attribute).size().constantValue()->toInt();
+            auto sizeValue = downcast<AST::SizeAttribute>(attribute).size().constantValue()->integerValue();
             if (sizeValue < 0)
                 error(attribute.span(), "@size value must be non-negative");
             else if (sizeValue < member.type().inferredType()->size())
@@ -302,7 +302,7 @@ void AttributeValidator::visit(AST::StructureMember& member)
 
         if (is<AST::AlignAttribute>(attribute)) {
             m_hasSizeOrAlignmentAttributes = true;
-            auto alignmentValue = downcast<AST::AlignAttribute>(attribute).alignment().constantValue()->toInt();
+            auto alignmentValue = downcast<AST::AlignAttribute>(attribute).alignment().constantValue()->integerValue();
             auto isPowerOf2 = !(alignmentValue & (alignmentValue - 1));
             if (alignmentValue < 0)
                 error(attribute.span(), "@align value must be non-negative");
@@ -366,7 +366,7 @@ bool AttributeValidator::parseLocation(AST::Function* function, std::optional<un
     if (!isNumeric && !isNumericVector)
         error(attribute.span(), "@location must only be applied to declarations of numeric scalar or numeric vector type");
 
-    auto locationValue = downcast<AST::LocationAttribute>(attribute).location().constantValue()->toInt();
+    auto locationValue = downcast<AST::LocationAttribute>(attribute).location().constantValue()->integerValue();
     if (locationValue < 0)
         error(attribute.span(), "@location value must be non-negative");
     else

--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -43,12 +43,15 @@ static ConstantValue zeroValue(const Type* type)
         [&](const Types::Primitive& primitive) -> ConstantValue {
             switch (primitive.kind) {
             case Types::Primitive::AbstractInt:
+                return static_cast<int64_t>(0);
             case Types::Primitive::I32:
-            case Types::Primitive::U32:
                 return 0;
+            case Types::Primitive::U32:
+                return 0u;
             case Types::Primitive::AbstractFloat:
-            case Types::Primitive::F32:
                 return 0.0;
+            case Types::Primitive::F32:
+                return 0.0f;
             case Types::Primitive::Bool:
                 return false;
             case Types::Primitive::Void:
@@ -125,16 +128,29 @@ static ConstantValue constantUnaryOperation(const FixedVector<ConstantValue>& ar
     ASSERT(arguments.size() == 1);
     return scalarOrVector([&](auto& arg) -> ConstantValue {
         if constexpr (constraint & Constraints::Bool) {
-            if (arg.isBool())
-                return fn(arg.toBool());
+            if (auto* boolean = std::get_if<bool>(&arg))
+                return fn(*boolean);
         }
-        if constexpr (constraint & Constraints::Integer) {
-            if (arg.isInt())
-                return fn(arg.toInt());
+        if constexpr (constraint & Constraints::I32) {
+            if (auto* i32 = std::get_if<int32_t>(&arg))
+                return fn(*i32);
         }
-        if constexpr (constraint & Constraints::Float) {
-            if (arg.isNumber())
-                return fn(arg.toDouble());
+        if constexpr (constraint & Constraints::U32) {
+            if (auto* u32 = std::get_if<uint32_t>(&arg))
+                return fn(*u32);
+        }
+        if constexpr (constraint & Constraints::AbstractInt) {
+            if (auto* abstractInt = std::get_if<int64_t>(&arg))
+                return fn(*abstractInt);
+        }
+        // FIXME: implement f16
+        if constexpr (constraint & Constraints::F32) {
+            if (auto* f32 = std::get_if<float>(&arg))
+                return fn(*f32);
+        }
+        if constexpr (constraint & Constraints::AbstractFloat) {
+            if (auto* abstractFloat = std::get_if<double>(&arg))
+                return fn(*abstractFloat);
         }
         RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0]);
@@ -146,16 +162,29 @@ static ConstantValue constantBinaryOperation(const FixedVector<ConstantValue>& a
     ASSERT(arguments.size() == 2);
     return scalarOrVector([&](auto& left, auto& right) -> ConstantValue {
         if constexpr (constraint & Constraints::Bool) {
-            if (left.isBool() && right.isBool())
-                return fn(left.toBool(), right.toBool());
+            if (auto* leftBool = std::get_if<bool>(&left))
+                return fn(*leftBool, std::get<bool>(right));
         }
-        if constexpr (constraint & Constraints::Integer) {
-            if (left.isInt() && right.isInt())
-                return fn(left.toInt(), right.toInt());
+        if constexpr (constraint & Constraints::I32) {
+            if (auto* leftI32 = std::get_if<int32_t>(&left))
+                return fn(*leftI32, std::get<int32_t>(right));
         }
-        if constexpr (constraint & Constraints::Float) {
-            if (left.isNumber() && right.isNumber())
-                return fn(left.toDouble(), right.toDouble());
+        if constexpr (constraint & Constraints::U32) {
+            if (auto* leftU32 = std::get_if<uint32_t>(&left))
+                return fn(*leftU32, std::get<uint32_t>(right));
+        }
+        if constexpr (constraint & Constraints::AbstractInt) {
+            if (auto* leftAbstractInt = std::get_if<int64_t>(&left))
+                return fn(*leftAbstractInt, std::get<int64_t>(right));
+        }
+        // FIXME: implement f16
+        if constexpr (constraint & Constraints::F32) {
+            if (auto* leftF32 = std::get_if<float>(&left))
+                return fn(*leftF32, std::get<float>(right));
+        }
+        if constexpr (constraint & Constraints::AbstractFloat) {
+            if (auto* leftAbstractFloat = std::get_if<double>(&left))
+                return fn(*leftAbstractFloat, std::get<double>(right));
         }
         RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0], arguments[1]);
@@ -167,16 +196,29 @@ static ConstantValue constantTernaryOperation(const FixedVector<ConstantValue>& 
     ASSERT(arguments.size() == 3);
     return scalarOrVector([&](auto& first, auto& second, auto& third) -> ConstantValue {
         if constexpr (constraint & Constraints::Bool) {
-            if (first.isBool() && second.isBool() && third.isBool())
-                return fn(first.toBool(), second.toBool(), third.toBool());
+            if (auto* firstBool = std::get_if<bool>(&first))
+                return fn(*firstBool, std::get<bool>(second), std::get<bool>(third));
         }
-        if constexpr (constraint & Constraints::Integer) {
-            if (first.isInt() && second.isInt() && third.isInt())
-                return fn(first.toInt(), second.toInt(), third.toInt());
+        if constexpr (constraint & Constraints::I32) {
+            if (auto* firstI32 = std::get_if<int32_t>(&first))
+                return fn(*firstI32, std::get<int32_t>(second), std::get<int32_t>(third));
         }
-        if constexpr (constraint & Constraints::Float) {
-            if (first.isNumber() && second.isNumber() && third.isNumber())
-                return fn(first.toDouble(), second.toDouble(), third.toDouble());
+        if constexpr (constraint & Constraints::U32) {
+            if (auto* firstU32 = std::get_if<uint32_t>(&first))
+                return fn(*firstU32, std::get<uint32_t>(second), std::get<uint32_t>(third));
+        }
+        if constexpr (constraint & Constraints::AbstractInt) {
+            if (auto* firstAbstractInt = std::get_if<int64_t>(&first))
+                return fn(*firstAbstractInt, std::get<int64_t>(second), std::get<int64_t>(third));
+        }
+        // FIXME: implement f16
+        if constexpr (constraint & Constraints::F32) {
+            if (auto* firstF32 = std::get_if<float>(&first))
+                return fn(*firstF32, std::get<float>(second), std::get<float>(third));
+        }
+        if constexpr (constraint & Constraints::AbstractFloat) {
+            if (auto* firstAbstractFloat = std::get_if<double>(&first))
+                return fn(*firstAbstractFloat, std::get<double>(second), std::get<double>(third));
         }
         RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0], arguments[1], arguments[2]);
@@ -190,12 +232,21 @@ static ConstantValue constantConstructor(const Type* resultType, const FixedVect
 
     ASSERT(arguments.size() == 1);
     const auto& arg = arguments[0];
-    if (arg.isBool())
-        return static_cast<DestinationType>(arg.toBool());
-    if (arg.isInt())
-        return static_cast<DestinationType>(arg.toInt());
-    ASSERT(arg.isNumber());
-    return static_cast<DestinationType>(arg.toDouble());
+
+    if (auto* boolean = std::get_if<bool>(&arg))
+        return static_cast<DestinationType>(*boolean);
+    if (auto* i32 = std::get_if<int32_t>(&arg))
+        return static_cast<DestinationType>(*i32);
+    if (auto* u32 = std::get_if<uint32_t>(&arg))
+        return static_cast<DestinationType>(*u32);
+    if (auto* abstractInt = std::get_if<int64_t>(&arg))
+        return static_cast<DestinationType>(*abstractInt);
+    // FIXME: implement f16
+    if (auto* f32 = std::get_if<float>(&arg))
+        return static_cast<DestinationType>(*f32);
+    if (auto* abstractFloat = std::get_if<double>(&arg))
+        return static_cast<DestinationType>(*abstractFloat);
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 template<typename Functor, typename... Arguments>
@@ -328,17 +379,18 @@ static ConstantValue constantMatrix(const Type* resultType, const FixedVector<Co
     [&]<typename... Args>(Args&&... args) { return std::fn(std::forward<Args>(args)...); }
 
 // Arithmetic operators
-static ConstantValue constantAdd(const Type*, const FixedVector<ConstantValue>& arguments)
+static ConstantValue constantAdd(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     ASSERT(arguments.size() == 2);
 
     if (auto* left = std::get_if<ConstantMatrix>(&arguments[0])) {
         auto& right = std::get<ConstantMatrix>(arguments[1]);
+        auto* elementType = std::get<Types::Matrix>(*resultType).element;
         ASSERT(left->columns == right.columns);
         ASSERT(left->rows == right.rows);
         ConstantMatrix result(left->columns, left->rows);
         for (unsigned i = 0; i < result.elements.size(); ++i)
-            result.elements[i] = left->elements[i].toDouble() + right.elements[i].toDouble();
+            result.elements[i] = constantAdd(elementType, { left->elements[i], right.elements[i] });
         return result;
     }
 
@@ -369,12 +421,15 @@ static ConstantValue constantMultiply(const Type* resultType, const FixedVector<
     auto* rightMatrix = std::get_if<ConstantMatrix>(&arguments[1]);
     if (leftMatrix && rightMatrix) {
         ASSERT(leftMatrix->columns == rightMatrix->rows);
+        auto* elementType = std::get<Types::Matrix>(*resultType).element;
         ConstantMatrix result(rightMatrix->columns, leftMatrix->rows);
         for (unsigned i = 0; i < rightMatrix->columns; ++i) {
             for (unsigned j = 0; j < leftMatrix->rows; ++j) {
-                double value = 0;
-                for (unsigned k = 0; k < leftMatrix->columns; ++k)
-                    value += leftMatrix->elements[k * leftMatrix->rows + j].toDouble() * rightMatrix->elements[i * rightMatrix->rows + k].toDouble();
+                ConstantValue value = zeroValue(elementType);
+                for (unsigned k = 0; k < leftMatrix->columns; ++k) {
+                    auto tmp = constantMultiply(elementType, { leftMatrix->elements[k * leftMatrix->rows + j], rightMatrix->elements[i * rightMatrix->rows + k] });
+                    value = constantAdd(elementType, { value, tmp });
+                }
                 result.elements[i * result.rows + j] = value;
             }
         }
@@ -382,6 +437,7 @@ static ConstantValue constantMultiply(const Type* resultType, const FixedVector<
     }
     if (leftMatrix || rightMatrix) {
         if (auto* rightVector = std::get_if<ConstantVector>(&arguments[1])) {
+            auto* elementType = std::get<Types::Vector>(*resultType).element;
             auto columns = leftMatrix->columns;
             auto rows = leftMatrix->rows;
             ConstantVector result(rows);
@@ -389,12 +445,13 @@ static ConstantValue constantMultiply(const Type* resultType, const FixedVector<
             for (unsigned i = 0; i < rows; ++i) {
                 for (unsigned j = 0; j < columns; ++j)
                     leftVector.elements[j] = leftMatrix->elements[j * rows + i];
-                result.elements[i] = constantDot(resultType, { leftVector, *rightVector });
+                result.elements[i] = constantDot(elementType, { leftVector, *rightVector });
             }
             return result;
         }
 
         if (auto* leftVector = std::get_if<ConstantVector>(&arguments[0])) {
+            auto* elementType = std::get<Types::Vector>(*resultType).element;
             auto columns = rightMatrix->columns;
             auto rows = rightMatrix->rows;
             ConstantVector result(columns);
@@ -402,24 +459,25 @@ static ConstantValue constantMultiply(const Type* resultType, const FixedVector<
             for (unsigned i = 0; i < columns; ++i) {
                 for (unsigned j = 0; j < rows; ++j)
                     rightVector.elements[j] = rightMatrix->elements[i * rows + j];
-                result.elements[i] = constantDot(resultType, { *leftVector, rightVector });
+                result.elements[i] = constantDot(elementType, { *leftVector, rightVector });
             }
             return result;
         }
 
         const ConstantMatrix* matrix;
-        double scalar;
+        ConstantValue scalar;
         if (leftMatrix) {
             matrix = leftMatrix;
-            scalar = arguments[1].toDouble();
+            scalar = arguments[1];
         } else {
             matrix = rightMatrix;
-            scalar = arguments[0].toDouble();
+            scalar = arguments[0];
         }
 
+        auto* elementType = std::get<Types::Matrix>(*resultType).element;
         ConstantMatrix result(matrix->columns, matrix->rows);
         for (unsigned i = 0; i < result.elements.size(); ++i)
-            result.elements[i] = matrix->elements[i].toDouble() * scalar;
+            result.elements[i] = constantMultiply(elementType, { matrix->elements[i], scalar });
         return result;
     }
 
@@ -433,7 +491,7 @@ BINARY_OPERATION(Divide, Number, [&](auto left, auto right) {
 });
 
 BINARY_OPERATION(Modulo, Number, [&](auto left, auto right) {
-    if constexpr (std::is_same_v<decltype(left), double>)
+    if constexpr (std::is_floating_point_v<decltype(left)>)
         return fmod(left, right);
     else
         return left % right;
@@ -460,18 +518,30 @@ BINARY_OPERATION(And, Bool, [&](bool left, bool right) { return left && right; }
 static ConstantValue constantBitwiseOr(const Type*, const FixedVector<ConstantValue>& arguments)
 {
     return scalarOrVector([&](const auto& left, auto& right) -> ConstantValue {
-        if (left.isBool() && right.isBool())
-            return static_cast<bool>(static_cast<int>(left.toBool()) | static_cast<int>(right.toBool()));
-        return left.toInt() | right.toInt();
+        if (auto* leftBool = std::get_if<bool>(&left))
+            return static_cast<bool>(static_cast<int>(*leftBool) | static_cast<int>(std::get<bool>(right)));
+        if (auto* leftI32 = std::get_if<int32_t>(&left))
+            return *leftI32 | std::get<int32_t>(right);
+        if (auto* leftU32 = std::get_if<uint32_t>(&left))
+            return *leftU32 | std::get<uint32_t>(right);
+        if (auto* leftAbstractInt = std::get_if<int64_t>(&left))
+            return *leftAbstractInt | std::get<int64_t>(right);
+        RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0], arguments[1]);
 }
 
 static ConstantValue constantBitwiseAnd(const Type*, const FixedVector<ConstantValue>& arguments)
 {
     return scalarOrVector([&](const auto& left, auto& right) -> ConstantValue {
-        if (left.isBool() && right.isBool())
-            return static_cast<bool>(static_cast<int>(left.toBool()) & static_cast<int>(right.toBool()));
-        return left.toInt() & right.toInt();
+        if (auto* leftBool = std::get_if<bool>(&left))
+            return static_cast<bool>(static_cast<int>(*leftBool) & static_cast<int>(std::get<bool>(right)));
+        if (auto* leftI32 = std::get_if<int32_t>(&left))
+            return *leftI32 & std::get<int32_t>(right);
+        if (auto* leftU32 = std::get_if<uint32_t>(&left))
+            return *leftU32 & std::get<uint32_t>(right);
+        if (auto* leftAbstractInt = std::get_if<int64_t>(&left))
+            return *leftAbstractInt & std::get<int64_t>(right);
+        RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0], arguments[1]);
 }
 
@@ -590,7 +660,13 @@ CONSTANT_TRIGONOMETRIC(Cosh, cosh);
 CONSTANT_TRIGONOMETRIC(Sinh, sinh);
 CONSTANT_TRIGONOMETRIC(Tanh, tanh);
 
-UNARY_OPERATION(Abs, Number, WRAP_STD(abs))
+UNARY_OPERATION(Abs, Number, [&](auto n) {
+    if constexpr (std::is_same_v<decltype(n), uint32_t>)
+        return static_cast<uint32_t>(std::abs(static_cast<int32_t>(n)));
+    else
+        return std::abs(n);
+});
+
 BINARY_OPERATION(Atan2, Float, WRAP_STD(atan2))
 UNARY_OPERATION(Ceil, Float, WRAP_STD(ceil))
 TERNARY_OPERATION(Clamp, Number, [&](auto e, auto low, auto high) { return std::min(std::max(e, low), high); })
@@ -605,21 +681,30 @@ static ConstantValue constantCross(const Type*, const FixedVector<ConstantValue>
     auto& lhs = arguments[0].toVector();
     auto& rhs = arguments[1].toVector();
 
-    auto u0 = lhs.elements[0].toDouble();
-    auto u1 = lhs.elements[1].toDouble();
-    auto u2 = lhs.elements[2].toDouble();
-    auto v0 = rhs.elements[0].toDouble();
-    auto v1 = rhs.elements[1].toDouble();
-    auto v2 = rhs.elements[2].toDouble();
+    const auto& cross = [&]<typename T>() {
+        auto u0 = std::get<T>(lhs.elements[0]);
+        auto u1 = std::get<T>(lhs.elements[1]);
+        auto u2 = std::get<T>(lhs.elements[2]);
+        auto v0 = std::get<T>(rhs.elements[0]);
+        auto v1 = std::get<T>(rhs.elements[1]);
+        auto v2 = std::get<T>(rhs.elements[2]);
 
-    ConstantVector result(3);
-    result.elements[0] = u1 * v2 - u2 * v1;
-    result.elements[1] = u2 * v0 - u0 * v2;
-    result.elements[2] = u0 * v1 - u1 * v0;
-    return result;
+        ConstantVector result(3);
+        result.elements[0] = u1 * v2 - u2 * v1;
+        result.elements[1] = u2 * v0 - u0 * v2;
+        result.elements[2] = u0 * v1 - u1 * v0;
+        return result;
+    };
+
+    if (std::holds_alternative<float>(lhs.elements[0]))
+        return cross.operator()<float>();
+    if (std::holds_alternative<double>(lhs.elements[0]))
+        return cross.operator()<double>();
+    // FIXME: implement f16
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
-UNARY_OPERATION(Degrees, Float, [&](float arg) { return arg * (180 / std::numbers::pi); })
+UNARY_OPERATION(Degrees, Float, [&]<typename T>(T arg) -> T { return arg * (180 / std::numbers::pi); })
 
 static ConstantValue constantDeterminant(const Type*, const FixedVector<ConstantValue>& arguments)
 {
@@ -650,29 +735,38 @@ static ConstantValue constantDeterminant(const Type*, const FixedVector<Constant
         return a * solve3(f, g, h, j, k, l, n, o, p) - b * solve3(e, g, h, i, k, l, m, o, p) + c * solve3(e, f, h, i, j, l, m, n, p) - d * solve3(e, f, g, i, j, k, m, n, o);
     };
 
-    switch (columns) {
-    case 2:
-        return solve2(
-            matrix.elements[0].toDouble(), matrix.elements[2].toDouble(),
-            matrix.elements[1].toDouble(), matrix.elements[3].toDouble()
-        );
+    const auto& determinant = [&]<typename T>() {
+        switch (columns) {
+        case 2:
+            return solve2(
+                std::get<T>(matrix.elements[0]), std::get<T>(matrix.elements[2]),
+                std::get<T>(matrix.elements[1]), std::get<T>(matrix.elements[3])
+            );
 
-    case 3:
-        return solve3(
-            matrix.elements[0].toDouble(), matrix.elements[3].toDouble(), matrix.elements[6].toDouble(),
-            matrix.elements[1].toDouble(), matrix.elements[4].toDouble(), matrix.elements[7].toDouble(),
-            matrix.elements[2].toDouble(), matrix.elements[5].toDouble(), matrix.elements[8].toDouble()
-        );
-    case 4:
-        return solve4(
-            matrix.elements[0].toDouble(), matrix.elements[4].toDouble(), matrix.elements[8].toDouble(),  matrix.elements[12].toDouble(),
-            matrix.elements[1].toDouble(), matrix.elements[5].toDouble(), matrix.elements[9].toDouble(),  matrix.elements[13].toDouble(),
-            matrix.elements[2].toDouble(), matrix.elements[6].toDouble(), matrix.elements[10].toDouble(), matrix.elements[14].toDouble(),
-            matrix.elements[3].toDouble(), matrix.elements[7].toDouble(), matrix.elements[11].toDouble(), matrix.elements[15].toDouble()
-        );
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
+        case 3:
+            return solve3(
+                std::get<T>(matrix.elements[0]), std::get<T>(matrix.elements[3]), std::get<T>(matrix.elements[6]),
+                std::get<T>(matrix.elements[1]), std::get<T>(matrix.elements[4]), std::get<T>(matrix.elements[7]),
+                std::get<T>(matrix.elements[2]), std::get<T>(matrix.elements[5]), std::get<T>(matrix.elements[8])
+            );
+        case 4:
+            return solve4(
+                std::get<T>(matrix.elements[0]), std::get<T>(matrix.elements[4]), std::get<T>(matrix.elements[8]),  std::get<T>(matrix.elements[12]),
+                std::get<T>(matrix.elements[1]), std::get<T>(matrix.elements[5]), std::get<T>(matrix.elements[9]),  std::get<T>(matrix.elements[13]),
+                std::get<T>(matrix.elements[2]), std::get<T>(matrix.elements[6]), std::get<T>(matrix.elements[10]), std::get<T>(matrix.elements[14]),
+                std::get<T>(matrix.elements[3]), std::get<T>(matrix.elements[7]), std::get<T>(matrix.elements[11]), std::get<T>(matrix.elements[15])
+            );
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    };
+
+    if (std::holds_alternative<float>(matrix.elements[0]))
+        return determinant.operator()<float>();
+    if (std::holds_alternative<double>(matrix.elements[0]))
+        return determinant.operator()<double>();
+    // FIXME: implement f16
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 static ConstantValue constantLength(const Type*, const FixedVector<ConstantValue>&);
@@ -684,57 +778,65 @@ static ConstantValue constantDistance(const Type* resultType, const FixedVector<
 static ConstantValue constantDot(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     auto product = constantMultiply(resultType, arguments).toVector();
-    if (satisfies(resultType, Constraints::Integer)) {
-        int64_t result = 0;
-        for (auto& element : product.elements)
-            result += element.toInt();
-        return result;
-    }
-
-    double result = 0;
+    ConstantValue result = zeroValue(resultType);
     for (auto& element : product.elements)
-        result += element.toDouble();
+        result = constantAdd(resultType,  { result, element });
     return result;
 }
 
-static ConstantValue constantLength(const Type*, const FixedVector<ConstantValue>& arguments)
+static ConstantValue constantLength(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     ASSERT(arguments.size() == 1);
     const auto& arg = arguments[0];
     if (!arg.isVector())
         return arg;
-    double result = 0;
-    for (auto& element : arg.toVector().elements)
-        result += std::pow(element.toDouble(), 2);
+
+    ConstantValue result = zeroValue(resultType);
+    for (auto& element : arg.toVector().elements) {
+        auto tmp = constantMultiply(resultType, { element, element });
+        result = constantAdd(resultType, { result, tmp });
+    }
     return result;
 }
 
 UNARY_OPERATION(Exp, Float, WRAP_STD(exp));
 UNARY_OPERATION(Exp2, Float, WRAP_STD(exp2));
 
-TERNARY_OPERATION(ExtractBits, Integer, [&](auto e, unsigned offset, unsigned count) {
-    if (auto* vector = std::get_if<Types::Vector>(resultType))
-        resultType = vector->element;
-    auto& primitive = std::get<Types::Primitive>(*resultType);
-    bool isSigned = primitive.kind != Types::Primitive::U32;
+static ConstantValue constantExtractBits(const Type*, const FixedVector<ConstantValue>& arguments)
+{
+    // We can't use a TERNARY_OPERATION here since the arguments might not all have the same type
+    // i.e. we accept (u32, u32, u32) as well as (i32, u32, u32)
+    ASSERT(arguments.size() == 3);
+    auto offset = std::get<uint32_t>(arguments[1]);
+    auto count = std::get<uint32_t>(arguments[2]);
 
-    constexpr unsigned w = 32;
-    unsigned o = std::min(offset, w);
-    unsigned c = std::min(count, w - o);
-    if (!c)
-        return 0;
-    if (c == w)
-        return static_cast<int>(e);
-    unsigned srcMask = ((1 << c) - 1) << o;
-    int result = (e & srcMask) >> o;
-    if (isSigned) {
-        if (result & (1 << (c - 1))) {
-            unsigned dstMask = srcMask >> o;
-            result |= (~0 & ~dstMask);
+    const auto& extractBits = [&]<typename T>(T e) {
+        constexpr unsigned w = 32;
+        unsigned o = std::min(offset, w);
+        unsigned c = std::min(count, w - o);
+        if (!c)
+            return static_cast<T>(0);
+        if (c == w)
+            return e;
+        unsigned srcMask = ((1 << c) - 1) << o;
+        T result = (e & srcMask) >> o;
+        if constexpr (std::is_signed_v<T>) {
+            if (result & (1 << (c - 1))) {
+                unsigned dstMask = srcMask >> o;
+                result |= (~0 & ~dstMask);
+            }
         }
-    }
-    return result;
-})
+        return result;
+    };
+
+    return scalarOrVector([&](const auto& e) -> ConstantValue {
+        if (auto* i32 = std::get_if<int32_t>(&e))
+            return extractBits(*i32);
+        if (auto* u32 = std::get_if<uint32_t>(&e))
+            return extractBits(*u32);
+        RELEASE_ASSERT_NOT_REACHED();
+    }, arguments[0]);
+}
 
 static ConstantValue constantFaceForward(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
@@ -743,36 +845,32 @@ static ConstantValue constantFaceForward(const Type* resultType, const FixedVect
     const auto& e2 = arguments[1];
     const auto& e3 = arguments[2];
 
-    auto dot = constantDot(resultType, { e2, e3 });
-    if (constantLt(resultType, { dot, 0.0 }).toBool())
+    auto* elementType = std::get<Types::Vector>(*resultType).element;
+    auto dot = constantDot(elementType, { e2, e3 });
+    if (constantLt(elementType, { dot, zeroValue(elementType) }).toBool())
         return e1;
     return constantMinus(resultType, { e1 });
 }
 
-UNARY_OPERATION(FirstLeadingBit, Integer, [&](auto e) {
-    if (auto* vector = std::get_if<Types::Vector>(resultType))
-        resultType = vector->element;
-    auto& primitive = std::get<Types::Primitive>(*resultType);
-    bool isSigned = primitive.kind != Types::Primitive::U32;
-
-    unsigned ue = e;
-    if (isSigned) {
+UNARY_OPERATION(FirstLeadingBit, ConcreteInteger, [&](auto e) {
+    if constexpr (std::is_same_v<decltype(e), int32_t>) {
+        unsigned ue = e;
         if (!e || e == -1)
             return -1;
         unsigned count = e < 0 ? std::countl_one(ue) : std::countl_zero(ue);
-        return static_cast<int>(31 - count);
+        return static_cast<int32_t>(31 - count);
+    } else {
+        if (!e)
+            return static_cast<uint32_t>(-1);
+        return static_cast<uint32_t>(31 - std::countl_zero(e));
     }
-
-    if (!e)
-        return -1;
-    return static_cast<int>(31 - std::countl_zero(ue));
 })
 
-UNARY_OPERATION(FirstTrailingBit, Integer, [&](auto e) {
+UNARY_OPERATION(FirstTrailingBit, ConcreteInteger, [&](auto e) {
     if (!e)
-        return -1;
+        return static_cast<decltype(e)>(-1);
     unsigned ue = e;
-    return static_cast<int>(std::countr_zero(ue));
+    return static_cast<decltype(e)>(std::countr_zero(ue));
 })
 
 UNARY_OPERATION(Floor, Float, WRAP_STD(floor));
@@ -798,35 +896,43 @@ static ConstantValue constantFrexp(const Type*, const FixedVector<ConstantValue>
 
 static ConstantValue constantInsertBits(const Type*, const FixedVector<ConstantValue>& arguments)
 {
-    return scalarOrVector([&](auto e, auto newbits, auto offset, auto count) -> ConstantValue {
+    return scalarOrVector([&](auto eValue, auto newbitsValue, auto offset, auto count) -> ConstantValue {
         constexpr unsigned w = 32;
-        unsigned o = std::min(static_cast<unsigned>(offset.toInt()), w);
-        unsigned c = std::min(static_cast<unsigned>(count.toInt()), w - o);
+        unsigned o = std::min(std::get<uint32_t>(offset), w);
+        unsigned c = std::min(std::get<uint32_t>(count), w - o);
         if (!c)
-            return e;
+            return eValue;
         if (c == w)
-            return newbits;
-        unsigned from = newbits.toInt() << o;
-        unsigned mask = ((1 << c) - 1) << o;
-        int result = e.toInt();
-        result &= ~mask;
-        result |= (from & mask);
-        return result;
+            return newbitsValue;
+
+        const auto& fn = [&](auto e, auto newbits) {
+            auto from = newbits << o;
+            auto mask = ((1 << c) - 1) << o;
+            auto result = e;
+            result &= ~mask;
+            result |= (from & mask);
+            return result;
+        };
+
+        if (auto* e = std::get_if<int32_t>(&eValue))
+            return fn(*e, std::get<int32_t>(newbitsValue));
+        return fn(std::get<uint32_t>(eValue), std::get<uint32_t>(newbitsValue));
     }, arguments[0], arguments[1], arguments[2], arguments[3]);
 }
 
-static ConstantValue constantSqrt(const Type*, const FixedVector<ConstantValue>&);
-static ConstantValue constantInverseSqrt(const Type* resultType, const FixedVector<ConstantValue>& arguments)
-{
-    ASSERT(arguments.size() == 1);
-    const auto& arg = arguments[0];
-    return constantDivide(resultType, { 1, constantSqrt(resultType, { arg }) });
-}
+UNARY_OPERATION(InverseSqrt, Float, [&]<typename T>(T arg) -> T {
+    return 1.0 / std::sqrt(arg);
+})
 
 static ConstantValue constantLdexp(const Type*, const FixedVector<ConstantValue>& arguments)
 {
     return scalarOrVector([&](const auto& e1, auto& e2) -> ConstantValue {
-        return e1.toDouble() * std::pow(2, e2.toInt());
+        if (auto* abstractE2 = std::get_if<int64_t>(&e2))
+            return std::get<double>(e1) * std::pow(2.0, static_cast<double>(*abstractE2));
+        if (auto* f32E1 = std::get_if<float>(&e1))
+            return *f32E1 * std::pow(2.f, static_cast<float>(std::get<int32_t>(e2)));
+        // FIXME: implement f16
+        RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0], arguments[1]);
 }
 
@@ -845,8 +951,9 @@ static ConstantValue constantModf(const Type*, const FixedVector<ConstantValue>&
 static ConstantValue constantNormalize(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     ASSERT(arguments.size() == 1);
+    auto* elementType = std::get<Types::Vector>(*resultType).element;
     const auto& arg = arguments[0];
-    return constantDivide(resultType, { arg, constantLength(nullptr, arguments) });
+    return constantDivide(resultType, { arg, constantLength(elementType, arguments) });
 }
 
 BINARY_OPERATION(Pow, Float, WRAP_STD(pow))
@@ -857,19 +964,32 @@ static ConstantValue constantQuantizeToF16(const Type*, const FixedVector<Consta
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-UNARY_OPERATION(Radians, Float, [&](float arg) { return arg * std::numbers::pi / 180; })
+UNARY_OPERATION(Radians, Float, [&]<typename T>(T arg) -> T { return arg * std::numbers::pi / 180; })
 
 static ConstantValue constantReflect(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     ASSERT(arguments.size() == 2);
     const auto& e1 = arguments[0];
     const auto& e2 = arguments[1];
-    auto dot = constantDot(resultType, { e2, e1 });
-    auto prod = constantMultiply(resultType, { dot, e2 });
-    auto doubleResult = constantMultiply(resultType, { 2, e2 });
-    return constantMinus(resultType, { e1, doubleResult });
+    auto* elementType = std::get<Types::Vector>(*resultType).element;
+    auto& primitive = std::get<Types::Primitive>(*elementType);
+
+    const auto& reflect = [&]<typename T>() {
+        auto dot = constantDot(elementType, { e2, e1 });
+        auto prod = constantMultiply(resultType, { dot, e2 });
+        auto doubleResult = constantMultiply(resultType, { static_cast<T>(2), e2 });
+        return constantMinus(resultType, { e1, doubleResult });
+    };
+
+    if (primitive.kind == Types::Primitive::F32)
+        return reflect.operator()<float>();
+    if (primitive.kind == Types::Primitive::AbstractFloat)
+        return reflect.operator()<double>();
+    // FIXME: implement f16
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
+static ConstantValue constantSqrt(const Type*, const FixedVector<ConstantValue>&);
 static ConstantValue constantRefract(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     ASSERT(arguments.size() == 3);
@@ -877,29 +997,39 @@ static ConstantValue constantRefract(const Type* resultType, const FixedVector<C
     const auto& e2 = arguments[1];
     const auto& e3 = arguments[2];
 
-    auto dot = constantDot(resultType, { e2, e1 });
-    auto pow = constantPow(resultType, { dot, 2.0 });
-    auto sub = constantMinus(resultType, { 1.0, pow });
-    auto pow2 = constantPow(resultType, { e3, 2.0 });
-    auto mul = constantMultiply(resultType, { pow2, sub });
-    auto k = constantMinus(resultType, { 1.0, mul });
+    const auto& refract = [&]<typename T>(T e3) {
+        auto* elementType = std::get<Types::Vector>(*resultType).element;
+        auto dot = constantDot(elementType, { e2, e1 });
+        auto pow = constantPow(elementType, { dot, static_cast<T>(2.0) });
+        auto sub = constantMinus(elementType, { static_cast<T>(1.0), pow });
+        auto pow2 = constantPow(elementType, { e3, static_cast<T>(2.0) });
+        auto mul = constantMultiply(elementType, { pow2, sub });
+        auto k = constantMinus(elementType, { static_cast<T>(1.0), mul });
 
-    if (constantLt(resultType, { k, 0.0 }).toBool())
-        return zeroValue(resultType);
+        if (constantLt(elementType, { k, static_cast<T>(0.0) }).toBool())
+            return zeroValue(resultType);
 
-    {
-        auto mul = constantMultiply(resultType, { e3, dot });
-        auto sqrt = constantSqrt(resultType, { k });
-        auto sum = constantAdd(resultType, { mul, sqrt });
-        auto mul2 = constantMultiply(resultType, { e3, e1 });
-        auto mul3 = constantMultiply(resultType, { sum, e2 });
-        return constantMinus(resultType, { mul2, mul3 });
-    }
+        {
+            auto mul = constantMultiply(elementType, { e3, dot });
+            auto sqrt = constantSqrt(elementType, { k });
+            auto sum = constantAdd(elementType, { mul, sqrt });
+            auto mul2 = constantMultiply(resultType, { e3, e1 });
+            auto mul3 = constantMultiply(resultType, { sum, e2 });
+            return constantMinus(resultType, { mul2, mul3 });
+        }
+    };
+
+    if (auto* f32 = std::get_if<float>(&e3))
+        return refract(*f32);
+    if (auto* abstractFloat = std::get_if<double>(&e3))
+        return refract(*abstractFloat);
+    // FIXME: implement f16
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
-UNARY_OPERATION(ReverseBits, Integer, [&](auto e) {
+UNARY_OPERATION(ReverseBits, Integer, [&]<typename T>(T e) -> T {
     unsigned v = e;
-    int result = 0;
+    T result = 0;
     for (unsigned k = 0; k < 32; ++k)
         result |= (v & (31 - k)) << k;
     return result;
@@ -913,7 +1043,7 @@ UNARY_OPERATION(Round, Float, [&](auto v) {
 })
 
 UNARY_OPERATION(Saturate, Float, [&](auto e) {
-    return std::min(std::max(e, 0.0), 1.0);
+    return std::min(std::max(e, static_cast<decltype(e)>(0)), static_cast<decltype(e)>(1));
 })
 
 UNARY_OPERATION(Sign, Number, [&](auto e) {
@@ -929,7 +1059,7 @@ UNARY_OPERATION(Sign, Number, [&](auto e) {
 
 TERNARY_OPERATION(Smoothstep, Float, [&](auto low, auto high, auto x) {
     auto e = (x - low) / (high - low);
-    auto t = std::min(std::max(e, 0.0), 1.0);
+    auto t = std::min(std::max(e, static_cast<decltype(e)>(0)), static_cast<decltype(e)>(1));
     return t * t * (3.0 - 2.0 * t);
 })
 

--- a/Source/WebGPU/WGSL/ConstantValue.cpp
+++ b/Source/WebGPU/WGSL/ConstantValue.cpp
@@ -37,8 +37,17 @@ void ConstantValue::dump(PrintStream& out) const
         [&](double d) {
             out.print(String::number(d));
         },
+        [&](float f) {
+            out.print(String::number(f), "f");
+        },
         [&](int64_t i) {
             out.print(String::number(i));
+        },
+        [&](int32_t i) {
+            out.print(String::number(i), "i");
+        },
+        [&](uint32_t u) {
+            out.print(String::number(u), "u");
         },
         [&](bool b) {
             out.print(b ? "true" : "false");

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -87,7 +87,7 @@ struct ConstantMatrix {
     FixedVector<ConstantValue> elements;
 };
 
-using BaseValue = std::variant<double, int64_t, bool, ConstantArray, ConstantVector, ConstantMatrix>;
+using BaseValue = std::variant<float, double, int32_t, uint32_t, int64_t, bool, ConstantArray, ConstantVector, ConstantMatrix>;
 struct ConstantValue : BaseValue {
     ConstantValue() = default;
 
@@ -96,27 +96,29 @@ struct ConstantValue : BaseValue {
     void dump(PrintStream&) const;
 
     bool isBool() const { return std::holds_alternative<bool>(*this); }
-    bool isInt() const { return std::holds_alternative<int64_t>(*this); }
-    bool isNumber() const { return isInt() || std::holds_alternative<double>(*this); }
+    bool isI32() const { return std::holds_alternative<int32_t>(*this); }
+    bool isU32() const { return std::holds_alternative<uint32_t>(*this); }
+    bool isAbstractInt() const { return std::holds_alternative<int64_t>(*this); }
+    bool isF32() const { return std::holds_alternative<float>(*this); }
+    bool isAbstractFloat() const { return std::holds_alternative<double>(*this); }
     bool isVector() const { return std::holds_alternative<ConstantVector>(*this); }
     bool isMatrix() const { return std::holds_alternative<ConstantMatrix>(*this); }
     bool isArray() const { return std::holds_alternative<ConstantArray>(*this); }
 
     bool toBool() const { return std::get<bool>(*this); }
-    int64_t toInt() const
+    float toF32() const { return std::get<float>(*this); }
+
+    int64_t integerValue() const
     {
-        ASSERT(isNumber());
-        if (auto* i = std::get_if<int64_t>(this))
-            return *i;
-        return static_cast<int64_t>(std::get<double>(*this));
+        if (auto* i32 = std::get_if<int32_t>(this))
+            return *i32;
+        if (auto* u32 = std::get_if<uint32_t>(this))
+            return *u32;
+        if (auto* abstractInt = std::get_if<int64_t>(this))
+            return *abstractInt;
+        RELEASE_ASSERT_NOT_REACHED();
     }
-    double toDouble() const
-    {
-        ASSERT(isNumber());
-        if (auto* d = std::get_if<double>(this))
-            return *d;
-        return static_cast<double>(std::get<int64_t>(*this));
-    }
+
     const ConstantVector& toVector() const
     {
         return std::get<ConstantVector>(*this);

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -57,9 +57,9 @@ static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> devi
 
 static MTLSize metalSize(auto workgroupSize, const HashMap<String, WGSL::ConstantValue>& wgslConstantValues)
 {
-    auto width = WGSL::evaluate(*workgroupSize.width, wgslConstantValues).toInt();
-    auto height = workgroupSize.height ? WGSL::evaluate(*workgroupSize.height, wgslConstantValues).toInt() : 1;
-    auto depth = workgroupSize.depth ? WGSL::evaluate(*workgroupSize.depth, wgslConstantValues).toInt() : 1;
+    auto width = WGSL::evaluate(*workgroupSize.width, wgslConstantValues).integerValue();
+    auto height = workgroupSize.height ? WGSL::evaluate(*workgroupSize.height, wgslConstantValues).integerValue() : 1;
+    auto depth = workgroupSize.depth ? WGSL::evaluate(*workgroupSize.depth, wgslConstantValues).integerValue() : 1;
 
     return MTLSizeMake(width, height, depth);
 }

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -76,22 +76,22 @@ std::tuple<MTLFunctionConstantValues *, HashMap<String, WGSL::ConstantValue>> cr
 
         switch (specializationConstant.type) {
         case WGSL::Reflection::SpecializationConstantType::Boolean: {
-            bool value = constantValue.toBool();
+            auto value = std::get<bool>(constantValue);
             [constantValues setConstantValue:&value type:MTLDataTypeBool withName:specializationConstant.mangledName];
             break;
         }
         case WGSL::Reflection::SpecializationConstantType::Float: {
-            float value = constantValue.toDouble();
+            auto value = std::get<float>(constantValue);
             [constantValues setConstantValue:&value type:MTLDataTypeFloat withName:specializationConstant.mangledName];
             break;
         }
         case WGSL::Reflection::SpecializationConstantType::Int: {
-            int value = constantValue.toInt();
+            auto value = std::get<int32_t>(constantValue);
             [constantValues setConstantValue:&value type:MTLDataTypeInt withName:specializationConstant.mangledName];
             break;
         }
         case WGSL::Reflection::SpecializationConstantType::Unsigned: {
-            unsigned value = constantValue.toInt();
+            auto value = std::get<uint32_t>(constantValue);
             [constantValues setConstantValue:&value type:MTLDataTypeUInt withName:specializationConstant.mangledName];
             break;
         }


### PR DESCRIPTION
#### 1247773905f1474dd11fd62a3ceeee8f14e9c16b
<pre>
[WGSL] ConstantValue should be more precise
<a href="https://bugs.webkit.org/show_bug.cgi?id=263984">https://bugs.webkit.org/show_bug.cgi?id=263984</a>
<a href="https://rdar.apple.com/117749165">rdar://117749165</a>

Reviewed by Mike Wyrzykowski.

Currently, we use 3 types to represent constant scalars: bool, int64_t and double.
These are technically sufficient, as they can fit all the possible scalar values.
However, constant functions need to be able to distinguish between the different
types of scalars, e.g. i32 vs u32 vs abstract_int. We could do that in two ways:
we could add a `Type*` to ConstantValue, which was the original approach, or we
can add more representations to ConstantValue (int32_t and uint32_t in this case).
- The issue with the first approach, and the reason I removed the type from ConstantValue,
  is that every intermediate value must be assigned a type, which means we have
  to construct these types and that is quite verbose.
- The second approach, which is the one this PR uses, makes sure that every scalar
  has its own representation in ConstantValue, this allows using only the value as
  the source of truth without having to also carry the type around. The downside is
  that we must guarantee that the two are kept in sync. This has been helpful while
  writing this PR though, as it highlights places where the two have diverged, and
  forces us to perform the correct conversion of the values.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
(WGSL::AttributeValidator::parseLocation):
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::zeroValue):
(WGSL::constantUnaryOperation):
(WGSL::constantBinaryOperation):
(WGSL::constantTernaryOperation):
(WGSL::constantConstructor):
(WGSL::constantAdd):
(WGSL::constantMultiply):
(WGSL::BINARY_OPERATION):
(WGSL::constantBitwiseOr):
(WGSL::constantBitwiseAnd):
(WGSL::UNARY_OPERATION):
(WGSL::constantCross):
(WGSL::constantDeterminant):
(WGSL::constantDot):
(WGSL::constantLength):
(WGSL::constantExtractBits):
(WGSL::constantFaceForward):
(WGSL::constantInsertBits):
(WGSL::constantLdexp):
(WGSL::constantNormalize):
(WGSL::constantReflect):
(WGSL::constantRefract):
(WGSL::TERNARY_OPERATION):
(WGSL::constantInverseSqrt): Deleted.
* Source/WebGPU/WGSL/ConstantValue.cpp:
(WGSL::ConstantValue::dump const):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantValue::isI32 const):
(WGSL::ConstantValue::isU32 const):
(WGSL::ConstantValue::isAbstractInt const):
(WGSL::ConstantValue::isF32 const):
(WGSL::ConstantValue::isAbstractFloat const):
(WGSL::ConstantValue::toF32 const):
(WGSL::ConstantValue::integerValue const):
(WGSL::ConstantValue::isInt const): Deleted.
(WGSL::ConstantValue::isNumber const): Deleted.
(WGSL::ConstantValue::toInt const): Deleted.
(WGSL::ConstantValue::toDouble const): Deleted.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
(WGSL::TypeChecker::convertValue):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::metalSize):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createConstantValues):

Canonical link: <a href="https://commits.webkit.org/270052@main">https://commits.webkit.org/270052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b454101c5494466fb5cc5efe4111af4208639745

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24436 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22477 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27151 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1783 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28237 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22355 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26030 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/62 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2173 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->