### PR TITLE
Regression(265870.536@safari-7616-branch) Crashes under DeferredPromise::callFunction()

### DIFF
--- a/LayoutTests/webaudio/promise-resolution-crash-expected.txt
+++ b/LayoutTests/webaudio/promise-resolution-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/webaudio/promise-resolution-crash.html
+++ b/LayoutTests/webaudio/promise-resolution-crash.html
@@ -1,0 +1,7 @@
+This test passes if it doesn't crash.
+<script>
+  if (window.testRunner)
+      testRunner.dumpAsText();
+
+  onbeforeunload = () => new AudioContext().close();
+</script>


### PR DESCRIPTION
#### 1457c8d75c8fb91a65e20bf64ddf13749e73ab68
<pre>
Regression(265870.536@safari-7616-branch) Crashes under DeferredPromise::callFunction()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261829">https://bugs.webkit.org/show_bug.cgi?id=261829</a>
<a href="https://rdar.apple.com/115712299">rdar://115712299</a>

Reviewed by Brent Fulgham and Mark Lam.

The RELEASE_ASSERT() added by  Ryosuke in 265870.536@safari-7616-branch in DeferredPromise::callFunction()
is hitting a lot in the wild, from various call sites. The assertion makes sure we&apos;re allowed to run
script when resolving a promise (i.e. we&apos;re not in the middle of layout or style resolution).

* LayoutTests/webaudio/promise-resolution-crash-expected.txt: Added.
* LayoutTests/webaudio/promise-resolution-crash.html: Added.
New test coverage.

* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::callFunction):
Drop the release assertion and instead schedule a task to resolve the promise
asynchronously when we&apos;re not allowed to run script, similarly to what we were
already doing when b/f cache suspended.

Originally-landed-as: 265870.579@safari-7616-branch (587ed3048a75). <a href="https://rdar.apple.com/117810995">rdar://117810995</a>
Canonical link: <a href="https://commits.webkit.org/270157@main">https://commits.webkit.org/270157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ba68056392bd99cf5a16537fc1bef0882769319

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/688 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27406 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22264 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26235 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/261 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5919 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->