### PR TITLE
Variable used to obtain a bit value from mModeFlags is sign extended

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -371,7 +371,7 @@ size_t PacketDurationParser::framesInPacket(SharedBuffer& packet)
             return 0; // Invalid mode.
 
         uint32_t blockSize = 0;
-        if (!(m_vorbisModeInfo->mModeFlags & (1 << modeIndex)))
+        if (!(m_vorbisModeInfo->mModeFlags & (1ULL << modeIndex)))
             blockSize = m_vorbisModeInfo->mShortBlockSize;
         else
             blockSize = m_vorbisModeInfo->mLongBlockSize;
@@ -381,7 +381,6 @@ size_t PacketDurationParser::framesInPacket(SharedBuffer& packet)
         m_lastVorbisBlockSize = blockSize;
 
         return framesOfOutput;
-        break;
         }
 #endif
     default:


### PR DESCRIPTION
#### bb40425085b9f49ff6091ce774729aca2db3f1ab
<pre>
Variable used to obtain a bit value from mModeFlags is sign extended
<a href="https://bugs.webkit.org/show_bug.cgi?id=263994">https://bugs.webkit.org/show_bug.cgi?id=263994</a>

Reviewed by Simon Fraser.

mModeFlags is a UInt64, which means we risk overflowing an integer when
we use a signed integer to obtain bit-packed flags from it instead of
using an unsigned long long.

* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::PacketDurationParser::framesInPacket): Use an unsigned value
  to obtain the flags stored in mModeFlags.

Canonical link: <a href="https://commits.webkit.org/273298@main">https://commits.webkit.org/273298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aafedec726305108c8fd1ccf860da09e03b36b70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23030 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21310 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/2070 "Found 2 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, /WPE/TestLoaderClient:/webkit/WebKitWebPage/get-uri (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28414 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26218 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3227 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8023 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->