### PR TITLE
[TextureMapper] Make WrapMode an enum class

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -478,7 +478,7 @@ void TextureMapper::drawTexture(GLuint texture, OptionSet<TextureMapperFlags> fl
         options.add(TextureMapperShaderProgram::Antialiasing);
         flags.add(TextureMapperFlags::ShouldAntialias);
     }
-    if (wrapMode() == RepeatWrap && !m_contextAttributes.supportsNPOTTextures)
+    if (m_wrapMode == WrapMode::Repeat && !m_contextAttributes.supportsNPOTTextures)
         options.add(TextureMapperShaderProgram::ManualRepeat);
 
     RefPtr<const FilterOperation> filter = data().filterInfo ? data().filterInfo->filter: nullptr;
@@ -543,7 +543,7 @@ void TextureMapper::drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, 
         options.add(TextureMapperShaderProgram::Antialiasing);
         flags.add(TextureMapperFlags::ShouldAntialias);
     }
-    if (wrapMode() == RepeatWrap && !m_contextAttributes.supportsNPOTTextures)
+    if (m_wrapMode == WrapMode::Repeat && !m_contextAttributes.supportsNPOTTextures)
         options.add(TextureMapperShaderProgram::ManualRepeat);
 
     RefPtr<const FilterOperation> filter = data().filterInfo ? data().filterInfo->filter: nullptr;
@@ -599,7 +599,7 @@ void TextureMapper::drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textur
         options.add(TextureMapperShaderProgram::Antialiasing);
         flags.add(TextureMapperFlags::ShouldAntialias);
     }
-    if (wrapMode() == RepeatWrap && !m_contextAttributes.supportsNPOTTextures)
+    if (m_wrapMode == WrapMode::Repeat && !m_contextAttributes.supportsNPOTTextures)
         options.add(TextureMapperShaderProgram::ManualRepeat);
 
     RefPtr<const FilterOperation> filter = data().filterInfo ? data().filterInfo->filter: nullptr;
@@ -647,7 +647,7 @@ void TextureMapper::drawTexturePackedYUV(GLuint texture, const std::array<GLfloa
         options.add(TextureMapperShaderProgram::Antialiasing);
         flags.add(TextureMapperFlags::ShouldAntialias);
     }
-    if (wrapMode() == RepeatWrap && !m_contextAttributes.supportsNPOTTextures)
+    if (m_wrapMode == WrapMode::Repeat && !m_contextAttributes.supportsNPOTTextures)
         options.add(TextureMapperShaderProgram::ManualRepeat);
 
     RefPtr<const FilterOperation> filter = data().filterInfo ? data().filterInfo->filter: nullptr;
@@ -794,7 +794,7 @@ void TextureMapper::drawTexturedQuadWithProgram(TextureMapperShaderProgram& prog
 {
     glUseProgram(program.programID());
 
-    bool repeatWrap = wrapMode() == RepeatWrap && m_contextAttributes.supportsNPOTTextures;
+    bool repeatWrap = m_wrapMode == WrapMode::Repeat && m_contextAttributes.supportsNPOTTextures;
     GLenum target = GLenum(GL_TEXTURE_2D);
     if (flags.contains(TextureMapperFlags::ShouldUseExternalOESTextureRect))
         target = GLenum(GL_TEXTURE_EXTERNAL_OES);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -50,9 +50,9 @@ enum class TextureMapperFlags : uint16_t;
 class TextureMapper {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    enum WrapMode {
-        StretchWrap,
-        RepeatWrap
+    enum class WrapMode : uint8_t {
+        Stretch,
+        Repeat
     };
 
     WEBCORE_EXPORT static std::unique_ptr<TextureMapper> create();
@@ -102,7 +102,6 @@ private:
     std::unique_ptr<BitmapTexturePool> m_texturePool;
 
     bool isInMaskMode() const { return m_isMaskMode; }
-    WrapMode wrapMode() const { return m_wrapMode; }
     const TransformationMatrix& patternTransform() const { return m_patternTransform; }
 
     enum class Direction { X, Y };
@@ -130,7 +129,7 @@ private:
 
     bool m_isMaskMode { false };
     TransformationMatrix m_patternTransform;
-    WrapMode m_wrapMode { StretchWrap };
+    WrapMode m_wrapMode { WrapMode::Stretch };
     TextureMapperContextAttributes m_contextAttributes;
     TextureMapperGLData* m_data;
     ClipStack m_clipStack;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -201,7 +201,7 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
         backingStore = &solidColorLayer;
     }
 
-    options.textureMapper.setWrapMode(TextureMapper::StretchWrap);
+    options.textureMapper.setWrapMode(TextureMapper::WrapMode::Stretch);
     options.textureMapper.setPatternTransform(TransformationMatrix());
 
     if (backingStore) {
@@ -222,7 +222,7 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
         return;
 
     if (!m_state.contentsTileSize.isEmpty()) {
-        options.textureMapper.setWrapMode(TextureMapper::RepeatWrap);
+        options.textureMapper.setWrapMode(TextureMapper::WrapMode::Repeat);
 
         auto patternTransform = TransformationMatrix::rectToRect({ { }, m_state.contentsTileSize }, { { }, m_state.contentsRect.size() })
             .translate(m_state.contentsTilePhase.width() / m_state.contentsRect.width(), m_state.contentsTilePhase.height() / m_state.contentsRect.height());


### PR DESCRIPTION
#### 2d7df2a047705353b33d3d87fc273e2dfba8fa4b
<pre>
[TextureMapper] Make WrapMode an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=264147">https://bugs.webkit.org/show_bug.cgi?id=264147</a>

Reviewed by Fujii Hironori.

* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawTexture):
(WebCore::TextureMapper::drawTexturePlanarYUV):
(WebCore::TextureMapper::drawTextureSemiPlanarYUV):
(WebCore::TextureMapper::drawTexturePackedYUV):
(WebCore::TextureMapper::drawTexturedQuadWithProgram):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
(WebCore::TextureMapper::isInMaskMode const):
(WebCore::TextureMapper::wrapMode const): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintSelf):

Canonical link: <a href="https://commits.webkit.org/270168@main">https://commits.webkit.org/270168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01e8a2cc68832cc838fbb597d6c28387d3a78379

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26895 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/758 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25021 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27478 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/22321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2012 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2463 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3151 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->