### PR TITLE
Repeated calls to scrollIntoView({ block: 'center' }) can cause jiggling (affects Spotify lyrics)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4540,6 +4540,8 @@ webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertic
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertical-alignment-slr-033.xht [ ImageOnlyFailure ]
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertical-alignment-slr-035.xht [ ImageOnlyFailure ]
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertical-alignment-slr-041.xht [ ImageOnlyFailure ]
+webkit.org/b/209080 imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-sideways-lr-writing-mode-and-rtl-direction.html [ Pass Failure ]
+webkit.org/b/209080 imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-sideways-lr-writing-mode.html [ Pass Failure ]
 
 webkit.org/b/219343 imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-column-012.html [ ImageOnlyFailure ]
 webkit.org/b/219343 imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/scrolling/scroll-into-view-block-center-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-into-view-block-center-expected.txt
@@ -1,0 +1,6 @@
+This should not jiggle
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS scroller.scrollTop is scrollTopAfterFirstScrollIntoView
+

--- a/LayoutTests/fast/scrolling/scroll-into-view-block-center.html
+++ b/LayoutTests/fast/scrolling/scroll-into-view-block-center.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 300px;
+            height: 300px; /* Chosen to cause the available height to be odd with 15px scrollbars */
+            overflow: scroll;
+            border: 1px solid black;
+        }
+        
+        #target {
+            width: 100%;
+            height: 30px;
+        }
+        
+        .spacer {
+            width: 10px;
+            height: 1000px;
+            background-color: silver;
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        let scroller;
+        let scrollTopAfterFirstScrollIntoView;
+        window.addEventListener('load', () => {
+            let target = document.getElementById('target');
+            scroller = document.getElementsByClassName('scroller')[0];
+
+            target.scrollIntoView({ block: 'center' });
+            scrollTopAfterFirstScrollIntoView = scroller.scrollTop;
+
+            target.scrollIntoView({ block: 'center' });
+            shouldBe('scroller.scrollTop', 'scrollTopAfterFirstScrollIntoView');
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="spacer"></div>
+        <div id="target">This should not jiggle</div>
+        <div class="spacer"></div>
+    </div>
+    <div id="console"></div>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -953,9 +953,10 @@ LayoutRect ScrollableArea::getRectToExposeForScrollIntoView(const LayoutRect& vi
         y = visibleBounds.y();
     else if (scrollY == ScrollAlignment::Behavior::AlignBottom)
         y = exposeRect.maxY() - visibleBounds.height();
-    else if (scrollY == ScrollAlignment::Behavior::AlignCenter)
-        y = exposeRect.y() + (exposeRect.height() - visibleBounds.height()) / 2;
-    else
+    else if (scrollY == ScrollAlignment::Behavior::AlignCenter) {
+        auto halfHeight = (exposeRect.height() - visibleBounds.height()) / 2;
+        y = exposeRect.y() + halfHeight.ceil();
+    } else
         y = exposeRect.y();
 
     return LayoutRect(LayoutPoint(x, y), visibleBounds.size());

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1896,6 +1896,7 @@ void RenderLayerScrollableArea::panScrollFromPoint(const IntPoint& sourcePoint)
 
     scrollByRecursively(adjustedScrollDelta(delta));
 }
+
 static LayoutRect getLocalExposeRect(const LayoutRect& absoluteRect, RenderBox* box, int verticalScrollbarWidth, const LayoutRect& layerBounds)
 {
     LayoutRect localExposeRect(box->absoluteToLocalQuad(FloatQuad(FloatRect(absoluteRect))).boundingBox());


### PR DESCRIPTION
#### 7688e6c7f81ab7985e5de04e5e7a153baf94c0d2
<pre>
Repeated calls to scrollIntoView({ block: &apos;center&apos; }) can cause jiggling (affects Spotify lyrics)
<a href="https://bugs.webkit.org/show_bug.cgi?id=263995">https://bugs.webkit.org/show_bug.cgi?id=263995</a>
<a href="https://rdar.apple.com/117755250">rdar://117755250</a>

Reviewed by Tim Horton.

Computation of the destination scroll position for `scrollIntoView({ block: &apos;center&apos; })` involves a divide
by 2, which gives a fractional result for some scroller sizes. This causes the computed scroll position to
alternate between two values 1px apart when called repeatedly, since our scroll positions are integral.

Fix by ceiling the target y value in the `ScrollAlignment::Behavior::AlignCenter` case in
`ScrollableArea::getRectToExposeForScrollIntoView()`.

* LayoutTests/TestExpectations:
* LayoutTests/fast/scrolling/scroll-into-view-block-center-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-into-view-block-center.html: Added.
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::getRectToExposeForScrollIntoView const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:

Canonical link: <a href="https://commits.webkit.org/270160@main">https://commits.webkit.org/270160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31cc7532f1c53479e901fc1a894f497642089641

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27398 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28422 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/256 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22001 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5920 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->