### PR TITLE
[WTF] Remove countTrailingZeros

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -1192,7 +1192,7 @@ private:
                 && m_value->child(1)->hasInt()) {
                 uint64_t shiftAmount = m_value->child(0)->child(1)->asInt();
                 uint64_t maskShift = m_value->child(1)->asInt();
-                uint64_t maskShiftAmount = WTF::countTrailingZeros(maskShift);
+                uint64_t maskShiftAmount = WTF::ctz(maskShift);
                 uint64_t mask = maskShift >> maskShiftAmount;
                 uint64_t width = WTF::bitCount(mask);
                 uint64_t datasize = m_value->child(0)->child(0)->type() == Int64 ? 64 : 32;
@@ -1600,7 +1600,7 @@ private:
                 && m_value->child(1)->asInt() >= 0) {
                 uint64_t shiftAmount = m_value->child(1)->asInt();
                 uint64_t maskShift = m_value->child(0)->child(1)->asInt();
-                uint64_t maskShiftAmount = WTF::countTrailingZeros(maskShift);
+                uint64_t maskShiftAmount = WTF::ctz(maskShift);
                 uint64_t mask = maskShift >> maskShiftAmount;
                 uint64_t width = WTF::bitCount(mask);
                 uint64_t datasize = m_value->child(0)->child(0)->type() == Int64 ? 64 : 32;

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -732,28 +732,6 @@ constexpr unsigned getMSBSetConstexpr(T t)
     return bitSize - 1 - clzConstexpr(t);
 }
 
-inline size_t countTrailingZeros(uint32_t v)
-{
-    static const unsigned Mod37BitPosition[] = {
-        32, 0, 1, 26, 2, 23, 27, 0, 3, 16, 24, 30, 28, 11, 0, 13,
-        4, 7, 17, 0, 25, 22, 31, 15, 29, 10, 12, 6, 0, 21, 14, 9,
-        5, 20, 8, 19, 18
-    };
-    return Mod37BitPosition[((1 + ~v) & v) % 37];
-}
-
-inline size_t countTrailingZeros(uint64_t v)
-{
-    static const unsigned Mod67Position[] = {
-        64, 0, 1, 39, 2, 15, 40, 23, 3, 12, 16, 59, 41, 19, 24, 54,
-        4, 64, 13, 10, 17, 62, 60, 28, 42, 30, 20, 51, 25, 44, 55,
-        47, 5, 32, 65, 38, 14, 22, 11, 58, 18, 53, 63, 9, 61, 27,
-        29, 50, 43, 46, 31, 37, 21, 57, 52, 8, 26, 49, 45, 36, 56,
-        7, 48, 35, 6, 34, 33, 0
-    };
-    return Mod67Position[((1 + ~v) & v) % 67];
-}
-
 inline uint32_t reverseBits32(uint32_t value)
 {
 #if COMPILER(GCC_COMPATIBLE) && CPU(ARM64)


### PR DESCRIPTION
#### 37c77f48561ad37be5e08424748d81a23f503040
<pre>
[WTF] Remove countTrailingZeros
<a href="https://bugs.webkit.org/show_bug.cgi?id=264041">https://bugs.webkit.org/show_bug.cgi?id=264041</a>

Reviewed by Yusuke Suzuki.

In addition to being redundant because of ctz existing, the lookup table
in itself is slower due to the operations happening to the variable v
before retrieving the value. Source: <a href="https://godbolt.org/z/Pnd9nPPbo">https://godbolt.org/z/Pnd9nPPbo</a>

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp: Switch to WTF:ctz.
* Source/WTF/wtf/MathExtras.h:
  (WTF::countTrailingZeros): Deleted.

Canonical link: <a href="https://commits.webkit.org/270076@main">https://commits.webkit.org/270076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ecca8d993e973713f02b53d5f6ec54eed028741

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22510 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/456 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27187 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22068 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21292 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26071 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23763 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1762 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/97 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31160 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3045 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6835 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2216 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31128 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3123 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2136 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6509 "Passed tests") | 
<!--EWS-Status-Bubble-End-->