### PR TITLE
Stop using delayedPreviewProviderForDroppingItem to update drop previews asynchronously

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1196,6 +1196,10 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @property (nonatomic, readonly) CGRect _selectionClipRect;
 @end
 
+@interface UIDragItem (Staging_117702233)
+- (void)_setNeedsDropPreviewUpdate;
+@end
+
 @interface UIDevice ()
 @property (nonatomic, setter=_setBacklightLevel:) float _backlightLevel;
 @end

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -53,11 +53,11 @@ static UIDragItem *dragItemMatchingIdentifier(id <UIDragSession> session, NSInte
 static RetainPtr<UITargetedDragPreview> createTargetedDragPreview(UIImage *image, UIView *rootView, UIView *previewContainer, const FloatRect& frameInRootViewCoordinates, const Vector<FloatRect>& clippingRectsInFrameCoordinates, UIColor *backgroundColor, UIBezierPath *visiblePath, AddPreviewViewToContainer addPreviewViewToContainer)
 {
     if (frameInRootViewCoordinates.isEmpty() || !image || !previewContainer.window)
-        return nullptr;
+        return nil;
 
     FloatRect frameInContainerCoordinates = [rootView convertRect:frameInRootViewCoordinates toView:previewContainer];
     if (frameInContainerCoordinates.isEmpty())
-        return nullptr;
+        return nil;
 
     FloatSize scalingRatio = frameInContainerCoordinates.size() / frameInRootViewCoordinates.size();
     auto clippingRectValuesInFrameCoordinates = createNSArray(clippingRectsInFrameCoordinates, [&] (auto rect) {
@@ -198,76 +198,64 @@ void DragDropInteractionState::dragSessionWillBegin()
     updatePreviewsForActiveDragSources();
 }
 
-void DragDropInteractionState::setDefaultDropPreview(UIDragItem *item, UITargetedDragPreview *preview)
+void DragDropInteractionState::addDefaultDropPreview(UIDragItem *item, UITargetedDragPreview *preview)
 {
-    m_defaultDropPreviews.append({ item, preview });
+    m_defaultDropPreviews.add(item, preview);
 }
 
 UITargetedDragPreview *DragDropInteractionState::defaultDropPreview(UIDragItem *item) const
 {
-    auto matchIndex = m_defaultDropPreviews.findIf([&] (auto& itemAndPreview) {
-        return itemAndPreview.item == item;
-    });
-    return matchIndex == notFound ? nil : m_defaultDropPreviews[matchIndex].preview.get();
+    return m_defaultDropPreviews.get(item).get();
 }
 
-BlockPtr<void(UITargetedDragPreview *)> DragDropInteractionState::dropPreviewProvider(UIDragItem *item)
+UITargetedDragPreview *DragDropInteractionState::finalDropPreview(UIDragItem *item) const
 {
-    auto matchIndex = m_delayedItemPreviewProviders.findIf([&] (auto& itemAndProvider) {
-        return itemAndProvider.item == item;
-    });
-
-    if (matchIndex == notFound)
-        return nil;
-
-    return m_delayedItemPreviewProviders[matchIndex].provider;
+    return m_finalDropPreviews.get(item).get();
 }
 
-void DragDropInteractionState::prepareForDelayedDropPreview(UIDragItem *item, void(^provider)(UITargetedDragPreview *preview))
+inline static bool dragItemSupportsAsynchronousUpdates()
 {
-    m_delayedItemPreviewProviders.append({ item, provider });
+    static bool hasSupport = [UIDragItem instancesRespondToSelector:@selector(_setNeedsDropPreviewUpdate)];
+    return hasSupport;
 }
 
 void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UIView *previewContainer, const WebCore::TextIndicatorData& indicator)
 {
-    if (m_delayedItemPreviewProviders.isEmpty())
-        return;
-
     auto textIndicatorImage = uiImageForImage(indicator.contentImage.get());
     auto preview = createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicator.textBoundingRectInRootViewCoordinates, indicator.textRectsInBoundingRectCoordinates, cocoaColor(indicator.estimatedBackgroundColor).get(), nil, AddPreviewViewToContainer::No);
-    for (auto& itemAndPreviewProvider : m_delayedItemPreviewProviders)
-        itemAndPreviewProvider.provider(preview.get());
-    m_delayedItemPreviewProviders.clear();
+    if (!preview)
+        return;
+
+    for (auto item : m_defaultDropPreviews.keys()) {
+        m_finalDropPreviews.add(item, preview.get());
+        if (dragItemSupportsAsynchronousUpdates())
+            [item _setNeedsDropPreviewUpdate];
+    }
 }
 
 void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, CGRect unobscuredContentRect, NSArray<UIDragItem *> *items, const Vector<IntRect>& placeholderRects)
 {
     if (items.count != placeholderRects.size()) {
-        RELEASE_LOG(DragAndDrop, "Failed to animate image placeholders: number of drag items (%tu) does not match number of placeholders (%tu)", items.count, placeholderRects.size());
-        clearAllDelayedItemPreviewProviders();
+        RELEASE_LOG_ERROR(DragAndDrop, "Failed to animate image placeholders: number of drag items (%tu) does not match number of placeholders (%tu)", items.count, placeholderRects.size());
         return;
     }
 
     for (size_t i = 0; i < placeholderRects.size(); ++i) {
         UIDragItem *item = [items objectAtIndex:i];
         auto& placeholderRect = placeholderRects[i];
-        auto provider = dropPreviewProvider(item);
-        if (!provider)
-            continue;
-
         auto defaultPreview = defaultDropPreview(item);
         auto defaultPreviewSize = [defaultPreview size];
-        if (!defaultPreview || defaultPreviewSize.width <= 0 || defaultPreviewSize.height <= 0 || placeholderRect.isEmpty()) {
-            provider(nil);
+        if (!defaultPreview || defaultPreviewSize.width <= 0 || defaultPreviewSize.height <= 0 || placeholderRect.isEmpty())
             continue;
-        }
 
         FloatRect previewIntersectionRect = enclosingIntRect(CGRectIntersection(unobscuredContentRect, placeholderRect));
         if (previewIntersectionRect.isEmpty()) {
             // If the preview rect is completely offscreen, don't bother trying to clip out or scale the default preview;
             // simply retarget the default preview.
             auto target = adoptNS([[UIDragPreviewTarget alloc] initWithContainer:contentView center:placeholderRect.center()]);
-            provider([defaultPreview retargetedPreviewWithTarget:target.get()]);
+            m_finalDropPreviews.add(item, [defaultPreview retargetedPreviewWithTarget:target.get()]);
+            if (dragItemSupportsAsynchronousUpdates())
+                [item _setNeedsDropPreviewUpdate];
             continue;
         }
 
@@ -288,18 +276,10 @@ void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, CG
         auto transform = CGAffineTransformMakeScale(placeholderRect.width() / defaultPreviewSize.width, placeholderRect.height() / defaultPreviewSize.height);
         auto target = adoptNS([[UIDragPreviewTarget alloc] initWithContainer:contentView center:previewIntersectionRect.center() transform:transform]);
         [defaultPreview parameters].visiblePath = [UIBezierPath bezierPathWithRect:insetPreviewBounds];
-        auto newPreview = adoptNS([[UITargetedDragPreview alloc] initWithView:[defaultPreview view] parameters:[defaultPreview parameters] target:target.get()]);
-        provider(newPreview.get());
+        m_finalDropPreviews.add(item, adoptNS([[UITargetedDragPreview alloc] initWithView:[defaultPreview view] parameters:[defaultPreview parameters] target:target.get()]));
+        if (dragItemSupportsAsynchronousUpdates())
+            [item _setNeedsDropPreviewUpdate];
     }
-
-    m_delayedItemPreviewProviders.clear();
-}
-
-void DragDropInteractionState::clearAllDelayedItemPreviewProviders()
-{
-    for (auto& itemAndPreviewProvider : m_delayedItemPreviewProviders)
-        itemAndPreviewProvider.provider(nil);
-    m_delayedItemPreviewProviders.clear();
 }
 
 UITargetedDragPreview *DragDropInteractionState::previewForLifting(UIDragItem *item, UIView *contentView, UIView *previewContainer, const std::optional<WebCore::TextIndicatorData>& indicator) const
@@ -395,10 +375,8 @@ void DragDropInteractionState::clearStagedDragSource(DidBecomeActive didBecomeAc
     m_stagedDragSource = std::nullopt;
 }
 
-void DragDropInteractionState::dragAndDropSessionsDidEnd()
+void DragDropInteractionState::dragAndDropSessionsDidBecomeInactive()
 {
-    clearAllDelayedItemPreviewProviders();
-
     if (auto previewView = takePreviewViewForDragCancel())
         [previewView removeFromSuperview];
 


### PR DESCRIPTION
#### 69303581ae36c561183cca0a5fdea24e9500ee5e
<pre>
Stop using delayedPreviewProviderForDroppingItem to update drop previews asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=263983">https://bugs.webkit.org/show_bug.cgi?id=263983</a>
<a href="https://rdar.apple.com/114331921">rdar://114331921</a>

Reviewed by Aditya Keerthi.

Stop relying on this private `UIDropInteraction` delegate method. Instead, adopt a new method,
`-[UIDragItem _setNeedsDropPreviewUpdate]`, to inform UIKit that a given item&apos;s associated drop
preview is changing. The drop session will then query the normal API again
(`-[UIDropInteractionDelegate dropInteraction:previewForDroppingItem:withDefault:]`), and
automatically retarget the drop animation based on the new result preview.

See below for more details.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::createTargetedDragPreview):
(WebKit::DragDropInteractionState::addDefaultDropPreview):
(WebKit::DragDropInteractionState::defaultDropPreview const):
(WebKit::DragDropInteractionState::finalDropPreview const):

Refactor the drag and drop interaction state to accomodate the new way of updating previews on drop.
In particular, replace `m_delayedItemPreviewProviders` with `m_finalDropPreviews` instead. We no
longer need to save a list of preview-provider blocks, and can instead:

1.  Stash away any incoming asynchronously-delivered previews on the interaction state…
2.  Call `-_setNeedsDropPreviewUpdate` on the drag item, and finally…
3.  Return the final drag preview in `-dropInteraction:previewForDroppingItem:withDefault:`, for
    that drag item.

(WebKit::dragItemSupportsAsynchronousUpdates):
(WebKit::DragDropInteractionState::deliverDelayedDropPreview):
(WebKit::DragDropInteractionState::dragAndDropSessionsDidBecomeInactive):
(WebKit::DragDropInteractionState::setDefaultDropPreview): Deleted.
(WebKit::BlockPtr&lt;void): Deleted.
(WebKit::DragDropInteractionState::prepareForDelayedDropPreview): Deleted.
(WebKit::DragDropInteractionState::clearAllDelayedItemPreviewProviders): Deleted.
(WebKit::DragDropInteractionState::dragAndDropSessionsDidEnd): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpDragSourceSessionState]):
(-[WKContentView _handleDropByInsertingImagePlaceholders:session:]):
(-[WKContentView dropInteraction:concludeDrop:]):
(-[WKContentView dropInteraction:previewForDroppingItem:withDefault:]):

Return the final drop preview, if available. See above for more details.

(-[WKContentView _dropInteraction:delayedPreviewProviderForDroppingItem:previewProvider:]): Deleted.
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[UIDragItem _dragAndDropSimulator]):
(-[UIDragItem _setDragAndDropSimulator:]):
(-[UIDragItem _setNeedsDropPreviewUpdate]):
(-[DragAndDropSimulator _resetSimulatedState]):
(-[DragAndDropSimulator runFrom:to:additionalItemRequestLocations:]):
(-[DragAndDropSimulator defaultDropPreviewForItemAtIndex:]):
(-[DragAndDropSimulator _setNeedsDropPreviewUpdate:]):
(-[DragAndDropSimulator _concludeDropAndPerformOperationIfNecessary]):

Update our drag and drop test infrastructure to handle calls to `-_setNeedsDropPreviewUpdate` by
having the drop simulator query `-dropInteraction:previewForDroppingItem:withDefault:` again and
save the result, which aligns with platform behavior support for this new API.

Canonical link: <a href="https://commits.webkit.org/270290@main">https://commits.webkit.org/270290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a405856c3362ac5f3bf79a57548024cee7d66a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4055 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/24772 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22831 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27030 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28152 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1615 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/24772 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2892 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6009 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->