### PR TITLE
REGRESSION (267754@main): Unable to play embedded web videos in iWork apps

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
@@ -202,6 +202,9 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk);
     }
 
+    if (linkedBefore(dyld_2023_SU_C_os_versions, DYLD_IOS_VERSION_17_2, DYLD_MACOSX_VERSION_14_2))
+        disableBehavior(SDKAlignedBehavior::OnlyLoadWellKnownAboutURLs);
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -112,6 +112,7 @@ enum class SDKAlignedBehavior {
     DoesNotOverrideUAFromNSUserDefault,
     EvaluateJavaScriptWithoutTransientActivation,
     ResettingTransitionCancelsRunningTransitionQuirk,
+    OnlyLoadWellKnownAboutURLs,
 
     NumberOfBehaviors
 };

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -86,7 +86,11 @@
 #endif
 
 #ifndef DYLD_IOS_VERSION_17_0
-#define DYLD_IOS_VERSION_17_0 0x00200000
+#define DYLD_IOS_VERSION_17_0 0x00110000
+#endif
+
+#ifndef DYLD_IOS_VERSION_17_2
+#define DYLD_IOS_VERSION_17_2 0x00110200
 #endif
 
 #ifndef DYLD_MACOSX_VERSION_10_13
@@ -137,6 +141,10 @@
 #define DYLD_MACOSX_VERSION_14_0 0x000e0000
 #endif
 
+#ifndef DYLD_MACOSX_VERSION_14_2
+#define DYLD_MACOSX_VERSION_14_2 0x000e0200
+#endif
+
 #else
 
 typedef uint32_t dyld_platform_t;
@@ -167,7 +175,8 @@ typedef struct {
 #define DYLD_IOS_VERSION_15_4 0x000f0400
 #define DYLD_IOS_VERSION_16_0 0x00100000
 #define DYLD_IOS_VERSION_16_4 0x00100400
-#define DYLD_IOS_VERSION_17_0 0x00200000
+#define DYLD_IOS_VERSION_17_0 0x00110000
+#define DYLD_IOS_VERSION_17_2 0x00110200
 
 #define DYLD_MACOSX_VERSION_10_10 0x000A0A00
 #define DYLD_MACOSX_VERSION_10_11 0x000A0B00
@@ -186,6 +195,7 @@ typedef struct {
 #define DYLD_MACOSX_VERSION_13_0 0x000d0000
 #define DYLD_MACOSX_VERSION_13_3 0x000d0300
 #define DYLD_MACOSX_VERSION_14_0 0x000e0000
+#define DYLD_MACOSX_VERSION_14_2 0x000e0200
 
 #endif
 
@@ -269,6 +279,10 @@ WTF_EXTERN_C_BEGIN
 
 #ifndef dyld_fall_2023_os_versions
 #define dyld_fall_2023_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_2023_SU_C_os_versions
+#define dyld_2023_SU_C_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 uint32_t dyld_get_program_sdk_version();


### PR DESCRIPTION
#### 86dd02d51f92ee483eecf65ff8e52047f3df066e
<pre>
REGRESSION (267754@main): Unable to play embedded web videos in iWork apps
<a href="https://bugs.webkit.org/show_bug.cgi?id=264135">https://bugs.webkit.org/show_bug.cgi?id=264135</a>
<a href="https://rdar.apple.com/116493190">rdar://116493190</a>

Reviewed by Chris Dumez.

In 267754@main we changed DocumentLoader to cancel loads to about: URLs that are not well-known, but
iWork apps load embedded web videos using URLs of the form &quot;about:blank/&lt;uuid&gt;&quot;. To maintain binary
compatibility, added a quirk to allow loading any about: URL in apps linked before iOS 17.2 and
macOS 14.2 SDKs.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/spi/darwin/dyldSPI.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::shouldCancelLoadingAboutURL):
(WebCore::DocumentLoader::startLoadingMainResource):

Canonical link: <a href="https://commits.webkit.org/270196@main">https://commits.webkit.org/270196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7c01531c7d696f5b8131319fcca12af07e1bc0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/789 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27509 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28504 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21570 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26327 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24066 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/345 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31473 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3332 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6901 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5943 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2493 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31451 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2394 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6581 "Passed tests") | 
<!--EWS-Status-Bubble-End-->