### PR TITLE
[WebGPU] Buffer synchronization is implemented incorrectly leading to data races between the CPU and GPU

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -224,6 +224,7 @@ void* Buffer::getMappedRange(size_t offset, size_t size)
     m_mappedRanges.add({ offset, offset + rangeSize });
     m_mappedRanges.compact();
 
+    m_device->getQueue().waitUntilIdle();
     ASSERT(m_buffer.contents);
     return static_cast<char*>(m_buffer.contents) + offset;
 }

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -72,6 +72,7 @@ public:
     id<MTLCommandQueue> commandQueue() const { return m_commandQueue; }
 
     const Device& device() const { return m_device; }
+    void waitUntilIdle();
 
 private:
     Queue(id<MTLCommandQueue>, Device&);
@@ -102,6 +103,7 @@ private:
     HashMap<uint64_t, OnSubmittedWorkScheduledCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkScheduledCallbacks;
     using OnSubmittedWorkDoneCallbacks = Vector<WTF::Function<void(WGPUQueueWorkDoneStatus)>>;
     HashMap<uint64_t, OnSubmittedWorkDoneCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkDoneCallbacks;
+    NSMutableSet<id<MTLCommandBuffer>> *m_pendingCommandBuffers;
 };
 
 } // namespace WebGPU


### PR DESCRIPTION
#### 1ab3947e3854e90ab6b5b114ab1138b2d7804bad
<pre>
[WebGPU] Buffer synchronization is implemented incorrectly leading to data races between the CPU and GPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=264111">https://bugs.webkit.org/show_bug.cgi?id=264111</a>
&lt;radar://117869389&gt;

Reviewed by Tadeu Zagallo.

Some of the CTS tests write to a buffer via copyBufferToBuffer or
similar methods which uses an MTLBlitCommandEncoder and then they
immedietly map the buffer contents with GPUBuffer.getMappedRange
which returns buffer.contents.

However it is not safe to access buffer.contents prior to the command
buffers being completed, so wait for these to complete prior to returning
from getMappedRange.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::getMappedRange):
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::Queue):
(WebGPU::Queue::commitMTLCommandBuffer):
(WebGPU::Queue::waitUntilIdle):

Canonical link: <a href="https://commits.webkit.org/270195@main">https://commits.webkit.org/270195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4df1d8d156bc76a791e5d77a6c67497efca39e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26879 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22730 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27462 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2058 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28464 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26275 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3287 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->