### PR TITLE
Add <input type=checkbox switch> macOS implementation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS switch IDL attribute, setter
+PASS switch IDL attribute, getter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window.js
@@ -1,0 +1,19 @@
+test(t => {
+  const input = document.createElement("input");
+  input.switch = true;
+
+  assert_true(input.hasAttribute("switch"));
+  assert_equals(input.getAttribute("switch"), "");
+  assert_equals(input.type, "text");
+}, "switch IDL attribute, setter");
+
+test(t => {
+  const container = document.createElement("div");
+  container.innerHTML = "<input type=checkbox switch>";
+  const input = container.firstChild;
+
+  assert_true(input.hasAttribute("switch"));
+  assert_equals(input.getAttribute("switch"), "");
+  assert_equals(input.type, "checkbox");
+  assert_true(input.switch);
+}, "switch IDL attribute, getter");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window-expected.txt
@@ -4,4 +4,5 @@ PASS Checkbox that is no longer a switch control does match :indeterminate
 PASS Checkbox that becomes a switch control does not match :indeterminate
 PASS Parent of a checkbox that becomes a switch control does not match :has(:indeterminate)
 PASS Parent of a switch control that becomes a checkbox continues to match :has(:checked)
+PASS A switch control that becomes a checkbox in a roundabout way
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window.js
@@ -4,7 +4,7 @@ test(t => {
   input.type = "checkbox";
   input.switch = true;
   input.indeterminate = true;
-  
+
   assert_false(input.matches(":indeterminate"));
 }, "Switch control does not match :indeterminate");
 
@@ -60,3 +60,16 @@ test(t => {
   input.checked = false;
   assert_false(document.body.matches(":has(:checked)"));
 }, "Parent of a switch control that becomes a checkbox continues to match :has(:checked)");
+
+test(t => {
+  const input = document.body.appendChild(document.createElement("input"));
+  t.add_cleanup(() => input.remove());
+  input.type = "checkbox";
+  input.switch = true;
+  input.indeterminate = true;
+  assert_false(input.matches(":indeterminate"));
+  input.type = "text";
+  input.removeAttribute("switch");
+  input.type = "checkbox";
+  assert_true(input.matches(":indeterminate"));
+}, "A switch control that becomes a checkbox in a roundabout way");

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2044,6 +2044,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/SearchFieldResultsPart.h
     platform/graphics/controls/SliderThumbPart.h
     platform/graphics/controls/SliderTrackPart.h
+    platform/graphics/controls/SwitchThumbPart.h
+    platform/graphics/controls/SwitchTrackPart.h
     platform/graphics/controls/TextAreaPart.h
     platform/graphics/controls/TextFieldPart.h
     platform/graphics/controls/ToggleButtonPart.h

--- a/Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h
@@ -60,6 +60,7 @@ extern const CFStringRef kCUIStatePressed;
 
 extern const CFStringRef kCUIUserInterfaceLayoutDirectionKey;
 extern const CFStringRef kCUIUserInterfaceLayoutDirectionLeftToRight;
+extern const CFStringRef kCUIUserInterfaceLayoutDirectionRightToLeft;
 
 extern const CFStringRef kCUIValueKey;
 
@@ -69,5 +70,10 @@ extern const CFStringRef kCUIWidgetButtonLittleArrows;
 extern const CFStringRef kCUIWidgetProgressIndeterminateBar;
 extern const CFStringRef kCUIWidgetProgressBar;
 extern const CFStringRef kCUIWidgetScrollBarTrackCorner;
+extern const CFStringRef kCUIWidgetSwitchKnob;
+extern const CFStringRef kCUIWidgetSwitchBorder;
+extern const CFStringRef kCUIWidgetSwitchFill;
+extern const CFStringRef kCUIWidgetSwitchFillMask;
+extern const CFStringRef kCUIWidgetSwitchOnOffLabel;
 
 #endif

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -501,6 +501,9 @@ platform/graphics/mac/controls/SearchFieldMac.mm
 platform/graphics/mac/controls/SearchFieldResultsMac.mm
 platform/graphics/mac/controls/SliderThumbMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm
+platform/graphics/mac/controls/SwitchMacUtilities.mm
+platform/graphics/mac/controls/SwitchThumbMac.mm
+platform/graphics/mac/controls/SwitchTrackMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm
 platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/ToggleButtonMac.mm

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -383,6 +383,7 @@ constexpr CSSValueID toCSSValueID(StyleAppearance e)
     case StyleAppearance::SearchFieldCancelButton:
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
+    case StyleAppearance::Switch:
     case StyleAppearance::SwitchThumb:
     case StyleAppearance::SwitchTrack:
         ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();

--- a/Source/WebCore/css/htmlSwitchControl.css
+++ b/Source/WebCore/css/htmlSwitchControl.css
@@ -26,8 +26,10 @@
 
 input[type="checkbox"][switch] {
     margin: initial;
+    display: inline-grid;
 }
 
 input[type="checkbox"][switch]::thumb, input[type="checkbox"][switch]::track {
     appearance: inherit !important;
+    grid-area: 1/1;
 }

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -58,8 +58,7 @@ bool CheckboxInputType::valueMissing(const String&) const
 
 String CheckboxInputType::valueMissingText() const
 {
-    ASSERT(element());
-    if (element()->isSwitch())
+    if (isSwitch())
         return validationMessageValueMissingForSwitchText();
     return validationMessageValueMissingForCheckboxText();
 }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -854,8 +854,6 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
     case AttributeNames::switchAttr:
         if (document().settings().switchControlEnabled()) {
             auto hasSwitchAttribute = !newValue.isNull();
-            if (hasSwitchAttribute == isSwitch())
-                return;
             m_hasSwitchAttribute = hasSwitchAttribute;
             if (isSwitch())
                 m_inputType->createShadowSubtreeIfNeeded();

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -42,6 +42,8 @@ class SearchFieldPart;
 class SearchFieldResultsPart;
 class SliderThumbPart;
 class SliderTrackPart;
+class SwitchThumbPart;
+class SwitchTrackPart;
 class TextAreaPart;
 class TextFieldPart;
 class ToggleButtonPart;
@@ -74,6 +76,8 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSwitchThumb(SwitchThumbPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSwitchTrack(SwitchTrackPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SwitchThumbPart final : public ControlPart {
+public:
+    static Ref<SwitchThumbPart> create()
+    {
+        return adoptRef(*new SwitchThumbPart());
+    }
+
+private:
+    SwitchThumbPart()
+        : ControlPart(StyleAppearance::SwitchThumb)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSwitchThumb(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SwitchTrackPart final : public ControlPart {
+public:
+    static Ref<SwitchTrackPart> create()
+    {
+        return adoptRef(*new SwitchTrackPart());
+    }
+
+private:
+    SwitchTrackPart()
+        : ControlPart(StyleAppearance::SwitchTrack)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSwitchTrack(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h
+++ b/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h
@@ -50,6 +50,8 @@ private:
     std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchThumb(SwitchThumbPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchTrack(SwitchTrackPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;

--- a/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
+++ b/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
@@ -111,6 +111,18 @@ std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformSliderTrack(Sl
     return nullptr;
 }
 
+std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformSwitchThumb(SwitchThumbPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformSwitchTrack(SwitchTrackPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
 std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformTextArea(TextAreaPart&)
 {
     notImplemented();

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -67,6 +67,8 @@ private:
     std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchThumb(SwitchThumbPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchTrack(SwitchTrackPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -44,6 +44,8 @@
 #import "SearchFieldResultsPart.h"
 #import "SliderThumbMac.h"
 #import "SliderTrackMac.h"
+#import "SwitchThumbMac.h"
+#import "SwitchTrackMac.h"
 #import "TextAreaMac.h"
 #import "TextFieldMac.h"
 #import "ToggleButtonMac.h"
@@ -293,6 +295,16 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSliderThumb(Sl
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSliderTrack(SliderTrackPart& part)
 {
     return makeUnique<SliderTrackMac>(part, *this);
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSwitchThumb(SwitchThumbPart& part)
+{
+    return makeUnique<SwitchThumbMac>(part, *this);
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSwitchTrack(SwitchTrackPart& part)
+{
+    return makeUnique<SwitchTrackMac>(part, *this);
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextArea(TextAreaPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -43,6 +43,7 @@ public:
 
 protected:
     static bool userPrefersContrast();
+    static bool userPrefersWithoutColorDifferentiation();
     static FloatRect inflatedRect(const FloatRect& bounds, const FloatSize&, const IntOutsets&, const ControlStyle&);
 
     static void updateCheckedState(NSCell *, const ControlStyle&);

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -57,6 +57,11 @@ bool ControlMac::userPrefersContrast()
     return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
 }
 
+bool ControlMac::userPrefersWithoutColorDifferentiation()
+{
+    return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldDifferentiateWithoutColor];
+}
+
 FloatRect ControlMac::inflatedRect(const FloatRect& bounds, const FloatSize& size, const IntOutsets& outsets, const ControlStyle& style)
 {
     auto scaledOutsets = FloatBoxExtent {

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+namespace WebCore::SwitchMacUtilities {
+
+static IntSize cellSize(NSControlSize);
+static IntOutsets cellOutsets(NSControlSize);
+static FloatRect rectForBounds(const FloatRect&);
+static NSString *coreUISizeForControlSize(const NSControlSize);
+
+} // namespace WebCore::SwitchMacUtilities
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SwitchMacUtilities.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import <pal/spi/mac/CoreUISPI.h>
+#import <pal/spi/mac/NSAppearanceSPI.h>
+
+namespace WebCore::SwitchMacUtilities {
+
+static IntSize cellSize(NSControlSize controlSize)
+{
+    static const std::array<IntSize, 4> sizes =
+    {
+        IntSize { 38, 22 },
+        IntSize { 32, 18 },
+        IntSize { 26, 15 },
+        IntSize { 38, 22 }
+    };
+    return sizes[controlSize];
+}
+
+static IntOutsets cellOutsets(NSControlSize controlSize)
+{
+    static const IntOutsets margins[] =
+    {
+        // top right bottom left
+        { 2, 2, 1, 2 },
+        { 2, 2, 1, 2 },
+        { 1, 1, 0, 1 },
+        { 2, 2, 1, 2 },
+    };
+    return margins[controlSize];
+}
+
+static FloatRect rectForBounds(const FloatRect& bounds)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return bounds;
+}
+
+static NSString *coreUISizeForControlSize(const NSControlSize controlSize)
+{
+    if (controlSize == NSControlSizeMini)
+        return (__bridge NSString *)kCUISizeMini;
+    if (controlSize == NSControlSizeSmall)
+        return (__bridge NSString *)kCUISizeSmall;
+    return (__bridge NSString *)kCUISizeRegular;
+}
+
+} // namespace WebCore::SwitchMacUtilities
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class SwitchThumbPart;
+
+class SwitchThumbMac final : public ControlMac {
+public:
+    SwitchThumbMac(SwitchThumbPart&, ControlFactoryMac&);
+
+private:
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
+    FloatRect rectForBounds(const FloatRect&, const ControlStyle&) const override;
+
+    void draw(GraphicsContext&, const FloatRoundedRect&, float, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SwitchThumbMac.h"
+
+#if PLATFORM(MAC)
+
+#import "SwitchMacUtilities.h"
+#import "SwitchThumbPart.h"
+
+namespace WebCore {
+
+SwitchThumbMac::SwitchThumbMac(SwitchThumbPart& part, ControlFactoryMac& controlFactory)
+    : ControlMac(part, controlFactory)
+{
+    ASSERT(part.type() == StyleAppearance::SwitchThumb);
+}
+
+IntSize SwitchThumbMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
+{
+    // For now we need the track sizes to paint the thumb. As it happens the thumb is the square
+    // of the track's height. We (ab)use that fact later on.
+    return SwitchMacUtilities::cellSize(controlSize);
+}
+
+IntOutsets SwitchThumbMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
+{
+    return SwitchMacUtilities::cellOutsets(controlSize);
+}
+
+FloatRect SwitchThumbMac::rectForBounds(const FloatRect& bounds, const ControlStyle&) const
+{
+    return SwitchMacUtilities::rectForBounds(bounds);
+}
+
+void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    bool isOn = style.states.contains(ControlStyle::State::Checked);
+    bool isRTL = style.states.contains(ControlStyle::State::RightToLeft);
+    bool isEnabled = style.states.contains(ControlStyle::State::Enabled);
+    bool isPressed = style.states.contains(ControlStyle::State::Pressed);
+
+    auto borderRectRect = borderRect.rect();
+    auto controlSize = controlSizeForSize(borderRectRect.size(), style);
+    auto size = cellSize(controlSize, style);
+    auto outsets = cellOutsets(controlSize, style);
+
+    size.scale(style.zoomFactor);
+
+    auto trackY = std::max(((borderRectRect.height() - size.height()) / 2.0f), 0.0f);
+    auto trackRect = FloatRect { FloatPoint { borderRectRect.x(), borderRectRect.y() + trackY }, size };
+
+    auto inflatedTrackRect = inflatedRect(trackRect, size, outsets, style);
+
+    auto drawingThumbX = isOn ? inflatedTrackRect.width() - inflatedTrackRect.height() : 0;
+    auto drawingThumbRect = NSMakeRect(drawingThumbX, 0, inflatedTrackRect.height(), inflatedTrackRect.height());
+
+    auto trackBuffer = context.createImageBuffer(inflatedTrackRect.size(), deviceScaleFactor);
+
+    if (!trackBuffer)
+        return;
+
+    auto cgContext = trackBuffer->context().platformContext();
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingThumbRect context:cgContext options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchKnob,
+        (__bridge NSString *)kCUIStateKey: (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : isPressed ? kCUIStatePressed : kCUIStateActive),
+        (__bridge NSString *)kCUISizeKey: SwitchMacUtilities::coreUISizeForControlSize(controlSize),
+        (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: (__bridge NSString *)(isRTL ? kCUIUserInterfaceLayoutDirectionRightToLeft : kCUIUserInterfaceLayoutDirectionLeftToRight),
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    context.drawConsumingImageBuffer(WTFMove(trackBuffer), inflatedTrackRect.location());
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class SwitchTrackMac;
+
+class SwitchTrackMac final : public ControlMac {
+public:
+    SwitchTrackMac(SwitchTrackPart&, ControlFactoryMac&);
+
+private:
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
+    FloatRect rectForBounds(const FloatRect&, const ControlStyle&) const override;
+
+    void draw(GraphicsContext&, const FloatRoundedRect&, float, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SwitchTrackMac.h"
+
+#if PLATFORM(MAC)
+
+#import "SwitchMacUtilities.h"
+#import "SwitchTrackPart.h"
+
+namespace WebCore {
+
+SwitchTrackMac::SwitchTrackMac(SwitchTrackPart& part, ControlFactoryMac& controlFactory)
+    : ControlMac(part, controlFactory)
+{
+    ASSERT(part.type() == StyleAppearance::SwitchTrack);
+}
+
+IntSize SwitchTrackMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
+{
+    return SwitchMacUtilities::cellSize(controlSize);
+}
+
+IntOutsets SwitchTrackMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
+{
+    return SwitchMacUtilities::cellOutsets(controlSize);
+}
+
+FloatRect SwitchTrackMac::rectForBounds(const FloatRect& bounds, const ControlStyle&) const
+{
+    return SwitchMacUtilities::rectForBounds(bounds);
+}
+
+void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    bool isOn = style.states.contains(ControlStyle::State::Checked);
+    bool isRTL = style.states.contains(ControlStyle::State::RightToLeft);
+    bool isEnabled = style.states.contains(ControlStyle::State::Enabled);
+    bool isPressed = style.states.contains(ControlStyle::State::Pressed);
+    bool isInActiveWindow = style.states.contains(ControlStyle::State::WindowActive);
+
+    auto borderRectRect = borderRect.rect();
+    auto controlSize = controlSizeForSize(borderRectRect.size(), style);
+    auto size = cellSize(controlSize, style);
+    auto outsets = cellOutsets(controlSize, style);
+
+    size.scale(style.zoomFactor);
+
+    auto trackY = std::max(((borderRectRect.height() - size.height()) / 2.0f), 0.0f);
+    auto trackRect = FloatRect { FloatPoint { borderRectRect.x(), borderRectRect.y() + trackY }, size };
+    auto inflatedTrackRect = inflatedRect(trackRect, size, outsets, style);
+    auto drawingTrackRect = NSMakeRect(0, 0, inflatedTrackRect.width(), inflatedTrackRect.height());
+
+    auto trackBuffer = context.createImageBuffer(inflatedTrackRect.size(), deviceScaleFactor);
+    auto trackMaskBuffer = context.createImageBuffer(inflatedTrackRect.size(), deviceScaleFactor);
+
+    if (!trackBuffer || !trackMaskBuffer)
+        return;
+
+    auto cgContext = trackBuffer->context().platformContext();
+    auto cgContextForMask = trackMaskBuffer->context().platformContext();
+
+    auto coreUIState = (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : isPressed ? kCUIStatePressed : kCUIStateActive);
+    auto coreUIValue = @(isOn ? 1 : 0);
+    auto coreUIPresentation = (__bridge NSString *)(isInActiveWindow ? kCUIPresentationStateActiveKey : kCUIPresentationStateInactive);
+    auto coreUISize = SwitchMacUtilities::coreUISizeForControlSize(controlSize);
+    auto coreUIDirection = (__bridge NSString *)(isRTL ? kCUIUserInterfaceLayoutDirectionRightToLeft : kCUIUserInterfaceLayoutDirectionLeftToRight);
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContextForMask options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchFillMask,
+        (__bridge NSString *)kCUISizeKey: coreUISize,
+        (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: coreUIDirection,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    trackBuffer->context().clipToImageBuffer(*trackMaskBuffer, drawingTrackRect);
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchFill,
+        (__bridge NSString *)kCUIStateKey: coreUIState,
+        (__bridge NSString *)kCUIValueKey: coreUIValue,
+        (__bridge NSString *)kCUIPresentationStateKey: coreUIPresentation,
+        (__bridge NSString *)kCUISizeKey: coreUISize,
+        (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: coreUIDirection,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchBorder,
+        (__bridge NSString *)kCUISizeKey: coreUISize,
+        (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: coreUIDirection,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    if (userPrefersWithoutColorDifferentiation()) {
+        [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext options:@{
+            (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchOnOffLabel,
+            // FIXME: below does not pass kCUIStatePressed like NSCoreUIStateForSwitchState does,
+            // as passing that does not appear to work correctly.
+            (__bridge NSString *)kCUIStateKey: (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : kCUIStateActive),
+            (__bridge NSString *)kCUIValueKey: coreUIValue,
+            (__bridge NSString *)kCUIPresentationStateKey: coreUIPresentation,
+            (__bridge NSString *)kCUISizeKey: coreUISize,
+            (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: coreUIDirection,
+            (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+        }];
+    }
+
+    context.drawConsumingImageBuffer(WTFMove(trackBuffer), inflatedTrackRect.location());
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
 #import "TextAreaPart.h"
 #import <pal/spi/mac/NSCellSPI.h>
 

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -510,6 +510,42 @@ void ThemeMac::setFocusRingClipRect(const FloatRect& rect)
     focusRingClipRect = rect;
 }
 
+// Switch
+
+static const std::array<IntSize, 4>& switchSizes()
+{
+    static const std::array<IntSize, 4> sizes =
+    {
+        IntSize { 38, 22 },
+        IntSize { 32, 18 },
+        IntSize { 26, 15 },
+        IntSize { 38, 22 }
+    };
+    return sizes;
+}
+
+static const int* switchMargins(NSControlSize controlSize)
+{
+    static const int margins[4][4] =
+    {
+        // top right bottom left
+        { 2, 2, 1, 2 },
+        { 2, 2, 1, 2 },
+        { 1, 1, 0, 1 },
+        { 2, 2, 1, 2 },
+    };
+    return margins[controlSize];
+}
+
+static LengthSize switchSize(const LengthSize& zoomedSize, float zoomFactor)
+{
+    // If the width and height are both specified, then we have nothing to do.
+    if (!zoomedSize.width.isIntrinsicOrAuto() && !zoomedSize.height.isIntrinsicOrAuto())
+        return zoomedSize;
+
+    return sizeFromNSControlSize(NSControlSizeSmall, zoomedSize, zoomFactor, switchSizes());
+}
+
 // Theme overrides
 
 int ThemeMac::baselinePositionAdjustment(StyleAppearance appearance) const
@@ -544,6 +580,8 @@ LengthSize ThemeMac::controlSize(StyleAppearance appearance, const FontCascade& 
         return checkboxSize(zoomedSize, zoomFactor);
     case StyleAppearance::Radio:
         return radioSize(zoomedSize, zoomFactor);
+    case StyleAppearance::Switch:
+        return switchSize(zoomedSize, zoomFactor);
     case StyleAppearance::PushButton:
         // Height is reset to auto so that specified heights can be ignored.
         return sizeFromFont(font, { zoomedSize.width, { } }, zoomFactor, buttonSizes());
@@ -633,6 +671,14 @@ void ThemeMac::inflateControlPaintRect(StyleAppearance appearance, const Control
         zoomedSize.setHeight(zoomedSize.height() * zoomFactor);
         zoomedSize.setWidth(zoomedSize.width() * zoomFactor);
         zoomedRect = inflateRect(zoomedRect, zoomedSize, radioMargins(controlSize), zoomFactor);
+        break;
+    }
+    case StyleAppearance::Switch: {
+        NSControlSize controlSize = controlSizeFromPixelSize(switchSizes(), zoomRectSize, zoomFactor);
+        IntSize zoomedSize = switchSizes()[controlSize];
+        zoomedSize.setHeight(zoomedSize.height() * zoomFactor);
+        zoomedSize.setWidth(zoomedSize.width() * zoomFactor);
+        zoomedRect = inflateRect(zoomedRect, zoomedSize, switchMargins(controlSize), zoomFactor);
         break;
     }
     case StyleAppearance::PushButton:

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -68,6 +68,8 @@
 #include "SliderTrackPart.h"
 #include "SpinButtonElement.h"
 #include "StringTruncator.h"
+#include "SwitchThumbPart.h"
+#include "SwitchTrackPart.h"
 #include "TextAreaPart.h"
 #include "TextControlInnerElements.h"
 #include "TextFieldPart.h"
@@ -223,6 +225,7 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
     case StyleAppearance::Radio:
     case StyleAppearance::PushButton:
     case StyleAppearance::SquareButton:
+    case StyleAppearance::Switch:
 #if ENABLE(INPUT_TYPE_COLOR)
     case StyleAppearance::ColorWell:
 #endif
@@ -397,7 +400,7 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
             return StyleAppearance::Button;
 
         if (input.isSwitch())
-            return StyleAppearance::Auto;
+            return StyleAppearance::Switch;
 
         if (input.isCheckbox())
             return StyleAppearance::Checkbox;
@@ -684,9 +687,14 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
     case StyleAppearance::SliderThumbVertical:
         return SliderThumbPart::create(appearance);
 
-    case StyleAppearance::SwitchThumb:
-    case StyleAppearance::SwitchTrack:
+    case StyleAppearance::Switch:
         break;
+
+    case StyleAppearance::SwitchThumb:
+        return SwitchThumbPart::create();
+
+    case StyleAppearance::SwitchTrack:
+        return SwitchTrackPart::create();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -171,6 +171,8 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Style
     case StyleAppearance::SliderThumbVertical:
     case StyleAppearance::SliderHorizontal:
     case StyleAppearance::SliderVertical:
+    case StyleAppearance::SwitchThumb:
+    case StyleAppearance::SwitchTrack:
     case StyleAppearance::SquareButton:
     case StyleAppearance::TextArea:
     case StyleAppearance::TextField:
@@ -215,7 +217,9 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
         || type == StyleAppearance::SliderThumbVertical
         || type == StyleAppearance::SliderHorizontal
         || type == StyleAppearance::SliderVertical
-        || type == StyleAppearance::SquareButton;
+        || type == StyleAppearance::SquareButton
+        || type == StyleAppearance::SwitchThumb
+        || type == StyleAppearance::SwitchTrack;
 }
 
 bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& renderer) const
@@ -799,6 +803,7 @@ void RenderThemeMac::adjustRepaintRect(const RenderObject& renderer, FloatRect& 
     case StyleAppearance::DefaultButton:
     case StyleAppearance::Button:
     case StyleAppearance::InnerSpinButton:
+    case StyleAppearance::Switch:
             return RenderTheme::adjustRepaintRect(renderer, rect);
     default:
             break;

--- a/Source/WebCore/style/StyleAppearance.cpp
+++ b/Source/WebCore/style/StyleAppearance.cpp
@@ -139,6 +139,9 @@ TextStream& operator<<(TextStream& ts, StyleAppearance appearance)
     case StyleAppearance::SliderThumbVertical:
         ts << "sliderthumb-vertical";
         break;
+    case StyleAppearance::Switch:
+        ts << "switch";
+        break;
     case StyleAppearance::SwitchThumb:
         ts << "switch-thumb";
         break;

--- a/Source/WebCore/style/StyleAppearance.h
+++ b/Source/WebCore/style/StyleAppearance.h
@@ -78,6 +78,7 @@ enum class StyleAppearance : uint8_t {
     SearchFieldCancelButton,
     SliderThumbHorizontal,
     SliderThumbVertical,
+    Switch,
     SwitchThumb,
     SwitchTrack
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -143,6 +143,8 @@
 #include <WebCore/SourceAlpha.h>
 #include <WebCore/SourceGraphic.h>
 #include <WebCore/SpotLightSource.h>
+#include <WebCore/SwitchThumbPart.h>
+#include <WebCore/SwitchTrackPart.h>
 #include <WebCore/SystemImage.h>
 #include <WebCore/TestReportBody.h>
 #include <WebCore/TextAreaPart.h>
@@ -1259,6 +1261,7 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
     case WebCore::StyleAppearance::SearchFieldCancelButton:
     case WebCore::StyleAppearance::SliderThumbHorizontal:
     case WebCore::StyleAppearance::SliderThumbVertical:
+    case WebCore::StyleAppearance::Switch:
     case WebCore::StyleAppearance::SwitchThumb:
     case WebCore::StyleAppearance::SwitchTrack:
         break;
@@ -1383,9 +1386,14 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::StyleAppearance::SliderThumbVertical:
         return WebCore::SliderThumbPart::create(*type);
 
-    case WebCore::StyleAppearance::SwitchThumb:
-    case WebCore::StyleAppearance::SwitchTrack:
+    case WebCore::StyleAppearance::Switch:
         break;
+
+    case WebCore::StyleAppearance::SwitchThumb:
+        return WebCore::SwitchThumbPart::create();
+
+    case WebCore::StyleAppearance::SwitchTrack:
+        return WebCore::SwitchTrackPart::create();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3244,6 +3244,7 @@ enum class WebCore::StyleAppearance : uint8_t {
     SearchFieldCancelButton,
     SliderThumbHorizontal,
     SliderThumbVertical,
+    Switch,
     SwitchThumb,
     SwitchTrack
 };


### PR DESCRIPTION
#### 9ccdb741ae1c6be732cb630042f27590d0d30c69
<pre>
Add &lt;input type=checkbox switch&gt; macOS implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=263372">https://bugs.webkit.org/show_bug.cgi?id=263372</a>
<a href="https://rdar.apple.com/117199685">rdar://117199685</a>

Reviewed by Aditya Keerthi.

Add a macOS implementation that has these known shortcomings:

- There&apos;s no animation support.
- There&apos;s no focus support.
- There&apos;s no support for dragging the thumb.

Also correct an issue with m_hasSwitchAttribute invalidation. An early
return could be triggered when modifying the control through Web
Inspector which then resulted in the state not being updated correctly.

This builds on excellent prototyping work done by Lily Spiniolas. And
also greatly benefited from the advice and guidance of Aditya, Elika,
and Wenson.

Tests have been added in 270176@main and tests added here are upstreamed
via <a href="https://github.com/web-platform-tests/wpt/pull/42945.">https://github.com/web-platform-tests/wpt/pull/42945.</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-type-checkbox-switch.tentative.window.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window.js:
* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
* Source/WebCore/css/htmlSwitchControl.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
(input[type=&quot;checkbox&quot;][switch]::thumb, input[type=&quot;checkbox&quot;][switch]::track):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::valueMissingText const):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::attributeChanged):
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/SwitchThumbPart.h: Added.
* Source/WebCore/platform/graphics/controls/SwitchTrackPart.h: Added.
* Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h:
* Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm:
(WebCore::ControlFactoryIOS::createPlatformSwitchThumb):
(WebCore::ControlFactoryIOS::createPlatformSwitchTrack):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::createPlatformSwitchThumb):
(WebCore::ControlFactoryMac::createPlatformSwitchTrack):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::userPrefersWithoutColorDifferentiation):
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h: Added.
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm: Added.
(WebCore::SwitchMacUtilities::cellSize):
(WebCore::SwitchMacUtilities::cellOutsets):
(WebCore::SwitchMacUtilities::rectForBounds):
(WebCore::SwitchMacUtilities::coreUISizeForControlSize):
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h: Added.
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm: Added.
(WebCore::SwitchThumbMac::SwitchThumbMac):
(WebCore::SwitchThumbMac::cellSize const):
(WebCore::SwitchThumbMac::cellOutsets const):
(WebCore::SwitchThumbMac::rectForBounds const):
(WebCore::SwitchThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h: Added.
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm: Added.
(WebCore::SwitchTrackMac::SwitchTrackMac):
(WebCore::SwitchTrackMac::cellSize const):
(WebCore::SwitchTrackMac::cellOutsets const):
(WebCore::SwitchTrackMac::rectForBounds const):
(WebCore::SwitchTrackMac::draw):
* Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::switchSizes):
(WebCore::switchMargins):
(WebCore::switchSize):
(WebCore::ThemeMac::controlSize const):
(WebCore::ThemeMac::inflateControlPaintRect const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::adjustRepaintRect):
* Source/WebCore/style/StyleAppearance.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleAppearance.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270342@main">https://commits.webkit.org/270342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05b134204f2b4891d44d2b684f27d03a66c4bf79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23107 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27510 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28514 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26332 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/347 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22099 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->