### PR TITLE
Use CompactContextMenuPresenter to show context menus for focused elements with datalist

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -978,16 +978,6 @@ typedef NS_OPTIONS(NSInteger, UIWKDocumentRequestFlags) {
 @property (nonatomic, strong) UIImage *image;
 @end
 
-typedef NS_ENUM(NSUInteger, _UIContextMenuLayout) {
-    _UIContextMenuLayoutCompactMenu = 3,
-};
-
-@interface _UIContextMenuStyle : NSObject <NSCopying>
-@property (nonatomic) _UIContextMenuLayout preferredLayout;
-@property (nonatomic) UIEdgeInsets preferredEdgeInsets;
-+ (instancetype)defaultStyle;
-@end
-
 #if USE(UICONTEXTMENU)
 
 @interface UIContextMenuInteraction ()

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
@@ -44,6 +44,8 @@ public:
     void present(CGPoint locationInRootView);
     void dismiss();
 
+    void updateVisibleMenu(UIMenu *(^)(UIMenu *));
+
     UIContextMenuInteraction *interaction() const;
 
 private:

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
@@ -117,6 +117,11 @@ void CompactContextMenuPresenter::dismiss()
     [[m_button contextMenuInteraction] dismissMenu];
 }
 
+void CompactContextMenuPresenter::updateVisibleMenu(UIMenu *(^updateBlock)(UIMenu *))
+{
+    [interaction() updateVisibleMenuWithBlock:updateBlock];
+}
+
 } // namespace WebKit
 
 #endif // USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -229,6 +229,11 @@ enum class InputViewUpdateDeferralSource : uint8_t {
     ChangingFocusedElement = 1 << 2,
 };
 
+enum class TargetedPreviewPositioning : uint8_t {
+    Default,
+    LeadingOrTrailingEdge,
+};
+
 using InputViewUpdateDeferralSources = OptionSet<InputViewUpdateDeferralSource>;
 
 struct WKSelectionDrawingInfo {
@@ -799,7 +804,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 
 - (void)presentContextMenu:(UIContextMenuInteraction *)contextMenuInteraction atLocation:(CGPoint)location;
 
-- (UITargetedPreview *)_createTargetedContextMenuHintPreviewForFocusedElement;
+- (UITargetedPreview *)_createTargetedContextMenuHintPreviewForFocusedElement:(WebKit::TargetedPreviewPositioning)positioning;
 - (UITargetedPreview *)_createTargetedContextMenuHintPreviewIfPossible;
 - (void)_removeContextMenuHintContainerIfPossible;
 - (void)_targetedPreviewContainerDidRemoveLastSubview:(WKTargetedPreviewContainer *)containerView;

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -28,7 +28,7 @@
 
 #if ENABLE(DATALIST_ELEMENT) && PLATFORM(IOS_FAMILY)
 
-#import "UIKitSPI.h"
+#import "CompactContextMenuPresenter.h"
 #import "WKContentView.h"
 #import "WKContentViewInteraction.h"
 #import "WKFormPeripheral.h"
@@ -408,7 +408,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 @implementation WKDataListSuggestionsDropdown {
 #if USE(UICONTEXTMENU)
     RetainPtr<NSArray<UIMenuElement *>> _suggestionsMenuElements;
-    RetainPtr<UIContextMenuInteraction> _suggestionsContextMenuInteraction;
+    std::unique_ptr<WebKit::CompactContextMenuPresenter> _suggestionsContextMenuPresenter;
 #endif
 }
 
@@ -467,22 +467,31 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if USE(UICONTEXTMENU)
     [self _updateSuggestionsMenuElements];
 
-    if (!_suggestionsContextMenuInteraction) {
-        _suggestionsContextMenuInteraction = adoptNS([[UIContextMenuInteraction alloc] initWithDelegate:self]);
-        [self.view addInteraction:_suggestionsContextMenuInteraction.get()];
-
+    if (!_suggestionsContextMenuPresenter) {
+        _suggestionsContextMenuPresenter = makeUnique<WebKit::CompactContextMenuPresenter>(self.view, self);
         [self.view doAfterEditorStateUpdateAfterFocusingElement:[weakSelf = WeakObjCPtr<WKDataListSuggestionsDropdown>(self)] {
             auto strongSelf = weakSelf.get();
             if (!strongSelf)
                 return;
 
-            auto view = [strongSelf view];
-            [view presentContextMenu:strongSelf->_suggestionsContextMenuInteraction.get() atLocation:[view lastInteractionLocation]];
+            if (strongSelf->_suggestionsContextMenuPresenter) {
+                strongSelf->_suggestionsContextMenuPresenter->present([&] {
+                    RetainPtr contentView = [strongSelf view];
+                    auto elementRect = [contentView focusedElementInformation].interactionRect;
+                    if (elementRect.isEmpty()) {
+                        elementRect = WebCore::IntRect {
+                            WebCore::IntPoint([contentView lastInteractionLocation]),
+                            WebCore::IntSize { }
+                        };
+                    }
+                    return elementRect;
+                }());
+            }
         }];
     } else {
-        [_suggestionsContextMenuInteraction updateVisibleMenuWithBlock:[&](UIMenu *visibleMenu) -> UIMenu * {
+        _suggestionsContextMenuPresenter->updateVisibleMenu(^UIMenu *(UIMenu *visibleMenu) {
             return [visibleMenu menuByReplacingChildren:_suggestionsMenuElements.get()];
-        }];
+        });
     }
 #endif
 }
@@ -515,11 +524,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_removeContextMenuInteraction
 {
-    if (!_suggestionsContextMenuInteraction)
+    if (!_suggestionsContextMenuPresenter)
         return;
 
-    [self.view removeInteraction:_suggestionsContextMenuInteraction.get()];
-    _suggestionsContextMenuInteraction = nil;
+    _suggestionsContextMenuPresenter->dismiss();
+    _suggestionsContextMenuPresenter = nullptr;
     [self.view _removeContextMenuHintContainerIfPossible];
     [self.view.webView _didDismissContextMenu];
 }
@@ -541,32 +550,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _removeContextMenuInteraction];
 }
 
-- (UIEdgeInsets)_preferredEdgeInsetsForSuggestionsMenu
-{
-    CGRect windowBounds = self.view.textEffectsWindow.bounds;
-    CGRect elementFrameInWindowCoordinates = [self.view convertRect:self.view.focusedElementInformation.interactionRect toView:nil];
-
-    if (CGRectGetMidY(elementFrameInWindowCoordinates) > CGRectGetMidY(windowBounds))
-        return UIEdgeInsetsMake(0, 0, CGRectGetMaxY(windowBounds) - CGRectGetMinY(elementFrameInWindowCoordinates), 0);
-
-    // Use MinY rather than MaxY to account for the hint preview.
-    return UIEdgeInsetsMake(CGRectGetMinY(elementFrameInWindowCoordinates), 0, 0, 0);
-}
-
 #pragma mark UIContextMenuInteractionDelegate
 
 - (UITargetedPreview *)contextMenuInteraction:(UIContextMenuInteraction *)interaction configuration:(UIContextMenuConfiguration *)configuration highlightPreviewForItemWithIdentifier:(id<NSCopying>)identifier
 {
-    return [self.view _createTargetedContextMenuHintPreviewForFocusedElement];
-}
-
-- (_UIContextMenuStyle *)_contextMenuInteraction:(UIContextMenuInteraction *)interaction styleForMenuWithConfiguration:(UIContextMenuConfiguration *)configuration
-{
-    _UIContextMenuStyle *style = [_UIContextMenuStyle defaultStyle];
-    style.preferredLayout = _UIContextMenuLayoutCompactMenu;
-    style.preferredEdgeInsets = [self _preferredEdgeInsetsForSuggestionsMenu];
-
-    return style;
+    return [self.view _createTargetedContextMenuHintPreviewForFocusedElement:WebKit::TargetedPreviewPositioning::LeadingOrTrailingEdge];
 }
 
 - (UIContextMenuConfiguration *)contextMenuInteraction:(UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -647,7 +647,7 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 
 - (UITargetedPreview *)contextMenuInteraction:(UIContextMenuInteraction *)interaction configuration:(UIContextMenuConfiguration *)configuration highlightPreviewForItemWithIdentifier:(id<NSCopying>)identifier
 {
-    return [_view _createTargetedContextMenuHintPreviewForFocusedElement];
+    return [_view _createTargetedContextMenuHintPreviewForFocusedElement:WebKit::TargetedPreviewPositioning::Default];
 }
 
 - (UIContextMenuConfiguration *)contextMenuInteraction:(UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location


### PR DESCRIPTION
#### f1278a15b8232ad9b2d90746f59f373a6ccbe576
<pre>
Use CompactContextMenuPresenter to show context menus for focused elements with datalist
<a href="https://bugs.webkit.org/show_bug.cgi?id=264038">https://bugs.webkit.org/show_bug.cgi?id=264038</a>
<a href="https://rdar.apple.com/117809656">rdar://117809656</a>

Reviewed by Richard Robinson and Megan Gardner.

Deploy `CompactContextMenuPresenter` in `WKDataListSuggestionsDropdown`, to support compact context
menu presentation without relying on UIKit SPI. Note that this (in theory) means we no longer need
logic to manually specify preferred edge insets for the suggestions menu, since we now lay out the
hidden native `UIButton` over the bounds of the focused datalist element, which UIKit will
automatically avoid obscuring when presenting or updating the menu.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove SPI declarations that are no longer necessary.

* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h:
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm:
(WebKit::CompactContextMenuPresenter::updateVisibleMenu):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _createTargetedContextMenuHintPreviewForFocusedElement:]):
(-[WKContentView _createTargetedContextMenuHintPreviewForFocusedElement]): Deleted.

Add support for an option to create a targeted context menu hint that&apos;s positioned against the left
or right edge of the input, provided there&apos;s sufficient space to fit the 250pt (by default) menu.
When the view is RTL, note that we&apos;ll prefer to position the menu at the the right edge of the
element, fall back to the left edge if there&apos;s not enough horizonal space, and finally fall back to
the element rect itself if there&apos;s no space on either side.

* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsDropdown _showSuggestions]):
(-[WKDataListSuggestionsDropdown _removeContextMenuInteraction]):
(-[WKDataListSuggestionsDropdown contextMenuInteraction:configuration:highlightPreviewForItemWithIdentifier:]):
(-[WKDataListSuggestionsDropdown _preferredEdgeInsetsForSuggestionsMenu]): Deleted.
(-[WKDataListSuggestionsDropdown _contextMenuInteraction:styleForMenuWithConfiguration:]): Deleted.
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker contextMenuInteraction:configuration:highlightPreviewForItemWithIdentifier:]):

Canonical link: <a href="https://commits.webkit.org/270373@main">https://commits.webkit.org/270373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5952d7d48201fc40f65a2793536a3bdba050701

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1271 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27985 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2524 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28871 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26707 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/764 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3834 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2921 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2814 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->