### PR TITLE
[JSC] Fix LocaleIDBuilder::setKeywordValue by letting the callers to handle U_SUCCESS

### DIFF
--- a/JSTests/stress/intl-locale-exceptions.js
+++ b/JSTests/stress/intl-locale-exceptions.js
@@ -1,0 +1,35 @@
+function shouldThrow(func, errorType) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name}!`);
+}
+
+shouldThrow(() => {
+    let calendarValue = 'buddhist';
+    calendarValue = calendarValue.toLocaleString().padEnd(calendarValue.length + 510 * 4, -169);
+    var loc = new Intl.Locale('ko', {
+        calendar: calendarValue,
+    });
+}, RangeError);
+
+shouldThrow(() => {
+    let collationValue = 'zhuyin';
+    collationValue = collationValue.toLocaleString().padEnd(collationValue.length + 510 * 4, -169);
+    var loc = new Intl.Locale('ko', {
+        collation: collationValue,
+    });
+}, RangeError);
+
+shouldThrow(() => {
+    let numberingSystemValue = 'latn';
+    numberingSystemValue = numberingSystemValue.toLocaleString().padEnd(numberingSystemValue.length + 510 * 4, -169);
+    var loc = new Intl.Locale('ko', {
+        numberingSystem: numberingSystemValue,
+    });
+}, RangeError);


### PR DESCRIPTION
#### f1ab7fe7c2dec3f5cadbc42bc138a946aa8070fc
<pre>
[JSC] Fix LocaleIDBuilder::setKeywordValue by letting the callers to handle U_SUCCESS
<a href="https://bugs.webkit.org/show_bug.cgi?id=264105">https://bugs.webkit.org/show_bug.cgi?id=264105</a>
<a href="https://rdar.apple.com/117548205">rdar://117548205</a>

Reviewed by Yusuke Suzuki.

In LocaleIDBuilder::setKeywordValue, the status may ended with
U_INTERNAL_PROGRAM_ERROR. We should let the callers to handle
the success of setKeywordValue.

* JSTests/stress/intl-locale-exceptions.js: Added.
(shouldThrow):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::setKeywordValue):
(JSC::IntlLocale::initializeLocale):

Canonical link: <a href="https://commits.webkit.org/270149@main">https://commits.webkit.org/270149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fb186ca18b8f3d6fd64e4799639a140fe99176a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22660 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/654 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27373 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28408 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21450 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26211 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/235 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31346 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3221 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6873 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2370 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31318 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3142 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2283 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6547 "Passed tests") | 
<!--EWS-Status-Bubble-End-->