### PR TITLE
Use more smart pointers in SubresourceLoader

### DIFF
--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -287,6 +287,11 @@ FrameLoader* ResourceLoader::frameLoader() const
     return &m_frame->loader();
 }
 
+RefPtr<DocumentLoader> ResourceLoader::protectedDocumentLoader() const
+{
+    return m_documentLoader;
+}
+
 void ResourceLoader::loadDataURL()
 {
     auto url = m_request.url();

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include "CachedResourceHandle.h"
 #include "ResourceHandleClient.h"
 #include "ResourceLoadTiming.h"
 #include "ResourceLoaderIdentifier.h"
@@ -80,6 +81,7 @@ public:
 
     WEBCORE_EXPORT FrameLoader* frameLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
+    RefPtr<DocumentLoader> protectedDocumentLoader() const;
     const ResourceRequest& originalRequest() const { return m_originalRequest; }
 
     WEBCORE_EXPORT void start();
@@ -136,6 +138,7 @@ public:
     WEBCORE_EXPORT bool shouldIncludeCertificateInfo() const;
     
     virtual CachedResource* cachedResource() const { return nullptr; }
+    CachedResourceHandle<CachedResource> protectedCachedResource() const { return cachedResource(); }
 
     bool reachedTerminalState() const { return m_reachedTerminalState; }
 


### PR DESCRIPTION
#### 85c7594d6be4e0c79e0981f2f6638baddd6dac5e
<pre>
Use more smart pointers in SubresourceLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=263999">https://bugs.webkit.org/show_bug.cgi?id=263999</a>

Reviewed by Chris Dumez.

* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::protectedDocumentLoader const):
* Source/WebCore/loader/ResourceLoader.h:
(WebCore::ResourceLoader::protectedCachedResource const):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::init):
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::didSendData):
(WebCore::SubresourceLoader::didReceivePreviewResponse):
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::didReceiveBuffer):
(WebCore::SubresourceLoader::responseHasHTTPStatusCodeError const):
(WebCore::SubresourceLoader::checkRedirectionCrossOriginAccessControl):
(WebCore::SubresourceLoader::didFinishLoading):
(WebCore::SubresourceLoader::didFail):
(WebCore::SubresourceLoader::willCancel):
(WebCore::SubresourceLoader::didCancel):
(WebCore::SubresourceLoader::notifyDone):
(WebCore::SubresourceLoader::releaseResources):
(WebCore::SubresourceLoader::reportResourceTiming):

Canonical link: <a href="https://commits.webkit.org/270049@main">https://commits.webkit.org/270049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afc8527affea36736ec18ac8687dc48fe0d25a57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24390 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26521 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/57 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27107 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21995 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22310 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1685 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/32 "Found 2 new test failures: fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html, fast/scrolling/scroll-to-focused-element-asynchronously.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2099 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3114 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->