### PR TITLE
Applying wavy underline text decoration on <del> text will hang if the font size is zero

### DIFF
--- a/LayoutTests/fast/text/del-text-zero-size-wavy-style-expected.txt
+++ b/LayoutTests/fast/text/del-text-zero-size-wavy-style-expected.txt
@@ -1,0 +1,1 @@
+Passes if it does not crash.

--- a/LayoutTests/fast/text/del-text-zero-size-wavy-style.html
+++ b/LayoutTests/fast/text/del-text-zero-size-wavy-style.html
@@ -5,7 +5,7 @@
     }
 </style>
 <body>
-    <ins class="class6">Passes if it does not crash.</ins>
+    <del class="class6">Passes if it does not crash.</del>
     <script>
         if (window.testRunner) {
             testRunner.dumpAsText();

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -67,8 +67,8 @@ namespace WebCore {
  */
 static void strokeWavyTextDecoration(GraphicsContext& context, const FloatRect& rect, WavyStrokeParameters wavyStrokeParameters)
 {
-    ASSERT(!rect.isEmpty());
-    ASSERT(wavyStrokeParameters.step);
+    if (rect.isEmpty() || !wavyStrokeParameters.step)
+        return;
 
     FloatPoint p1 = rect.minXMinYCorner();
     FloatPoint p2 = rect.maxXMinYCorner();


### PR DESCRIPTION
#### 1034f6e167610d43cd755fad80180c9c08ce23a4
<pre>
Applying wavy underline text decoration on &lt;del&gt; text will hang if the font size is zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=263989">https://bugs.webkit.org/show_bug.cgi?id=263989</a>
<a href="https://rdar.apple.com/117357827">rdar://117357827</a>

Reviewed by Simon Fraser.

This should complete the intended fix of .

TextDecorationPainter::paintLineThrough() can still call strokeWavyTextDecoration()
even if the font size is zero. This part was missed from 269493@main.

Like bug 260372, text within &lt;del&gt; tags and zero font size will cause WebKit to
hang and eventually jetsam by the system. The for-loop in strokeWavyTextDecoration()
will never terminate.

strokeWavyTextDecoration() should return if any of its parameters is zero.

* LayoutTests/fast/text/del-text-zero-size-wavy-style-expected.txt: Added.
* LayoutTests/fast/text/del-text-zero-size-wavy-style.html: Added.
* LayoutTests/fast/text/text-zero-size-wavy-style.html:
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::strokeWavyTextDecoration):

Canonical link: <a href="https://commits.webkit.org/270033@main">https://commits.webkit.org/270033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e4a430dbe840a8778b3b527c53bbf838539453

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4066 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27040 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28155 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25943 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1620 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21703 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->