### PR TITLE
Reflect.construct can churn cached internalFunctionAllocationStructure

### DIFF
--- a/JSTests/stress/reflect-construct-reenter-prototype-get-different-global.js
+++ b/JSTests/stress/reflect-construct-reenter-prototype-get-different-global.js
@@ -1,0 +1,25 @@
+var buffer = new ArrayBuffer(3);
+
+var newTarget = function () {
+}.bind(null)
+
+let i = 0
+
+let newGlobal = $vm.createGlobalObject()
+
+Object.defineProperty(newTarget, 'prototype', {
+  get: function () {
+    let iter = i
+    ++i;
+    // print(iter)
+    if (iter >= 1)
+      return { }
+    // print("Construct B", iter)
+    Reflect.construct(newGlobal.Object, [], newTarget);
+    // print("Construct B Done: ", iter)
+    return { };
+  }
+});
+
+// print("Construct A")
+var result = Reflect.construct(Object, [], newTarget);

--- a/JSTests/stress/reflect-construct-reenter-prototype-get.js
+++ b/JSTests/stress/reflect-construct-reenter-prototype-get.js
@@ -1,0 +1,23 @@
+var buffer = new ArrayBuffer(3);
+
+var newTarget = function () {
+}.bind(null)
+
+let i = 0
+
+Object.defineProperty(newTarget, 'prototype', {
+  get: function () {
+    let iter = i
+    ++i;
+    // print(iter)
+    if (iter >= 1)
+        return { }
+    // print("Construct B", iter)
+    Reflect.construct(Object, [], newTarget);
+    // print("Construct B Done: ", iter)
+    return { };
+  }
+});
+
+// print("Construct A")
+var result = Reflect.construct(Object, [], newTarget);


### PR DESCRIPTION
#### ae0b70efbe6b5326518eef3160144494748d8b11
<pre>
Reflect.construct can churn cached internalFunctionAllocationStructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263945">https://bugs.webkit.org/show_bug.cgi?id=263945</a>
<a href="https://rdar.apple.com/117556294">rdar://117556294</a>

Reviewed by Keith Miller.
Reviewed by Mark Lam.

Reflect.construct can churn the cached internalFunctionAllocationStructure
when calling the target&apos;s prototype getter, causing us to fail a debug assert.
This isn&apos;t really a problem though, since accidentally making a second structure
shouldn&apos;t break anything (like our watchpoints or structure transition logic).

We just add an extra check to silence the debug assert and be slightly more optimal.

* JSTests/stress/reflect-construct-reenter-prototype-get-different-global.js: Added.
(newTarget):
(get let):
* JSTests/stress/reflect-construct-reenter-prototype-get.js: Added.
(newTarget):
(get let):
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::InternalFunction::createSubclassStructure):

Canonical link: <a href="https://commits.webkit.org/270084@main">https://commits.webkit.org/270084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14fe3dc886a524327d31f7314615367d4eefe0b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3089 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/25804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26666 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/524 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24784 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/25804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/25804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/27253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/21340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/25804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23815 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31223 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/25804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6851 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31191 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3126 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/6525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->