### PR TITLE
[CSS Fonts] The size-adjust descriptor shouldn't scale system fallback fonts.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<link rel="author" href="mailto:changseok@webkit.org">
+<title>Tests that the size-adjust descriptor does not affect system fallback font size.</title>
+<style>
+@font-face {
+  font-family: large-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf);
+  size-adjust: 1000%;
+  unicode-range: U+0020;
+}
+
+.space {
+  font-family: large-font;
+}
+
+.ref {
+  font-family: sans-serif;
+}
+</style>
+<span class="space"> </span><span class="ref">あ</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<link rel="author" href="mailto:changseok@webkit.org">
+<title>Tests that the size-adjust descriptor does not affect system fallback font size.</title>
+<style>
+@font-face {
+  font-family: large-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf);
+  size-adjust: 1000%;
+  unicode-range: U+0020;
+}
+
+.space {
+  font-family: large-font;
+}
+
+.ref {
+  font-family: sans-serif;
+}
+</style>
+<span class="space"> </span><span class="ref">あ</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<link rel="author" title="ChangSeok Oh" href="mailto:changseok@webkit.org">
+<link rel="help" href="https://crbug.com/1441723">
+<link rel="match" href="size-adjust-unicode-range-system-fallback-ref.html">
+<link rel="assert" title="Tests that the size-adjust descriptor does not affect system fallback font size.">
+<title>Tests that the size-adjust descriptor does not affect system fallback font size.</title>
+<style>
+@font-face {
+  font-family: large-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf);
+  size-adjust: 1000%;
+  unicode-range: U+0020;
+}
+
+.test {
+  font-family: large-font;
+}
+</style>
+<span class="test"> あ</span>

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -794,7 +794,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     const FontCustomPlatformData* customPlatformData = nullptr;
     if (safeCFEqual(platformData.font(), substituteFont))
         customPlatformData = platformData.customPlatformData();
-    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), customPlatformData);
+    FontPlatformData alternateFont(substituteFont, description.computedSize(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), customPlatformData);
 
     return fontForPlatformData(alternateFont);
 }

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -38,6 +38,12 @@ FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool
 {
     ASSERT_ARG(font, font);
     m_font = font;
+    // If the CTFont size doesn't match the specified size, we must create a new
+    // CTFont with the specified size to avoid inconsistent line spacing incurred
+    // by the original CTFont's attributes.
+    if (CTFontGetSize(m_font.get()) != size)
+        updateSize(size);
+
     m_isColorBitmapFont = CTFontGetSymbolicTraits(font.get()) & kCTFontColorGlyphsTrait;
     m_isSystemFont = WebCore::isSystemFont(font.get());
     auto variations = adoptCF(static_cast<CFDictionaryRef>(CTFontCopyAttribute(font.get(), kCTFontVariationAttribute)));


### PR DESCRIPTION
#### 5501c6a9872635b96acc6cfa4a5ca94876f18441
<pre>
[CSS Fonts] The size-adjust descriptor shouldn&apos;t scale system fallback fonts.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264120">https://bugs.webkit.org/show_bug.cgi?id=264120</a>

Reviewed by NOBODY (OOPS!).

When creating a system fallback font for a character on Mac, we previously used
the primary font&apos;s platform data, which could inadvertently lead to scaling
when the size-adjust descriptor scaled the primary font. To resolve this, we now
utilize the computed size of the font description as the GTK/WPE ports do.

Test: imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback.html: Added.
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::systemFallbackForCharacterCluster):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::FontPlatformData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5501c6a9872635b96acc6cfa4a5ca94876f18441

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23049 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27422 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28442 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26251 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/272 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22018 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->