### PR TITLE
SVGTextMetricsBuilder::measureTextRenderer exhibits O(n^2) behavior

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -264,10 +264,7 @@ void RenderSVGText::willLayout()
 
     // Only update the metrics cache, but not the text positioning element cache
     // nor the layout attributes cached in the leaf #text renderers.
-    for (RenderObject* descendant = firstChild(); descendant; descendant = descendant->nextInPreOrder(this)) {
-        if (is<RenderSVGInlineText>(*descendant))
-            m_layoutAttributesBuilder.rebuildMetricsForTextRenderer(downcast<RenderSVGInlineText>(*descendant));
-    }
+    m_layoutAttributesBuilder.rebuildMetricsForSubtree(*this);
 }
 
 void RenderSVGText::subtreeTextDidChange(RenderSVGInlineText* text)
@@ -296,16 +293,16 @@ void RenderSVGText::subtreeTextDidChange(RenderSVGInlineText* text)
     }
 }
 
-static inline void updateFontInAllDescendants(RenderObject* start, SVGTextLayoutAttributesBuilder* builder = nullptr)
+static inline void updateFontInAllDescendants(RenderSVGText& text, SVGTextLayoutAttributesBuilder* builder = nullptr)
 {
-    for (RenderObject* descendant = start; descendant; descendant = descendant->nextInPreOrder(start)) {
+    for (RenderObject* descendant = &text; descendant; descendant = descendant->nextInPreOrder(&text)) {
         if (!is<RenderSVGInlineText>(*descendant))
             continue;
         auto& text = downcast<RenderSVGInlineText>(*descendant);
         text.updateScaledFont();
-        if (builder)
-            builder->rebuildMetricsForTextRenderer(text);
     }
+    if (builder)
+        builder->rebuildMetricsForSubtree(text);
 }
 
 void RenderSVGText::layout()
@@ -343,7 +340,7 @@ void RenderSVGText::layout()
         // and propogate resulting SVGLayoutAttributes to all RenderSVGInlineText children in the subtree.
         ASSERT(m_layoutAttributes.isEmpty());
         collectLayoutAttributes(this, m_layoutAttributes);
-        updateFontInAllDescendants(this);
+        updateFontInAllDescendants(*this);
         m_layoutAttributesBuilder.buildLayoutAttributesForForSubtree(*this);
 
         m_needsReordering = true;
@@ -354,7 +351,7 @@ void RenderSVGText::layout()
         // When the x/y/dx/dy/rotate lists change, recompute the layout attributes, and eventually
         // update the on-screen font objects as well in all descendants.
         if (m_needsTextMetricsUpdate) {
-            updateFontInAllDescendants(this);
+            updateFontInAllDescendants(*this);
             m_needsTextMetricsUpdate = false;
         }
 
@@ -374,7 +371,7 @@ void RenderSVGText::layout()
         if (m_needsTextMetricsUpdate || isLayoutSizeChanged) {
             // If the root layout size changed (eg. window size changes) or the transform to the root
             // context has changed then recompute the on-screen font size.
-            updateFontInAllDescendants(this, &m_layoutAttributesBuilder);
+            updateFontInAllDescendants(*this, &m_layoutAttributesBuilder);
 
             ASSERT(!m_needsReordering);
             ASSERT(!m_needsPositioningValuesUpdate);

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -73,9 +73,9 @@ bool SVGTextLayoutAttributesBuilder::buildLayoutAttributesForForSubtree(RenderSV
     return true;
 }
 
-void SVGTextLayoutAttributesBuilder::rebuildMetricsForTextRenderer(RenderSVGInlineText& text)
+void SVGTextLayoutAttributesBuilder::rebuildMetricsForSubtree(RenderSVGText& text)
 {
-    m_metricsBuilder.measureTextRenderer(text);
+    m_metricsBuilder.measureTextRenderer(text, nullptr);
 }
 
 static inline void processRenderSVGInlineText(const RenderSVGInlineText& text, unsigned& atCharacter, bool& lastCharacterWasSpace)

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.h
@@ -44,7 +44,7 @@ public:
     bool buildLayoutAttributesForForSubtree(RenderSVGText&);
     void buildLayoutAttributesForTextRenderer(RenderSVGInlineText&);
 
-    void rebuildMetricsForTextRenderer(RenderSVGInlineText&);
+    void rebuildMetricsForSubtree(RenderSVGText&);
 
     // Invoked whenever the underlying DOM tree changes, so that m_textPositions is rebuild.
     void clearTextPositioningElements() { m_textPositions.clear(); }

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -197,14 +197,10 @@ void SVGTextMetricsBuilder::walkTree(RenderElement& start, RenderSVGInlineText* 
     }
 }
 
-void SVGTextMetricsBuilder::measureTextRenderer(RenderSVGInlineText& text)
+void SVGTextMetricsBuilder::measureTextRenderer(RenderSVGText& textRoot, RenderSVGInlineText* stopAtLeaf)
 {
-    auto* textRoot = RenderSVGText::locateRenderSVGTextAncestor(text);
-    if (!textRoot)
-        return;
-
     MeasureTextData data(nullptr);
-    walkTree(*textRoot, &text, &data);
+    walkTree(textRoot, stopAtLeaf, &data);
 }
 
 void SVGTextMetricsBuilder::buildMetricsAndLayoutAttributes(RenderSVGText& textRoot, RenderSVGInlineText* stopAtLeaf, SVGCharacterDataMap& allCharactersMap)

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
@@ -34,7 +34,7 @@ class SVGTextMetricsBuilder {
     WTF_MAKE_NONCOPYABLE(SVGTextMetricsBuilder);
 public:
     SVGTextMetricsBuilder();
-    void measureTextRenderer(RenderSVGInlineText&);
+    void measureTextRenderer(RenderSVGText&, RenderSVGInlineText* stopAtLeaf);
     void buildMetricsAndLayoutAttributes(RenderSVGText&, RenderSVGInlineText* stopAtLeaf, SVGCharacterDataMap& allCharactersMap);
 
 private:


### PR DESCRIPTION
#### 1f27ea47a3924a8c56faae0fbf2e1346682949f5
<pre>
SVGTextMetricsBuilder::measureTextRenderer exhibits O(n^2) behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=264076">https://bugs.webkit.org/show_bug.cgi?id=264076</a>

Reviewed by Chris Dumez.

Prior to this PR, RenderSVGText::willLayout() called SVGTextLayoutAttributesBuilder&apos;s
rebuildMetricsForTextRenderer and therefore SVGTextMetricsBuilder&apos;s measureTextRenderer
on each descendant RenderObject of RenderSVGText. Since rebuildMetricsForTextRenderer
does a tree traversal from the ancestor RenderSVGText to the specified node, this
exhibited O(1+2+3+ ... +n) = O(n^2) behavior.

This PR rectifies this situation by combining all rebuildMetricsForTextRenderer calls
for descendants as a single call to SVGTextLayoutAttributesBuilder&apos;s now renamed
rebuildMetricsForSubtree.

This PR also eliminates O(n^2) behavior in updateFontInAllDescendants in RenderSVGText.cpp
by combining all calls to rebuildMetricsForTextRenderer.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::willLayout):
(WebCore::updateFontInAllDescendants):
(WebCore::RenderSVGText::layout):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::SVGTextLayoutAttributesBuilder::rebuildMetricsForSubtree):
(WebCore::SVGTextLayoutAttributesBuilder::rebuildMetricsForTextRenderer): Deleted.
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.h:
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::measureTextRenderer):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h:

Canonical link: <a href="https://commits.webkit.org/270110@main">https://commits.webkit.org/270110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e43ffb3bde0e1d502630a87d1e3d5d496d0d384

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/583 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27306 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28352 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26152 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/175 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2309 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3134 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->