### PR TITLE
[css-flex] Flex layout should not invalidate preferred width bits of flex items at the end of layout.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Loaded image correctly invalidates intrinsic widths of its ancestor chain so that it can be recomputed in flex layout">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+.flexbox {
+  display: flex;
+}
+.green-border {
+  border: 20px solid green;
+}
+.img {
+  max-width: 100%;
+  max-height: 100%;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="flexbox">
+    <div>
+      <div class="flexbox green-border">
+        <img src="/css/support/60x60-green.png" class="img">
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
#### efb0cb853cc0218e2a987af1a313ec360ea1419c
<pre>
[css-flex] Flex layout should not invalidate preferred width bits of flex items at the end of layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264303">https://bugs.webkit.org/show_bug.cgi?id=264303</a>
<a href="https://rdar.apple.com/117181858">rdar://117181858</a>

Reviewed by Alan Baradlay.

In certain situations flex layout will invalidate the preferred widths
bits of flex items towards the end of layout (in layoutAndPlaceChildren),
with a call to updateBlockChildDirtyBitsBeforeLayout. This is incorrect
since by the time we reach layoutAndPlaceChildren flex layout will not
compute the preferred widths of these items again. This leaves the
render tree in a bad state where we may compute the preferred widths
of a flex item at some point during layout, dirty this bit later, and
exit layout with this bit dirtied.

In this state we may not be able to correctly invalidate the ancestor
chain of a flex item in certain situations like in the added test case.
When the image is loaded in the test case we will be unable to
invalidate the preferred widths bits of its ancestor chain since the
item had already been dirtied so we assume the rest of the chain has
already been handled.

Instead, we should be performing this type of invalidation in one of
the following scenarios:
1.) The content of a flex item changes
2.) Certain style changes on the flex item that would impact the
preferred widths computations of its items. One example of this is a
flex item with an aspect ratio since the aspect ratio could impact its
&quot;content based minimum size,&quot; if the flexbox&apos;s cross size size changes
in a specific way: <a href="https://drafts.csswg.org/css-flexbox-1/#content-based-minimum-size">https://drafts.csswg.org/css-flexbox-1/#content-based-minimum-size</a>

This patch focuses on correcting flex layout to more closely follow
the principles in 2. updateFlexItemDirtyBitsBeforeLayout was added to
replace the call to updateBlockChildDirtyBitsBeforeLayout so that we
can continue to dirty flex items for layout without dirtying their
preferred widths bits as well.

Instead, in RenderFlexibleBox::styleDidChange we can call
needsPreferredWidthsRecalculation on each flex item to determine if we
should dirty the preferred widths bit of it.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes.html: Added.
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::updateFlexItemDirtyBitsBeforeLayout):
(WebCore::RenderFlexibleBox::styleDidChange):
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren):

Canonical link: <a href="https://commits.webkit.org/271995@main">https://commits.webkit.org/271995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7c16d3cc65ecddb1babfcc94a57bee066fcc599

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23315 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/2425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28755 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26576 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22379 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7171 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->