### PR TITLE
Use-after-free under WebCore::Scrollbar::supportsUpdateOnSecondaryThread

### DIFF
--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -288,7 +288,7 @@ using WebCore::LogOverlayScrollbars;
         break;
     }
 
-    if (!_scrollbar->supportsUpdateOnSecondaryThread())
+    if (_scrollbar && !_scrollbar->supportsUpdateOnSecondaryThread())
         _scrollbar->invalidate();
 }
 
@@ -313,7 +313,7 @@ using WebCore::LogOverlayScrollbars;
 @end
 
 @interface WebScrollerImpDelegate : NSObject<NSAnimationDelegate, NSScrollerImpDelegate> {
-    WebCore::Scrollbar* _scrollbar;
+    WeakPtr<WebCore::Scrollbar> _scrollbar;
 
     RetainPtr<WebScrollbarPartAnimation> _knobAlphaAnimation;
     RetainPtr<WebScrollbarPartAnimation> _trackAlphaAnimation;
@@ -458,7 +458,7 @@ using WebCore::LogOverlayScrollbars;
             [self scrollbarsController]->setVisibleScrollerThumbRect({ });
     }
 
-    scrollbarPartAnimation = adoptNS([[WebScrollbarPartAnimation alloc] initWithScrollbar:_scrollbar
+    scrollbarPartAnimation = adoptNS([[WebScrollbarPartAnimation alloc] initWithScrollbar:_scrollbar.get()
                                                                        featureToAnimate:part == WebCore::ThumbPart ? ThumbAlpha : TrackAlpha
                                                                             animateFrom:part == WebCore::ThumbPart ? [scrollerPainter knobAlpha] : [scrollerPainter trackAlpha]
                                                                               animateTo:newAlpha
@@ -515,7 +515,7 @@ using WebCore::LogOverlayScrollbars;
         [scrollerImp setUsePresentationValue:NO];
 
     if (!_uiStateTransitionAnimation) {
-        _uiStateTransitionAnimation = adoptNS([[WebScrollbarPartAnimation alloc] initWithScrollbar:_scrollbar
+        _uiStateTransitionAnimation = adoptNS([[WebScrollbarPartAnimation alloc] initWithScrollbar:_scrollbar.get()
             featureToAnimate:UIStateTransition
             animateFrom:[scrollerImp uiStateTransitionProgress]
             animateTo:1.0
@@ -540,7 +540,7 @@ using WebCore::LogOverlayScrollbars;
     [scrollerImp setExpansionTransitionProgress:1 - [scrollerImp expansionTransitionProgress]];
 
     if (!_expansionTransitionAnimation) {
-        _expansionTransitionAnimation = adoptNS([[WebScrollbarPartAnimation alloc] initWithScrollbar:_scrollbar
+        _expansionTransitionAnimation = adoptNS([[WebScrollbarPartAnimation alloc] initWithScrollbar:_scrollbar.get()
             featureToAnimate:ExpansionTransition
             animateFrom:[scrollerImp expansionTransitionProgress]
             animateTo:1.0


### PR DESCRIPTION
#### 868fdd2f60885a5095ab3888261aed0ba002cc03
<pre>
Use-after-free under WebCore::Scrollbar::supportsUpdateOnSecondaryThread
<a href="https://bugs.webkit.org/show_bug.cgi?id=259890">https://bugs.webkit.org/show_bug.cgi?id=259890</a>
<a href="https://rdar.apple.com/113037440">rdar://113037440</a>

Reviewed by Ryosuke Niwa.

Use a WeakPtr for _scrollbar instead of a raw pointer and add a null-check
in [WebScrollbarPartAnimation setCurrentProgress:].

* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(-[WebScrollbarPartAnimation setCurrentProgress:]):
(-[WebScrollerImpDelegate setUpAlphaAnimation:scrollerPainter:part:animateAlphaTo:duration:]):
(-[WebScrollerImpDelegate scrollerImp:animateUIStateTransitionWithDuration:]):
(-[WebScrollerImpDelegate scrollerImp:animateExpansionTransitionWithDuration:]):

Originally-landed-as: 265870.236@safari-7616-branch (bf54ee3c4df6). <a href="https://rdar.apple.com/117809355">rdar://117809355</a>
Canonical link: <a href="https://commits.webkit.org/270099@main">https://commits.webkit.org/270099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed8054283a50510faedca6260f2bf228278215f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27235 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28307 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22443 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26099 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/128 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3108 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5884 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->