### PR TITLE
WebCore::ProcessingUserGestureState should be an enum class

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -680,7 +680,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
             return;
         auto& mediaElement = *strongThis->m_mediaElement;
 
-        UserGestureIndicator gestureIndicator(ProcessingUserGesture, &mediaElement.document());
+        UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &mediaElement.document());
 
         auto selectedItem = idMap.get(selectedItemID);
         WTF::switchOn(selectedItem,

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -288,7 +288,7 @@ bool MediaSession::callActionHandler(const MediaSessionActionDetails& actionDeta
     if (handler) {
         std::optional<UserGestureIndicator> maybeGestureIndicator;
         if (triggerGestureIndicator == TriggerGestureIndicator::Yes)
-            maybeGestureIndicator.emplace(ProcessingUserGesture, document());
+            maybeGestureIndicator.emplace(IsProcessingUserGesture::Yes, document());
         handler->handleEvent(actionDetails);
         return true;
     }

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1352,13 +1352,13 @@ void AccessibilityNodeObject::alterRangeValue(StepAction stepAction)
     
 void AccessibilityNodeObject::increment()
 {
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, document());
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document());
     alterRangeValue(StepAction::Increment);
 }
 
 void AccessibilityNodeObject::decrement()
 {
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, document());
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document());
     alterRangeValue(StepAction::Decrement);
 }
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1307,7 +1307,7 @@ bool AccessibilityObject::press()
     if (hitTestElement && hitTestElement->isDescendantOf(*pressElement))
         pressElement = hitTestElement;
     
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, document);
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document);
     
     bool dispatchedEvent = false;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -594,7 +594,7 @@ ValueOrException ScriptController::executeScriptInWorld(DOMWrapperWorld& world, 
     m_frame.loader().client().notifyPageOfAppBoundBehavior();
 #endif
 
-    UserGestureIndicator gestureIndicator(parameters.forceUserGesture == ForceUserGesture::Yes ? std::optional<ProcessingUserGestureState>(ProcessingUserGesture) : std::nullopt, m_frame.document(), UserGestureType::ActivationTriggering, UserGestureIndicator::ProcessInteractionStyle::Never);
+    UserGestureIndicator gestureIndicator(parameters.forceUserGesture == ForceUserGesture::Yes ? std::optional<IsProcessingUserGesture>(IsProcessingUserGesture::Yes) : std::nullopt, m_frame.document(), UserGestureType::ActivationTriggering, UserGestureIndicator::ProcessInteractionStyle::Never);
 
     if (parameters.forceUserGesture == ForceUserGesture::Yes && UserGestureIndicator::currentUserGesture() && parameters.removeTransientActivation == RemoveTransientActivation::Yes) {
         UserGestureIndicator::currentUserGesture()->addDestructionObserver([](UserGestureToken& token) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9460,7 +9460,7 @@ void Document::dispatchSystemPreviewActionEvent(const SystemPreviewInfo& systemP
         return;
 
     auto event = MessageEvent::create(message, securityOrigin().toString());
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, this);
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, this);
     element->dispatchEvent(event);
 }
 #endif

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -309,7 +309,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
 
 void DocumentStorageAccess::enableTemporaryTimeUserGesture()
 {
-    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(ProcessingUserGesture, protectedDocument().ptr());
+    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(IsProcessingUserGesture::Yes, protectedDocument().ptr());
 }
 
 void DocumentStorageAccess::consumeTemporaryTimeUserGesture()

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -44,8 +44,8 @@ static RefPtr<UserGestureToken>& currentToken()
     return token;
 }
 
-UserGestureToken::UserGestureToken(ProcessingUserGestureState state, UserGestureType gestureType, Document* document, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
-    : m_state(state)
+UserGestureToken::UserGestureToken(IsProcessingUserGesture isProcessingUserGesture, UserGestureType gestureType, Document* document, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
+    : m_isProcessingUserGesture(isProcessingUserGesture)
     , m_gestureType(gestureType)
     , m_canRequestDOMPaste(canRequestDOMPaste)
     , m_authorizationToken(authorizationToken)
@@ -107,15 +107,15 @@ void UserGestureToken::forEachImpactedDocument(Function<void(Document&)>&& funct
     m_documentsImpactedByUserGesture.forEach(function);
 }
 
-UserGestureIndicator::UserGestureIndicator(std::optional<ProcessingUserGestureState> state, Document* document, UserGestureType gestureType, ProcessInteractionStyle processInteractionStyle, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
+UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture> isProcessingUserGesture, Document* document, UserGestureType gestureType, ProcessInteractionStyle processInteractionStyle, std::optional<WTF::UUID> authorizationToken, CanRequestDOMPaste canRequestDOMPaste)
     : m_previousToken { currentToken() }
 {
     ASSERT(isMainThread());
 
-    if (state)
-        currentToken() = UserGestureToken::create(state.value(), gestureType, document, authorizationToken, canRequestDOMPaste);
+    if (isProcessingUserGesture)
+        currentToken() = UserGestureToken::create(isProcessingUserGesture.value(), gestureType, document, authorizationToken, canRequestDOMPaste);
 
-    if (state && document && currentToken()->processingUserGesture()) {
+    if (isProcessingUserGesture && document && currentToken()->processingUserGesture()) {
         document->updateLastHandledUserGestureTimestamp(currentToken()->startTime());
         if (processInteractionStyle == ProcessInteractionStyle::Immediate)
             ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(document->topDocument());

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8445,7 +8445,7 @@ void HTMLMediaElement::didReceiveRemoteControlCommand(PlatformMediaSession::Remo
 {
     ALWAYS_LOG(LOGIDENTIFIER, command);
 
-    UserGestureIndicator remoteControlUserGesture(ProcessingUserGesture, &document());
+    UserGestureIndicator remoteControlUserGesture(IsProcessingUserGesture::Yes, &document());
     const double defaultSkipAmount = 15;
     switch (command) {
     case PlatformMediaSession::RemoteControlCommandType::PlayCommand:

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -284,7 +284,7 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
         return;
     Ref mainFrame = *localMainFrame;
 
-    UserGestureIndicator indicator { ProcessingUserGesture, mainFrame->document() };
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, mainFrame->document() };
 
     FrameLoadRequest frameLoadRequest { *mainFrame->document(), mainFrame->document()->securityOrigin(), { }, blankTargetFrameName(), InitiatedByMainFrame::Unknown };
 

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -124,7 +124,7 @@ private:
     void contextMenuItemSelected(ContextMenuAction action, const String&) override
     {
         if (m_frontendHost) {
-            UserGestureIndicator gestureIndicator(ProcessingUserGesture, dynamicDowncast<Document>(executionContext(m_globalObject)));
+            UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, dynamicDowncast<Document>(executionContext(m_globalObject)));
             int itemNumber = action - ContextMenuItemBaseCustomTag;
 
             ScriptFunctionCall function(m_globalObject, m_frontendApiObject.get(), "contextMenuItemSelected"_s, WebCore::functionCallHandlerFromAnyThread);

--- a/Source/WebCore/inspector/UserGestureEmulationScope.cpp
+++ b/Source/WebCore/inspector/UserGestureEmulationScope.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 UserGestureEmulationScope::UserGestureEmulationScope(Page& inspectedPage, bool emulateUserGesture, Document* document)
     : m_pageChromeClient(inspectedPage.chrome().client())
-    , m_gestureIndicator(emulateUserGesture ? std::optional<ProcessingUserGestureState>(ProcessingUserGesture) : std::nullopt, document)
+    , m_gestureIndicator(emulateUserGesture ? std::optional<IsProcessingUserGesture>(IsProcessingUserGesture::Yes) : std::nullopt, document)
     , m_emulateUserGesture(emulateUserGesture)
     , m_userWasInteracting(false)
 {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -426,7 +426,7 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::navigate(const String& url)
     if (!localMainFrame)
         return { };
 
-    UserGestureIndicator indicator { ProcessingUserGesture, localMainFrame->document() };
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, localMainFrame->document() };
 
     ResourceRequest resourceRequest { localMainFrame->document()->completeURL(url) };
     FrameLoadRequest frameLoadRequest { *localMainFrame->document(), localMainFrame->document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1794,7 +1794,7 @@ HandleMouseEventResult EventHandler::handleMousePressEvent(const PlatformMouseEv
         return true;
 #endif
 
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent));
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent));
 
     // FIXME (bug 68185): this call should be made at another abstraction layer
     frame->checkedLoader()->resetMultipleFormSubmissionProtection();
@@ -1946,7 +1946,7 @@ bool EventHandler::handleMouseDoubleClickEvent(const PlatformMouseEvent& platfor
 
     frame->selection().setCaretBlinkingSuspended(false);
 
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent));
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent));
 
 #if ENABLE(POINTER_LOCK)
     if (frame->page()->pointerLockController().isLocked()) {
@@ -2261,7 +2261,7 @@ HandleMouseEventResult EventHandler::handleMouseReleaseEvent(const PlatformMouse
         return true;
 #endif
 
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent), UserGestureIndicator::ProcessInteractionStyle::Immediate, platformMouseEvent.authorizationToken());
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent), UserGestureIndicator::ProcessInteractionStyle::Immediate, platformMouseEvent.authorizationToken());
 
 #if ENABLE(PAN_SCROLLING)
     m_autoscrollController->handleMouseReleaseEvent(platformMouseEvent);
@@ -3783,7 +3783,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     UserGestureType gestureType = userGestureTypeForPlatformEvent(initialKeyEvent);
 
     auto canRequestDOMPaste = frame->protectedDocument()->quirks().needsDisableDOMPasteAccessQuirk() ? CanRequestDOMPaste::No : CanRequestDOMPaste::Yes;
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, frame->protectedDocument().get(), gestureType, UserGestureIndicator::ProcessInteractionStyle::Delayed, std::nullopt, canRequestDOMPaste);
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), gestureType, UserGestureIndicator::ProcessInteractionStyle::Delayed, std::nullopt, canRequestDOMPaste);
     UserTypingGestureIndicator typingGestureIndicator(frame);
 
     // FIXME (bug 68185): this call should be made at another abstraction layer
@@ -4862,7 +4862,7 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
 
     const Vector<PlatformTouchPoint>& points = event.touchPoints();
 
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(event));
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(event));
 
     bool freshTouchEvents = true;
     bool allTouchReleased = true;

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -249,7 +249,7 @@ void VideoPresentationModelVideoElement::fullscreenModeChanged(HTMLMediaElementE
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoFullscreenMode);
     if (m_videoElement) {
-        UserGestureIndicator gestureIndicator(ProcessingUserGesture, &m_videoElement->document());
+        UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &m_videoElement->document());
         m_videoElement->setPresentationMode(HTMLVideoElement::toPresentationMode(videoFullscreenMode));
     }
 }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -516,7 +516,7 @@ void HitTestResult::toggleMediaFullscreenState() const
 #if ENABLE(VIDEO)
     if (HTMLMediaElement* mediaElement = this->mediaElement()) {
         if (mediaElement->isVideo() && mediaElement->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard)) {
-            UserGestureIndicator indicator(ProcessingUserGesture, &mediaElement->document());
+            UserGestureIndicator indicator(IsProcessingUserGesture::Yes, &mediaElement->document());
             mediaElement->toggleStandardFullscreenState();
         }
     }
@@ -530,7 +530,7 @@ void HitTestResult::enterFullscreenForVideo() const
     if (is<HTMLVideoElement>(mediaElement)) {
         HTMLVideoElement& videoElement = downcast<HTMLVideoElement>(*mediaElement);
         if (!videoElement.isFullscreen() && mediaElement->supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard)) {
-            UserGestureIndicator indicator(ProcessingUserGesture, &mediaElement->document());
+            UserGestureIndicator indicator(IsProcessingUserGesture::Yes, &mediaElement->document());
             videoElement.webkitEnterFullscreen();
         }
     }
@@ -855,7 +855,7 @@ void HitTestResult::toggleEnhancedFullscreenForVideo() const
         return;
 
     HTMLVideoElement& videoElement = downcast<HTMLVideoElement>(*mediaElement);
-    UserGestureIndicator indicator(ProcessingUserGesture, &mediaElement->document());
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes, &mediaElement->document());
     if (videoElement.webkitPresentationMode() == HTMLVideoElement::VideoPresentationMode::PictureInPicture)
         videoElement.webkitSetPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
     else

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5430,13 +5430,13 @@ bool Internals::isProcessingUserGesture()
 
 void Internals::withUserGesture(RefPtr<VoidCallback>&& callback)
 {
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, contextDocument());
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, contextDocument());
     callback->handleEvent();
 }
 
 void Internals::withoutUserGesture(RefPtr<VoidCallback>&& callback)
 {
-    UserGestureIndicator gestureIndicator(NotProcessingUserGesture, contextDocument());
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::No, contextDocument());
     callback->handleEvent();
 }
 

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -110,7 +110,7 @@ void WebXRTest::simulateUserActivation(Document& document, XRSimulateUserActivat
 {
     // https://immersive-web.github.io/webxr-test-api/#dom-xrtest-simulateuseractivation
     // Invoke function as if it had transient activation.
-    UserGestureIndicator gestureIndicator(ProcessingUserGesture, &document);
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &document);
     function.handleEvent();
 }
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -378,7 +378,7 @@ void WebFullScreenManager::requestRestoreFullScreen()
     }
 
     ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
-    WebCore::UserGestureIndicator gestureIndicator(WebCore::ProcessingUserGesture, &element->document());
+    WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, &element->document());
     element->document().fullscreenManager().requestFullscreenForElement(*element, nullptr, WebCore::FullscreenManager::ExemptIFrameAllowFullscreenRequirement);
 }
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -268,7 +268,7 @@ void WebNotificationManager::didClickNotification(const WTF::UUID& notificationI
 
         // Indicate that this event is being dispatched in reaction to a user's interaction with a platform notification.
         if (isMainRunLoop()) {
-            UserGestureIndicator indicator(ProcessingUserGesture);
+            UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
             notification->dispatchClickEvent();
         } else
             notification->dispatchClickEvent();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -57,7 +57,7 @@ void WebContextMenuClient::searchWithGoogle(const WebCore::LocalFrame* frame)
     searchString = makeStringByReplacingAll(encodeWithURLEscapeSequences(searchString), "%20"_s, "+"_s);
     auto searchURL = URL { "https://www.google.com/search?q=" + searchString + "&ie=UTF-8&oe=UTF-8" };
 
-    WebCore::UserGestureIndicator indicator { WebCore::ProcessingUserGesture };
+    WebCore::UserGestureIndicator indicator { WebCore::IsProcessingUserGesture::Yes };
     auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
     if (!localMainFrame)
         return;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6524,7 +6524,7 @@ void WebPage::insertTextAsync(const String& text, const EditingRange& replacemen
 
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
 
-    UserGestureIndicator gestureIndicator { options.processingUserGesture ? ProcessingUserGesture : NotProcessingUserGesture, frame->document() };
+    UserGestureIndicator gestureIndicator { options.processingUserGesture ? IsProcessingUserGesture::Yes : IsProcessingUserGesture::No, frame->document() };
 
     bool replacesText = false;
     if (replacementEditingRange.location != notFound) {

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5088,7 +5088,7 @@ void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementCo
 
     // FIXME: Do not focus an element if it moved or the caret point is outside its bounds
     // because we only want to do so if the caret can be placed.
-    UserGestureIndicator gestureIndicator { ProcessingUserGesture, &target->document() };
+    UserGestureIndicator gestureIndicator { IsProcessingUserGesture::Yes, &target->document() };
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
     CheckedRef(m_page->focusController())->setFocusedElement(target.get(), targetFrame);
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -422,85 +422,85 @@ void PlaybackSessionManager::isPictureInPictureSupportedChanged(PlaybackSessionC
 
 void PlaybackSessionManager::play(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).play();
 }
 
 void PlaybackSessionManager::pause(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).pause();
 }
 
 void PlaybackSessionManager::togglePlayState(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).togglePlayState();
 }
 
 void PlaybackSessionManager::beginScrubbing(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).beginScrubbing();
 }
 
 void PlaybackSessionManager::endScrubbing(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).endScrubbing();
 }
 
 void PlaybackSessionManager::seekToTime(PlaybackSessionContextIdentifier contextId, double time, double toleranceBefore, double toleranceAfter)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).seekToTime(time, toleranceBefore, toleranceAfter);
 }
 
 void PlaybackSessionManager::fastSeek(PlaybackSessionContextIdentifier contextId, double time)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).fastSeek(time);
 }
 
 void PlaybackSessionManager::beginScanningForward(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).beginScanningForward();
 }
 
 void PlaybackSessionManager::beginScanningBackward(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).beginScanningBackward();
 }
 
 void PlaybackSessionManager::endScanning(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).endScanning();
 }
 
 void PlaybackSessionManager::setDefaultPlaybackRate(PlaybackSessionContextIdentifier contextId, float defaultPlaybackRate)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).setDefaultPlaybackRate(defaultPlaybackRate);
 }
 
 void PlaybackSessionManager::setPlaybackRate(PlaybackSessionContextIdentifier contextId, float playbackRate)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).setPlaybackRate(playbackRate);
 }
 
 void PlaybackSessionManager::selectAudioMediaOption(PlaybackSessionContextIdentifier contextId, uint64_t index)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).selectAudioMediaOption(index);
 }
 
 void PlaybackSessionManager::selectLegibleMediaOption(PlaybackSessionContextIdentifier contextId, uint64_t index)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).selectLegibleMediaOption(index);
 }
 
@@ -512,37 +512,37 @@ void PlaybackSessionManager::handleControlledElementIDRequest(PlaybackSessionCon
 
 void PlaybackSessionManager::togglePictureInPicture(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).togglePictureInPicture();
 }
 
 void PlaybackSessionManager::toggleMuted(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).toggleMuted();
 }
 
 void PlaybackSessionManager::setMuted(PlaybackSessionContextIdentifier contextId, bool muted)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).setMuted(muted);
 }
 
 void PlaybackSessionManager::setVolume(PlaybackSessionContextIdentifier contextId, double volume)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).setVolume(volume);
 }
 
 void PlaybackSessionManager::setPlayingOnSecondScreen(PlaybackSessionContextIdentifier contextId, bool value)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).setPlayingOnSecondScreen(value);
 }
 
 void PlaybackSessionManager::sendRemoteCommand(PlaybackSessionContextIdentifier contextId, WebCore::PlatformMediaSession::RemoteControlCommandType command, const WebCore::PlatformMediaSession::RemoteCommandArgument& argument)
 {
-    UserGestureIndicator indicator(ProcessingUserGesture);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).sendRemoteCommand(command, argument);
 }
 


### PR DESCRIPTION
#### 0dadce54c06a309fc5d01d6426151ed8f482f472
<pre>
WebCore::ProcessingUserGestureState should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=264073">https://bugs.webkit.org/show_bug.cgi?id=264073</a>
<a href="https://rdar.apple.com/117826651">rdar://117826651</a>

Reviewed by Wenson Hsieh.

This is a pretty mechanical patch that converts
`ProcessingUserGestureState` to an `enum class` and renames it
to `IsProcessingUserGesture`, such that the enum cases read more
naturally.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::callActionHandler):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::increment):
(WebCore::AccessibilityNodeObject::decrement):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::press):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeScriptInWorld):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchSystemPreviewActionEvent):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::enableTemporaryTimeUserGesture):
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureToken::UserGestureToken):
(WebCore::UserGestureIndicator::UserGestureIndicator):
* Source/WebCore/dom/UserGestureIndicator.h:
(WebCore::UserGestureToken::create):
(WebCore::UserGestureToken::isProcessingUserGesture const):
(WebCore::UserGestureToken::processingUserGesture const):
(WebCore::UserGestureToken::processingUserGestureForMedia const):
(WebCore::UserGestureToken::state const): Deleted.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::didReceiveRemoteControlCommand):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::openURLExternally):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
* Source/WebCore/inspector/UserGestureEmulationScope.cpp:
(WebCore::UserGestureEmulationScope::UserGestureEmulationScope):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::navigate):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::fullscreenModeChanged):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::toggleMediaFullscreenState const):
(WebCore::HitTestResult::enterFullscreenForVideo const):
(WebCore::HitTestResult::toggleEnhancedFullscreenForVideo const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::withUserGesture):
(WebCore::Internals::withoutUserGesture):
* Source/WebCore/testing/WebXRTest.cpp:
(WebCore::WebXRTest::simulateUserActivation):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::requestRestoreFullScreen):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::didClickNotification):
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
(WebKit::WebContextMenuClient::searchWithGoogle):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::insertTextAsync):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::play):
(WebKit::PlaybackSessionManager::pause):
(WebKit::PlaybackSessionManager::togglePlayState):
(WebKit::PlaybackSessionManager::beginScrubbing):
(WebKit::PlaybackSessionManager::endScrubbing):
(WebKit::PlaybackSessionManager::seekToTime):
(WebKit::PlaybackSessionManager::fastSeek):
(WebKit::PlaybackSessionManager::beginScanningForward):
(WebKit::PlaybackSessionManager::beginScanningBackward):
(WebKit::PlaybackSessionManager::endScanning):
(WebKit::PlaybackSessionManager::setDefaultPlaybackRate):
(WebKit::PlaybackSessionManager::setPlaybackRate):
(WebKit::PlaybackSessionManager::selectAudioMediaOption):
(WebKit::PlaybackSessionManager::selectLegibleMediaOption):
(WebKit::PlaybackSessionManager::togglePictureInPicture):
(WebKit::PlaybackSessionManager::toggleMuted):
(WebKit::PlaybackSessionManager::setMuted):
(WebKit::PlaybackSessionManager::setVolume):
(WebKit::PlaybackSessionManager::setPlayingOnSecondScreen):
(WebKit::PlaybackSessionManager::sendRemoteCommand):

Canonical link: <a href="https://commits.webkit.org/270124@main">https://commits.webkit.org/270124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64d13f0ea944cd6e87134482528531e394203da9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27285 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28342 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26138 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/161 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3147 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5901 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->