### PR TITLE
Add empty stub for browser.notifications for Web Extensions behind test mode.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -418,6 +418,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINotifications.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIPort.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -56,6 +56,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPILocalization.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPILocalization.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINotifications.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINotifications.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPermissions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPermissions.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPort.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -757,6 +757,7 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIExtension \
     WebExtensionAPILocalization \
     WebExtensionAPINamespace \
+    WebExtensionAPINotifications \
     WebExtensionAPIPermissions \
     WebExtensionAPIPort \
     WebExtensionAPIRuntime \

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -416,6 +416,10 @@
 		1C2B4D442A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */; };
 		1C2B4D4B2A819D0D00C528A1 /* JSWebExtensionAPIAlarms.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C386F302AF4082F004108F0 /* WebExtensionAPINotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C386F2F2AF4082F004108F0 /* WebExtensionAPINotifications.h */; };
+		1C386F322AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C386F312AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C386F352AF409F9004108F0 /* JSWebExtensionAPINotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C386F332AF409F9004108F0 /* JSWebExtensionAPINotifications.h */; };
+		1C386F362AF409F9004108F0 /* JSWebExtensionAPINotifications.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C386F342AF409F9004108F0 /* JSWebExtensionAPINotifications.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C3BEB502887492F00E66E38 /* WebExtensionControllerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3BEB492887492600E66E38 /* WebExtensionControllerMessages.h */; };
 		1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3BEB4E2887492700E66E38 /* WebExtensionControllerProxyMessages.h */; };
 		1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C3BEB4A2887492600E66E38 /* WebExtensionControllerMessageReceiver.cpp */; };
@@ -2197,7 +2201,6 @@
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
 		E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */; };
 		E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */; };
-		E377EC902AD9D32200528777 /* ExtensionKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E377EC8F2AD9D32200528777 /* ExtensionKitSPI.h */; };
 		E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */; };
 		E3816B3E27E2463A005EAFC0 /* WebMockContentFilterManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E3816B3C27E24639005EAFC0 /* WebMockContentFilterManager.h */; };
 		E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3866AE42397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm */; };
@@ -3492,6 +3495,11 @@
 		1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIAlarms.idl; sourceTree = "<group>"; };
 		1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIAlarms.h; sourceTree = "<group>"; };
 		1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIAlarms.mm; sourceTree = "<group>"; };
+		1C386F2E2AF407B1004108F0 /* WebExtensionAPINotifications.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPINotifications.idl; sourceTree = "<group>"; };
+		1C386F2F2AF4082F004108F0 /* WebExtensionAPINotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPINotifications.h; sourceTree = "<group>"; };
+		1C386F312AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPINotificationsCocoa.mm; sourceTree = "<group>"; };
+		1C386F332AF409F9004108F0 /* JSWebExtensionAPINotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPINotifications.h; sourceTree = "<group>"; };
+		1C386F342AF409F9004108F0 /* JSWebExtensionAPINotifications.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPINotifications.mm; sourceTree = "<group>"; };
 		1C3BEB46288740AE00E66E38 /* WebExtensionControllerParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerParameters.h; sourceTree = "<group>"; };
 		1C3BEB482887415100E66E38 /* WebExtensionControllerIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerIdentifier.h; sourceTree = "<group>"; };
 		1C3BEB492887492600E66E38 /* WebExtensionControllerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerMessages.h; sourceTree = "<group>"; };
@@ -7299,7 +7307,6 @@
 		E36D701D27B718EF006531B7 /* WebAttachmentElementClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebAttachmentElementClient.cpp; sourceTree = "<group>"; };
 		E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SandboxStateVariables.h; sourceTree = "<group>"; };
 		E36FF00227F36FBD004BE21A /* preferences.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = preferences.sb; sourceTree = "<group>"; };
-		E377EC8F2AD9D32200528777 /* ExtensionKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtensionKitSPI.h; sourceTree = "<group>"; };
 		E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebMockContentFilterManager.cpp; path = Network/WebMockContentFilterManager.cpp; sourceTree = "<group>"; };
 		E3816B3C27E24639005EAFC0 /* WebMockContentFilterManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebMockContentFilterManager.h; path = Network/WebMockContentFilterManager.h; sourceTree = "<group>"; };
 		E3866AE42397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebDeviceOrientationUpdateProviderProxy.mm; path = ios/WebDeviceOrientationUpdateProviderProxy.mm; sourceTree = "<group>"; };
@@ -8853,6 +8860,7 @@
 				1C5DC468290B239C0061EC62 /* WebExtensionAPIExtension.h */,
 				B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */,
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
+				1C386F2F2AF4082F004108F0 /* WebExtensionAPINotifications.h */,
 				1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */,
 				B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */,
 				1C9A15C92ABDEF13002CC12A /* WebExtensionAPIPort.h */,
@@ -8877,6 +8885,7 @@
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
 				B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
+				1C386F312AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm */,
 				B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */,
 				1C9A15D02ABDF334002CC12A /* WebExtensionAPIPortCocoa.mm */,
 				1C5DC464290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm */,
@@ -9030,6 +9039,7 @@
 				1C9DD99028FA19A30093BDB0 /* WebExtensionAPIExtension.idl */,
 				B6E5F2A3299C0FFB00DBCEA3 /* WebExtensionAPILocalization.idl */,
 				1C9DD9A428FA19A30093BDB0 /* WebExtensionAPINamespace.idl */,
+				1C386F2E2AF407B1004108F0 /* WebExtensionAPINotifications.idl */,
 				B6544F76293560B000034EB0 /* WebExtensionAPIPermissions.idl */,
 				1C9A15CB2ABDF10C002CC12A /* WebExtensionAPIPort.idl */,
 				1C9DD99C28FA19A30093BDB0 /* WebExtensionAPIRuntime.idl */,
@@ -13726,6 +13736,8 @@
 				B6CCAAB729A445E90092E846 /* JSWebExtensionAPILocalization.mm */,
 				1C5DC4532908AC260061EC62 /* JSWebExtensionAPINamespace.h */,
 				1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */,
+				1C386F332AF409F9004108F0 /* JSWebExtensionAPINotifications.h */,
+				1C386F342AF409F9004108F0 /* JSWebExtensionAPINotifications.mm */,
 				B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */,
 				B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */,
 				1C9A15CC2ABDF1E1002CC12A /* JSWebExtensionAPIPort.h */,
@@ -14890,6 +14902,7 @@
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,
 				1CC94E542AC92F190045F269 /* JSWebExtensionAPIAction.h in Headers */,
+				1C386F352AF409F9004108F0 /* JSWebExtensionAPINotifications.h in Headers */,
 				B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */,
 				1C9A15CE2ABDF1E2002CC12A /* JSWebExtensionAPIPort.h in Headers */,
 				B63E9A6E2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.h in Headers */,
@@ -15361,6 +15374,7 @@
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
 				B6E5F2A5299C105500DBCEA3 /* WebExtensionAPILocalization.h in Headers */,
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,
+				1C386F302AF4082F004108F0 /* WebExtensionAPINotifications.h in Headers */,
 				1C5DC46B290B271E0061EC62 /* WebExtensionAPIObject.h in Headers */,
 				B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */,
 				1C9A15CA2ABDEF13002CC12A /* WebExtensionAPIPort.h in Headers */,
@@ -17651,6 +17665,7 @@
 				1C5DC471290B33A20061EC62 /* JSWebExtensionAPIExtension.mm in Sources */,
 				B6CCAAB929A445E90092E846 /* JSWebExtensionAPILocalization.mm in Sources */,
 				1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */,
+				1C386F362AF409F9004108F0 /* JSWebExtensionAPINotifications.mm in Sources */,
 				B61AFA4929510D0F008220B1 /* JSWebExtensionAPIPermissions.mm in Sources */,
 				1C9A15CF2ABDF1E2002CC12A /* JSWebExtensionAPIPort.mm in Sources */,
 				1C5DC472290B33A60061EC62 /* JSWebExtensionAPIRuntime.mm in Sources */,
@@ -17983,6 +17998,7 @@
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,
 				B6E5F2A7299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm in Sources */,
 				1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */,
+				1C386F322AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm in Sources */,
 				B65DA1D3294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm in Sources */,
 				1C9A15D12ABDF335002CC12A /* WebExtensionAPIPortCocoa.mm in Sources */,
 				1C5DC466290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,14 @@ bool WebExtensionAPINamespace::isPropertyAllowed(ASCIILiteral name, WebPage*)
 
     if (name == "browserAction"_s)
         return !extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"browser_action");
+
+    if (name == "notifications"_s) {
+        // FIXME: <rdar://problem/57202210> Add support for browser.notifications.
+        // Notifications are currently only available in test mode as an empty stub.
+        if (!extensionContext().inTestingMode())
+            return false;
+        // Fall through to the permissions check below.
+    }
 
     if (name == "pageAction"_s)
         return !extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"page_action");
@@ -93,6 +101,16 @@ WebExtensionAPILocalization& WebExtensionAPINamespace::i18n()
         m_i18n = WebExtensionAPILocalization::create(forMainWorld(), runtime(), extensionContext());
 
     return *m_i18n;
+}
+
+WebExtensionAPINotifications& WebExtensionAPINamespace::notifications()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications
+
+    if (!m_notifications)
+        m_notifications = WebExtensionAPINotifications::create(forMainWorld(), runtime(), extensionContext());
+
+    return *m_notifications;
 }
 
 WebExtensionAPIPermissions& WebExtensionAPINamespace::permissions()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINotificationsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINotificationsCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,37 +23,37 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPINamespace {
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction action;
+#import "config.h"
+#import "WebExtensionAPINotifications.h"
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction browserAction;
+namespace WebKit {
 
-    readonly attribute WebExtensionAPIExtension extension;
+WebExtensionAPIEvent& WebExtensionAPINotifications::onClicked()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClicked
 
-    readonly attribute WebExtensionAPILocalization i18n;
+    if (!m_onClicked)
+        m_onClicked = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::NotificationsOnClicked);
 
-    readonly attribute WebExtensionAPIRuntime runtime;
+    return *m_onClicked;
+}
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPINotifications notifications;
+WebExtensionAPIEvent& WebExtensionAPINotifications::onButtonClicked()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onButtonClicked
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction pageAction;
+    if (!m_onButtonClicked)
+        m_onButtonClicked = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::NotificationsOnButtonClicked);
 
-    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
+    return *m_onButtonClicked;
+}
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIScripting scripting;
+} // namespace WebKit
 
-    [MainWorldOnly] readonly attribute WebExtensionAPITabs tabs;
-
-    [MainWorldOnly] readonly attribute WebExtensionAPIWindows windows;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
-
-    [Dynamic] readonly attribute WebExtensionAPITest test;
-
-};
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -32,6 +32,7 @@
 #include "WebExtensionAPIAlarms.h"
 #include "WebExtensionAPIExtension.h"
 #include "WebExtensionAPILocalization.h"
+#include "WebExtensionAPINotifications.h"
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionAPIPermissions.h"
 #include "WebExtensionAPIRuntime.h"
@@ -58,6 +59,7 @@ public:
     WebExtensionAPIAction& browserAction() { return action(); }
     WebExtensionAPIExtension& extension();
     WebExtensionAPILocalization& i18n();
+    WebExtensionAPINotifications& notifications();
     WebExtensionAPIAction& pageAction() { return action(); }
     WebExtensionAPIPermissions& permissions();
     WebExtensionAPIRuntime& runtime() final;
@@ -73,6 +75,7 @@ private:
     RefPtr<WebExtensionAPIAlarms> m_alarms;
     RefPtr<WebExtensionAPIExtension> m_extension;
     RefPtr<WebExtensionAPILocalization> m_i18n;
+    RefPtr<WebExtensionAPINotifications> m_notifications;
     RefPtr<WebExtensionAPIPermissions> m_permissions;
     RefPtr<WebExtensionAPIRuntime> m_runtime;
     RefPtr<WebExtensionAPIScripting> m_scripting;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,37 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPINamespace {
+#pragma once
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction action;
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
+#include "JSWebExtensionAPINotifications.h"
+#include "WebExtensionAPIEvent.h"
+#include "WebExtensionAPIObject.h"
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction browserAction;
+namespace WebKit {
 
-    readonly attribute WebExtensionAPIExtension extension;
+class WebExtensionAPINotifications : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINotifications, notifications);
 
-    readonly attribute WebExtensionAPILocalization i18n;
+public:
+#if PLATFORM(COCOA)
+    WebExtensionAPIEvent& onClicked();
+    WebExtensionAPIEvent& onButtonClicked();
 
-    readonly attribute WebExtensionAPIRuntime runtime;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPINotifications notifications;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction pageAction;
-
-    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIScripting scripting;
-
-    [MainWorldOnly] readonly attribute WebExtensionAPITabs tabs;
-
-    [MainWorldOnly] readonly attribute WebExtensionAPIWindows windows;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
-
-    [Dynamic] readonly attribute WebExtensionAPITest test;
-
+private:
+    RefPtr<WebExtensionAPIEvent> m_onClicked;
+    RefPtr<WebExtensionAPIEvent> m_onButtonClicked;
+#endif
 };
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINotifications.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINotifications.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,11 @@
 
 [
     Conditional=WK_WEB_EXTENSIONS,
+    MainWorldOnly,
     ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPINamespace {
+] interface WebExtensionAPINotifications {
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction action;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction browserAction;
-
-    readonly attribute WebExtensionAPIExtension extension;
-
-    readonly attribute WebExtensionAPILocalization i18n;
-
-    readonly attribute WebExtensionAPIRuntime runtime;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPINotifications notifications;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction pageAction;
-
-    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIScripting scripting;
-
-    [MainWorldOnly] readonly attribute WebExtensionAPITabs tabs;
-
-    [MainWorldOnly] readonly attribute WebExtensionAPIWindows windows;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
-
-    [Dynamic] readonly attribute WebExtensionAPITest test;
+    readonly attribute WebExtensionAPIEvent onClicked;
+    readonly attribute WebExtensionAPIEvent onButtonClicked;
 
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
@@ -37,8 +37,6 @@ TEST(WKWebExtensionAPINamespace, NoWebNavigationObjectWithoutPermission)
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.webNavigation, 'undefined')",
-
-        // Finish
         @"browser.test.notifyPass()"
     ]);
 
@@ -51,8 +49,45 @@ TEST(WKWebExtensionAPINamespace, WebNavigationObjectWithPermission)
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.webNavigation, 'object')",
+        @"browser.test.notifyPass()"
+    ]);
 
-        // Finish
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPINamespace, NoNotificationsObjectWithoutPermission)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(typeof browser.notifications, 'undefined')",
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPINamespace, NotificationsObjectWithPermission)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"notifications" ],
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(typeof browser.notifications, 'object')",
         @"browser.test.notifyPass()"
     ]);
 


### PR DESCRIPTION
#### 813aa2842251bc0f5b48f1a8bb817de1e6277c34
<pre>
Add empty stub for browser.notifications for Web Extensions behind test mode.
<a href="https://webkit.org/b/264098">https://webkit.org/b/264098</a>
<a href="https://rdar.apple.com/problem/117860475">rdar://problem/117860475</a>

Reviewed by Brian Weinstein.

We don&apos;t support this API, but it is useful to have a stub for testing extensions that
assume it is always present.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Added new files. Xcode removed some duplicate
entries for ExtensionKitSPI.h, it is still present in one place.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Custom availability based on test mode
and permissions.
(WebKit::WebExtensionAPINamespace::notifications): Added.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINotificationsCocoa.mm: Added.
(WebKit::WebExtensionAPINotifications::onClicked):
(WebKit::WebExtensionAPINotifications::onButtonClicked):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h: Added.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINotifications.idl: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270132@main">https://commits.webkit.org/270132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c10cf3d8fed1ad8990a38d853aa67973d1e1fb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/628 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27351 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22213 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26196 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/218 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2351 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3138 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->