### PR TITLE
Adopt more smart pointers in DocumentWriter

### DIFF
--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -71,29 +71,30 @@ static inline bool canReferToParentFrameEncoding(const LocalFrame* frame, const 
 // This is the <iframe src="javascript:'html'"> case.
 void DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL(const String& source, Document* ownerDocument)
 {
-    m_frame->loader().stopAllLoaders();
+    Ref frame = *m_frame;
+    frame->checkedLoader()->stopAllLoaders();
 
     // If we are in the midst of changing the frame's document, don't execute script
     // that modifies the document further:
-    if (m_frame->documentIsBeingReplaced())
+    if (frame->documentIsBeingReplaced())
         return;
 
-    begin(m_frame->document()->url(), true, ownerDocument);
+    begin(frame->document()->url(), true, ownerDocument);
 
     setEncoding("UTF-8"_s, IsEncodingUserChosen::No);
 
     // begin() might fire an unload event, which will result in a situation where no new document has been attached,
     // and the old document has been detached. Therefore, bail out if no document is attached.
-    if (!m_frame->document())
+    if (!frame->document())
         return;
 
     if (!source.isNull()) {
         if (!m_hasReceivedSomeData) {
             m_hasReceivedSomeData = true;
-            m_frame->document()->setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
+            frame->protectedDocument()->setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
         }
 
-        if (DocumentParser* parser = m_frame->document()->parser()) {
+        if (RefPtr parser = frame->document()->parser()) {
             auto utf8Source = source.utf8();
             parser->appendBytes(*this, reinterpret_cast<const uint8_t*>(utf8Source.data()), utf8Source.length());
         }
@@ -117,31 +118,33 @@ bool DocumentWriter::begin()
 
 Ref<Document> DocumentWriter::createDocument(const URL& url, ScriptExecutionContextIdentifier documentIdentifier)
 {
-    if (!m_frame->loader().stateMachine().isDisplayingInitialEmptyDocument() && m_frame->loader().client().shouldAlwaysUsePluginDocument(m_mimeType))
-        return PluginDocument::create(*m_frame, url);
+    Ref frame = *m_frame;
+    CheckedRef frameLoader = frame->loader();
+    if (!frameLoader->stateMachine().isDisplayingInitialEmptyDocument() && frameLoader->client().shouldAlwaysUsePluginDocument(m_mimeType))
+        return PluginDocument::create(frame, url);
 
     auto useSinkDocument = [&]() {
 #if ENABLE(PDF_PLUGIN)
-        if (m_frame->loader().client().shouldUsePDFPlugin(m_mimeType, url.path()))
+        if (frameLoader->client().shouldUsePDFPlugin(m_mimeType, url.path()))
             return false;
 #endif
 #if PLATFORM(IOS_FAMILY)
-        if (m_frame->isMainFrame())
+        if (frame->isMainFrame())
             return true;
 
-        return !m_frame->settings().useImageDocumentForSubframePDF();
+        return !frame->settings().useImageDocumentForSubframePDF();
 #else
         return false;
 #endif
     };
 
     if (MIMETypeRegistry::isPDFMIMEType(m_mimeType) && useSinkDocument())
-        return SinkDocument::create(*m_frame, url);
+        return SinkDocument::create(frame, url);
 
-    if (!m_frame->loader().client().hasHTMLView())
-        return Document::createNonRenderedPlaceholder(*m_frame, url);
+    if (!frameLoader->client().hasHTMLView())
+        return Document::createNonRenderedPlaceholder(frame, url);
 
-    return DOMImplementation::createDocument(m_mimeType, m_frame.get(), m_frame->settings(), url, documentIdentifier);
+    return DOMImplementation::createDocument(m_mimeType, frame.ptr(), frame->settings(), url, documentIdentifier);
 }
 
 bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* ownerDocument, ScriptExecutionContextIdentifier documentIdentifier, const NavigationAction* triggeringAction)
@@ -153,53 +156,56 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
 
     // Create a new document before clearing the frame, because it may need to
     // inherit an aliased security context.
-    Ref<Document> document = createDocument(url, documentIdentifier);
+    Ref document = createDocument(url, documentIdentifier);
     
+    Ref frame = *m_frame;
+    CheckedRef frameLoader = frame->loader();
+
     // If the new document is for a Plugin but we're supposed to be sandboxed from Plugins,
     // then replace the document with one whose parser will ignore the incoming data (bug 39323)
     if (document->isPluginDocument() && document->isSandboxed(SandboxPlugins))
-        document = SinkDocument::create(*m_frame, url);
+        document = SinkDocument::create(frame, url);
 
     // FIXME: Do we need to consult the content security policy here about blocked plug-ins?
 
-    bool shouldReuseDefaultView = m_frame->loader().stateMachine().isDisplayingInitialEmptyDocument()
-        && m_frame->document()->isSecureTransitionTo(url)
-        && (m_frame->window() && !m_frame->window()->wasWrappedWithoutInitializedSecurityOrigin() && m_frame->window()->mayReuseForNavigation());
+    bool shouldReuseDefaultView = frameLoader->stateMachine().isDisplayingInitialEmptyDocument()
+        && frame->document()->isSecureTransitionTo(url)
+        && (frame->window() && !frame->window()->wasWrappedWithoutInitializedSecurityOrigin() && frame->window()->mayReuseForNavigation());
 
     if (shouldReuseDefaultView) {
-        ASSERT(m_frame->loader().documentLoader());
-        if (auto* contentSecurityPolicy = m_frame->loader().documentLoader()->contentSecurityPolicy())
+        ASSERT(frameLoader->documentLoader());
+        if (CheckedPtr contentSecurityPolicy = frameLoader->documentLoader()->contentSecurityPolicy())
             shouldReuseDefaultView = !(contentSecurityPolicy->sandboxFlags() & SandboxOrigin);
     }
 
     // Temporarily extend the lifetime of the existing document so that FrameLoader::clear() doesn't destroy it as
     // we need to retain its ongoing set of upgraded requests in new navigation contexts per <http://www.w3.org/TR/upgrade-insecure-requests/>
     // and we may also need to inherit its Content Security Policy below.
-    RefPtr<Document> existingDocument = m_frame->document();
+    RefPtr existingDocument = frame->document();
 
-    Function<void()> handleDOMWindowCreation = [this, document, shouldReuseDefaultView] {
+    Function<void()> handleDOMWindowCreation = [document, frame, shouldReuseDefaultView] {
         if (shouldReuseDefaultView)
-            document->takeDOMWindowFrom(*m_frame->document());
+            document->takeDOMWindowFrom(*frame->protectedDocument());
         else
             document->createDOMWindow();
     };
 
-    m_frame->loader().clear(document.ptr(), !shouldReuseDefaultView, !shouldReuseDefaultView, true, WTFMove(handleDOMWindowCreation));
+    frameLoader->clear(document.ptr(), !shouldReuseDefaultView, !shouldReuseDefaultView, true, WTFMove(handleDOMWindowCreation));
     clear();
 
-    // m_frame->loader().clear() might fire unload event which could remove the view of the document.
+    // frameLoader->clear() might fire unload event which could remove the view of the document.
     // Bail out if document has no view.
     if (!document->view())
         return false;
 
     if (!shouldReuseDefaultView)
-        m_frame->script().updatePlatformScriptObjects();
+        frame->checkedScript()->updatePlatformScriptObjects();
 
-    m_frame->loader().setOutgoingReferrer(url);
-    m_frame->setDocument(document.copyRef());
+    frameLoader->setOutgoingReferrer(url);
+    frame->setDocument(document.copyRef());
 
-    if (m_decoder)
-        document->setDecoder(m_decoder.get());
+    if (RefPtr decoder = m_decoder)
+        document->setDecoder(decoder.get());
     if (ownerDocument) {
         // |document| is the result of evaluating a JavaScript URL.
         document->setCookieURL(ownerDocument->cookieURL());
@@ -208,25 +214,27 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         document->setCrossOriginEmbedderPolicy(ownerDocument->crossOriginEmbedderPolicy());
 
         document->setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { url }, document));
-        document->contentSecurityPolicy()->copyStateFrom(ownerDocument->contentSecurityPolicy());
-        document->contentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(ownerDocument->contentSecurityPolicy()->takeNavigationRequestsToUpgrade());
+        CheckedRef contentSecurityPolicy = *document->contentSecurityPolicy();
+        CheckedRef ownerContentSecurityPolicy = *ownerDocument->contentSecurityPolicy();
+        contentSecurityPolicy->copyStateFrom(ownerContentSecurityPolicy.ptr());
+        contentSecurityPolicy->setInsecureNavigationRequestsToUpgrade(ownerContentSecurityPolicy->takeNavigationRequestsToUpgrade());
     } else if (url.protocolIsAbout() || url.protocolIsData()) {
         // https://html.spec.whatwg.org/multipage/origin.html#determining-navigation-params-policy-container
-        auto* currentHistoryItem = m_frame->loader().history().currentItem();
+        RefPtr currentHistoryItem = frameLoader->history().currentItem();
 
         if (currentHistoryItem && currentHistoryItem->policyContainer()) {
             const auto& policyContainerFromHistory = currentHistoryItem->policyContainer();
             ASSERT(policyContainerFromHistory);
             document->inheritPolicyContainerFrom(*policyContainerFromHistory);
         } else if (url == aboutSrcDocURL()) {
-            auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
+            RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
             if (parentFrame && parentFrame->document()) {
                 document->inheritPolicyContainerFrom(parentFrame->document()->policyContainer());
-                document->contentSecurityPolicy()->updateSourceSelf(parentFrame->document()->securityOrigin());
+                document->checkedContentSecurityPolicy()->updateSourceSelf(parentFrame->document()->securityOrigin());
             }
         } else if (triggeringAction && triggeringAction->requester()) {
             document->inheritPolicyContainerFrom(triggeringAction->requester()->policyContainer);
-            document->contentSecurityPolicy()->updateSourceSelf(triggeringAction->requester()->securityOrigin);
+            document->checkedContentSecurityPolicy()->updateSourceSelf(triggeringAction->requester()->securityOrigin);
         }
 
         // https://html.spec.whatwg.org/multipage/origin.html#requires-storing-the-policy-container-in-history
@@ -235,11 +243,9 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     }
 
     if (existingDocument && existingDocument->contentSecurityPolicy() && document->contentSecurityPolicy())
-        document->contentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(existingDocument->contentSecurityPolicy()->takeNavigationRequestsToUpgrade());
+        document->checkedContentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(existingDocument->checkedContentSecurityPolicy()->takeNavigationRequestsToUpgrade());
 
-    Ref protectedFrame = *m_frame;
-
-    m_frame->loader().didBeginDocument(dispatch);
+    frameLoader->didBeginDocument(dispatch);
 
     document->implicitOpen();
 
@@ -248,8 +254,8 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     // document.open).
     m_parser = document->parser();
 
-    if (m_frame->view() && m_frame->loader().client().hasHTMLView())
-        m_frame->view()->setContentsSize(IntSize());
+    if (frame->view() && frameLoader->client().hasHTMLView())
+        frame->protectedView()->setContentsSize(IntSize());
 
     m_state = State::Started;
     return true;
@@ -258,10 +264,10 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
 TextResourceDecoder& DocumentWriter::decoder()
 {
     if (!m_decoder) {
-        m_decoder = TextResourceDecoder::create(m_mimeType,
-            m_frame->settings().defaultTextEncodingName(),
-            m_frame->settings().usesEncodingDetector());
-        auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
+        Ref frame = *m_frame;
+        Ref decoder = TextResourceDecoder::create(m_mimeType, frame->settings().defaultTextEncodingName(), frame->settings().usesEncodingDetector());
+        m_decoder = decoder.copyRef();
+        RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
         // Set the hint encoding to the parent frame encoding only if
         // the parent and the current frames share the security origin.
         // We impose this condition because somebody can make a child frame
@@ -271,16 +277,16 @@ TextResourceDecoder& DocumentWriter::decoder()
         // an attack vector.
         // FIXME: This might be too cautious for non-7bit-encodings and
         // we may consider relaxing this later after testing.
-        if (canReferToParentFrameEncoding(m_frame.get(), parentFrame))
-            m_decoder->setHintEncoding(parentFrame->document()->decoder());
+        if (canReferToParentFrameEncoding(frame.ptr(), parentFrame.get()))
+            decoder->setHintEncoding(parentFrame->document()->protectedDecoder().get());
         if (m_encoding.isEmpty()) {
-            if (canReferToParentFrameEncoding(m_frame.get(), parentFrame))
-                m_decoder->setEncoding(parentFrame->document()->textEncoding(), TextResourceDecoder::EncodingFromParentFrame);
+            if (canReferToParentFrameEncoding(frame.ptr(), parentFrame.get()))
+                decoder->setEncoding(parentFrame->document()->textEncoding(), TextResourceDecoder::EncodingFromParentFrame);
         } else {
-            m_decoder->setEncoding(m_encoding,
+            decoder->setEncoding(m_encoding,
                 m_encodingWasChosenByUser ? TextResourceDecoder::UserChosenEncoding : TextResourceDecoder::EncodingFromHTTPHeader);
         }
-        m_frame->document()->setDecoder(m_decoder.get());
+        frame->protectedDocument()->setDecoder(WTFMove(decoder));
     }
     return *m_decoder;
 }
@@ -291,9 +297,15 @@ void DocumentWriter::reportDataReceived()
     if (m_hasReceivedSomeData)
         return;
     m_hasReceivedSomeData = true;
+    Ref document = *m_frame->document();
     if (m_decoder->encoding().usesVisualOrdering())
-        m_frame->document()->setVisuallyOrdered();
-    m_frame->document()->resolveStyle(Document::ResolveStyleType::Rebuild);
+        document->setVisuallyOrdered();
+    document->resolveStyle(Document::ResolveStyleType::Rebuild);
+}
+
+RefPtr<DocumentParser> DocumentWriter::protectedParser() const
+{
+    return m_parser;
 }
 
 void DocumentWriter::addData(const SharedBuffer& data)
@@ -305,7 +317,7 @@ void DocumentWriter::addData(const SharedBuffer& data)
         return;
     }
     ASSERT(m_parser);
-    m_parser->appendBytes(*this, data.data(), data.size());
+    protectedParser()->appendBytes(*this, data.data(), data.size());
 }
 
 void DocumentWriter::insertDataSynchronously(const String& markup)
@@ -313,7 +325,7 @@ void DocumentWriter::insertDataSynchronously(const String& markup)
     ASSERT(m_state != State::NotStarted);
     ASSERT(m_state != State::Finished);
     ASSERT(m_parser);
-    m_parser->insert(markup);
+    protectedParser()->insert(markup);
 }
 
 void DocumentWriter::end()
@@ -333,10 +345,10 @@ void DocumentWriter::end()
     if (!m_parser)
         return;
     // FIXME: m_parser->finish() should imply m_parser->flush().
-    m_parser->flush(*this);
+    protectedParser()->flush(*this);
     if (!m_parser)
         return;
-    m_parser->finish();
+    protectedParser()->finish();
     m_parser = nullptr;
 }
 
@@ -354,7 +366,7 @@ void DocumentWriter::setFrame(LocalFrame& frame)
 void DocumentWriter::setDocumentWasLoadedAsPartOfNavigation()
 {
     ASSERT(m_parser && !m_parser->isStopped());
-    m_parser->setDocumentWasLoadedAsPartOfNavigation();
+    protectedParser()->setDocumentWasLoadedAsPartOfNavigation();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentWriter.h
+++ b/Source/WebCore/loader/DocumentWriter.h
@@ -71,6 +71,7 @@ public:
 private:
     Ref<Document> createDocument(const URL&, ScriptExecutionContextIdentifier);
     void clear();
+    RefPtr<DocumentParser> protectedParser() const;
 
     WeakPtr<LocalFrame> m_frame;
 


### PR DESCRIPTION
#### c0a99308ad00b774576eac9ffafb78c57247d694
<pre>
Adopt more smart pointers in DocumentWriter
<a href="https://bugs.webkit.org/show_bug.cgi?id=263998">https://bugs.webkit.org/show_bug.cgi?id=263998</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL):
(WebCore::DocumentWriter::createDocument):
(WebCore::DocumentWriter::begin):
(WebCore::DocumentWriter::decoder):
(WebCore::DocumentWriter::reportDataReceived):
(WebCore::DocumentWriter::protectedParser const):
(WebCore::DocumentWriter::addData):
(WebCore::DocumentWriter::insertDataSynchronously):
(WebCore::DocumentWriter::end):
(WebCore::DocumentWriter::setDocumentWasLoadedAsPartOfNavigation):
* Source/WebCore/loader/DocumentWriter.h:

Canonical link: <a href="https://commits.webkit.org/270045@main">https://commits.webkit.org/270045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eeeb89eab6581fe6411a6e19640aef7b8eae3bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22840 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27075 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28177 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22278 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25967 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/handle-corrupted-local-storage (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2927 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5840 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->