### PR TITLE
Add 2d-transform-inline-js.html for WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-transform-inline-js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-transform-inline-js-expected.txt
@@ -1,0 +1,5 @@
+Transform values should be indentical between the blue box(block element) and red box(inline element)
+
+
+PASS JS test: Inline renderer must return the correct computed transform
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-transform-inline-js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-transform-inline-js.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>JS test: Inline renderer must return the correct computed transform</title>
+    <link rel="author" title="Joone Hur" href="https://joone.github.io">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#serialization-of-the-computed-value">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#serialization-of-transform-functions">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <meta name="assert" content="Asserting that you can apply transform to an inline element and it show up in CSS computed values as a matrix">
+    <style>
+      .container {
+      height: 100px;
+      width: 200px;
+      margin: 30px;
+      outline: 1px solid black;
+    }
+    .box {
+      height: 100%;
+      width: 100%;
+      padding: 5px;
+      margin: 5px;
+      border: 5px solid gray;
+      transform-origin: 20% 50%;
+    }
+    #test-div {
+      background-color: blue;
+    }
+
+    #test-span {
+      background-color: red;
+    }
+    </style>
+
+  </head>
+  <body>
+    <h1>Transform values should be indentical between
+      the blue box(block element) and red box(inline element) </h1>
+    <div class="container">
+      <div id="test-div" class="box"></div>
+    </div>
+    <span id="test-span" class="box"></span>
+    <script>
+      const testCases = [
+        { 'transform' : 'translate(80px, 90px)',  'result' : 'matrix(1, 0, 0, 1, 80, 90)' },
+        { 'transform' : 'scale(1.2, 0.8)',        'result' : 'matrix(1.2, 0, 0, 0.8, 0, 0)' },
+        { 'transform' : 'skew(-0.7rad, 20deg)',   'result' : 'matrix(1, 0.36397, -0.842288, 1, 0, 0)' },
+        { 'transform' : 'rotate(45deg)',          'result' : 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)' },
+      ];
+
+      test(function() {
+        var testBox = document.getElementById('test-div');
+        var testSpan = document.getElementById('test-span');
+
+        testCases.forEach(function(curTest) {
+          // set one of our test transforms
+          testBox.style.transform = curTest.transform;
+          testSpan.style.transform = curTest.transform;
+
+          // read back computed style
+          var computedTransform = window.getComputedStyle(testBox).transform;
+          var computedSpanTransform = window.getComputedStyle(testSpan).transform;
+
+          assert_equals(computedTransform, curTest.result);
+          assert_equals(computedSpanTransform, curTest.result);
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
#### f998524614f722dd55969e7279d7506d96761106
<pre>
Add 2d-transform-inline-js.html for WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263699">https://bugs.webkit.org/show_bug.cgi?id=263699</a>
<a href="https://rdar.apple.com/problem/117523629">rdar://problem/117523629</a>

Reviewed by Antoine Quint.

This test ensures that getComputedStyle provides a valid transform value
for inline elements. Originally written for WebKit, it is rewritten for
WPT since such a test didn&apos;t exist there.

 * LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-transform-inline-js-expected.txt: Added.
 * LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-transform-inline-js.html: Added.

Canonical link: <a href="https://commits.webkit.org/270557@main">https://commits.webkit.org/270557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70f76f79c08da71a7e06305a8f1494609cb7ccd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23052 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23309 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27816 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28745 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/626 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6195 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->