### PR TITLE
Refactor Scrollbar to hold NSScrollerImp

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -587,6 +587,7 @@ platform/mac/RevealUtilities.mm
 platform/mac/ScrollAnimatorMac.mm @no-unify
 platform/mac/ScrollAnimationRubberBand.mm
 platform/mac/ScrollViewMac.mm
+platform/mac/ScrollbarMac.mm @no-unify
 platform/mac/ScrollbarsControllerMac.mm @no-unify
 platform/mac/ScrollbarThemeMac.mm @no-unify
 platform/mac/ScrollingEffectsController.mm

--- a/Source/WebCore/page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
@@ -43,9 +43,9 @@ void ScrollingStateScrollingNode::setScrollerImpsFromScrollbars(Scrollbar* verti
     ScrollbarThemeMac& macTheme = static_cast<ScrollbarThemeMac&>(scrollbarTheme);
 
     NSScrollerImp *verticalPainter = verticalScrollbar && verticalScrollbar->supportsUpdateOnSecondaryThread()
-        ? macTheme.painterForScrollbar(*verticalScrollbar) : nullptr;
+        ? macTheme.scrollerImpForScrollbar(*verticalScrollbar) : nullptr;
     NSScrollerImp *horizontalPainter = horizontalScrollbar && horizontalScrollbar->supportsUpdateOnSecondaryThread()
-        ? macTheme.painterForScrollbar(*horizontalScrollbar) : nullptr;
+        ? macTheme.scrollerImpForScrollbar(*horizontalScrollbar) : nullptr;
 
     if (m_verticalScrollerImp == verticalPainter && m_horizontalScrollerImp == horizontalPainter)
         return;

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -38,6 +38,10 @@
 #include "ScrollbarsController.h"
 #include <algorithm>
 
+#if PLATFORM(MAC)
+#include "ScrollbarMac.h"
+#endif
+
 #if PLATFORM(GTK)
 // The position of the scrollbar thumb affects the appearance of the steppers, so
 // when the thumb moves, we have to invalidate them for painting.
@@ -48,7 +52,11 @@ namespace WebCore {
 
 Ref<Scrollbar> Scrollbar::createNativeScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth width)
 {
+#if PLATFORM(MAC)
+    return adoptRef(*new ScrollbarMac(scrollableArea, orientation, width));
+#else
     return adoptRef(*new Scrollbar(scrollableArea, orientation, width));
+#endif
 }
 
 static bool s_shouldUseFixedPixelsPerLineStepForTesting;

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -144,6 +144,8 @@ public:
     bool shouldRegisterScrollbar() const;
     int minimumThumbLength() const;
 
+    virtual bool isMacScrollbar() const { return false; }
+
 protected:
     Scrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth, ScrollbarTheme* = nullptr, bool isCustomScrollbar = false);
 
@@ -196,3 +198,7 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_WIDGET(Scrollbar, isScrollbar())
 
+#define SPECIALIZE_TYPE_TRAITS_SCROLLBAR_HOLDS_SCROLLER_IMP(ToValueTypeName, predicate) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
+    static bool isType(const WebCore::Scrollbar& scrollbar) { return scrollbar.predicate; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/ScrollbarTheme.h
+++ b/Source/WebCore/platform/ScrollbarTheme.h
@@ -105,6 +105,7 @@ public:
 
     virtual void registerScrollbar(Scrollbar&) { }
     virtual void unregisterScrollbar(Scrollbar&) { }
+    virtual void didCreateScrollerImp(Scrollbar&) { };
 
     virtual bool isMockTheme() const { return false; }
 

--- a/Source/WebCore/platform/mac/ScrollbarMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarMac.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#include "Scrollbar.h"
+
+OBJC_CLASS NSScrollerImp;
+
+namespace WebCore {
+
+class ScrollbarMac : public Scrollbar {
+public:
+    ScrollbarMac(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth);
+    ~ScrollbarMac() { }
+
+    NSScrollerImp* scrollerImp() const;
+    void createScrollerImp(NSScrollerImp* oldScrollerImp = nullptr);
+    bool isMacScrollbar() const override { return true; }
+
+private:
+    void updateScrollerImpState();
+
+    RetainPtr<NSScrollerImp> m_scrollerImp;
+};
+
+}
+
+SPECIALIZE_TYPE_TRAITS_SCROLLBAR_HOLDS_SCROLLER_IMP(ScrollbarMac, isMacScrollbar())
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ScrollbarMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarMac.mm
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#import "config.h"
+#import "ScrollbarMac.h"
+
+#if PLATFORM(MAC)
+
+#import "NSScrollerImpDetails.h"
+#import "ScrollTypesMac.h"
+#import "ScrollbarThemeMac.h"
+
+#import <pal/spi/mac/NSScrollerImpSPI.h>
+
+namespace WebCore {
+
+ScrollbarMac::ScrollbarMac(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth width)
+    : Scrollbar(scrollableArea, orientation, width)
+{
+    createScrollerImp();
+}
+
+NSScrollerImp* ScrollbarMac::scrollerImp() const
+{
+    return m_scrollerImp.get();
+}
+
+void ScrollbarMac::createScrollerImp(NSScrollerImp* oldScrollerImp)
+{
+    if (shouldRegisterScrollbar()) {
+        m_scrollerImp = retainPtr([NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(widthStyle()) horizontal:orientation() == ScrollbarOrientation::Horizontal replacingScrollerImp:oldScrollerImp]);
+        updateScrollerImpState();
+    }
+}
+
+void ScrollbarMac::updateScrollerImpState()
+{
+    theme().didCreateScrollerImp(*this);
+    theme().updateEnabledState(*this);
+    theme().updateScrollbarOverlayStyle(*this);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.h
@@ -60,15 +60,14 @@ public:
     void registerScrollbar(Scrollbar&) override;
     void unregisterScrollbar(Scrollbar&) override;
 
-    void setNewPainterForScrollbar(Scrollbar&, RetainPtr<NSScrollerImp>&&);
-    static NSScrollerImp *painterForScrollbar(Scrollbar&);
+    static NSScrollerImp *scrollerImpForScrollbar(Scrollbar&);
 
     void setPaintCharacteristicsForScrollbar(Scrollbar&);
 
     static bool isCurrentlyDrawingIntoLayer();
     static void setIsCurrentlyDrawingIntoLayer(bool);
 
-    void didCreateScrollerImp(Scrollbar&);
+    void didCreateScrollerImp(Scrollbar&) override;
     bool isLayoutDirectionRTL(Scrollbar&);
 
 #if HAVE(RUBBER_BANDING)

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -34,6 +34,7 @@
 #import "ScrollAnimator.h"
 #import "ScrollableArea.h"
 #import "Scrollbar.h"
+#import "ScrollbarMac.h"
 #import "ScrollbarThemeMac.h"
 #import "TimingFunction.h"
 #import "WheelEventTestMonitor.h" // FIXME: This is  layering violation.
@@ -53,7 +54,7 @@ static ScrollbarThemeMac* macScrollbarTheme()
 
 static NSScrollerImp *scrollerImpForScrollbar(Scrollbar& scrollbar)
 {
-    return ScrollbarThemeMac::painterForScrollbar(scrollbar);
+    return ScrollbarThemeMac::scrollerImpForScrollbar(scrollbar);
 }
 
 } // namespace WebCore
@@ -954,11 +955,10 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         verticalScrollbar->invalidate();
 
         NSScrollerImp *oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
-        auto newVerticalPainter = retainPtr([NSScrollerImp scrollerImpWithStyle:newStyle controlSize:(NSControlSize)verticalScrollbar->widthStyle() horizontal:NO replacingScrollerImp:oldVerticalPainter]);
+        auto* verticalScrollbarMac = dynamicDowncast<ScrollbarMac>(verticalScrollbar);
+        verticalScrollbarMac->createScrollerImp(WTFMove(oldVerticalPainter));
 
-        [m_scrollerImpPair setVerticalScrollerImp:newVerticalPainter.get()];
-        macTheme->setNewPainterForScrollbar(*verticalScrollbar, WTFMove(newVerticalPainter));
-        macTheme->didCreateScrollerImp(*verticalScrollbar);
+        [m_scrollerImpPair setVerticalScrollerImp:verticalScrollbarMac->scrollerImp()];
 
         // The different scrollbar styles have different thicknesses, so we must re-set the
         // frameRect to the new thickness, and the re-layout below will ensure the position
@@ -972,11 +972,10 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         horizontalScrollbar->invalidate();
 
         NSScrollerImp *oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];
-        auto newHorizontalPainter = retainPtr([NSScrollerImp scrollerImpWithStyle:newStyle controlSize:(NSControlSize)horizontalScrollbar->widthStyle() horizontal:YES replacingScrollerImp:oldHorizontalPainter]);
+        auto* horizontalScrollbarMac = dynamicDowncast<ScrollbarMac>(horizontalScrollbar);
+        horizontalScrollbarMac->createScrollerImp(WTFMove(oldHorizontalPainter));
 
-        [m_scrollerImpPair setHorizontalScrollerImp:newHorizontalPainter.get()];
-        macTheme->setNewPainterForScrollbar(*horizontalScrollbar, WTFMove(newHorizontalPainter));
-        macTheme->didCreateScrollerImp(*horizontalScrollbar);
+        [m_scrollerImpPair setHorizontalScrollerImp:horizontalScrollbarMac->scrollerImp()];
 
         // The different scrollbar styles have different thicknesses, so we must re-set the
         // frameRect to the new thickness, and the re-layout below will ensure the position


### PR DESCRIPTION
#### fdbd1e818def7f92e7c7e410229619c18d419d08
<pre>
Refactor Scrollbar to hold NSScrollerImp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264014">https://bugs.webkit.org/show_bug.cgi?id=264014</a>
<a href="https://rdar.apple.com/117770817">rdar://117770817</a>

Reviewed by Simon Fraser.

Decouple creation of NSScrollerImps from the global map in
ScrollbarThemeMac. Instead, create ScrollbarMac to hold a reference to the
NSScrollerImp, and change the map to a set of scrollbars (which is still
necessary due to the WebScrollbarPrefsObserver stuff).

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::createNativeScrollbar):
* Source/WebCore/platform/mac/ScrollbarMac.h: Added.
(WebCore::ScrollbarMac::~ScrollbarMac):
* Source/WebCore/platform/mac/ScrollbarMac.mm: Added.
(WebCore::ScrollbarMac::ScrollbarMac):
(WebCore::ScrollbarMac::painterForScrollbar):
(WebCore::ScrollbarMac::createNSScrollerImp):
(WebCore::macScrollbarTheme):
(WebCore::ScrollbarMac::updateNSScrollerImpState):
(WebCore::ScrollbarMac::setNewPainterForScrollbar):
* Source/WebCore/platform/mac/ScrollbarThemeMac.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::scrollbarMap):
(+[WebScrollbarPrefsObserver appearancePrefsChanged:]):
(WebCore::ScrollbarThemeMac::registerScrollbar):
(WebCore::ScrollbarThemeMac::unregisterScrollbar):
(WebCore::ScrollbarThemeMac::painterForScrollbar):
(WebCore::ScrollbarThemeMac::hasThumb):
(WebCore::ScrollbarThemeMac::minimumThumbLength):
(WebCore::ScrollbarThemeMac::updateEnabledState):
(WebCore::paintScrollbar):
(WebCore::ScrollbarThemeMac::setNewPainterForScrollbar): Deleted.
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::updateScrollerStyle):

Canonical link: <a href="https://commits.webkit.org/272044@main">https://commits.webkit.org/272044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeaed4a80a769a95012315bc76f88ed809dde5b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27415 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32816 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30629 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7353 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3939 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->