### PR TITLE
Move duplicated methods from MediaSourcePrivate/SourceBufferPrivate to base class

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -806,9 +806,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer() const
         return true;
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
     return isCopyDisplayedPixelBufferAvailable() && [&] {
-        if (m_mediaSourcePrivate && anyOf(m_mediaSourcePrivate->sourceBuffers(), [] (auto& sourceBuffer) {
-            return sourceBuffer->needsVideoLayer();
-        }))
+        if (m_mediaSourcePrivate && m_mediaSourcePrivate->needsVideoLayer())
             return true;
         auto player = m_player.get();
         return player && player->renderingCanBeAccelerated();
@@ -1190,8 +1188,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setCDMSession(LegacyCDMSession* sessi
     if (!m_mediaSourcePrivate)
         return;
 
-    for (auto& sourceBuffer : m_mediaSourcePrivate->sourceBuffers())
-        sourceBuffer->setCDMSession(m_session.get());
+    m_mediaSourcePrivate->setCDMSession(session);
 }
 #endif // ENABLE(LEGACY_ENCRYPTED_MEDIA)
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -63,28 +63,23 @@ public:
     virtual ~MediaSourcePrivateAVFObjC();
 
     MediaPlayerPrivateMediaSourceAVFObjC* player() const { return m_player.get(); }
-    const Vector<RefPtr<SourceBufferPrivateAVFObjC>>& sourceBuffers() const { return m_sourceBuffers; }
-    const Vector<SourceBufferPrivateAVFObjC*>& activeSourceBuffers() const { return m_activeSourceBuffers; }
 
     AddStatus addSourceBuffer(const ContentType&, bool webMParserEnabled, RefPtr<SourceBufferPrivate>&) final;
     void durationChanged(const MediaTime&) final;
     void markEndOfStream(EndOfStreamStatus) final;
-    void unmarkEndOfStream() final;
-    bool isEnded() const final { return m_isEnded; }
+
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;
 
     void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
     void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
 
-    MediaTime duration() const;
+    MediaTime duration() const final;
     const PlatformTimeRanges& buffered();
 
-    bool hasAudio() const;
-    bool hasVideo() const;
     bool hasSelectedVideo() const;
 
-    MediaTime currentMediaTime() const;
+    MediaTime currentMediaTime() const final;
     void willSeek();
 
     FloatSize naturalSize() const;
@@ -100,7 +95,7 @@ public:
     void cdmInstanceDetached(CDMInstance&);
     void attemptToDecryptWithInstance(CDMInstance&);
     bool waitingForKey() const;
-    
+
     CDMInstance* cdmInstance() const { return m_cdmInstance.get(); }
     void outputObscuredDueToInsufficientExternalProtectionChanged(bool);
 #endif
@@ -116,15 +111,16 @@ public:
 
     using RendererType = MediaSourcePrivateClient::RendererType;
     void failedToCreateRenderer(RendererType);
+    bool needsVideoLayer() const;
 
 private:
     MediaSourcePrivateAVFObjC(MediaPlayerPrivateMediaSourceAVFObjC&, MediaSourcePrivateClient&);
 
-    void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivateAVFObjC*, bool active);
+    void notifyActiveSourceBuffersChanged() final;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     void sourceBufferKeyNeeded(SourceBufferPrivateAVFObjC*, const SharedBuffer&);
 #endif
-    void removeSourceBuffer(SourceBufferPrivate*);
+    void removeSourceBuffer(SourceBufferPrivate&) final;
 
     void setSourceBufferWithSelectedVideo(SourceBufferPrivateAVFObjC*);
 
@@ -132,11 +128,8 @@ private:
 
     WeakPtr<MediaPlayerPrivateMediaSourceAVFObjC> m_player;
     WeakPtr<MediaSourcePrivateClient> m_client;
-    Vector<RefPtr<SourceBufferPrivateAVFObjC>> m_sourceBuffers;
-    Vector<SourceBufferPrivateAVFObjC*> m_activeSourceBuffers;
     Deque<SourceBufferPrivateAVFObjC*> m_sourceBuffersNeedingSessions;
     SourceBufferPrivateAVFObjC* m_sourceBufferWithSelectedVideo { nullptr };
-    bool m_isEnded { false };
 #if ENABLE(ENCRYPTED_MEDIA)
     RefPtr<CDMInstance> m_cdmInstance;
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -566,7 +566,7 @@ void AppendPipeline::didReceiveInitializationSegment()
     m_hasReceivedFirstInitializationSegment = true;
     GST_DEBUG_OBJECT(pipeline(), "Notifying SourceBuffer of initialization segment.");
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, "append-pipeline-received-init-segment");
-    m_sourceBufferPrivate.didReceiveInitializationSegment(WTFMove(initializationSegment), [](SourceBufferPrivateClient::ReceiveResult) { });
+    m_sourceBufferPrivate.didReceiveInitializationSegment(WTFMove(initializationSegment));
 }
 
 void AppendPipeline::consumeAppsinksAvailableSamples()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -75,8 +75,6 @@ MediaSourcePrivateGStreamer::MediaSourcePrivateGStreamer(MediaSourcePrivateClien
 MediaSourcePrivateGStreamer::~MediaSourcePrivateGStreamer()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    for (auto& sourceBufferPrivate : m_sourceBuffers)
-        sourceBufferPrivate->clearMediaSource();
 }
 
 MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuffer(const ContentType& contentType, bool, RefPtr<SourceBufferPrivate>& sourceBufferPrivate)
@@ -90,20 +88,9 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
     if (!SourceBufferPrivateGStreamer::isContentTypeSupported(contentType))
         return MediaSourcePrivateGStreamer::AddStatus::NotSupported;
 
-    sourceBufferPrivate = SourceBufferPrivateGStreamer::create(this, contentType, m_playerPrivate);
-    RefPtr<SourceBufferPrivateGStreamer> sourceBufferPrivateGStreamer = static_cast<SourceBufferPrivateGStreamer*>(sourceBufferPrivate.get());
-    m_sourceBuffers.add(sourceBufferPrivateGStreamer);
+    m_sourceBuffers.append(SourceBufferPrivateGStreamer::create(*this, contentType, m_playerPrivate));
+    sourceBufferPrivate = m_sourceBuffers.last();
     return MediaSourcePrivateGStreamer::AddStatus::Ok;
-}
-
-void MediaSourcePrivateGStreamer::removeSourceBuffer(SourceBufferPrivate* sourceBufferPrivate)
-{
-    RefPtr<SourceBufferPrivateGStreamer> sourceBufferPrivateGStreamer = static_cast<SourceBufferPrivateGStreamer*>(sourceBufferPrivate);
-    ASSERT(m_sourceBuffers.contains(sourceBufferPrivateGStreamer));
-
-    sourceBufferPrivateGStreamer->clearMediaSource();
-    m_sourceBuffers.remove(sourceBufferPrivateGStreamer);
-    m_activeSourceBuffers.remove(sourceBufferPrivateGStreamer.get());
 }
 
 void MediaSourcePrivateGStreamer::durationChanged(const MediaTime&)
@@ -138,14 +125,7 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
 #endif
     if (endOfStreamStatus == EosNoError)
         m_playerPrivate.setNetworkState(MediaPlayer::NetworkState::Loaded);
-    m_isEnded = true;
-}
-
-void MediaSourcePrivateGStreamer::unmarkEndOfStream()
-{
-    ASSERT(isMainThread());
-    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Un-marking EOS");
-    m_isEnded = false;
+    MediaSourcePrivate::markEndOfStream(endOfStreamStatus);
 }
 
 MediaPlayer::ReadyState MediaSourcePrivateGStreamer::readyState() const
@@ -184,14 +164,6 @@ MediaTime MediaSourcePrivateGStreamer::currentMediaTime() const
     return m_playerPrivate.currentMediaTime();
 }
 
-void MediaSourcePrivateGStreamer::sourceBufferPrivateDidChangeActiveState(SourceBufferPrivateGStreamer* sourceBufferPrivate, bool isActive)
-{
-    if (!isActive)
-        m_activeSourceBuffers.remove(sourceBufferPrivate);
-    else if (!m_activeSourceBuffers.contains(sourceBufferPrivate))
-        m_activeSourceBuffers.add(sourceBufferPrivate);
-}
-
 void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
 {
     if (m_hasAllTracks) {
@@ -200,7 +172,7 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
     }
 
     for (auto& sourceBuffer : m_sourceBuffers) {
-        if (!sourceBuffer->hasReceivedInitializationSegment()) {
+        if (!sourceBuffer->hasReceivedFirstInitializationSegment()) {
             GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "There are still SourceBuffers without an initialization segment, not starting source yet.");
             return;
         }
@@ -210,8 +182,10 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
     m_hasAllTracks = true;
 
     Vector<RefPtr<MediaSourceTrackGStreamer>> tracks;
-    for (auto& sourceBuffer : m_sourceBuffers)
+    for (auto& privateSourceBuffer : m_sourceBuffers) {
+        auto sourceBuffer = downcast<SourceBufferPrivateGStreamer>(privateSourceBuffer);
         tracks.appendRange(sourceBuffer->tracks().begin(), sourceBuffer->tracks().end());
+    }
     m_playerPrivate.startSource(tracks);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -57,12 +57,9 @@ public:
     virtual ~MediaSourcePrivateGStreamer();
 
     AddStatus addSourceBuffer(const ContentType&, bool, RefPtr<SourceBufferPrivate>&) override;
-    void removeSourceBuffer(SourceBufferPrivate*);
 
     void durationChanged(const MediaTime&) override;
     void markEndOfStream(EndOfStreamStatus) override;
-    void unmarkEndOfStream() override;
-    bool isEnded() const override { return m_isEnded; }
 
     MediaPlayer::ReadyState readyState() const override;
     void setReadyState(MediaPlayer::ReadyState) override;
@@ -70,10 +67,11 @@ public:
     void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
     void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
 
-    MediaTime duration() const;
-    MediaTime currentMediaTime() const;
+    MediaTime duration() const final;
+    MediaTime currentMediaTime() const final;
 
-    void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivateGStreamer*, bool);
+    void notifyActiveSourceBuffersChanged() final { }
+
     void startPlaybackIfHasAllTracks();
     bool hasAllTracks() const { return m_hasAllTracks; }
 
@@ -91,11 +89,8 @@ public:
 private:
     MediaSourcePrivateGStreamer(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
 
-    HashSet<RefPtr<SourceBufferPrivateGStreamer>> m_sourceBuffers;
-    HashSet<SourceBufferPrivateGStreamer*> m_activeSourceBuffers;
     WeakPtr<MediaSourcePrivateClient> m_mediaSource;
     MediaPlayerPrivateGStreamerMSE& m_playerPrivate;
-    bool m_isEnded { false };
     bool m_hasAllTracks { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -56,11 +56,7 @@ MockMediaSourcePrivate::MockMediaSourcePrivate(MockMediaPlayerMediaSource& paren
 #endif
 }
 
-MockMediaSourcePrivate::~MockMediaSourcePrivate()
-{
-    for (auto& buffer : m_sourceBuffers)
-        buffer->clearMediaSource();
-}
+MockMediaSourcePrivate::~MockMediaSourcePrivate() = default;
 
 MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const ContentType& contentType, bool, RefPtr<SourceBufferPrivate>& outPrivate)
 {
@@ -70,20 +66,13 @@ MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const Cont
     if (MockMediaPlayerMediaSource::supportsType(parameters) == MediaPlayer::SupportsType::IsNotSupported)
         return AddStatus::NotSupported;
 
-    m_sourceBuffers.append(MockSourceBufferPrivate::create(this));
+    m_sourceBuffers.append(MockSourceBufferPrivate::create(*this));
     outPrivate = m_sourceBuffers.last();
 
     return AddStatus::Ok;
 }
 
-void MockMediaSourcePrivate::removeSourceBuffer(SourceBufferPrivate* buffer)
-{
-    ASSERT(m_sourceBuffers.contains(buffer));
-    m_activeSourceBuffers.removeFirst(buffer);
-    m_sourceBuffers.removeFirst(buffer);
-}
-
-MediaTime MockMediaSourcePrivate::duration()
+MediaTime MockMediaSourcePrivate::duration() const
 {
     if (m_client)
         return m_client->duration();
@@ -106,12 +95,7 @@ void MockMediaSourcePrivate::markEndOfStream(EndOfStreamStatus status)
 {
     if (status == EosNoError)
         m_player.setNetworkState(MediaPlayer::NetworkState::Loaded);
-    m_isEnded = true;
-}
-
-void MockMediaSourcePrivate::unmarkEndOfStream()
-{
-    m_isEnded = false;
+    MediaSourcePrivate::markEndOfStream(status);
 }
 
 MediaPlayer::ReadyState MockMediaSourcePrivate::readyState() const
@@ -124,33 +108,9 @@ void MockMediaSourcePrivate::setReadyState(MediaPlayer::ReadyState readyState)
     m_player.setReadyState(readyState);
 }
 
-void MockMediaSourcePrivate::sourceBufferPrivateDidChangeActiveState(MockSourceBufferPrivate* buffer, bool active)
+void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
 {
-    if (active && !m_activeSourceBuffers.contains(buffer))
-        m_activeSourceBuffers.append(buffer);
-
-    if (!active)
-        m_activeSourceBuffers.removeFirst(buffer);
-}
-
-static bool MockSourceBufferPrivateHasAudio(MockSourceBufferPrivate* sourceBuffer)
-{
-    return sourceBuffer->hasAudio();
-}
-
-bool MockMediaSourcePrivate::hasAudio() const
-{
-    return std::any_of(m_activeSourceBuffers.begin(), m_activeSourceBuffers.end(), MockSourceBufferPrivateHasAudio);
-}
-
-static bool MockSourceBufferPrivateHasVideo(MockSourceBufferPrivate* sourceBuffer)
-{
-    return sourceBuffer->hasVideo();
-}
-
-bool MockMediaSourcePrivate::hasVideo() const
-{
-    return std::any_of(m_activeSourceBuffers.begin(), m_activeSourceBuffers.end(), MockSourceBufferPrivateHasVideo);
+    m_player.notifyActiveSourceBuffersChanged();
 }
 
 void MockMediaSourcePrivate::waitForTarget(const SeekTarget& target, CompletionHandler<void(const MediaTime&)>&& completionHandler)

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -46,19 +46,14 @@ public:
     static Ref<MockMediaSourcePrivate> create(MockMediaPlayerMediaSource&, MediaSourcePrivateClient&);
     virtual ~MockMediaSourcePrivate();
 
-    const Vector<MockSourceBufferPrivate*>& activeSourceBuffers() const { return m_activeSourceBuffers; }
-
-    bool hasAudio() const;
-    bool hasVideo() const;
-
-    MediaTime duration();
     const PlatformTimeRanges& buffered();
 
     MockMediaPlayerMediaSource& player() const { return m_player; }
 
     void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
     void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
-    MediaTime currentMediaTime() const;
+    MediaTime currentMediaTime() const final;
+    MediaTime duration() const final;
 
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics();
 
@@ -83,21 +78,16 @@ private:
     AddStatus addSourceBuffer(const ContentType&, bool webMParserEnabled, RefPtr<SourceBufferPrivate>&) override;
     void durationChanged(const MediaTime&) override;
     void markEndOfStream(EndOfStreamStatus) override;
-    bool isEnded() const override { return m_isEnded; }
-    void unmarkEndOfStream() override;
+
     MediaPlayer::ReadyState readyState() const override;
     void setReadyState(MediaPlayer::ReadyState) override;
 
-    void sourceBufferPrivateDidChangeActiveState(MockSourceBufferPrivate*, bool active);
-    void removeSourceBuffer(SourceBufferPrivate*);
+    void notifyActiveSourceBuffersChanged() final;
 
     friend class MockSourceBufferPrivate;
 
     MockMediaPlayerMediaSource& m_player;
     WeakPtr<MediaSourcePrivateClient> m_client;
-    Vector<RefPtr<MockSourceBufferPrivate>> m_sourceBuffers;
-    Vector<MockSourceBufferPrivate*> m_activeSourceBuffers;
-    bool m_isEnded { false };
 
     unsigned m_totalVideoFrames { 0 };
     unsigned m_droppedVideoFrames { 0 };

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -41,33 +41,27 @@ class VideoTrackPrivate;
 
 class MockSourceBufferPrivate final : public SourceBufferPrivate {
 public:
-    static Ref<MockSourceBufferPrivate> create(MockMediaSourcePrivate*);
+    static Ref<MockSourceBufferPrivate> create(MockMediaSourcePrivate&);
     virtual ~MockSourceBufferPrivate();
 
-    void clearMediaSource() { m_mediaSource = nullptr; }
-
-    bool isActive() const final;
-
+    constexpr PlatformType platformType() const final { return PlatformType::Mock; }
 private:
-    explicit MockSourceBufferPrivate(MockMediaSourcePrivate*);
+    explicit MockSourceBufferPrivate(MockMediaSourcePrivate&);
+    MockMediaSourcePrivate* mediaSourcePrivate() const;
 
     // SourceBufferPrivate overrides
     void appendInternal(Ref<SharedBuffer>&&) final;
     void resetParserStateInternal() final;
-    void removedFromMediaSource() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;
     bool canSetMinimumUpcomingPresentationTime(const AtomString&) const final;
     void setMinimumUpcomingPresentationTime(const AtomString&, const MediaTime&) final;
     void clearMinimumUpcomingPresentationTime(const AtomString&) final;
     bool canSwitchToType(const ContentType&) final;
-    MediaTime currentMediaTime() const final;
-    MediaTime duration() const final;
 
     void flush(const AtomString&) final { m_enqueuedSamples.clear(); m_minimumUpcomingPresentationTime = MediaTime::invalidTime(); }
     void enqueueSample(Ref<MediaSample>&&, const AtomString&) final;
     bool isReadyForMoreSamples(const AtomString&) final { return !m_maxQueueDepth || m_enqueuedSamples.size() < m_maxQueueDepth.value(); }
-    void setActive(bool) final;
 
     void enqueuedSamplesForTrackID(const AtomString&, CompletionHandler<void(Vector<String>&&)>&&) final;
     MediaTime minimumUpcomingPresentationTimeForTrackID(const AtomString&) final;
@@ -86,7 +80,6 @@ private:
     const void* sourceBufferLogIdentifier() final { return logIdentifier(); }
 #endif
 
-    MockMediaSourcePrivate* m_mediaSource;
     bool m_isActive { false };
     MediaTime m_minimumUpcomingPresentationTime;
     Vector<String> m_enqueuedSamples;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -78,9 +78,6 @@ MediaSourcePrivateRemote::~MediaSourcePrivateRemote()
     ALWAYS_LOG(LOGIDENTIFIER);
     if (auto gpuProcessConnection = m_gpuProcessConnection.get())
         gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::MediaSourcePrivateRemote::messageReceiverName(), m_identifier.toUInt64());
-
-    for (auto& sourceBuffer : m_sourceBuffers)
-        sourceBuffer->clearMediaSource();
 }
 
 MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const ContentType& contentType, bool, RefPtr<SourceBufferPrivate>& outPrivate)
@@ -130,22 +127,17 @@ void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffere
 
 void MediaSourcePrivateRemote::markEndOfStream(EndOfStreamStatus status)
 {
-    m_ended = true;
     if (auto gpuProcessConnection = m_gpuProcessConnection.get())
         gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::MarkEndOfStream(status), m_identifier);
+    MediaSourcePrivate::markEndOfStream(status);
 }
 
 void MediaSourcePrivateRemote::unmarkEndOfStream()
 {
     // FIXME(125159): implement unmarkEndOfStream()
-    m_ended = false;
     if (auto gpuProcessConnection = m_gpuProcessConnection.get())
         gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::UnmarkEndOfStream(), m_identifier);
-}
-
-bool MediaSourcePrivateRemote::isEnded() const
-{
-    return m_ended;
+    MediaSourcePrivate::unmarkEndOfStream();
 }
 
 MediaPlayer::ReadyState MediaSourcePrivateRemote::readyState() const

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -62,11 +62,12 @@ public:
 
     // MediaSourcePrivate overrides
     AddStatus addSourceBuffer(const WebCore::ContentType&, bool webMParserEnabled, RefPtr<WebCore::SourceBufferPrivate>&) final;
+    void removeSourceBuffer(WebCore::SourceBufferPrivate&) final { }
+    void notifyActiveSourceBuffersChanged() final { };
     void durationChanged(const MediaTime&) final;
     void bufferedChanged(const WebCore::PlatformTimeRanges&) final;
     void markEndOfStream(EndOfStreamStatus) final;
     void unmarkEndOfStream() final;
-    bool isEnded() const final;
     WebCore::MediaPlayer::ReadyState readyState() const final;
     void setReadyState(WebCore::MediaPlayer::ReadyState) final;
 
@@ -75,7 +76,12 @@ public:
 
     void setTimeFudgeFactor(const MediaTime&) final;
 
-    MediaTime duration() const { return m_client ? m_client->duration() : MediaTime(); }
+    MediaTime duration() const final { return m_client ? m_client->duration() : MediaTime(); }
+    MediaTime currentMediaTime() const final
+    {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
@@ -95,7 +101,6 @@ private:
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
     WeakPtr<WebCore::MediaSourcePrivateClient> m_client;
     Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
-    bool m_ended { false };
     bool m_shutdown { false };
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -62,14 +62,15 @@ class SourceBufferPrivateRemote final
     , public IPC::MessageReceiver
 {
 public:
-    static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, const MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
+    static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
     virtual ~SourceBufferPrivateRemote();
 
-    void clearMediaSource() { m_mediaSourcePrivate = nullptr; }
+    constexpr PlatformType platformType() const final { return PlatformType::Remote; }
+
     void disconnect() { m_disconnected = true; }
 
 private:
-    SourceBufferPrivateRemote(GPUProcessConnection&, RemoteSourceBufferIdentifier, const MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
+    SourceBufferPrivateRemote(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
 
     // SourceBufferPrivate overrides
     void setActive(bool) final;
@@ -109,8 +110,6 @@ private:
 
     void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded) final;
 
-    bool isActive() const final { return m_isActive; }
-
     // Internals Utility methods
     void bufferedSamplesForTrackId(const AtomString&, CompletionHandler<void(Vector<String>&&)>&&) final;
     void enqueuedSamplesForTrackID(const AtomString&, CompletionHandler<void(Vector<String>&&)>&&) final;
@@ -132,14 +131,12 @@ private:
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
-    WeakPtr<MediaSourcePrivateRemote> m_mediaSourcePrivate;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
 
     HashMap<AtomString, TrackPrivateRemoteIdentifier> m_trackIdentifierMap;
     HashMap<AtomString, TrackPrivateRemoteIdentifier> m_prevTrackIdentifierMap;
     Vector<WebCore::PlatformTimeRanges> m_trackBufferRanges;
 
-    bool m_isActive { false };
     uint64_t m_totalTrackBufferSizeInBytes = { 0 };
 
     bool isGPURunning() const { return !m_disconnected && m_gpuProcessConnection.get(); }


### PR DESCRIPTION
#### e25a76a6050724c85a623b23746c2a143f844be3
<pre>
Move duplicated methods from MediaSourcePrivate/SourceBufferPrivate to base class
<a href="https://bugs.webkit.org/show_bug.cgi?id=264142">https://bugs.webkit.org/show_bug.cgi?id=264142</a>
<a href="https://rdar.apple.com/117892834">rdar://117892834</a>

Reviewed by Jer Noble.

We have three MSE implementations in our tree:
- Cocoa/AVFObjC
- Mock
- GStreamer

In a lot of instances, all three duplicate the same code. It makes it harder to maintain and too easy to introduce discrepancy between the three implementations.

So we move to their respective base classes what can be moved.

Covered by existing tests.

* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::~MediaSourcePrivate):
(WebCore::MediaSourcePrivate::removeSourceBuffer):
(WebCore::MediaSourcePrivate::sourceBufferPrivateDidChangeActiveState):
(WebCore::MediaSourcePrivate::hasAudio const):
(WebCore::MediaSourcePrivate::hasVideo const):
(WebCore::MediaSourcePrivate::setCDMSession):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
(WebCore::MediaSourcePrivate::bufferedChanged): Deleted.
(WebCore::MediaSourcePrivate::setTimeFudgeFactor): Deleted.
(WebCore::MediaSourcePrivate::timeFudgeFactor const): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::SourceBufferPrivate):
(WebCore::SourceBufferPrivate::removedFromMediaSource):
(WebCore::SourceBufferPrivate::currentMediaTime const):
(WebCore::SourceBufferPrivate::duration const):
(WebCore::SourceBufferPrivate::setActive):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::clearMediaSource):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment const):
(WebCore::SourceBufferPrivate::setCDMSession):
(WebCore::SourceBufferPrivate::setCDMInstance):
(WebCore::SourceBufferPrivate::waitingForKey const):
(WebCore::SourceBufferPrivate::attemptToDecrypt):
(WebCore::SourceBufferPrivate::isActive const):
(WebCore::SourceBufferPrivate::isSeeking const):
(WebCore::SourceBufferPrivate::currentMediaTime const): Deleted.
(WebCore::SourceBufferPrivate::duration const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setCDMSession):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::MediaSourcePrivateAVFObjC):
(WebCore::MediaSourcePrivateAVFObjC::~MediaSourcePrivateAVFObjC):
(WebCore::MediaSourcePrivateAVFObjC::addSourceBuffer):
(WebCore::MediaSourcePrivateAVFObjC::removeSourceBuffer):
(WebCore::MediaSourcePrivateAVFObjC::notifyActiveSourceBuffersChanged):
(WebCore::MediaSourcePrivateAVFObjC::markEndOfStream):
(WebCore::MediaSourcePrivateAVFObjC::hasSelectedVideo const):
(WebCore::MediaSourcePrivateAVFObjC::willSeek):
(WebCore::MediaSourcePrivateAVFObjC::naturalSize const):
(WebCore::MediaSourcePrivateAVFObjC::flushActiveSourceBuffersIfNeeded):
(WebCore::MediaSourcePrivateAVFObjC::needsVideoLayer const):
(WebCore::MediaSourcePrivateAVFObjC::unmarkEndOfStream): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::sourceBufferPrivateDidChangeActiveState): Deleted.
(WebCore::MediaSourcePrivateAVFObjCHasAudio): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::hasAudio const): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::hasVideo const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::create):
(WebCore::SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC):
(WebCore::m_logIdentifier):
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::setCDMSession):
(WebCore::SourceBufferPrivateAVFObjC::outputObscuredDueToInsufficientExternalProtectionChanged):
(WebCore::SourceBufferPrivateAVFObjC::player const):
(WebCore::SourceBufferPrivateAVFObjC::removedFromMediaSource): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::setActive): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::isActive const): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::currentMediaTime const): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::duration const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::~MediaSourcePrivateGStreamer):
(WebCore::MediaSourcePrivateGStreamer::addSourceBuffer):
(WebCore::MediaSourcePrivateGStreamer::markEndOfStream):
(WebCore::MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks):
(WebCore::MediaSourcePrivateGStreamer::removeSourceBuffer): Deleted.
(WebCore::MediaSourcePrivateGStreamer::unmarkEndOfStream): Deleted.
(WebCore::MediaSourcePrivateGStreamer::sourceBufferPrivateDidChangeActiveState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::create):
(WebCore::SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer):
(WebCore::SourceBufferPrivateGStreamer::removedFromMediaSource):
(WebCore::SourceBufferPrivateGStreamer::flush):
(WebCore::SourceBufferPrivateGStreamer::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivateGStreamer::setActive): Deleted.
(WebCore::SourceBufferPrivateGStreamer::isActive const): Deleted.
(WebCore::SourceBufferPrivateGStreamer::currentMediaTime const): Deleted.
(WebCore::SourceBufferPrivateGStreamer::duration const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
(isType):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::addSourceBuffer):
(WebCore::MockMediaSourcePrivate::duration const):
(WebCore::MockMediaSourcePrivate::markEndOfStream):
(WebCore::MockMediaSourcePrivate::notifyActiveSourceBuffersChanged):
(WebCore::MockMediaSourcePrivate::~MockMediaSourcePrivate): Deleted.
(WebCore::MockMediaSourcePrivate::removeSourceBuffer): Deleted.
(WebCore::MockMediaSourcePrivate::duration): Deleted.
(WebCore::MockMediaSourcePrivate::unmarkEndOfStream): Deleted.
(WebCore::MockMediaSourcePrivate::sourceBufferPrivateDidChangeActiveState): Deleted.
(WebCore::MockSourceBufferPrivateHasAudio): Deleted.
(WebCore::MockMediaSourcePrivate::hasAudio const): Deleted.
(WebCore::MockSourceBufferPrivateHasVideo): Deleted.
(WebCore::MockMediaSourcePrivate::hasVideo const): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::create):
(WebCore::MockSourceBufferPrivate::MockSourceBufferPrivate):
(WebCore::MockSourceBufferPrivate::mediaSourcePrivate const):
(WebCore::MockSourceBufferPrivate::readyState const):
(WebCore::MockSourceBufferPrivate::setReadyState):
(WebCore::MockSourceBufferPrivate::enqueueSample):
(WebCore::MockSourceBufferPrivate::removedFromMediaSource): Deleted.
(WebCore::MockSourceBufferPrivate::setActive): Deleted.
(WebCore::MockSourceBufferPrivate::isActive const): Deleted.
(WebCore::MockSourceBufferPrivate::currentMediaTime const): Deleted.
(WebCore::MockSourceBufferPrivate::duration const): Deleted.
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::markEndOfStream):
(WebKit::MediaSourcePrivateRemote::unmarkEndOfStream):
(WebKit::MediaSourcePrivateRemote::isEnded const): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::create):
(WebKit::SourceBufferPrivateRemote::SourceBufferPrivateRemote):
(WebKit::SourceBufferPrivateRemote::setReadyState):
(WebKit::SourceBufferPrivateRemote::setActive):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/270354@main">https://commits.webkit.org/270354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25c7c4feaf01fe06dcf2b648c8ab80506cd88274

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25196 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27311 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23356 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27890 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28805 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/687 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3747 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6051 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2836 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2731 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->