### PR TITLE
[WebAuthn] Start serializing credProps

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt
@@ -1,5 +1,6 @@
 
 PASS PublicKeyCredential's [[create]] with minimum options in a mock local authenticator.
+PASS PublicKeyCredential's [[create]] with credProps in a mock local authenticator.
 PASS PublicKeyCredential's [[create]] with minimum options in a mock local authenticator checking getPublicKey()
 PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'platform' } in a mock local authenticator.
 PASS PublicKeyCredential's [[create]] with matched exclude credential ids but not transports in a mock local authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
@@ -68,8 +68,44 @@
 
         return navigator.credentials.create(options).then(credential => {
             checkResult(credential, credentialID);
+            assert_not_own_property(credential.getClientExtensionResults(), "credProps");
         });
     }, "PublicKeyCredential's [[create]] with minimum options in a mock local authenticator.");
+
+    promise_test(async t => {
+        const privateKeyBase64 = await generatePrivateKeyBase64();
+        const credentialID = await calculateCredentialID(privateKeyBase64);
+        const userhandleBase64 = generateUserhandleBase64();
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({
+                local: {
+                    userVerification: "yes",
+                    acceptAttestation: false,
+                    privateKeyBase64: privateKeyBase64,
+                }
+            });
+
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: userhandleBase64,
+                    id: Base64URL.parse(userhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                extensions: { credProps: true },
+            }
+        };
+
+        return navigator.credentials.create(options).then(credential => {
+            checkResult(credential, credentialID);
+            assert_true(credential.getClientExtensionResults().credProps.rk);
+        });
+    }, "PublicKeyCredential's [[create]] with credProps in a mock local authenticator.");
 
     promise_test(async t => {
         const privateKeyBase64 = "BKeelnM8D7ykBNa79wacy6FW8UYZ+PG0Cr2Dr4Rzo+qJHExNkPVdzQ1/hjrqg8iY3IzM/NUvJJOzmtuchS6TLqTfzmsXsVdApUn9kx4Lh/cv01hbXt7/Q8kAbubi8Mqmqw==";

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
@@ -40,7 +40,7 @@ struct AuthenticationExtensionsClientInputs {
     };
 
     String appid;
-    bool credProps; // Not serialized but probably should be. Don't re-introduce rdar://101057340 though.
+    bool credProps;
     std::optional<AuthenticationExtensionsClientInputs::LargeBlobInputs> largeBlob;
 
     WEBCORE_EXPORT Vector<uint8_t> toCBOR() const;

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
@@ -35,7 +35,6 @@
     Conditional=WEB_AUTHN,
 ] dictionary AuthenticationExtensionsClientInputs {
     USVString appid;
-    // For Google to turn off the legacy AppID support.
     boolean credProps;
     AuthenticationExtensionsLargeBlobInputs largeBlob;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1467,7 +1467,7 @@ struct WebCore::WebLockManagerSnapshot {
 
 [LegacyPopulateFromEmptyConstructor] struct WebCore::AuthenticationExtensionsClientInputs {
     String appid;
-    [NotSerialized] bool credProps;
+    bool credProps;
     std::optional<WebCore::AuthenticationExtensionsClientInputs::LargeBlobInputs> largeBlob;
 }
 


### PR DESCRIPTION
#### 005919a38d0eb76f427b39ffcaf6a10ef2fc8e0d
<pre>
[WebAuthn] Start serializing credProps
<a href="https://bugs.webkit.org/show_bug.cgi?id=264110">https://bugs.webkit.org/show_bug.cgi?id=264110</a>
<a href="https://rdar.apple.com/problem/117869015">rdar://problem/117869015</a>

Reviewed by NOBODY (OOPS!).

This patch starts to serialize credProps, which wasn&apos;t serialized before.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/005919a38d0eb76f427b39ffcaf6a10ef2fc8e0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26959 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23123 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27539 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28528 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22658 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22722 "Found 4 new test failures: http/wpt/webauthn/public-key-credential-create-success-hid.https.html, http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html, http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html, http/wpt/webauthn/public-key-credential-get-success-u2f.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26346 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/379 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22126 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->