### PR TITLE
[iOS] Support text selection and interaction using UIAsyncTextInteraction

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1227,6 +1227,27 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @end
 #endif
 
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+
+@interface UIAsyncTextInteraction (Staging_117831560)
+
+- (void)presentEditMenuForSelection;
+- (void)dismissEditMenuForSelection;
+
+- (void)selectionChanged;
+- (void)editabilityChanged;
+
+@property (nonatomic, readonly) UITextSelectionDisplayInteraction *textSelectionDisplayInteraction;
+
+#if USE(UICONTEXTMENU)
+@property (nonatomic, weak) id<UIContextMenuInteractionDelegate> contextMenuInteractionDelegate;
+@property (nonatomic, readonly) UIContextMenuInteraction *contextMenuInteraction;
+#endif
+
+@end
+
+#endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
+
 WTF_EXTERN_C_BEGIN
 
 BOOL UIKeyboardEnabledInputModesAllowOneToManyShortcuts(void);

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -67,41 +67,67 @@ SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
 - (void)activateSelection
 {
     [_textInteractionAssistant activateSelection];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction textSelectionDisplayInteraction].activated = YES;
+#endif
 }
 
 - (void)deactivateSelection
 {
     [_textInteractionAssistant deactivateSelection];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction textSelectionDisplayInteraction].activated = NO;
+#endif
 }
 
 - (void)selectionChanged
 {
     [_textInteractionAssistant selectionChanged];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction selectionChanged];
+#endif
 }
 
 - (void)setGestureRecognizers
 {
     [_textInteractionAssistant setGestureRecognizers];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction editabilityChanged];
+#endif
 }
 
 - (void)willStartScrollingOverflow
 {
     [_textInteractionAssistant willStartScrollingOverflow];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction dismissEditMenuForSelection];
+    [_asyncTextInteraction textSelectionDisplayInteraction].activated = NO;
+#endif
 }
 
 - (void)didEndScrollingOverflow
 {
     [_textInteractionAssistant didEndScrollingOverflow];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction presentEditMenuForSelection];
+    [_asyncTextInteraction textSelectionDisplayInteraction].activated = YES;
+#endif
 }
 
 - (void)willStartScrollingOrZooming
 {
     [_textInteractionAssistant willStartScrollingOrZooming];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction dismissEditMenuForSelection];
+#endif
 }
 
 - (void)didEndScrollingOrZooming
 {
     [_textInteractionAssistant didEndScrollingOrZooming];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction presentEditMenuForSelection];
+#endif
 }
 
 - (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(UIWKGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(UIWKSelectionFlags)flags
@@ -190,12 +216,19 @@ SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
 
 - (UIContextMenuInteraction *)contextMenuInteraction
 {
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    if (_asyncTextInteraction)
+        return [_asyncTextInteraction contextMenuInteraction];
+#endif
     return [_textInteractionAssistant contextMenuInteraction];
 }
 
 - (void)setExternalContextMenuInteractionDelegate:(id<UIContextMenuInteractionDelegate>)delegate
 {
     [_textInteractionAssistant setExternalContextMenuInteractionDelegate:delegate];
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    [_asyncTextInteraction setContextMenuInteractionDelegate:delegate];
+#endif
 }
 
 #endif // USE(UICONTEXTMENU)


### PR DESCRIPTION
#### 3805718abdffd5643d6513d874002e19e6d061af
<pre>
[iOS] Support text selection and interaction using UIAsyncTextInteraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=264094">https://bugs.webkit.org/show_bug.cgi?id=264094</a>
<a href="https://rdar.apple.com/117857833">rdar://117857833</a>

Reviewed by Aditya Keerthi.

Implement the remaining set of methods on `WKTextInteractionWrapper`, in the case where the wrapper
is backed by `UIAsyncTextInteraction`. This enables basic text interactions (such as multi-tap,
range adjustment, and tap-and-half gestures), as well as context menu interactions for links and
images in the page, and finally the ability to temporarily suppress the text selection when we&apos;re
either inside of a hidden editable container, or while the selection is inside of a scrolling
overflow container.

Depends on the changes in <a href="https://rdar.apple.com/117831560">rdar://117831560</a> as well.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper activateSelection]):
(-[WKTextInteractionWrapper deactivateSelection]):
(-[WKTextInteractionWrapper selectionChanged]):
(-[WKTextInteractionWrapper setGestureRecognizers]):
(-[WKTextInteractionWrapper willStartScrollingOverflow]):
(-[WKTextInteractionWrapper didEndScrollingOverflow]):
(-[WKTextInteractionWrapper willStartScrollingOrZooming]):
(-[WKTextInteractionWrapper didEndScrollingOrZooming]):
(-[WKTextInteractionWrapper contextMenuInteraction]):
(-[WKTextInteractionWrapper setExternalContextMenuInteractionDelegate:]):

Canonical link: <a href="https://commits.webkit.org/270296@main">https://commits.webkit.org/270296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad4f30c3b9357f6ec705382ffbc17274bc65b71f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23010 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1044 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27762 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2339 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28706 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/585 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3587 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6007 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2723 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2620 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->