### PR TITLE
Adopt UIAsyncTextInteraction behind the "Async UIKit Interactions" setting

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -120,6 +120,8 @@
 
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
 #import <UIKit/UIAsyncTextInput.h>
+#import <UIKit/UIAsyncTextInputClient.h>
+#import <UIKit/UIAsyncTextInteraction.h>
 #import <UIKit/UIKeyEventContext.h>
 #endif
 
@@ -542,6 +544,7 @@ typedef enum {
 @end
 
 @interface UITextInteractionAssistant : NSObject
+- (instancetype)initWithView:(UIResponder <UITextInput> *)view;
 @end
 
 @interface UITextInteractionAssistant ()
@@ -1063,6 +1066,7 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @interface UITextInteractionAssistant (IPI)
 - (void)willStartScrollingOrZooming;
 - (void)didEndScrollingOrZooming;
+- (void)selectWord;
 @end
 
 #if USE(UICONTEXTMENU)

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -500,6 +500,7 @@ UIProcess/ios/WKStylusDeviceObserver.mm
 UIProcess/ios/WKSyntheticFlagsChangedWebEvent.mm
 UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
 UIProcess/ios/WKTapHighlightView.mm
+UIProcess/ios/WKTextInteractionWrapper.mm
 UIProcess/ios/WKTouchActionGestureRecognizer.mm
 UIProcess/ios/WKTouchEventsGestureRecognizer.mm
 UIProcess/ios/WKTextSelectionRect.mm

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -503,7 +503,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_needsDeferredEndScrollingSelectionUpdate)
         return;
 
-    [_textInteractionAssistant deactivateSelection];
+    [_textInteractionWrapper deactivateSelection];
 }
 
 static WebCore::FloatBoxExtent floatBoxExtent(UIEdgeInsets insets)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -129,6 +129,7 @@ class WebPageProxy;
 @class WKInspectorNodeSearchGestureRecognizer;
 @class WKTapHighlightView;
 @class WKTargetedPreviewContainer;
+@class WKTextInteractionWrapper;
 @class WKTextRange;
 @class _WKTextInputContext;
 
@@ -335,7 +336,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _pointerInteractionRegionNeedsUpdate;
 #endif
 
-    RetainPtr<UIWKTextInteractionAssistant> _textInteractionAssistant;
+    RetainPtr<WKTextInteractionWrapper> _textInteractionWrapper;
     OptionSet<WebKit::SuppressSelectionAssistantReason> _suppressSelectionAssistantReasons;
 
     RetainPtr<UITextInputTraits> _traits;
@@ -846,6 +847,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)cancelTextRecognitionForVideoInElementFullscreen;
 
 - (BOOL)_tryToHandlePressesEvent:(UIPressesEvent *)event;
+
+@property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "UIKitSPI.h"
+
+@class WKContentView;
+
+@interface WKTextInteractionWrapper : NSObject
+
+- (instancetype)initWithView:(WKContentView *)contentView;
+
+- (void)activateSelection;
+- (void)deactivateSelection;
+- (void)didEndScrollingOverflow;
+- (void)selectionChanged;
+- (void)setGestureRecognizers;
+- (void)willStartScrollingOverflow;
+- (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(UIWKGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(UIWKSelectionFlags)flags;
+- (void)showDictionaryFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect;
+- (void)selectionChangedWithTouchAt:(CGPoint)point withSelectionTouch:(UIWKSelectionTouch)touch withFlags:(UIWKSelectionFlags)flags;
+- (void)lookup:(NSString *)textWithContext withRange:(NSRange)range fromRect:(CGRect)presentationRect;
+- (void)showShareSheetFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect;
+- (void)showTextServiceFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect;
+- (void)scheduleReplacementsForText:(NSString *)text;
+- (void)scheduleChineseTransliterationForText:(NSString *)text;
+- (void)willStartScrollingOrZooming;
+- (void)didEndScrollingOrZooming;
+- (void)selectWord;
+- (void)selectAll:(id)sender;
+- (void)translate:(NSString *)text fromRect:(CGRect)presentationRect;
+
+#if USE(UICONTEXTMENU)
+- (void)setExternalContextMenuInteractionDelegate:(id<UIContextMenuInteractionDelegate>)delegate;
+@property (nonatomic, strong, readonly) UIContextMenuInteraction *contextMenuInteraction;
+#endif
+
+@property (nonatomic, readonly) UIWKTextInteractionAssistant *textInteractionAssistant;
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "config.h"
+#import "WKTextInteractionWrapper.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "WKContentViewInteraction.h"
+#import <wtf/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK(UIKit) // NOLINT
+SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
+
+@implementation WKTextInteractionWrapper {
+    RetainPtr<UIWKTextInteractionAssistant> _textInteractionAssistant;
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    RetainPtr<UIAsyncTextInteraction> _asyncTextInteraction;
+#endif
+}
+
+- (instancetype)initWithView:(WKContentView *)view
+{
+    if (!(self = [super init]))
+        return nil;
+
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    static bool hasAsyncTextInteraction = !!getUIAsyncTextInteractionClass();
+    if (hasAsyncTextInteraction && view.shouldUseAsyncInteractions) {
+        _asyncTextInteraction = adoptNS([allocUIAsyncTextInteractionInstance() init]);
+        [view addInteraction:_asyncTextInteraction.get()];
+    } else
+#endif
+        _textInteractionAssistant = adoptNS([[UIWKTextInteractionAssistant alloc] initWithView:view]);
+
+    return self;
+}
+
+- (UIWKTextInteractionAssistant *)textInteractionAssistant
+{
+    return _textInteractionAssistant.get();
+}
+
+- (void)activateSelection
+{
+    [_textInteractionAssistant activateSelection];
+}
+
+- (void)deactivateSelection
+{
+    [_textInteractionAssistant deactivateSelection];
+}
+
+- (void)selectionChanged
+{
+    [_textInteractionAssistant selectionChanged];
+}
+
+- (void)setGestureRecognizers
+{
+    [_textInteractionAssistant setGestureRecognizers];
+}
+
+- (void)willStartScrollingOverflow
+{
+    [_textInteractionAssistant willStartScrollingOverflow];
+}
+
+- (void)didEndScrollingOverflow
+{
+    [_textInteractionAssistant didEndScrollingOverflow];
+}
+
+- (void)willStartScrollingOrZooming
+{
+    [_textInteractionAssistant willStartScrollingOrZooming];
+}
+
+- (void)didEndScrollingOrZooming
+{
+    [_textInteractionAssistant didEndScrollingOrZooming];
+}
+
+- (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(UIWKGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(UIWKSelectionFlags)flags
+{
+    [_textInteractionAssistant selectionChangedWithGestureAt:point withGesture:gestureType withState:gestureState withFlags:flags];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction selectionChangedWithGestureAt:point withGesture:gestureType withState:gestureState withFlags:flags];
+#endif
+}
+
+- (void)showDictionaryFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect
+{
+    [_textInteractionAssistant showDictionaryFor:selectedTerm fromRect:presentationRect];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction showDictionaryFor:selectedTerm fromRect:presentationRect];
+#endif
+}
+
+- (void)selectionChangedWithTouchAt:(CGPoint)point withSelectionTouch:(UIWKSelectionTouch)touch withFlags:(UIWKSelectionFlags)flags
+{
+    [_textInteractionAssistant selectionChangedWithTouchAt:point withSelectionTouch:touch withFlags:flags];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction selectionChangedWithTouchAt:point withSelectionTouch:touch withFlags:flags];
+#endif
+}
+
+- (void)lookup:(NSString *)textWithContext withRange:(NSRange)range fromRect:(CGRect)presentationRect
+{
+    [_textInteractionAssistant lookup:textWithContext withRange:range fromRect:presentationRect];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction lookup:textWithContext withRange:range fromRect:presentationRect];
+#endif
+}
+
+- (void)showShareSheetFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect
+{
+    [_textInteractionAssistant showShareSheetFor:selectedTerm fromRect:presentationRect];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction showShareSheetFor:selectedTerm fromRect:presentationRect];
+#endif
+}
+
+- (void)showTextServiceFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect
+{
+    [_textInteractionAssistant showTextServiceFor:selectedTerm fromRect:presentationRect];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction showTextServiceFor:selectedTerm fromRect:presentationRect];
+#endif
+}
+
+- (void)scheduleReplacementsForText:(NSString *)text
+{
+    [_textInteractionAssistant scheduleReplacementsForText:text];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction scheduleReplacementsForText:text];
+#endif
+}
+
+- (void)scheduleChineseTransliterationForText:(NSString *)text
+{
+    [_textInteractionAssistant scheduleChineseTransliterationForText:text];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction scheduleChineseTransliterationForText:text];
+#endif
+}
+
+- (void)translate:(NSString *)text fromRect:(CGRect)presentationRect
+{
+    [_textInteractionAssistant translate:text fromRect:presentationRect];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction translate:text fromRect:presentationRect];
+#endif
+}
+
+- (void)selectWord
+{
+    [_textInteractionAssistant selectWord];
+}
+
+- (void)selectAll:(id)sender
+{
+    [_textInteractionAssistant selectAll:sender];
+}
+
+#if USE(UICONTEXTMENU)
+
+- (UIContextMenuInteraction *)contextMenuInteraction
+{
+    return [_textInteractionAssistant contextMenuInteraction];
+}
+
+- (void)setExternalContextMenuInteractionDelegate:(id<UIContextMenuInteractionDelegate>)delegate
+{
+    [_textInteractionAssistant setExternalContextMenuInteractionDelegate:delegate];
+}
+
+#endif // USE(UICONTEXTMENU)
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2297,6 +2297,7 @@
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
 		F4BCBBEC2AC332AA00C1858D /* WKFormAccessoryView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
+		F4C359532AF19BC40083B0EA /* WKTextInteractionWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F4C359512AF18F620083B0EA /* WKTextInteractionWrapper.h */; };
 		F4C627E72A7AC17B00F546BF /* WKMouseInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = F4C627E62A7AC17400F546BF /* WKMouseInteraction.h */; };
 		F4CB09E5225D5A0900891487 /* WebsiteMediaSourcePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CB09E4225D5A0300891487 /* WebsiteMediaSourcePolicy.h */; };
 		F4CBF79E2A6ADF7E00C066BF /* WebEventType.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CBF79D2A6ADF5400C066BF /* WebEventType.h */; };
@@ -7477,6 +7478,8 @@
 		F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormAccessoryView.h; path = ios/forms/WKFormAccessoryView.h; sourceTree = "<group>"; };
 		F4BCBBE72AC3295300C1858D /* WKFormAccessoryView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKFormAccessoryView.mm; path = ios/forms/WKFormAccessoryView.mm; sourceTree = "<group>"; };
 		F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlaybackSessionContextIdentifier.h; sourceTree = "<group>"; };
+		F4C359512AF18F620083B0EA /* WKTextInteractionWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTextInteractionWrapper.h; path = ios/WKTextInteractionWrapper.h; sourceTree = "<group>"; };
+		F4C359522AF18F620083B0EA /* WKTextInteractionWrapper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKTextInteractionWrapper.mm; path = ios/WKTextInteractionWrapper.mm; sourceTree = "<group>"; };
 		F4C627E52A7AC17300F546BF /* WKMouseInteraction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKMouseInteraction.mm; path = ios/WKMouseInteraction.mm; sourceTree = "<group>"; };
 		F4C627E62A7AC17400F546BF /* WKMouseInteraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKMouseInteraction.h; path = ios/WKMouseInteraction.h; sourceTree = "<group>"; };
 		F4C8A13A2AC6289900B94BA6 /* DrawingAreaInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = DrawingAreaInfo.serialization.in; sourceTree = "<group>"; };
@@ -10046,6 +10049,8 @@
 				26F10BE719187E2E001D0E68 /* WKSyntheticTapGestureRecognizer.mm */,
 				F4E8912E2AB7C344005AEBC3 /* WKTapHighlightView.h */,
 				F4E8912F2AB7C344005AEBC3 /* WKTapHighlightView.mm */,
+				F4C359512AF18F620083B0EA /* WKTextInteractionWrapper.h */,
+				F4C359522AF18F620083B0EA /* WKTextInteractionWrapper.mm */,
 				CE21215D240EE571006ED443 /* WKTextPlaceholder.h */,
 				CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */,
 				CE45945A240F85B90078019F /* WKTextSelectionRect.h */,
@@ -15947,6 +15952,7 @@
 				2DD67A351BD861060053B251 /* WKTextFinderClient.h in Headers */,
 				F4D5F51D206087A10038BBA8 /* WKTextInputListViewController.h in Headers */,
 				0FCB4E6818BBE3D9000FCFC9 /* WKTextInputWindowController.h in Headers */,
+				F4C359532AF19BC40083B0EA /* WKTextInteractionWrapper.h in Headers */,
 				CE21215F240EE571006ED443 /* WKTextPlaceholder.h in Headers */,
 				CE45945C240F88550078019F /* WKTextSelectionRect.h in Headers */,
 				2EB6FC01203021960017E619 /* WKTimePickerViewController.h in Headers */,


### PR DESCRIPTION
#### d23335f7ed29a16f0efa731cfdfd4cde398b6a59
<pre>
Adopt UIAsyncTextInteraction behind the &quot;Async UIKit Interactions&quot; setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=264020">https://bugs.webkit.org/show_bug.cgi?id=264020</a>

Reviewed by Megan Gardner.

Replace the existing `_textInteractionAssistant` in `WKContentView` with a `_textInteractionWrapper`
object instead, which wraps either a `UIWKTextInteractionAssistant` (in the case where the &quot;Async
UIKit Interactions&quot; feature flag is off), or a `UIAsyncTextInteraction` (in the case where the
feature flag is on).

For the legacy codepath, all methods on this new wrapper object correspond directly to the existing
methods already on `UIWKTextInteractionAssistant`, so there&apos;s no change in behavior; however, in the
case where we&apos;re using the new `UIAsyncTextInteraction`, only a subset of the methods have been
implemented so far, so we only plumb calls into `WKTextInteractionWrapper` through in those cases.

As we continue iterating on the modern async text interaction, we&apos;ll implement the remainder of
these methods which are currently no-ops when using `UIAsyncTextInteraction`.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _didExitStableState]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView shouldUseAsyncInteractions]):
(-[WKContentView _shouldUseUIContextMenuAsyncConfiguration]):
(-[WKContentView _shouldUseTextCursorDragAnimator]):
(-[WKContentView _updateRuntimeProtocolConformanceIfNeeded]):

Additionally declare conformance to `UIAsyncTextInputClient`, which extends from `UIAsyncTextInput`
and provides some additional functionality around text input via dictation (and more areas in the
near future).

(-[WKContentView cleanUpInteraction]):
(-[WKContentView becomeFirstResponderForWebView]):
(-[WKContentView endEditingAndUpdateFocusAppearanceWithReason:]):
(-[WKContentView _scrollingNodeScrollingWillBegin:]):
(-[WKContentView _scrollingNodeScrollingDidEnd:]):
(-[WKContentView setUpTextSelectionAssistant]):

Initialize a `WKTextInteractionWrapper` instead of a `UIWKTextInteractionAssistant`; this object
internally wraps either a legacy `UIWKTextInteractionAssistant`, or a new `UIAsyncTextInteraction`.

(-[WKContentView _willStartScrollingOrZooming]):
(-[WKContentView _didEndScrollingOrZooming]):
(-[WKContentView _lookupForWebView:]):
(-[WKContentView _shareForWebView:]):
(-[WKContentView _translateForWebView:]):
(-[WKContentView _addShortcutForWebView:]):
(-[WKContentView _promptForReplaceForWebView:]):
(-[WKContentView _transliterateChineseForWebView:]):
(-[WKContentView tintColorDidChange]):
(-[WKContentView selectForWebView:]):
(-[WKContentView selectAllForWebView:]):
(-[WKContentView _showDictionary:]):
(selectionChangedWithGesture):
(selectionChangedWithTouch):
(-[WKContentView changeSelectionWithGestureAt:withGesture:withState:withFlags:]):
(-[WKContentView changeSelectionWithTouchAt:withSelectionTouch:baseIsStart:withFlags:]):
(-[WKContentView changeSelectionWithTouchesFrom:to:withGesture:withState:]):
(-[WKContentView interactionAssistant]):
(-[WKContentView _showKeyboard]):
(-[WKContentView _hideKeyboard]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _updateChangedSelection:]):
(-[WKContentView prepareSelectionForContextMenuWithLocationInView:completionHandler:]):
(-[WKContentView _startSuppressingSelectionAssistantForReason:]):
(-[WKContentView _stopSuppressingSelectionAssistantForReason:]):
(-[WKContentView _dragInteractionClass]):
(-[WKContentView _restoreEditMenuIfNeeded]):
(-[WKContentView dragInteraction:willAnimateLiftWithAnimator:session:]):
(-[WKContentView textInteractionAssistant]):
(-[WKContentView contextMenuInteraction]):
(-[WKContentView _registerPreview]):

Mechanically replace `_textInteractionAssistant` with `_textInteractionWrapper` in the content view.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h: Added.
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm: Added.
(SOFT_LINK_CLASS_OPTIONAL):
(-[WKTextInteractionWrapper initWithView:]):
(-[WKTextInteractionWrapper textInteractionAssistant]):
(-[WKTextInteractionWrapper activateSelection]):
(-[WKTextInteractionWrapper deactivateSelection]):
(-[WKTextInteractionWrapper didEndScrollingOverflow]):
(-[WKTextInteractionWrapper selectionChanged]):
(-[WKTextInteractionWrapper setGestureRecognizers]):
(-[WKTextInteractionWrapper willStartScrollingOverflow]):
(-[WKTextInteractionWrapper selectionChangedWithGestureAt:withGesture:withState:withFlags:]):
(-[WKTextInteractionWrapper showDictionaryFor:fromRect:]):
(-[WKTextInteractionWrapper selectionChangedWithTouchAt:withSelectionTouch:withFlags:]):
(-[WKTextInteractionWrapper lookup:withRange:fromRect:]):
(-[WKTextInteractionWrapper showShareSheetFor:fromRect:]):
(-[WKTextInteractionWrapper showTextServiceFor:fromRect:]):
(-[WKTextInteractionWrapper scheduleReplacementsForText:]):
(-[WKTextInteractionWrapper scheduleChineseTransliterationForText:]):
(-[WKTextInteractionWrapper willStartScrollingOrZooming]):
(-[WKTextInteractionWrapper didEndScrollingOrZooming]):
(-[WKTextInteractionWrapper selectWord]):
(-[WKTextInteractionWrapper selectAll:]):
(-[WKTextInteractionWrapper contextMenuInteraction]):
(-[WKTextInteractionWrapper setExternalContextMenuInteractionDelegate:]):
(-[WKTextInteractionWrapper translate:fromRect:]):

Plumb from the text interaction wrapper to the inner interaction assistant; we also call into the
`_textInteractionWrapper` in only the methods that currently have parity with
`UIWKTextInteractionAssistant`.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270136@main">https://commits.webkit.org/270136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e328b33e24ddf5fe68da13cf670f429a5b43089

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/610 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27331 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1956 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28378 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22535 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26180 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/204 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3185 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5905 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->