### PR TITLE
WebKit Cursor Pulsing is too slow while dictating

### DIFF
--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -40,8 +40,9 @@ static constexpr size_t dictationCaretAnimatorUpdateRate = 60;
 
 static constexpr KeyFrame keyframe(size_t i)
 {
-    i %= dictationCaretAnimatorUpdateRate;
-    constexpr float inverseFrameRate = 1.f / static_cast<float>(dictationCaretAnimatorUpdateRate);
+    constexpr auto updateRate = 40;
+    i %= updateRate;
+    constexpr float inverseFrameRate = 1.f / static_cast<float>(updateRate);
     return KeyFrame { Seconds(i * inverseFrameRate), fabs(sinf(static_cast<float>(M_PI * i * inverseFrameRate))) };
 }
 
@@ -158,7 +159,7 @@ void DictationCaretAnimator::updateAnimationProperties()
 
         m_currentKeyframeIndex++;
         updateGlowTail(elapsedTime);
-        constexpr auto scaleAnimationSpeed = 2.f;
+        constexpr auto scaleAnimationSpeed = 4.f;
         m_initialScale = std::max(0.f, m_initialScale - scaleAnimationSpeed * static_cast<float>(elapsedTime.value()));
 
         m_blinkTimer.startOneShot(keyframeTimeDelta());
@@ -280,7 +281,7 @@ FloatRoundedRect DictationCaretAnimator::expandedCaretRect(const FloatRect& rect
     auto extraScaleFactor = 1.f;
     auto pulseExpansion = 1.f;
     if (m_initialScale > 0.f)
-        extraScaleFactor = 1.f + sinf(2.f * m_initialScale);
+        extraScaleFactor = 1.f + 1.4f * sinf(2.f * m_initialScale);
     else
         pulseExpansion = 0.75f * m_presentationProperties.opacity * extraScaleFactor;
 


### PR DESCRIPTION
#### 3666f20911e03c5ffeeebaaec35cb2a0e303b92b
<pre>
WebKit Cursor Pulsing is too slow while dictating
<a href="https://bugs.webkit.org/show_bug.cgi?id=264061">https://bugs.webkit.org/show_bug.cgi?id=264061</a>
&lt;radar://111583491&gt;

Reviewed by Aditya Keerthi.

Refine the animation so it matches Messages.

* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::keyframe):
Decouple the pulse speed from the animation rate.

(WebCore::DictationCaretAnimator::updateAnimationProperties):
The initial pulse is shorter in Messages, shorten it in WebKit to match.

(WebCore::DictationCaretAnimator::expandedCaretRect const):
Adjust how much the cursor expands during the initial pulse animation.

Canonical link: <a href="https://commits.webkit.org/270138@main">https://commits.webkit.org/270138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a366f83bfc2ad4bd79f0979c0668b77db710cc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22563 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27260 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28323 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26116 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1815 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3125 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5909 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->