### PR TITLE
[JSC] Fix StringAppend crash with tryMakeString in initializeDateTimeFormat

### DIFF
--- a/JSTests/stress/intl-data-time-format-string-overflow.js
+++ b/JSTests/stress/intl-data-time-format-string-overflow.js
@@ -1,0 +1,6 @@
+(async function () {
+    arguments = 'a'.repeat(2147483647 - null);
+    new Intl.DateTimeFormat(['de-de'], {
+        timeZone: arguments
+    });
+})();

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -747,7 +747,10 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         } else {
             tz = canonicalizeTimeZoneName(originalTz);
             if (tz.isNull()) {
-                throwRangeError(globalObject, scope, "invalid time zone: "_s + originalTz);
+                String message = tryMakeString("invalid time zone: "_s, originalTz);
+                if (!message)
+                    message = "invalid time zone"_s;
+                throwRangeError(globalObject, scope, message);
                 return;
             }
         }


### PR DESCRIPTION
#### 9a421c3685d06e979ed32af719dcee62e15e7aee
<pre>
[JSC] Fix StringAppend crash with tryMakeString in initializeDateTimeFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=264056">https://bugs.webkit.org/show_bug.cgi?id=264056</a>
<a href="https://rdar.apple.com/116647363">rdar://116647363</a>

Reviewed by Yusuke Suzuki.

StringAppend may crash due to string concatenation may has int32
overflow in tryMakeStringFromAdapters. So, to fix issue, we should
use tryMakeString instead to avoid the crash.

* JSTests/stress/intl-data-time-format-string-overflow.js: Added.
(async arguments):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):

Canonical link: <a href="https://commits.webkit.org/270080@main">https://commits.webkit.org/270080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c29cdf14e6a6b54e804fffab430b5eb630d5d91c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26640 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24758 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27225 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22105 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/21323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26093 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23796 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31198 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6846 "Found 10 new JSC stress test failures: stress/intl-data-time-format-string-overflow.js.bytecode-cache, stress/intl-data-time-format-string-overflow.js.default, stress/intl-data-time-format-string-overflow.js.dfg-eager, stress/intl-data-time-format-string-overflow.js.dfg-eager-no-cjit-validate, stress/intl-data-time-format-string-overflow.js.eager-jettison-no-cjit, stress/intl-data-time-format-string-overflow.js.lockdown, stress/intl-data-time-format-string-overflow.js.mini-mode, stress/intl-data-time-format-string-overflow.js.no-cjit-collect-continuously, stress/intl-data-time-format-string-overflow.js.no-cjit-validate-phases, stress/intl-data-time-format-string-overflow.js.no-llint (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5867 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31166 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6521 "Passed tests") | 
<!--EWS-Status-Bubble-End-->