### PR TITLE
Serialize content of style information element with URL replacement

### DIFF
--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -50,9 +50,24 @@ CSSStyleDeclaration& CSSFontFaceRule::style()
 
 String CSSFontFaceRule::cssText() const
 {
-    String declarations = m_fontFaceRule->properties().asText();
+    return cssTextInternal(m_fontFaceRule->properties().asText());
+}
+
+String CSSFontFaceRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings) const
+{
+    auto mutableStyleProperties = m_fontFaceRule->properties().mutableCopy();
+    mutableStyleProperties->setReplacementURLForSubresources(replacementURLStrings);
+    auto declarations = mutableStyleProperties->asText();
+    mutableStyleProperties->clearReplacementURLForSubresources();
+
+    return cssTextInternal(declarations);
+}
+
+String CSSFontFaceRule::cssTextInternal(const String& declarations) const
+{
     if (declarations.isEmpty())
         return "@font-face { }"_s;
+
     return makeString("@font-face { ", declarations, " }");
 }
 

--- a/Source/WebCore/css/CSSFontFaceRule.h
+++ b/Source/WebCore/css/CSSFontFaceRule.h
@@ -42,6 +42,8 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFace; }
     String cssText() const final;
+    String cssTextWithReplacementURLs(const HashMap<String, String>&) const final;
+    String cssTextInternal(const String& declarations) const;
     void reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleFontFace> m_fontFaceRule;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -123,10 +123,25 @@ bool CSSFontFaceSrcResourceValue::customTraverseSubresources(const Function<bool
     return m_cachedFont && handler(*m_cachedFont);
 }
 
+void CSSFontFaceSrcResourceValue::customSetReplacementURLForSubresources(const HashMap<String, String>& replacementURLStrings)
+{
+    auto replacementURLString = replacementURLStrings.get(m_location.resolvedURL.string());
+    if (!replacementURLString.isNull())
+        m_replacementURLString = replacementURLString;
+}
+
+void CSSFontFaceSrcResourceValue::customClearReplacementURLForSubresources()
+{
+    m_replacementURLString = { };
+}
+
 String CSSFontFaceSrcResourceValue::customCSSText() const
 {
     StringBuilder builder;
-    builder.append(serializeURL(m_location.specifiedURLString));
+    if (!m_replacementURLString.isEmpty())
+        builder.append(serializeURL(m_replacementURLString));
+    else
+        builder.append(serializeURL(m_location.specifiedURLString));
     if (!m_format.isEmpty())
         builder.append(" format(", serializeString(m_format), ')');
     if (!m_technologies.isEmpty()) {

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -116,6 +116,8 @@ public:
 
     String customCSSText() const;
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
+    void customSetReplacementURLForSubresources(const HashMap<String, String>&);
+    void customClearReplacementURLForSubresources();
     bool equals(const CSSFontFaceSrcResourceValue&) const;
 
 private:
@@ -126,6 +128,7 @@ private:
     Vector<FontTechnology> m_technologies;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     CachedResourceHandle<CachedFont> m_cachedFont;
+    String m_replacementURLString;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -123,6 +123,18 @@ bool CSSImageValue::customTraverseSubresources(const Function<bool(const CachedR
     return m_cachedImage && *m_cachedImage && handler(**m_cachedImage);
 }
 
+void CSSImageValue::customSetReplacementURLForSubresources(const HashMap<String, String>& replacementURLStrings)
+{
+    auto replacementURLString = replacementURLStrings.get(m_location.resolvedURL.string());
+    if (!replacementURLString.isNull())
+        m_replacementURLString = replacementURLString;
+}
+
+void CSSImageValue::customClearReplacementURLForSubresources()
+{
+    m_replacementURLString = { };
+}
+
 bool CSSImageValue::equals(const CSSImageValue& other) const
 {
     return m_location == other.m_location;
@@ -132,6 +144,10 @@ String CSSImageValue::customCSSText() const
 {
     if (m_isInvalid)
         return ""_s;
+
+    if (!m_replacementURLString.isEmpty())
+        return serializeURL(m_replacementURLString);
+
     return serializeURL(m_location.specifiedURLString);
 }
 

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -61,6 +61,8 @@ public:
     Ref<DeprecatedCSSOMValue> createDeprecatedCSSOMWrapper(CSSStyleDeclaration&) const;
 
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
+    void customSetReplacementURLForSubresources(const HashMap<String, String>&);
+    void customClearReplacementURLForSubresources();
 
     bool equals(const CSSImageValue&) const;
 
@@ -80,6 +82,7 @@ private:
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     RefPtr<CSSImageValue> m_unresolvedValue;
     bool m_isInvalid { false };
+    String m_replacementURLString;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -43,6 +43,7 @@ public:
 
     virtual StyleRuleType styleRuleType() const = 0;
     virtual String cssText() const = 0;
+    virtual String cssTextWithReplacementURLs(const HashMap<String, String>&) const { return cssText(); }
     virtual void reattach(StyleRuleBase&) = 0;
 
     void setParentStyleSheet(CSSStyleSheet*);

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -63,11 +63,14 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Style; }
     String cssText() const final;
+    String cssTextWithReplacementURLs(const HashMap<String, String>&) const final;
+    String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
     void reattach(StyleRuleBase&) final;
 
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;
-    void cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const;
+    void cssTextForRules(StringBuilder& rules) const;
+    void cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>& replacementURLStrings) const;
 
     Ref<StyleRule> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -250,6 +250,20 @@ bool CSSValue::traverseSubresources(const Function<bool(const CachedResource&)>&
     });
 }
 
+void CSSValue::setReplacementURLForSubresources(const HashMap<String, String>& replacementURLStrings)
+{
+    return visitDerived([&](auto& value) {
+        return value.customSetReplacementURLForSubresources(replacementURLStrings);
+    });
+}
+
+void CSSValue::clearReplacementURLForSubresources()
+{
+    return visitDerived([&](auto& value) {
+        return value.customClearReplacementURLForSubresources();
+    });
+}
+
 ComputedStyleDependencies CSSValue::computedStyleDependencies() const
 {
     ComputedStyleDependencies dependencies;

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -150,6 +150,8 @@ public:
     Ref<DeprecatedCSSOMValue> createDeprecatedCSSOMWrapper(CSSStyleDeclaration&) const;
 
     bool traverseSubresources(const Function<bool(const CachedResource&)>&) const;
+    void setReplacementURLForSubresources(const HashMap<String, String>&);
+    void clearReplacementURLForSubresources();
 
     // What properties does this value rely on (eg, font-size for em units)
     ComputedStyleDependencies computedStyleDependencies() const;
@@ -187,6 +189,9 @@ public:
     // FIXME: Should these be named isIdent and ident instead?
     inline bool isValueID() const;
     inline CSSValueID valueID() const;
+
+    void customSetReplacementURLForSubresources(const HashMap<String, String>&) { }
+    void customClearReplacementURLForSubresources() { }
 
 protected:
     static const size_t ClassTypeBits = 6;

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -278,4 +278,16 @@ bool CSSValueContainingVector::customTraverseSubresources(const Function<bool(co
     return false;
 }
 
+void CSSValueContainingVector::customSetReplacementURLForSubresources(const HashMap<String, String>& replacementURLStrings)
+{
+    for (auto& value : *this)
+        const_cast<CSSValue&>(value).setReplacementURLForSubresources(replacementURLStrings);
+}
+
+void CSSValueContainingVector::customClearReplacementURLForSubresources()
+{
+    for (auto& value : *this)
+        const_cast<CSSValue&>(value).clearReplacementURLForSubresources();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -66,6 +66,8 @@ public:
     using CSSValue::separatorCSSText;
 
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
+    void customSetReplacementURLForSubresources(const HashMap<String, String>&);
+    void customClearReplacementURLForSubresources();
 
     CSSValueListBuilder copyValues() const;
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -349,6 +349,18 @@ bool StyleProperties::traverseSubresources(const Function<bool(const CachedResou
     return false;
 }
 
+void StyleProperties::setReplacementURLForSubresources(const HashMap<String, String>& replacementURLStrings)
+{
+    for (auto property : *this)
+        property.value()->setReplacementURLForSubresources(replacementURLStrings);
+}
+
+void StyleProperties::clearReplacementURLForSubresources()
+{
+    for (auto property : *this)
+        property.value()->clearReplacementURLForSubresources();
+}
+
 bool StyleProperties::propertyMatches(CSSPropertyID propertyID, const CSSValue* propertyValue) const
 {
     int foundPropertyIndex = findPropertyIndex(propertyID);

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -130,6 +130,8 @@ public:
     bool isMutable() const { return m_isMutable; }
 
     bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
+    void setReplacementURLForSubresources(const HashMap<String, String>&);
+    void clearReplacementURLForSubresources();
 
     static unsigned averageSizeInBytes();
 

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -87,6 +87,7 @@ protected:
     virtual void appendEndTag(StringBuilder&, const Element&);
     virtual void appendCustomAttributes(StringBuilder&, const Element&, Namespaces*);
     virtual void appendText(StringBuilder&, const Text&);
+    virtual bool appendContentsForNode(StringBuilder& result, const Node&);
 
     void appendOpenTag(StringBuilder&, const Element&, Namespaces*);
     void appendCloseTag(StringBuilder&, const Element&);

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "HTMLStyleElement.h"
 
+#include "CSSRule.h"
 #include "CachedResource.h"
 #include "Document.h"
 #include "Event.h"
@@ -38,6 +39,7 @@
 #include "ShadowRoot.h"
 #include "StyleScope.h"
 #include "StyleSheetContents.h"
+#include "TextNodeTraversal.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -150,7 +152,7 @@ void HTMLStyleElement::notifyLoadedSheetAndAllCriticalSubresources(bool errorOcc
 }
 
 void HTMLStyleElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
-{    
+{
     HTMLElement::addSubresourceAttributeURLs(urls);
 
     if (RefPtr styleSheet = this->sheet()) {
@@ -173,6 +175,31 @@ void HTMLStyleElement::setDisabled(bool setDisabled)
 {
     if (CSSStyleSheet* styleSheet = sheet())
         styleSheet->setDisabled(setDisabled);
+}
+
+String HTMLStyleElement::textContentWithReplacementURLs(const HashMap<String, String>& replacementURLStrings) const
+{
+    RefPtr styleSheet = sheet();
+    if (!styleSheet)
+        return TextNodeTraversal::contentsAsString(*this);
+
+    auto ruleList = styleSheet->cssRules();
+    if (!ruleList)
+        return TextNodeTraversal::contentsAsString(*this);
+
+    StringBuilder result;
+    for (unsigned index = 0; index < ruleList->length(); ++index) {
+        auto rule = ruleList->item(index);
+        if (!rule)
+            continue;
+
+        auto ruleText = rule->cssTextWithReplacementURLs(replacementURLStrings);
+        if (!result.isEmpty() && !ruleText.isEmpty())
+            result.append(" ");
+
+        result.append(ruleText);
+    }
+    return result.toString();
 }
 
 }

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -43,6 +43,7 @@ public:
     virtual ~HTMLStyleElement();
 
     CSSStyleSheet* sheet() const { return m_styleSheetOwner.sheet(); }
+    String textContentWithReplacementURLs(const HashMap<String, String>&) const;
 
     WEBCORE_EXPORT bool disabled() const;
     WEBCORE_EXPORT void setDisabled(bool);


### PR DESCRIPTION
#### 3520ab7bac786d2b9d2bac921f67b0dfdddda6b7
<pre>
Serialize content of style information element with URL replacement
<a href="https://bugs.webkit.org/show_bug.cgi?id=264022">https://bugs.webkit.org/show_bug.cgi?id=264022</a>
<a href="https://rdar.apple.com/116883064">rdar://116883064</a>

Reviewed by Ryosuke Niwa.

Instead of directly appending plain text content of style information element to markup, building up a contents string
from rules in the element and appending the string to markup. In this way, we could replace the subresource URLs on
demand.

API test: WebArchive.SaveResourcesStyle

* Source/WebCore/css/CSSFontFaceRule.cpp:
(WebCore::CSSFontFaceRule::cssText const):
(WebCore::CSSFontFaceRule::cssTextWithReplacementURLs const):
(WebCore::CSSFontFaceRule::cssTextInternal const):
* Source/WebCore/css/CSSFontFaceRule.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::customSetReplacementURLForSubresources):
(WebCore::CSSFontFaceSrcResourceValue::customClearReplacementURLForSubresources):
(WebCore::CSSFontFaceSrcResourceValue::customCSSText const):
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::customSetReplacementURLForSubresources):
(WebCore::CSSImageValue::customClearReplacementURLForSubresources):
(WebCore::CSSImageValue::customCSSText const):
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::cssTextWithReplacementURLs const):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::cssText const):
(WebCore::CSSStyleRule::cssTextForRules const):
(WebCore::CSSStyleRule::cssTextWithReplacementURLs const):
(WebCore::CSSStyleRule::cssTextForRulesWithReplacementURLs const):
(WebCore::CSSStyleRule::cssTextInternal const):
(WebCore::CSSStyleRule::cssTextForDeclsAndRules const): Deleted.
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::setReplacementURLForSubresources):
(WebCore::CSSValue::clearReplacementURLForSubresources):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::customSetReplacementURLForSubresources):
(WebCore::CSSValue::customClearReplacementURLForSubresources):
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueContainingVector::customSetReplacementURLForSubresources):
(WebCore::CSSValueContainingVector::customClearReplacementURLForSubresources):
* Source/WebCore/css/CSSValueList.h:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::setReplacementURLForSubresources):
(WebCore::StyleProperties::clearReplacementURLForSubresources):
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::appendContentsForNode):
(WebCore::MarkupAccumulator::serializeNodesWithNamespaces):
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::addSubresourceAttributeURLs const):
(WebCore::HTMLStyleElement::textContentWithReplacementURLs const):
* Source/WebCore/html/HTMLStyleElement.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/270114@main">https://commits.webkit.org/270114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97e77bb3ac9871f693f557f3a087deabf71cee2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24594 "3 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3143 "Hash 97e77bb3 for PR 19819 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22593 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22979 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27300 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28346 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26154 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/170 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3156 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->