### PR TITLE
Adopt more smart pointers in WidthIterator

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -71,6 +71,7 @@ FontCascade::FontCascade(FontCascadeDescription&& fd, float letterSpacing, float
 
 FontCascade::FontCascade(const FontCascade& other)
     : CanMakeWeakPtr<FontCascade>()
+    , CanMakeCheckedPtr()
     , m_fontDescription(other.m_fontDescription)
     , m_fonts(other.m_fonts)
     , m_letterSpacing(other.m_letterSpacing)

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -32,6 +32,7 @@
 #include "Path.h"
 #include "TextSpacing.h"
 #include <optional>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -105,7 +106,7 @@ public:
     void operator()(TextLayout*) const;
 };
 
-class FontCascade : public CanMakeWeakPtr<FontCascade> {
+class FontCascade : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr {
 public:
     WEBCORE_EXPORT FontCascade();
     WEBCORE_EXPORT FontCascade(FontCascadeDescription&&, float letterSpacing = 0, float wordSpacing = 0);

--- a/Source/WebCore/platform/graphics/TextRun.cpp
+++ b/Source/WebCore/platform/graphics/TextRun.cpp
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-struct ExpectedTextRunSize {
+struct ExpectedTextRunSize : public CanMakeCheckedPtr {
     String text;
     TabSize tabSize;
     float float1;

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -26,6 +26,7 @@
 #include "TabSize.h"
 #include "TextFlags.h"
 #include "WritingMode.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {
@@ -39,7 +40,7 @@ class Font;
 
 struct GlyphData;
 
-class TextRun {
+class TextRun : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
     friend void add(Hasher&, const TextRun&);
 public:

--- a/Source/WebCore/platform/graphics/WidthIterator.h
+++ b/Source/WebCore/platform/graphics/WidthIterator.h
@@ -95,8 +95,8 @@ private:
     bool rtl() const { return m_direction == TextDirection::RTL; }
     bool ltr() const { return m_direction == TextDirection::LTR; }
 
-    const FontCascade& m_font;
-    const TextRun& m_run;
+    CheckedRef<const FontCascade> m_font;
+    CheckedRef<const TextRun> m_run;
     WeakHashSet<const Font>* m_fallbackFonts { nullptr };
 
     std::optional<unsigned> m_lastCharacterIndex;

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -165,9 +165,9 @@ void SVGTextMetricsBuilder::measureTextRenderer(RenderSVGInlineText& text, Measu
         data->lastCharacter = currentCharacter;
     }
 
-    if (m_simpleWidthIterator) {
+    if (auto simpleWidthIterator = std::exchange(m_simpleWidthIterator, nullptr)) {
         GlyphBuffer glyphBuffer;
-        m_simpleWidthIterator->finalize(glyphBuffer);
+        simpleWidthIterator->finalize(glyphBuffer);
     }
 
     if (!data->allCharactersMap)


### PR DESCRIPTION
#### 6a0c0be86c69992d84adf54c1c83bc46b8617a8d
<pre>
Adopt more smart pointers in WidthIterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=264052">https://bugs.webkit.org/show_bug.cgi?id=264052</a>

Reviewed by Ryosuke Niwa.

Adopt more smart pointers in WidthIterator. This tested as performance
neutral on the benchmark we track.

* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/TextRun.cpp:
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::WidthIterator):
(WebCore::WidthIterator::applyFontTransforms):
(WebCore::WidthIterator::hasExtraSpacing const):
(WebCore::WidthIterator::advanceInternal):
(WebCore::WidthIterator::calculateAdditionalWidth const):
(WebCore::WidthIterator::applyExtraSpacingAfterShaping):
(WebCore::WidthIterator::applyCSSVisibilityRules):
(WebCore::WidthIterator::advance):
* Source/WebCore/platform/graphics/WidthIterator.h:

Canonical link: <a href="https://commits.webkit.org/270145@main">https://commits.webkit.org/270145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaa76806dec5799d145add0382d641d8972437b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27297 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28345 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/168 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3154 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5911 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->