### PR TITLE
[css-grid][aspect-ratio] availableLogicalHeightUsing needs to consider AvailableLogicalHeightType when computing logical height from the aspect ratio

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing-expected.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<meta name="assert" content="Grid's definite free space for row track sizing should be the content box logical height when computed from the aspect ratio">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-stretch">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#free-space">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#definite">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+.grid {
+  display: grid;
+  width: 100px;
+  border-block: 10px solid green;
+  padding-block: 20px;
+  background: green;
+  aspect-ratio: 5 / 2;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="grid">
+    <div></div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3761,8 +3761,13 @@ LayoutUnit RenderBox::availableLogicalHeightUsing(const Length& h, AvailableLogi
     if (isFlexItem() && downcast<RenderFlexibleBox>(*parent()).useChildOverridingLogicalHeightForPercentageResolution(*this))
         return overridingContentLogicalHeight();
 
-    if (shouldComputeLogicalHeightFromAspectRatio())
-        return blockSizeFromAspectRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight(), style().logicalAspectRatio(), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatioType(), isRenderReplaced());
+    if (shouldComputeLogicalHeightFromAspectRatio()) {
+        auto borderAndPaddingLogicalHeight = this->borderAndPaddingLogicalHeight();
+        auto borderBoxLogicalHeight = blockSizeFromAspectRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight, style().logicalAspectRatio(), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatioType(), isRenderReplaced());
+        if (heightType == AvailableLogicalHeightType::ExcludeMarginBorderPadding)
+            return borderBoxLogicalHeight - borderAndPaddingLogicalHeight;
+        return borderBoxLogicalHeight;
+    }
 
     if (h.isPercentOrCalculated() && isOutOfFlowPositioned() && !isRenderFragmentedFlow()) {
         // FIXME: This is wrong if the containingBlock has a perpendicular writing mode.


### PR DESCRIPTION
#### 2c5b45546cbb71e62c00d1fefb3f20afbb74f0d0
<pre>
[css-grid][aspect-ratio] availableLogicalHeightUsing needs to consider AvailableLogicalHeightType when computing logical height from the aspect ratio
<a href="https://bugs.webkit.org/show_bug.cgi?id=263310">https://bugs.webkit.org/show_bug.cgi?id=263310</a>
<a href="https://rdar.apple.com/117138268">rdar://117138268</a>

Reviewed by Alan Baradlay.

When availableLogicalHeightUsing determines that it needs to use the
box&apos;s logical width and aspect-ratio to compute the logical height, it
simply returns the value given from blockSizeFromAspectRatio. This is
not correct because blockSizeFromAspectRatio returns the computed border
box size which is not what the caller may want depending on the
specified value of heightType.

If the caller specifies a heightType of ExcludeMarginBorderPadding,
then we should remove the border and padding from the block sides of the
box. This is what grid expects when calling
availableLogicalHeight(ExcludeMarginBorderPadding)) to compute the
definite free space for the rows for the track sizing algorithm.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-with-aspect-ratio-uses-content-box-height-for-track-sizing.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::availableLogicalHeightUsing const):

Canonical link: <a href="https://commits.webkit.org/270098@main">https://commits.webkit.org/270098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53d94d36fdac1f18e08d594456cb867a2ac3d41c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22544 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/501 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27230 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28304 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/125 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21869 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5883 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->