### PR TITLE
Refactor RevealItem to replace RVItem for IPC messaging

### DIFF
--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -397,9 +397,7 @@ std::tuple<NSString *, NSDictionary *> DictionaryLookup::stringForPDFSelection(P
     auto fullPlainTextString = [selectionForLookup string];
     auto rangeToPass = NSMakeRange(charactersAddedBeforeStart, 0);
 
-    auto item = adoptNS([PAL::allocRVItemInstance() initWithText:fullPlainTextString selectedRange:rangeToPass]);
-    NSRange extractedRange = item.get().highlightRange;
-    
+    NSRange extractedRange = adoptNS([PAL::allocRVItemInstance() initWithText:fullPlainTextString selectedRange:rangeToPass]).get().highlightRange;
     if (extractedRange.location == NSNotFound)
         return { selection.string, nil };
 

--- a/Source/WebKit/Shared/Cocoa/RevealItem.h
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.h
@@ -27,24 +27,44 @@
 
 #if ENABLE(REVEAL)
 
-#import "ArgumentCoders.h"
-
 #import <wtf/RetainPtr.h>
 
 OBJC_CLASS RVItem;
 
+typedef struct _NSRange NSRange;
+typedef unsigned long NSUInteger;
+
 namespace WebKit {
 
+struct RevealItemRange {
+    RevealItemRange() = default;
+    RevealItemRange(NSRange);
+    RevealItemRange(NSUInteger loc, NSUInteger len)
+        : location(loc)
+        , length(len)
+    {
+    }
+
+    NSUInteger location { 0 };
+    NSUInteger length { 0 };
+};
+
 class RevealItem {
-    
 public:
     RevealItem() = default;
-    RevealItem(RetainPtr<RVItem>&&);
-    
-    RVItem *item() const { return m_item.get(); }
+    RevealItem(const String& text, RevealItemRange selectedRange);
+
+    const String& text() const { return m_text; }
+    const RevealItemRange& selectedRange() const { return m_selectedRange; }
+    NSRange highlightRange() const;
+
+    RVItem *item() const;
+
 private:
-    friend struct IPC::ArgumentCoder<RevealItem, void>;
-    RetainPtr<RVItem> m_item;
+    String m_text;
+    RevealItemRange m_selectedRange;
+
+    mutable RetainPtr<RVItem> m_item;
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/RevealItem.mm
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.mm
@@ -34,11 +34,30 @@ namespace WebKit {
 
 #if ENABLE(REVEAL)
 
-RevealItem::RevealItem(RetainPtr<RVItem>&& item)
-    : m_item { WTFMove(item) }
+RevealItemRange::RevealItemRange(NSRange range)
+    : location(range.location)
+    , length(range.length)
 {
 }
 
-#endif
-
+RevealItem::RevealItem(const String& text, RevealItemRange selectedRange)
+    : m_text(text)
+    , m_selectedRange(selectedRange)
+{
 }
+
+NSRange RevealItem::highlightRange() const
+{
+    return item().highlightRange;
+}
+
+RVItem *RevealItem::item() const
+{
+    if (!m_item)
+        m_item = adoptNS([PAL::allocRVItemInstance() initWithText:m_text selectedRange:NSMakeRange(m_selectedRange.location, m_selectedRange.length)]);
+    return m_item.get();
+}
+
+#endif // ENABLE(REVEAL)
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/RevealItem.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.serialization.in
@@ -20,12 +20,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-headers: <pal/cocoa/RevealSoftLink.h>
+webkit_platform_headers: "RevealItem.h" <pal/cocoa/RevealSoftLink.h>
 
 #if ENABLE(REVEAL)
 
+[WebKitPlatform, CustomHeader] struct WebKit::RevealItemRange {
+    NSUInteger location;
+    NSUInteger length;
+}
+
 class WebKit::RevealItem {
-    [SecureCodingAllowed=[PAL::getRVItemClass()]] RetainPtr<RVItem> m_item;
+    String text();
+    WebKit::RevealItemRange selectedRange();
 };
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -155,7 +155,6 @@ OBJC_CLASS NSDictionary;
 OBJC_CLASS NSObject;
 OBJC_CLASS PDFDocument;
 OBJC_CLASS PDFSelection;
-OBJC_CLASS RVItem;
 OBJC_CLASS WKAccessibilityWebPageObject;
 #endif
 
@@ -877,8 +876,8 @@ public:
     void updateSelectionWithExtentPointAndBoundary(const WebCore::IntPoint&, WebCore::TextGranularity, bool isInteractingWithFocusedElement, CompletionHandler<void(bool)>&&);
 
 #if ENABLE(REVEAL)
-    RetainPtr<RVItem> revealItemForCurrentSelection();
-    void requestRVItemInCurrentSelectedRange(CompletionHandler<void(const WebKit::RevealItem&)>&&);
+    RevealItem revealItemForCurrentSelection();
+    void requestRVItemInCurrentSelectedRange(CompletionHandler<void(const RevealItem&)>&&);
     void prepareSelectionForContextMenuWithLocationInView(WebCore::IntPoint, CompletionHandler<void(bool, const RevealItem&)>&&);
 #endif
     void willInsertFinalDictationResult();

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2434,11 +2434,10 @@ void WebPage::updateSelectionWithExtentPoint(const WebCore::IntPoint& point, boo
 }
 
 #if ENABLE(REVEAL)
-RetainPtr<RVItem> WebPage::revealItemForCurrentSelection()
+RevealItem WebPage::revealItemForCurrentSelection()
 {
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
     auto selection = frame->selection().selection();
-    RetainPtr<RVItem> item;
     if (!selection.isNone()) {
         std::optional<SimpleRange> fullCharacterRange;
         if (selection.isRange()) {
@@ -2453,11 +2452,11 @@ RetainPtr<RVItem> WebPage::revealItemForCurrentSelection()
             if (fullCharacterRange) {
                 auto selectionRange = NSMakeRange(characterCount(*makeSimpleRange(fullCharacterRange->start, selectionStart)), characterCount(*makeSimpleRange(selectionStart, selectionEnd)));
                 String itemString = plainText(*fullCharacterRange);
-                item = adoptNS([PAL::allocRVItemInstance() initWithText:itemString selectedRange:selectionRange]);
+                return { itemString, selectionRange };
             }
         }
     }
-    return item;
+    return { };
 }
 
 void WebPage::requestRVItemInCurrentSelectedRange(CompletionHandler<void(const WebKit::RevealItem&)>&& completionHandler)


### PR DESCRIPTION
#### 413e473787ebd7cd36840613a9a3d6216ab18c6b
<pre>
Refactor RevealItem to replace RVItem for IPC messaging
<a href="https://bugs.webkit.org/show_bug.cgi?id=264065">https://bugs.webkit.org/show_bug.cgi?id=264065</a>
<a href="https://rdar.apple.com/117822336">rdar://117822336</a>

Reviewed by Megan Gardner.

The only RVItems that RevealItem every serialized for IPC were created internally with text and a range.
This patch changes serializing the RVItem to simply serializing the text and range.

* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
* Source/WebKit/Shared/Cocoa/RevealItem.h:
(WebKit::RevealItemRange::RevealItemRange):
(WebKit::RevealItem::text const):
(WebKit::RevealItem::selectedRange const):
(WebKit::RevealItem::item const): Deleted.
* Source/WebKit/Shared/Cocoa/RevealItem.mm:
(WebKit::RevealItemRange::RevealItemRange):
(WebKit::RevealItem::RevealItem):
(WebKit::RevealItem::highlightRange const):
(WebKit::RevealItem::item const):
* Source/WebKit/Shared/Cocoa/RevealItem.serialization.in:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::revealItemForCurrentSelection):

Canonical link: <a href="https://commits.webkit.org/270131@main">https://commits.webkit.org/270131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6eec41475e420eb4d179a105704dfc300a206097

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26685 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22966 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27268 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28328 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/160 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3135 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5902 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->