### PR TITLE
WebGL default framebuffer state management should be part of WebGLRenderingContext

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2030,6 +2030,7 @@ if (ENABLE_WEBGL)
         html/canvas/WebGLContextEvent.cpp
         html/canvas/WebGLDebugRendererInfo.cpp
         html/canvas/WebGLDebugShaders.cpp
+        html/canvas/WebGLDefaultFramebuffer.cpp
         html/canvas/WebGLDepthTexture.cpp
         html/canvas/WebGLDrawBuffers.cpp
         html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1546,6 +1546,7 @@ html/canvas/WebGLCompressedTextureS3TCsRGB.cpp
 html/canvas/WebGLContextEvent.cpp
 html/canvas/WebGLDebugRendererInfo.cpp
 html/canvas/WebGLDebugShaders.cpp
+html/canvas/WebGLDefaultFramebuffer.cpp
 html/canvas/WebGLDepthTexture.cpp
 html/canvas/WebGLDrawBuffers.cpp
 html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -43,6 +43,7 @@
 #include "WebCoreOpaqueRootInlines.h"
 #include "WebGLActiveInfo.h"
 #include "WebGLBuffer.h"
+#include "WebGLDefaultFramebuffer.h"
 #include "WebGLExtensionAnyInlines.h"
 #include "WebGLFramebuffer.h"
 #include "WebGLProgram.h"
@@ -128,8 +129,9 @@ long long WebGL2RenderingContext::getInt64Parameter(GCGLenum pname)
     return m_context->getInteger64(pname);
 }
 
-void WebGL2RenderingContext::initializeVertexArrayObjects()
+void WebGL2RenderingContext::initializeDefaultObjects()
 {
+    WebGLRenderingContextBase::initializeDefaultObjects();
     m_defaultVertexArrayObject = WebGLVertexArrayObject::create(*this, WebGLVertexArrayObject::Type::Default);
     m_boundVertexArrayObject = m_defaultVertexArrayObject;
     if (!m_defaultVertexArrayObject)
@@ -3533,7 +3535,7 @@ void WebGL2RenderingContext::updateBuffersToAutoClear(ClearBufferCaller caller, 
         return;
     }
 
-    m_context->setBuffersToAutoClear(m_context->getBuffersToAutoClear() & (~buffersToClear));
+    m_defaultFramebuffer->markBuffersClear(buffersToClear);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -272,7 +272,7 @@ private:
     long long getInt64Parameter(GCGLenum) final;
     Vector<bool> getIndexedBooleanArrayParameter(GCGLenum pname, GCGLuint index);
 
-    void initializeVertexArrayObjects() final;
+    void initializeDefaultObjects() final;
     bool validateBufferTarget(const char* functionName, GCGLenum target) final;
     bool validateBufferTargetCompatibility(const char*, GCGLenum, WebGLBuffer*);
     WebGLBuffer* validateBufferDataParameters(const char* functionName, GCGLenum target, GCGLenum usage) final;

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include "config.h"
+
+#if ENABLE(WEBGL)
+#include "WebGLDefaultFramebuffer.h"
+
+namespace WebCore {
+
+std::unique_ptr<WebGLDefaultFramebuffer> WebGLDefaultFramebuffer::create(WebGLRenderingContextBase& context, IntSize size)
+{
+    auto instance = std::unique_ptr<WebGLDefaultFramebuffer> { new WebGLDefaultFramebuffer(context) };
+    instance->reshape(size);
+    return instance;
+}
+
+WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& context)
+    : m_context(context)
+{
+    auto attributes = m_context.graphicsContextGL()->contextAttributes();
+    m_hasStencil = attributes.stencil;
+    m_hasDepth = attributes.depth;
+    if (!attributes.preserveDrawingBuffer) {
+        m_unpreservedBuffers = GraphicsContextGL::COLOR_BUFFER_BIT;
+        if (m_hasStencil)
+            m_unpreservedBuffers |= GraphicsContextGL::STENCIL_BUFFER_BIT;
+        if (m_hasDepth)
+            m_unpreservedBuffers |= GraphicsContextGL::DEPTH_BUFFER_BIT;
+    }
+}
+
+void WebGLDefaultFramebuffer::reshape(IntSize size)
+{
+    m_context.graphicsContextGL()->reshape(size.width(), size.height());
+}
+
+void WebGLDefaultFramebuffer::markBuffersClear(GCGLbitfield clearBuffers)
+{
+    m_dirtyBuffers &= ~clearBuffers;
+}
+
+void WebGLDefaultFramebuffer::markAllUnpreservedBuffersDirty()
+{
+    m_dirtyBuffers = m_unpreservedBuffers;
+}
+
+}
+
+#endif

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBGL)
+
+#include "WebGLRenderingContextBase.h"
+
+namespace WebCore {
+
+// Implementation for the WebGL context default framebuffer.
+class WebGLDefaultFramebuffer {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(WebGLDefaultFramebuffer);
+public:
+    static std::unique_ptr<WebGLDefaultFramebuffer> create(WebGLRenderingContextBase&, IntSize);
+    ~WebGLDefaultFramebuffer() = default;
+
+    PlatformGLObject object() const { return 0; }
+    bool hasStencil() const { return m_hasStencil; }
+    bool hasDepth() const { return m_hasDepth; }
+    void reshape(IntSize);
+    GCGLbitfield dirtyBuffers() const { return m_dirtyBuffers; }
+    void markBuffersClear(GCGLbitfield clearBuffers);
+    void markAllUnpreservedBuffersDirty();
+
+private:
+    WebGLDefaultFramebuffer(WebGLRenderingContextBase&);
+
+    WebGLRenderingContextBase& m_context;
+    GCGLbitfield m_unpreservedBuffers { 0 };
+    GCGLbitfield m_dirtyBuffers { 0 };
+    bool m_hasStencil : 1;
+    bool m_hasDepth : 1;
+};
+
+}
+
+#endif

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -121,8 +121,9 @@ WebGLRenderingContext::~WebGLRenderingContext()
     m_activeQuery = nullptr;
 }
 
-void WebGLRenderingContext::initializeVertexArrayObjects()
+void WebGLRenderingContext::initializeDefaultObjects()
 {
+    WebGLRenderingContextBase::initializeDefaultObjects();
     m_defaultVertexArrayObject = WebGLVertexArrayObjectOES::createDefault(*this);
     m_boundVertexArrayObject = m_defaultVertexArrayObject;
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -52,7 +52,7 @@ public:
 
     GCGLint getMaxDrawBuffers() final;
     GCGLint getMaxColorAttachments() final;
-    void initializeVertexArrayObjects() final;
+    void initializeDefaultObjects() final;
     bool validateBlendEquation(const char* functionName, GCGLenum mode) final;
 
     void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) final;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -82,6 +82,7 @@ class IntSize;
 class WebCodecsVideoFrame;
 class WebCoreOpaqueRoot;
 class WebGLActiveInfo;
+class WebGLDefaultFramebuffer;
 class WebGLObject;
 class WebGLPolygonMode;
 class WebGLShader;
@@ -475,10 +476,13 @@ protected:
 
     // Implementation helpers.
     friend class InspectorScopedShaderProgramHighlight;
+    friend class ScopedDisableRasterizerDiscard;
+    friend class ScopedEnableBackbuffer;
+    friend class ScopedDisableScissorTest;
 
     void initializeNewContext(Ref<GraphicsContextGL>);
     virtual void initializeContextState();
-    virtual void initializeVertexArrayObjects() = 0;
+    virtual void initializeDefaultObjects();
 
     // ActiveDOMObject
     void stop() override;
@@ -564,6 +568,7 @@ protected:
     // List of bound VBO's. Used to maintain info about sizes for ARRAY_BUFFER and stored values for ELEMENT_ARRAY_BUFFER
     WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::ARRAY_BUFFER> m_boundArrayBuffer;
 
+    std::unique_ptr<WebGLDefaultFramebuffer> m_defaultFramebuffer;
     RefPtr<WebGLVertexArrayObjectBase> m_defaultVertexArrayObject;
     WebGLBindingPoint<WebGLVertexArrayObjectBase> m_boundVertexArrayObject;
 
@@ -748,9 +753,6 @@ protected:
     // clearMask is set to the bitfield of any clear that would happen anyway at this time
     // and the function returns true if that clear is now unnecessary.
     bool clearIfComposited(CallerType, GCGLbitfield clearMask = 0);
-
-    // Helper to restore state that clearing the framebuffer may destroy.
-    void restoreStateAfterClear();
 
     enum class TexImageFunctionType {
         TexImage,

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -575,33 +575,6 @@ void GraphicsContextGL::setDrawingBufferColorSpace(const DestinationColorSpace&)
 {
 }
 
-void GraphicsContextGL::markContextChanged()
-{
-}
-
-void GraphicsContextGL::setBuffersToAutoClear(GCGLbitfield buffers)
-{
-    if (!contextAttributes().preserveDrawingBuffer)
-        m_buffersToAutoClear = buffers;
-}
-
-GCGLbitfield GraphicsContextGL::getBuffersToAutoClear() const
-{
-    return m_buffersToAutoClear;
-}
-
-void GraphicsContextGL::markLayerComposited()
-{
-    auto attrs = contextAttributes();
-    if (!attrs.preserveDrawingBuffer) {
-        m_buffersToAutoClear = GraphicsContextGL::COLOR_BUFFER_BIT;
-        if (attrs.depth)
-            m_buffersToAutoClear |= GraphicsContextGL::DEPTH_BUFFER_BIT;
-        if (attrs.stencil)
-            m_buffersToAutoClear |= GraphicsContextGL::STENCIL_BUFFER_BIT;
-    }
-}
-
 void GraphicsContextGL::paintToCanvas(NativeImage& image, const IntSize& canvasSize, GraphicsContext& context)
 {
     if (canvasSize.isEmpty())

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1634,15 +1634,6 @@ public:
 
     virtual void prepareForDisplay() = 0;
 
-    // FIXME: should be removed, caller should keep track of changed state.
-    WEBCORE_EXPORT virtual void markContextChanged();
-
-    // FIXME: these should be removed, caller is interested in buffer clear status and
-    // should track that in a variable that the caller holds. Caller should receive
-    // the value from reshape().
-    void setBuffersToAutoClear(GCGLbitfield);
-    GCGLbitfield getBuffersToAutoClear() const;
-
     // FIXME: these should be removed, they're part of drawing buffer and
     // display buffer abstractions that the caller should hold separate to
     // the context.
@@ -1655,11 +1646,6 @@ public:
     virtual RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) = 0;
 #endif
     virtual RefPtr<PixelBuffer> drawingBufferToPixelBuffer(FlipY) = 0;
-
-    // FIXME: this should be removed. The layer should be marked composited by
-    // preparing for display, so that canvas image buffer and the layer agree
-    // on the content.
-    WEBCORE_EXPORT void markLayerComposited();
 
     using SimulatedEventForTesting = GraphicsContextGLSimulatedEventForTesting;
     virtual void simulateEventForTesting(SimulatedEventForTesting) = 0;
@@ -1729,10 +1715,6 @@ protected:
     int m_currentWidth { 0 };
     int m_currentHeight { 0 };
     Client* m_client { nullptr };
-    // A bitmask of GL buffer bits (GL_COLOR_BUFFER_BIT,
-    // GL_DEPTH_BUFFER_BIT, GL_STENCIL_BUFFER_BIT) which need to be
-    // auto-cleared.
-    GCGLbitfield m_buffersToAutoClear { 0 };
     bool m_contextLost { false };
 
 private:

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -672,8 +672,6 @@ void GraphicsContextGLANGLE::reshape(int width, int height)
     updateErrors();
     validateAttributes();
 
-    markContextChanged();
-
     m_currentWidth = width;
     m_currentHeight = height;
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -783,7 +783,6 @@ void GraphicsContextGLCocoa::prepareForDisplayWithFinishedSignal(Function<void()
         forceContextLost();
         return;
     }
-    markLayerComposited();
 }
 
 

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -104,7 +104,6 @@ void GraphicsContextGLGBM::prepareForDisplay()
 
     prepareTexture();
     GL_Flush();
-    markLayerComposited();
 
     m_swapchain.displayBO = WTFMove(m_swapchain.drawBO);
     allocateDrawBufferObject();

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -352,7 +352,6 @@ void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
 
     prepareTexture();
     swapCompositorTexture();
-    markLayerComposited();
 }
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -203,12 +203,6 @@ void RemoteGraphicsContextGL::ensureExtensionEnabled(String&& extension)
     m_context->ensureExtensionEnabled(extension);
 }
 
-void RemoteGraphicsContextGL::markContextChanged()
-{
-    assertIsCurrent(workQueue());
-    m_context->markContextChanged();
-}
-
 void RemoteGraphicsContextGL::drawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBufferIdentifier, CompletionHandler<void()>&& completionHandler)
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -108,7 +108,6 @@ protected:
 
     // Messages to be received.
     void ensureExtensionEnabled(String&&);
-    void markContextChanged();
     void createAndBindEGLImage(GCGLenum, WebCore::GraphicsContextGL::EGLImageSource, CompletionHandler<void(uint64_t, WebCore::IntSize)>&&);
     void reshape(int32_t width, int32_t height);
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -39,7 +39,6 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void PrepareForDisplay() -> () Synchronous
 #endif
     void EnsureExtensionEnabled(String extension)
-    void MarkContextChanged()
     void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
     void DrawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -130,16 +130,6 @@ void RemoteGraphicsContextGLProxy::setContextVisibility(bool)
     notImplemented();
 }
 
-void RemoteGraphicsContextGLProxy::markContextChanged()
-{
-    GraphicsContextGL::markContextChanged();
-    if (isContextLost())
-        return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::MarkContextChanged());
-    if (sendResult != IPC::Error::NoError)
-        markContextLost();
-}
-
 bool RemoteGraphicsContextGLProxy::supportsExtension(const String& name)
 {
     waitUntilInitialized();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -76,7 +76,6 @@ public:
     std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint() final;
     void reshape(int width, int height) final;
     void setContextVisibility(bool) final;
-    void markContextChanged() final;
     bool supportsExtension(const String&) final;
     void ensureExtensionEnabled(const String&) final;
     bool isExtensionEnabled(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -202,7 +202,6 @@ void RemoteGraphicsContextGLProxyCocoa::prepareForDisplay()
     auto [displayBufferSendRight] = sendResult.takeReply();
     if (!displayBufferSendRight)
         return;
-    markLayerComposited();
     auto finishedFence = DisplayBufferFence::create(WTFMove(finishedSignaller));
     addNewFence(finishedFence);
     m_layerContentsDisplayDelegate->setDisplayBuffer(WTFMove(displayBufferSendRight), WTFMove(finishedFence));

--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -135,7 +135,6 @@ void RemoteGraphicsContextGLProxyGBM::prepareForDisplay()
 
     auto& [dmabufObject] = sendResult.reply();
     m_layerContentsDisplayDelegate->present(WTFMove(dmabufObject));
-    markLayerComposited();
 }
 
 Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(IPC::Connection& connection, Ref<IPC::StreamClientConnection> streamConnection, const WebCore::GraphicsContextGLAttributes& attributes, Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy)

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
@@ -98,7 +98,6 @@ void RemoteGraphicsContextGLProxyWC::prepareForDisplay()
     auto& [contentBuffer] = sendResult.reply();
     if (contentBuffer)
         static_cast<WCPlatformLayerGCGL*>(m_layerContentsDisplayDelegate->platformLayer())->addContentBufferIdentifier(*contentBuffer);
-    markLayerComposited();
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -129,7 +129,6 @@ static const int expectedDisplayBufferPoolSize = 3;
 
 static ::testing::AssertionResult changeContextContents(TestedGraphicsContextGLCocoa& context, int iteration)
 {
-    context.markContextChanged();
     WebCore::Color expected { iteration % 2 ? WebCore::Color::green : WebCore::Color::yellow };
     auto [r, g, b, a] = expected.toColorTypeLossy<WebCore::SRGBA<float>>().resolved();
     context.clearColor(r, g, b, a);
@@ -440,7 +439,6 @@ TEST_P(AnyContextAttributeTest, FinishIsSignaled)
 {
     auto context = createTestContext({ 2048, 2048 });
     ASSERT_NE(context, nullptr);
-    context->markContextChanged();
     context->clearColor(0.f, 1.f, 0.f, 1.f);
     context->clear(WebCore::GraphicsContextGL::COLOR_BUFFER_BIT);
     std::atomic<bool> signalled = false;


### PR DESCRIPTION
#### f4b3b4be605183a7cf4e3d79cdada5bb73668d2b
<pre>
WebGL default framebuffer state management should be part of WebGLRenderingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=263963">https://bugs.webkit.org/show_bug.cgi?id=263963</a>
<a href="https://rdar.apple.com/117788476">rdar://117788476</a>

Reviewed by Dan Glastonbury.

Move the default framebuffer dirty buffer accounting from GraphicsContextGL
to WebGLDefaultFramebuffer class. This is the beginning of moving all
the default framebuffer state and objects to the WebGL layer. Currently
the implementation is in lower level at GraphicsContextGL level.

This is work towards implementing premultipliedAlpha=false compositing.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::initializeDefaultObjects):
(WebCore::WebGL2RenderingContext::updateBuffersToAutoClear):
(WebCore::WebGL2RenderingContext::initializeVertexArrayObjects): Deleted.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp: Added.
(WebCore::WebGLDefaultFramebuffer::create):
(WebCore::WebGLDefaultFramebuffer::WebGLDefaultFramebuffer):
(WebCore::WebGLDefaultFramebuffer::reshape):
(WebCore::WebGLDefaultFramebuffer::markBuffersClear):
(WebCore::WebGLDefaultFramebuffer::markAllUnpreservedBuffersDirty):
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h: Copied from Source/WebCore/html/canvas/WebGLRenderingContext.h.
(WebCore::WebGLDefaultFramebuffer::object const):
(WebCore::WebGLDefaultFramebuffer::hasStencil const):
(WebCore::WebGLDefaultFramebuffer::hasDepth const):
(WebCore::WebGLDefaultFramebuffer::dirtyBuffers const):
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::initializeDefaultObjects):
(WebCore::WebGLRenderingContext::initializeVertexArrayObjects): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::ScopedDisableRasterizerDiscard::ScopedDisableRasterizerDiscard):
(WebCore::ScopedDisableRasterizerDiscard::~ScopedDisableRasterizerDiscard):
(WebCore::ScopedEnableBackbuffer::ScopedEnableBackbuffer):
(WebCore::ScopedEnableBackbuffer::~ScopedEnableBackbuffer):
(WebCore::WebGLRenderingContextBase::initializeNewContext):
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::initializeDefaultObjects):
(WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver):
(WebCore::WebGLRenderingContextBase::clearIfComposited):
(WebCore::WebGLRenderingContextBase::reshape):
(WebCore::WebGLRenderingContextBase::setFramebuffer):
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
(WebCore::WebGLRenderingContextBase::restoreStateAfterClear): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::markContextChanged): Deleted.
(WebCore::GraphicsContextGL::setBuffersToAutoClear): Deleted.
(WebCore::GraphicsContextGL::getBuffersToAutoClear const): Deleted.
(WebCore::GraphicsContextGL::markLayerComposited): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::reshape):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::prepareForDisplayWithFinishedSignal):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::prepareForDisplay):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::markContextChanged): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::markContextChanged): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:
(WebKit::RemoteGraphicsContextGLProxyGBM::prepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::changeContextContents):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/270263@main">https://commits.webkit.org/270263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/281357e89737ec81f48ce40835817457d2ea636a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23233 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27703 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28645 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/527 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3507 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->