### PR TITLE
[JSC] Add stackcollapse-sampling-profiler-output script

### DIFF
--- a/Tools/Scripts/stackcollapse-sampling-profiler-output
+++ b/Tools/Scripts/stackcollapse-sampling-profiler-output
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'rubygems'
+
+begin
+    require 'json'
+rescue LoadError
+    $stderr.puts "Error: some required gems are not installed!"
+    $stderr.puts
+    $stderr.puts "Try running:"
+    $stderr.puts
+    $stderr.puts "sudo gem install json"
+    exit 1
+end
+
+def dump(database)
+  database["traces"].each do |stackTrace|
+    next if stackTrace["frames"].empty?
+    line = stackTrace["frames"].reverse.map do |frame|
+        hash, category, offset = frame["location"].split(":")
+        "#{frame["name"]}#{hash}".gsub(/;/, '_').gsub(/[\n\r]/, ' ')
+    end.join(';')
+    puts "#{line} 1"
+  end
+end
+
+def main
+    json = nil
+    if ARGV.empty?
+        json = JSON.parse(STDIN.read)
+    else
+        json = JSON::parse(IO::read(ARGV[0]))
+    end
+    dump(json)
+end
+
+main


### PR DESCRIPTION
#### 77c606018747ff07dc679f49dce38ed1ff9957e2
<pre>
[JSC] Add stackcollapse-sampling-profiler-output script
<a href="https://bugs.webkit.org/show_bug.cgi?id=264102">https://bugs.webkit.org/show_bug.cgi?id=264102</a>
<a href="https://rdar.apple.com/117863428">rdar://117863428</a>

Reviewed by Justin Michaud.

This patch adds stackcollapse-sampling-profiler-output. This is FlameGraph&apos;s stackcollapse script
for JSC sampling profiler output JSON. We can use this with FlameGraph[1] scripts to generate FrameGraph.
The stackcollapse script&apos;s purpose is making stack sample to one line per sample in a specific format (as
the same to the other stackcollapse scripts in FlameGraph repository).

Usage is just like, `cat dump.json | stackcollapse-sampling-profiler-output | ~/dev/FlameGraph/flamegraph.pl &gt; result.svg`

[1]: <a href="https://github.com/brendangregg/FlameGraph">https://github.com/brendangregg/FlameGraph</a>

* Tools/Scripts/stackcollapse-sampling-profiler-output: Added.

Canonical link: <a href="https://commits.webkit.org/270119@main">https://commits.webkit.org/270119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8ecddc18759ce361ce86e57eacaa53361bb44cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26776 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24901 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/22219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/27359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1901 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2356 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3137 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->