### PR TITLE
[CSS Highlight API] Argument is missing from CSS highlight pseudo-element serialization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL "::highlight(foo)" should be a valid selector assert_equals: serialization should be canonical expected "::highlight(foo)" but got "::highlight"
-FAIL ".a::highlight(foo)" should be a valid selector assert_equals: serialization should be canonical expected ".a::highlight(foo)" but got ".a::highlight"
-FAIL "div ::highlight(foo)" should be a valid selector assert_equals: serialization should be canonical expected "div ::highlight(foo)" but got "div ::highlight"
-FAIL "::part(my-part)::highlight(foo)" should be a valid selector assert_equals: serialization should be canonical expected "::part(my-part)::highlight(foo)" but got "::part(my-part)::highlight"
+PASS "::highlight(foo)" should be a valid selector
+PASS ".a::highlight(foo)" should be a valid selector
+PASS "div ::highlight(foo)" should be a valid selector
+PASS "::part(my-part)::highlight(foo)" should be a valid selector
 PASS "::before::highlight(foo)" should be an invalid selector
 PASS "::highlight(foo).a" should be an invalid selector
 PASS "::highlight(foo) div" should be an invalid selector

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -735,6 +735,12 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
+            case CSSSelector::PseudoElementHighlight: {
+                builder.append("::highlight(");
+                serializeIdentifier(cs->argumentList()->first().identifier, builder);
+                builder.append(')');
+                break;
+            }
             case CSSSelector::PseudoElementPart: {
                 builder.append("::part(");
                 bool isFirst = true;


### PR DESCRIPTION
#### b63317aba187a3b13a34f1e04f3f74cbc21f7592
<pre>
[CSS Highlight API] Argument is missing from CSS highlight pseudo-element serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=264104">https://bugs.webkit.org/show_bug.cgi?id=264104</a>
<a href="https://rdar.apple.com/117864974">rdar://117864974</a>

Reviewed by Aditya Keerthi.

::highlight(foo) currently serializes to ::highlight which is an invalid selector.

Re-use ::part() serialization, since parsing is indentical (except highlight only takes one identifier).

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):

Canonical link: <a href="https://commits.webkit.org/270146@main">https://commits.webkit.org/270146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce5b27b2c0ad888b8a7f79e08389453affbf3e6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27369 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22221 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26207 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/232 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3217 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2366 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3140 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->