### PR TITLE
Changing width or height of a canvas synchronously creates the backing store

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -98,6 +98,11 @@ ImageBuffer* CanvasBase::buffer() const
     return m_imageBuffer.get();
 }
 
+ImageBuffer* CanvasBase::bufferIfExists() const
+{
+    return m_imageBuffer.get();
+}
+
 AffineTransform CanvasBase::baseTransform() const
 {
     ASSERT(hasCreatedImageBuffer());

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -78,6 +78,7 @@ public:
     const IntSize& size() const { return m_size; }
 
     ImageBuffer* buffer() const;
+    ImageBuffer* bufferIfExists() const;
 
     virtual void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) { }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -879,7 +879,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::setTransform(DOMMatrix2DInit&& m
 
 void CanvasRenderingContext2DBase::resetTransform()
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = canvasBase().existingDrawingContext();
     if (!c)
         return;
 
@@ -1859,7 +1859,7 @@ void CanvasRenderingContext2DBase::drawImageFromRect(HTMLImageElement& imageElem
 
 void CanvasRenderingContext2DBase::clearCanvas()
 {
-    auto* c = drawingContext();
+    auto* c = canvasBase().existingDrawingContext();
     if (!c)
         return;
 
@@ -2271,13 +2271,13 @@ GraphicsContext* CanvasRenderingContext2DBase::drawingContext() const
 
 void CanvasRenderingContext2DBase::prepareForDisplay()
 {
-    if (auto buffer = canvasBase().buffer())
+    if (auto buffer = canvasBase().bufferIfExists())
         buffer->flushDrawingContextAsync();
 }
 
 bool CanvasRenderingContext2DBase::needsPreparationForDisplay() const
 {
-    RefPtr buffer = canvasBase().buffer();
+    RefPtr buffer = canvasBase().bufferIfExists();
     if (buffer && buffer->prefersPreparationForDisplay())
         return true;
 


### PR DESCRIPTION
#### b97605cc8a50c689275c060ce75da8e2b96ab926
<pre>
Changing width or height of a canvas synchronously creates the backing store
<a href="https://bugs.webkit.org/show_bug.cgi?id=264026">https://bugs.webkit.org/show_bug.cgi?id=264026</a>

Reviewed by NOBODY (OOPS!).

Avoid synchronously creating the graphics context when updating the width or the height of a canvas.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::bufferIfExists const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::resetTransform):
(WebCore::CanvasRenderingContext2DBase::clearCanvas):
(WebCore::CanvasRenderingContext2DBase::prepareForDisplay):
(WebCore::CanvasRenderingContext2DBase::needsPreparationForDisplay const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b97605cc8a50c689275c060ce75da8e2b96ab926

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24686 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4411 "Hash b97605cc for PR 19823 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/112 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22878 "Found 1 new test failure: fast/canvas/offscreen-giant-transfer-to-imagebitmap.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24661 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/4411 "Hash b97605cc for PR 19823 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27132 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/4411 "Hash b97605cc for PR 19823 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22016 "Found 2 new test failures: fast/canvas/offscreen-giant-transfer-to-imagebitmap.html, fast/css/transform-function-perspective-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28218 "Found 1 new test failure: fast/canvas/offscreen-giant-transfer-to-imagebitmap.html (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/4411 "Hash b97605cc for PR 19823 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22335 "Found 1 new test failure: fast/canvas/offscreen-giant-transfer-to-imagebitmap.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26009 "Found 2 new API test failures: /WebKitGTK/TestBackForwardList:/webkit/BackForwardList/list-limit-and-cache, /WebKitGTK/TestBackForwardList:/webkit/WebKitWebView/session-state-with-form-data (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1721 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/50 "Found 1 new test failure: fast/canvas/offscreen-giant-transfer-to-imagebitmap.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->