### PR TITLE
heap-use-after-free | Style::Scope::removeStyleSheetCandidateNode; WebCore::SVGStyleElement::~SVGStyleElement; WebCore::ContainerNode::~ContainerNode

### DIFF
--- a/LayoutTests/fast/css/style-scope-destruction-crash-expected.txt
+++ b/LayoutTests/fast/css/style-scope-destruction-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/css/style-scope-destruction-crash.html
+++ b/LayoutTests/fast/css/style-scope-destruction-crash.html
@@ -1,0 +1,34 @@
+This test passes if it doesn't crash.
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function gc() {
+    if (window.GCController) {
+        GCController.collect();
+        return;
+    }
+   for(var i=0;i<100;i++) {
+       new Uint8Array(1024*1024);
+   }
+}
+
+function main() {
+    var v63 = x5.attachShadow({mode: "open", delegatesFocus: false});
+    x18.scrollTop;
+    v63.appendChild(x11);
+    gc();
+}
+</script>
+</head>
+
+<body onload="main()">
+<svg id="x11" id="x44" tabindex="-1">
+<animateTransform id="x18" 0.97 0.23 0" min="0.5s">
+</animateTransform>
+<clipPath id="x20" 8em id="x25" vector-effect="non-scaling-size" clip-path="url(#x20)" markerUnits="strokeWidth" 1 clip="rect(1em,auto,auto,546px)" patternUnits="userSpaceOnUse">
+<style width="0.20em" translate="no" draggable="true" itemref="x50" itemgroup="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">
+<blockquote id="x5" onfocusout="f3()">
+</pre>
+AAAA
+</content>

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -57,21 +57,15 @@ ReferencePathOperation::ReferencePathOperation(const String& url, const AtomStri
     : PathOperation(Reference)
     , m_url(url)
     , m_fragment(fragment)
-    , m_element(element)
 {
-    if (is<SVGPathElement>(m_element) || is<SVGGeometryElement>(m_element))
-        m_path = pathFromGraphicsElement(m_element.get());
+    if (is<SVGPathElement>(element) || is<SVGGeometryElement>(element))
+        m_path = pathFromGraphicsElement(element.get());
 }
 
 ReferencePathOperation::ReferencePathOperation(std::optional<Path>&& path)
     : PathOperation(Reference)
     , m_path(WTFMove(path))
 {
-}
-
-const SVGElement* ReferencePathOperation::element() const
-{
-    return m_element.get();
 }
 
 Ref<RayPathOperation> RayPathOperation::create(float angle, Size size, bool isContaining, LengthPoint&& position, CSSBoxType referenceBox)

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -90,7 +90,6 @@ public:
     Ref<PathOperation> clone() const final;
     const String& url() const { return m_url; }
     const AtomString& fragment() const { return m_fragment; }
-    const SVGElement* element() const;
     const std::optional<Path> getPath(const TransformOperationData&) const final { return m_path; }
     const std::optional<Path> path() const { return m_path; }
 private:
@@ -107,7 +106,6 @@ private:
 
     String m_url;
     AtomString m_fragment;
-    RefPtr<SVGElement> m_element;
     std::optional<Path> m_path;
 };
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -87,6 +87,7 @@ Scope::Scope(ShadowRoot& shadowRoot)
 Scope::~Scope()
 {
     ASSERT(!hasPendingSheets());
+    weakPtrFactory().revokeAll();
 }
 
 Resolver& Scope::resolver()


### PR DESCRIPTION
#### a926e4a4fe7fd5c7d7a4e209465c0e01b95a59e9
<pre>
heap-use-after-free | Style::Scope::removeStyleSheetCandidateNode; WebCore::SVGStyleElement::~SVGStyleElement; WebCore::ContainerNode::~ContainerNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=260896">https://bugs.webkit.org/show_bug.cgi?id=260896</a>
<a href="https://rdar.apple.com/114231775">rdar://114231775</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/style-scope-destruction-crash-expected.txt: Added.
* LayoutTests/fast/css/style-scope-destruction-crash.html: Added.
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ReferencePathOperation::ReferencePathOperation):
(WebCore::ReferencePathOperation::element const): Deleted.

Get rid of the unused element field. This creates a RenderStyle -&gt; DOM ownership cycle which
allows this crash to happen.

* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::~Scope):

Ensure we revoke weak pointers at the start of the destructor to avoid this class of problems.

Originally-landed-as: 265870.481@safari-7616-branch (382b02a5fc10). rdar://117809896
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a926e4a4fe7fd5c7d7a4e209465c0e01b95a59e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22952 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27251 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28319 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26112 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/140 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21878 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5908 "Failed to checkout and rebase branch from PR 19862") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->