### PR TITLE
Add test function for WebCore::SincResampler

### DIFF
--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011, 2015 Google Inc. All rights reserved.
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,7 @@
 #include "ProcessWarming.h"
 #include "SWContextManager.h"
 #include "ServiceWorkerGlobalScope.h"
+#include "SincResampler.h"
 #include "WheelEventTestMonitor.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/CallFrame.h>
@@ -285,5 +286,12 @@ void populateDisassemblyLabels()
 #endif // ENABLE(JIT_OPERATION_DISASSEMBLY)
 
 #endif // ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
+
+#if ENABLE(WEB_AUDIO)
+void testSincResamplerProcessBuffer(std::span<const float> source, std::span<float> destination, double scaleFactor)
+{
+    SincResampler::processBuffer(source, destination, scaleFactor);
+}
+#endif // ENABLE(WEB_AUDIO)
 
 } // namespace WebCoreTestSupport

--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <span>
 #include <wtf/Forward.h>
 
 typedef const struct OpaqueJSContext* JSContextRef;
@@ -86,5 +87,9 @@ inline void populateJITOperations() { populateDisassemblyLabels(); }
 #else
 inline void populateJITOperations() { }
 #endif // ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
+
+#if ENABLE(WEB_AUDIO)
+void testSincResamplerProcessBuffer(std::span<const float> source, std::span<float> destination, double scaleFactor) TEST_SUPPORT_EXPORT;
+#endif
 
 } // namespace WebCoreTestSupport


### PR DESCRIPTION
#### 0050db7b5b7bb2f9c4fa3d569eecdcb9d4695c3a
<pre>
Add test function for WebCore::SincResampler
<a href="https://bugs.webkit.org/show_bug.cgi?id=261702">https://bugs.webkit.org/show_bug.cgi?id=261702</a>
&lt;<a href="https://rdar.apple.com/115682448">rdar://115682448</a>&gt;

Reviewed by Chris Dumez and Alex Christensen.

Add test method that calls SincResampler::processBuffer().

* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::testSincResamplerProcessBuffer): Add.
* Source/WebCore/testing/js/WebCoreTestSupport.h:
(WebCoreTestSupport::testSincResamplerProcessBuffer): Add.

Originally-landed-as: 265870.567@safari-7616-branch (6380262a8580). rdar://117819812
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0050db7b5b7bb2f9c4fa3d569eecdcb9d4695c3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24705 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3250 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25958 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26822 "Hash 0050db7b for PR 19911 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24973 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4922 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/687 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/26822 "Hash 0050db7b for PR 19911 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24949 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/4922 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/25958 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27405 "Hash 0050db7b for PR 19911 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/4922 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/25958 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/27405 "Hash 0050db7b for PR 19911 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/4922 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/25958 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/27405 "Hash 0050db7b for PR 19911 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1945 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/687 "Hash 0050db7b for PR 19911 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3242 "Hash 0050db7b for PR 19911 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/25958 "Hash 0050db7b for PR 19911 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2397 "Hash 0050db7b for PR 19911 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2303 "Hash 0050db7b for PR 19911 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->