### PR TITLE
[iOS] vimeo.com: Full screen, wide aspect-ratio videos are vertically offset

### DIFF
--- a/Source/WebCore/dom/Document+Fullscreen.idl
+++ b/Source/WebCore/dom/Document+Fullscreen.idl
@@ -27,6 +27,7 @@
 [
     Conditional=FULLSCREEN_API,
     EnabledBySetting=FullScreenEnabled,
+    DisabledByQuirk=shouldDisableElementFullscreen,
     ImplementedBy=DocumentFullscreen
 ] partial interface Document {
     [LegacyLenientSetter, EnabledBySetting=UnprefixedFullscreenAPIEnabled, ImplementedAs=fullscreenEnabled] readonly attribute boolean fullscreenEnabled;

--- a/Source/WebCore/dom/DocumentOrShadowRoot+Fullscreen.idl
+++ b/Source/WebCore/dom/DocumentOrShadowRoot+Fullscreen.idl
@@ -27,6 +27,7 @@
 [
     Conditional=FULLSCREEN_API,
     EnabledBySetting=UnprefixedFullscreenAPIEnabled,
+    DisabledByQuirk=shouldDisableElementFullscreen,
     ImplementedBy=DocumentOrShadowRootFullscreen
 ] partial interface mixin DocumentOrShadowRoot {
     [LegacyLenientSetter] readonly attribute Element? fullscreenElement;

--- a/Source/WebCore/dom/Element+Fullscreen.idl
+++ b/Source/WebCore/dom/Element+Fullscreen.idl
@@ -26,7 +26,8 @@
 // https://fullscreen.spec.whatwg.org/#api
 [
     Conditional=FULLSCREEN_API,
-    EnabledBySetting=FullScreenEnabled
+    EnabledBySetting=FullScreenEnabled,
+    DisabledByQuirk=shouldDisableElementFullscreen
 ] partial interface Element {
     [EnabledBySetting=UnprefixedFullscreenAPIEnabled] Promise<undefined> requestFullscreen(optional FullscreenOptions options = {});
     [EnabledBySetting=UnprefixedFullscreenAPIEnabled] attribute EventHandler onfullscreenchange;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -368,6 +368,23 @@ bool Quirks::shouldAvoidUsingIOS17UserAgentForFacebook() const
 #endif
 }
 
+bool Quirks::shouldDisableElementFullscreenQuirk() const
+{
+#if PLATFORM(IOS_FAMILY)
+    if (!needsQuirks())
+        return false;
+
+    // Vimeo.com has incorrect layout on iOS on certain videos with wider
+    // aspect ratios than the device's screen in landscape mode.
+    // (Ref: rdar://116531089)
+    if (!m_shouldDisableElementFullscreen)
+        m_shouldDisableElementFullscreen = isDomain("vimeo.com"_s);
+    return m_shouldDisableElementFullscreen.value();
+#else
+    return false;
+#endif
+}
+
 #if ENABLE(TOUCH_EVENTS)
 bool Quirks::isAmazon() const
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -177,6 +177,8 @@ public:
 
     bool needsDisableDOMPasteAccessQuirk() const;
 
+    bool shouldDisableElementFullscreenQuirk() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;
@@ -241,6 +243,7 @@ private:
     mutable std::optional<bool> m_shouldDisableDataURLPaddingValidation;
     mutable std::optional<bool> m_needsDisableDOMPasteAccessQuirk;
     mutable std::optional<bool> m_shouldAvoidUsingIOS17UserAgentForFacebook;
+    mutable std::optional<bool> m_shouldDisableElementFullscreen;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9af6b6771f33582f16c25548dfa26c6ae11ae990
<pre>
[iOS] vimeo.com: Full screen, wide aspect-ratio videos are vertically offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=264059">https://bugs.webkit.org/show_bug.cgi?id=264059</a>
<a href="https://rdar.apple.com/116531089">rdar://116531089</a>

Reviewed by Andy Estes.

Add a quirk which disables Element Fullscreen for Vimeo.com.

* Source/WebCore/dom/Document+Fullscreen.idl:
* Source/WebCore/dom/DocumentOrShadowRoot+Fullscreen.idl:
* Source/WebCore/dom/Element+Fullscreen.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldAvoidUsingIOS17UserAgentForFacebook const):
(WebCore::Quirks::shouldDisableElementFullscreenQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/270116@main">https://commits.webkit.org/270116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b539330cf4f3fb9fc2bd0efce00e3957869ec7c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27257 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28322 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26115 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/141 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3122 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->