### PR TITLE
We should cache the first base element in Document

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3776,13 +3776,22 @@ void Document::setBaseURLOverride(const URL& url)
     updateBaseURL();
 }
 
+HTMLBaseElement* Document::firstBaseElement() const
+{
+    return m_firstBaseElement.get();
+}
+
 void Document::processBaseElement()
 {
     // Find the first href attribute in a base element and the first target attribute in a base element.
     AtomString href;
     AtomString target;
+    RefPtr<HTMLBaseElement> baseElement;
     auto baseDescendants = descendantsOfType<HTMLBaseElement>(*this);
     for (auto& base : baseDescendants) {
+        if (!baseElement)
+            baseElement = &base;
+
         if (href.isNull()) {
             auto& value = base.attributeWithoutSynchronization(hrefAttr);
             if (!value.isNull()) {
@@ -3816,6 +3825,7 @@ void Document::processBaseElement()
     }
 
     m_baseTarget = WTFMove(target);
+    m_firstBaseElement = WTFMove(baseElement);
 }
 
 String Document::userAgent(const URL& url) const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -136,6 +136,7 @@ class GPUCanvasContext;
 class GraphicsClient;
 class HTMLAllCollection;
 class HTMLAttachmentElement;
+class HTMLBaseElement;
 class HTMLBodyElement;
 class HTMLCanvasElement;
 class HTMLCollection;
@@ -789,6 +790,7 @@ public:
     const URL& baseURLOverride() const { return m_baseURLOverride; }
     const URL& baseElementURL() const { return m_baseElementURL; }
     const AtomString& baseTarget() const { return m_baseTarget; }
+    HTMLBaseElement* firstBaseElement() const;
     void processBaseElement();
 
     URL baseURLForComplete(const URL& baseURLOverride) const;
@@ -2005,6 +2007,8 @@ private:
     String m_documentURI;
 
     AtomString m_baseTarget;
+
+    WeakPtr<HTMLBaseElement, WeakPtrImplWithEventTargetData> m_firstBaseElement;
 
     // MIME type of the document in case it was cloned or created by XHR.
     String m_overriddenMIMEType;

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -31,6 +31,7 @@
 #include "CSSTokenizer.h"
 #include "CommonAtomStrings.h"
 #include "ElementAncestorIteratorInlines.h"
+#include "HTMLBaseElement.h"
 #include "HTMLNames.h"
 #include "SelectorChecker.h"
 #include "StaticNodeList.h"
@@ -277,6 +278,16 @@ static ALWAYS_INLINE bool localNameMatches(const Element& element, const AtomStr
 template<typename OutputType>
 static inline void elementsForLocalName(const ContainerNode& rootNode, const AtomString& localName, const AtomString& lowercaseLocalName, OutputType& output)
 {
+    if (is<Document>(rootNode) && lowercaseLocalName == HTMLNames::baseTag->localName()) {
+        RefPtr firstBaseElement = downcast<Document>(rootNode).firstBaseElement();
+        if (!firstBaseElement)
+            return;
+        if constexpr (std::is_same_v<OutputType, Element*>) {
+            appendOutputForElement(output, *firstBaseElement);
+            return;
+        }
+    }
+
     if (localName == lowercaseLocalName) {
         for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
             if (element.tagQName().localName() == localName) {


### PR DESCRIPTION
#### 6a6005d1bc7feef0f500d36e1d05677d06c050bd
<pre>
We should cache the first base element in Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=264113">https://bugs.webkit.org/show_bug.cgi?id=264113</a>
<a href="https://rdar.apple.com/117871556">rdar://117871556</a>

Reviewed by Ryosuke Niwa.

Sometimes, we consume much time for document.querySelector(&quot;base&quot;),
because this document ends up not having `base`. It means that it is traversing all the tree.
But this traversal is already paid cost when we call Document::processBaseElement, which is called
everytime `base` element is inserted or removed into the document to update baseURL. So we should just
cache the first element here, and use this information in querySelector and querySelectorAll.

This patch adds Document::firstBaseElement and adding a fast path for querySelector and querySelectorAll.
querySelector uses this element directly. And querySelectorAll stops traversal when this firstBaseElement is nullptr.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::firstBaseElement const):
(WebCore::Document::processBaseElement):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::elementsForLocalName):

Canonical link: <a href="https://commits.webkit.org/270150@main">https://commits.webkit.org/270150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a32f931b1047408cbdb401b932254ee2c2288a31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/686 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27404 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22259 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/260 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2396 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3143 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->