### PR TITLE
[JSC] DFG AI GetById adhoc folding should insert watchpoints for structures

### DIFF
--- a/JSTests/stress/date-set-time-purify-nan.js
+++ b/JSTests/stress/date-set-time-purify-nan.js
@@ -1,0 +1,21 @@
+function opt(date, float64_array) {
+    date.setTime(float64_array[0]);
+}
+
+function main() {
+    const uint64_array = new BigUint64Array(1);
+    const float64_array = new Float64Array(uint64_array.buffer);
+
+    const date = new Date();
+
+    for (let i = 0; i < 1000000; i++) {
+        opt(date, float64_array);
+    }
+
+    uint64_array[0] = 0xfffe000000001234n;
+    opt(date, float64_array);
+
+    print(date.getTime());
+}
+
+main();

--- a/JSTests/stress/same-offset-different-property-name-multiple-get-by-variants.js
+++ b/JSTests/stress/same-offset-different-property-name-multiple-get-by-variants.js
@@ -1,0 +1,65 @@
+function opt(wrapper, object, call, get) {
+    // CheckStructure
+    object.prototype.p1;
+    object.prototype.p2;
+
+    if (call) {
+        // CheckIsConstant
+        wrapper instanceof object;
+
+        if (get) {
+            // GetById
+            return object.prototype.p1.value;
+        }
+    }
+}
+
+function main() {
+    const object1 = function () {};
+    const object2 = function () {};
+    const object3 = function () {};
+    const object4 = {value: 1};
+
+    const wrapper1 = new object1();
+    const wrapper2 = new object2();
+
+    // S1
+    object1.prototype.p1 = object4;
+    object1.prototype.p2 = object4;
+
+    // S1 -> S2
+    object2.prototype.p1 = 1;
+    object2.prototype.p2 = 1;
+
+    delete object2.prototype.p2;
+    delete object2.prototype.p1;
+
+    object2.prototype.p2 = 2;
+    object2.prototype.p1 = 2;
+
+    Reflect.defineProperty(object3.prototype, 'p1', {
+        get() {
+            return object4;
+        }
+    });
+
+    // Just to force the compiler to emit the GetById node. Otherwise, it'll optimize it into a GetByOffset node.
+    opt(wrapper1, object3, /* call */ true, /* get */ true);
+
+    for (let i = 0; i < 1000000; i++) {
+        opt(wrapper1, object1, /* call */ true, /* get */ false);
+        opt(wrapper1, object2, /* call */ false, /* get */ false);
+    }
+
+    // S1 -> S2
+    delete object1.prototype.p2;
+    delete object1.prototype.p1;
+
+    object1.prototype.p2 = 1;
+    object1.prototype.p1 = 0x1234;
+
+    String(opt(wrapper1, object1, /* call */ true, /* get */ true));
+}
+
+main();
+

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3808,10 +3808,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     // This thing won't give us a variant that involves prototypes. If it did, we'd
                     // have more work to do here.
                     DFG_ASSERT(m_graph, node, status[i].conditionSet().isEmpty());
-
-                    result.merge(
-                        m_graph.inferredValueForProperty(
-                            value, status[i].offset(), m_state.structureClobberState()));
+                    const auto& variant = status[i];
+                    result.merge(m_graph.inferredValueForProperty(value, *m_graph.addStructureSet(variant.structureSet()), variant.offset(), m_state.structureClobberState()));
                 }
             
                 m_state.setShouldTryConstantFolding(true);

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1385,6 +1385,17 @@ AbstractValue Graph::inferredValueForProperty(
     return AbstractValue::heapTop();
 }
 
+AbstractValue Graph::inferredValueForProperty(const AbstractValue& base, const RegisteredStructureSet& structureSet, PropertyOffset offset, StructureClobberState clobberState)
+{
+    if (JSValue value = tryGetConstantProperty(base.m_value, structureSet, offset)) {
+        AbstractValue result;
+        result.set(*this, *freeze(value), clobberState);
+        return result;
+    }
+
+    return AbstractValue::heapTop();
+}
+
 JSValue Graph::tryGetConstantClosureVar(JSValue base, ScopeOffset offset)
 {
     // This has an awesome concurrency story. See comment for GetGlobalVar in ByteCodeParser.

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -923,8 +923,8 @@ public:
 
     // This uses either constant property inference or property type inference to derive a good abstract
     // value for some property accessed with the given abstract value base.
-    AbstractValue inferredValueForProperty(
-        const AbstractValue& base, PropertyOffset, StructureClobberState);
+    AbstractValue inferredValueForProperty(const AbstractValue& base, PropertyOffset, StructureClobberState);
+    AbstractValue inferredValueForProperty(const AbstractValue& base, const RegisteredStructureSet&, PropertyOffset, StructureClobberState);
     
     FullBytecodeLiveness& livenessFor(CodeBlock*);
     FullBytecodeLiveness& livenessFor(InlineCallFrame*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6682,7 +6682,7 @@ void SpeculativeJIT::compileDateSet(Node* node)
     loadDouble(TrustedImmPtr(&max), scratch3FPR);
     loadDouble(TrustedImmPtr(&NaN), scratch4FPR);
     absDouble(timeFPR, scratch2FPR);
-    moveDoubleConditionallyDouble(DoubleGreaterThanAndOrdered, scratch2FPR, scratch3FPR, scratch4FPR, scratch1FPR, scratch1FPR);
+    moveDoubleConditionallyDouble(DoubleGreaterThanOrUnordered, scratch2FPR, scratch3FPR, scratch4FPR, scratch1FPR, scratch1FPR);
 
     storeDouble(scratch1FPR, Address(baseGPR, DateInstance::offsetOfInternalNumber()));
     doubleResult(scratch1FPR, node);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -18120,7 +18120,7 @@ IGNORE_CLANG_WARNINGS_END
         LValue base = lowDateObject(m_node->child1());
         LValue arg = lowDouble(m_node->child2());
         LValue time = m_out.add(m_out.doubleTrunc(arg), m_out.constDouble(0));
-        LValue result = m_out.select(m_out.doubleGreaterThan(m_out.doubleAbs(arg), m_out.constDouble(WTF::maxECMAScriptTime)), m_out.constDouble(PNaN), time);
+        LValue result = m_out.select(m_out.doubleGreaterThanOrUnordered(m_out.doubleAbs(arg), m_out.constDouble(WTF::maxECMAScriptTime)), m_out.constDouble(PNaN), time);
         m_out.storeDouble(result, base, m_heaps.DateInstance_internalNumber);
         setDouble(result);
     }

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -171,6 +171,15 @@ ServiceWorkerThread& ServiceWorkerGlobalScope::thread()
     return static_cast<ServiceWorkerThread&>(WorkerGlobalScope::thread());
 }
 
+void ServiceWorkerGlobalScope::prepareForDestruction()
+{
+    // Make sure we destroy fetch events objects before the VM goes away, since their
+    // destructor may access the VM.
+    m_extendedEvents.clear();
+
+    WorkerGlobalScope::prepareForDestruction();
+}
+
 // https://w3c.github.io/ServiceWorker/#update-service-worker-extended-events-set-algorithm
 void ServiceWorkerGlobalScope::updateExtendedEventsSet(ExtendableEvent* newEvent)
 {

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -115,6 +115,8 @@ private:
     ServiceWorkerGlobalScope(ServiceWorkerContextData&&, ServiceWorkerData&&, const WorkerParameters&, Ref<SecurityOrigin>&&, ServiceWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&);
     void notifyServiceWorkerPageOfCreationIfNecessary();
 
+    void prepareForDestruction() final;
+
     Type type() const final { return Type::ServiceWorker; }
     bool hasPendingEvents() const { return !m_extendedEvents.isEmpty(); }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -43,6 +43,7 @@ class NavigationAction;
 
 namespace WebCore {
 class ResourceResponse;
+class SecurityOrigin;
 }
 
 namespace WebKit {
@@ -112,6 +113,9 @@ private:
 #endif
     void continueStartAfterGetAuthorizationHints(const String&);
     void continueStartAfterDecidePolicy(const SOAuthorizationLoadPolicy&);
+
+    bool shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions(const WebCore::ResourceResponse&);
+    bool shouldInterruptLoadForXFrameOptions(Vector<RefPtr<WebCore::SecurityOrigin>>&& frameAncestorOrigins, const String& xFrameOptions, const URL&);
 
     State m_state  { State::Idle };
     RetainPtr<SOAuthorization> m_soAuthorization;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -28,6 +28,7 @@
 
 #if HAVE(APP_SSO)
 
+#import "APIFrameHandle.h"
 #import "APIHTTPCookieStore.h"
 #import "APINavigation.h"
 #import "APINavigationAction.h"
@@ -40,6 +41,8 @@
 #import "WebFrameProxy.h"
 #import "WebPageProxy.h"
 #import "WebsiteDataStore.h"
+#import <WebCore/ContentSecurityPolicy.h>
+#import <WebCore/HTTPParsers.h>
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/SecurityOrigin.h>
 #import <pal/cocoa/AppSSOSoftLink.h>
@@ -49,6 +52,7 @@
 #define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] SOAuthorizationSession::" fmt, this, toString(m_action), stateString(), ##__VA_ARGS__)
 
 namespace WebKit {
+using namespace WebCore;
 
 namespace {
 
@@ -305,6 +309,13 @@ void SOAuthorizationSession::complete(NSHTTPURLResponse *httpResponse, NSData *d
     becomeCompleted();
 
     auto response = WebCore::ResourceResponse(httpResponse);
+
+    if (shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions(response)) {
+        AUTHORIZATIONSESSION_RELEASE_LOG("complete: CSP failed. Falling back to web path.");
+        fallBackToWebPathInternal();
+        return;
+    }
+
     if (!isSameOrigin(m_navigationAction->request(), response)) {
         AUTHORIZATIONSESSION_RELEASE_LOG("complete:  Origins don't match. Falling back to web path.");
         fallBackToWebPathInternal();
@@ -391,6 +402,69 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
 #endif
 
     uiCallback(YES, nil);
+}
+
+bool SOAuthorizationSession::shouldInterruptLoadForXFrameOptions(Vector<RefPtr<SecurityOrigin>>&& frameAncestorOrigins, const String& xFrameOptions, const URL& url)
+{
+    switch (parseXFrameOptionsHeader(xFrameOptions)) {
+    case XFrameOptionsDisposition::None:
+    case XFrameOptionsDisposition::AllowAll:
+        return false;
+    case XFrameOptionsDisposition::Deny:
+        return true;
+    case XFrameOptionsDisposition::SameOrigin: {
+        auto origin = SecurityOrigin::create(url);
+        for (auto& ancestorOrigin : frameAncestorOrigins) {
+            if (!origin->isSameSchemeHostPort(*ancestorOrigin))
+                return true;
+        }
+        return false;
+    }
+    case XFrameOptionsDisposition::Conflict: {
+        String errorMessage = "Multiple 'X-Frame-Options' headers with conflicting values ('" + xFrameOptions + "') encountered. Falling back to 'DENY'.";
+        AUTHORIZATIONSESSION_RELEASE_LOG("shouldInterruptLoadForXFrameOptions: %s", errorMessage.utf8().data());
+        return true;
+    }
+    case XFrameOptionsDisposition::Invalid: {
+        String errorMessage = "Invalid 'X-Frame-Options' header encountered: '" + xFrameOptions + "' is not a recognized directive. The header will be ignored.";
+        AUTHORIZATIONSESSION_RELEASE_LOG("shouldInterruptLoadForXFrameOptions: %s", errorMessage.utf8().data());
+        return false;
+    }
+    }
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+bool SOAuthorizationSession::shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions(const WebCore::ResourceResponse& response)
+{
+    Vector<RefPtr<SecurityOrigin>> frameAncestorOrigins;
+    if (auto* targetFrame = m_navigationAction->targetFrame()) {
+        if (auto parentFrameHandle = targetFrame->parentFrameHandle()) {
+            for (auto* parent = WebFrameProxy::webFrame(parentFrameHandle->frameID()); parent; parent = parent->parentFrame()) {
+                auto origin = SecurityOrigin::create(parent->url());
+                RefPtr<SecurityOrigin> frameOrigin = origin.ptr();
+                frameAncestorOrigins.append(frameOrigin);
+            }
+        }
+    }
+
+    auto url = response.url();
+    ContentSecurityPolicy contentSecurityPolicy { URL { url }, nullptr, nullptr };
+    contentSecurityPolicy.didReceiveHeaders(ContentSecurityPolicyResponseHeaders { response }, m_navigationAction->request().httpReferrer());
+    if (!contentSecurityPolicy.allowFrameAncestors(frameAncestorOrigins, url))
+        return true;
+
+    if (!contentSecurityPolicy.overridesXFrameOptions()) {
+        String xFrameOptions = response.httpHeaderField(HTTPHeaderName::XFrameOptions);
+        if (!xFrameOptions.isNull() && shouldInterruptLoadForXFrameOptions(WTFMove(frameAncestorOrigins), xFrameOptions, response.url())) {
+            String errorMessage = makeString("Refused to display '", response.url().stringCenterEllipsizedToLength(), "' in a frame because it set 'X-Frame-Options' to '", xFrameOptions, "'.");
+            AUTHORIZATIONSESSION_RELEASE_LOG("shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions: %s", errorMessage.utf8().data());
+
+            return true;
+        }
+    }
+
+    return false;
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5743,9 +5743,13 @@ void WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared(Ref<
 
     auto transaction = internals().pageLoadState.transaction();
 
-    if (frame->isMainFrame())
+    if (frame->isMainFrame()) {
         internals().pageLoadState.didReceiveServerRedirectForProvisionalLoad(transaction, request.url().string());
-
+        // If the main frame in a provisional page is getting a server-side redirect, make sure the
+        // committed page's provisional URL is kept up-to-date too.
+        if (frame != m_mainFrame && !m_mainFrame->frameLoadState().provisionalURL().isEmpty())
+            m_mainFrame->didReceiveServerRedirectForProvisionalLoad(request.url());
+    }
     frame->didReceiveServerRedirectForProvisionalLoad(request.url());
 
     internals().pageLoadState.commitChanges();


### PR DESCRIPTION
#### 690ddf9c00c2d19da81d1833b1e29db2780955b6
<pre>
[JSC] DFG AI GetById adhoc folding should insert watchpoints for structures
<a href="https://bugs.webkit.org/show_bug.cgi?id=260678">https://bugs.webkit.org/show_bug.cgi?id=260678</a>
<a href="https://rdar.apple.com/114072069">rdar://114072069</a>

Reviewed by Keith Miller.

For DFG AI GetById&apos;s variants, they are tuples of StructureSet and offset.
So, we should not obtain constant property just with offset since we first need to
ensure that the base object is having a structure in StructureSet.
Let&apos;s say [S0, 0] [S1, 1] variants are produced. In that case, we should not load
a value from offset 1 when object is S0. But previously we were doing that since
only thing we checked is that base is S0 or S1.
This patch just extends DFG AI GetById handling to use existing tryGetConstantProperty
mechanism with StructureSet. This properly inserts replacement watchpoints too, so that
we can guarantee that the loaded value is inferred constant (if it gets different, then
watchpoint fires). And we correctly check that the current object&apos;s structure is meeting
the requirement against *variant*&apos;s structure set.

* JSTests/stress/same-offset-different-property-name-multiple-get-by-variants.js: Added.
(main.const.object1):
(main.const.object2):
(main.const.object3):
(main.get opt):
(main):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::inferredValueForProperty):
* Source/JavaScriptCore/dfg/DFGGraph.h:

Originally-landed-as: 265870.440@safari-7616-branch (965be685c2ff). <a href="https://rdar.apple.com/117809719">rdar://117809719</a>
Canonical link: <a href="https://commits.webkit.org/270143@main">https://commits.webkit.org/270143@main</a>
</pre>
----------------------------------------------------------------------
#### 506a38b00501c414cc748abd41d53f47e329e726
<pre>
[JSC] Purify NaN for Date#setTime DFG / FTL implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=260497">https://bugs.webkit.org/show_bug.cgi?id=260497</a>
<a href="https://rdar.apple.com/114177456">rdar://114177456</a>

Reviewed by Mark Lam.

Date#setTime should purify NaN, otherwise, it can put arbitrary NaN boxed values, and cause type-confusion.
We can just use canonical NaN when the input is NaN.

* JSTests/stress/date-set-time-purify-nan.js: Added.
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileDateSet):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Originally-landed-as: 265870.404@safari-7616-branch (aa32244a89e7). <a href="https://rdar.apple.com/117809448">rdar://117809448</a>
Canonical link: <a href="https://commits.webkit.org/270142@main">https://commits.webkit.org/270142@main</a>
</pre>
----------------------------------------------------------------------
#### 70c12516bb62c6a7f33ab2be9895c97c055e86c1
<pre>
Check CSP and X-Frame-Options for subframe AppSSO
<a href="https://bugs.webkit.org/show_bug.cgi?id=260100">https://bugs.webkit.org/show_bug.cgi?id=260100</a>
<a href="https://rdar.apple.com/108625087">rdar://108625087</a>

Reviewed by Alex Christensen.

Before this patch, AppSSO unconditionally sets cookies whenever
a session occurs without considering the headers in the response.
This patch starts considering CSP and X-Frame-Options for AppSSO responses.

Added API tests for this behavior.

* Source/WebKit/UIProcess/API/APIFrameInfo.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::complete):
(WebKit::SOAuthorizationSession::shouldInterruptLoadForXFrameOptions):
(WebKit::SOAuthorizationSession::shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions):
(): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST):

Originally-landed-as: 265870.403@safari-7616-branch (43c01fefcaa5). <a href="https://rdar.apple.com/117809541">rdar://117809541</a>
Canonical link: <a href="https://commits.webkit.org/270141@main">https://commits.webkit.org/270141@main</a>
</pre>
----------------------------------------------------------------------
#### 950758759f71415f03308692ebd0feae8e6591f9
<pre>
Main frame URL is wrong after server-side redirect to a page serving the COOP header
<a href="https://bugs.webkit.org/show_bug.cgi?id=260046">https://bugs.webkit.org/show_bug.cgi?id=260046</a>
<a href="https://rdar.apple.com/111855179">rdar://111855179</a>

Reviewed by Brent Fulgham and Alex Christensen.

In the poc, the page is opening a popup (without opener) to the same origin URL1.
This URL1 does a server-side redirect to URL2 which serves the `COOP: same-origin`
HTTP header. After the navigation, Safari was displaying URL1 instead of URL2 in
the URL bar.

It is important to note that that 2 process-swap occur here. The first occurs when
we do the navigation to URL1 in a popup that doesn&apos;t have an opener (in the
decidePolicyForNavigationAction). The second one occurs when we receive the
COOP header from URL2 (on navigation response).

In ProvisionalPageProxy::didCreateMainFrame(), we have code which does the following:
```
if (previousMainFrame &amp;&amp; !previousMainFrame-&gt;provisionalURL().isEmpty()) {
        // In case of a process swap after response policy, the didStartProvisionalLoad already happened but the new main frame doesn&apos;t know about it
        // so we need to tell it so it can update its provisional URL.
        m_mainFrame-&gt;didStartProvisionalLoad(previousMainFrame-&gt;provisionalURL());
    }
```

During the second process-swap, we forward the provisional URL from the committed
frame to the provisional one. This is because the didStartProvisionalLoad IPC was
handled by the committed main frame, before we decided to process-swap on resource
response later on. As a result, the provisional main frame doesn&apos;t know yet about
the provisional load and we have to let it know about it so it sets its provisional
URL.

This worked fine in the usual case where the COOP process-swap doesn&apos;t follow
another process swap. However, in this case, the provisional URL got updated by
an earlier server side redirect which got handled by a provisional frame, not the
committed one. As a result, the committed frame didn&apos;t know about the latest
provisional URL, only the original one before the server side redirect.

To address the issue, whenever a provisional main frame receives a server-side
redirect, we now let the committed main frame know about it too so that the
committed frame&apos;s provisional URL always stays up-to-date. As a result, when
ProvisionalPageProxy::didCreateMainFrame() forwards the committed frame&apos;s URL to
the new provisional frame, it is now accurate.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Originally-landed-as: 265870.357@safari-7616-branch (8e677b301cae). <a href="https://rdar.apple.com/117809466">rdar://117809466</a>
Canonical link: <a href="https://commits.webkit.org/270140@main">https://commits.webkit.org/270140@main</a>
</pre>
----------------------------------------------------------------------
#### a330ea7722cdc25074b046571d2b627400ce68b5
<pre>
Potential use-after-free of the VM under ~FetchEvent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259896">https://bugs.webkit.org/show_bug.cgi?id=259896</a>
<a href="https://rdar.apple.com/113148936">rdar://113148936</a>

Reviewed by Brent Fulgham.

The VM gets destroyed in between the call for WorkerGlobalScope::prepareForDestruction()
and the call for the WorkerGlobalScope destructor. The crash trace indicates that
the ServiceWorkerGlobalScope destructor destroys FetchEvent objects which end up needing
the VM in their destructor.

This is a speculative fix as I cannot reproduce the issue. Brady already imported the
test case at 266608@main.

* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::prepareForDestruction):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:

Originally-landed-as: 265870.237@safari-7616-branch (76715edd316d). <a href="https://rdar.apple.com/117809542">rdar://117809542</a>
Canonical link: <a href="https://commits.webkit.org/270139@main">https://commits.webkit.org/270139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf6f69dcb50f1d8d68d2286312c865095eeafd69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22946 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24766 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2232 "Found 1 new test failure: scrollbars/scrollevent-iframe-no-scrolling-wheel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27236 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28377 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21330 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26100 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/129 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31206 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3109 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6848 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5906 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2257 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31174 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2174 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6523 "Passed tests") | 
<!--EWS-Status-Bubble-End-->