### PR TITLE
REGRESSION (Sonoma): [ Sonoma wk1 arm64 ] imported/blink/compositing/layer-creation/incremental-destruction.html is constant failure

### DIFF
--- a/LayoutTests/imported/blink/compositing/layer-creation/incremental-destruction-expected.html
+++ b/LayoutTests/imported/blink/compositing/layer-creation/incremental-destruction-expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <style>
 #target {
-    opacity: 0.5;
+    opacity: 0.52;
 }
 </style>
 <div id="target" style="width: 500px; height: 500px; background-color: blue;"></div>

--- a/LayoutTests/imported/blink/compositing/layer-creation/incremental-destruction.html
+++ b/LayoutTests/imported/blink/compositing/layer-creation/incremental-destruction.html
@@ -2,7 +2,7 @@
 <style>
 #target {
     transition: opacity 10ms;
-    opacity: 0.5;
+    opacity: 0.52;
 }
 #target.dim {
     opacity: 0.2;

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2685,5 +2685,3 @@ fast/events/cancel-mousedown-and-drag-to-frame.html [ Failure ]
 webkit.org/b/142192 svg/transforms/transformed-text-fill-gradient.html [ ImageOnlyFailure ]
 
 webkit.org/b/263568 [ arm64 ] media/media-source/media-source-webm-configuration-framerate.html [ Failure ]
-
-webkit.org/b/263601 [ Sonoma arm64 ] imported/blink/compositing/layer-creation/incremental-destruction.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 8a9f21d3f1049f36362e2cacb1fcf0bbfc14b4dc
<pre>
REGRESSION (Sonoma): [ Sonoma wk1 arm64 ] imported/blink/compositing/layer-creation/incremental-destruction.html is constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263601">https://bugs.webkit.org/show_bug.cgi?id=263601</a>
<a href="https://rdar.apple.com/117424936">rdar://117424936</a>

Reviewed by Dan Glastonbury.

In WebKitLegacy, which uses AppKit NSViews for drawing, the results of drawing `background-color; blue; opacity: 0.5`
can be slightly different based on NSView&apos;s adaptive backing store behavior.

Work around this by using a slightly different opacity in this test.

* LayoutTests/imported/blink/compositing/layer-creation/incremental-destruction-expected.html:
* LayoutTests/imported/blink/compositing/layer-creation/incremental-destruction.html:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270057@main">https://commits.webkit.org/270057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9facdf818723a5b99070316693cfc8fbfdedadc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24392 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/69 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22862 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24638 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2009 "Found 1 new test failure: fast/dom/focus-dialog-blur-input-type-change-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27109 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28201 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25992 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1689 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/35 "Found 1 new test failure: fast/scrolling/scroll-to-focused-element-asynchronously.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21753 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5848 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->