### PR TITLE
[WebGPU] MSL compilation error opening https://kishimisu.github.io/WebGPU-Fluid-Simulation/

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/return.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/return.wgsl
@@ -1,0 +1,19 @@
+// RUN: %not %wgslc | %check
+
+fn noReturn()
+{
+    // CHECK-L: return statement type does not match its function return type, returned 'i32', expected 'void'
+    return 0i;
+}
+
+fn typeMisMatch() -> f32
+{
+    // CHECK-L: return statement type does not match its function return type, returned 'i32', expected 'f32'
+    return 0i;
+}
+
+fn conversionFailure() -> i32
+{
+    // CHECK-L: value 500000000000 cannot be represented as 'i32'
+    return 500000000000;
+}

--- a/Source/WebGPU/WGSL/tests/valid/return.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/return.wgsl
@@ -1,0 +1,18 @@
+// RUN: %metal-compile main
+
+fn testScalarPromotion() -> f32
+{
+    return 0;
+}
+
+fn testVectorPromotion() -> vec3f
+{
+    return vec3(0);
+}
+
+@compute
+@workgroup_size(1, 1, 1)
+fn main() {
+    _ = testScalarPromotion();
+    _ = testVectorPromotion();
+}


### PR DESCRIPTION
#### 67be1e0883407c894c71a4c903e5030059a7b5e9
<pre>
[WebGPU] MSL compilation error opening <a href="https://kishimisu.github.io/WebGPU-Fluid-Simulation/">https://kishimisu.github.io/WebGPU-Fluid-Simulation/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=264009">https://bugs.webkit.org/show_bug.cgi?id=264009</a>
<a href="https://rdar.apple.com/117768138">rdar://117768138</a>

Reviewed by Mike Wyrzykowski.

The cause of the crash was that we weren&apos;t type checking return statements. The
expression being returned needs to be unified with the function&apos;s return type,
which causes the type to be promoted and fixes the sample.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/return.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/return.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/270104@main">https://commits.webkit.org/270104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60f48de71717014cad02f0a91e91c71635a51836

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22512 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22918 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24720 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2094 "Found 1 new test failure: fast/dom/focus-dialog-blur-input-type-change-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27189 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1856 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28267 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22397 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26060 "Found 4 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestResources:/webkit/WebKitWebResource/mime-type, /WebKitGTK/TestResources:/webkit/WebKitWebResource/active-uri, /WebKitGTK/TestResources:/webkit/WebKitWebResource/loading (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/99 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3058 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5888 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->