### PR TITLE
[ThreadedCompositor] The compositing thread should not wait for paint threads

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
@@ -103,4 +103,11 @@ auto BackingStore::takeUpdate() -> TileUpdate
     return WTFMove(m_update.pending);
 }
 
+void BackingStore::waitUntilPaintingComplete()
+{
+    Locker locker { m_update.lock };
+    for (auto& update : m_update.pending.tilesToUpdate)
+        update.updateInfo.buffer->waitUntilPaintingComplete();
+}
+
 } // namespace Nicosia

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
@@ -113,6 +113,8 @@ public:
     void updateTile(uint32_t, const WebCore::SurfaceUpdateInfo&, const WebCore::IntRect&) override;
     void removeTile(uint32_t) override;
 
+    void waitUntilPaintingComplete();
+
 private:
     LayerState m_layerState;
     CompositionState m_compositionState;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
@@ -257,6 +257,13 @@ public:
     }
 
     template<typename T>
+    void accessStaging(const T& functor)
+    {
+        Locker locker { PlatformLayer::m_state.lock };
+        functor(m_state.staging);
+    }
+
+    template<typename T>
     void accessCommitted(const T& functor)
     {
         Locker locker { PlatformLayer::m_state.lock };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -52,7 +52,6 @@ void CoordinatedBackingStoreTile::swapBuffers(TextureMapper& textureMapper)
         } else if (update.buffer->supportsAlpha() == m_texture->isOpaque())
             m_texture->reset(update.tileRect.size(), update.buffer->supportsAlpha());
 
-        update.buffer->waitUntilPaintingComplete();
         m_texture->updateContents(update.buffer->data(), update.sourceRect, update.bufferOffset, update.buffer->stride());
         update.buffer = nullptr;
     }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -168,6 +168,13 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
                 state.rootLayer = m_nicosia.state.rootLayer;
             });
 
+        for (auto& compositionLayer : m_nicosia.state.layers) {
+            compositionLayer->accessStaging([](const Nicosia::CompositionLayer::LayerState& state) {
+                if (state.backingStore)
+                    state.backingStore->waitUntilPaintingComplete();
+            });
+        }
+
         m_client.commitSceneState(m_nicosia.scene);
 #if !HAVE(DISPLAY_LINK)
         m_forceFrameSync = false;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -346,6 +346,15 @@ void DrawingAreaCoordinatedGraphics::triggerRenderingUpdate()
         scheduleDisplay();
 }
 
+#if HAVE(DISPLAY_LINK)
+void DrawingAreaCoordinatedGraphics::didCompleteRenderingUpdateDisplay()
+{
+    if (m_layerTreeHost)
+        m_layerTreeHost->didCompleteRenderingUpdateDisplay();
+    DrawingArea::didCompleteRenderingUpdateDisplay();
+}
+#endif
+
 RefPtr<DisplayRefreshMonitor> DrawingAreaCoordinatedGraphics::createDisplayRefreshMonitor(PlatformDisplayID displayID)
 {
 #if HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -74,6 +74,10 @@ private:
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void triggerRenderingUpdate() override;
 
+#if HAVE(DISPLAY_LINK)
+    void didCompleteRenderingUpdateDisplay() override;
+#endif
+
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;
 
     void activityStateDidChange(OptionSet<WebCore::ActivityState>, ActivityStateChangeID, CompletionHandler<void()>&&) override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -101,6 +101,8 @@ public:
 
     void deviceOrPageScaleFactorChanged();
 
+    void didCompleteRenderingUpdateDisplay();
+
 #if !HAVE(DISPLAY_LINK)
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID);
     WebCore::PlatformDisplayID displayID() const { return m_displayID; }
@@ -114,10 +116,9 @@ private:
 #if USE(COORDINATED_GRAPHICS)
     void layerFlushTimerFired();
     void didChangeViewport();
-#if HAVE(DISPLAY_LINK)
-    void didRenderFrameTimerFired();
-#endif
+#if !HAVE(DISPLAY_LINK)
     void renderNextFrame(bool);
+#endif
 
     // CompositingCoordinator::Client
     void didFlushRootLayer(const WebCore::FloatRect& visibleContentRect) override;
@@ -156,8 +157,10 @@ private:
 #if USE(COORDINATED_GRAPHICS)
     bool m_layerFlushSchedulingEnabled { true };
     bool m_isSuspended { false };
+#if !HAVE(DISPLAY_LINK)
     bool m_isWaitingForRenderer { false };
     bool m_scheduledWhileWaitingForRenderer { false };
+#endif
     float m_lastPageScaleFactor { 1 };
     WebCore::IntPoint m_lastScrollPosition;
     WebCore::GraphicsLayer* m_viewOverlayRootLayer { nullptr };
@@ -166,12 +169,11 @@ private:
     SimpleViewportController m_viewportController;
     struct {
         CompletionHandler<void()> callback;
+#if !HAVE(DISPLAY_LINK)
         bool needsFreshFlush { false };
+#endif
     } m_forceRepaintAsync;
     RunLoop::Timer m_layerFlushTimer;
-#if HAVE(DISPLAY_LINK)
-    RunLoop::Timer m_didRenderFrameTimer;
-#endif
     CompositingCoordinator m_coordinator;
 #endif // USE(COORDINATED_GRAPHICS)
 #if !HAVE(DISPLAY_LINK)


### PR DESCRIPTION
#### 2bf118e5bf78aaccfb3dcb3de85a7a84ad0a6279
<pre>
[ThreadedCompositor] The compositing thread should not wait for paint threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=264090">https://bugs.webkit.org/show_bug.cgi?id=264090</a>

Reviewed by Alejandro G. Castro.

If there&apos;s an async scrolling request the compositing thread might be
busy just waiting for the painting threads. We can wait for them in the
main thread, which is already expected to be blocked painting.

* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp:
(Nicosia::BackingStore::waitUntilPaintingComplete):
* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStoreTile::swapBuffers):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::scheduleLayerFlush):
(WebKit::LayerTreeHost::layerFlushTimerFired):
(WebKit::LayerTreeHost::forceRepaint):
(WebKit::LayerTreeHost::forceRepaintAsync):
(WebKit::LayerTreeHost::commitSceneState):
(WebKit::LayerTreeHost::didRenderFrame):
(WebKit::LayerTreeHost::handleDisplayRefreshMonitorUpdate):
(WebKit::LayerTreeHost::renderNextFrame):
(WebKit::LayerTreeHost::didRenderFrameTimerFired): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:

Canonical link: <a href="https://commits.webkit.org/270388@main">https://commits.webkit.org/270388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c05d7a7ef775f503c22c73dbbd911a1328cd4e75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1311 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28026 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28898 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26741 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/798 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2957 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3234 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2849 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->