### PR TITLE
[CSS] visited color should not be computed only for links

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>currentcolor and visited inherited parent color fallback</title>
+<style>
+a {
+    color: green;
+}
+</style>
+<div>
+    <a href="">This should be green</a>
+</div>
+<div>
+    <a href="">This should be green</a>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>currentcolor and visited inherited parent color fallback</title>
+<style>
+a {
+    color: green;
+}
+</style>
+<div>
+    <a href="">This should be green</a>
+</div>
+<div>
+    <a href="">This should be green</a>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="currentcolor-visited-fallback-ref.html">
+<title>currentcolor and visited inherited parent color fallback</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#resolving-other-colors">
+<link rel="author" title="Matthieu Dubet" href="https://github.com/mdubet">
+<style>
+body { color: red; }
+div { color: green; }
+a {
+    color: currentcolor;
+}
+</style>
+<div>
+    <a href="">This should be green</a>
+</div>
+<div>
+    <a href="unvisited">This should be green</a>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-expected.html
@@ -1,0 +1,8 @@
+<svg width="100" height="100" fill="green" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector"/>
+  <html:link rel="match" href="color-inherit-link-visited-ref.svg"/>
+  <html:meta name="assert" content="Tests that color is correctly inherited in the presence of visited link"/>
+  <a xlink:href="">
+    <rect width="100" height="100"></rect>
+  </a>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-ref.html
@@ -1,0 +1,8 @@
+<svg width="100" height="100" fill="green" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector"/>
+  <html:link rel="match" href="color-inherit-link-visited-ref.svg"/>
+  <html:meta name="assert" content="Tests that color is correctly inherited in the presence of visited link"/>
+  <a xlink:href="">
+    <rect width="100" height="100" fill="green"></rect>
+  </a>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited.html
@@ -1,0 +1,8 @@
+<svg width="100" height="100" fill="green" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector"/>
+  <html:link rel="match" href="color-inherit-link-visited-ref.svg"/>
+  <html:meta name="assert" content="Tests that color is correctly inherited in the presence of visited link"/>
+  <a xlink:href="">
+    <rect width="100" height="100"></rect>
+  </a>
+</svg>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt
@@ -100,7 +100,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (455,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {polyline} at (455,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
             RenderSVGContainer {a} at (638,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#000000]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+              RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (280,196) size 437x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (280,196) size 70x21
@@ -148,7 +148,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,237) size 18x3 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (466,237) size 18x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
             RenderSVGContainer {a} at (650,237) size 17x3 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (650,237) size 17x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
+              RenderSVGPath {line} at (650,237) size 17x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
           RenderSVGContainer {g} at (283,261) size 431x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,80.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,261) size 64x21
@@ -170,7 +170,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,261) size 4x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (466,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
             RenderSVGContainer {a} at (650,261) size 4x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (650,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
+              RenderSVGPath {line} at (650,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
           RenderSVGContainer {g} at (282,292) size 444x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(5.00,100.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (282,292) size 77x16
@@ -236,7 +236,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (441,364) size 43x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (441,364) size 43x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
             RenderSVGContainer {a} at (625,364) size 42x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (625,364) size 42x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#000000]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
+              RenderSVGPath {line} at (625,364) size 42x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
           RenderSVGContainer {g} at (283,391) size 381x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,160.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,391) size 14x14
@@ -254,7 +254,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,391) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (466,391) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (650,391) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (650,391) size 14x14 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (650,391) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,425) size 381x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,180.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,425) size 14x14
@@ -272,7 +272,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (466,425) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (650,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (650,425) size 14x14 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (650,425) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,448) size 431x24 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,200.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,448) size 64x7

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt
@@ -97,7 +97,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (505,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {polyline} at (505,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
             RenderSVGContainer {a} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {polyline} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#000000] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+              RenderSVGPath {polyline} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (283,199) size 432x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,200) size 64x14
@@ -141,7 +141,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (514,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (514,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
             RenderSVGContainer {a} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
+              RenderSVGPath {line} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
           RenderSVGContainer {g} at (281,255) size 439x20 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,80.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (281,255) size 73x20
@@ -163,7 +163,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (513,255) size 24x20 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (513,255) size 24x20 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
             RenderSVGContainer {a} at (696,255) size 24x20 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (696,255) size 24x20 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
+              RenderSVGPath {line} at (696,255) size 24x20 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
           RenderSVGContainer {g} at (282,292) size 444x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(5.00,100.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (282,292) size 77x16
@@ -229,7 +229,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (510,364) size 35x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (510,364) size 35x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
             RenderSVGContainer {a} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#000000]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
+              RenderSVGPath {line} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
           RenderSVGContainer {g} at (283,391) size 431x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,160.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,391) size 64x14
@@ -270,7 +270,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (516,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (516,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,458) size 431x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,200.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,458) size 64x14

--- a/LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt
+++ b/LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt
@@ -100,7 +100,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (455,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {polyline} at (455,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
             RenderSVGContainer {a} at (638,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#000000]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+              RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (280,196) size 437x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (280,196) size 70x21
@@ -148,7 +148,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,237) size 18x3 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (466,237) size 18x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
             RenderSVGContainer {a} at (650,237) size 17x3 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (650,237) size 17x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
+              RenderSVGPath {line} at (650,237) size 17x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
           RenderSVGContainer {g} at (283,261) size 431x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,80.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,261) size 64x21
@@ -170,7 +170,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,261) size 4x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (466,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
             RenderSVGContainer {a} at (650,261) size 4x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (650,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
+              RenderSVGPath {line} at (650,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
           RenderSVGContainer {g} at (282,292) size 444x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(5.00,100.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (282,292) size 77x16
@@ -236,7 +236,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (441,364) size 43x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (441,364) size 43x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
             RenderSVGContainer {a} at (625,364) size 42x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (625,364) size 42x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#000000]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
+              RenderSVGPath {line} at (625,364) size 42x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
           RenderSVGContainer {g} at (283,391) size 381x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,160.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,391) size 14x14
@@ -254,7 +254,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,391) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (466,391) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (650,391) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (650,391) size 14x14 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (650,391) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,425) size 381x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,180.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,425) size 14x14
@@ -272,7 +272,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (466,425) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (650,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (650,425) size 14x14 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (650,425) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,448) size 431x24 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,200.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,448) size 64x7

--- a/LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt
+++ b/LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt
@@ -97,7 +97,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (505,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {polyline} at (505,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
             RenderSVGContainer {a} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {polyline} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#000000] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+              RenderSVGPath {polyline} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (283,199) size 432x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,200) size 64x14
@@ -141,7 +141,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (514,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (514,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
             RenderSVGContainer {a} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
+              RenderSVGPath {line} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
           RenderSVGContainer {g} at (281,254) size 440x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,80.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (281,254) size 73x22
@@ -163,7 +163,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (512,254) size 26x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (512,254) size 26x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
             RenderSVGContainer {a} at (696,254) size 25x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (696,254) size 25x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
+              RenderSVGPath {line} at (696,254) size 25x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
           RenderSVGContainer {g} at (282,292) size 444x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(5.00,100.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (282,292) size 77x16
@@ -229,7 +229,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (510,364) size 35x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (510,364) size 35x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
             RenderSVGContainer {a} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#000000]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
+              RenderSVGPath {line} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
           RenderSVGContainer {g} at (283,391) size 431x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,160.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,391) size 64x14
@@ -270,7 +270,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (516,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (516,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,458) size 431x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,200.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,458) size 64x14

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt
@@ -100,7 +100,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (455,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {polyline} at (455,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
             RenderSVGContainer {a} at (638,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#000000]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+              RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (280,196) size 437x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (280,196) size 70x21
@@ -148,7 +148,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,237) size 18x3 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (466,237) size 18x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
             RenderSVGContainer {a} at (650,237) size 17x3 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (650,237) size 17x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
+              RenderSVGPath {line} at (650,237) size 17x3 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=8.00]
           RenderSVGContainer {g} at (283,261) size 431x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,80.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,261) size 64x21
@@ -170,7 +170,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,261) size 4x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (466,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
             RenderSVGContainer {a} at (650,261) size 4x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (650,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
+              RenderSVGPath {line} at (650,261) size 4x21 [stroke={[type=SOLID] [color=#CC0066] [stroke width=12.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=12.00] [y2=8.00]
           RenderSVGContainer {g} at (282,292) size 444x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(5.00,100.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (282,292) size 77x16
@@ -236,7 +236,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (441,364) size 43x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (441,364) size 43x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
             RenderSVGContainer {a} at (625,364) size 42x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (625,364) size 42x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#000000]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
+              RenderSVGPath {line} at (625,364) size 42x6 [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
           RenderSVGContainer {g} at (283,391) size 381x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,160.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,391) size 14x14
@@ -254,7 +254,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,391) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (466,391) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (650,391) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (650,391) size 14x14 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (650,391) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,425) size 381x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,180.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,425) size 14x14
@@ -272,7 +272,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (466,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (466,425) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (650,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (650,425) size 14x14 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (650,425) size 14x14 [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,448) size 431x24 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,200.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,448) size 64x7

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt
@@ -97,7 +97,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (505,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {polyline} at (505,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
             RenderSVGContainer {a} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {polyline} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#000000] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+              RenderSVGPath {polyline} at (688,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (283,199) size 432x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,200) size 64x14
@@ -141,7 +141,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (514,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (514,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
             RenderSVGContainer {a} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
+              RenderSVGPath {line} at (697,222) size 22x19 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
           RenderSVGContainer {g} at (281,254) size 440x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,80.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (281,254) size 73x22
@@ -163,7 +163,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (512,254) size 26x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (512,254) size 26x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
             RenderSVGContainer {a} at (696,254) size 25x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (696,254) size 25x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
+              RenderSVGPath {line} at (696,254) size 25x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=4.00] [line cap=ROUND]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=10.00] [y1=8.00] [x2=20.00] [y2=0.00]
           RenderSVGContainer {g} at (282,292) size 444x16 [transform={m=((1.00,0.00)(0.00,1.00)) t=(5.00,100.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (282,292) size 77x16
@@ -229,7 +229,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (510,364) size 35x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGPath {line} at (510,364) size 35x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
             RenderSVGContainer {a} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGPath {line} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#000000]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
+              RenderSVGPath {line} at (694,364) size 34x6 [transform={m=((1.00,0.00)(0.00,1.00)) t=(40.00,0.00)}] [stroke={[type=SOLID] [color=#CC0066] [stroke width=3.00] [dash offset=5.50] [dash array={3.00, 4.00, 5.00}]}] [fill={[type=SOLID] [color=#CC0066]}] [x1=0.00] [y1=0.00] [x2=25.00] [y2=0.00]
           RenderSVGContainer {g} at (283,391) size 431x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,160.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,391) size 64x14
@@ -270,7 +270,7 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (516,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
               RenderSVGRect {rect} at (516,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
             RenderSVGContainer {a} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-              RenderSVGRect {rect} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
+              RenderSVGRect {rect} at (700,425) size 14x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CC0066]}] [x=10.00] [y=0.00] [width=8.00] [height=8.00]
           RenderSVGContainer {g} at (283,458) size 431x14 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,200.00)}]
             RenderSVGHiddenContainer {defs} at (0,0) size 0x0
               RenderSVGContainer {g} at (283,458) size 64x14

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -344,7 +344,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
 
     ASSERT(!isInherit || !isInitial); // isInherit -> !isInitial && isInitial -> !isInherit
 
-    if (m_state.applyPropertyToVisitedLinkStyle() && !isValidVisitedLinkProperty(id)) {
+    if (!m_state.applyPropertyToRegularStyle() && !isValidVisitedLinkProperty(id)) {
         // Limit the properties that can be applied to only the ones honored by :visited.
         return;
     }

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -83,9 +83,8 @@ public:
     inline const FontCascadeDescription& fontDescription();
     inline const FontCascadeDescription& parentFontDescription();
 
-    // FIXME: These are mutually exclusive, clean up the code to take that into account.
     bool applyPropertyToRegularStyle() const { return m_linkMatch != SelectorChecker::MatchVisited; }
-    bool applyPropertyToVisitedLinkStyle() const { return m_linkMatch == SelectorChecker::MatchVisited; }
+    bool applyPropertyToVisitedLinkStyle() const { return m_linkMatch != SelectorChecker::MatchLink; }
 
     bool useSVGZoomRules() const;
     bool useSVGZoomRulesForLength() const;


### PR DESCRIPTION
#### f93d71021b6613c26c7db8da6be03f88169d32c5
<pre>
[CSS] visited color should not be computed only for links
<a href="https://bugs.webkit.org/show_bug.cgi?id=264109">https://bugs.webkit.org/show_bug.cgi?id=264109</a>
<a href="https://rdar.apple.com/115289075">rdar://115289075</a>

Reviewed by Antti Koivisto and Tim Nguyen.

Before this patch, we are computing the visited link color only
when inside a link which creates a bug when we should inherit a computed color from another kind of element.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-visited-fallback.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/color-inherit-link-visited.html: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt:
* LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt:
* LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/animate-elem-41-t-manual-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/animate-elem-78-t-manual-expected.txt:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::applyPropertyToVisitedLinkStyle const):

Canonical link: <a href="https://commits.webkit.org/270270@main">https://commits.webkit.org/270270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e4c926e7e23ea3e4beb906a9d42b6c7834be06b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27142 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1007 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25270 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27722 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28663 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/545 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5994 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2688 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->