### PR TITLE
Fix integer overflow in BitstreamReader::ReadBit called from H265SpsParser::ParseSpsInternal

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.cc
@@ -81,7 +81,12 @@ int BitstreamReader::ReadBit() {
 void BitstreamReader::ConsumeBits(int bits) {
   RTC_DCHECK_GE(bits, 0);
   set_last_read_is_verified(false);
-  if (remaining_bits_ < bits) {
+#if WEBRTC_WEBKIT_BUILD
+  if (remaining_bits_ < bits || bits < 0)
+#else
+  if (remaining_bits_ < bits)
+#endif
+  {
     Invalidate();
     return;
   }

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-Fix-integer-overflow-in-BitstreamReader-ReadBit-call.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-Fix-integer-overflow-in-BitstreamReader-ReadBit-call.patch
@@ -1,0 +1,51 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
+index 7a3c8c6cb387..e53e2c405b32 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
+@@ -269,12 +269,25 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
+     conf_win_bottom_offset = reader.ReadExponentialGolomb();
+   }
+ 
++#if WEBRTC_WEBKIT_BUILD
++  // log2_max_pic_order_cnt_lsb_minus4 is used with
++  // BitstreamReader::ConsumeBits, which can read at most INT_MAX bits at
++  // a time. We also have to avoid overflow when adding 4 to the on-wire
++  // golomb value, e.g., for evil input data.
++  const uint32_t kMaxLog2LsbMinus4 = std::numeric_limits<int>::max() - 4;
++#endif
++
+   // bit_depth_luma_minus8: ue(v)
+   reader.ReadExponentialGolomb();
+   // bit_depth_chroma_minus8: ue(v)
+   reader.ReadExponentialGolomb();
+   // log2_max_pic_order_cnt_lsb_minus4: ue(v)
+   sps.log2_max_pic_order_cnt_lsb_minus4 = reader.ReadExponentialGolomb();
++#if WEBRTC_WEBKIT_BUILD
++  if (!reader.Ok() || sps.log2_max_pic_order_cnt_lsb_minus4 > kMaxLog2LsbMinus4) {
++    return absl::nullopt;
++  }
++#endif
+   uint32_t sps_sub_layer_ordering_info_present_flag = 0;
+   // sps_sub_layer_ordering_info_present_flag: u(1)
+   sps_sub_layer_ordering_info_present_flag = reader.Read<bool>();
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.cc
+index 3e1b94d8d411..2442d1664eed 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.cc
+@@ -81,7 +81,12 @@ int BitstreamReader::ReadBit() {
+ void BitstreamReader::ConsumeBits(int bits) {
+   RTC_DCHECK_GE(bits, 0);
+   set_last_read_is_verified(false);
+-  if (remaining_bits_ < bits) {
++#if WEBRTC_WEBKIT_BUILD
++  if (remaining_bits_ < bits || bits < 0)
++#else
++  if (remaining_bits_ < bits)
++#endif
++  {
+     Invalidate();
+     return;
+   }
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
#### b05fd50ce4ab18d1d6ba009364bb645ea43e354c
<pre>
Fix integer overflow in BitstreamReader::ReadBit called from H265SpsParser::ParseSpsInternal
<a href="https://bugs.webkit.org/show_bug.cgi?id=264019">https://bugs.webkit.org/show_bug.cgi?id=264019</a>
&lt;<a href="https://rdar.apple.com/117763685">rdar://117763685</a>&gt;

Reviewed by Jer Noble.

* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc:
(webrtc::H265SpsParser::ParseSpsInternal):
- Cap maximum value of log2_max_pic_order_cnt_lsb_minus4 that is later
  passed to BitstreamReader::ConsumeBits() to prevent integer overflow.

* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.cc:
(webrtc::BitstreamReader::ConsumeBits):
- Add runtime check for (bits &lt; 0) since this would have caught the
  issue sooner.

* Source/ThirdParty/libwebrtc/WebKit/0001-Fix-integer-overflow-in-BitstreamReader-ReadBit-call.patch: Add.

Canonical link: <a href="https://commits.webkit.org/270062@main">https://commits.webkit.org/270062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f3589b1b709a7d6a4eed328e3d87cc73131a30b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22446 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/76 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27117 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28210 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22319 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26000 "Found 3 new API test failures: /WebKitGTK/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestLoaderClient:/webkit/WebKitURIRequest/http-headers (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/39 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/2986 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2116 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3119 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->