### PR TITLE
[TextureMapper] Use OptionSet for TextureMapperFlags

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.h
@@ -24,12 +24,15 @@
 
 #include "MediaPlayerPrivateGStreamer.h"
 #include "TextureMapperPlatformLayerBuffer.h"
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 
+enum class TextureMapperFlags : uint16_t;
+
 class GstVideoFrameHolder : public TextureMapperPlatformLayerBuffer::UnmanagedBufferDataHolder {
 public:
-    explicit GstVideoFrameHolder(GstSample*, std::optional<GstVideoDecoderPlatform>, TextureMapper::Flags, bool gstGLEnabled);
+    explicit GstVideoFrameHolder(GstSample*, std::optional<GstVideoDecoderPlatform>, OptionSet<TextureMapperFlags>, bool gstGLEnabled);
     virtual ~GstVideoFrameHolder();
 
 #if USE(GSTREAMER_GL)
@@ -38,7 +41,7 @@ public:
 
     const IntSize& size() const { return m_size; }
     bool hasAlphaChannel() const { return m_hasAlphaChannel; }
-    TextureMapper::Flags flags() const { return m_flags; }
+    OptionSet<TextureMapperFlags> flags() const { return m_flags; }
     GLuint textureID() const { return m_textureID; }
     bool hasMappedTextures() const { return m_hasMappedTextures; }
     const GstVideoFrame& videoFrame() const { return m_videoFrame; }
@@ -53,7 +56,7 @@ private:
     IntSize m_size;
     bool m_hasAlphaChannel;
     std::optional<GstVideoDecoderPlatform> m_videoDecoderPlatform;
-    TextureMapper::Flags m_flags { };
+    OptionSet<TextureMapperFlags> m_flags;
     GLuint m_textureID { 0 };
 #if USE(GSTREAMER_GL)
     GstGLTextureTarget m_textureTarget { GST_GL_TEXTURE_TARGET_NONE };

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3270,7 +3270,10 @@ void MediaPlayerPrivateGStreamer::pushTextureToCompositor()
                 layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(texture));
             }
             frameHolder->updateTexture(layerBuffer->texture());
-            layerBuffer->setExtraFlags(m_textureMapperFlags | (frameHolder->hasAlphaChannel() ? TextureMapper::ShouldBlend | TextureMapper::ShouldPremultiply : 0));
+            auto extraFlags = m_textureMapperFlags;
+            if (frameHolder->hasAlphaChannel())
+                extraFlags.add({ TextureMapperFlags::ShouldBlend, TextureMapperFlags::ShouldPremultiply });
+            layerBuffer->setExtraFlags(extraFlags);
         }
         proxy.pushNextBuffer(WTFMove(layerBuffer));
     };
@@ -3938,23 +3941,23 @@ void MediaPlayerPrivateGStreamer::updateTextureMapperFlags()
 {
     switch (m_videoSourceOrientation.orientation()) {
     case ImageOrientation::Orientation::OriginTopLeft:
-        m_textureMapperFlags = 0;
+        m_textureMapperFlags = { };
         break;
     case ImageOrientation::Orientation::OriginRightTop:
-        m_textureMapperFlags = TextureMapper::ShouldRotateTexture90;
+        m_textureMapperFlags = { TextureMapperFlags::ShouldRotateTexture90 };
         break;
     case ImageOrientation::Orientation::OriginBottomRight:
-        m_textureMapperFlags = TextureMapper::ShouldRotateTexture180;
+        m_textureMapperFlags = { TextureMapperFlags::ShouldRotateTexture180 };
         break;
     case ImageOrientation::Orientation::OriginLeftBottom:
-        m_textureMapperFlags = TextureMapper::ShouldRotateTexture270;
+        m_textureMapperFlags = { TextureMapperFlags::ShouldRotateTexture270 };
         break;
     case ImageOrientation::Orientation::OriginBottomLeft:
-        m_textureMapperFlags = TextureMapper::ShouldFlipTexture;
+        m_textureMapperFlags = { TextureMapperFlags::ShouldFlipTexture };
         break;
     default:
         // FIXME: Handle OriginTopRight, OriginLeftTop and OriginRightBottom.
-        m_textureMapperFlags = 0;
+        m_textureMapperFlags = { };
         break;
     }
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -45,6 +45,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/OptionSet.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomStringHash.h>
@@ -60,7 +61,6 @@ typedef struct _GstMpegtsSection GstMpegtsSection;
 #endif
 
 #if USE(TEXTURE_MAPPER)
-#include "TextureMapper.h"
 #if USE(NICOSIA)
 #include "NicosiaContentLayer.h"
 #else
@@ -101,6 +101,8 @@ class VideoTrackPrivateGStreamer;
 #if USE(TEXTURE_MAPPER_DMABUF)
 class GBMBufferSwapchain;
 #endif
+
+enum class TextureMapperFlags : uint16_t;
 
 void registerWebKitGStreamerElements();
 
@@ -374,7 +376,7 @@ protected:
     bool m_areVolumeAndMuteInitialized { false };
 
 #if USE(TEXTURE_MAPPER)
-    TextureMapper::Flags m_textureMapperFlags { TextureMapper::NoFlag };
+    OptionSet<TextureMapperFlags> m_textureMapperFlags;
 #endif
 
     GRefPtr<GstStreamVolume> m_volumeElement;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
@@ -32,6 +32,7 @@
 #if USE(NICOSIA) && USE(TEXTURE_MAPPER)
 
 #include "GraphicsContextGLTextureMapperANGLE.h"
+#include "TextureMapperFlags.h"
 #include "TextureMapperPlatformLayerBuffer.h"
 #include "TextureMapperPlatformLayerProxyGL.h"
 #include <epoxy/gl.h>
@@ -56,9 +57,9 @@ void GCGLANGLELayer::swapBuffersIfNeeded()
         if (bo) {
             Locker locker { proxy.lock() };
 
-            TextureMapper::Flags flags = TextureMapper::ShouldFlipTexture;
+            OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
             if (m_context.contextAttributes().alpha)
-                flags |= TextureMapper::ShouldBlend;
+                flags.add(TextureMapperFlags::ShouldBlend);
 
             downcast<TextureMapperPlatformLayerProxyDMABuf>(proxy).pushDMABuf(
                 DMABufObject(reinterpret_cast<uintptr_t>(swapchain.swapchain.get()) + bo->handle()),
@@ -71,10 +72,10 @@ void GCGLANGLELayer::swapBuffersIfNeeded()
     ASSERT(is<TextureMapperPlatformLayerProxyGL>(proxy));
 #endif
 
-    TextureMapper::Flags flags = TextureMapper::ShouldFlipTexture;
+    OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
     GLint colorFormat;
     if (m_context.contextAttributes().alpha) {
-        flags |= TextureMapper::ShouldBlend;
+        flags.add(TextureMapperFlags::ShouldBlend);
         colorFormat = GL_RGBA;
     } else
         colorFormat = GL_RGB;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
@@ -30,6 +30,7 @@
 #include "ImageBuffer.h"
 #include "NativeImage.h"
 #include "NicosiaPlatformLayer.h"
+#include "TextureMapperFlags.h"
 #include "TextureMapperPlatformLayerBuffer.h"
 #include "TextureMapperPlatformLayerProxyGL.h"
 
@@ -95,7 +96,7 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
                 }
 
                 auto layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(texture));
-                layerBuffer->setExtraFlags(TextureMapper::ShouldBlend);
+                layerBuffer->setExtraFlags(TextureMapperFlags::ShouldBlend);
                 downcast<TextureMapperPlatformLayerProxyGL>(proxy).pushNextBuffer(WTFMove(layerBuffer));
             });
         };

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -30,6 +30,8 @@
 #include "ImageBuffer.h"
 #include "LengthFunctions.h"
 #include "NativeImage.h"
+#include "TextureMapper.h"
+#include "TextureMapperFlags.h"
 #include "TextureMapperShaderProgram.h"
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
@@ -66,7 +68,7 @@ void BitmapTexture::didReset()
         glGenTextures(1, &m_id);
 
     m_shouldClear = true;
-    m_colorConvertFlags = TextureMapper::NoFlag;
+    m_colorConvertFlags = { };
     m_filterInfo = FilterInfo();
     if (m_textureSize == contentSize())
         return;
@@ -86,7 +88,7 @@ void BitmapTexture::updateContents(const void* srcData, const IntRect& targetRec
     // We are updating a texture with format RGBA with content from a buffer that has BGRA format. Instead of turning BGRA
     // into RGBA and then uploading it, we upload it as is. This causes the texture format to be RGBA but the content to be BGRA,
     // so we mark the texture to convert the colors when painting the texture.
-    m_colorConvertFlags = TextureMapper::ShouldConvertTextureBGRAToRGBA;
+    m_colorConvertFlags = TextureMapperFlags::ShouldConvertTextureBGRAToRGBA;
 
     glBindTexture(GL_TEXTURE_2D, m_id);
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -31,16 +31,19 @@
 #include "IntPoint.h"
 #include "IntRect.h"
 #include "IntSize.h"
-#include "TextureMapper.h"
 #include "TextureMapperContextAttributes.h"
 #include "TextureMapperGLHeaders.h"
+#include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
 
+class FilterOperations;
 class GraphicsLayer;
 class NativeImage;
+class TextureMapper;
+enum class TextureMapperFlags : uint16_t;
 
 #if OS(WINDOWS)
 #define USE_TEXMAP_DEPTH_STENCIL_BUFFER 1
@@ -108,7 +111,7 @@ public:
 
     void copyFromExternalTexture(GLuint textureID);
 
-    TextureMapper::Flags colorConvertFlags() const { return m_colorConvertFlags; }
+    OptionSet<TextureMapperFlags> colorConvertFlags() const { return m_colorConvertFlags; }
 
 private:
     BitmapTexture(const TextureMapperContextAttributes&, const Flags, GLint internalFormat);
@@ -128,7 +131,7 @@ private:
     bool m_shouldClear { true };
     ClipStack m_clipStack;
     TextureMapperContextAttributes m_contextAttributes;
-    TextureMapper::Flags m_colorConvertFlags { TextureMapper::NoFlag };
+    OptionSet<TextureMapperFlags> m_colorConvertFlags;
     FilterInfo m_filterInfo;
     GLint m_internalFormat { 0 };
     GLenum m_format { 0 };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -30,6 +30,7 @@
 #include "TextureMapperGLHeaders.h"
 #include "TransformationMatrix.h"
 #include <array>
+#include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
 // TextureMapper is a mechanism that enables hardware acceleration of CSS animations (accelerated compositing) without
@@ -44,27 +45,11 @@ class TextureMapperGLData;
 class TextureMapperShaderProgram;
 class FilterOperations;
 class FloatRoundedRect;
+enum class TextureMapperFlags : uint16_t;
 
 class TextureMapper {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    enum Flag {
-        NoFlag = 0x00,
-        ShouldBlend = 0x01,
-        ShouldFlipTexture = 0x02,
-        ShouldAntialias = 0x08,
-        ShouldRotateTexture90 = 0x10,
-        ShouldRotateTexture180 = 0x20,
-        ShouldRotateTexture270 = 0x40,
-        ShouldConvertTextureBGRAToRGBA = 0x80,
-        ShouldConvertTextureARGBToRGBA = 0x100,
-        ShouldNotBlend = 0x200,
-        ShouldUseExternalOESTextureRect = 0x400,
-        ShouldPremultiply = 0x800
-    };
-
-    typedef int Flags;
-
     enum PaintFlag {
         PaintingMirrored = 1 << 0,
     };
@@ -94,11 +79,11 @@ public:
     void drawNumber(int number, const Color&, const FloatPoint&, const TransformationMatrix&);
 
     WEBCORE_EXPORT void drawTexture(const BitmapTexture&, const FloatRect& target, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0f, unsigned exposedEdges = AllEdges);
-    void drawTexture(GLuint texture, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
-    void drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges = AllEdges);
-    void drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
-    void drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
-    void drawTextureExternalOES(GLuint texture, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
+    void drawTexture(GLuint texture, OptionSet<TextureMapperFlags>, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 16>& yuvToRgbMatrix, OptionSet<TextureMapperFlags>, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges = AllEdges);
+    void drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 16>& yuvToRgbMatrix, OptionSet<TextureMapperFlags>, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 16>& yuvToRgbMatrix, OptionSet<TextureMapperFlags>, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTextureExternalOES(GLuint texture, OptionSet<TextureMapperFlags>, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
     void drawSolidColor(const FloatRect&, const TransformationMatrix&, const Color&, bool);
     void clearColor(const Color&);
 
@@ -141,9 +126,9 @@ private:
     void drawTextureCopy(const BitmapTexture& sourceTexture, const FloatRect& sourceRect, const FloatRect& targetRect);
     void drawBlurred(const BitmapTexture& sourceTexture, const FloatRect&, float radius, Direction, bool alphaBlur = false);
     void drawFilterPass(const BitmapTexture& sourceTexture, const BitmapTexture* contentTexture, const FilterOperation&, int pass);
-    void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, uint32_t texture, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
-    void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, const Vector<std::pair<GLuint, GLuint> >& texturesAndSamplers, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
-    void draw(const FloatRect&, const TransformationMatrix& modelViewMatrix, TextureMapperShaderProgram&, GLenum drawingMode, Flags);
+    void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, uint32_t texture, OptionSet<TextureMapperFlags>, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
+    void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, const Vector<std::pair<GLuint, GLuint> >& texturesAndSamplers, OptionSet<TextureMapperFlags>, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
+    void draw(const FloatRect&, const TransformationMatrix& modelViewMatrix, TextureMapperShaderProgram&, GLenum drawingMode, OptionSet<TextureMapperFlags>);
     void drawUnitRect(TextureMapperShaderProgram&, GLenum drawingMode);
     void drawEdgeTriangles(TextureMapperShaderProgram&);
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperFlags.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperFlags.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(TEXTURE_MAPPER)
+
+namespace WebCore {
+
+enum class TextureMapperFlags : uint16_t {
+    ShouldBlend = 1 << 0,
+    ShouldFlipTexture = 1 << 1,
+    ShouldAntialias = 1 << 2,
+    ShouldRotateTexture90 = 1 << 3,
+    ShouldRotateTexture180 = 1 << 4,
+    ShouldRotateTexture270 = 1 << 5,
+    ShouldConvertTextureBGRAToRGBA = 1 << 6,
+    ShouldConvertTextureARGBToRGBA = 1 << 7,
+    ShouldNotBlend = 1 << 8,
+    ShouldUseExternalOESTextureRect = 1 << 9,
+    ShouldPremultiply = 1 << 10
+};
+
+} // namespace WebCore
+
+#endif // USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
@@ -26,6 +26,7 @@
 #include "ANGLEHeaders.h"
 #include "BitmapTexture.h"
 #include "GLContext.h"
+#include "TextureMapperFlags.h"
 #include "TextureMapperGLHeaders.h"
 #include "TextureMapperPlatformLayerBuffer.h"
 #include "TextureMapperPlatformLayerProxy.h"
@@ -46,7 +47,9 @@ TextureMapperGCGLPlatformLayer::~TextureMapperGCGLPlatformLayer()
 void TextureMapperGCGLPlatformLayer::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& matrix, float opacity)
 {
     auto attrs = m_context.contextAttributes();
-    TextureMapper::Flags flags = TextureMapper::ShouldFlipTexture | (attrs.alpha ? TextureMapper::ShouldBlend : 0);
+    OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
+    if (attrs.alpha)
+        flags.add(TextureMapperFlags::ShouldBlend);
     textureMapper.drawTexture(m_context.m_compositorTexture, flags, targetRect, matrix, opacity);
 }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -24,6 +24,7 @@
 #include "BitmapTexture.h"
 #include "FloatQuad.h"
 #include "Region.h"
+#include "TextureMapper.h"
 #include <wtf/MathExtras.h>
 #include <wtf/SetForScope.h>
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -22,7 +22,6 @@
 #include "FilterOperations.h"
 #include "FloatRect.h"
 #include "NicosiaAnimation.h"
-#include "TextureMapper.h"
 #include "TextureMapperSolidColorLayer.h"
 #include <wtf/WeakPtr.h>
 
@@ -33,6 +32,7 @@
 namespace WebCore {
 
 class Region;
+class TextureMapper;
 class TextureMapperPaintOptions;
 class TextureMapperPlatformLayer;
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer(RefPtr<BitmapTexture>&& texture, TextureMapper::Flags flags)
+TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer(RefPtr<BitmapTexture>&& texture, OptionSet<TextureMapperFlags> flags)
     : m_variant(RGBTexture { 0 })
     , m_texture(WTFMove(texture))
     , m_extraFlags(flags)
@@ -41,12 +41,12 @@ TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer(RefPtr<Bitmap
 {
 }
 
-TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer(GLuint textureID, const IntSize& size, TextureMapper::Flags flags, GLint internalFormat)
+TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer(GLuint textureID, const IntSize& size, OptionSet<TextureMapperFlags> flags, GLint internalFormat)
     : TextureMapperPlatformLayerBuffer({ RGBTexture { textureID } }, size, flags, internalFormat)
 {
 }
 
-TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer(TextureVariant&& variant, const IntSize& size, TextureMapper::Flags flags, GLint internalFormat)
+TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer(TextureVariant&& variant, const IntSize& size, OptionSet<TextureMapperFlags> flags, GLint internalFormat)
     : m_variant(WTFMove(variant))
     , m_size(size)
     , m_internalFormat(internalFormat)
@@ -78,7 +78,7 @@ std::unique_ptr<TextureMapperPlatformLayerBuffer> TextureMapperPlatformLayerBuff
                 return nullptr;
             }
 
-            auto clonedTexture = BitmapTexture::create(TextureMapperContextAttributes::get(), TextureMapper::NoFlag, m_internalFormat);
+            auto clonedTexture = BitmapTexture::create(TextureMapperContextAttributes::get(), BitmapTexture::NoFlag, m_internalFormat);
             clonedTexture->reset(m_size);
             clonedTexture->copyFromExternalTexture(texture.id);
             return makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(clonedTexture), m_extraFlags);
@@ -103,7 +103,7 @@ void TextureMapperPlatformLayerBuffer::paintToTextureMapper(TextureMapper& textu
         return;
     }
 
-    if (m_extraFlags & TextureMapper::ShouldNotBlend) {
+    if (m_extraFlags.contains(TextureMapperFlags::ShouldNotBlend)) {
         ASSERT(!m_texture);
         if (m_holePunchClient)
             m_holePunchClient->setVideoRectangle(enclosingIntRect(modelViewMatrix.mapRect(targetRect)));

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
@@ -28,10 +28,12 @@
 #if USE(COORDINATED_GRAPHICS)
 
 #include "BitmapTexture.h"
+#include "TextureMapperFlags.h"
 #include "TextureMapperGLHeaders.h"
 #include "TextureMapperPlatformLayer.h"
 #include <variant>
 #include <wtf/MonotonicTime.h>
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 
@@ -39,9 +41,9 @@ class TextureMapperPlatformLayerBuffer : public TextureMapperPlatformLayer {
     WTF_MAKE_NONCOPYABLE(TextureMapperPlatformLayerBuffer);
     WTF_MAKE_FAST_ALLOCATED();
 public:
-    TextureMapperPlatformLayerBuffer(RefPtr<BitmapTexture>&&, TextureMapper::Flags = 0);
+    TextureMapperPlatformLayerBuffer(RefPtr<BitmapTexture>&&, OptionSet<TextureMapperFlags> = { });
 
-    TextureMapperPlatformLayerBuffer(GLuint textureID, const IntSize&, TextureMapper::Flags, GLint internalFormat);
+    TextureMapperPlatformLayerBuffer(GLuint textureID, const IntSize&, OptionSet<TextureMapperFlags>, GLint internalFormat);
 
     struct RGBTexture {
         GLuint id;
@@ -58,7 +60,7 @@ public:
     };
     using TextureVariant = std::variant<RGBTexture, YUVTexture, ExternalOESTexture>;
 
-    TextureMapperPlatformLayerBuffer(TextureVariant&&, const IntSize&, TextureMapper::Flags, GLint internalFormat);
+    TextureMapperPlatformLayerBuffer(TextureVariant&&, const IntSize&, OptionSet<TextureMapperFlags>, GLint internalFormat);
 
     virtual ~TextureMapperPlatformLayerBuffer();
 
@@ -84,7 +86,7 @@ public:
 
     bool hasManagedTexture() const { return m_hasManagedTexture; }
     void setUnmanagedBufferDataHolder(std::unique_ptr<UnmanagedBufferDataHolder> holder) { m_unmanagedBufferDataHolder = WTFMove(holder); }
-    void setExtraFlags(TextureMapper::Flags flags) { m_extraFlags = flags; }
+    void setExtraFlags(OptionSet<TextureMapperFlags> flags) { m_extraFlags = flags; }
 
     virtual std::unique_ptr<TextureMapperPlatformLayerBuffer> clone();
 
@@ -109,7 +111,7 @@ private:
 
     IntSize m_size;
     GLint m_internalFormat;
-    TextureMapper::Flags m_extraFlags;
+    OptionSet<TextureMapperFlags> m_extraFlags;
     bool m_hasManagedTexture;
     std::unique_ptr<UnmanagedBufferDataHolder> m_unmanagedBufferDataHolder;
     std::unique_ptr<HolePunchClient> m_holePunchClient;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -30,7 +30,6 @@
 #if USE(COORDINATED_GRAPHICS) && USE(TEXTURE_MAPPER_DMABUF)
 
 #include "PlatformDisplay.h"
-#include "TextureMapper.h"
 #include "TextureMapperGLHeaders.h"
 #include "TextureMapperLayer.h"
 #include <fcntl.h>
@@ -162,10 +161,11 @@ void TextureMapperPlatformLayerProxyDMABuf::pushDMABuf(Ref<DMABufLayer>&& dmabuf
         m_compositor->onNewBufferAvailable();
 }
 
-TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::DMABufLayer(DMABufObject&& object, TextureMapper::Flags flags)
+TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::DMABufLayer(DMABufObject&& object, OptionSet<TextureMapperFlags> flags)
     : m_object(WTFMove(object))
     , m_flags(flags)
-{ }
+{
+}
 
 TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::~DMABufLayer() = default;
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h
@@ -32,12 +32,15 @@
 
 #include "DMABufFormat.h"
 #include "DMABufObject.h"
-#include "TextureMapper.h"
+#include "TextureMapperFlags.h"
 #include "TextureMapperPlatformLayer.h"
 #include <cstdint>
 #include <memory>
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
+
+class TextureMapper;
 
 class TextureMapperPlatformLayerProxyDMABuf final : public TextureMapperPlatformLayerProxy {
     WTF_MAKE_FAST_ALLOCATED;
@@ -54,7 +57,7 @@ public:
     class DMABufLayer : public ThreadSafeRefCounted<DMABufLayer>, public TextureMapperPlatformLayer {
         WTF_MAKE_FAST_ALLOCATED;
     public:
-        DMABufLayer(DMABufObject&&, TextureMapper::Flags = 0);
+        explicit DMABufLayer(DMABufObject&&, OptionSet<TextureMapperFlags> = { });
         virtual ~DMABufLayer();
 
         void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = { }, float opacity = 1.0) final;
@@ -72,14 +75,14 @@ public:
 
         DMABufObject m_object;
         std::unique_ptr<EGLImageData> m_imageData;
-        TextureMapper::Flags m_flags;
+        OptionSet<TextureMapperFlags> m_flags;
 
         static constexpr unsigned c_maximumAge { 16 };
         unsigned m_age { 0 };
     };
 
     template<typename F>
-    void pushDMABuf(DMABufObject&& dmabufObject, const F& constructor, TextureMapper::Flags flags = 0)
+    void pushDMABuf(DMABufObject&& dmabufObject, const F& constructor, OptionSet<TextureMapperFlags> flags = { })
     {
         ASSERT(m_lock.isHeld());
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperTile.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperTile.h
@@ -21,12 +21,13 @@
 
 #include "FloatRect.h"
 #include "Image.h"
-#include "TextureMapper.h"
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
 
+class BitmapTexture;
 class GraphicsLayer;
+class TextureMapper;
 
 class TextureMapperTile {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -22,7 +22,6 @@
 #if USE(COORDINATED_GRAPHICS)
 
 #include "NicosiaBuffer.h"
-#include "TextureMapper.h"
 #include "TextureMapperBackingStore.h"
 #include "TextureMapperTile.h"
 #include <wtf/HashMap.h>
@@ -31,6 +30,8 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+class TextureMapper;
 
 class CoordinatedBackingStoreTile : public TextureMapperTile {
 public:

--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/DMABufObject.h>
 #include <WebCore/GraphicsLayerContentsDisplayDelegate.h>
 #include <WebCore/NicosiaContentLayerTextureMapperImpl.h>
+#include <WebCore/TextureMapperFlags.h>
 #include <WebCore/TextureMapperPlatformLayerProxyDMABuf.h>
 
 namespace WebKit {
@@ -88,9 +89,9 @@ void NicosiaDisplayDelegate::swapBuffersIfNeeded()
     if (!!m_pending.handle) {
         Locker locker { proxy.lock() };
 
-        WebCore::TextureMapper::Flags flags = WebCore::TextureMapper::ShouldFlipTexture;
+        OptionSet<WebCore::TextureMapperFlags> flags = WebCore::TextureMapperFlags::ShouldFlipTexture;
         if (!m_isOpaque)
-            flags |= WebCore::TextureMapper::ShouldBlend;
+            flags.add(WebCore::TextureMapperFlags::ShouldBlend);
 
         downcast<WebCore::TextureMapperPlatformLayerProxyDMABuf>(proxy).pushDMABuf(WTFMove(m_pending),
             [](auto&& object) { return object; }, flags);


### PR DESCRIPTION
#### bcb36a613468e08238a239c251f4a4633f76b3ca
<pre>
[TextureMapper] Use OptionSet for TextureMapperFlags
<a href="https://bugs.webkit.org/show_bug.cgi?id=264033">https://bugs.webkit.org/show_bug.cgi?id=264033</a>

Reviewed by Adrian Perez de Castro.

And move it to its own header, since we are including TextureMapper.h in
several places where we only need the flags.

* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp:
(WebCore::GstVideoFrameHolder::GstVideoFrameHolder):
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.h:
(WebCore::GstVideoFrameHolder::flags const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushTextureToCompositor):
(WebCore::MediaPlayerPrivateGStreamer::updateTextureMapperFlags):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp:
(Nicosia::GCGLANGLELayer::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:
(Nicosia::NicosiaImageBufferPipeSource::handle):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::didReset):
(WebCore::BitmapTexture::updateContents):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawBorder):
(WebCore::colorSpaceMatrixForFlags):
(WebCore::TextureMapper::drawTexture):
(WebCore::prepareTransformationMatrixWithFlags):
(WebCore::TextureMapper::drawTexturePlanarYUV):
(WebCore::TextureMapper::drawTextureSemiPlanarYUV):
(WebCore::TextureMapper::drawTexturePackedYUV):
(WebCore::TextureMapper::drawSolidColor):
(WebCore::TextureMapper::draw):
(WebCore::TextureMapper::drawTexturedQuadWithProgram):
(WebCore::TextureMapper::drawTextureCopy):
(WebCore::TextureMapper::drawBlurred):
(WebCore::TextureMapper::applyDropShadowFilter):
(WebCore::TextureMapper::applySinglePassFilter):
(WebCore::TextureMapper::drawTextureExternalOES):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperFlags.h: Added.
* Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp:
(WebCore::TextureMapperGCGLPlatformLayer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp:
(WebCore::TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer):
(WebCore::TextureMapperPlatformLayerBuffer::clone):
(WebCore::TextureMapperPlatformLayerBuffer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h:
(WebCore::TextureMapperPlatformLayerBuffer::TextureMapperPlatformLayerBuffer):
(WebCore::TextureMapperPlatformLayerBuffer::setExtraFlags):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::DMABufLayer):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperTile.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:
(WebKit::NicosiaDisplayDelegate::swapBuffersIfNeeded):

Canonical link: <a href="https://commits.webkit.org/270051@main">https://commits.webkit.org/270051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ead3b9e26a0582791d6b4de50f6c9e3213fd65ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24444 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/343 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24688 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27159 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/22040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22281 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26037 "Found 3 new API test failures: /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-subresource, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors, /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-redirect-to-http (failure)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/68 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3115 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->