### PR TITLE
[ Sonoma+ iOS ] compositing/masks/compositing-clip-path-change-no-repaint.html is a consistent failure.

### DIFF
--- a/LayoutTests/compositing/masks/compositing-clip-path-change-no-repaint.html
+++ b/LayoutTests/compositing/masks/compositing-clip-path-change-no-repaint.html
@@ -25,28 +25,27 @@
             -webkit-clip-path: inset(0 70px);
         }
     </style>
+    <script src="../../resources/ui-helper.js"></script>
     <script>
         if (window.testRunner) {
             testRunner.waitUntilDone();
             testRunner.dumpAsText();
         }
 
-        function doTest()
+        async function doTest()
         {
-            window.setTimeout(function() {
-                window.setTimeout(function() {
-                    if (window.internals)
-                        window.internals.startTrackingRepaints();
+            await UIHelper.renderingUpdate();
 
-                    document.body.classList.add('changed');
+            if (window.internals)
+                window.internals.startTrackingRepaints();
 
-                    if (window.internals)
-                        document.getElementById('repaintRects').textContent = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+            document.body.classList.add('changed');
 
-                    if (window.testRunner)
-                        testRunner.notifyDone();
-                }, 0)
-            }, 0)
+            if (window.internals)
+                document.getElementById('repaintRects').textContent = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+
+            if (window.testRunner)
+                testRunner.notifyDone();
         }
         window.addEventListener('load', doTest, false);
     </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2791,8 +2791,6 @@ webkit.org/b/177323 imported/w3c/web-platform-tests/fetch/security/embedded-cred
 
 webkit.org/b/177445 fast/loader/form-submission-after-beforeunload-cancel.html [ Pass Timeout ]
 
-webkit.org/b/177397 [ Release ] compositing/masks/compositing-clip-path-change-no-repaint.html [ Pass Failure ]
-
 webkit.org/b/177617 http/tests/storageAccess/request-storage-access-top-frame.html [ Pass Timeout ]
 
 webkit.org/b/177547 imported/w3c/web-platform-tests/fetch/security/dangling-markup-mitigation-data-url.tentative.sub.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1990,8 +1990,6 @@ webkit.org/b/262411 [ Sonoma+ ] fast/scrolling/scroll-to-anchor-zoomed-header.ht
 # rdar://114294654 (REGRESSION (265615@main): [ Sonoma ] fast/attachment/cocoa/wide-attachment-rendering.html is a constant failure)
 [ Sonoma+ ] fast/attachment/cocoa/wide-attachment-rendering.html [ Failure ]
 
-webkit.org/b/177397 [ Sonoma+ Release ] compositing/masks/compositing-clip-path-change-no-repaint.html [ Pass Failure ]
-
 # webkit.org/b/263027 REGRESSION ( Sonoma ): [ Sonoma wk2 ] 3 tests in webrtc are consistent failure
 [ Sonoma+ Release arm64 ] webrtc/video-replace-track.html [ Failure ]
 [ Sonoma+ Release arm64 ] webrtc/video-stats.html [ Failure ]


### PR DESCRIPTION
#### e2b5ce4e288cffcb00ae13705bbf0776dacdc001
<pre>
[ Sonoma+ iOS ] compositing/masks/compositing-clip-path-change-no-repaint.html is a consistent failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=177397">https://bugs.webkit.org/show_bug.cgi?id=177397</a>
<a href="https://rdar.apple.com/116780102">rdar://116780102</a>

Unreviewed text fix.

Make this repaint test not flakey by waiting for a frame before starting the test.

* LayoutTests/compositing/masks/compositing-clip-path-change-no-repaint.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270097@main">https://commits.webkit.org/270097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ff96e9942771e5becfffb614d03e65193e5d908

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22444 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/72 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22867 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27115 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28208 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22314 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25998 "Found 55 new API test failures: /WebKitGTK/TestLoaderClient:/webkit/WebKitURIRequest/http-headers, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-cancel, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/user-agent, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-storage, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-subresource, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/default-content-security-policy ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/37 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21755 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5882 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->