### PR TITLE
[SVG] Use native rounded rect path when dasharray is not specified

### DIFF
--- a/Source/WebCore/rendering/svg/SVGPathData.cpp
+++ b/Source/WebCore/rendering/svg/SVGPathData.cpp
@@ -175,10 +175,14 @@ static Path pathFromRectElement(const SVGElement& element)
     // value of width for the same shape.
     radii.constrainedBetween(radii, size / 2);
 
-    // FIXME: We currently enforce using beziers here, as at least on CoreGraphics/Lion, as
-    // the native method uses a different line dash origin, causing svg/custom/dashOrigin.svg to fail.
-    // See bug https://bugs.webkit.org/show_bug.cgi?id=79932 which tracks this issue.
-    path.addRoundedRect(FloatRect { location, size }, radii, PathRoundedRect::Strategy::PreferBezier);
+    auto strategy = PathRoundedRect::Strategy::PreferNative;
+    if (!style.svgStyle().strokeDashArray().isEmpty()) {
+        // FIXME: We currently enforce using beziers here, as at least on CoreGraphics/Lion, as
+        // the native method uses a different line dash origin, causing svg/custom/dashOrigin.svg to fail.
+        // See bug https://bugs.webkit.org/show_bug.cgi?id=79932 which tracks this issue.
+        strategy = PathRoundedRect::Strategy::PreferBezier;
+    }
+    path.addRoundedRect(FloatRect { location, size }, radii, strategy);
     return path;
 }
 


### PR DESCRIPTION
#### 763f8e9741e138297670a242867ff756d9ae49ba
<pre>
[SVG] Use native rounded rect path when dasharray is not specified
<a href="https://bugs.webkit.org/show_bug.cgi?id=263992">https://bugs.webkit.org/show_bug.cgi?id=263992</a>
<a href="https://rdar.apple.com/problem/117760362">rdar://problem/117760362</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/rendering/svg/SVGPathData.cpp:
(WebCore::pathFromRectElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/763f8e9741e138297670a242867ff756d9ae49ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26463 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22828 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27053 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1705 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/text/reftests/textpath-shape-001.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21952 "Found 2 new test failures: fast/css/transform-function-perspective-crash.html, imported/w3c/web-platform-tests/svg/text/reftests/textpath-shape-001.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28165 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22186 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPITabs.CaptureVisibleTab (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22261 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/text/reftests/textpath-shape-001.svg (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25954 "Found 2 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/handle-corrupted-local-storage, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1630 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5 "Found 3 new test failures: imported/w3c/web-platform-tests/svg/text/reftests/textpath-shape-001.svg, svg/clip-path/clip-path-shape-rounded-inset-1.svg, svg/clip-path/clip-path-shape-rounded-inset-2.svg (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->