### PR TITLE
[iOS] Keyboard should not learn autocorrections after revealing password in Gmail login flow

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -614,6 +614,9 @@ inline void HTMLInputElement::runPostTypeUpdateTasks()
     }
 #endif
 
+    if (isPasswordField())
+        m_hasEverBeenPasswordField = true;
+
     if (renderer())
         invalidateStyleAndRenderersForSubtree();
 

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -339,6 +339,8 @@ public:
     bool isInnerTextElementEditable() const final { return !hasAutoFillStrongPasswordButton() && HTMLTextFormControlElement::isInnerTextElementEditable(); }
     void finishParsingChildren() final;
 
+    bool hasEverBeenPasswordField() const { return m_hasEverBeenPasswordField; }
+
 protected:
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
 
@@ -483,6 +485,7 @@ private:
     bool m_isSpellcheckDisabledExceptTextReplacement : 1 { false };
     bool m_hasPendingUserAgentShadowTreeUpdate : 1 { false };
     bool m_hasSwitchAttribute : 1 { false };
+    bool m_hasEverBeenPasswordField : 1 { false };
     RefPtr<InputType> m_inputType;
     // The ImageLoader must be owned by this element because the loader code assumes
     // that it lives as long as its owning element lives. If we move the loader into

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -507,7 +507,8 @@ typedef enum {
 @property (nonatomic, retain) UIColor *insertionPointColor;
 @property (nonatomic, retain) UIColor *selectionBarColor;
 @property (nonatomic, retain) UIColor *selectionHighlightColor;
-@property (nonatomic, readwrite) BOOL isSingleLineDocument;
+@property (nonatomic) BOOL isSingleLineDocument;
+@property (nonatomic) BOOL learnsCorrections;
 @end
 
 @protocol UITextInputDelegatePrivate

--- a/Source/WebKit/Shared/FocusedElementInformation.h
+++ b/Source/WebKit/Shared/FocusedElementInformation.h
@@ -131,6 +131,7 @@ struct FocusedElementInformation {
     Vector<WebCore::Color> suggestedColors;
 #endif
 #endif
+    bool hasEverBeenPasswordField { false };
     bool shouldSynthesizeKeyEventsForEditing { false };
     bool isSpellCheckingEnabled { true };
     bool shouldAvoidResizingWhenInputViewBoundsChange { false };

--- a/Source/WebKit/Shared/FocusedElementInformation.serialization.in
+++ b/Source/WebKit/Shared/FocusedElementInformation.serialization.in
@@ -76,6 +76,7 @@ headers: "FocusedElementInformation.h" "WebCoreArgumentCoders.h"
     Vector<WebCore::Color> suggestedColors;
 #endif
 #endif
+    bool hasEverBeenPasswordField;
     bool shouldSynthesizeKeyEventsForEditing;
     bool isSpellCheckingEnabled;
     bool shouldAvoidResizingWhenInputViewBoundsChange;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6504,6 +6504,9 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
         }
     }
 
+    if ([privateTraits respondsToSelector:@selector(setLearnsCorrections:)] && _focusedElementInformation.hasEverBeenPasswordField)
+        privateTraits.learnsCorrections = NO;
+
     if ([privateTraits respondsToSelector:@selector(setShortcutConversionType:)])
         privateTraits.shortcutConversionType = _focusedElementInformation.elementType == WebKit::InputType::Password ? UITextShortcutConversionTypeNo : UITextShortcutConversionTypeDefault;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3649,6 +3649,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         information.autocapitalizeType = element.autocapitalizeType();
         information.isAutocorrect = element.shouldAutocorrect();
         information.placeholder = element.attributeWithoutSynchronization(HTMLNames::placeholderAttr);
+        information.hasEverBeenPasswordField = element.hasEverBeenPasswordField();
         if (element.isPasswordField())
             information.elementType = InputType::Password;
         else if (element.isSearchField())

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -133,7 +133,8 @@ WTF_EXTERN_C_END
 @protocol UITextInputTraits_Private <NSObject, UITextInputTraits>
 @property (nonatomic, readonly) UIColor *insertionPointColor;
 @property (nonatomic, readonly) UIColor *selectionBarColor;
-@property (nonatomic, readwrite) BOOL isSingleLineDocument;
+@property (nonatomic) BOOL isSingleLineDocument;
+@property (nonatomic) BOOL learnsCorrections;
 @end
 
 @interface UITextInputTraits : NSObject <UITextInputTraits, UITextInputTraits_Private, NSCopying>

--- a/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
@@ -146,6 +146,32 @@ TEST(AutocorrectionTests, AutocorrectionContextDoesNotIncludeNewlineInTextField)
     EXPECT_EQ(0U, [contextAfterTyping contextAfterSelection].length);
 }
 
+TEST(AutocorrectionTests, DoNotLearnCorrectionsAfterChangingInputTypeFromPassword)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    auto inputDelegate = adoptNS([TestInputDelegate new]);
+
+    bool startedInputSession = false;
+    [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
+        startedInputSession = true;
+        return _WKFocusStartsInputSessionPolicyAllow;
+    }];
+    [webView _setInputDelegate:inputDelegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<input id='first' type='password'></input><input id='second'></input>"];
+    [webView stringByEvaluatingJavaScript:@"let first = document.querySelector('#first'); first.type = 'text'; first.focus();"];
+    TestWebKitAPI::Util::run(&startedInputSession);
+
+    auto learnsCorrections = [&] {
+        return static_cast<id<UITextInputTraits_Private>>([webView textInputContentView].textInputTraits).learnsCorrections;
+    };
+    EXPECT_FALSE(learnsCorrections());
+
+    startedInputSession = false;
+    [webView stringByEvaluatingJavaScript:@"document.querySelector('#second').focus()"];
+    TestWebKitAPI::Util::run(&startedInputSession);
+    EXPECT_TRUE(learnsCorrections());
+}
+
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)
 
 TEST(AutocorrectionTests, AutocorrectionIndicatorsDismissAfterNextWord)


### PR DESCRIPTION
#### 63bfab4cff442ccc4552bc35e27e4c287e286549
<pre>
[iOS] Keyboard should not learn autocorrections after revealing password in Gmail login flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=260864">https://bugs.webkit.org/show_bug.cgi?id=260864</a>
<a href="https://rdar.apple.com/111393742">rdar://111393742</a>

Reviewed by Aditya Keerthi.

When focusing and editing secure inputs (i.e. input type=&quot;password&quot;), we set `isSecureTextEntry` on
`UITextInputTraits` to `YES`, which disables autocorrection learning when the user types in this
field, suppresses the keyboard in screen recordings, and more.

However, some webpages (e.g. Gmail login) offer the ability to reveal the password as plain text as
a convenience to the user — this typically works by changing the input type from `&quot;password&quot;` to
just `&quot;text&quot;`. This currently causes all of the secure text entry behaviors to be disabled, which
includes disabling correction learning; this is undesirable, since the password may be offered as an
autocorrection candidate when editing in other plain text fields in the future, in non-secure
contexts.

Because the user opted to reveal the input, it doesn&apos;t really make sense to treat the input as fully
secure (for instance, there&apos;s no reason to suppress keyboard visibility in screen recordings if the
password text itself is fully visible). However, we need to (at least) prevent the keyboard from
learning suggestions when typing in this field. To achieve this, we add a flag on `HTMLInputElement`
to remember whether it was ever a password field; if so, we set the `-learnsCorrections` property on
text input traits to `NO`.

Test: AutocorrectionTests.DoNotLearnCorrectionsAfterChangingInputTypeFromPassword

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::runPostTypeUpdateTasks):

Set `m_hasEverBeenPasswordField` here.

* Source/WebCore/html/HTMLInputElement.h:
(WebCore::HTMLInputElement::hasEverBeenPasswordField const):
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/Shared/FocusedElementInformation.h:
* Source/WebKit/Shared/FocusedElementInformation.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateTextInputTraits:]):

Consult `hasEverBeenPasswordField` on the focused element information, and disable learning from
corrections if it&apos;s set.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:

Propagate `hasEverBeenPasswordField` state to the UI process when focusing an input element.

(WebKit::WebPage::focusedElementInformation):
* Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm:

Add an API test to exercise the change.

* Tools/TestWebKitAPI/ios/UIKitSPI.h:

Originally-landed-as: 265870.476@safari-7616-branch (5cfdf9b1cbac). <a href="https://rdar.apple.com/117808918">rdar://117808918</a>
Canonical link: <a href="https://commits.webkit.org/270184@main">https://commits.webkit.org/270184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6150126149cdcc26afd610d5339571eb5ab07d2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22703 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23060 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27431 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28446 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26255 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/279 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3263 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5936 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->