### PR TITLE
Fix incorrect storage of AudioSourceProviderGStreamer

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
@@ -40,23 +40,20 @@ typedef struct _GstAppSink GstAppSink;
 
 namespace WebCore {
 
-#if ENABLE(MEDIA_STREAM)
 class AudioSourceProviderGStreamer final : public WebAudioSourceProvider {
 public:
+    static Ref<AudioSourceProviderGStreamer> create()
+    {
+        return adoptRef(*new AudioSourceProviderGStreamer());
+    }
+
+#if ENABLE(MEDIA_STREAM)
     static Ref<AudioSourceProviderGStreamer> create(MediaStreamTrackPrivate& source)
     {
         return adoptRef(*new AudioSourceProviderGStreamer(source));
     }
     AudioSourceProviderGStreamer(MediaStreamTrackPrivate&);
-#else
-class AudioSourceProviderGStreamer : public AudioSourceProvider {
-    WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(AudioSourceProviderGStreamer);
-public:
 #endif
-
-    AudioSourceProviderGStreamer();
-    ~AudioSourceProviderGStreamer();
 
     void configureAudioBin(GstElement* audioBin, GstElement* audioSink);
 
@@ -72,6 +69,9 @@ public:
     void clearAdapters();
 
 private:
+    AudioSourceProviderGStreamer();
+    ~AudioSourceProviderGStreamer();
+
 #if ENABLE(MEDIA_STREAM)
     WeakPtr<MediaStreamTrackPrivate> m_captureSource;
     RefPtr<MediaStreamPrivate> m_streamPrivate;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -867,7 +867,7 @@ void MediaPlayerPrivateGStreamer::simulateAudioInterruption()
 void MediaPlayerPrivateGStreamer::ensureAudioSourceProvider()
 {
     if (!m_audioSourceProvider)
-        m_audioSourceProvider = makeUnique<AudioSourceProviderGStreamer>();
+        m_audioSourceProvider = AudioSourceProviderGStreamer::create();
 }
 
 AudioSourceProvider* MediaPlayerPrivateGStreamer::audioSourceProvider()

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -580,7 +580,7 @@ private:
     AtomString m_requestedTextStreamId;
 
 #if ENABLE(WEB_AUDIO)
-    std::unique_ptr<AudioSourceProviderGStreamer> m_audioSourceProvider;
+    RefPtr<AudioSourceProviderGStreamer> m_audioSourceProvider;
 #endif
     GRefPtr<GstElement> m_downloadBuffer;
 


### PR DESCRIPTION
#### 0f803ec2d5e6630eb8915594772e31036d460537
<pre>
Fix incorrect storage of AudioSourceProviderGStreamer
<a href="https://bugs.webkit.org/show_bug.cgi?id=264119">https://bugs.webkit.org/show_bug.cgi?id=264119</a>

Reviewed by Xabier Rodriguez-Calvar and Philippe Normand

We cannot store refcounted objects in a std::unique_ptr since the object
may be deleted with an outstanding reference.

Part of the problem here is that AudioSourceProviderGStreamer may or may
not be a refcounted object depending on whether ENABLE(MEDIA_STREAM) is
used. If disabled, then it inherits from AudioSourceProvider, which is
not refcounted. If enabled, then it inherits from
WebAudioSourceProvider, which just adds refcounting and nothing else.
There is no reason this should be dependent on the value of
ENABLE(MEDIA_STREAM) so we can just always inherit from
WebAudioSourceProvider.

* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::ensureAudioSourceProvider):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/270266@main">https://commits.webkit.org/270266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79039ae081588ef5ec1d16105e44694cb06de1eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26916 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23099 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27499 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2097 "Found 1 new test failure: imported/w3c/web-platform-tests/beacon/beacon-cors.https.window.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28496 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/337 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3323 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5992 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->