### PR TITLE
REGRESSION (267119@main?): Occasional unrecognized selector under -[WKWebEvent initWithEvent:]

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKWebEvent.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebEvent.mm
@@ -40,7 +40,8 @@
     uint16_t keyCode;
     UIKeyboardInputFlags inputFlags;
     NSInteger modifierFlags;
-    BOOL isHardwareKeyboardEvent = !!event._hidEvent;
+    static auto physicalKeyboardEventClass = NSClassFromString(@"UIPhysicalKeyboardEvent");
+    BOOL isHardwareKeyboardEvent = [event isKindOfClass:physicalKeyboardEventClass] && event._hidEvent;
     RetainPtr<UIEvent> uiEvent;
     if (!isHardwareKeyboardEvent) {
         keyCode = 0;


### PR DESCRIPTION
#### 28ea5280429e1169a1de69fe994432713b6fde99
<pre>
REGRESSION (267119@main?): Occasional unrecognized selector under -[WKWebEvent initWithEvent:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=264044">https://bugs.webkit.org/show_bug.cgi?id=264044</a>
<a href="https://rdar.apple.com/117727776">rdar://117727776</a>

Reviewed by Aditya Keerthi.

After the changes in 267119@main, it&apos;s theoretically possible that we end up passing a
`UIPressesEvent` into `-initWithEvent:` that is not a `UIPhysicalKeyboardEvent`, but returns a non-
null `-_hidEvent` anyways.

It&apos;s unclear how this reproduces in practice, but we should be robust in this scenario by adding an
explicit class check for `UIPhysicalKeyboardEvent` before accessing methods and properties on the
event.

* Source/WebKit/UIProcess/ios/WKWebEvent.mm:
(-[WKWebEvent initWithEvent:]):

Canonical link: <a href="https://commits.webkit.org/270090@main">https://commits.webkit.org/270090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ec23214f6b808df88923eecdb50c20445d30c28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22523 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/469 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27200 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1842 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28277 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22408 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26072 "Found 4 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/loading, /WebKitGTK/TestResources:/webkit/WebKitWebResource/mime-type, /WebKitGTK/TestResources:/webkit/WebKitWebResource/active-uri, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/107 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3079 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2226 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3128 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->