### PR TITLE
SubtleCrypto:wrapKey ensure promise is not garbage collected

### DIFF
--- a/JSTests/stress/regress-114860483.js
+++ b/JSTests/stress/regress-114860483.js
@@ -1,0 +1,40 @@
+function assertArgumentsContent() {
+    const str = [...arguments].join();
+    if (str !== `,1.1,1.1,1.1,1.1,1.1`)
+        throw new Error("Bad assertion!");
+}
+
+function createClonedArguments() {
+    return arguments.callee.arguments;
+}
+
+function main() {
+    gc();
+
+    const global_proxy = this;
+    Reflect.defineProperty(global_proxy, 0, {
+        get() {
+            for (let i = 100; i < 200; i++)
+                cloned_arguments[i] = 1.1;
+
+            for (let i = 0; i < 100; i++)
+                cloned_arguments[i] = 1.1;
+
+            gc();
+
+            // Creating invalid date objects.
+            for (let i = 0; i < 100; i++) {
+                new Date('a');
+            }
+        }
+    });
+
+    const cloned_arguments = createClonedArguments(null, new Date(), new Date(), new Date(), new Date(), new Date());
+    delete cloned_arguments[0];
+
+    Reflect.setPrototypeOf(cloned_arguments, global_proxy);
+
+    assertArgumentsContent.apply(null, cloned_arguments);
+}
+
+main();

--- a/LayoutTests/animations/resolve-animation-should-not-execute-scripts-expected.txt
+++ b/LayoutTests/animations/resolve-animation-should-not-execute-scripts-expected.txt
@@ -1,0 +1,1 @@
+PASS if WebKit did not hit an assertion.

--- a/LayoutTests/animations/resolve-animation-should-not-execute-scripts.html
+++ b/LayoutTests/animations/resolve-animation-should-not-execute-scripts.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/gc.js"></script>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const canvas = document.body.appendChild(document.createElement('canvas'));
+const context = canvas.getContext('2d');
+
+let div = document.body.appendChild(document.createElement('div'));
+
+const keyframeEffect = new KeyframeEffect(div, [{transform: 'translate(100px)'}], {fill: 'forwards'});
+const animation = new Animation(keyframeEffect);
+
+animation.play();
+animation.finished;
+
+Reflect.defineProperty(Object.prototype, 'then', {
+    configurable: true,
+
+    get() {
+        Reflect.deleteProperty(Object.prototype, 'then');
+
+        keyframeEffect.target = null;
+        div.remove();
+        div = null;
+
+        gc();
+    }
+});
+
+// Just a random method that calls updateStyleIfNeeded
+context.font = 'a';
+document.write('PASS if WebKit did not hit an assertion.');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -2,5 +2,5 @@ fragment
 
 PASS Performing a fragment navigation must not abort the screen orientation change
 PASS Performing a fragment navigation within an iframe must not abort the lock promise
-FAIL Unloading an iframe by navigating it must abort the lock promise assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Unloading an iframe by navigating it must abort the lock promise
 

--- a/LayoutTests/webaudio/audioworklet-bad-array-type-expected.txt
+++ b/LayoutTests/webaudio/audioworklet-bad-array-type-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/webaudio/audioworklet-bad-array-type.html
+++ b/LayoutTests/webaudio/audioworklet-bad-array-type.html
@@ -1,0 +1,31 @@
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+async function runTest() {
+    const audio_context = new OfflineAudioContext(2, 1, 44100);
+    await audio_context.audioWorklet.addModule('bad-array-type-processor.js?' + Math.random());
+
+    const node1 = new AudioWorkletNode(audio_context, 'bad-array-type-processor');
+    const node2 = new AudioWorkletNode(audio_context, 'bad-array-type-processor', {
+        numberOfOutputs: 2,
+        outputChannelCount: [1, 1]
+    });
+
+    const buffer_source = audio_context.createBufferSource();
+    buffer_source.buffer = audio_context.createBuffer(1, 1, 44100);
+    buffer_source.connect(node1).connect(node2).connect(audio_context.destination);
+    buffer_source.start();
+
+    await audio_context.startRendering();
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+runTest();
+</script>
+</body>

--- a/LayoutTests/webaudio/bad-array-type-processor.js
+++ b/LayoutTests/webaudio/bad-array-type-processor.js
@@ -1,0 +1,22 @@
+Array.prototype[1] = [new Float32Array(0x80)];
+
+let count = 0;
+class CustomProcessor extends AudioWorkletProcessor {
+    process(inputs, outputs, parameters) {
+        count++;
+
+        if (count === 2) {
+            Array.prototype[1] = 0x1234;
+        }
+
+        return true;
+    }
+}
+
+let processor = null;
+registerProcessor('bad-array-type-processor', function (options) {
+    if (processor !== null)
+        return processor;
+
+    return processor = new CustomProcessor(options);
+});

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1162,6 +1162,11 @@ void JSObject::enterDictionaryIndexingMode(VM& vm)
 
 void JSObject::notifyPresenceOfIndexedAccessors(VM& vm)
 {
+    if (UNLIKELY(isGlobalObject())) {
+        jsCast<JSGlobalObject*>(this)->globalThis()->notifyPresenceOfIndexedAccessors(vm);
+        return;
+    }
+
     if (mayInterceptIndexedAccesses())
         return;
     

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -30,6 +30,7 @@
 #include "JSArrayInlines.h"
 #include "JSFunction.h"
 #include "JSGenericTypedArrayViewInlines.h"
+#include "JSGlobalProxy.h"
 #include "JSObject.h"
 #include "JSTypedArrays.h"
 #include "Lookup.h"
@@ -525,6 +526,9 @@ inline void JSObject::didBecomePrototype(VM& vm)
         DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
         setStructure(vm, Structure::becomePrototypeTransition(vm, oldStructure, &deferred));
     }
+
+    if (UNLIKELY(type() == GlobalProxyType))
+        jsCast<JSGlobalProxy*>(this)->target()->didBecomePrototype(vm);
 }
 
 inline bool JSObject::canGetIndexQuicklyForTypedArray(unsigned i) const

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -362,7 +362,7 @@ PaymentRequest::PaymentRequest(Document& document, PaymentOptions&& options, Pay
 
 PaymentRequest::~PaymentRequest()
 {
-    ASSERT(!hasPendingActivity());
+    ASSERT(!hasPendingActivity() || isContextStopped());
     ASSERT(!m_activePaymentHandler);
 }
 
@@ -471,7 +471,9 @@ void PaymentRequest::closeActivePaymentHandler()
 void PaymentRequest::stop()
 {
     closeActivePaymentHandler();
-    settleShowPromise(Exception { AbortError });
+    queueTaskKeepingObjectAlive(*this, TaskSource::Payment, [this] {
+        settleShowPromise(Exception { AbortError });
+    });
 }
 
 void PaymentRequest::suspend(ReasonForSuspension reason)

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -82,7 +82,7 @@ void OfflineAudioContext::uninitialize()
 
     BaseAudioContext::uninitialize();
 
-    if (auto promise = std::exchange(m_pendingRenderingPromise, nullptr))
+    if (auto promise = std::exchange(m_pendingRenderingPromise, nullptr); promise && !isContextStopped())
         promise->reject(Exception { InvalidStateError, "Context is going away"_s });
 }
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -32,6 +32,7 @@
 #include "JSLocalDOMWindow.h"
 #include "LocalDOMWindow.h"
 #include "ScriptController.h"
+#include "ScriptDisallowedScope.h"
 #include "WorkerGlobalScope.h"
 #include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/Exception.h>
@@ -56,6 +57,8 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
 {
     if (shouldIgnoreRequestToFulfill())
         return;
+
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::isScriptAllowedInMainThread());
 
     JSC::VM& vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_CATCH_SCOPE(vm);

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -1093,7 +1093,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
     WeakPtr weakThis { *this };
     auto callback = [index, weakThis, wrapAlgorithm, wrappingKey = Ref { wrappingKey }, wrapParams = WTFMove(wrapParams), isEncryption, context, workQueue = m_workQueue](SubtleCrypto::KeyFormat format, KeyData&& key) mutable {
         if (weakThis) {
-            if (auto promise = weakThis->m_pendingPromises.get(index)) {
+            if (RefPtr promise = weakThis->m_pendingPromises.get(index)) {
                 Vector<uint8_t> bytes;
                 switch (format) {
                 case SubtleCrypto::KeyFormat::Spki:

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -39,6 +39,7 @@ enum class TaskSource : uint8_t {
     MediaElement,
     Microtask,
     Networking,
+    Payment,
     PerformanceTimeline,
     Permission,
     PostedMessageQueue,

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -267,8 +267,11 @@ void ScreenOrientation::stop()
         return;
 
     manager->removeObserver(*this);
-    if (manager->lockRequester() == this)
-        manager->takeLockPromise()->reject(Exception { AbortError, "Document is no longer fully active"_s });
+    if (manager->lockRequester() == this) {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = manager->takeLockPromise()] {
+            promise->reject(Exception { AbortError, "Document is no longer fully active"_s });
+        });
+    }
 }
 
 bool ScreenOrientation::virtualHasPendingActivity() const


### PR DESCRIPTION
#### eb3a8c2925c527c15ac432c60457d5d592be71c3
<pre>
SubtleCrypto:wrapKey ensure promise is not garbage collected
<a href="https://bugs.webkit.org/show_bug.cgi?id=261519">https://bugs.webkit.org/show_bug.cgi?id=261519</a>
<a href="https://rdar.apple.com/115349445">rdar://115349445</a>

Reviewed by Tim Nguyen.

We need to ensure that the promise always remains alive when in use.
Adding a RefPtr guarantees that it will not be garbage collected.

* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::wrapKey):

Originally-landed-as: 8e9332694594. <a href="https://rdar.apple.com/117810508">rdar://117810508</a>
Canonical link: <a href="https://commits.webkit.org/270123@main">https://commits.webkit.org/270123@main</a>
</pre>
----------------------------------------------------------------------
#### d73e7a76fb08ed4cd7678293862000808f4e843e
<pre>
ScriptDisallowedScope bypass via a `then` getter in Document::updateStyleIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=261256">https://bugs.webkit.org/show_bug.cgi?id=261256</a>
&lt;<a href="https://rdar.apple.com/114545310">rdar://114545310</a>&gt;

Reviewed by Ryosuke Niwa.

This PR addresses several bugs:
1. There is a ScriptDisallowedScope bypass via DeferredPromise::callFunction.
2. WebAnimation::resolve() tries to execute scripts by rejecting promises during updateStyle.
3. WebAnimation::cancel() and WebAnimation::resetPendingTasks() also tries to execute scripts by
rejecting promises during updateStyle.
4. PaymentRequest and PaymentResponse try to reject promises during active DOM object suspension
as well as the script execution context is being stopped.
5. WebAudio tries to reject promises during active DOM object suspension.

For (1), this PR adds a release assertion in DeferredPromise::callFunction like the one we have in
ScriptController::canExecuteScripts. Note this has to be a thread safe variant since this code can be
executed in a worker thread.

For (2), this PR makes WebAnimation::resolve call updateFinishedState with SynchronouslyNotify::No
instead of SynchronouslyNotify::Yes. Note that in the spec [1], the only scenario in which this flag
is set to yes is when the author script calls finish() on an Animation object.

For (3), (4), and (5), this PR makes these actions asynchronous by scheduling a task / microtask
instead of synchronously rejecting promises.

[1] <a href="https://drafts.csswg.org/web-animations-1/#update-an-animations-finished-state">https://drafts.csswg.org/web-animations-1/#update-an-animations-finished-state</a>

Based on original patch by Ryosuke Niwa.

* LayoutTests/animations/resolve-animation-should-not-execute-scripts-expected.txt: Added.
* LayoutTests/animations/resolve-animation-should-not-execute-scripts.html: Added.

* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::~PaymentRequest): Now allows pending activity to exist when the associated
script execution context had been stopped.
(WebCore::PaymentRequest::stop): Don&apos;t try to settle the promise in the middle of stopping this
active DOM object.
(WebCore::PaymentRequest::suspend): Ditto for suspension. Schedule a task to settle promise instead.

* Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp:
(WebCore::PaymentResponse::~PaymentResponse): Now allows pending activity to exist when
the associated script execution context had been stopped.
(WebCore::PaymentResponse::suspend): Don&apos;t try to settle the promise in the middle of stopping this
active DOM object.

* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::uninitialize): Don&apos;t reject the promise when the active DOM objects
had already been stopped.

* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::cancel): Reject the finished promise in a newly scheduled task instead of
synchronously rejecting it, which would result in script execution.
(WebCore::WebAnimation::resolve): Resolve the promise asynchronously.

* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::callFunction): Added a release assertion.
* Source/WebCore/dom/TaskSource.h:

Originally-landed-as: 265870.536@safari-7616-branch (6d865c4bf3da). <a href="https://rdar.apple.com/117810274">rdar://117810274</a>
Canonical link: <a href="https://commits.webkit.org/270122@main">https://commits.webkit.org/270122@main</a>
</pre>
----------------------------------------------------------------------
#### 363afc5630dc2505f43771739954542fa4f58831
<pre>
JSObject::anyObjectInChainMayInterceptIndexedAccesses and JSObject::didBecomePrototype need to account for JSGlobalProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=261287">https://bugs.webkit.org/show_bug.cgi?id=261287</a>
<a href="https://rdar.apple.com/114860483">rdar://114860483</a>

Reviewed by Yusuke Suzuki.

Since JSObject::anyObjectInChainMayInterceptIndexedAccesses() walks up the [[Prototype]] chain,
whenever an indexed property is defined on a JSGlobalObject, we should add MayHaveIndexedAccessors
flag to JSGlobalProxy instead.

Currently, mayInterceptIndexedAccesses() is never queried on JSGlobalObject instances.

This change also fixes mayBePrototype() to be queried from JSGlobalProxy rather than JSGlobalObject,
which is correct given setPrototypeDirect() used to call didBecomePrototype() only on the proxy.
However, for extra robustness, this we propagate didBecomePrototype() to the global object as well.

* JSTests/stress/regress-114860483.js: Added.
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::didBecomePrototype):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::notifyPresenceOfIndexedAccessors):

Originally-landed-as: 265870.535@safari-7616-branch (049d074c4b1b). <a href="https://rdar.apple.com/117810163">rdar://117810163</a>
Canonical link: <a href="https://commits.webkit.org/270121@main">https://commits.webkit.org/270121@main</a>
</pre>
----------------------------------------------------------------------
#### d7514794b61f7eca9936b334471ac444e2493ace
<pre>
Bad jsCast&lt;&gt;() in copyDataFromJSArrayToBuses() in AudioWorkletProcessor.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=261289">https://bugs.webkit.org/show_bug.cgi?id=261289</a>
<a href="https://rdar.apple.com/115042475">rdar://115042475</a>

Reviewed by Ryosuke Niwa.

Use jsDynamicCast&lt;&gt;() instead of jsCast&lt;&gt;() in AudioWorkletProcessor.cpp for
safety.

* LayoutTests/webaudio/audioworklet-bad-array-type-expected.txt: Added.
* LayoutTests/webaudio/audioworklet-bad-array-type.html: Added.
* LayoutTests/webaudio/bad-array-type-processor.js: Added.
(CustomProcessor.prototype.process):
(CustomProcessor):
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::toJSArray):
(WebCore::toJSObject):
(WebCore::copyDataFromJSArrayToBuses):
(WebCore::AudioWorkletProcessor::process):

Originally-landed-as: 265870.534@safari-7616-branch (3be781681be0). <a href="https://rdar.apple.com/117810073">rdar://117810073</a>
Canonical link: <a href="https://commits.webkit.org/270120@main">https://commits.webkit.org/270120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53bf19fd71b8a2d77ce4f44f8fbf8c13445b2413

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26675 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22960 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27262 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28327 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21348 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26120 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23823 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/203 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31232 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21887 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6853 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5900 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2275 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31200 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2191 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6527 "Passed tests") | 
<!--EWS-Status-Bubble-End-->