### PR TITLE
Adopt more smart pointers in DocumentThreadableLoader

### DIFF
--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -53,6 +53,11 @@ SecurityOrigin* SecurityContext::securityOrigin() const
     return &m_securityOriginPolicy->origin();
 }
 
+RefPtr<SecurityOrigin> SecurityContext::protectedSecurityOrigin() const
+{
+    return securityOrigin();
+}
+
 void SecurityContext::setContentSecurityPolicy(std::unique_ptr<ContentSecurityPolicy>&& contentSecurityPolicy)
 {
     m_contentSecurityPolicy = WTFMove(contentSecurityPolicy);

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -108,6 +108,7 @@ public:
     virtual void inheritPolicyContainerFrom(const PolicyContainer&);
 
     WEBCORE_EXPORT SecurityOrigin* securityOrigin() const;
+    WEBCORE_EXPORT RefPtr<SecurityOrigin> protectedSecurityOrigin() const;
 
     static SandboxFlags parseSandboxPolicy(StringView policy, String& invalidTokensErrorMessage);
     static bool isSupportedSandboxPolicy(StringView);

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -75,7 +75,7 @@ namespace WebCore {
 void DocumentThreadableLoader::loadResourceSynchronously(Document& document, ResourceRequest&& request, ThreadableLoaderClient& client, const ThreadableLoaderOptions& options, RefPtr<SecurityOrigin>&& origin, std::unique_ptr<ContentSecurityPolicy>&& contentSecurityPolicy, std::optional<CrossOriginEmbedderPolicy>&& crossOriginEmbedderPolicy)
 {
     // The loader will be deleted as soon as this function exits.
-    Ref<DocumentThreadableLoader> loader = adoptRef(*new DocumentThreadableLoader(document, client, LoadSynchronously, WTFMove(request), options, WTFMove(origin), WTFMove(contentSecurityPolicy), WTFMove(crossOriginEmbedderPolicy), String(), ShouldLogError::Yes));
+    Ref loader = adoptRef(*new DocumentThreadableLoader(document, client, LoadSynchronously, WTFMove(request), options, WTFMove(origin), WTFMove(contentSecurityPolicy), WTFMove(crossOriginEmbedderPolicy), String(), ShouldLogError::Yes));
     ASSERT(loader->hasOneRef());
 }
 
@@ -88,7 +88,7 @@ RefPtr<DocumentThreadableLoader> DocumentThreadableLoader::create(Document& docu
 ResourceRequest&& request, const ThreadableLoaderOptions& options, RefPtr<SecurityOrigin>&& origin,
 std::unique_ptr<ContentSecurityPolicy>&& contentSecurityPolicy, std::optional<CrossOriginEmbedderPolicy>&& crossOriginEmbedderPolicy, String&& referrer, ShouldLogError shouldLogError)
 {
-    RefPtr<DocumentThreadableLoader> loader = adoptRef(new DocumentThreadableLoader(document, client, LoadAsynchronously, WTFMove(request), options, WTFMove(origin), WTFMove(contentSecurityPolicy), WTFMove(crossOriginEmbedderPolicy), WTFMove(referrer), shouldLogError));
+    RefPtr loader = adoptRef(new DocumentThreadableLoader(document, client, LoadAsynchronously, WTFMove(request), options, WTFMove(origin), WTFMove(contentSecurityPolicy), WTFMove(crossOriginEmbedderPolicy), WTFMove(referrer), shouldLogError));
     if (!loader->isLoading())
         loader = nullptr;
     return loader;
@@ -111,7 +111,7 @@ bool DocumentThreadableLoader::shouldSetHTTPHeadersToKeep() const
 
 #if ENABLE(SERVICE_WORKER)
     if (m_options.serviceWorkersMode == ServiceWorkersMode::All && m_async)
-        return m_options.serviceWorkerRegistrationIdentifier || m_document.activeServiceWorker();
+        return m_options.serviceWorkerRegistrationIdentifier || m_document->activeServiceWorker();
 #endif
 
     return false;
@@ -159,7 +159,7 @@ DocumentThreadableLoader::DocumentThreadableLoader(Document& document, Threadabl
         m_options.httpHeadersToKeep = httpHeadersToKeepFromCleaning(request.httpHeaderFields());
 
     bool shouldDisableCORS = document.isRunningUserScripts() && LegacySchemeRegistry::isUserExtensionScheme(request.url().protocol());
-    if (auto* page = document.page())
+    if (CheckedPtr page = document.page())
         shouldDisableCORS |= page->shouldDisableCorsForRequestTo(request.url());
 
     if (shouldDisableCORS) {
@@ -227,7 +227,7 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
             return;
 
         m_simpleRequest = false;
-        if (auto* page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), securityOrigin().toString(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
+        if (CheckedPtr page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), securityOrigin().toString(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
             preflightSuccess(WTFMove(request));
         else
             makeCrossOriginAccessRequestWithPreflight(WTFMove(request));
@@ -239,7 +239,7 @@ void DocumentThreadableLoader::makeSimpleCrossOriginAccessRequest(ResourceReques
     ASSERT(m_options.preflightPolicy != PreflightPolicy::Force || shouldPerformSecurityChecks());
     ASSERT(m_options.preflightPolicy == PreflightPolicy::Prevent || isSimpleCrossOriginAccessRequest(request.httpMethod(), request.httpHeaderFields()) || shouldPerformSecurityChecks());
 
-    updateRequestForAccessControl(request, securityOrigin(), m_options.storedCredentialsPolicy);
+    updateRequestForAccessControl(request, protectedSecurityOrigin(), m_options.storedCredentialsPolicy);
     loadRequest(WTFMove(request), SecurityCheckPolicy::DoSecurityCheck);
 }
 
@@ -255,19 +255,19 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequestWithPreflight(Resourc
 
 DocumentThreadableLoader::~DocumentThreadableLoader()
 {
-    if (m_resource)
-        m_resource->removeClient(*this);
+    if (CachedResourceHandle resource = m_resource)
+        resource->removeClient(*this);
 }
 
 void DocumentThreadableLoader::cancel()
 {
-    Ref<DocumentThreadableLoader> protectedThis(*this);
+    Ref protectedThis { *this };
 
     // Cancel can re-enter and m_resource might be null here as a result.
     if (m_client && m_resource) {
         // FIXME: This error is sent to the client in didFail(), so it should not be an internal one. Use LocalFrameLoaderClient::cancelledError() instead.
         ResourceError error(errorDomainWebKitInternal, 0, m_resource->url(), "Load cancelled"_s, ResourceError::Type::Cancellation);
-        m_client->didFail(error);
+        m_client->didFail(error); // May destroy the client.
     }
     clearResource();
     m_client = nullptr;
@@ -280,16 +280,22 @@ void DocumentThreadableLoader::computeIsDone()
             m_client->notifyIsDone(m_async && !m_preflightChecker && !m_resource);
         return;
     }
-    platformStrategies()->loaderStrategy()->isResourceLoadFinished(*m_resource, [this, weakThis = WeakPtr { *this }](bool isDone) {
-        if (weakThis && m_client)
-            m_client->notifyIsDone(isDone);
+    platformStrategies()->loaderStrategy()->isResourceLoadFinished(*protectedResource(), [weakThis = WeakPtr { *this }](bool isDone) {
+        RefPtr protectedThis = weakThis.get();
+        if (protectedThis && protectedThis->m_client)
+            protectedThis->m_client->notifyIsDone(isDone);
     });
+}
+
+CachedResourceHandle<CachedRawResource> DocumentThreadableLoader::protectedResource() const
+{
+    return m_resource;
 }
 
 void DocumentThreadableLoader::setDefersLoading(bool value)
 {
-    if (m_resource)
-        m_resource->setDefersLoading(value);
+    if (CachedResourceHandle resource = m_resource)
+        resource->setDefersLoading(value);
     if (m_preflightChecker)
         m_preflightChecker->setDefersLoading(value);
 }
@@ -300,7 +306,7 @@ void DocumentThreadableLoader::clearResource()
     // which could lead to calling CachedResource::removeClient() multiple times for
     // this DocumentThreadableLoader. Save off a copy of m_resource and clear it to
     // prevent the reentrancy.
-    if (CachedResourceHandle<CachedRawResource> resource = m_resource) {
+    if (CachedResourceHandle resource = m_resource) {
         m_resource = nullptr;
         resource->removeClient(*this);
     }
@@ -313,7 +319,7 @@ void DocumentThreadableLoader::redirectReceived(CachedResource& resource, Resour
     ASSERT(m_client);
     ASSERT_UNUSED(resource, &resource == m_resource);
 
-    Ref<DocumentThreadableLoader> protectedThis(*this);
+    Ref protectedThis { *this };
     --m_options.maxRedirectCount;
 
     m_responseURL = request.url();
@@ -351,7 +357,7 @@ void DocumentThreadableLoader::redirectReceived(CachedResource& resource, Resour
     // Use a unique for subsequent loads if needed.
     // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch (Step 10).
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
-    if (!securityOrigin().canRequest(redirectResponse.url(), OriginAccessPatternsForWebProcess::singleton()) && !protocolHostAndPortAreEqual(redirectResponse.url(), request.url()))
+    if (!protectedSecurityOrigin()->canRequest(redirectResponse.url(), OriginAccessPatternsForWebProcess::singleton()) && !protocolHostAndPortAreEqual(redirectResponse.url(), request.url()))
         m_origin = SecurityOrigin::createOpaque();
 
     // Except in case where preflight is needed, loading should be able to continue on its own.
@@ -494,16 +500,17 @@ void DocumentThreadableLoader::didFinishLoading(ResourceLoaderIdentifier identif
     ASSERT(m_client);
 
     if (m_delayCallbacksForIntegrityCheck) {
-        if (!matchIntegrityMetadata(*m_resource, m_options.integrity)) {
-            reportIntegrityMetadataError(*m_resource, m_options.integrity);
+        CachedResourceHandle resource = m_resource;
+        if (!matchIntegrityMetadata(*resource, m_options.integrity)) {
+            reportIntegrityMetadataError(*resource, m_options.integrity);
             return;
         }
 
-        auto response = m_resource->response();
+        auto response = resource->response();
 
         RefPtr<SharedBuffer> buffer;
-        if (m_resource->resourceBuffer())
-            buffer = m_resource->resourceBuffer()->makeContiguous();
+        if (resource->resourceBuffer())
+            buffer = resource->resourceBuffer()->makeContiguous();
         if (options().filteringPolicy == ResponseFilteringPolicy::Disable) {
             m_client->didReceiveResponse(identifier, response);
             if (buffer)
@@ -536,15 +543,21 @@ void DocumentThreadableLoader::didFail(ResourceLoaderIdentifier, const ResourceE
 #endif
 
     if (m_shouldLogError == ShouldLogError::Yes)
-        logError(m_document, error, m_options.initiatorType);
+        logError(protectedDocument(), error, m_options.initiatorType);
 
-    m_client->didFail(error);
+    if (m_client)
+        m_client->didFail(error); // May cause the client to get destroyed.
+}
+
+Ref<Document> DocumentThreadableLoader::protectedDocument()
+{
+    return *m_document;
 }
 
 void DocumentThreadableLoader::preflightSuccess(ResourceRequest&& request)
 {
     ResourceRequest actualRequest(WTFMove(request));
-    updateRequestForAccessControl(actualRequest, securityOrigin(), m_options.storedCredentialsPolicy);
+    updateRequestForAccessControl(actualRequest, protectedSecurityOrigin(), m_options.storedCredentialsPolicy);
 
     m_preflightChecker = std::nullopt;
 
@@ -556,10 +569,11 @@ void DocumentThreadableLoader::preflightFailure(ResourceLoaderIdentifier identif
 {
     m_preflightChecker = std::nullopt;
 
-    InspectorInstrumentation::didFailLoading(m_document.frame(), m_document.frame()->loader().documentLoader(), identifier, error);
+    RefPtr frame = m_document->frame();
+    InspectorInstrumentation::didFailLoading(frame.get(), frame->loader().protectedDocumentLoader().get(), identifier, error);
 
     if (m_shouldLogError == ShouldLogError::Yes)
-        logError(m_document, error, m_options.initiatorType);
+        logError(protectedDocument(), error, m_options.initiatorType);
 
     m_client->didFail(error);
 }
@@ -590,18 +604,16 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         request.setAllowCookies(m_options.storedCredentialsPolicy == StoredCredentialsPolicy::Use);
         CachedResourceRequest newRequest(WTFMove(request), options);
         newRequest.setInitiatorType(AtomString { m_options.initiatorType });
-        newRequest.setOrigin(securityOrigin());
+        newRequest.setOrigin(protectedSecurityOrigin());
 
         ASSERT(!m_resource);
-        if (m_resource) {
-            CachedResourceHandle<CachedRawResource> resource = std::exchange(m_resource, nullptr);
+        if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
             resource->removeClient(*this);
-        }
 
-        auto cachedResource = m_document.cachedResourceLoader().requestRawResource(WTFMove(newRequest));
+        auto cachedResource = m_document->protectedCachedResourceLoader()->requestRawResource(WTFMove(newRequest));
         m_resource = cachedResource.value_or(nullptr);
-        if (m_resource)
-            m_resource->addClient(*this);
+        if (CachedResourceHandle resource = m_resource)
+            resource->addClient(*this);
         else
             logErrorAndFail(cachedResource.error());
         return;
@@ -618,11 +630,11 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     ResourceError error;
     ResourceResponse response;
     auto identifier = AtomicObjectIdentifier<ResourceLoader> { std::numeric_limits<uint64_t>::max() };
-    if (auto* frame = m_document.frame()) {
-        if (!MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*frame, m_document.securityOrigin(), requestURL))
+    if (RefPtr frame = m_document->frame()) {
+        if (!MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*frame, *m_document->protectedSecurityOrigin(), requestURL))
             return;
-        auto& frameLoader = frame->loader();
-        identifier = frameLoader.loadResourceSynchronously(request, m_options.clientCredentialPolicy, m_options, *m_originalHeaders, error, response, data);
+        CheckedRef frameLoader = frame->loader();
+        identifier = frameLoader->loadResourceSynchronously(request, m_options.clientCredentialPolicy, m_options, *m_originalHeaders, error, response, data);
     }
 
     loadTiming.markEndTime();
@@ -666,7 +678,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
             else {
                 ASSERT(m_options.mode == FetchOptions::Mode::Cors);
                 response.setTainting(ResourceResponse::Tainting::Cors);
-                auto accessControlCheckResult = passesAccessControlCheck(response, m_options.storedCredentialsPolicy, securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+                auto accessControlCheckResult = passesAccessControlCheck(response, m_options.storedCredentialsPolicy, protectedSecurityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
                 if (!accessControlCheckResult) {
                     logErrorAndFail(ResourceError(errorDomainWebKitInternal, 0, response.url(), accessControlCheckResult.error(), ResourceError::Type::AccessControl));
                     return;
@@ -684,8 +696,8 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     if (options().initiatorContext == InitiatorContext::Worker)
         finishedTimingForWorkerLoad(resourceTiming);
     else {
-        if (auto* window = document().domWindow())
-            window->performance().addResourceTiming(WTFMove(resourceTiming));
+        if (RefPtr window = document().domWindow())
+            window->protectedPerformance()->addResourceTiming(WTFMove(resourceTiming));
     }
 
     didFinishLoading(identifier, { });
@@ -717,27 +729,32 @@ bool DocumentThreadableLoader::isAllowedRedirect(const URL& url)
     if (m_options.mode == FetchOptions::Mode::NoCors)
         return true;
 
-    return m_sameOriginRequest && securityOrigin().canRequest(url, OriginAccessPatternsForWebProcess::singleton());
+    return m_sameOriginRequest && protectedSecurityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton());
 }
 
 SecurityOrigin& DocumentThreadableLoader::securityOrigin() const
 {
-    return m_origin ? *m_origin : m_document.securityOrigin();
+    return m_origin ? *m_origin : m_document->securityOrigin();
+}
+
+Ref<SecurityOrigin> DocumentThreadableLoader::protectedSecurityOrigin() const
+{
+    return securityOrigin();
 }
 
 const ContentSecurityPolicy& DocumentThreadableLoader::contentSecurityPolicy() const
 {
     if (m_contentSecurityPolicy)
         return *m_contentSecurityPolicy.get();
-    ASSERT(m_document.contentSecurityPolicy());
-    return *m_document.contentSecurityPolicy();
+    ASSERT(m_document->contentSecurityPolicy());
+    return *m_document->contentSecurityPolicy();
 }
 
 const CrossOriginEmbedderPolicy& DocumentThreadableLoader::crossOriginEmbedderPolicy() const
 {
     if (m_crossOriginEmbedderPolicy)
         return *m_crossOriginEmbedderPolicy;
-    return m_document.crossOriginEmbedderPolicy();
+    return m_document->crossOriginEmbedderPolicy();
 }
 
 void DocumentThreadableLoader::reportRedirectionWithBadScheme(const URL& url)
@@ -763,12 +780,14 @@ void DocumentThreadableLoader::reportIntegrityMetadataError(const CachedResource
 void DocumentThreadableLoader::logErrorAndFail(const ResourceError& error)
 {
     if (m_shouldLogError == ShouldLogError::Yes) {
+        Ref document = *m_document;
         if (error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && !error.localizedDescription().isEmpty())
-            m_document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
-        logError(m_document, error, m_options.initiatorType);
+            document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
+        logError(document, error, m_options.initiatorType);
     }
     ASSERT(m_client);
-    m_client->didFail(error);
+    if (m_client)
+        m_client->didFail(error); // May cause the client to get destroyed.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -109,10 +109,13 @@ namespace WebCore {
         bool isResponseAllowedByContentSecurityPolicy(const ResourceResponse&);
 
         SecurityOrigin& securityOrigin() const;
+        Ref<SecurityOrigin> protectedSecurityOrigin() const;
         const ContentSecurityPolicy& contentSecurityPolicy() const;
         const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const;
 
-        Document& document() { return m_document; }
+        Document& document() { return *m_document; }
+        Ref<Document> protectedDocument();
+
         const ThreadableLoaderOptions& options() const { return m_options; }
         const String& referrer() const { return m_referrer; }
         bool isLoading() { return m_resource || m_preflightChecker; }
@@ -126,9 +129,11 @@ namespace WebCore {
         bool shouldSetHTTPHeadersToKeep() const;
         bool checkURLSchemeAsCORSEnabled(const URL&);
 
+        CachedResourceHandle<CachedRawResource> protectedResource() const;
+
         CachedResourceHandle<CachedRawResource> m_resource;
-        ThreadableLoaderClient* m_client;
-        Document& m_document;
+        ThreadableLoaderClient* m_client; // FIXME: Use a smart pointer.
+        WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
         ThreadableLoaderOptions m_options;
         bool m_responsesCanBeOpaque { true };
         RefPtr<SecurityOrigin> m_origin;

--- a/Source/WebCore/loader/ThreadableLoaderClient.h
+++ b/Source/WebCore/loader/ThreadableLoaderClient.h
@@ -32,6 +32,7 @@
 
 #include "LoaderMalloc.h"
 #include "ResourceLoaderIdentifier.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -41,7 +42,7 @@ class ResourceResponse;
 class ResourceTiming;
 class SharedBuffer;
 
-class ThreadableLoaderClient {
+class ThreadableLoaderClient : public CanMakeThreadSafeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     virtual void didSendData(unsigned long long /*bytesSent*/, unsigned long long /*totalBytesToBeSent*/) { }

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -779,6 +779,11 @@ Performance& LocalDOMWindow::performance() const
     return *m_performance;
 }
 
+Ref<Performance> LocalDOMWindow::protectedPerformance() const
+{
+    return performance();
+}
+
 ReducedResolutionSeconds LocalDOMWindow::nowTimestamp() const
 {
     return performance().nowInReducedResolutionSeconds();

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -347,6 +347,8 @@ public:
 #endif
 
     Performance& performance() const;
+    Ref<Performance> protectedPerformance() const;
+
     WEBCORE_EXPORT ReducedResolutionSeconds nowTimestamp() const;
     void freezeNowTimestamp();
     void unfreezeNowTimestamp();


### PR DESCRIPTION
#### b2ec6cbea7f0e5f16a1432d6d0769011e126cfe7
<pre>
Adopt more smart pointers in DocumentThreadableLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=264017">https://bugs.webkit.org/show_bug.cgi?id=264017</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/fetch/FetchLoader.cpp:
(WebCore::FetchLoader::~FetchLoader):
(WebCore::FetchLoader::didFail):
* Source/WebCore/Modules/fetch/FetchLoader.h:
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::protectedSecurityOrigin const):
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadResourceSynchronously):
(WebCore::DocumentThreadableLoader::create):
(WebCore::DocumentThreadableLoader::shouldSetHTTPHeadersToKeep const):
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::makeSimpleCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::~DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::cancel):
(WebCore::DocumentThreadableLoader::computeIsDone):
(WebCore::DocumentThreadableLoader::clearClient):
(WebCore::DocumentThreadableLoader::protectedResource const):
(WebCore::DocumentThreadableLoader::setDefersLoading):
(WebCore::DocumentThreadableLoader::clearResource):
(WebCore::DocumentThreadableLoader::redirectReceived):
(WebCore::DocumentThreadableLoader::didFinishLoading):
(WebCore::DocumentThreadableLoader::didFail):
(WebCore::DocumentThreadableLoader::protectedDocument):
(WebCore::DocumentThreadableLoader::preflightSuccess):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::loadRequest):
(WebCore::DocumentThreadableLoader::isAllowedRedirect):
(WebCore::DocumentThreadableLoader::securityOrigin const):
(WebCore::DocumentThreadableLoader::protectedSecurityOrigin const):
(WebCore::DocumentThreadableLoader::contentSecurityPolicy const):
(WebCore::DocumentThreadableLoader::crossOriginEmbedderPolicy const):
(WebCore::DocumentThreadableLoader::logErrorAndFail):
* Source/WebCore/loader/DocumentThreadableLoader.h:
(WebCore::DocumentThreadableLoader::clearClient): Deleted.
* Source/WebCore/loader/ThreadableLoaderClient.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::protectedPerformance const):
* Source/WebCore/page/LocalDOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/270211@main">https://commits.webkit.org/270211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8d70616b5ca01cde55d1da89c5a3858e4ee818b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23036 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27390 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28424 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26229 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/250 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3231 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5955 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->