### PR TITLE
Add --release and --debug arguments to run-web-platform-tests

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/wpt_runner.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_runner.py
@@ -99,6 +99,10 @@ def parse_args(args):
                              help='Alias for --platform=gtk')
     option_parser.add_option('--wpe', action='store_const', dest='platform', const='wpe',
                              help='Alias for --platform=wpe')
+    option_parser.add_option('--release', action='store_const', dest='configuration', const='Release',
+                             help='Set the configuration to Release')
+    option_parser.add_option('--debug', action='store_const', dest='configuration', const='Debug',
+                             help='Set the configuration to Debug')
     option_parser.add_option('--child-processes',
                              help='Number of tests to run in parallel'),
     option_parser.add_option('--wpt-checkout', default=None,


### PR DESCRIPTION
#### 8dedd163435d472ee13f0a06b2b1c64b92f3ddef
<pre>
Add --release and --debug arguments to run-web-platform-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=264066">https://bugs.webkit.org/show_bug.cgi?id=264066</a>

Reviewed by Michael Catanzaro.

Previously, run-web-platform-tests was hardcoded to use a release build.
This adds --release and --debug arguments similar to other scripts, to
allow selecting a debug build.

* Tools/Scripts/webkitpy/w3c/wpt_runner.py:
(parse_args): Add --release and --debug arguments.

Canonical link: <a href="https://commits.webkit.org/270113@main">https://commits.webkit.org/270113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2556d6d23bd1bac8be70e323742e34b928cedcb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27273 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/24732 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28332 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26128 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1831 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3140 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5894 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->