### PR TITLE
Fix bad cases of refcounted objects being stored in std::unique_ptr

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -62,6 +62,12 @@ void Worklist::dump(PrintStream& out) const
 class Worklist::Thread final : public AutomaticThread {
 public:
     using Base = AutomaticThread;
+    static Ref<Thread> create(const AbstractLocker& locker, Worklist& work)
+    {
+        return adoptRef(*new Thread(locker, work));
+    }
+
+private:
     Thread(const AbstractLocker& locker, Worklist& work)
         : Base(locker, work.m_lock, work.m_planEnqueued.copyRef())
         , worklist(work)
@@ -69,7 +75,6 @@ public:
 
     }
 
-private:
     PollResult poll(const AbstractLocker&) final
     {
         auto& queue = worklist.m_queue;

--- a/Source/JavaScriptCore/wasm/WasmWorklist.h
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.h
@@ -91,7 +91,7 @@ private:
     // Priority it the wrong order, which isn't wrong, just suboptimal.
     Ticket m_lastGrantedTicket { 0 };
     PriorityQueue<QueueElement, isHigherPriority, 10> m_queue;
-    Vector<std::unique_ptr<Thread>> m_threads;
+    Vector<Ref<Thread>> m_threads;
 };
 
 Worklist* existingWorklistOrNull();

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -52,7 +52,7 @@ Ref<IDBConnectionToServer> IDBConnectionToServer::create(IDBConnectionToServerDe
 
 IDBConnectionToServer::IDBConnectionToServer(IDBConnectionToServerDelegate& delegate)
     : m_delegate(delegate)
-    , m_proxy(makeUnique<IDBConnectionProxy>(*this))
+    , m_proxy(makeUniqueWithoutRefCountedCheck<IDBConnectionProxy>(*this))
 {
 }
 

--- a/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
+++ b/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
@@ -50,7 +50,7 @@ PushManager& ServiceWorkerRegistrationPushAPI::pushManager(ServiceWorkerRegistra
 PushManager& ServiceWorkerRegistrationPushAPI::pushManager()
 {
     if (!m_pushManager)
-        m_pushManager = makeUnique<PushManager>(m_serviceWorkerRegistration);
+        m_pushManager = makeUniqueWithoutRefCountedCheck<PushManager>(m_serviceWorkerRegistration);
 
     return *m_pushManager;
 }

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -189,7 +189,7 @@ CSSRule* CSSGroupingRule::item(unsigned index) const
 CSSRuleList& CSSGroupingRule::cssRules() const
 {
     if (!m_ruleListCSSOMWrapper)
-        m_ruleListCSSOMWrapper = makeUnique<LiveCSSRuleList<CSSGroupingRule>>(const_cast<CSSGroupingRule&>(*this));
+        m_ruleListCSSOMWrapper = makeUniqueWithoutRefCountedCheck<LiveCSSRuleList<CSSGroupingRule>>(const_cast<CSSGroupingRule&>(*this));
     return *m_ruleListCSSOMWrapper;
 }
 

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -186,7 +186,7 @@ CSSKeyframeRule* CSSKeyframesRule::item(unsigned index) const
 CSSRuleList& CSSKeyframesRule::cssRules()
 {
     if (!m_ruleListCSSOMWrapper)
-        m_ruleListCSSOMWrapper = makeUnique<LiveCSSRuleList<CSSKeyframesRule>>(*this);
+        m_ruleListCSSOMWrapper = makeUniqueWithoutRefCountedCheck<LiveCSSRuleList<CSSKeyframesRule>>(*this);
     return *m_ruleListCSSOMWrapper;
 }
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -308,7 +308,7 @@ CSSRule* CSSStyleRule::item(unsigned index) const
 CSSRuleList& CSSStyleRule::cssRules() const
 {
     if (!m_ruleListCSSOMWrapper)
-        m_ruleListCSSOMWrapper = makeUnique<LiveCSSRuleList<CSSStyleRule>>(const_cast<CSSStyleRule&>(*this));
+        m_ruleListCSSOMWrapper = makeUniqueWithoutRefCountedCheck<LiveCSSRuleList<CSSStyleRule>>(const_cast<CSSStyleRule&>(*this));
 
     return *m_ruleListCSSOMWrapper;
 }

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -311,7 +311,7 @@ void DataTransfer::didAddFileToItemList()
 DataTransferItemList& DataTransfer::items(Document& document)
 {
     if (!m_itemList)
-        m_itemList = makeUnique<DataTransferItemList>(document, *this);
+        m_itemList = makeUniqueWithoutRefCountedCheck<DataTransferItemList>(document, *this);
     return *m_itemList;
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1028,7 +1028,7 @@ void Document::resetActiveLinkColor()
 DOMImplementation& Document::implementation()
 {
     if (!m_implementation)
-        m_implementation = makeUnique<DOMImplementation>(*this);
+        m_implementation = makeUniqueWithoutRefCountedCheck<DOMImplementation>(*this);
     return *m_implementation;
 }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -674,7 +674,7 @@ NamedNodeMap& Element::attributes() const
     if (NamedNodeMap* attributeMap = rareData.attributeMap())
         return *attributeMap;
 
-    rareData.setAttributeMap(makeUnique<NamedNodeMap>(const_cast<Element&>(*this)));
+    rareData.setAttributeMap(makeUniqueWithoutRefCountedCheck<NamedNodeMap>(const_cast<Element&>(*this)));
     return *rareData.attributeMap();
 }
 
@@ -4337,7 +4337,7 @@ DOMTokenList& Element::classList()
 {
     ElementRareData& data = ensureElementRareData();
     if (!data.classList())
-        data.setClassList(makeUnique<DOMTokenList>(*this, HTMLNames::classAttr));
+        data.setClassList(makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::classAttr));
     return *data.classList();
 }
 
@@ -4350,7 +4350,7 @@ DOMTokenList& Element::part()
 {
     auto& data = ensureElementRareData();
     if (!data.partList())
-        data.setPartList(makeUnique<DOMTokenList>(*this, HTMLNames::partAttr));
+        data.setPartList(makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::partAttr));
     return *data.partList();
 }
 
@@ -4358,7 +4358,7 @@ DatasetDOMStringMap& Element::dataset()
 {
     ElementRareData& data = ensureElementRareData();
     if (!data.dataset())
-        data.setDataset(makeUnique<DatasetDOMStringMap>(*this));
+        data.setDataset(makeUniqueWithoutRefCountedCheck<DatasetDOMStringMap>(*this));
     return *data.dataset();
 }
 
@@ -5400,7 +5400,7 @@ void Element::ensureFormAssociatedCustomElement()
     RELEASE_ASSERT(is<HTMLMaybeFormAssociatedCustomElement>(*this));
     auto& data = ensureElementRareData();
     if (!data.formAssociatedCustomElement())
-        data.setFormAssociatedCustomElement(makeUnique<FormAssociatedCustomElement>(downcast<HTMLMaybeFormAssociatedCustomElement>(*this)));
+        data.setFormAssociatedCustomElement(makeUniqueWithoutRefCountedCheck<FormAssociatedCustomElement>(downcast<HTMLMaybeFormAssociatedCustomElement>(*this)));
 }
 
 FormAssociatedCustomElement& Element::formAssociatedCustomElementUnsafe() const

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -309,7 +309,7 @@ bool HTMLAnchorElement::hasRel(Relation relation) const
 DOMTokenList& HTMLAnchorElement::relList()
 {
     if (!m_relList) {
-        m_relList = makeUnique<DOMTokenList>(*this, HTMLNames::relAttr, [](Document& document, StringView token) {
+        m_relList = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::relAttr, [](Document& document, StringView token) {
 #if USE(SYSTEM_PREVIEW)
             if (equalLettersIgnoringASCIICase(token, "ar"_s))
                 return document.settings().systemPreviewEnabled();

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -783,7 +783,7 @@ ExceptionOr<Ref<OffscreenCanvas>> HTMLCanvasElement::transferControlToOffscreen(
     if (m_context)
         return Exception { InvalidStateError };
 
-    m_context = makeUnique<PlaceholderRenderingContext>(*this);
+    m_context = makeUniqueWithoutRefCountedCheck<PlaceholderRenderingContext>(*this);
     if (m_context->isAccelerated())
         invalidateStyleAndLayerComposition();
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -713,7 +713,7 @@ void HTMLFormElement::setMethod(const AtomString& value)
 DOMTokenList& HTMLFormElement::relList()
 {
     if (!m_relList) {
-        m_relList = makeUnique<DOMTokenList>(*this, HTMLNames::relAttr, [](Document&, StringView token) {
+        m_relList = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::relAttr, [](Document&, StringView token) {
             return equalLettersIgnoringASCIICase(token, "noreferrer"_s) || equalLettersIgnoringASCIICase(token, "noopener"_s) || equalLettersIgnoringASCIICase(token, "opener"_s);
         });
     }

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -66,7 +66,7 @@ int HTMLIFrameElement::defaultTabIndex() const
 DOMTokenList& HTMLIFrameElement::sandbox()
 {
     if (!m_sandbox) {
-        m_sandbox = makeUnique<DOMTokenList>(*this, sandboxAttr, [](Document&, StringView token) {
+        m_sandbox = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, sandboxAttr, [](Document&, StringView token) {
             return SecurityContext::isSupportedSandboxPolicy(token);
         });
     }

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -511,7 +511,7 @@ bool HTMLLinkElement::styleSheetIsLoading() const
 DOMTokenList& HTMLLinkElement::sizes()
 {
     if (!m_sizes)
-        m_sizes = makeUnique<DOMTokenList>(*this, sizesAttr);
+        m_sizes = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, sizesAttr);
     return *m_sizes;
 }
 
@@ -566,7 +566,7 @@ void HTMLLinkElement::dispatchPendingEvent(LinkEventSender* eventSender, const A
 DOMTokenList& HTMLLinkElement::relList()
 {
     if (!m_relList) 
-        m_relList = makeUnique<DOMTokenList>(*this, HTMLNames::relAttr, [](Document& document, StringView token) {
+        m_relList = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::relAttr, [](Document& document, StringView token) {
             return LinkRelAttribute::isSupported(document, token);
         });
     return *m_relList;

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -111,7 +111,7 @@ void HTMLOutputElement::setDefaultValue(String&& value)
 DOMTokenList& HTMLOutputElement::htmlFor()
 {
     if (!m_forTokens)
-        m_forTokens = makeUnique<DOMTokenList>(*this, HTMLNames::forAttr);
+        m_forTokens = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::forAttr);
     return *m_forTokens;
 }
 

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -232,7 +232,7 @@ SharedStringHash SVGAElement::visitedLinkHash() const
 DOMTokenList& SVGAElement::relList()
 {
     if (!m_relList) {
-        m_relList = makeUnique<DOMTokenList>(*this, SVGNames::relAttr, [](Document&, StringView token) {
+        m_relList = makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, SVGNames::relAttr, [](Document&, StringView token) {
 #if USE(SYSTEM_PREVIEW)
             if (equalLettersIgnoringASCIICase(token, "ar"_s))
                 return true;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -272,7 +272,7 @@ String XMLHttpRequest::responseURL() const
 XMLHttpRequestUpload& XMLHttpRequest::upload()
 {
     if (!m_upload)
-        m_upload = makeUnique<XMLHttpRequestUpload>(*this);
+        m_upload = makeUniqueWithoutRefCountedCheck<XMLHttpRequestUpload>(*this);
     return *m_upload;
 }
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -211,7 +211,7 @@ RemoteVideoFrameObjectHeapProxy& GPUProcessConnection::videoFrameObjectHeapProxy
 
 RemoteMediaPlayerManager& GPUProcessConnection::mediaPlayerManager()
 {
-    return *WebProcess::singleton().supplement<RemoteMediaPlayerManager>();
+    return WebProcess::singleton().remoteMediaPlayerManager();
 }
 #endif
 
@@ -228,7 +228,7 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
 {
 #if ENABLE(VIDEO)
     if (decoder.messageReceiverName() == Messages::MediaPlayerPrivateRemote::messageReceiverName()) {
-        WebProcess::singleton().supplement<RemoteMediaPlayerManager>()->didReceivePlayerMessage(connection, decoder);
+        WebProcess::singleton().remoteMediaPlayerManager().didReceivePlayerMessage(connection, decoder);
         return true;
     }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -59,9 +59,12 @@ void RemoteImageDecoderAVFManager::deleteRemoteImageDecoder(const ImageDecoderId
         gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::DeleteDecoder(identifier), 0);
 }
 
-RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager(WebProcess&)
+Ref<RemoteImageDecoderAVFManager> RemoteImageDecoderAVFManager::create()
 {
+    return adoptRef(*new RemoteImageDecoderAVFManager);
 }
+
+RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager() = default;
 
 RemoteImageDecoderAVFManager::~RemoteImageDecoderAVFManager()
 {
@@ -76,11 +79,6 @@ void RemoteImageDecoderAVFManager::gpuProcessConnectionDidClose(GPUProcessConnec
         gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName());
     m_gpuProcessConnection = nullptr;
     // FIXME: Do we need to do more when m_remoteImageDecoders is not empty to re-create them?
-}
-
-const char*  RemoteImageDecoderAVFManager::supplementName()
-{
-    return "RemoteImageDecoderAVFManager";
 }
 
 GPUProcessConnection& RemoteImageDecoderAVFManager::ensureGPUProcessConnection()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -30,7 +30,6 @@
 #include "Connection.h"
 #include "GPUProcessConnection.h"
 #include "MessageReceiver.h"
-#include "WebProcessSupplement.h"
 #include <WebCore/ImageDecoderIdentifier.h>
 #include <WebCore/ImageTypes.h>
 #include <WebCore/IntSize.h>
@@ -43,18 +42,15 @@ class RemoteImageDecoderAVF;
 class WebProcess;
 
 class RemoteImageDecoderAVFManager final
-    : public WebProcessSupplement
-    , private GPUProcessConnection::Client
+    : private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit RemoteImageDecoderAVFManager(WebProcess&);
+    static Ref<RemoteImageDecoderAVFManager> create();
     virtual ~RemoteImageDecoderAVFManager();
 
     void deleteRemoteImageDecoder(const WebCore::ImageDecoderIdentifier&);
-
-    static const char* supplementName();
 
     void setUseGPUProcess(bool);
     GPUProcessConnection& ensureGPUProcessConnection();
@@ -64,6 +60,7 @@ public:
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager>::controlBlock(); }
 
 private:
+    RemoteImageDecoderAVFManager();
     RefPtr<RemoteImageDecoderAVF> createImageDecoder(WebCore::FragmentedSharedBuffer& data, const String& mimeType, WebCore::AlphaOption, WebCore::GammaAndColorProfileOption);
 
     // GPUProcessConnection::Client.

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -103,18 +103,14 @@ private:
     RemoteMediaPlayerManager& m_manager;
 };
 
-RemoteMediaPlayerManager::RemoteMediaPlayerManager(WebProcess&)
+Ref<RemoteMediaPlayerManager> RemoteMediaPlayerManager::create()
 {
+    return adoptRef(*new RemoteMediaPlayerManager);
 }
 
-RemoteMediaPlayerManager::~RemoteMediaPlayerManager()
-{
-}
+RemoteMediaPlayerManager::RemoteMediaPlayerManager() = default;
 
-const char* RemoteMediaPlayerManager::supplementName()
-{
-    return "RemoteMediaPlayerManager";
-}
+RemoteMediaPlayerManager::~RemoteMediaPlayerManager() = default;
 
 using RemotePlayerTypeCache = HashMap<MediaPlayerEnums::MediaEngineIdentifier, std::unique_ptr<RemoteMediaPlayerMIMETypeCache>, WTF::IntHash<MediaPlayerEnums::MediaEngineIdentifier>, WTF::StrongEnumHashTraits<MediaPlayerEnums::MediaEngineIdentifier>>;
 static RemotePlayerTypeCache& mimeCaches()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -28,7 +28,6 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
 #include "GPUProcessConnection.h"
-#include "WebProcessSupplement.h"
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <wtf/HashMap.h>
@@ -44,17 +43,15 @@ class RemoteMediaPlayerMIMETypeCache;
 class WebProcess;
 struct PlatformTextTrackData;
 struct TrackPrivateRemoteConfiguration;
+struct WebProcessCreationParameters;
 
 class RemoteMediaPlayerManager
-    : public WebProcessSupplement
-    , public GPUProcessConnection::Client
+    : public GPUProcessConnection::Client
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit RemoteMediaPlayerManager(WebProcess&);
+    static Ref<RemoteMediaPlayerManager> create();
     ~RemoteMediaPlayerManager();
-
-    static const char* supplementName();
 
     void setUseGPUProcess(bool);
 
@@ -72,11 +69,11 @@ public:
     void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::controlBlock(); }
 
-private:
-    std::unique_ptr<WebCore::MediaPlayerPrivateInterface> createRemoteMediaPlayer(WebCore::MediaPlayer*, WebCore::MediaPlayerEnums::MediaEngineIdentifier);
+    void initialize(const WebProcessCreationParameters&);
 
-    // WebProcessSupplement
-    void initialize(const WebProcessCreationParameters&) final;
+private:
+    RemoteMediaPlayerManager();
+    std::unique_ptr<WebCore::MediaPlayerPrivateInterface> createRemoteMediaPlayer(WebCore::MediaPlayer*, WebCore::MediaPlayerEnums::MediaEngineIdentifier);
 
     // GPUProcessConnection::Client
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
@@ -41,8 +41,10 @@ std::unique_ptr<WebCore::MediaRecorderPrivate> MediaRecorderProvider::createMedi
 {
 #if ENABLE(GPU_PROCESS)
     auto* page = m_webPage.corePage();
-    if (page && page->settings().webRTCPlatformCodecsInGPUProcessEnabled())
-        return makeUnique<MediaRecorderPrivate>(stream, options);
+    if (page && page->settings().webRTCPlatformCodecsInGPUProcessEnabled()) {
+        // FIXME: It seems wrong to return a refcounted object in a unique_ptr.
+        return makeUniqueWithoutRefCountedCheck<MediaRecorderPrivate>(stream, options);
+    }
 #endif
     return WebCore::MediaRecorderProvider::createMediaRecorderPrivate(stream, options);
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4559,10 +4559,10 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 #if ENABLE(GPU_PROCESS)
     static_cast<WebMediaStrategy&>(platformStrategies()->mediaStrategy()).setUseGPUProcess(m_shouldPlayMediaInGPUProcess);
 #if ENABLE(VIDEO)
-    WebProcess::singleton().supplement<RemoteMediaPlayerManager>()->setUseGPUProcess(m_shouldPlayMediaInGPUProcess);
+    WebProcess::singleton().remoteMediaPlayerManager().setUseGPUProcess(m_shouldPlayMediaInGPUProcess);
 #endif
 #if HAVE(AVASSETREADER)
-    WebProcess::singleton().supplement<RemoteImageDecoderAVFManager>()->setUseGPUProcess(m_shouldPlayMediaInGPUProcess);
+    WebProcess::singleton().remoteImageDecoderAVFManager().setUseGPUProcess(m_shouldPlayMediaInGPUProcess);
 #endif
     WebProcess::singleton().setUseGPUProcessForCanvasRendering(m_shouldRenderCanvasInGPUProcess);
     bool usingGPUProcessForDOMRendering = m_shouldRenderDOMInGPUProcess && DrawingArea::supportsGPUProcessRendering(m_drawingAreaType);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -285,6 +285,12 @@ WebProcess::WebProcess()
 #endif
     , m_cacheStorageProvider(WebCacheStorageProvider::create())
     , m_badgeClient(WebBadgeClient::create())
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+    , m_remoteMediaPlayerManager(RemoteMediaPlayerManager::create())
+#endif
+#if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
+    , m_remoteImageDecoderAVFManager(RemoteImageDecoderAVFManager::create())
+#endif
     , m_broadcastChannelRegistry(WebBroadcastChannelRegistry::create())
     , m_cookieJar(WebCookieJar::create())
     , m_dnsPrefetchHystereris([this](PAL::HysteresisState state) { if (state == PAL::HysteresisState::Stopped) m_dnsPrefetchedHosts.clear(); })
@@ -313,14 +319,6 @@ WebProcess::WebProcess()
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     addSupplement<UserMediaCaptureManager>();
-#endif
-
-#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
-    addSupplement<RemoteMediaPlayerManager>();
-#endif
-
-#if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
-    addSupplement<RemoteImageDecoderAVFManager>();
 #endif
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
@@ -507,6 +505,9 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
 
     for (auto& supplement : m_supplements.values())
         supplement->initialize(parameters);
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+    m_remoteMediaPlayerManager->initialize(parameters);
+#endif
 
     setCacheModel(parameters.cacheModel);
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -129,8 +129,10 @@ class LibWebRTCNetwork;
 class NetworkProcessConnection;
 class ObjCObjectGraph;
 class RemoteCDMFactory;
+class RemoteImageDecoderAVFManager;
 class RemoteLegacyCDMFactory;
 class RemoteMediaEngineConfigurationFactory;
+class RemoteMediaPlayerManager;
 class StorageAreaMap;
 class UserData;
 class WebAutomationSessionProxy;
@@ -339,6 +341,12 @@ public:
 
     WebCacheStorageProvider& cacheStorageProvider() { return m_cacheStorageProvider.get(); }
     WebBadgeClient& badgeClient() { return m_badgeClient.get(); }
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+    RemoteMediaPlayerManager& remoteMediaPlayerManager() { return m_remoteMediaPlayerManager.get(); }
+#endif
+#if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
+    RemoteImageDecoderAVFManager& remoteImageDecoderAVFManager() { return m_remoteImageDecoderAVFManager.get(); }
+#endif
     WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
     WebCookieJar& cookieJar() { return m_cookieJar.get(); }
     WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
@@ -711,6 +719,12 @@ private:
 #endif
     Ref<WebCacheStorageProvider> m_cacheStorageProvider;
     Ref<WebBadgeClient> m_badgeClient;
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+    Ref<RemoteMediaPlayerManager> m_remoteMediaPlayerManager;
+#endif
+#if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
+    Ref<RemoteImageDecoderAVFManager> m_remoteImageDecoderAVFManager;
+#endif
     Ref<WebBroadcastChannelRegistry> m_broadcastChannelRegistry;
     Ref<WebCookieJar> m_cookieJar;
     WebSocketChannelManager m_webSocketChannelManager;

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -766,7 +766,7 @@ struct DerefObserver {
 
 TEST(WTF_HashMap, RefPtrNotZeroedBeforeDeref)
 {
-    auto observer = makeUnique<DerefObserver>();
+    auto observer = makeUniqueWithoutRefCountedCheck<DerefObserver>();
 
     HashMap<RefPtr<DerefObserver>, int> map;
     map.add(adoptRef(observer.get()), 5);

--- a/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
@@ -304,7 +304,7 @@ struct DerefObserver {
 
 TEST(WTF_HashSet, RefPtrNotZeroedBeforeDeref)
 {
-    auto observer = makeUnique<DerefObserver>();
+    auto observer = makeUniqueWithoutRefCountedCheck<DerefObserver>();
 
     HashSet<RefPtr<DerefObserver>> set;
     set.add(adoptRef(observer.get()));

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
@@ -768,7 +768,7 @@ struct DerefObserver {
 
 TEST(WTF_RobinHoodHashMap, RefPtrNotZeroedBeforeDeref)
 {
-    auto observer = makeUnique<DerefObserver>();
+    auto observer = makeUniqueWithoutRefCountedCheck<DerefObserver>();
 
     MemoryCompactLookupOnlyRobinHoodHashMap<RefPtr<DerefObserver>, int, RobinHoodHash<RefPtr<DerefObserver>>> map;
     map.add(adoptRef(observer.get()), 5);

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp
@@ -314,7 +314,7 @@ struct DerefObserver {
 
 TEST(WTF_RobinHoodHashSet, RefPtrNotZeroedBeforeDeref)
 {
-    auto observer = makeUnique<DerefObserver>();
+    auto observer = makeUniqueWithoutRefCountedCheck<DerefObserver>();
 
     MemoryCompactLookupOnlyRobinHoodHashSet<RefPtr<DerefObserver>, RobinHoodHash<RefPtr<DerefObserver>>> set;
     set.add(adoptRef(observer.get()));


### PR DESCRIPTION
#### d2a83bca0544e9b6c974a8eeb9dc921b20134217
<pre>
Fix bad cases of refcounted objects being stored in std::unique_ptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=261280">https://bugs.webkit.org/show_bug.cgi?id=261280</a>
<a href="https://rdar.apple.com/115122287">rdar://115122287</a>

Reviewed by David Kilzer and Alex Christensen.

In Bug 261224, I fixed a security bug where an object was refcounted but was
incorrectly stored in a std::unique_ptr&lt;&gt;, leading to use-after-frees.

In this patch, I am adding a check to WTF::makeUnique&lt;T&gt;() to fail if T::ref()
exists. This founds bugs / unsafe code, which I am fixing in this patch.

There is also a common pattern in our code where an object implements ref() &amp;
deref() to forward the refcounting to their owner. In turn, the owner then owns
the object via a std::unique_ptr&lt;&gt;. This is obviously tripping my check and yet
this is usually safe. As a result, I am introducing a
makeUniqueWithoutRefCountedCheck() for these cases.

* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
(JSC::Wasm::Worklist::Worklist):
* Source/JavaScriptCore/wasm/WasmWorklist.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::makeUnique):
(WTF::makeUniqueWithoutRefCountedCheck):
(WTF::makeUniqueWithoutFastMallocCheck):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::IDBConnectionToServer):
* Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp:
(WebCore::ServiceWorkerRegistrationPushAPI::pushManager):
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::cssRules const):
* Source/WebCore/css/CSSKeyframesRule.cpp:
(WebCore::CSSKeyframesRule::cssRules):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::cssRules const):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::items):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implementation):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributes const):
(WebCore::Element::classList):
(WebCore::Element::part):
(WebCore::Element::dataset):
(WebCore::Element::ensureFormAssociatedCustomElement):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::relList):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::transferControlToOffscreen):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::relList):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::sandbox):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::sizes):
(WebCore::HTMLLinkElement::relList):
* Source/WebCore/html/HTMLOutputElement.cpp:
(WebCore::HTMLOutputElement::htmlFor):
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::relList):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::upload):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::mediaPlayerManager):
(WebKit::GPUProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
(WebKit::RemoteImageDecoderAVFManager::create):
(WebKit::RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager): Deleted.
(WebKit::RemoteImageDecoderAVFManager::supplementName): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::create):
(WebKit::RemoteMediaPlayerManager::RemoteMediaPlayerManager): Deleted.
(WebKit::RemoteMediaPlayerManager::~RemoteMediaPlayerManager): Deleted.
(WebKit::RemoteMediaPlayerManager::supplementName): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::WebProcess):
(WebKit::WebProcess::initializeWebProcess):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::remoteMediaPlayerManager):
(WebKit::WebProcess::remoteImageDecoderAVFManager):
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashSet.cpp:
(TestWebKitAPI::TEST):

Originally-landed-as: 265870.533@safari-7616-branch (f5992c6c2848). rdar://117810061
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2a83bca0544e9b6c974a8eeb9dc921b20134217

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24733 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3278 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25986 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26851 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22706 "Hash d2a83bca for PR 19924 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25002 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4951 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/715 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/26851 "Hash d2a83bca for PR 19924 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24978 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/4951 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/25986 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27434 "Hash d2a83bca for PR 19924 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/4951 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/25986 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/27434 "Hash d2a83bca for PR 19924 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21500 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/4951 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/25986 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/27434 "Hash d2a83bca for PR 19924 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23993 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1969 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/715 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31404 "Hash d2a83bca for PR 19924 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3266 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/25986 "Hash d2a83bca for PR 19924 does not build (failure)") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/31404 "Hash d2a83bca for PR 19924 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2421 "Hash d2a83bca for PR 19924 does not build (failure)") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31379 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2328 "Hash d2a83bca for PR 19924 does not build (failure)") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6561 "Passed tests") | 
<!--EWS-Status-Bubble-End-->