### PR TITLE
plainText(): avoid extra buffer allocation for empty ranges

### DIFF
--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -2530,24 +2530,25 @@ bool hasAnyPlainText(const SimpleRange& range, TextIteratorBehaviors behaviors)
 
 String plainText(const SimpleRange& range, TextIteratorBehaviors defaultBehavior, bool isDisplayString)
 {
+    TextIterator it(range, defaultBehavior);
+    if (it.atEnd())
+        return emptyString();
+
     // The initial buffer size can be critical for performance: https://bugs.webkit.org/show_bug.cgi?id=81192
     constexpr unsigned initialCapacity = 1 << 15;
 
     Ref document = range.start.document();
 
-    unsigned bufferLength = 0;
     StringBuilder builder;
     builder.reserveCapacity(initialCapacity);
     TextIteratorBehaviors behaviors = defaultBehavior;
     if (!isDisplayString)
         behaviors.add(TextIteratorBehavior::EmitsTextsWithoutTranscoding);
 
-    for (TextIterator it(range, behaviors); !it.atEnd(); it.advance()) {
+    for (; !it.atEnd(); it.advance())
         it.appendTextToStringBuilder(builder);
-        bufferLength += it.text().length();
-    }
 
-    if (!bufferLength)
+    if (builder.isEmpty())
         return emptyString();
 
     String result = builder.toString();


### PR DESCRIPTION
<pre>
plainText(): avoid extra buffer allocation for empty ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=264018">https://bugs.webkit.org/show_bug.cgi?id=264018</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/0b34a706cb547c672215c108270ffb8d344fb097">https://chromium.googlesource.com/chromium/blink/+/0b34a706cb547c672215c108270ffb8d344fb097</a>

The pre-allocation of the StringBuilder is redundant if the range is
empty, hence avoid.

While here, simplify empty string builder testing also.

* Source/WebCore/editing/TextIterator.cpp:
(plainText):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e11007bd53acfb5bd4faf8d15abcb8088328dc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/342 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22907 "Found 3 new test failures: fast/encoding/yentest.html, fast/encoding/yentest2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-backslash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24686 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2052 "Found 3 new test failures: editing/execCommand/transpose-backslash-with-euc.html, fast/encoding/yentest.html, fast/encoding/yentest2.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27157 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1788 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-backslash.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22038 "Found 6 new test failures: editing/execCommand/transpose-backslash-with-euc.html, editing/pasteboard/copy-backslash-with-euc.html, fast/css/transform-function-perspective-crash.html, fast/encoding/yentest.html, fast/encoding/yentest2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-backslash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28240 "Found 5 new test failures: editing/execCommand/transpose-backslash-with-euc.html, editing/pasteboard/copy-backslash-with-euc.html, fast/encoding/yentest.html, fast/encoding/yentest2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-backslash.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22343 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22360 "Found 5 new test failures: editing/execCommand/transpose-backslash-with-euc.html, editing/pasteboard/copy-backslash-with-euc.html, fast/encoding/yentest.html, fast/encoding/yentest2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-backslash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1738 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/67 "Found 6 new test failures: editing/execCommand/transpose-backslash-with-euc.html, editing/pasteboard/copy-backslash-with-euc.html, fast/encoding/yentest.html, fast/encoding/yentest2.html, fast/scrolling/scroll-to-focused-element-asynchronously.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-backslash.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->