### PR TITLE
Fix REGRESSION (267685@main): lldb-webkit-test is failing

### DIFF
--- a/Tools/Scripts/test-lldb-webkit
+++ b/Tools/Scripts/test-lldb-webkit
@@ -136,7 +136,7 @@ def main():
 
     if lldb_python_directory not in sys.path:
         sys.path.insert(0, lldb_python_directory)
-    tester.add_tree(host.filesystem.join(webkit_root, 'Tools', 'lldb'))
+    tester.add_tree(host.filesystem.join(webkit_root, 'Tools', 'lldb'), '')
 
     return not tester.run(host=host, webkit_root=webkit_root)
 

--- a/Tools/Scripts/webkitpy/test/finder_unittest.py
+++ b/Tools/Scripts/webkitpy/test/finder_unittest.py
@@ -121,3 +121,11 @@ class FinderTest(unittest.TestCase):
 
         # Names that don't exist are caught later, at load time.
         self.check_names(['bar.notexist_unittest'], ['bar.notexist_unittest'])
+
+    def test_non_package(self):
+        finder = Finder(self.fs)
+        finder.add_tree('/foo/bar', '')
+        expected_names = ['baz_unittest']
+        self.assertEqual(finder.find_names([], True), expected_names)
+        self.assertEqual(finder.find_names([], False), expected_names)
+        self.assertEqual(finder.find_names(['baz_unittest'], False), expected_names)


### PR DESCRIPTION
#### 3b3a233a19aebc370253fedc00c02255e4b8ce65
<pre>
Fix REGRESSION (267685@main): lldb-webkit-test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=263919">https://bugs.webkit.org/show_bug.cgi?id=263919</a>

Reviewed by Jonathan Bedard.

267685@main (375f0a128550) made starting_directory required, but I
missed one callsite: lldb-webkit-test. This corrects this one case, and
adds a test to finder_unittest.py to ensure the (edge) case it&apos;s relying
on continues to work.

* Tools/Scripts/test-lldb-webkit:
(main):
* Tools/Scripts/webkitpy/test/finder_unittest.py:
(FinderTest.test_non_package):

Canonical link: <a href="https://commits.webkit.org/270137@main">https://commits.webkit.org/270137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887f41dbcdc5c51e110e63af16bd056870ce2d06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/640 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27361 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/24823 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22223 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26200 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/224 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3209 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5907 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->