### PR TITLE
Optimize clz and ctz

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -617,14 +617,12 @@ void shuffleVector(VectorType& vector, const RandomFunc& randomFunc)
 template <typename T>
 constexpr unsigned clzConstexpr(T value)
 {
-    constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
-
     using UT = typename std::make_unsigned<T>::type;
     UT uValue = value;
 
     unsigned zeroCount = 0;
-    for (int i = bitSize - 1; i >= 0; i--) {
-        if (uValue >> i)
+    for (unsigned i = countOfBits<T>; i--;) {
+        if (uValue & (static_cast<UT>(1) << i))
             break;
         zeroCount++;
     }
@@ -634,27 +632,49 @@ constexpr unsigned clzConstexpr(T value)
 template<typename T>
 inline unsigned clz(T value)
 {
-    constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
+#if COMPILER(GCC_COMPATIBLE)
+    constexpr unsigned bitSize = countOfBits<T>;
+
+    if (!value)
+        return bitSize;
 
     using UT = typename std::make_unsigned<T>::type;
     UT uValue = value;
 
-#if COMPILER(GCC_COMPATIBLE)
-    constexpr unsigned bitSize64 = sizeof(uint64_t) * CHAR_BIT;
-    if (uValue)
-        return __builtin_clzll(uValue) - (bitSize64 - bitSize);
-    return bitSize;
-#elif COMPILER(MSVC) && !CPU(X86)
+    // unsigned int and below
+    if constexpr (bitSize <= countOfBits<unsigned>)
+        return __builtin_clz(uValue) - (countOfBits<unsigned> - bitSize);
+
+    // unsigned long
+    if constexpr (bitSize == countOfBits<unsigned long>)
+        return __builtin_clzl(uValue);
+
+    // unsigned long long
+    return __builtin_clzll(uValue);
+#elif COMPILER(MSVC)
+    constexpr unsigned bitSize = countOfBits<T>;
+
+    using UT = typename std::make_unsigned<T>::type;
+    UT uValue = value;
+
     // Visual Studio 2008 or upper have __lzcnt, but we can't detect Intel AVX at compile time.
     // So we use bit-scan-reverse operation to calculate clz.
-    // _BitScanReverse64 is defined in X86_64 and ARM in MSVC supported environments.
     unsigned long ret = 0;
-    if (_BitScanReverse64(&ret, uValue))
-        return bitSize - 1 - ret;
-    return bitSize;
+    if constexpr (bitSize <= 32) {
+        if (_BitScanReverse(&ret, uValue))
+            return bitSize - 1 - ret;
+        return bitSize;
+    }
+
+#if CPU(X86_64) || CPU(ARM64)
+    if constexpr (bitSize == 64) {
+        if (_BitScanReverse64(&ret, uValue))
+            return ret ^ 63;
+        return 64;
+    }
+#endif
+    return clzConstexpr(value);
 #else
-    UNUSED_PARAM(bitSize);
-    UNUSED_PARAM(uValue);
     return clzConstexpr(value);
 #endif
 }
@@ -662,18 +682,15 @@ inline unsigned clz(T value)
 template <typename T>
 constexpr unsigned ctzConstexpr(T value)
 {
-    constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
+    constexpr unsigned bitSize = countOfBits<T>;
 
     using UT = typename std::make_unsigned<T>::type;
     UT uValue = value;
 
     unsigned zeroCount = 0;
-    for (unsigned i = 0; i < bitSize; i++) {
-        if (uValue & 1)
+    for (; zeroCount < bitSize; zeroCount++) {
+        if (uValue & (static_cast<UT>(1) << zeroCount))
             break;
-
-        zeroCount++;
-        uValue >>= 1;
     }
     return zeroCount;
 }
@@ -681,23 +698,46 @@ constexpr unsigned ctzConstexpr(T value)
 template<typename T>
 inline unsigned ctz(T value)
 {
-    constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
+#if COMPILER(GCC_COMPATIBLE)
+    constexpr unsigned bitSize = countOfBits<T>;
+
+    if (!value)
+        return bitSize;
 
     using UT = typename std::make_unsigned<T>::type;
     UT uValue = value;
 
-#if COMPILER(GCC_COMPATIBLE)
-    if (uValue)
-        return __builtin_ctzll(uValue);
-    return bitSize;
-#elif COMPILER(MSVC) && !CPU(X86)
+    // unsigned int and below
+    if constexpr (bitSize <= countOfBits<unsigned>)
+        return __builtin_ctz(uValue);
+
+    // unsigned long
+    if constexpr (bitSize == countOfBits<unsigned long>)
+        return __builtin_ctzl(uValue);
+
+    // unsigned long long
+    return __builtin_ctzll(uValue);
+#elif COMPILER(MSVC)
+    constexpr unsigned bitSize = countOfBits<T>;
+
+    using UT = typename std::make_unsigned<T>::type;
+    UT uValue = value;
+
     unsigned long ret = 0;
+    if constexpr (bitSize <= 32) {
+        if (_BitScanForward(&ret, uValue))
+            return ret;
+        return bitSize;
+    }
+
+#if CPU(X86_64) || CPU(ARM64)
     if (_BitScanForward64(&ret, uValue))
         return ret;
     return bitSize;
 #else
-    UNUSED_PARAM(bitSize);
-    UNUSED_PARAM(uValue);
+    return ctzConstexpr(value);
+#endif
+#else
     return ctzConstexpr(value);
 #endif
 }
@@ -719,7 +759,7 @@ constexpr unsigned getLSBSetConstexpr(T t)
 template<typename T>
 inline unsigned getMSBSet(T t)
 {
-    constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
+    constexpr unsigned bitSize = countOfBits<T>;
     ASSERT(t);
     return bitSize - 1 - clz(t);
 }
@@ -727,7 +767,7 @@ inline unsigned getMSBSet(T t)
 template<typename T>
 constexpr unsigned getMSBSetConstexpr(T t)
 {
-    constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
+    constexpr unsigned bitSize = countOfBits<T>;
     ASSERT_UNDER_CONSTEXPR_CONTEXT(t);
     return bitSize - 1 - clzConstexpr(t);
 }

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -79,7 +79,7 @@ ALWAYS_INLINE bool equal(const LChar* aLChar, const LChar* bLChar, unsigned leng
         return *aLChar == *bLChar;
 
 #if COMPILER(GCC_COMPATIBLE)
-    switch (sizeof(unsigned) * CHAR_BIT - clz(length - 1)) { // Works as really fast log2, since length != 0.
+    switch (sizeof(unsigned) * CHAR_BIT - __builtin_clz(length - 1)) { // Works as really fast log2, since length > 1.
 #else
     switch (fastLog2(length)) {
 #endif
@@ -131,7 +131,7 @@ ALWAYS_INLINE bool equal(const UChar* aUChar, const UChar* bUChar, unsigned leng
         return *aUChar == *bUChar;
 
 #if COMPILER(GCC_COMPATIBLE)
-    switch (sizeof(unsigned) * CHAR_BIT - clz(length - 1)) { // Works as really fast log2, since length != 0.
+    switch (sizeof(unsigned) * CHAR_BIT - __builtin_clz(length - 1)) { // Works as really fast log2, since length > 1.
 #else
     switch (fastLog2(length)) {
 #endif


### PR DESCRIPTION
<pre>
Optimize clz and ctz
<a href="https://bugs.webkit.org/show_bug.cgi?id=262970">https://bugs.webkit.org/show_bug.cgi?id=262970</a>

Reviewed by NOBODY (OOPS!).

The functions used to count leading zeros and trailing zeros can make
use of constexpr as opposed to putting every single value into the
intrinsic meant for unsigned long long values.

In addition, the constexpr versions have been refactored because clang
performs loop unrolling when it sees "a & (1 << b)" as opposed to
"a >>= 1" every iteration. Source: <a href="https://godbolt.org/z/vo5xqG896">https://godbolt.org/z/vo5xqG896</a>

* Source/WTF/wtf/MathExtras.h:
  (WTF::clzConstexpr): Refactor to allow loop unrolling.
  (WTF::clz): Use constexpr to determine the correct intrinsic to use.
  (WTF::ctzConstexpr): Refactor to allow loop unrolling.
  (WTF::ctz): Use constexpr to determine the correct intrinsic to use.
* Source/WTF/wtf/text/StringCommon.h: Avoid extra check that happens
  when calling clz by replacing it with __builtin_clz, as the check for
  "length == 1" makes it impossible to happen and the code only compiles
   under a GCC-compatible compiler anyway.
* Source/bmalloc/bmalloc/Algorithm.h: 
  (bmalloc::clzConstexpr): Refactor to allow loop unrolling.
  (bmalloc::ctzConstexpr): Ditto.
  (bmalloc::ctz): Use constexpr to determine the correct intrinsic to use.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6440db361f6018978a704d087511af342a953b1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30481 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10239 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38916 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29663 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36343 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34304 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12219 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41431 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10946 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8628 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->