### PR TITLE
Add --ignore-external-source-id option to display-sampling-profiler-output

### DIFF
--- a/Tools/Scripts/display-sampling-profiler-output
+++ b/Tools/Scripts/display-sampling-profiler-output
@@ -23,8 +23,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'rubygems'
-
-require 'readline'
+require 'getoptlong'
 
 begin
     require 'json'
@@ -39,9 +38,18 @@ rescue LoadError
     exit 1
 end
 
+
+$samplingProfilerIgnoreExternalSourceID = false
 $samplingProfilerTopFunctionsCount = 12
 $samplingProfilerTopBytecodesCount = 40
-$json = JSON::parse(IO::read(ARGV[0]))
+
+GetoptLong.new(['--ignore-external-source-id', '-s', GetoptLong::NO_ARGUMENT]).each {
+    | opt, arg |
+    case opt
+    when '--ignore-external-source-id'
+      $samplingProfilerIgnoreExternalSourceID = true
+    end
+}
 
 def reportTopFunctions database
   totalSamples = 0
@@ -50,7 +58,10 @@ def reportTopFunctions database
     next if stackTrace["frames"].empty?
     frame = stackTrace["frames"][0]
     hash, category, offset = frame["location"].split(":")
-    description = "#{frame["name"]}#{hash}:#{frame["sourceID"]}"
+    description = "#{frame["name"]}#{hash}"
+    unless $samplingProfilerIgnoreExternalSourceID
+      description = "#{description}:#{frame["sourceID"]}"
+    end
     functionCounts[description] += 1
     totalSamples += 1
   end
@@ -152,6 +163,17 @@ def reportTopBytecodes database
   end
 end
 
-reportTopFunctions($json)
-puts ""
-reportTopBytecodes($json)
+def main
+  json = nil
+  if ARGV.empty?
+      json = JSON.parse(STDIN.read)
+  else
+      json = JSON::parse(IO::read(ARGV[0]))
+  end
+
+  reportTopFunctions(json)
+  puts ""
+  reportTopBytecodes(json)
+end
+
+main


### PR DESCRIPTION
#### 7ae51b240131f81c7ec073ff5154fdcffde32799
<pre>
Add --ignore-external-source-id option to display-sampling-profiler-output
<a href="https://bugs.webkit.org/show_bug.cgi?id=264131">https://bugs.webkit.org/show_bug.cgi?id=264131</a>
<a href="https://rdar.apple.com/117887932">rdar://117887932</a>

Reviewed by Justin Michaud.

Add --ignore-external-source-id option, which corresponds to samplingProfilerIgnoreExternalSourceID in JSC option.
It ignores source ID when unifying samples.

* Tools/Scripts/display-sampling-profiler-output:

Canonical link: <a href="https://commits.webkit.org/270158@main">https://commits.webkit.org/270158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de824b65b0c0f9a40c39b61c859530d3d6006b7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26856 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/720 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2334 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27439 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/22288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22564 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/26259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/284 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2426 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3147 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->