### PR TITLE
Unreviewed, fix iOS production builds after 270071@main

### DIFF
--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 		2E63EDA61891BDC0002A7AFC /* TestRunner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCC9981711D3F51E0017BCA2 /* TestRunner.cpp */; };
 		2E749BF21891EBFA007FC175 /* EventSenderProxyIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E63ED7A1891ACE9002A7AFC /* EventSenderProxyIOS.mm */; };
 		31DA8A3D1E7205CC00E1DF2F /* IOSLayoutTestCommunication.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3148A0531E6F85B600D3B316 /* IOSLayoutTestCommunication.cpp */; };
-		33558B2D2AF1BF600041E63F /* WPTFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C7881F250C69E400C0AA24 /* WPTFunctions.cpp */; };
 		33558B2E2AF1C22B0041E63F /* WPTFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C7881F250C69E400C0AA24 /* WPTFunctions.cpp */; };
 		41C5378E21F13414008B1FAD /* TestWebsiteDataStoreDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41C5378D21F1333C008B1FAD /* TestWebsiteDataStoreDelegate.mm */; };
 		41D5B62622DD9D36000F4C4A /* FakeHelvetica-SingleExtendedCharacter.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D5B62522DD9D36000F4C4A /* FakeHelvetica-SingleExtendedCharacter.ttf */; };
@@ -1265,7 +1264,6 @@
 				E132AA3D17CE776F00611DF0 /* WebKitTestRunnerEvent.mm in Sources */,
 				E1C642C617CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm in Sources */,
 				9376417A210D737200A3DAAE /* WebKitTestRunnerWindow.mm in Sources */,
-				33558B2D2AF1BF600041E63F /* WPTFunctions.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
#### d31887d84bdcc60ea1bbeee66b1006fae4e16cb4
<pre>
Unreviewed, fix iOS production builds after 270071@main

Fix the following build error:
```
Undefined symbols for architecture arm64e:
  &quot;_JSContextGetGlobalObject&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
      WTR::hasTestWaitAttribute(OpaqueJSContext*) in WPTFunctions.o
  &quot;_JSObjectMake&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
  &quot;_JSValueProtect&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
  &quot;_JSValueToBoolean&quot;, referenced from:
      WTR::hasTestWaitAttribute(OpaqueJSContext*) in WPTFunctions.o
  &quot;_JSValueUnprotect&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
  &quot;WTR::setProperty(OpaqueJSContext const*, OpaqueJSValue*, char const*, bool)&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
  &quot;WTR::objectProperty(OpaqueJSContext const*, OpaqueJSValue*, std::initializer_list&lt;char const*&gt;)&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o

 WTR::hasTestWaitAttribute(OpaqueJSContext*) in WPTFunctions.o
  &quot;WTR::callConstructor(OpaqueJSContext*, char const*, std::initializer_list&lt;OpaqueJSValue const*&gt;)&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
  &quot;WTR::call(OpaqueJSContext const*, OpaqueJSValue*, char const*, std::initializer_list&lt;OpaqueJSValue const*&gt;)&quot;, refe
renced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
      WTR::hasTestWaitAttribute(OpaqueJSContext*) in WPTFunctions.o
  &quot;WTR::makeValue(OpaqueJSContext const*, char const*)&quot;, referenced from:
      WTR::sendTestRenderedEvent(OpaqueJSContext*) in WPTFunctions.o
      WTR::hasTestWaitAttribute(OpaqueJSContext*) in WPTFunctions.o
  &quot;WTF::URL::host() const&quot;, referenced from:
      WTR::isWebPlatformTestURL(WTF::URL const&amp;) in WPTFunctions.o
  &quot;WTF::URL::port() const&quot;, referenced from:
      WTR::isWebPlatformTestURL(WTF::URL const&amp;) in WPTFunctions.o
ld: symbol(s) not found for architecture arm64e
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

...by removing `WPTFunctions.o` from the `WebKitTestRunner` binary
target. This is the correct thing to do because we pull in the symbols
in the `WPTFunctions` TU through the `WebKitTestRunnerLibrary` target
anyways, and because we don&apos;t link against WTF/JSC/etc. when building
the `WebKitTestRunner` binary on iOS.

* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270093@main">https://commits.webkit.org/270093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a59712470b981b94d0db29c43f57b0d771a97ff1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3100 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/25815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26677 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/536 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24796 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/25815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/25815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/27264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/25815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/25815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3129 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->