### PR TITLE
[JSC] Add @alwaysInline attribute

### DIFF
--- a/JSTests/microbenchmarks/array-filter-inline.js
+++ b/JSTests/microbenchmarks/array-filter-inline.js
@@ -1,0 +1,13 @@
+var array = [];
+for (var i = 0; i < 1000; ++i)
+    array.push(i);
+
+function test(array)
+{
+    return array.filter((value) => value < 1e5);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i) {
+    test(array);
+}

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1073,6 +1073,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/IndexingType.h
     runtime/InferredValue.h
     runtime/InitializeThreading.h
+    runtime/InlineAttribute.h
     runtime/Int16Array.h
     runtime/Int32Array.h
     runtime/Int8Array.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2061,6 +2061,7 @@
 		E3CDCFAF28DD065A00215350 /* ImportMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CDCFAE28DD065A00215350 /* ImportMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D239C91B829C1C00BBEF67 /* JSModuleEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D239C71B829C1C00BBEF67 /* JSModuleEnvironment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D3515F241B89D7008DC16E /* MarkedJSValueRefArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D3515D241B89CE008DC16E /* MarkedJSValueRefArray.h */; };
+		E3D4FFE22AF21D96004ED359 /* InlineAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D4FFE12AF21D96004ED359 /* InlineAttribute.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D7086E29FA66820061F230 /* ScriptFunctionCall.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D7086C29FA667E0061F230 /* ScriptFunctionCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D877741E65C0A000BE945A /* BytecodeDumper.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D877721E65C08900BE945A /* BytecodeDumper.h */; };
 		E3E6E9CC28F3C33F00EDE7C0 /* ChainedWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E3E6E9CB28F3C33F00EDE7C0 /* ChainedWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5735,6 +5736,7 @@
 		E3D2642A1D38C042000BE174 /* BytecodeRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BytecodeRewriter.h; sourceTree = "<group>"; };
 		E3D3515D241B89CE008DC16E /* MarkedJSValueRefArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MarkedJSValueRefArray.h; sourceTree = "<group>"; };
 		E3D3515E241B89CF008DC16E /* MarkedJSValueRefArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MarkedJSValueRefArray.cpp; sourceTree = "<group>"; };
+		E3D4FFE12AF21D96004ED359 /* InlineAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineAttribute.h; sourceTree = "<group>"; };
 		E3D7086C29FA667E0061F230 /* ScriptFunctionCall.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScriptFunctionCall.h; sourceTree = "<group>"; };
 		E3D7086D29FA667E0061F230 /* ScriptFunctionCall.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScriptFunctionCall.cpp; sourceTree = "<group>"; };
 		E3D877711E65C08900BE945A /* BytecodeDumper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeDumper.cpp; sourceTree = "<group>"; };
@@ -8108,6 +8110,7 @@
 				0F4AE0421FE0D25400E20839 /* InferredValueInlines.h */,
 				E178636C0D9BEEC300D74E75 /* InitializeThreading.cpp */,
 				E178633F0D9BEC0000D74E75 /* InitializeThreading.h */,
+				E3D4FFE12AF21D96004ED359 /* InlineAttribute.h */,
 				A7A8AF2C17ADB5F3005AB174 /* Int16Array.h */,
 				A7A8AF2D17ADB5F3005AB174 /* Int32Array.h */,
 				A7A8AF2B17ADB5F3005AB174 /* Int8Array.h */,
@@ -10927,6 +10930,7 @@
 				A5840E21187B7B8600843B10 /* InjectedScriptModule.h in Headers */,
 				9959E9321BD18279001AA413 /* inline-and-minify-stylesheets-and-scripts.py in Headers */,
 				7905BB691D12050E0019FE57 /* InlineAccess.h in Headers */,
+				E3D4FFE22AF21D96004ED359 /* InlineAttribute.h in Headers */,
 				0FF9CE741B9CD6D0004EDCA6 /* InlineCacheCompiler.h in Headers */,
 				148A7BF01B82975A002D9157 /* InlineCallFrame.h in Headers */,
 				0F24E55617F0B71C00ABB217 /* InlineCallFrameSet.h in Headers */,

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result
@@ -38,6 +38,7 @@ class VM;
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
 enum class ImplementationVisibility : uint8_t;
+enum class InlineAttribute : uint8_t;
 }
 
 namespace JSC {
@@ -52,11 +53,13 @@ extern const int s_builtinPromiseRejectPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPromiseRejectPromiseCodeInlineAttribute;
 extern const char* const s_builtinPromiseFulfillPromiseCode;
 extern const int s_builtinPromiseFulfillPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPromiseFulfillPromiseCodeInlineAttribute;
 
 #define JSC_FOREACH_BUILTINPROMISE_BUILTIN_DATA(macro) \
     macro(rejectPromise, builtinPromiseRejectPromise, 2) \
@@ -132,6 +135,7 @@ const unsigned s_JSCCombinedCodeLength = 673;
 const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPromiseFulfillPromiseCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPromiseFulfillPromiseCodeLength = 336;
 static const JSC::Intrinsic s_builtinPromiseFulfillPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseFulfillPromiseCode =
@@ -141,6 +145,7 @@ s_JSCCombinedCode + 0
 const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPromiseRejectPromiseCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPromiseRejectPromiseCodeLength = 337;
 static const JSC::Intrinsic s_builtinPromiseRejectPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseRejectPromiseCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Separate.js-result
@@ -45,11 +45,13 @@ extern const int s_builtinPromiseRejectPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPromiseRejectPromiseCodeInlineAttribute;
 extern const char* const s_builtinPromiseFulfillPromiseCode;
 extern const int s_builtinPromiseFulfillPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPromiseFulfillPromiseCodeInlineAttribute;
 
 #define JSC_FOREACH_BUILTIN_PROMISE_BUILTIN_DATA(macro) \
     macro(rejectPromise, builtinPromiseRejectPromise, 2) \
@@ -121,6 +123,7 @@ namespace JSC {
 const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPromiseRejectPromiseCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPromiseRejectPromiseCodeLength = 337;
 static const JSC::Intrinsic s_builtinPromiseRejectPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseRejectPromiseCode =
@@ -141,6 +144,7 @@ const char* const s_builtinPromiseRejectPromiseCode =
 const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPromiseFulfillPromiseCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPromiseFulfillPromiseCodeLength = 336;
 static const JSC::Intrinsic s_builtinPromiseFulfillPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseFulfillPromiseCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result
@@ -38,6 +38,7 @@ class VM;
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
 enum class ImplementationVisibility : uint8_t;
+enum class InlineAttribute : uint8_t;
 }
 
 namespace JSC {
@@ -52,21 +53,25 @@ extern const int s_builtinPrototypeEveryCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeEveryCodeInlineAttribute;
 extern const char* const s_builtinPrototypeForEachCode;
 extern const int s_builtinPrototypeForEachCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeForEachCodeInlineAttribute;
 extern const char* const s_builtinPrototypeMatchCode;
 extern const int s_builtinPrototypeMatchCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeMatchCodeInlineAttribute;
 extern const char* const s_builtinPrototypeTestCode;
 extern const int s_builtinPrototypeTestCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeTestCodeInlineAttribute;
 
 #define JSC_FOREACH_BUILTINPROTOTYPE_BUILTIN_DATA(macro) \
     macro(every, builtinPrototypeEvery, 1) \
@@ -148,6 +153,7 @@ const unsigned s_JSCCombinedCodeLength = 3198;
 const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeEveryCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeEveryCodeLength = 762;
 static const JSC::Intrinsic s_builtinPrototypeEveryCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeEveryCode =
@@ -157,6 +163,7 @@ s_JSCCombinedCode + 0
 const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeForEachCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeForEachCodeLength = 694;
 static const JSC::Intrinsic s_builtinPrototypeForEachCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeForEachCode =
@@ -166,6 +173,7 @@ s_JSCCombinedCode + 762
 const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeMatchCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeMatchCodeLength = 1238;
 static const JSC::Intrinsic s_builtinPrototypeMatchCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeMatchCode =
@@ -175,6 +183,7 @@ s_JSCCombinedCode + 1456
 const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeTestCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeTestCodeLength = 504;
 static const JSC::Intrinsic s_builtinPrototypeTestCodeIntrinsic = JSC::RegExpTestIntrinsic;
 const char* const s_builtinPrototypeTestCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Separate.js-result
@@ -45,21 +45,25 @@ extern const int s_builtinPrototypeEveryCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeEveryCodeInlineAttribute;
 extern const char* const s_builtinPrototypeForEachCode;
 extern const int s_builtinPrototypeForEachCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeForEachCodeInlineAttribute;
 extern const char* const s_builtinPrototypeMatchCode;
 extern const int s_builtinPrototypeMatchCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeMatchCodeInlineAttribute;
 extern const char* const s_builtinPrototypeTestCode;
 extern const int s_builtinPrototypeTestCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinPrototypeTestCodeInlineAttribute;
 
 #define JSC_FOREACH_BUILTIN_PROTOTYPE_BUILTIN_DATA(macro) \
     macro(every, builtinPrototypeEvery, 1) \
@@ -139,6 +143,7 @@ namespace JSC {
 const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeEveryCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeEveryCodeLength = 762;
 static const JSC::Intrinsic s_builtinPrototypeEveryCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeEveryCode =
@@ -174,6 +179,7 @@ const char* const s_builtinPrototypeEveryCode =
 const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeForEachCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeForEachCodeLength = 694;
 static const JSC::Intrinsic s_builtinPrototypeForEachCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeForEachCode =
@@ -205,6 +211,7 @@ const char* const s_builtinPrototypeForEachCode =
 const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeMatchCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeMatchCodeLength = 1238;
 static const JSC::Intrinsic s_builtinPrototypeMatchCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeMatchCode =
@@ -263,6 +270,7 @@ const char* const s_builtinPrototypeMatchCode =
 const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinPrototypeTestCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinPrototypeTestCodeLength = 504;
 static const JSC::Intrinsic s_builtinPrototypeTestCodeIntrinsic = JSC::RegExpTestIntrinsic;
 const char* const s_builtinPrototypeTestCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result
@@ -37,6 +37,7 @@ class VM;
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
 enum class ImplementationVisibility : uint8_t;
+enum class InlineAttribute : uint8_t;
 }
 
 namespace JSC {
@@ -51,11 +52,13 @@ extern const int s_builtinConstructorOfCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinConstructorOfCodeInlineAttribute;
 extern const char* const s_builtinConstructorFromCode;
 extern const int s_builtinConstructorFromCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinConstructorFromCodeInlineAttribute;
 
 #define JSC_FOREACH_BUILTINCONSTRUCTOR_BUILTIN_DATA(macro) \
     macro(of, builtinConstructorOf, 0) \
@@ -130,6 +133,7 @@ const unsigned s_JSCCombinedCodeLength = 2340;
 const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinConstructorFromCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinConstructorFromCodeLength = 2046;
 static const JSC::Intrinsic s_builtinConstructorFromCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorFromCode =
@@ -139,6 +143,7 @@ s_JSCCombinedCode + 0
 const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinConstructorOfCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinConstructorOfCodeLength = 294;
 static const JSC::Intrinsic s_builtinConstructorOfCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorOfCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Separate.js-result
@@ -44,11 +44,13 @@ extern const int s_builtinConstructorOfCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinConstructorOfCodeInlineAttribute;
 extern const char* const s_builtinConstructorFromCode;
 extern const int s_builtinConstructorFromCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_builtinConstructorFromCodeInlineAttribute;
 
 #define JSC_FOREACH_BUILTINCONSTRUCTOR_BUILTIN_DATA(macro) \
     macro(of, builtinConstructorOf, 0) \
@@ -119,6 +121,7 @@ namespace JSC {
 const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinConstructorOfCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinConstructorOfCodeLength = 294;
 static const JSC::Intrinsic s_builtinConstructorOfCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorOfCode =
@@ -139,6 +142,7 @@ const char* const s_builtinConstructorOfCode =
 const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_builtinConstructorFromCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_builtinConstructorFromCodeLength = 2046;
 static const JSC::Intrinsic s_builtinConstructorFromCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorFromCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result
@@ -38,6 +38,7 @@ class VM;
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
 enum class ImplementationVisibility : uint8_t;
+enum class InlineAttribute : uint8_t;
 }
 
 namespace JSC {
@@ -52,11 +53,13 @@ extern const int s_internalClashingNamesIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_internalClashingNamesIsReadableStreamLockedCodeInlineAttribute;
 extern const char* const s_internalClashingNamesIsReadableStreamLockedCode;
 extern const int s_internalClashingNamesIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_internalClashingNamesIsReadableStreamLockedCodeInlineAttribute;
 
 #define JSC_FOREACH_INTERNALCLASHINGNAMES_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, internalClashingNamesIsReadableStreamLocked, 1) \
@@ -131,6 +134,7 @@ const unsigned s_JSCCombinedCodeLength = 142;
 const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_internalClashingNamesIsReadableStreamLockedCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_internalClashingNamesIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_internalClashingNamesIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_internalClashingNamesIsReadableStreamLockedCode =
@@ -140,6 +144,7 @@ s_JSCCombinedCode + 0
 const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_internalClashingNamesIsReadableStreamLockedCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_internalClashingNamesIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_internalClashingNamesIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_internalClashingNamesIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-AnotherGuardedInternalBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-AnotherGuardedInternalBuiltin-Separate.js-result
@@ -49,6 +49,7 @@ extern const int s_anotherGuardedInternalBuiltinLetsFetchCodeLength;
 extern const JSC::ConstructAbility s_anotherGuardedInternalBuiltinLetsFetchCodeConstructAbility;
 extern const JSC::ConstructorKind s_anotherGuardedInternalBuiltinLetsFetchCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_anotherGuardedInternalBuiltinLetsFetchCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_anotherGuardedInternalBuiltinLetsFetchCodeInlineAttribute;
 
 #define WEBCORE_FOREACH_ANOTHERGUARDEDINTERNALBUILTIN_BUILTIN_DATA(macro) \
     macro(letsFetch, anotherGuardedInternalBuiltinLetsFetch, 0) \
@@ -108,7 +109,7 @@ inline JSC::UnlinkedFunctionExecutable* AnotherGuardedInternalBuiltinBuiltinsWra
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -211,6 +212,7 @@ namespace WebCore {
 const JSC::ConstructAbility s_anotherGuardedInternalBuiltinLetsFetchCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_anotherGuardedInternalBuiltinLetsFetchCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_anotherGuardedInternalBuiltinLetsFetchCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_anotherGuardedInternalBuiltinLetsFetchCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_anotherGuardedInternalBuiltinLetsFetchCodeLength = 83;
 static const JSC::Intrinsic s_anotherGuardedInternalBuiltinLetsFetchCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_anotherGuardedInternalBuiltinLetsFetchCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-ArbitraryConditionalGuard-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-ArbitraryConditionalGuard-Separate.js-result
@@ -50,6 +50,7 @@ extern const int s_arbitraryConditionalGuardIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_arbitraryConditionalGuardIsReadableStreamLockedCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_arbitraryConditionalGuardIsReadableStreamLockedCodeInlineAttribute;
 
 #define WEBCORE_FOREACH_ARBITRARYCONDITIONALGUARD_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, arbitraryConditionalGuardIsReadableStreamLocked, 1) \
@@ -109,7 +110,7 @@ inline JSC::UnlinkedFunctionExecutable* ArbitraryConditionalGuardBuiltinsWrapper
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -176,6 +177,7 @@ namespace WebCore {
 const JSC::ConstructAbility s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_arbitraryConditionalGuardIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_arbitraryConditionalGuardIsReadableStreamLockedCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_arbitraryConditionalGuardIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_arbitraryConditionalGuardIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_arbitraryConditionalGuardIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedBuiltin-Separate.js-result
@@ -50,6 +50,7 @@ extern const int s_guardedBuiltinIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_guardedBuiltinIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_guardedBuiltinIsReadableStreamLockedCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_guardedBuiltinIsReadableStreamLockedCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_guardedBuiltinIsReadableStreamLockedCodeInlineAttribute;
 
 #define WEBCORE_FOREACH_GUARDEDBUILTIN_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, guardedBuiltinIsReadableStreamLocked, 1) \
@@ -109,7 +110,7 @@ inline JSC::UnlinkedFunctionExecutable* GuardedBuiltinBuiltinsWrapper::name##Exe
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -176,6 +177,7 @@ namespace WebCore {
 const JSC::ConstructAbility s_guardedBuiltinIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_guardedBuiltinIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_guardedBuiltinIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_guardedBuiltinIsReadableStreamLockedCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_guardedBuiltinIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_guardedBuiltinIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_guardedBuiltinIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedInternalBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedInternalBuiltin-Separate.js-result
@@ -50,6 +50,7 @@ extern const int s_guardedInternalBuiltinIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_guardedInternalBuiltinIsReadableStreamLockedCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_guardedInternalBuiltinIsReadableStreamLockedCodeInlineAttribute;
 
 #define WEBCORE_FOREACH_GUARDEDINTERNALBUILTIN_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, guardedInternalBuiltinIsReadableStreamLocked, 1) \
@@ -109,7 +110,7 @@ inline JSC::UnlinkedFunctionExecutable* GuardedInternalBuiltinBuiltinsWrapper::n
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -213,6 +214,7 @@ namespace WebCore {
 const JSC::ConstructAbility s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_guardedInternalBuiltinIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_guardedInternalBuiltinIsReadableStreamLockedCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_guardedInternalBuiltinIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_guardedInternalBuiltinIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_guardedInternalBuiltinIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-UnguardedBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-UnguardedBuiltin-Separate.js-result
@@ -48,6 +48,7 @@ extern const int s_unguardedBuiltinIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_unguardedBuiltinIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_unguardedBuiltinIsReadableStreamLockedCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_unguardedBuiltinIsReadableStreamLockedCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_unguardedBuiltinIsReadableStreamLockedCodeInlineAttribute;
 
 #define WEBCORE_FOREACH_UNGUARDEDBUILTIN_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, unguardedBuiltinIsReadableStreamLocked, 1) \
@@ -107,7 +108,7 @@ inline JSC::UnlinkedFunctionExecutable* UnguardedBuiltinBuiltinsWrapper::name##E
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -170,6 +171,7 @@ namespace WebCore {
 const JSC::ConstructAbility s_unguardedBuiltinIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_unguardedBuiltinIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_unguardedBuiltinIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_unguardedBuiltinIsReadableStreamLockedCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_unguardedBuiltinIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_unguardedBuiltinIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_unguardedBuiltinIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-xmlCasingTest-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-xmlCasingTest-Separate.js-result
@@ -50,16 +50,19 @@ extern const int s_xmlCasingTestXMLCasingTestCodeLength;
 extern const JSC::ConstructAbility s_xmlCasingTestXMLCasingTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_xmlCasingTestXMLCasingTestCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_xmlCasingTestXMLCasingTestCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_xmlCasingTestXMLCasingTestCodeInlineAttribute;
 extern const char* const s_xmlCasingTestCssCasingTestCode;
 extern const int s_xmlCasingTestCssCasingTestCodeLength;
 extern const JSC::ConstructAbility s_xmlCasingTestCssCasingTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_xmlCasingTestCssCasingTestCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_xmlCasingTestCssCasingTestCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_xmlCasingTestCssCasingTestCodeInlineAttribute;
 extern const char* const s_xmlCasingTestUrlCasingTestCode;
 extern const int s_xmlCasingTestUrlCasingTestCodeLength;
 extern const JSC::ConstructAbility s_xmlCasingTestUrlCasingTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_xmlCasingTestUrlCasingTestCodeConstructorKind;
 extern const JSC::ImplementationVisibility s_xmlCasingTestUrlCasingTestCodeImplementationVisibility;
+extern const JSC::InlineAttribute s_xmlCasingTestUrlCasingTestCodeInlineAttribute;
 
 #define WEBCORE_FOREACH_XMLCASINGTEST_BUILTIN_DATA(macro) \
     macro(xmlCasingTest, xmlCasingTestXMLCasingTest, 1) \
@@ -127,7 +130,7 @@ inline JSC::UnlinkedFunctionExecutable* xmlCasingTestBuiltinsWrapper::name##Exec
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -231,6 +234,7 @@ namespace WebCore {
 const JSC::ConstructAbility s_xmlCasingTestXMLCasingTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_xmlCasingTestXMLCasingTestCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_xmlCasingTestXMLCasingTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_xmlCasingTestXMLCasingTestCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_xmlCasingTestXMLCasingTestCodeLength = 71;
 static const JSC::Intrinsic s_xmlCasingTestXMLCasingTestCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_xmlCasingTestXMLCasingTestCode =
@@ -245,6 +249,7 @@ const char* const s_xmlCasingTestXMLCasingTestCode =
 const JSC::ConstructAbility s_xmlCasingTestCssCasingTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_xmlCasingTestCssCasingTestCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_xmlCasingTestCssCasingTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_xmlCasingTestCssCasingTestCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_xmlCasingTestCssCasingTestCodeLength = 402;
 static const JSC::Intrinsic s_xmlCasingTestCssCasingTestCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_xmlCasingTestCssCasingTestCode =
@@ -265,6 +270,7 @@ const char* const s_xmlCasingTestCssCasingTestCode =
 const JSC::ConstructAbility s_xmlCasingTestUrlCasingTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_xmlCasingTestUrlCasingTestCodeConstructorKind = JSC::ConstructorKind::None;
 const JSC::ImplementationVisibility s_xmlCasingTestUrlCasingTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
+const JSC::InlineAttribute s_xmlCasingTestUrlCasingTestCodeInlineAttribute = JSC::InlineAttribute::None;
 const int s_xmlCasingTestUrlCasingTestCodeLength = 338;
 static const JSC::Intrinsic s_xmlCasingTestUrlCasingTestCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_xmlCasingTestUrlCasingTestCode =

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py
@@ -81,6 +81,7 @@ class VM;
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
 enum class ImplementationVisibility : uint8_t;
+enum class InlineAttribute : uint8_t;
 }"""
 
     def generate_section_for_object(self, object):
@@ -103,7 +104,8 @@ enum class ImplementationVisibility : uint8_t;
 extern const int s_%(codeName)sLength;
 extern const JSC::ConstructAbility s_%(codeName)sConstructAbility;
 extern const JSC::ConstructorKind s_%(codeName)sConstructorKind;
-extern const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility;""" % function_args)
+extern const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility;
+extern const JSC::InlineAttribute s_%(codeName)sInlineAttribute;""" % function_args)
 
         return lines
 

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py
@@ -129,7 +129,8 @@ class FunctionExecutable;
 extern const int s_%(codeName)sLength;
 extern const JSC::ConstructAbility s_%(codeName)sConstructAbility;
 extern const JSC::ConstructorKind s_%(codeName)sConstructorKind;
-extern const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility;""" % function_args)
+extern const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility;
+extern const JSC::InlineAttribute s_%(codeName)sInlineAttribute;""" % function_args)
 
         return lines
 

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
@@ -133,6 +133,10 @@ class BuiltinsGenerator:
         if function.is_naked_constructor:
             constructorKind = "Naked"
 
+        inlineAttribute = "None"
+        if function.is_always_inline:
+            inlineAttribute = "Always"
+
         return {
             'codeName': BuiltinsGenerator.mangledNameForFunction(function) + 'Code',
             'embeddedSource': embeddedSource,
@@ -140,18 +144,20 @@ class BuiltinsGenerator:
             'originalSource': text + "\n",
             'constructAbility': constructAbility,
             'constructorKind': constructorKind,
+            'inlineAttribute': inlineAttribute,
             'visibility': function.visibility,
             'intrinsic': function.intrinsic
         }
 
     def generate_embedded_code_string_section_for_data(self, data):
         lines = []
-        lines.append("const JSC::ConstructAbility s_%(codeName)sConstructAbility = JSC::ConstructAbility::%(constructAbility)s;" % data);
-        lines.append("const JSC::ConstructorKind s_%(codeName)sConstructorKind = JSC::ConstructorKind::%(constructorKind)s;" % data);
-        lines.append("const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility = JSC::ImplementationVisibility::%(visibility)s;" % data);
-        lines.append("const int s_%(codeName)sLength = %(embeddedSourceLength)d;" % data);
-        lines.append("static const JSC::Intrinsic s_%(codeName)sIntrinsic = JSC::%(intrinsic)s;" % data);
-        lines.append("const char* const s_%(codeName)s =\n%(embeddedSource)s\n;" % data);
+        lines.append("const JSC::ConstructAbility s_%(codeName)sConstructAbility = JSC::ConstructAbility::%(constructAbility)s;" % data)
+        lines.append("const JSC::ConstructorKind s_%(codeName)sConstructorKind = JSC::ConstructorKind::%(constructorKind)s;" % data)
+        lines.append("const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility = JSC::ImplementationVisibility::%(visibility)s;" % data)
+        lines.append("const JSC::InlineAttribute s_%(codeName)sInlineAttribute = JSC::InlineAttribute::%(inlineAttribute)s;" % data)
+        lines.append("const int s_%(codeName)sLength = %(embeddedSourceLength)d;" % data)
+        lines.append("static const JSC::Intrinsic s_%(codeName)sIntrinsic = JSC::%(intrinsic)s;" % data)
+        lines.append("const char* const s_%(codeName)s =\n%(embeddedSource)s\n;" % data)
         return '\n'.join(lines)
 
     # Helper methods.

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
@@ -44,6 +44,7 @@ _FRAMEWORK_CONFIG_MAP = {
 
 functionHeadRegExp = re.compile(r"(?:@[\w|=\[\] \"\.]+\s*\n)*(?:async\s+)?function\s+\w+\s*\(.*?\)", re.MULTILINE | re.DOTALL)
 functionLinkTimeConstantRegExp = re.compile(r".*^@linkTimeConstant", re.MULTILINE | re.DOTALL)
+functionAlwaysInlineRegExp = re.compile(r".*^@alwaysInline", re.MULTILINE | re.DOTALL)
 functionVisibilityRegExp = re.compile(r".*^@visibility=(\w+)", re.MULTILINE | re.DOTALL)
 functionNakedConstructorRegExp = re.compile(r".*^@nakedConstructor", re.MULTILINE | re.DOTALL)
 functionIntrinsicRegExp = re.compile(r".*^@intrinsic=(\w+)", re.MULTILINE | re.DOTALL)
@@ -104,13 +105,14 @@ class BuiltinObject:
 
 
 class BuiltinFunction:
-    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, intrinsic, visibility, overridden_name):
+    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, intrinsic, visibility, overridden_name):
         self.function_name = function_name
         self.function_source = function_source
         self.parameters = parameters
         self.is_async = is_async
         self.is_constructor = is_constructor
         self.is_naked_constructor = is_naked_constructor
+        self.is_always_inline = is_always_inline
         self.is_link_time_constant = is_link_time_constant
         self.intrinsic = intrinsic
         self.visibility = visibility
@@ -146,6 +148,7 @@ class BuiltinFunction:
         is_getter = functionIsGetterRegExp.match(function_source) != None
         is_link_time_constant = functionLinkTimeConstantRegExp.match(function_source) != None
         is_naked_constructor = functionNakedConstructorRegExp.match(function_source) != None
+        is_always_inline = functionAlwaysInlineRegExp.match(function_source) != None
         if is_naked_constructor:
             is_constructor = True
 
@@ -170,7 +173,7 @@ class BuiltinFunction:
         if overridden_name[-1] == "\"":
             overridden_name += "_s"
 
-        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, intrinsic, visibility, overridden_name)
+        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, is_always_inline, intrinsic, visibility, overridden_name)
 
     def __str__(self):
         interface = "%s(%s)" % (self.function_name, ', '.join(self.parameters))

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py
@@ -168,7 +168,7 @@ inline JSC::UnlinkedFunctionExecutable* ${objectName}BuiltinsWrapper::name##Exec
         JSC::Identifier executableName = functionName##PublicName();\\
         if (overriddenName)\\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute), this, &m_##name##Executable);\\
     }\\
     return m_##name##Executable.get();\\
 }

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -130,6 +130,7 @@ function forEach(callback /*, thisArg */)
     }
 }
 
+@alwaysInline
 function filter(callback /*, thisArg */)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h
@@ -28,11 +28,12 @@
 #include "ConstructAbility.h"
 #include "ConstructorKind.h"
 #include "ImplementationVisibility.h"
+#include "InlineAttribute.h"
 #include "ParserModes.h"
 #include "SourceCode.h"
 
 namespace JSC {
 
-JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
+JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, InlineAttribute);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -67,18 +67,18 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createDefaultConstructor(Constru
         break;
     case ConstructorKind::Base:
     case ConstructorKind::Extends:
-        return createExecutable(m_vm, defaultConstructorSourceCode(constructorKind), name, ImplementationVisibility::Public, constructorKind, ConstructAbility::CanConstruct, needsClassFieldInitializer, privateBrandRequirement);
+        return createExecutable(m_vm, defaultConstructorSourceCode(constructorKind), name, ImplementationVisibility::Public, constructorKind, ConstructAbility::CanConstruct, InlineAttribute::Always, needsClassFieldInitializer, privateBrandRequirement);
     }
     ASSERT_NOT_REACHED();
     return nullptr;
 }
 
-UnlinkedFunctionExecutable* BuiltinExecutables::createBuiltinExecutable(const SourceCode& code, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility)
+UnlinkedFunctionExecutable* BuiltinExecutables::createBuiltinExecutable(const SourceCode& code, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute)
 {
-    return createExecutable(m_vm, code, name, implementationVisibility, constructorKind, constructAbility, NeedsClassFieldInitializer::No);
+    return createExecutable(m_vm, code, name, implementationVisibility, constructorKind, constructAbility, inlineAttribute, NeedsClassFieldInitializer::No);
 }
 
-UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const SourceCode& source, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement)
+UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const SourceCode& source, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement)
 {
     // FIXME: Can we just make MetaData computation be constexpr and have the compiler do this for us?
     // https://bugs.webkit.org/show_bug.cgi?id=193272
@@ -258,7 +258,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         }
     }
 
-    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, &metadata, kind, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
+    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, &metadata, kind, constructAbility, inlineAttribute, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
     return functionExecutable;
 }
 
@@ -283,7 +283,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::name##Executable() \
         Identifier executableName = m_vm.propertyNames->builtinNames().functionName##PublicName();\
         if (overrideName)\
             executableName = Identifier::fromString(m_vm, overrideName);\
-        m_unlinkedExecutables[index] = createBuiltinExecutable(name##Source(), executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility);\
+        m_unlinkedExecutables[index] = createBuiltinExecutable(name##Source(), executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility, s_##name##InlineAttribute);\
     }\
     return m_unlinkedExecutables[index];\
 }

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.h
@@ -60,14 +60,14 @@ SourceCode name##Source();
     static SourceCode defaultConstructorSourceCode(ConstructorKind);
     UnlinkedFunctionExecutable* createDefaultConstructor(ConstructorKind, const Identifier& name, NeedsClassFieldInitializer, PrivateBrandRequirement);
 
-    static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, NeedsClassFieldInitializer, PrivateBrandRequirement = PrivateBrandRequirement::None);
+    static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, InlineAttribute, NeedsClassFieldInitializer, PrivateBrandRequirement = PrivateBrandRequirement::None);
 
     void finalizeUnconditionally(CollectionScope);
 
 private:
     VM& m_vm;
 
-    UnlinkedFunctionExecutable* createBuiltinExecutable(const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
+    UnlinkedFunctionExecutable* createBuiltinExecutable(const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, InlineAttribute);
 
     Ref<StringSourceProvider> m_combinedSourceProvider;
     UnlinkedFunctionExecutable* m_unlinkedExecutables[static_cast<unsigned>(BuiltinCodeIndex::NumberOfBuiltinCodes)] { };

--- a/Source/JavaScriptCore/builtins/BuiltinUtils.h
+++ b/Source/JavaScriptCore/builtins/BuiltinUtils.h
@@ -29,6 +29,7 @@
 #include "ConstructAbility.h"
 #include "ConstructorKind.h"
 #include "ImplementationVisibility.h"
+#include "InlineAttribute.h"
 
 namespace JSC {
 
@@ -43,6 +44,6 @@ class SourceCode;
 class UnlinkedFunctionExecutable;
 class VM;
 
-JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
+JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, InlineAttribute);
     
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -81,7 +81,7 @@ static UnlinkedFunctionCodeBlock* generateUnlinkedFunctionCodeBlock(
     return result;
 }
 
-UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* structure, const SourceCode& parentSource, FunctionMetadataNode* node, UnlinkedFunctionKind kind, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor)
+UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* structure, const SourceCode& parentSource, FunctionMetadataNode* node, UnlinkedFunctionKind kind, ConstructAbility constructAbility, InlineAttribute inlineAttribute, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor)
     : Base(vm, structure)
     , m_firstLineOffset(node->firstLine() - parentSource.firstLine().oneBasedInt())
     , m_isGeneratedFromCache(false)
@@ -110,6 +110,7 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_lexicalScopeFeatures(node->lexicalScopeFeatures())
     , m_functionMode(static_cast<unsigned>(node->functionMode()))
     , m_derivedContextType(static_cast<unsigned>(derivedContextType))
+    , m_inlineAttribute(static_cast<unsigned>(inlineAttribute))
     , m_unlinkedCodeBlockForCall()
     , m_unlinkedCodeBlockForConstruct()
     , m_name(node->ident())
@@ -123,6 +124,7 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     ASSERT(m_scriptMode == static_cast<unsigned>(scriptMode));
     ASSERT(m_superBinding == static_cast<unsigned>(node->superBinding()));
     ASSERT(m_derivedContextType == static_cast<unsigned>(derivedContextType));
+    ASSERT(m_inlineAttribute == static_cast<unsigned>(inlineAttribute));
     ASSERT(m_privateBrandRequirement == static_cast<unsigned>(privateBrandRequirement));
     ASSERT(!(m_isBuiltinDefaultClassConstructor && constructorKind() == ConstructorKind::None));
     ASSERT(!m_needsClassFieldInitializer || (isClassConstructorFunction() || derivedContextType == DerivedContextType::DerivedConstructorContext));

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -32,6 +32,7 @@
 #include "ExpressionRangeInfo.h"
 #include "Identifier.h"
 #include "ImplementationVisibility.h"
+#include "InlineAttribute.h"
 #include "Intrinsic.h"
 #include "JSCast.h"
 #include "ParserModes.h"
@@ -72,10 +73,10 @@ public:
         return &vm.unlinkedFunctionExecutableSpace();
     }
 
-    static UnlinkedFunctionExecutable* create(VM& vm, const SourceCode& source, FunctionMetadataNode* node, UnlinkedFunctionKind unlinkedFunctionKind, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor = false)
+    static UnlinkedFunctionExecutable* create(VM& vm, const SourceCode& source, FunctionMetadataNode* node, UnlinkedFunctionKind unlinkedFunctionKind, ConstructAbility constructAbility, InlineAttribute inlineAttribute, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor = false)
     {
         UnlinkedFunctionExecutable* instance = new (NotNull, allocateCell<UnlinkedFunctionExecutable>(vm))
-            UnlinkedFunctionExecutable(vm, vm.unlinkedFunctionExecutableStructure.get(), source, node, unlinkedFunctionKind, constructAbility, scriptMode, WTFMove(parentScopeTDZVariables), WTFMove(parentPrivateNameEnvironment), derivedContextType, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
+            UnlinkedFunctionExecutable(vm, vm.unlinkedFunctionExecutableStructure.get(), source, node, unlinkedFunctionKind, constructAbility, inlineAttribute, scriptMode, WTFMove(parentScopeTDZVariables), WTFMove(parentPrivateNameEnvironment), derivedContextType, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
         instance->finishCreation(vm);
         return instance;
     }
@@ -192,6 +193,8 @@ public:
 
     JSC::DerivedContextType derivedContextType() const {return static_cast<JSC::DerivedContextType>(m_derivedContextType); }
 
+    InlineAttribute inlineAttribute() const { return static_cast<InlineAttribute>(m_inlineAttribute); }
+
     String sourceURLDirective() const
     {
         if (m_rareData)
@@ -243,7 +246,7 @@ public:
     }
 
 private:
-    UnlinkedFunctionExecutable(VM&, Structure*, const SourceCode&, FunctionMetadataNode*, UnlinkedFunctionKind, ConstructAbility, JSParserScriptMode, RefPtr<TDZEnvironmentLink>, std::optional<PrivateNameEnvironment>, JSC::DerivedContextType, JSC::NeedsClassFieldInitializer, PrivateBrandRequirement, bool isBuiltinDefaultClassConstructor);
+    UnlinkedFunctionExecutable(VM&, Structure*, const SourceCode&, FunctionMetadataNode*, UnlinkedFunctionKind, ConstructAbility, InlineAttribute, JSParserScriptMode, RefPtr<TDZEnvironmentLink>, std::optional<PrivateNameEnvironment>, JSC::DerivedContextType, JSC::NeedsClassFieldInitializer, PrivateBrandRequirement, bool isBuiltinDefaultClassConstructor);
     UnlinkedFunctionExecutable(Decoder&, const CachedFunctionExecutable&);
 
     DECLARE_VISIT_CHILDREN;
@@ -284,6 +287,7 @@ private:
     uint8_t m_lexicalScopeFeatures : bitWidthOfLexicalScopeFeatures;
     uint8_t m_functionMode : 2; // FunctionMode
     uint8_t m_derivedContextType : 2;
+    uint8_t m_inlineAttribute : 1;
 
     union {
         WriteBarrier<UnlinkedFunctionCodeBlock> m_unlinkedCodeBlockForCall;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3414,7 +3414,7 @@ RegisterID* BytecodeGenerator::emitNewClassFieldInitializerFunction(RegisterID* 
 
     FunctionMetadataNode metadata(parserArena(), JSTokenLocation(), JSTokenLocation(), 0, 0, 0, 0, 0, ImplementationVisibility::Private, StrictModeLexicalFeature, ConstructorKind::None, superBinding, 0, parseMode, false);
     metadata.finishParsing(m_scopeNode->source(), Identifier(), FunctionMode::MethodDefinition);
-    auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, scriptMode(), WTFMove(variablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
+    auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, InlineAttribute::Always, scriptMode(), WTFMove(variablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
     initializer->setClassFieldLocations(WTFMove(classFieldLocations));
 
     unsigned index = m_codeBlock->addFunctionExpr(initializer);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1172,7 +1172,7 @@ namespace JSC {
             if (parseMode == SourceParseMode::MethodMode && metadata->constructorKind() != ConstructorKind::None)
                 constructAbility = ConstructAbility::CanConstruct;
 
-            return UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, scriptMode(), WTFMove(optionalVariablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, needsClassFieldInitializer, privateBrandRequirement);
+            return UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, InlineAttribute::None, scriptMode(), WTFMove(optionalVariablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, needsClassFieldInitializer, privateBrandRequirement);
         }
 
         RefPtr<TDZEnvironmentLink> getVariablesUnderTDZ();

--- a/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
@@ -72,18 +72,21 @@ bool mightCompileFunctionForConstruct(CodeBlock* codeBlock)
 
 bool mightInlineFunctionForCall(CodeBlock* codeBlock)
 {
-    return codeBlock->bytecodeCost() <= Options::maximumFunctionForCallInlineCandidateBytecodeCost()
-        && isSupportedForInlining(codeBlock);
+    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always && codeBlock->bytecodeCost() > Options::maximumFunctionForCallInlineCandidateBytecodeCost())
+        return false;
+    return isSupportedForInlining(codeBlock);
 }
 bool mightInlineFunctionForClosureCall(CodeBlock* codeBlock)
 {
-    return codeBlock->bytecodeCost() <= Options::maximumFunctionForClosureCallInlineCandidateBytecodeCost()
-        && isSupportedForInlining(codeBlock);
+    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always && codeBlock->bytecodeCost() > Options::maximumFunctionForClosureCallInlineCandidateBytecodeCost())
+        return false;
+    return isSupportedForInlining(codeBlock);
 }
 bool mightInlineFunctionForConstruct(CodeBlock* codeBlock)
 {
-    return codeBlock->bytecodeCost() <= Options::maximumFunctionForConstructInlineCandidateBytecoodeCost()
-        && isSupportedForInlining(codeBlock);
+    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always && codeBlock->bytecodeCost() > Options::maximumFunctionForConstructInlineCandidateBytecoodeCost())
+        return false;
+    return isSupportedForInlining(codeBlock);
 }
 bool canUseOSRExitFuzzing(CodeBlock* codeBlock)
 {

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -28,6 +28,7 @@
 #include "ConstructAbility.h"
 #include "ConstructorKind.h"
 #include "Identifier.h"
+#include "InlineAttribute.h"
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1806,6 +1806,7 @@ public:
     unsigned scriptMode() const { return m_scriptMode; }
     unsigned superBinding() const { return m_superBinding; }
     unsigned derivedContextType() const { return m_derivedContextType; }
+    unsigned inlineAttribute() const { return m_inlineAttribute; }
     unsigned needsClassFieldInitializer() const { return m_needsClassFieldInitializer; }
     unsigned privateBrandRequirement() const { return m_privateBrandRequirement; }
 
@@ -1840,6 +1841,7 @@ private:
     unsigned m_constructorKind : 2;
     unsigned m_functionMode : 2; // FunctionMode
     unsigned m_derivedContextType: 2;
+    unsigned m_inlineAttribute : 1;
     unsigned m_needsClassFieldInitializer : 1;
     unsigned m_implementationVisibility : bitWidthOfImplementationVisibility;
 
@@ -2216,6 +2218,7 @@ ALWAYS_INLINE void CachedFunctionExecutable::encode(Encoder& encoder, const Unli
     m_scriptMode = executable.m_scriptMode;
     m_superBinding = executable.m_superBinding;
     m_derivedContextType = executable.m_derivedContextType;
+    m_inlineAttribute = executable.m_inlineAttribute;
     m_needsClassFieldInitializer = executable.m_needsClassFieldInitializer;
     m_implementationVisibility = executable.m_implementationVisibility;
     m_privateBrandRequirement = executable.m_privateBrandRequirement;
@@ -2268,6 +2271,7 @@ ALWAYS_INLINE UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(Decoder& de
     , m_lexicalScopeFeatures(cachedExecutable.lexicalScopeFeatures())
     , m_functionMode(cachedExecutable.functionMode())
     , m_derivedContextType(cachedExecutable.derivedContextType())
+    , m_inlineAttribute(cachedExecutable.inlineAttribute())
     , m_unlinkedCodeBlockForCall()
     , m_unlinkedCodeBlockForConstruct()
 

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -248,7 +248,7 @@ UnlinkedFunctionExecutable* CodeCache::getUnlinkedGlobalFunctionExecutable(VM& v
     // The Function constructor only has access to global variables, so no variables will be under TDZ unless they're
     // in the global lexical environment, which we always TDZ check accesses from.
     ConstructAbility constructAbility = constructAbilityForParseMode(metadata->parseMode());
-    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, metadata, UnlinkedNormalFunction, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
+    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, metadata, UnlinkedNormalFunction, constructAbility, InlineAttribute::None, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
 
     if (!source.provider()->sourceURLDirective().isNull())
         functionExecutable->setSourceURLDirective(source.provider()->sourceURLDirective());

--- a/Source/JavaScriptCore/runtime/ExecutableBase.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.h
@@ -206,6 +206,7 @@ public:
     inline Intrinsic intrinsicFor(CodeSpecializationKind) const;
 
     ImplementationVisibility implementationVisibility() const;
+    InlineAttribute inlineAttribute() const;
 
     CodePtr<JSEntryPtrTag> swapGeneratedJITCodeWithArityCheckForDebugger(CodeSpecializationKind kind, CodePtr<JSEntryPtrTag> jitCodeWithArityCheck)
     {

--- a/Source/JavaScriptCore/runtime/ExecutableBaseInlines.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBaseInlines.h
@@ -62,6 +62,13 @@ inline ImplementationVisibility ExecutableBase::implementationVisibility() const
     return ImplementationVisibility::Public;
 }
 
+inline InlineAttribute ExecutableBase::inlineAttribute() const
+{
+    if (isFunctionExecutable())
+        return jsCast<const FunctionExecutable*>(this)->inlineAttribute();
+    return InlineAttribute::None;
+}
+
 inline bool ExecutableBase::hasJITCodeForCall() const
 {
     if (isHostFunction())

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -132,6 +132,7 @@ public:
     ImplementationVisibility implementationVisibility() const { return m_unlinkedExecutable->implementationVisibility(); }
     bool isBuiltinFunction() const { return m_unlinkedExecutable->isBuiltinFunction(); }
     ConstructAbility constructAbility() const { return m_unlinkedExecutable->constructAbility(); }
+    InlineAttribute inlineAttribute() const { return m_unlinkedExecutable->inlineAttribute(); }
     bool isClass() const { return m_unlinkedExecutable->isClass(); }
     bool isArrowFunction() const { return parseMode() == SourceParseMode::ArrowFunctionMode; }
     bool isGetter() const { return parseMode() == SourceParseMode::GetterMode; }

--- a/Source/JavaScriptCore/runtime/InlineAttribute.h
+++ b/Source/JavaScriptCore/runtime/InlineAttribute.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,16 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "BuiltinExecutableCreator.h"
-
-#include "BuiltinExecutables.h"
+#pragma once
 
 namespace JSC {
 
-UnlinkedFunctionExecutable* createBuiltinExecutable(VM& vm, const SourceCode& source, const Identifier& ident, ImplementationVisibility implementationVisibility, ConstructorKind kind, ConstructAbility ability, InlineAttribute inlineAttribute)
-{
-    return BuiltinExecutables::createExecutable(vm, source, ident, implementationVisibility, kind, ability, inlineAttribute, NeedsClassFieldInitializer::No);
-}
-    
+enum class InlineAttribute : uint8_t {
+    None,
+    Always,
+};
+
 } // namespace JSC

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3270,7 +3270,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateBuiltin, (JSGlobalObject* globalObject, C
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     SourceCode source = makeSource(WTFMove(functionText), { }, SourceTaintedOrigin::Untainted);
-    JSFunction* func = JSFunction::create(vm, createBuiltinExecutable(vm, source, Identifier::fromString(vm, "foo"_s), ImplementationVisibility::Public, ConstructorKind::None, ConstructAbility::CannotConstruct)->link(vm, nullptr, source), globalObject);
+    JSFunction* func = JSFunction::create(vm, createBuiltinExecutable(vm, source, Identifier::fromString(vm, "foo"_s), ImplementationVisibility::Public, ConstructorKind::None, ConstructAbility::CannotConstruct, InlineAttribute::None)->link(vm, nullptr, source), globalObject);
 
     return JSValue::encode(func);
 }


### PR DESCRIPTION
#### 6cb56ee3051f43ee8030b9c34b4ea035a2effa6a
<pre>
[JSC] Add @alwaysInline attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=264047">https://bugs.webkit.org/show_bug.cgi?id=264047</a>
<a href="https://rdar.apple.com/117807025">rdar://117807025</a>

Reviewed by Mark Lam and Justin Michaud.

This patch adds @alwaysInline attribute to our builtin JS.
This allows certain builtin JS functions to be inlined in DFG / FTL (unless it exceeds bytecode cost crazily).
There are certain amount of critical builtin JS functions, and it is not great that we need to keep the size of bytecode cost
for them manually. Let&apos;s just annotate them with @alwaysInline and ensure they get inlined regardless of the layout of bytecodes.

* JSTests/microbenchmarks/array-filter-inline.js: Added.
(test):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-AnotherGuardedInternalBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-ArbitraryConditionalGuard-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedInternalBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-UnguardedBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-xmlCasingTest-Separate.js-result:
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py:
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py:
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py:
(BuiltinsGenerator.generate_embedded_code_data_for_function):
(BuiltinsGenerator.generate_embedded_code_string_section_for_data):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py:
(BuiltinFunction.__init__):
(BuiltinFunction.fromString):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py:
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(filter): Deleted.
* Source/JavaScriptCore/builtins/BuiltinExecutableCreator.cpp:
(JSC::createBuiltinExecutable):
* Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h:
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createDefaultConstructor):
(JSC::BuiltinExecutables::createBuiltinExecutable):
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/builtins/BuiltinExecutables.h:
* Source/JavaScriptCore/builtins/BuiltinUtils.h:
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::UnlinkedFunctionExecutable):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitNewClassFieldInitializerFunction):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::makeFunction):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inliningCost):
(JSC::DFG::ByteCodeParser::handleCallVariant):
(JSC::DFG::ByteCodeParser::handleVarargsInlining):
* Source/JavaScriptCore/dfg/DFGCapabilities.cpp:
(JSC::DFG::mightInlineFunctionForCall):
(JSC::DFG::mightInlineFunctionForClosureCall):
(JSC::DFG::mightInlineFunctionForConstruct):
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedFunctionExecutable::inlineAttribute const):
(JSC::CachedFunctionExecutable::encode):
(JSC::UnlinkedFunctionExecutable::UnlinkedFunctionExecutable):
* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::CodeCache::getUnlinkedGlobalFunctionExecutable):
* Source/JavaScriptCore/runtime/ExecutableBase.h:
* Source/JavaScriptCore/runtime/ExecutableBaseInlines.h:
(JSC::ExecutableBase::inlineAttribute const):
* Source/JavaScriptCore/runtime/FunctionExecutable.h:
* Source/JavaScriptCore/runtime/InlineAttribute.h: Copied from Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h.
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/270081@main">https://commits.webkit.org/270081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b765ec01a5c46c36d27de65e76418611abf08e79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24492 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26619 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/474 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24736 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27205 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28293 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/21308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22422 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26085 "Found 4 new API test failures: /WebKitGTK/TestResources:/webkit/WebKitWebResource/mime-type, /WebKitGTK/TestResources:/webkit/WebKitWebResource/active-uri, /WebKitGTK/TestResources:/webkit/WebKitWebResource/loading, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23784 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1777 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31178 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3087 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6841 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2230 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31146 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3125 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2151 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6517 "Passed tests") | 
<!--EWS-Status-Bubble-End-->