### PR TITLE
[WGSL] Add validation to integer division during code generation

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -467,6 +467,7 @@ auto RewriteGlobalVariables::getPacking(AST::CallExpression& call) -> Packing
             );
             strideExpression.m_inferredType = m_callGraph.ast().types().u32Type();
 
+            m_callGraph.ast().setUsesDivision();
             auto& elementCount = m_callGraph.ast().astBuilder().construct<AST::BinaryExpression>(
                 SourceSpan::empty(),
                 length,

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -41,6 +41,7 @@ static StringView metalCodePrologue()
 {
     return StringView {
         "#include <metal_stdlib>\n"
+        "#include <metal_types>\n"
         "\n"
         "using namespace metal;\n"
         "\n"_s

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -573,6 +573,8 @@ void TypeChecker::visit(AST::CompoundAssignmentStatement& statement)
 {
     // FIXME: Implement type checking - infer is called to avoid ASSERT in
     // TypeChecker::visit(AST::Expression&)
+    if (statement.operation() == AST::BinaryOperation::Divide)
+        m_shaderModule.setUsesDivision();
     infer(statement.leftExpression());
     infer(statement.rightExpression());
 }
@@ -813,6 +815,8 @@ void TypeChecker::visit(AST::IndexAccessExpression& access)
 
 void TypeChecker::visit(AST::BinaryExpression& binary)
 {
+    if (binary.operation() == AST::BinaryOperation::Divide)
+        m_shaderModule.setUsesDivision();
     chooseOverload("operator", binary, toString(binary.operation()), ReferenceWrapperVector<AST::Expression, 2> { binary.leftExpression(), binary.rightExpression() }, { });
 }
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -80,6 +80,10 @@ public:
     void setUsesWorkgroupUniformLoad() { m_usesWorkgroupUniformLoad = true; }
     void clearUsesWorkgroupUniformLoad() { m_usesWorkgroupUniformLoad = false; }
 
+    bool usesDivision() const { return m_usesDivision; }
+    void setUsesDivision() { m_usesDivision = true; }
+    void clearUsesDivision() { m_usesDivision = false; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -218,6 +222,7 @@ private:
     bool m_usesPackedStructs { false };
     bool m_usesUnpackArray { false };
     bool m_usesWorkgroupUniformLoad { false };
+    bool m_usesDivision { false };
     Configuration m_configuration;
     AST::Directive::List m_directives;
     AST::Function::List m_functions;

--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -24,6 +24,7 @@ config.environment['DYLD_FRAMEWORK_PATH'] = port._build_path()
 ignored_warnings = [
     '-Wno-unused-variable',
     '-Wno-missing-braces',
+    '-Wno-c++17-extensions',
 ]
 
 config.substitutions.append(('%check', '{}/bin/OutputCheck --comment=".*//" %s'.format(site.getuserbase())))
@@ -31,7 +32,7 @@ config.substitutions.append(('%wgslc', '{} %s _ 2>&1'.format(wgslc)))
 config.substitutions.append(('%not', 'eval !'))
 config.substitutions.append(('%metal-compile', (
     "function metal_compile() {"
-    "    set -e -o pipefail;"
+    "     set -e -o pipefail;"
     f"    {wgslc} --dump-generated-code '%s' \"$1\" > '%t.metal';"
     f"    xcrun -sdk macosx metal -Werror {' '.join(ignored_warnings)} -c '%t.metal' -o /dev/null;"
     "};"

--- a/Source/WebGPU/WGSL/tests/valid/division.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/division.wgsl
@@ -1,0 +1,75 @@
+// RUN: %metal-compile main
+
+fn testI32()
+{
+    var x: vec2<i32>;
+    var y: vec2<i32>;
+
+    let a = x / y;
+    let b = x / y[0];
+    let c = x[0] / y;
+    let d = x[0] / y[0];
+}
+
+fn testU32()
+{
+    var x: vec2<u32>;
+    var y: vec2<u32>;
+
+    let a = x / y;
+    let b = x / y[0];
+    let c = x[0] / y;
+    let d = x[0] / y[0];
+}
+
+fn testF32()
+{
+    var x: vec2<f32>;
+    var y: vec2<f32>;
+
+    let a = x / y;
+    let b = x / y[0];
+    let c = x[0] / y;
+    let d = x[0] / y[0];
+}
+
+fn testI32Compound()
+{
+    var x: vec2<i32>;
+    var y: vec2<i32>;
+
+    x /= y;
+    x /= y[0];
+    x[0] /= y[0];
+}
+
+fn testU32Compound()
+{
+    var x: vec2<u32>;
+    var y: vec2<u32>;
+
+    x /= y;
+    x /= y[0];
+    x[0] /= y[0];
+}
+
+fn testF32Compound()
+{
+    var x: vec2<f32>;
+    var y: vec2<f32>;
+
+    x /= y;
+    x /= y[0];
+    x[0] /= y[0];
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    testI32();
+    testU32();
+    testF32();
+
+    testI32Compound();
+    testU32Compound();
+    testF32Compound();
+}

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -54,6 +54,7 @@ fn main() -> @location(0) vec4<f32> {
 
     EXPECT_TRUE(mslSource.has_value());
     EXPECT_EQ(*mslSource, R"(#include <metal_stdlib>
+#include <metal_types>
 
 using namespace metal;
 
@@ -77,6 +78,7 @@ fn main(@builtin(position) position : vec4<f32>,
 
     EXPECT_TRUE(mslSource.has_value());
     EXPECT_EQ(*mslSource, R"(#include <metal_stdlib>
+#include <metal_types>
 
 using namespace metal;
 


### PR DESCRIPTION
#### 3bb0644a3e365f3db62b6a8781078b4b53d27a96
<pre>
[WGSL] Add validation to integer division during code generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=264106">https://bugs.webkit.org/show_bug.cgi?id=264106</a>
<a href="https://rdar.apple.com/117865769">rdar://117865769</a>

Reviewed by Mike Wyrzykowski.

According to the spec, the runtime behavior for integer division needs to handle
the following two corner cases:
- x / 0 = x
- INT_MIN / -1 = INT_MIN

The latter matches the default Metal behavior, but considering it&apos;s technically
undefined behavior, it seems safer to handle it explicitly.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::metalCodePrologue):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesDivision const):
(WGSL::ShaderModule::setUsesDivision):
(WGSL::ShaderModule::clearUsesDivision):
* Source/WebGPU/WGSL/tests/lit.cfg:
* Source/WebGPU/WGSL/tests/valid/division.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/270174@main">https://commits.webkit.org/270174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb465bcffb65e790d7a35ade0f41767ab1e53a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24775 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25020 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2370 "Found 1 new test failure: fast/dom/focus-dialog-blur-input-type-change-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27477 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22320 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26289 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3301 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5929 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->