### PR TITLE
[WGSL] Add validation to integer division during constant evaluation

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.cpp
+++ b/Source/WebGPU/WGSL/ConstantValue.cpp
@@ -38,7 +38,9 @@ void ConstantValue::dump(PrintStream& out) const
             out.print(String::number(d));
         },
         [&](float f) {
-            out.print(String::number(f), "f");
+            out.print(String::number(f));
+            if (std::isfinite(f))
+                out.print("f");
         },
         [&](int64_t i) {
             out.print(String::number(i));

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -132,7 +132,7 @@ struct OverloadedDeclaration {
     Kind kind;
     bool mustUse;
 
-    ConstantValue (*constantFunction)(const Type*, const FixedVector<ConstantValue>&);
+    Expected<ConstantValue, String> (*constantFunction)(const Type*, const FixedVector<ConstantValue>&);
     OptionSet<ShaderStage> visibility;
     Vector<OverloadCandidate> overloads;
 };

--- a/Source/WebGPU/WGSL/tests/invalid/division.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/division.wgsl
@@ -1,0 +1,212 @@
+// RUN: %not %wgslc | %check
+
+fn testAbstractInt()
+{
+    // CHECK-L: division by zero
+    _ = 42 / 0;
+    // CHECK-L: division by zero
+    _ = 42 / vec2(1, 0);
+    // CHECK-L: division by zero
+    _ = vec2(42) / 0;
+    // CHECK-L: division by zero
+    _ = vec2(42) / vec2(1, 0);
+
+    let x = 42;
+    // CHECK-L: division by zero
+    _ = x / 0;
+    // CHECK-L: division by zero
+    _ = x / vec2(1, 0);
+    // CHECK-L: division by zero
+    _ = vec2(x) / 0;
+    // CHECK-L: division by zero
+    _ = vec2(x) / vec2(1, 0);
+
+    // CHECK-NOT-L: invalid division overflow
+    _ = (-2147483647 - 1) / -1;
+    // CHECK-NOT-L: invalid division overflow
+    _ = vec2(-2147483647 - 1, 1) / vec2(-1, 1);
+
+    // CHECK-L: invalid division overflow
+    _ = (-9223372036854775807 - 1) / -1;
+    // CHECK-L: invalid division overflow
+    _ = vec2(-9223372036854775807 - 1, 1) / vec2(-1, 1);
+}
+
+fn testI32()
+{
+    // CHECK-L: division by zero
+    _ = 42i / 0i;
+    // CHECK-L: division by zero
+    _ = 42i / vec2(1i, 0i);
+    // CHECK-L: division by zero
+    _ = vec2(42i) / 0i;
+    // CHECK-L: division by zero
+    _ = vec2(42i) / vec2(1i, 0i);
+
+    let x = 42i;
+    // CHECK-L: division by zero
+    _ = x / 0i;
+    // CHECK-L: division by zero
+    _ = x / vec2(1i, 0i);
+    // CHECK-L: division by zero
+    _ = vec2(x) / 0i;
+    // CHECK-L: division by zero
+    _ = vec2(x) / vec2(1i, 0i);
+
+    // CHECK-L: invalid division overflow
+    _ = (-2147483647i - 1i) / -1i;
+    // CHECK-L: invalid division overflow
+    _ = vec2(-2147483647i - 1i, 1i) / vec2(-1i, 1i);
+}
+
+fn testU32()
+{
+    // CHECK-L: division by zero
+    _ = 42u / 0u;
+    // CHECK-L: division by zero
+    _ = 42u / vec2(1u, 0u);
+    // CHECK-L: division by zero
+    _ = vec2(42u) / 0u;
+    // CHECK-L: division by zero
+    _ = vec2(42u) / vec2(1u, 0u);
+
+    let x = 42u;
+    // CHECK-L: division by zero
+    _ = x / 0u;
+    // CHECK-L: division by zero
+    _ = x / vec2(1u, 0u);
+    // CHECK-L: division by zero
+    _ = vec2(x) / 0u;
+    // CHECK-L: division by zero
+    _ = vec2(x) / vec2(1u, 0u);
+}
+
+fn testAbstractFloat()
+{
+    // FIXME: values need to be converted after return from call
+    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    _ = 42.0 / 0.0;
+    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    _ = 42.0 / vec2(1.0, 0.0);
+    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    _ = vec2(42.0) / 0.0;
+    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    _ = vec2(42.0) / vec2(1.0, 0.0);
+
+    // CHECK-NOT-L: division by zero
+    let x = 42.0;
+    // CHECK-NOT-L: division by zero
+    _ = x / 0.0;
+    // CHECK-NOT-L: division by zero
+    _ = x / vec2(1.0, 0.0);
+    // CHECK-NOT-L: division by zero
+    _ = vec2(x) / 0.0;
+    // CHECK-NOT-L: division by zero
+    _ = vec2(x) / vec2(1.0, 0.0);
+
+    // CHECK-NOT-L: invalid division overflow
+    _ = (-2147483647.0 - 1.0) / -1.0;
+    // CHECK-NOT-L: invalid division overflow
+    _ = vec2(-2147483647.0 - 1.0, 1.0) / vec2(-1.0, 1.0);
+
+    // CHECK-NOT-L: invalid division overflow
+    _ = (-9223372036854775807.0 - 1.0) / -1.0;
+    // CHECK-NOT-L: invalid division overflow
+    _ = vec2(-9223372036854775807.0 - 1.0, 1.0) / vec2(-1.0, 1.0);
+
+    // CHECK-NOT-L: invalid division overflow
+    _ = -340282346638528859811704183484516925440.0 - 1.0 / -1.0;
+    // CHECK-NOT-L: invalid division overflow
+    _ = vec2(-340282346638528859811704183484516925440.0 - 1.0, 1.0) / vec2(-1.0, 1.0);
+}
+
+fn testF32()
+{
+    // FIXME: values need to be converted after return from call
+    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    _ = 42f / 0f;
+    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    _ = 42f / vec2(1f, 0f);
+    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    _ = vec2(42f) / 0f;
+    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    _ = vec2(42f) / vec2(1f, 0f);
+
+    let x = 42f;
+    // CHECK-NOT-L: division by zero
+    _ = x / 0f;
+    // CHECK-NOT-L: division by zero
+    _ = x / vec2(1f, 0f);
+    // CHECK-NOT-L: division by zero
+    _ = vec2(x) / 0f;
+    // CHECK-NOT-L: division by zero
+    _ = vec2(x) / vec2(1f, 0f);
+
+    // CHECK-NOT-L: invalid division overflow
+    _ = (-2147483647f - 1f) / -1f;
+    // CHECK-NOT-L: invalid division overflow
+    _ = vec2(-2147483647f - 1f, 1f) / vec2(-1f, 1f);
+
+    // CHECK-NOT-L: invalid division overflow
+    _ = (-9223372036854775807.f - 1.f) / -1.f;
+    // CHECK-NOT-L: invalid division overflow
+    _ = vec2(-9223372036854775807.f - 1.f, 1.f) / vec2(-1.f, 1.f);
+
+    // CHECK-NOT-L: invalid division overflow
+    _ = (-340282346638528859811704183484516925439.f - 1f) / -1f;
+    // CHECK-NOT-L: invalid division overflow
+    _ = vec2(-340282346638528859811704183484516925439.f - 1f, 1f) / vec2(-1f, 1f);
+}
+
+fn testI32Compound()
+{
+    var y: vec2<i32>;
+    // CHECK-L: division by zero
+    y /= 0;
+    // CHECK-L: division by zero
+    y /= vec2(1, 0);
+    // CHECK-L: division by zero
+    y[0] /= 0;
+    // CHECK-L: division by zero
+    y[0] /= vec2(1, 0);
+}
+
+fn testU32Compound()
+{
+    var y: vec2<u32>;
+    // CHECK-L: division by zero
+    y /= 0;
+    // CHECK-L: division by zero
+    y /= vec2(1, 0);
+    // CHECK-L: division by zero
+    y[0] /= 0;
+    // CHECK-L: division by zero
+    y[0] /= vec2(1, 0);
+}
+
+fn testF32Compound()
+{
+    // FIXME: these depende on proper typing for compound statements
+    // var y: vec2<f32>;
+    // skip-CHECK-NOT-L: division by zero
+    // y /= 0;
+    // skip-CHECK-NOT-L: division by zero
+    // y /= vec2(1, 0);
+    // skip-CHECK-NOT-L: division by zero
+    // y[0] /= 0;
+    // skip-CHECK-NOT-L: division by zero
+    // y[0] /= vec2(1, 0);
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    testAbstractInt();
+    testI32();
+    testU32();
+    testAbstractFloat();
+    testF32();
+
+    testI32Compound();
+    testU32Compound();
+    testF32Compound();
+}


### PR DESCRIPTION
#### 51a39e9c35c5c1e2105bcfa29662c294f012f99b
<pre>
[WGSL] Add validation to integer division during constant evaluation
<a href="https://bugs.webkit.org/show_bug.cgi?id=264107">https://bugs.webkit.org/show_bug.cgi?id=264107</a>
<a href="https://rdar.apple.com/117865966">rdar://117865966</a>

Reviewed by Mike Wyrzykowski.

Similar to PR#19898, but for constant evaluation. The patch is bigger since it
required changing the signature of all constant functions to reflect the fact
that the constant functions can fail, but the actual division validation is rather
straightforward. The test case still has a couple FIXMEs, which aren&apos;t too
complicated but will be implemented in separated PRs since this one was largely
a mechanical refactor.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantUnaryOperation):
(WGSL::constantBinaryOperation):
(WGSL::constantTernaryOperation):
(WGSL::scalarOrVector):
(WGSL::CONSTANT_FUNCTION):
(WGSL::BINARY_OPERATION):
(WGSL::containsZero):
(WGSL::constantAdd): Deleted.
(WGSL::constantMinus): Deleted.
(WGSL::constantMultiply): Deleted.
(WGSL::constantBitwiseOr): Deleted.
(WGSL::constantBitwiseAnd): Deleted.
(WGSL::constantBitwiseShiftLeft): Deleted.
(WGSL::constantBitwiseShiftRight): Deleted.
(WGSL::constantVec2): Deleted.
(WGSL::constantVec3): Deleted.
(WGSL::constantVec4): Deleted.
(WGSL::constantAll): Deleted.
(WGSL::constantAny): Deleted.
(WGSL::constantSelect): Deleted.
(WGSL::constantCross): Deleted.
(WGSL::constantDeterminant): Deleted.
(WGSL::constantDistance): Deleted.
(WGSL::constantDot): Deleted.
(WGSL::constantLength): Deleted.
(WGSL::constantExtractBits): Deleted.
(WGSL::constantFaceForward): Deleted.
(WGSL::constantFma): Deleted.
(WGSL::constantFract): Deleted.
(WGSL::constantFrexp): Deleted.
(WGSL::constantInsertBits): Deleted.
(WGSL::constantLdexp): Deleted.
(WGSL::constantModf): Deleted.
(WGSL::constantNormalize): Deleted.
(WGSL::constantQuantizeToF16): Deleted.
(WGSL::constantReflect): Deleted.
(WGSL::constantRefract): Deleted.
(WGSL::constantTranspose): Deleted.
* Source/WebGPU/WGSL/ConstantValue.cpp:
(WGSL::ConstantValue::dump const):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
(WGSL::TypeChecker::convertValue):
* Source/WebGPU/WGSL/tests/invalid/division.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/270177@main">https://commits.webkit.org/270177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c49f7550744128314cdfc613165821b6888da4e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24788 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22757 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/770 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27490 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2088 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28488 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26302 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2024 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/328 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3314 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5931 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->