### PR TITLE
Crash under HTMLBodyElement::didFinishInsertingNode()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -239,6 +239,9 @@ imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-f
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-worker-owner.https.html
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/cache-storage-reporting-document.https.html [ Skip ]
 
+# This test is a bit slow.
+fast/frames/frame-append-body-child-crash.html [ Slow ]
+
 # This test is failing in all major browser engines as of Sept 2022. The reason is that the Reporting-Endpoints header
 # is served on the parent of the reporting frame, not the reporting frame.
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-endpoint.https.html

--- a/LayoutTests/fast/css/style-scope-destruction-crash-expected.txt
+++ b/LayoutTests/fast/css/style-scope-destruction-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/css/style-scope-destruction-crash.html
+++ b/LayoutTests/fast/css/style-scope-destruction-crash.html
@@ -1,0 +1,34 @@
+This test passes if it doesn't crash.
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function gc() {
+    if (window.GCController) {
+        GCController.collect();
+        return;
+    }
+   for(var i=0;i<100;i++) {
+       new Uint8Array(1024*1024);
+   }
+}
+
+function main() {
+    var v63 = x5.attachShadow({mode: "open", delegatesFocus: false});
+    x18.scrollTop;
+    v63.appendChild(x11);
+    gc();
+}
+</script>
+</head>
+
+<body onload="main()">
+<svg id="x11" id="x44" tabindex="-1">
+<animateTransform id="x18" 0.97 0.23 0" min="0.5s">
+</animateTransform>
+<clipPath id="x20" 8em id="x25" vector-effect="non-scaling-size" clip-path="url(#x20)" markerUnits="strokeWidth" 1 clip="rect(1em,auto,auto,546px)" patternUnits="userSpaceOnUse">
+<style width="0.20em" translate="no" draggable="true" itemref="x50" itemgroup="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">
+<blockquote id="x5" onfocusout="f3()">
+</pre>
+AAAA
+</content>

--- a/LayoutTests/fast/frames/frame-append-body-child-crash-expected.txt
+++ b/LayoutTests/fast/frames/frame-append-body-child-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/fast/frames/frame-append-body-child-crash.html
+++ b/LayoutTests/fast/frames/frame-append-body-child-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function runTest() {
+    document.body.appendChild(testFrame);
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>This test passes if it doesn't crash.</p>
+<iframe id="testFrame" name="testFrameName"></iframe>
+<form id="testForm" target="testFrameName" method="GET">
+    <input type=hidden id="runInput" name="run" value="1">
+</form>
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+    if (run = urlParams.get("run"))
+        document.getElementById("runInput").setAttribute("value", Number.parseInt(run) + 1);
+    else {
+        setTimeout(() => {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 3000);
+    }
+       
+    if (run < 2) {
+        testForm.submit();
+        var video = document.createElement("video");
+        video.src = "data:";
+        testFrame.appendChild(document.createElement("body"));
+    } else if (window.testRunner)
+        testRunner.notifyDone();
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
@@ -165,7 +165,11 @@ ExceptionOr<void> MediaRecorder::startRecording(std::optional<unsigned> timeSlic
         return result.releaseException();
 
     m_private = result.releaseReturnValue();
-    m_private->startRecording([this, pendingActivity = makePendingActivity(*this)](auto&& mimeTypeOrException, unsigned audioBitsPerSecond, unsigned videoBitsPerSecond) mutable {
+    m_private->startRecording([this, weakThis = WeakPtr { *this }, pendingActivity = makePendingActivity(*this)](auto&& mimeTypeOrException, unsigned audioBitsPerSecond, unsigned videoBitsPerSecond) mutable {
+        auto protectedThis = RefPtr { weakThis.get() };
+        if (!protectedThis)
+            return;
+
         if (!m_isActive)
             return;
 

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -80,6 +80,10 @@ public:
 
     MediaStream& stream() { return m_stream.get(); }
 
+    using EventTarget::weakPtrFactory;
+    using EventTarget::WeakValueType;
+    using EventTarget::WeakPtrImplType;
+
 private:
     MediaRecorder(Document&, Ref<MediaStream>&&, Options&&);
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -638,7 +638,7 @@ static constexpr unsigned StringDataIs8BitFlag = 0x80000000;
  *      BigIntObjectTag BigIntData
  *
  * BigIntData :-
- *      <sign:uint8_t> <lengthInUint64:uint32_t> <contents:uint64_t{lengthInUint64}>
+ *      <sign:uint8_t> <numberOfUint64Elements:uint32_t> <contents:uint64_t{numberOfUint64Elements}>
  *
  * File :-
  *    FileTag FileData
@@ -1152,10 +1152,10 @@ private:
                 write(static_cast<uint64_t>(bigInt->digit(index)));
         } else {
             ASSERT(sizeof(JSBigInt::Digit) == sizeof(uint32_t));
-            uint32_t lengthInUint64 = bigInt->length() / 2;
+            uint32_t numberOfUint64Elements = bigInt->length() / 2;
             if (bigInt->length() & 0x1)
-                ++lengthInUint64;
-            write(lengthInUint64);
+                ++numberOfUint64Elements;
+            write(numberOfUint64Elements);
             uint64_t value = 0;
             for (unsigned index = 0; index < bigInt->length(); ++index) {
                 if (!(index & 0x1))
@@ -4173,11 +4173,11 @@ private:
         bool sign;
         if (!read(sign, ForceReadingAs8Bit::Yes))
             return JSValue();
-        uint32_t lengthInUint64 = 0;
-        if (!read(lengthInUint64))
+        uint32_t numberOfUint64Elements = 0;
+        if (!read(numberOfUint64Elements))
             return JSValue();
 
-        if (!lengthInUint64) {
+        if (!numberOfUint64Elements) {
 #if USE(BIGINT32)
             return jsBigInt32(0);
 #else
@@ -4193,7 +4193,7 @@ private:
 
 #if USE(BIGINT32)
         static_assert(sizeof(JSBigInt::Digit) == sizeof(uint64_t));
-        if (lengthInUint64 == 1) {
+        if (numberOfUint64Elements == 1) {
             uint64_t digit64 = 0;
             if (!read(digit64))
                 return JSValue();
@@ -4223,12 +4223,12 @@ private:
 #endif
         JSBigInt* bigInt = nullptr;
         if constexpr (sizeof(JSBigInt::Digit) == sizeof(uint64_t)) {
-            bigInt = JSBigInt::tryCreateWithLength(m_lexicalGlobalObject->vm(), lengthInUint64);
+            bigInt = JSBigInt::tryCreateWithLength(m_lexicalGlobalObject->vm(), numberOfUint64Elements);
             if (!bigInt) {
                 fail();
                 return JSValue();
             }
-            for (uint32_t index = 0; index < lengthInUint64; ++index) {
+            for (uint32_t index = 0; index < numberOfUint64Elements; ++index) {
                 uint64_t digit64 = 0;
                 if (!read(digit64))
                     return JSValue();
@@ -4236,12 +4236,17 @@ private:
             }
         } else {
             ASSERT(sizeof(JSBigInt::Digit) == sizeof(uint32_t));
-            bigInt = JSBigInt::tryCreateWithLength(m_lexicalGlobalObject->vm(), lengthInUint64 * 2);
+            auto actualBigIntLength = WTF::checkedProduct<uint32_t>(numberOfUint64Elements, 2);
+            if (actualBigIntLength.hasOverflowed()) {
+                fail();
+                return JSValue();
+            }
+            bigInt = JSBigInt::tryCreateWithLength(m_lexicalGlobalObject->vm(), actualBigIntLength.value());
             if (!bigInt) {
                 fail();
                 return JSValue();
             }
-            for (uint32_t index = 0; index < lengthInUint64; ++index) {
+            for (uint32_t index = 0; index < numberOfUint64Elements; ++index) {
                 uint64_t digit64 = 0;
                 if (!read(digit64))
                     return JSValue();

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -183,7 +183,11 @@ Node::InsertedIntoAncestorResult HTMLBodyElement::insertedIntoAncestor(Insertion
 
 void HTMLBodyElement::didFinishInsertingNode()
 {
-    ASSERT(is<HTMLFrameElementBase>(document().ownerElement()));
+    // A DOM mutation could have happened in between the call to insertedIntoAncestor() and the
+    // call to didFinishInsertingNode().
+    if (!is<HTMLFrameElementBase>(document().ownerElement()))
+        return;
+
     Ref ownerElement = *document().ownerElement();
 
     // FIXME: It's surprising this is web compatible since it means marginwidth and marginheight attributes

--- a/Source/WebCore/platform/audio/SincResampler.h
+++ b/Source/WebCore/platform/audio/SincResampler.h
@@ -48,7 +48,7 @@ public:
     size_t chunkSize() const { return m_chunkSize; }
 
     // Processes numberOfSourceFrames from source to produce numberOfSourceFrames / scaleFactor frames in destination.
-    static void processBuffer(const float* source, float* destination, unsigned numberOfSourceFrames, double scaleFactor);
+    WEBCORE_EXPORT static void processBuffer(const float* source, float* destination, unsigned numberOfSourceFrames, double scaleFactor);
 
     // Process with provideInput callback function for streaming applications.
     void process(float* destination, size_t framesToProcess);

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -414,7 +414,9 @@ IntRect Region::Shape::bounds() const
     ASSERT(minX <= maxX);
     ASSERT(minY <= maxY);
 
-    return IntRect(minX, minY, maxX - minX, maxY - minY);
+    CheckedInt32 width = checkedDifference<int32_t>(maxX, minX);
+    CheckedInt32 height = checkedDifference<int32_t>(maxY, minY);
+    return IntRect(minX, minY, width.hasOverflowed() ? std::numeric_limits<int32_t>::max() : width.value(), height.hasOverflowed() ? std::numeric_limits<int32_t>::max() : height.value());
 }
 
 void Region::Shape::translate(const IntSize& offset)

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -57,21 +57,15 @@ ReferencePathOperation::ReferencePathOperation(const String& url, const AtomStri
     : PathOperation(Reference)
     , m_url(url)
     , m_fragment(fragment)
-    , m_element(element)
 {
-    if (is<SVGPathElement>(m_element) || is<SVGGeometryElement>(m_element))
-        m_path = pathFromGraphicsElement(m_element.get());
+    if (is<SVGPathElement>(element) || is<SVGGeometryElement>(element))
+        m_path = pathFromGraphicsElement(element.get());
 }
 
 ReferencePathOperation::ReferencePathOperation(std::optional<Path>&& path)
     : PathOperation(Reference)
     , m_path(WTFMove(path))
 {
-}
-
-const SVGElement* ReferencePathOperation::element() const
-{
-    return m_element.get();
 }
 
 Ref<RayPathOperation> RayPathOperation::create(float angle, Size size, bool isContaining, LengthPoint&& position, CSSBoxType referenceBox)

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -90,7 +90,6 @@ public:
     Ref<PathOperation> clone() const final;
     const String& url() const { return m_url; }
     const AtomString& fragment() const { return m_fragment; }
-    const SVGElement* element() const;
     const std::optional<Path> getPath(const TransformOperationData&) const final { return m_path; }
     const std::optional<Path> path() const { return m_path; }
 private:
@@ -107,7 +106,6 @@ private:
 
     String m_url;
     AtomString m_fragment;
-    RefPtr<SVGElement> m_element;
     std::optional<Path> m_path;
 };
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -87,6 +87,7 @@ Scope::Scope(ShadowRoot& shadowRoot)
 Scope::~Scope()
 {
     ASSERT(!hasPendingSheets());
+    weakPtrFactory().revokeAll();
 }
 
 Resolver& Scope::resolver()


### PR DESCRIPTION
#### 81e5846d415723b37a4e466ed0a80b5335e877c9
<pre>
Crash under HTMLBodyElement::didFinishInsertingNode()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260907">https://bugs.webkit.org/show_bug.cgi?id=260907</a>
<a href="https://rdar.apple.com/114177696">rdar://114177696</a>

Reviewed by Ryosuke Niwa.

When a &lt;body&gt; is inserted into the document, `HTMLBodyElement::insertedIntoAncestor()`
gets called. This function would only return `InsertedIntoAncestorResult::NeedsPostInsertionCallback`
if `is&lt;HTMLFrameElementBase&gt;(document().ownerElement())`, causing `HTMLBodyElement::didFinishInsertingNode()`
to get called later on. We would then assume in didFinishInsertingNode() that the document&apos;s owner element
is a non-null HTMLFrameElementBase.

However, as proven by the test, DOM manipulations can happen in between the 2 calls
causing the assertion to no longer hold. To address the issue we now early return
if `is&lt;HTMLFrameElementBase&gt;(document().ownerElement())` is no longer true in
`HTMLBodyElement::didFinishInsertingNode()`.

In the case of the test, `document().frame()` becomes null because the frame gets
detached, causing `document().ownerElement()` to return null as well.

* LayoutTests/fast/frames/frame-append-body-child-crash-expected.txt: Added.
* LayoutTests/fast/frames/frame-append-body-child-crash.html: Added.
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::didFinishInsertingNode):

Originally-landed-as: 265870.486@safari-7616-branch (3fc6931dcc2c). <a href="https://rdar.apple.com/117810024">rdar://117810024</a>
Canonical link: <a href="https://commits.webkit.org/270130@main">https://commits.webkit.org/270130@main</a>
</pre>
----------------------------------------------------------------------
#### a043d05b6d0b277940c34b8fe55c0085e797d176
<pre>
Make WebCore::SincResampler testable
<a href="https://bugs.webkit.org/show_bug.cgi?id=260933">https://bugs.webkit.org/show_bug.cgi?id=260933</a>
&lt;<a href="https://rdar.apple.com/114732348">rdar://114732348</a>&gt;

Reviewed by Chris Dumez.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
- Make SincResampler.h a private header.
* Source/WebCore/platform/audio/SincResampler.h:
(WebCore::SincResampler::processBuffer):
- Export static class method.

Originally-landed-as: 265870.482@safari-7616-branch (aae3b70b0eff). <a href="https://rdar.apple.com/117809957">rdar://117809957</a>
Canonical link: <a href="https://commits.webkit.org/270129@main">https://commits.webkit.org/270129@main</a>
</pre>
----------------------------------------------------------------------
#### 13885ac4490643e1e00c0a4958aa48e0bad7124b
<pre>
heap-use-after-free | Style::Scope::removeStyleSheetCandidateNode; WebCore::SVGStyleElement::~SVGStyleElement; WebCore::ContainerNode::~ContainerNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=260896">https://bugs.webkit.org/show_bug.cgi?id=260896</a>
<a href="https://rdar.apple.com/114231775">rdar://114231775</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/style-scope-destruction-crash-expected.txt: Added.
* LayoutTests/fast/css/style-scope-destruction-crash.html: Added.
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ReferencePathOperation::ReferencePathOperation):
(WebCore::ReferencePathOperation::element const): Deleted.

Get rid of the unused element field. This creates a RenderStyle -&gt; DOM ownership cycle which
allows this crash to happen.

* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::~Scope):

Ensure we revoke weak pointers at the start of the destructor to avoid this class of problems.

Originally-landed-as: 265870.481@safari-7616-branch (382b02a5fc10). <a href="https://rdar.apple.com/117809896">rdar://117809896</a>
Canonical link: <a href="https://commits.webkit.org/270128@main">https://commits.webkit.org/270128@main</a>
</pre>
----------------------------------------------------------------------
#### c89614c803991659691622c0dc621ba10c9094ab
<pre>
CloneDeserializer::readBigInt() should check for overflow when reifying JSBigInt length on 32-bit platforms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260822">https://bugs.webkit.org/show_bug.cgi?id=260822</a>
<a href="https://rdar.apple.com/114547822">rdar://114547822</a>

Reviewed by Chris Dumez.

The serialized length is a number of Uint64 elements. On 32-bit platforms, this length gets multiplied by 2 in
order to compute the actual length of the backing store to re-construct the JSBigInt.  Both the transmitted length
and the JSBigInt length is stored as uint32_t.  Hence, the 2x multiplication can theoretically result in an
overflow.  This patch adds an overflow check to handle this edge case.

Also renamed lengthInUint64 to numberOfUint64Elements.  lengthInUint64 can be misread to mean a length stored as a
uint64_t value, which is not what it actually means.  The length value is store in a uint32_t, and is a count of
the number of uint64_t sized elements.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpHeapBigIntData):
(WebCore::CloneDeserializer::readBigInt):

Originally-landed-as: 265870.467@safari-7616-branch (1f9e21240663). <a href="https://rdar.apple.com/117809900">rdar://117809900</a>
Canonical link: <a href="https://commits.webkit.org/270127@main">https://commits.webkit.org/270127@main</a>
</pre>
----------------------------------------------------------------------
#### c180d85669a6aa81e5d3b746284999982d28baaa
<pre>
CRASH in MediaRecorderPrivate::startRecording()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260736">https://bugs.webkit.org/show_bug.cgi?id=260736</a>
<a href="https://rdar.apple.com/113544631">rdar://113544631</a>

Reviewed by Brent Fulgham and Eric Carlson.

MediaRecorder can be destroyed before the completion handler passed to
MediaRecorderPrivate::startRecording() is called. Detect this state by
passing a WeakPtr into the completion handler lambda. Because MediaRecoder
has multiple base classes which are CanMakeWeakPtr subclasses, disambiguate
which subclass&apos;s WeakPtr implementation to use in the MediaRecoder class
declaration.

* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::startRecording):
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:

Originally-landed-as: 265870.463@safari-7616-branch (f255dd40b82e). <a href="https://rdar.apple.com/117809782">rdar://117809782</a>
Canonical link: <a href="https://commits.webkit.org/270126@main">https://commits.webkit.org/270126@main</a>
</pre>
----------------------------------------------------------------------
#### cdb96bc02a635dd676c28b4b8a7f4388a0edc9e0
<pre>
WebContent may get killed due to invalid RemoteLayerTreeDrawingAreaProxy_CommitLayerTree IPC message
<a href="https://bugs.webkit.org/show_bug.cgi?id=260757">https://bugs.webkit.org/show_bug.cgi?id=260757</a>
<a href="https://rdar.apple.com/113860744">rdar://113860744</a>

Reviewed by Aditya Keerthi.

The fuzzer found a case where the RemoteLayerTreeDrawingAreaProxy_CommitLayerTree
IPC message may fail decoding because its contains an invalid IntRect. After some
investigation, I found that we didn&apos;t handle overflows in the arithmetics in
Region::Shape::bounds(), which means that we could end up with an IntRect that
had a negative width or height.

In the fuzzer case, we ended up with the following values:
minX=-2147483648, minY=3, maxX=62, maxY=2306

We would compute the width doing `62 - (-2147483648)` which would overflow and end
up with a negative width. We now use checkedDifference&lt;int32_t&gt;() to detect
overflows and clamp to std::numeric_limits&lt;int32_t&gt;::max() when it happens.

* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::Shape::bounds const):

Originally-landed-as: 265870.452@safari-7616-branch (ca4f7c9b9939). <a href="https://rdar.apple.com/117809786">rdar://117809786</a>
Canonical link: <a href="https://commits.webkit.org/270125@main">https://commits.webkit.org/270125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37f6a96a6b353818ca8a5672ff2b12dd36f594f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26651 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22947 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27238 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28318 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/130 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21873 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5899 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->