### PR TITLE
Regression(270013@main): Crash when loading bgtime.tv

### DIFF
--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -97,7 +97,7 @@ public:
     {
         Glyph glyph = glyphForIndex(index);
         auto colorGlyphType = colorGlyphTypeForIndex(index);
-        return GlyphData(glyph, glyph ? m_font.ptr() : nullptr, colorGlyphType);
+        return GlyphData(glyph, glyph ? m_font.get() : nullptr, colorGlyphType);
     }
 
     Glyph glyphForIndex(unsigned index) const
@@ -122,7 +122,7 @@ public:
 
     const Font& font() const
     {
-        return m_font.get();
+        return *m_font;
     }
 
     // Implemented by the platform.
@@ -135,7 +135,7 @@ private:
         ++s_count;
     }
 
-    CheckedRef<const Font> m_font;
+    WeakPtr<const Font> m_font;
     Glyph m_glyphs[size] { };
     WTF::BitSet<size> m_isColor;
 


### PR DESCRIPTION
#### 1f9b90609d2f001661daeefd7ea87d548dfe3fdc
<pre>
Regression(270013@main): Crash when loading bgtime.tv
<a href="https://bugs.webkit.org/show_bug.cgi?id=264132">https://bugs.webkit.org/show_bug.cgi?id=264132</a>
&lt;<a href="https://rdar.apple.com/117882210">rdar://117882210</a>&gt;

Reviewed by Brent Fulgham.

270013@main updated `GlyphPage::m_font` to be a CheckedPtr. However, the
assertion is the CanMakeCheckedPtrBase destructor is hitting when loading
bgtime.tv. As a result, I am downgrading to a simple WeakPtr to address
the crash.

* Source/WebCore/platform/graphics/GlyphPage.h:
(WebCore::GlyphPage::glyphDataForIndex const):
(WebCore::GlyphPage::font const):

Canonical link: <a href="https://commits.webkit.org/270190@main">https://commits.webkit.org/270190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb36a3726221ba261b809e9cb0e93b0e9e72cc45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23076 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27443 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28455 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26265 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1978 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/299 "Found 2 new test failures: webrtc/h264-high.html, webrtc/video.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3274 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2430 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3163 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->