### PR TITLE
Adopt more smart pointers in LocalFrame

### DIFF
--- a/Source/WebCore/animation/DocumentTimelinesController.h
+++ b/Source/WebCore/animation/DocumentTimelinesController.h
@@ -29,6 +29,7 @@
 #include "ReducedResolutionSeconds.h"
 #include "Timer.h"
 #include <wtf/CancellableTask.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Markable.h>
 #include <wtf/Seconds.h>
 #include <wtf/WeakHashSet.h>
@@ -41,7 +42,7 @@ class DocumentTimeline;
 class WebAnimation;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentTimelinesController);
-class DocumentTimelinesController {
+class DocumentTimelinesController : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentTimelinesController);
 public:
     explicit DocumentTimelinesController(Document&);

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -43,6 +43,7 @@
 #include "VisibleSelection.h"
 #include "WritingDirection.h"
 #include <memory>
+#include <wtf/CheckedRef.h>
 
 #if PLATFORM(COCOA)
 OBJC_CLASS NSAttributedString;
@@ -170,7 +171,7 @@ private:
     TemporarySelectionChange m_selectionChange;
 };
 
-class Editor {
+class Editor : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit Editor(Document&);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -57,6 +57,7 @@
 #include "FrameSelection.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
+#include "HTMLAttachmentElement.h"
 #include "HTMLFormControlElement.h"
 #include "HTMLFormElement.h"
 #include "HTMLFrameElementBase.h"
@@ -171,13 +172,13 @@ LocalFrame::LocalFrame(Page& page, UniqueRef<LocalFrameLoaderClient>&& frameLoad
     if (LocalFrame* parent = dynamicDowncast<LocalFrame>(tree().parent()); parent && parent->activeDOMObjectsAndAnimationsSuspended())
         suspendActiveDOMObjectsAndAnimations();
 
-    if (auto page = this->page(); page && isRootFrame())
+    if (CheckedPtr page = this->page(); page && isRootFrame())
         page->removeRootFrame(*this);
 }
 
 void LocalFrame::init()
 {
-    m_loader->init();
+    checkedLoader()->init();
 }
 
 Ref<LocalFrame> LocalFrame::createMainFrame(Page& page, UniqueRef<LocalFrameLoaderClient>&& client, FrameIdentifier identifier)
@@ -199,11 +200,12 @@ LocalFrame::~LocalFrame()
 {
     setView(nullptr);
 
-    if (!loader().isComplete())
-        loader().closeURL();
+    CheckedRef loader = this->loader();
+    if (!loader->isComplete())
+        loader->closeURL();
 
-    loader().clear(document(), false);
-    script().updatePlatformScriptObjects();
+    loader->clear(protectedDocument(), false);
+    checkedScript()->updatePlatformScriptObjects();
 
     // FIXME: We should not be doing all this work inside the destructor
 
@@ -244,17 +246,17 @@ void LocalFrame::setView(RefPtr<LocalFrameView>&& view)
     // We the custom scroll bars as early as possible to prevent m_doc->detach()
     // from messing with the view such that its scroll bars won't be torn down.
     // FIXME: We should revisit this.
-    if (m_view)
-        m_view->prepareForDetach();
+    if (RefPtr view = m_view)
+        view->prepareForDetach();
 
     // Prepare for destruction now, so any unload event handlers get run and the LocalDOMWindow is
     // notified. If we wait until the view is destroyed, then things won't be hooked up enough for
     // these calls to work.
     if (!view && m_doc && m_doc->backForwardCacheState() != Document::InBackForwardCache)
-        m_doc->willBeRemovedFromFrame();
+        protectedDocument()->willBeRemovedFromFrame();
     
-    if (m_view)
-        m_view->layoutContext().unscheduleLayout();
+    if (RefPtr view = m_view)
+        view->checkedLayoutContext()->unscheduleLayout();
     
     m_eventHandler->clear();
 
@@ -265,7 +267,17 @@ void LocalFrame::setView(RefPtr<LocalFrameView>&& view)
     // Only one form submission is allowed per view of a part.
     // Since this part may be getting reused as a result of being
     // pulled from the back/forward cache, reset this flag.
-    loader().resetMultipleFormSubmissionProtection();
+    checkedLoader()->resetMultipleFormSubmissionProtection();
+}
+
+CheckedRef<Editor> LocalFrame::checkedEditor()
+{
+    return editor();
+}
+
+CheckedRef<const Editor> LocalFrame::checkedEditor() const
+{
+    return editor();
 }
 
 void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
@@ -278,9 +290,9 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
     m_documentIsBeingReplaced = true;
 
     if (isMainFrame()) {
-        if (auto* page = this->page())
+        if (CheckedPtr page = this->page())
             page->didChangeMainDocument();
-        m_loader->client().dispatchDidChangeMainDocument();
+        checkedLoader()->client().dispatchDidChangeMainDocument();
 
         // We want to generate the same unique names whenever a page is loaded to avoid making layout tests
         // flaky and for things like form state restoration to work. To achieve this, we reset our frame
@@ -288,15 +300,15 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
         tree().resetFrameIdentifiers();
     }
 
+    if (RefPtr previousDocument = m_doc) {
 #if ENABLE(ATTACHMENT_ELEMENT)
-    if (m_doc) {
-        for (auto& attachment : m_doc->attachmentElementsByIdentifier().values())
-            editor().didRemoveAttachmentElement(attachment);
-    }
+        for (Ref attachment : previousDocument->attachmentElementsByIdentifier().values())
+            checkedEditor()->didRemoveAttachmentElement(attachment);
 #endif
 
-    if (m_doc && m_doc->backForwardCacheState() != Document::InBackForwardCache)
-        m_doc->willBeRemovedFromFrame();
+        if (previousDocument->backForwardCacheState() != Document::InBackForwardCache)
+            previousDocument->willBeRemovedFromFrame();
+    }
 
     m_doc = newDocument.copyRef();
     ASSERT(!m_doc || m_doc->domWindow());
@@ -308,14 +320,15 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
         newDocument->didBecomeCurrentDocumentInFrame();
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    if (m_doc) {
-        for (auto& attachment : m_doc->attachmentElementsByIdentifier().values())
-            editor().didInsertAttachmentElement(attachment);
+    if (RefPtr document = m_doc) {
+        CheckedRef editor = this->editor();
+        for (Ref attachment : document->attachmentElementsByIdentifier().values())
+            editor->didInsertAttachmentElement(attachment);
     }
 #endif
 
     if (page() && m_doc && isMainFrame() && !loader().stateMachine().isDisplayingInitialEmptyDocument())
-        page()->mainFrameDidChangeToNonInitialEmptyDocument();
+        checkedPage()->mainFrameDidChangeToNonInitialEmptyDocument();
 
     InspectorInstrumentation::frameDocumentUpdated(*this);
 
@@ -324,27 +337,27 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
 
 void LocalFrame::frameDetached()
 {
-    m_loader->frameDetached();
+    checkedLoader()->frameDetached();
 }
 
 bool LocalFrame::preventsParentFromBeingComplete() const
 {
-    return !m_loader->isComplete() && (!ownerElement() || !ownerElement()->isLazyLoadObserverActive());
+    return !checkedLoader()->isComplete() && (!ownerElement() || !ownerElement()->isLazyLoadObserverActive());
 }
 
 void LocalFrame::changeLocation(FrameLoadRequest&& request)
 {
-    loader().changeLocation(WTFMove(request));
+    checkedLoader()->changeLocation(WTFMove(request));
 }
 
 void LocalFrame::broadcastFrameRemovalToOtherProcesses()
 {
-    loader().client().broadcastFrameRemovalToOtherProcesses();
+    checkedLoader()->client().broadcastFrameRemovalToOtherProcesses();
 }
 
 void LocalFrame::didFinishLoadInAnotherProcess()
 {
-    loader().provisionalLoadFailedInAnotherProcess();
+    checkedLoader()->provisionalLoadFailedInAnotherProcess();
 }
 
 void LocalFrame::invalidateContentEventRegionsIfNeeded(InvalidateContentEventRegionsReason reason)
@@ -379,7 +392,7 @@ void LocalFrame::invalidateContentEventRegionsIfNeeded(InvalidateContentEventReg
         return;
 
     if (RefPtr ownerElement = this->ownerElement())
-        ownerElement->document().invalidateEventRegionsForFrame(*ownerElement);
+        ownerElement->protectedDocument()->invalidateEventRegionsForFrame(*ownerElement);
 }
 
 #if ENABLE(ORIENTATION_EVENTS)
@@ -392,7 +405,7 @@ void LocalFrame::orientationChanged()
 
 IntDegrees LocalFrame::orientation() const
 {
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         return page->chrome().client().deviceOrientation();
     return 0;
 }
@@ -427,11 +440,10 @@ static JSC::Yarr::RegularExpression createRegExpForLabels(const Vector<String>& 
 
 String LocalFrame::searchForLabelsAboveCell(const JSC::Yarr::RegularExpression& regExp, HTMLTableCellElement* cell, size_t* resultDistanceFromStartOfCell)
 {
-    HTMLTableCellElement* aboveCell = cell->cellAbove();
-    if (aboveCell) {
+    if (RefPtr aboveCell = cell->cellAbove()) {
         // search within the above cell we found for a match
-        size_t lengthSearched = 0;    
-        for (Text* textNode = TextNodeTraversal::firstWithin(*aboveCell); textNode; textNode = TextNodeTraversal::next(*textNode, aboveCell)) {
+        size_t lengthSearched = 0;
+        for (RefPtr textNode = TextNodeTraversal::firstWithin(*aboveCell); textNode; textNode = TextNodeTraversal::next(*textNode, aboveCell.get())) {
             if (!textNode->renderer() || textNode->renderer()->style().visibility() != Visibility::Visible)
                 continue;
             // For each text chunk, run the regexp
@@ -463,7 +475,7 @@ String LocalFrame::searchForLabelsBeforeElement(const Vector<String>& labels, El
     // charsSearchedThreshold, to make it more likely that we'll search whole nodes.
     const unsigned int maxCharsSearched = 600;
     // If the starting element is within a table, the cell that contains it
-    HTMLTableCellElement* startingTableCell = nullptr;
+    RefPtr<HTMLTableCellElement> startingTableCell;
     bool searchedCellAbove = false;
 
     if (resultDistance)
@@ -473,7 +485,7 @@ String LocalFrame::searchForLabelsBeforeElement(const Vector<String>& labels, El
     
     // walk backwards in the node tree, until another element, or form, or end of tree
     int unsigned lengthSearched = 0;
-    Node* n;
+    RefPtr<Node> n;
     for (n = NodeTraversal::previous(*element); n && lengthSearched < charsSearchedThreshold; n = NodeTraversal::previous(*n)) {
         // We hit another form element or the start of the form - bail out
         if (is<HTMLFormElement>(*n) || (is<Element>(*n) && downcast<Element>(*n).isValidatedFormListedElement()))
@@ -482,7 +494,7 @@ String LocalFrame::searchForLabelsBeforeElement(const Vector<String>& labels, El
         if (n->hasTagName(tdTag) && !startingTableCell)
             startingTableCell = downcast<HTMLTableCellElement>(n);
         else if (is<HTMLTableRowElement>(*n) && startingTableCell) {
-            String result = searchForLabelsAboveCell(regExp, startingTableCell, resultDistance);
+            String result = searchForLabelsAboveCell(regExp, startingTableCell.get(), resultDistance);
             if (!result.isEmpty()) {
                 if (resultIsInCellAbove)
                     *resultIsInCellAbove = true;
@@ -508,7 +520,7 @@ String LocalFrame::searchForLabelsBeforeElement(const Vector<String>& labels, El
     // If we started in a cell, but bailed because we found the start of the form or the
     // previous element, we still might need to search the row above us for a label.
     if (startingTableCell && !searchedCellAbove) {
-        String result = searchForLabelsAboveCell(regExp, startingTableCell, resultDistance);
+        String result = searchForLabelsAboveCell(regExp, startingTableCell.get(), resultDistance);
         if (!result.isEmpty()) {
             if (resultIsInCellAbove)
                 *resultIsInCellAbove = true;
@@ -627,26 +639,28 @@ void LocalFrame::setPrinting(bool printing, const FloatSize& pageSize, const Flo
 {
     if (!view() || !document())
         return;
+
+    RefPtr document = m_doc;
     // In setting printing, we should not validate resources already cached for the document.
     // See https://bugs.webkit.org/show_bug.cgi?id=43704
-    ResourceCacheValidationSuppressor validationSuppressor(m_doc->cachedResourceLoader());
+    ResourceCacheValidationSuppressor validationSuppressor(document->cachedResourceLoader());
 
-    m_doc->setPrinting(printing);
-    view()->adjustMediaTypeForPrinting(printing);
+    document->setPrinting(printing);
+    protectedView()->adjustMediaTypeForPrinting(printing);
 
     // FIXME: Consider invoking Page::updateRendering or an equivalent.
-    m_doc->styleScope().didChangeStyleSheetEnvironment();
-    m_doc->evaluateMediaQueriesAndReportChanges();
+    document->styleScope().didChangeStyleSheetEnvironment();
+    document->evaluateMediaQueriesAndReportChanges();
     if (!view())
         return;
 
-    auto& frameView = *view();
+    Ref frameView = *view();
     if (shouldUsePrintingLayout())
-        frameView.forceLayoutForPagination(pageSize, originalPageSize, maximumShrinkRatio, shouldAdjustViewSize);
+        frameView->forceLayoutForPagination(pageSize, originalPageSize, maximumShrinkRatio, shouldAdjustViewSize);
     else {
-        frameView.forceLayout();
+        frameView->forceLayout();
         if (shouldAdjustViewSize == AdjustViewSize)
-            frameView.adjustViewSize();
+            frameView->adjustViewSize();
     }
 
     // Subframes of the one we're printing don't lay out to the page size.
@@ -692,8 +706,9 @@ void LocalFrame::injectUserScripts(UserScriptInjectionTime injectionTime)
     if (loader().stateMachine().creatingInitialEmptyDocument() && !settings().shouldInjectUserScriptsInInitialEmptyDocument())
         return;
 
-    bool pageWasNotified = page()->hasBeenNotifiedToInjectUserScripts();
-    page()->userContentProvider().forEachUserScript([this, protectedThis = Ref { *this }, injectionTime, pageWasNotified] (DOMWrapperWorld& world, const UserScript& script) {
+    CheckedPtr page = this->page();
+    bool pageWasNotified = page->hasBeenNotifiedToInjectUserScripts();
+    page->protectedUserContentProvider()->forEachUserScript([this, protectedThis = Ref { *this }, injectionTime, pageWasNotified] (DOMWrapperWorld& world, const UserScript& script) {
         if (script.injectionTime() == injectionTime) {
             if (script.waitForNotificationBeforeInjecting() == WaitForNotificationBeforeInjecting::Yes && !pageWasNotified)
                 addUserScriptAwaitingNotification(world, script);
@@ -705,17 +720,18 @@ void LocalFrame::injectUserScripts(UserScriptInjectionTime injectionTime)
 
 void LocalFrame::injectUserScriptImmediately(DOMWrapperWorld& world, const UserScript& script)
 {
+    CheckedRef loader = this->loader();
 #if ENABLE(APP_BOUND_DOMAINS)
-    if (loader().client().shouldEnableInAppBrowserPrivacyProtections()) {
-        if (auto* document = this->document())
+    if (loader->client().shouldEnableInAppBrowserPrivacyProtections()) {
+        if (RefPtr document = this->document())
             document->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "Ignoring user script injection for non-app bound domain."_s);
         FRAME_RELEASE_LOG_ERROR(Loading, "injectUserScriptImmediately: Ignoring user script injection for non app-bound domain");
         return;
     }
-    loader().client().notifyPageOfAppBoundBehavior();
+    loader->client().notifyPageOfAppBoundBehavior();
 #endif
 
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return;
     if (script.injectedFrames() == UserContentInjectedFrames::InjectInTopFrameOnly && !isMainFrame())
@@ -724,8 +740,8 @@ void LocalFrame::injectUserScriptImmediately(DOMWrapperWorld& world, const UserS
         return;
 
     document->setAsRunningUserScripts();
-    loader().client().willInjectUserScript(world);
-    m_script->evaluateInWorldIgnoringException(ScriptSourceCode(script.source(), JSC::SourceTaintedOrigin::Untainted, URL(script.url())), world);
+    loader->client().willInjectUserScript(world);
+    checkedScript()->evaluateInWorldIgnoringException(ScriptSourceCode(script.source(), JSC::SourceTaintedOrigin::Untainted, URL(script.url())), world);
 }
 
 void LocalFrame::addUserScriptAwaitingNotification(DOMWrapperWorld& world, const UserScript& script)
@@ -773,15 +789,15 @@ void LocalFrame::clearTimers(LocalFrameView *view, Document *document)
 {
     if (!view)
         return;
-    view->layoutContext().unscheduleLayout();
-    if (auto* timelines = document->timelinesController())
+    view->checkedLayoutContext()->unscheduleLayout();
+    if (CheckedPtr timelines = document->timelinesController())
         timelines->suspendAnimations();
-    view->frame().eventHandler().stopAutoscrollTimer();
+    view->protectedFrame()->checkedEventHandler()->stopAutoscrollTimer();
 }
 
 void LocalFrame::clearTimers()
 {
-    clearTimers(m_view.get(), document());
+    clearTimers(protectedView().get(), protectedDocument().get());
 }
 
 CheckedRef<const FrameLoader> LocalFrame::checkedLoader() const
@@ -806,26 +822,27 @@ CheckedRef<const ScriptController> LocalFrame::checkedScript() const
 
 void LocalFrame::willDetachPage()
 {
-    if (LocalFrame* parent = dynamicDowncast<LocalFrame>(tree().parent()))
-        parent->loader().checkLoadComplete();
+    if (RefPtr parent = dynamicDowncast<LocalFrame>(tree().parent()))
+        parent->checkedLoader()->checkLoadComplete();
 
     for (auto& observer : m_destructionObservers)
         observer.willDetachPage();
 
     // FIXME: It's unclear as to why this is called more than once, but it is,
     // so page() could be NULL.
-    if (page()) {
-        CheckedRef focusController { page()->focusController() };
+    if (CheckedPtr page = this->page()) {
+        CheckedRef focusController = page->focusController();
         if (focusController->focusedFrame() == this)
             focusController->setFocusedFrame(nullptr);
     }
 
 
     if (page() && page()->scrollingCoordinator() && m_view)
-        page()->scrollingCoordinator()->willDestroyScrollableArea(*m_view);
+        page()->protectedScrollingCoordinator()->willDestroyScrollableArea(*protectedView());
 
-    script().clearScriptObjects();
-    script().updatePlatformScriptObjects();
+    CheckedRef script = this->script();
+    script->clearScriptObjects();
+    script->updatePlatformScriptObjects();
 
     // We promise that the Frame is always connected to a Page while the render tree is live.
     //
@@ -848,15 +865,15 @@ VisiblePosition LocalFrame::visiblePositionForPoint(const IntPoint& framePoint) 
 {
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowVisibleChildFrameContentOnly };
     HitTestResult result = eventHandler().hitTestResultAtPoint(framePoint, hitType);
-    Node* node = result.innerNonSharedNode();
+    RefPtr node = result.innerNonSharedNode();
     if (!node)
         return VisiblePosition();
-    auto renderer = node->renderer();
+    CheckedPtr renderer = node->renderer();
     if (!renderer)
         return VisiblePosition();
     VisiblePosition visiblePos = renderer->positionForPoint(result.localPoint(), nullptr);
     if (visiblePos.isNull())
-        visiblePos = firstPositionInOrBeforeNode(node);
+        visiblePos = firstPositionInOrBeforeNode(node.get());
     return visiblePos;
 }
 
@@ -865,12 +882,12 @@ Document* LocalFrame::documentAtPoint(const IntPoint& point)
     if (!view())
         return nullptr;
 
-    IntPoint pt = view()->windowToContents(point);
+    IntPoint pt = protectedView()->windowToContents(point);
     HitTestResult result = HitTestResult(pt);
 
     if (contentRenderer()) {
         constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-        result = eventHandler().hitTestResultAtPoint(pt, hitType);
+        result = checkedEventHandler()->hitTestResultAtPoint(pt, hitType);
     }
     return result.innerNode() ? &result.innerNode()->document() : 0;
 }
@@ -884,12 +901,12 @@ std::optional<SimpleRange> LocalFrame::rangeForPoint(const IntPoint& framePoint)
         return std::nullopt;
 
     if (auto previousCharacterRange = makeSimpleRange(position.previous(), position)) {
-        if (editor().firstRectForRange(*previousCharacterRange).contains(framePoint))
+        if (checkedEditor()->firstRectForRange(*previousCharacterRange).contains(framePoint))
             return *previousCharacterRange;
     }
 
     if (auto nextCharacterRange = makeSimpleRange(position, position.next())) {
-        if (editor().firstRectForRange(*nextCharacterRange).contains(framePoint))
+        if (checkedEditor()->firstRectForRange(*nextCharacterRange).contains(framePoint))
             return *nextCharacterRange;
     }
 
@@ -906,7 +923,7 @@ void LocalFrame::createView(const IntSize& viewportSize, const std::optional<Col
     bool isRootFrame = this->isRootFrame();
 
     if (isRootFrame && view())
-        view()->setParentVisible(false);
+        protectedView()->setParentVisible(false);
 
     setView(nullptr);
 
@@ -932,11 +949,11 @@ void LocalFrame::createView(const IntSize& viewportSize, const std::optional<Col
     if (isRootFrame)
         frameView->setParentVisible(true);
 
-    if (ownerRenderer())
-        ownerRenderer()->setWidget(frameView);
+    if (CheckedPtr ownerRenderer = this->ownerRenderer())
+        ownerRenderer->setWidget(frameView);
 
-    if (HTMLFrameOwnerElement* owner = ownerElement())
-        view()->setCanHaveScrollbars(owner->scrollingMode() != ScrollbarMode::AlwaysOff);
+    if (RefPtr owner = ownerElement())
+        protectedView()->setCanHaveScrollbars(owner->scrollingMode() != ScrollbarMode::AlwaysOff);
 }
 
 LocalDOMWindow* LocalFrame::window() const
@@ -958,7 +975,7 @@ String LocalFrame::trackedRepaintRectsAsText() const
 {
     if (!m_view)
         return String();
-    return m_view->trackedRepaintRectsAsText();
+    return protectedView()->trackedRepaintRectsAsText();
 }
 
 void LocalFrame::setPageZoomFactor(float factor)
@@ -976,15 +993,15 @@ void LocalFrame::setPageAndTextZoomFactors(float pageZoomFactor, float textZoomF
     if (m_pageZoomFactor == pageZoomFactor && m_textZoomFactor == textZoomFactor)
         return;
 
-    Page* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
 
-    Document* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return;
 
-    editor().dismissCorrectionPanelAsIgnored();
+    checkedEditor()->dismissCorrectionPanelAsIgnored();
 
     // Respect SVGs zoomAndPan="disabled" property in standalone SVG documents.
     // FIXME: How to handle compound documents + zoomAndPan="disabled"? Needs SVG WG clarification.
@@ -994,7 +1011,7 @@ void LocalFrame::setPageAndTextZoomFactors(float pageZoomFactor, float textZoomF
     std::optional<ScrollPosition> scrollPositionAfterZoomed;
     if (m_pageZoomFactor != pageZoomFactor) {
         // Compute the scroll position with scale after zooming to stay the same position in the content.
-        if (auto* view = this->view()) {
+        if (RefPtr view = this->view()) {
             scrollPositionAfterZoomed = view->scrollPosition();
             scrollPositionAfterZoomed->scale(pageZoomFactor / m_pageZoomFactor);
         }
@@ -1009,9 +1026,9 @@ void LocalFrame::setPageAndTextZoomFactors(float pageZoomFactor, float textZoomF
             localFrame->setPageAndTextZoomFactors(m_pageZoomFactor, m_textZoomFactor);
     }
 
-    if (auto* view = this->view()) {
+    if (RefPtr view = this->view()) {
         if (document->renderView() && document->renderView()->needsLayout() && view->didFirstLayout())
-            view->layoutContext().layout();
+            view->checkedLayoutContext()->layout();
 
         // Scrolling to the calculated position must be done after the layout.
         if (scrollPositionAfterZoomed)
@@ -1021,7 +1038,7 @@ void LocalFrame::setPageAndTextZoomFactors(float pageZoomFactor, float textZoomF
 
 float LocalFrame::frameScaleFactor() const
 {
-    Page* page = this->page();
+    CheckedPtr page = this->page();
 
     // Main frame is scaled with respect to he container but inner frames are not scaled with respect to the main frame.
     if (!page || !isMainFrame())
@@ -1044,8 +1061,8 @@ void LocalFrame::suspendActiveDOMObjectsAndAnimations()
 
     // FIXME: Suspend/resume calls will not match if the frame is navigated, and gets a new document.
     clearTimers(); // Suspends animations and pending relayouts.
-    if (m_doc)
-        m_doc->suspendScheduledTasks(ReasonForSuspension::PageWillBeSuspended);
+    if (RefPtr document = m_doc)
+        document->suspendScheduledTasks(ReasonForSuspension::PageWillBeSuspended);
 }
 
 void LocalFrame::resumeActiveDOMObjectsAndAnimations()
@@ -1061,15 +1078,16 @@ void LocalFrame::resumeActiveDOMObjectsAndAnimations()
     if (!m_doc)
         return;
 
+    Ref document = *m_doc;
     // FIXME: Suspend/resume calls will not match if the frame is navigated, and gets a new document.
-    m_doc->resumeScheduledTasks(ReasonForSuspension::PageWillBeSuspended);
+    document->resumeScheduledTasks(ReasonForSuspension::PageWillBeSuspended);
 
     // Frame::clearTimers() suspended animations and pending relayouts.
 
-    if (auto* timelines = m_doc->timelinesController())
+    if (CheckedPtr timelines = document->timelinesController())
         timelines->resumeAnimations();
-    if (m_view)
-        m_view->layoutContext().scheduleLayout();
+    if (RefPtr view = m_view)
+        view->checkedLayoutContext()->scheduleLayout();
 }
 
 void LocalFrame::deviceOrPageScaleFactorChanged()
@@ -1079,14 +1097,14 @@ void LocalFrame::deviceOrPageScaleFactorChanged()
             localFrame->deviceOrPageScaleFactorChanged();
     }
 
-    if (RenderView* root = contentRenderer())
+    if (CheckedPtr root = contentRenderer())
         root->compositor().deviceOrPageScaleFactorChanged();
 }
 
 void LocalFrame::dropChildren()
 {
     ASSERT(isMainFrame());
-    while (auto* child = tree().firstChild())
+    while (RefPtr child = tree().firstChild())
         tree().removeChild(*child);
 }
 
@@ -1104,7 +1122,7 @@ FloatSize LocalFrame::screenSize() const
     if (!loader || !loader->fingerprintingProtectionsEnabled())
         return defaultSize;
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         return page->chrome().client().screenSizeForFingerprintingProtections(*this, defaultSize);
 
     return defaultSize;
@@ -1116,7 +1134,7 @@ void LocalFrame::setOverrideScreenSize(FloatSize&& screenSize)
         return;
 
     m_overrideScreenSize = WTFMove(screenSize);
-    if (auto* document = this->document())
+    if (RefPtr document = this->document())
         document->updateViewportArguments();
 }
 
@@ -1215,9 +1233,9 @@ CheckedRef<const EventHandler> LocalFrame::checkedEventHandler() const
 
 void LocalFrame::documentURLDidChange(const URL& url)
 {
-    if (auto* page = this->page(); page && isMainFrame()) {
+    if (CheckedPtr page = this->page(); page && isMainFrame()) {
         page->setMainFrameURL(url);
-        m_loader->client().broadcastMainFrameURLChangeToOtherProcesses(url);
+        checkedLoader()->client().broadcastMainFrameURLChangeToOtherProcesses(url);
     }
 }
 

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -145,6 +145,8 @@ public:
 
     Editor& editor() { return document()->editor(); }
     const Editor& editor() const { return document()->editor(); }
+    CheckedRef<Editor> checkedEditor();
+    CheckedRef<const Editor> checkedEditor() const;
 
     EventHandler& eventHandler() { return m_eventHandler; }
     const EventHandler& eventHandler() const { return m_eventHandler; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -541,6 +541,11 @@ ScrollingCoordinator* Page::scrollingCoordinator()
     return m_scrollingCoordinator.get();
 }
 
+RefPtr<ScrollingCoordinator> Page::protectedScrollingCoordinator()
+{
+    return scrollingCoordinator();
+}
+
 String Page::scrollingStateTreeAsText()
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
@@ -3391,6 +3396,11 @@ PluginInfoProvider& Page::pluginInfoProvider()
 }
 
 UserContentProvider& Page::userContentProvider()
+{
+    return m_userContentProvider;
+}
+
+Ref<UserContentProvider> Page::protectedUserContentProvider()
 {
     return m_userContentProvider;
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -399,6 +399,7 @@ public:
     void updateValidationBubbleStateIfNeeded();
 
     WEBCORE_EXPORT ScrollingCoordinator* scrollingCoordinator();
+    WEBCORE_EXPORT RefPtr<ScrollingCoordinator> protectedScrollingCoordinator();
 
     WEBCORE_EXPORT String scrollingStateTreeAsText();
     WEBCORE_EXPORT String synchronousScrollingReasonsAsText();
@@ -843,6 +844,7 @@ public:
     PluginInfoProvider& pluginInfoProvider();
 
     WEBCORE_EXPORT UserContentProvider& userContentProvider();
+    WEBCORE_EXPORT Ref<UserContentProvider> protectedUserContentProvider();
     WEBCORE_EXPORT void setUserContentProvider(Ref<UserContentProvider>&&);
 
     ScreenOrientationManager* screenOrientationManager() const;


### PR DESCRIPTION
#### af577292e5e83fa845a3291e6f6402355e5a4558
<pre>
Adopt more smart pointers in LocalFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=263978">https://bugs.webkit.org/show_bug.cgi?id=263978</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/animation/DocumentTimelinesController.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
(WebCore::LocalFrame::init):
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::setView):
(WebCore::LocalFrame::checkedEditor):
(WebCore::LocalFrame::checkedEditor const):
(WebCore::LocalFrame::setDocument):
(WebCore::LocalFrame::frameDetached):
(WebCore::LocalFrame::preventsParentFromBeingComplete const):
(WebCore::LocalFrame::changeLocation):
(WebCore::LocalFrame::broadcastFrameRemovalToOtherProcesses):
(WebCore::LocalFrame::didFinishLoadInAnotherProcess):
(WebCore::LocalFrame::invalidateContentEventRegionsIfNeeded):
(WebCore::LocalFrame::orientation const):
(WebCore::LocalFrame::searchForLabelsAboveCell):
(WebCore::LocalFrame::searchForLabelsBeforeElement):
(WebCore::LocalFrame::setPrinting):
(WebCore::LocalFrame::injectUserScripts):
(WebCore::LocalFrame::injectUserScriptImmediately):
(WebCore::LocalFrame::clearTimers):
(WebCore::LocalFrame::willDetachPage):
(WebCore::LocalFrame::visiblePositionForPoint const):
(WebCore::LocalFrame::documentAtPoint):
(WebCore::LocalFrame::rangeForPoint):
(WebCore::LocalFrame::createView):
(WebCore::LocalFrame::trackedRepaintRectsAsText const):
(WebCore::LocalFrame::setPageAndTextZoomFactors):
(WebCore::LocalFrame::frameScaleFactor const):
(WebCore::LocalFrame::suspendActiveDOMObjectsAndAnimations):
(WebCore::LocalFrame::resumeActiveDOMObjectsAndAnimations):
(WebCore::LocalFrame::deviceOrPageScaleFactorChanged):
(WebCore::LocalFrame::dropChildren):
(WebCore::LocalFrame::screenSize const):
(WebCore::LocalFrame::setOverrideScreenSize):
(WebCore::LocalFrame::documentURLDidChange):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::protectedScrollingCoordinator):
(WebCore::Page::protectedUserContentProvider):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/270055@main">https://commits.webkit.org/270055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6fbd0e24bcddcfbdaf293c05dd86a2bf07f106d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26437 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22372 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22819 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1943 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21006 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27027 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28149 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1612 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2889 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2013 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3117 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->