### PR TITLE
[iOS] Element Fullscreen does not respect viewport-fit

### DIFF
--- a/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets-expected.txt
+++ b/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets-expected.txt
@@ -1,0 +1,47 @@
+
+Set main frame viewport-fit=contain and test iframes
+RUN(metaViewport.content = "width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, viewport-fit=contain")
+RUN(setSafeAreaInsets(100, 50))
+EXPECTED (visibleRect.left == '-100') OK
+EXPECTED (visibleRect.top == '-50') OK
+
+Test that fullscreen within an iframe with viewport-fit-cover has viewport-fit-cover behavior:
+RUN(frame.src = "resources/viewport-fit-cover.html")
+EVENT(load)
+RUN(enterFullscreen())
+EXPECTED (visibleRect.left == '0') OK
+EXPECTED (visibleRect.top == '0') OK
+RUN(exitFullscreen())
+
+Test that fullscreen within an iframe with viewport-fit-contain has viewport-fit-contain behavior:
+RUN(frame.src = "resources/viewport-fit-contain.html")
+EVENT(load)
+RUN(enterFullscreen())
+EXPECTED (visibleRect.left == '-100') OK
+EXPECTED (visibleRect.top == '-50') OK
+RUN(exitFullscreen())
+
+Set main frame viewport-fit=cover and re-test iframes
+RUN(metaViewport.content = "width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, viewport-fit=cover")
+EXPECTED (visibleRect.left == '0') OK
+EXPECTED (visibleRect.top == '0') OK
+
+RUN(frame.src = "resources/viewport-fit-cover.html")
+EVENT(load)
+Test that fullscreen within an iframe with viewport-fit-cover has viewport-fit-cover behavior:
+RUN(enterFullscreen())
+EXPECTED (visibleRect.left == '0') OK
+EXPECTED (visibleRect.top == '0') OK
+RUN(exitFullscreen())
+
+Test that fullscreen within an iframe with viewport-fit-contain has viewport-fit-contain behavior:
+RUN(frame.src = "resources/viewport-fit-contain.html")
+EVENT(load)
+RUN(enterFullscreen())
+EXPECTED (visibleRect.left == '-100') OK
+EXPECTED (visibleRect.top == '-50') OK
+RUN(exitFullscreen())
+
+RUN(setSafeAreaInsets(0, 0))
+END OF TEST
+

--- a/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets.html
+++ b/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>full-screen-safe-area-insets</title>
+    <script src="../../../fullscreen/full-screen-test.js"></script>
+    <script src="resources/viewport-test-utils.js"></script>
+    <script>
+    function setSafeAreaInsets(left, top) {
+        const script = `(function() {
+            uiController.setSafeAreaInsets(${top}, 0, 0, ${left});
+            uiController.doAfterVisibleContentRectUpdate(() => {
+                uiController.uiScriptComplete();
+            })
+        })();`;
+        return new Promise(resolve => {
+            testRunner.runUIScript(script, () => {
+                resolve();
+            });
+        });
+    }
+
+    function getVisibleRect() {
+        const script = `(function() {
+            return JSON.stringify(uiController.contentVisibleRect);
+        })();`
+        return new Promise(resolve => {
+            testRunner.runUIScript(script, value => {
+                var result = JSON.parse(value);
+                resolve(result);
+            })
+        });
+    }
+
+    async function enterFullscreen() {
+        return new Promise(resolve => {
+            internals.withUserGesture(() => {
+                frame.contentDocument.documentElement.requestFullscreen().then(resolve, resolve);
+            });
+        });
+    }
+
+    async function exitFullscreen() {
+        return new Promise(resolve => {
+            internals.withUserGesture(() => {
+                frame.contentDocument.exitFullscreen().then(resolve, resolve);
+            });
+        });
+    }
+
+    async function testExpectedVisibleRect(left, top) {
+        window.scrollTo(0, 0);
+        // await sleepFor(100);
+        window.visibleRect = await getVisibleRect();
+        testExpected('visibleRect.left', left)
+        testExpected('visibleRect.top', top)
+    }
+
+    async function runTest() {
+        consoleDiv = document.getElementById('console');
+        consoleWrite('Set main frame viewport-fit=contain and test iframes')
+        window.metaViewport = document.querySelector('meta[name="viewport"]');
+        run('metaViewport.content = "width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, viewport-fit=contain"')
+        await run('setSafeAreaInsets(100, 50)');
+        await testExpectedVisibleRect(-100, -50);
+
+        consoleWrite('')
+
+        consoleWrite('Test that fullscreen within an iframe with viewport-fit-cover has viewport-fit-cover behavior:')
+        run('frame.src = "resources/viewport-fit-cover.html"');
+        await waitFor(frame, 'load');
+
+        await run('enterFullscreen()');
+
+        await testExpectedVisibleRect(0, 0);
+
+        await run('exitFullscreen()');
+        consoleWrite('')
+
+        consoleWrite('Test that fullscreen within an iframe with viewport-fit-contain has viewport-fit-contain behavior:')
+        run('frame.src = "resources/viewport-fit-contain.html"');
+        await waitFor(frame, 'load');
+        await run('enterFullscreen()');
+        await testExpectedVisibleRect(-100, -50);
+        await run('exitFullscreen()');
+        consoleWrite('')
+
+        consoleWrite('Set main frame viewport-fit=cover and re-test iframes')
+        run('metaViewport.content = "width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"')
+        await testExpectedVisibleRect(0, 0);
+        consoleWrite('')
+
+        run('frame.src = "resources/viewport-fit-cover.html"');
+        await waitFor(frame, 'load');
+
+        consoleWrite('Test that fullscreen within an iframe with viewport-fit-cover has viewport-fit-cover behavior:')
+        await run('enterFullscreen()');
+        await testExpectedVisibleRect(0, 0);
+        await run('exitFullscreen()');
+        consoleWrite('')
+
+        consoleWrite('Test that fullscreen within an iframe with viewport-fit-contain has viewport-fit-contain behavior:')
+        run('frame.src = "resources/viewport-fit-contain.html"');
+        await waitFor(frame, 'load');
+        await run('enterFullscreen()');
+        await testExpectedVisibleRect(-100, -50);
+        await run('exitFullscreen()');
+        consoleWrite('')
+
+        await run('setSafeAreaInsets(0, 0)');
+    }
+
+    window.addEventListener('load', event => {
+        if (!window.internals) {
+            consoleWrite('This test requires internals; please run in WKTR/DRT.');
+            return;
+        }
+        runTest().finally(endTest);
+    })
+    </script>
+    <style>
+        #console { height: 200px; overflow: scroll; }
+    </style>
+</head>
+<body>
+    <iframe id=frame width=100 height=50></iframe>
+    <div id=console></div>
+</body>
+</html>

--- a/LayoutTests/fast/viewport/ios/resources/viewport-fit-contain.html
+++ b/LayoutTests/fast/viewport/ios/resources/viewport-fit-contain.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1,viewport-fit=contain">
+</head>
+<script>
+window.addEventListener('load', event => {
+    document.body.onclick = function() {
+        document.body.webkitRequestFullScreen();
+    };
+});
+</script>
+<body>
+</body>
+</html>

--- a/LayoutTests/fast/viewport/ios/resources/viewport-fit-cover.html
+++ b/LayoutTests/fast/viewport/ios/resources/viewport-fit-cover.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1,viewport-fit=cover">
+</head>
+<script>
+window.addEventListener('load', event => {
+    document.body.onclick = function() {
+        document.body.webkitRequestFullScreen();
+    };
+});
+</script>
+<body>
+</body>
+</html>

--- a/LayoutTests/fullscreen/full-screen-document-background-color-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-document-background-color-expected.txt
@@ -1,0 +1,8 @@
+
+EXPECTED (internals.documentBackgroundColor() == 'rgb(255, 255, 255)') OK
+RUN(enterFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(0, 128, 0)') OK
+RUN(exitFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(255, 255, 255)') OK
+END OF TEST
+

--- a/LayoutTests/fullscreen/full-screen-document-background-color.html
+++ b/LayoutTests/fullscreen/full-screen-document-background-color.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>full-screen-document-background-color</title>
+    <style>html { background-color: white; }</style>
+    <script src="full-screen-test.js"></script>
+    <script>
+    async function enterFullscreen() {
+        return new Promise(resolve => {
+            internals.withUserGesture(() => {
+                frame.contentDocument.body.requestFullscreen().then(resolve, resolve);
+            });
+        });
+    }
+
+    async function exitFullscreen() {
+        return new Promise(resolve => {
+            internals.withUserGesture(() => {
+                frame.contentDocument.exitFullscreen().then(resolve, resolve);
+            });
+        });
+    }
+
+    async function runTest() {
+        testExpected('internals.documentBackgroundColor()', 'rgb(255, 255, 255)');
+        await run('enterFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(0, 128, 0)');
+        await run('exitFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(255, 255, 255)');
+    }
+    window.addEventListener('load', event => {
+        runTest().finally(endTest);
+    })
+    </script>
+</head>
+<body>
+    <iframe id=frame width=100 height=50 src="resources/green.html"></iframe>
+</body>

--- a/LayoutTests/fullscreen/full-screen-test.js
+++ b/LayoutTests/fullscreen/full-screen-test.js
@@ -97,7 +97,7 @@ function run(testFuncString)
 {
     consoleWrite("RUN(" + testFuncString + ")");
     try {
-        eval(testFuncString);
+        return eval(testFuncString);
     } catch (ex) {
         consoleWrite(ex);
     }

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -680,6 +680,9 @@ void FullscreenManager::dispatchFullscreenChangeOrErrorEvent(Deque<GCReachableRe
                 queue.append(*element);
         }
 
+        // Gaining or losing fullscreen state may change viewport arguments
+        node->protectedDocument()->updateViewportArguments();
+
 #if ENABLE(VIDEO)
         if (shouldNotifyMediaElement && is<HTMLMediaElement>(node.get()))
             downcast<HTMLMediaElement>(node.get()).enteredOrExitedFullscreen();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -564,6 +564,8 @@ public:
     WEBCORE_EXPORT void setFullscreenAutoHideDuration(Seconds);
     WEBCORE_EXPORT void setFullscreenControlsHidden(bool);
 
+    Document* outermostFullscreenDocument() const;
+
     bool shouldSuppressScrollbarAnimations() const { return m_suppressScrollbarAnimations; }
     WEBCORE_EXPORT void setShouldSuppressScrollbarAnimations(bool suppressAnimations);
     void lockAllOverlayScrollbarsToHidden(bool lockOverlayScrollbars);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2146,6 +2146,14 @@ ExceptionOr<void> Internals::setViewBaseBackgroundColor(const String& colorValue
     return Exception { SyntaxError };
 }
 
+ExceptionOr<String> Internals::documentBackgroundColor()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view())
+        return Exception { InvalidAccessError };
+    return serializationForCSS(document->view()->documentBackgroundColor());
+}
+
 ExceptionOr<void> Internals::setPagination(const String& mode, int gap, int pageLength)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -349,6 +349,8 @@ public:
     ExceptionOr<String> viewBaseBackgroundColor();
     ExceptionOr<void> setViewBaseBackgroundColor(const String& colorValue);
 
+    ExceptionOr<String> documentBackgroundColor();
+
     ExceptionOr<void> setPagination(const String& mode, int gap, int pageLength);
     ExceptionOr<uint64_t> lineIndexAfterPageBreak(Element&);
     ExceptionOr<String> configurationForViewport(float devicePixelRatio, int deviceWidth, int deviceHeight, int availableWidth, int availableHeight);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -474,6 +474,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     DOMString viewBaseBackgroundColor();
     undefined setViewBaseBackgroundColor(DOMString colorValue);
 
+    DOMString documentBackgroundColor();
+
     undefined setPagination(DOMString mode, long gap, optional long pageLength = 0);
     unsigned long long lineIndexAfterPageBreak(Element element);
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -157,6 +157,7 @@ enum class TapHandlingResult : uint8_t;
 - (void)_dispatchSetDeviceOrientation:(WebCore::IntDegrees)deviceOrientation;
 - (WebCore::FloatSize)activeViewLayoutSize:(const CGRect&)bounds;
 - (void)_updateScrollViewInsetAdjustmentBehavior;
+- (void)_resetScrollViewInsetAdjustmentBehavior;
 
 - (BOOL)_effectiveAppearanceIsDark;
 - (BOOL)_effectiveUserInterfaceLevelIsElevated;
@@ -200,6 +201,14 @@ enum class TapHandlingResult : uint8_t;
 
 @property (nonatomic, readonly) WKVelocityTrackingScrollView *_scrollViewInternal;
 @property (nonatomic, readonly) CGRect _contentRectForUserInteraction;
+
+@property (nonatomic, readonly) BOOL _haveSetUnobscuredSafeAreaInsets;
+@property (nonatomic, readonly) BOOL _hasOverriddenLayoutParameters;
+@property (nonatomic, readonly) std::optional<CGSize> _viewLayoutSizeOverride;
+@property (nonatomic, readonly) std::optional<CGSize> _minimumUnobscuredSizeOverride;
+@property (nonatomic, readonly) std::optional<CGSize> _maximumUnobscuredSizeOverride;
+- (void)_resetUnobscuredSafeAreaInsets;
+- (void)_resetObscuredInsets;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3024,6 +3024,14 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
 #endif
 }
 
+- (void)_resetScrollViewInsetAdjustmentBehavior
+{
+#if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
+    [_scrollView _resetContentInsetAdjustmentBehavior];
+    [self _updateScrollViewInsetAdjustmentBehavior];
+#endif
+}
+
 - (void)_setAvoidsUnsafeArea:(BOOL)avoidsUnsafeArea
 {
     if (_perProcessState.avoidsUnsafeArea == avoidsUnsafeArea)
@@ -3409,6 +3417,46 @@ static bool isLockdownModeWarningNeeded()
     _page->findClient().didRemoveLayerForFindOverlay(_page.get());
 }
 
+- (BOOL)_haveSetUnobscuredSafeAreaInsets
+{
+    return _haveSetUnobscuredSafeAreaInsets;
+}
+
+- (void)_resetUnobscuredSafeAreaInsets
+{
+    _haveSetUnobscuredSafeAreaInsets = NO;
+    _unobscuredSafeAreaInsets = { };
+    [self _scheduleVisibleContentRectUpdate];
+}
+
+- (BOOL)_hasOverriddenLayoutParameters
+{
+    return _viewLayoutSizeOverride
+        || _minimumUnobscuredSizeOverride
+        || _maximumUnobscuredSizeOverride;
+}
+
+- (std::optional<CGSize>)_viewLayoutSizeOverride
+{
+    return _viewLayoutSizeOverride;
+}
+
+- (std::optional<CGSize>)_minimumUnobscuredSizeOverride
+{
+    return _minimumUnobscuredSizeOverride;
+}
+
+- (std::optional<CGSize>)_maximumUnobscuredSizeOverride
+{
+    return _maximumUnobscuredSizeOverride;
+}
+
+- (void)_resetObscuredInsets
+{
+    _haveSetObscuredInsets = NO;
+    _obscuredInsets = { };
+    [self _scheduleVisibleContentRectUpdate];
+}
 @end
 
 @implementation WKWebView (WKPrivateIOS)
@@ -4094,6 +4142,10 @@ static bool isLockdownModeWarningNeeded()
     _viewLayoutSizeOverride = std::nullopt;
     _minimumUnobscuredSizeOverride = std::nullopt;
     _maximumUnobscuredSizeOverride = std::nullopt;
+
+    _page->setMinimumUnobscuredSize({ });
+    _page->setDefaultUnobscuredSize({ });
+    _page->setMaximumUnobscuredSize({ });
 }
 
 static std::optional<WebCore::ViewportArguments> viewportArgumentsFromDictionary(NSDictionary<NSString *, NSString *> *viewportArgumentPairs)

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -43,10 +43,14 @@
 - (BOOL)_setContentScrollInsetInternal:(UIEdgeInsets)insets;
 - (void)_setDecelerationRateInternal:(UIScrollViewDecelerationRate)rate;
 
+- (void)_resetContentInset;
+@property (nonatomic, readonly) BOOL _contentInsetWasExternallyOverridden;
+
 // FIXME: Likely we can remove this special case for watchOS and tvOS.
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
 @property (nonatomic, assign, readonly) BOOL _contentInsetAdjustmentBehaviorWasExternallyOverridden;
 - (void)_setContentInsetAdjustmentBehaviorInternal:(UIScrollViewContentInsetAdjustmentBehavior)insetAdjustmentBehavior;
+- (void)_resetContentInsetAdjustmentBehavior;
 #endif
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -317,6 +317,17 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
     [_internalDelegate _scheduleVisibleContentRectUpdate];
 }
 
+- (BOOL)_contentInsetWasExternallyOverridden
+{
+    return _contentInsetWasExternallyOverridden;
+}
+
+- (void)_resetContentInset
+{
+    super.contentInset = UIEdgeInsetsZero;
+    [_internalDelegate _scheduleVisibleContentRectUpdate];
+}
+
 // FIXME: Likely we can remove this special case for watchOS and tvOS.
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
 
@@ -342,6 +353,12 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         return;
 
     [super setContentInsetAdjustmentBehavior:insetAdjustmentBehavior];
+}
+
+- (void)_resetContentInsetAdjustmentBehavior
+{
+    _contentInsetAdjustmentBehaviorWasExternallyOverridden = NO;
+    [self _setContentInsetAdjustmentBehaviorInternal:UIScrollViewContentInsetAdjustmentAutomatic];
 }
 
 #endif

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -677,15 +677,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     [self _updateWebViewFullscreenInsets];
     _secheuristic.setSize(self.view.bounds.size);
+    [self._webView setFrame:[_animatingView bounds]];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        [self._webView _beginAnimatedResizeWithUpdates:^{
-            [self._webView _overrideLayoutParametersWithMinimumLayoutSize:size maximumUnobscuredSizeOverride:size];
-        }];
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         [self._webView _setInterfaceOrientationOverride:UIApplication.sharedApplication.statusBarOrientation];
         ALLOW_DEPRECATED_DECLARATIONS_END


### PR DESCRIPTION
#### 56d49b081448ceac6d4f2fbd296ffe4e80b15aa6
<pre>
[iOS] Element Fullscreen does not respect viewport-fit
<a href="https://bugs.webkit.org/show_bug.cgi?id=264012">https://bugs.webkit.org/show_bug.cgi?id=264012</a>
<a href="https://rdar.apple.com/117304719">rdar://117304719</a>

Reviewed by Wenson Hsieh and Tim Horton.

Tests: fast/viewport/ios/full-screen-safe-area-insets.html
       fullscreen/full-screen-document-background-color.html

When configuring the WKWebView during the enter fullscreen operation, various settings of the view
must be returned to their default state for the &quot;automatic&quot; avoid-safe-areas behavior to kick in.
For some calls made by clients, there is no way to reset those behaviors to default, and the
existing implementation merely overrode those settings with other non-default values. The end
result was that all fullscreen content was behaving as if `viewport-fit=cover` was specified, which
allowed some content to slip into the safe areas.

Additionally, when embedded content is taken fullscreen, the viewport settings of that embedded
iframe are not respected, and the embedded content uses the viewport settings of whatever page
embedded it. Also, the fullscreen element&apos;s background is not used in the overflow areas when
iframe content is in fullscreen.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateViewportArguments):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::dispatchFullscreenChangeOrErrorEvent):
(WebCore::FullscreenManager::deepestFullscreenDocument const):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::documentBackgroundColor const):
* Source/WebCore/page/Page.cpp:
(WebCore::viewportDocumentForFrame):
(WebCore::Page::viewportArguments const):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _resetScrollViewInsetAdjustmentBehavior]):
(-[WKWebView _haveSetUnobscuredSafeAreaInsets]):
(-[WKWebView _resetUnobscuredSafeAreaInsets]):
(-[WKWebView _hasOverriddenLayoutParameters]):
(-[WKWebView _viewLayoutSizeOverride]):
(-[WKWebView _minimumUnobscuredSizeOverride]):
(-[WKWebView _maximumUnobscuredSizeOverride]):
(-[WKWebView _resetObscuredInsets]):
(-[WKWebView _clearOverrideLayoutParameters]):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView setFrame:]):
* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _contentInsetWasExternallyOverridden]):
(-[WKScrollView _resetContentInset]):
(-[WKScrollView _resetContentInsetAdjustmentBehavior]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController viewDidLayoutSubviews]):
(-[WKFullScreenViewController viewWillTransitionToSize:withTransitionCoordinator:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
(WebKit::WKWebViewState::store):
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):

Canonical link: <a href="https://commits.webkit.org/270199@main">https://commits.webkit.org/270199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f72f3883cd989428a30fb2fa23ee39238757cad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24816 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/798 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27518 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22358 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28512 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26330 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/354 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5947 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->