### PR TITLE
[webkitcorepy] Share log level with child processes

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py
@@ -22,6 +22,7 @@
 
 import argparse
 import logging
+import os
 
 from webkitcorepy import log
 
@@ -58,14 +59,19 @@ def CallbackAction(action, callback=lambda namespace: None):
     return Action
 
 
-def LoggingGroup(parser, loggers=None, default=logging.WARNING, help='{} amount of logging'):
+def LoggingGroup(parser, loggers=None, default=logging.WARNING, getenv=True, setenv=True, help='{} amount of logging'):
     if not isinstance(parser, argparse.ArgumentParser):
         raise ValueError('Provided parser is not a {}'.format(type(argparse.ArgumentParser)))
+
+    if getenv and 'LOG_LEVEL' in os.environ:
+        default = int(os.environ['LOG_LEVEL'])
 
     if not loggers:
         loggers = [logging.getLogger(), log]
     for logger in loggers:
         logger.setLevel(default)
+    if setenv:
+        os.environ['LOG_LEVEL'] = str(default)
 
     def verbose_callback(namespace):
         verbosity = getattr(namespace, 'verbose')
@@ -75,6 +81,8 @@ def LoggingGroup(parser, loggers=None, default=logging.WARNING, help='{} amount 
 
         for logger in loggers:
             logger.setLevel(log_level)
+        if setenv:
+            os.environ['LOG_LEVEL'] = str(log_level)
 
     group = parser.add_argument_group('Logging')
     group.add_argument(


### PR DESCRIPTION
#### 9d798c2e474022621381c3a6b4cf5729d1d2be4d
<pre>
[webkitcorepy] Share log level with child processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=264072">https://bugs.webkit.org/show_bug.cgi?id=264072</a>
<a href="https://rdar.apple.com/117826312">rdar://117826312</a>

Reviewed by NOBODY (OOPS!).

Set a LOG_LEVEL environment variable when parsing --verbose/--quiet
arguments with arguments.LoggingGroup. When this variable is present,
it overides the default log level.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/arguments.py:
(LoggingGroup):
(LoggingGroup.verbose_callback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d798c2e474022621381c3a6b4cf5729d1d2be4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22970 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27283 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/24742 "Found 26 webkitpy python3 test failures: webkitscmpy.test.canonicalize_unittest.TestCanonicalize.test_branch_commits, webkitscmpy.test.canonicalize_unittest.TestCanonicalize.test_formated_identifier, webkitscmpy.test.canonicalize_unittest.TestCanonicalize.test_number, webkitscmpy.test.install_git_lfs_unittest.TestInstallGitLFS.test_configure, webkitscmpy.test.install_hooks_unittest.TestInstallHooks.test_security_level_addition, webkitscmpy.test.land_unittest.TestLand.test_canonicalize, webkitscmpy.test.land_unittest.TestLand.test_canonicalize_with_bugzilla, webkitscmpy.test.land_unittest.TestLand.test_default_with_radar, webkitscmpy.test.land_unittest.TestLand.test_svn_with_bugzilla, webkitscmpy.test.land_unittest.TestLand.test_with_oops ...") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28338 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26134 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/159 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/24344 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->