### PR TITLE
Remove TransformStreamAPIEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6751,19 +6751,6 @@ TrackConfigurationEnabled:
     WebCore:
       default: false
 
-TransformStreamAPIEnabled:
-  type: bool
-  status: mature
-  humanReadableName: "TransformStream API"
-  humanReadableDescription: "Enable Transform Stream API"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-
 TreatsAnyTextCSSLinkAsStylesheet:
   type: bool
   status: embedder

--- a/Source/WebCore/Modules/streams/TransformStream.idl
+++ b/Source/WebCore/Modules/streams/TransformStream.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    EnabledBySetting=TransformStreamAPIEnabled,
     Exposed=*,
     JSCustomMarkFunction,
     PrivateIdentifier,

--- a/Source/WebCore/Modules/streams/TransformStreamDefaultController.idl
+++ b/Source/WebCore/Modules/streams/TransformStreamDefaultController.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    EnabledBySetting=TransformStreamAPIEnabled,
     Exposed=*,
     JSBuiltin,
     PrivateIdentifier,

--- a/Source/WebCore/dom/TextDecoderStream.idl
+++ b/Source/WebCore/dom/TextDecoderStream.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    EnabledBySetting=TransformStreamAPIEnabled,
     Exposed=*,
     JSBuiltin,
 ] interface TextDecoderStream {

--- a/Source/WebCore/dom/TextDecoderStreamDecoder.idl
+++ b/Source/WebCore/dom/TextDecoderStreamDecoder.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    EnabledBySetting=TransformStreamAPIEnabled,
     Exposed=(Window,Worker),
     PrivateIdentifier,
 ] interface TextDecoderStreamDecoder {

--- a/Source/WebCore/dom/TextEncoderStream.idl
+++ b/Source/WebCore/dom/TextEncoderStream.idl
@@ -24,7 +24,6 @@
 */
 
 [
-    EnabledBySetting=TransformStreamAPIEnabled,
     Exposed=*,
     JSBuiltin,
 ] interface TextEncoderStream {

--- a/Source/WebCore/dom/TextEncoderStreamEncoder.idl
+++ b/Source/WebCore/dom/TextEncoderStreamEncoder.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    EnabledBySetting=TransformStreamAPIEnabled,
     Exposed=(Window,Worker),
     PrivateIdentifier,
 ] interface TextEncoderStreamEncoder {

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -257,7 +257,6 @@
 #define WebKitLinkPreloadResponsiveImagesEnabledPreferenceKey @"WebKitLinkPreloadResponsiveImagesEnabled"
 #define WebKitRemotePlaybackEnabledPreferenceKey @"WebKitRemotePlaybackEnabled"
 #define WebKitReadableByteStreamAPIEnabledPreferenceKey @"WebKitReadableByteStreamAPIEnabled"
-#define WebKitTransformStreamAPIEnabledPreferenceKey @"WebKitTransformStreamAPIEnabled"
 #define WebKitMediaRecorderEnabledPreferenceKey @"WebKitMediaRecorderEnabled"
 #define WebKitCSSIndividualTransformPropertiesEnabledPreferenceKey @"WebKitCSSIndividualTransformPropertiesEnabled"
 #define WebKitContactPickerAPIEnabledPreferenceKey @"WebKitContactPickerAPIEnabled"
@@ -277,3 +276,4 @@
 #define WebKitXSSAuditorEnabledPreferenceKey @"WebKitXSSAuditorEnabled"
 #define WebKitAVFoundationNSURLSessionEnabledKey @"WebKitAVFoundationNSURLSessionEnabled"
 #define WebKitDisplayListDrawingEnabledPreferenceKey @"WebKitDisplayListDrawingEnabled"
+#define WebKitTransformStreamAPIEnabledPreferenceKey @"WebKitTransformStreamAPIEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -3096,16 +3096,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:flag forKey:WebKitReadableByteStreamAPIEnabledPreferenceKey];
 }
 
-- (BOOL)transformStreamAPIEnabled
-{
-    return [self _boolValueForKey:WebKitTransformStreamAPIEnabledPreferenceKey];
-}
-
-- (void)setTransformStreamAPIEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitTransformStreamAPIEnabledPreferenceKey];
-}
-
 - (BOOL)_mediaRecorderEnabled
 {
     return [self _boolValueForKey:WebKitMediaRecorderEnabledPreferenceKey];
@@ -3345,6 +3335,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 }
 
 - (void)setDisplayListDrawingEnabled:(BOOL)enabled
+{
+}
+
+- (BOOL)transformStreamAPIEnabled
+{
+    return YES;
+}
+
+- (void)setTransformStreamAPIEnabled:(BOOL)flag
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -322,7 +322,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL linkPreloadResponsiveImagesEnabled;
 @property (nonatomic) BOOL remotePlaybackEnabled;
 @property (nonatomic) BOOL readableByteStreamAPIEnabled;
-@property (nonatomic) BOOL transformStreamAPIEnabled;
 @property (nonatomic) BOOL mediaRecorderEnabled;
 @property (nonatomic, setter=_setMediaRecorderEnabled:) BOOL _mediaRecorderEnabled;
 @property (nonatomic) BOOL CSSIndividualTransformPropertiesEnabled;
@@ -356,6 +355,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL webGL2Enabled;
 @property (nonatomic) BOOL loadsSiteIconsIgnoringImageLoadingPreference;
 @property (nonatomic) BOOL displayListDrawingEnabled;
+@property (nonatomic) BOOL transformStreamAPIEnabled;
 
 - (void)setDiskImageCacheEnabled:(BOOL)enabled;
 


### PR DESCRIPTION
#### 6193f95238059959e8db589b1efa8e9631b1fae5
<pre>
Remove TransformStreamAPIEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=264151">https://bugs.webkit.org/show_bug.cgi?id=264151</a>
<a href="https://rdar.apple.com/117902656">rdar://117902656</a>

Reviewed by Brent Fulgham.

This has been enabled for at least two years. As such remove the
preference and deprecate the legacy API for it.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/streams/TransformStream.idl:
* Source/WebCore/Modules/streams/TransformStreamDefaultController.idl:
* Source/WebCore/dom/TextDecoderStream.idl:
* Source/WebCore/dom/TextDecoderStreamDecoder.idl:
* Source/WebCore/dom/TextEncoderStream.idl:
* Source/WebCore/dom/TextEncoderStreamEncoder.idl:
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences transformStreamAPIEnabled]):
(-[WebPreferences setTransformStreamAPIEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/270192@main">https://commits.webkit.org/270192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/756803d22e5f5e66c54ff909f44178dce7e3e902

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/761 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27481 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28480 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21543 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26294 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24039 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/320 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31445 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3305 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5939 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2466 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31423 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2366 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6573 "Passed tests") | 
<!--EWS-Status-Bubble-End-->