### PR TITLE
Add max samples accessor for WebGLRenderingContextBase

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -276,16 +276,7 @@ bool WebXROpaqueFramebuffer::setupFramebuffer()
     const bool hasDepthOrStencil = m_attributes.stencil || m_attributes.depth;
 
     // Set up recommended samples for WebXR.
-    auto sampleCount = [](GraphicsContextGL& gl, bool isAntialias) {
-        if (!isAntialias)
-            return 0;
-
-        // FIXME: check if we can get recommended values from each device platform.
-        GCGLint maxSampleCount;
-        gl.getIntegerv(GL::MAX_SAMPLES, std::span(&maxSampleCount, 1));
-        // Cap the maximum multisample count at 4. Any more than this is likely overkill and will impact performance.
-        return std::min(4, maxSampleCount);
-    }(gl, m_attributes.antialias);
+    auto sampleCount = m_attributes.antialias ? std::min(4, m_context.maxSamples()) : 0;
 
     gl.bindFramebuffer(GL::FRAMEBUFFER, m_framebuffer->object());
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1385,7 +1385,7 @@ void WebGL2RenderingContext::vertexAttribI4i(GCGLuint index, GCGLint x, GCGLint 
     if (isContextLost())
         return;
     m_context->vertexAttribI4i(index, x, y, z, w);
-    if (index < m_maxVertexAttribs) {
+    if (index < m_vertexAttribValue.size()) {
         m_vertexAttribValue[index].type = GraphicsContextGL::INT;
         m_vertexAttribValue[index].iValue[0] = x;
         m_vertexAttribValue[index].iValue[1] = y;
@@ -1409,7 +1409,7 @@ void WebGL2RenderingContext::vertexAttribI4iv(GCGLuint index, Int32List&& list)
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4iv", "array too small");
         return;
     }
-    if (index >= m_maxVertexAttribs) {
+    if (index >= m_vertexAttribValue.size()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4iv", "index out of range");
         return;
     }
@@ -1423,7 +1423,7 @@ void WebGL2RenderingContext::vertexAttribI4ui(GCGLuint index, GCGLuint x, GCGLui
     if (isContextLost())
         return;
     m_context->vertexAttribI4ui(index, x, y, z, w);
-    if (index < m_maxVertexAttribs) {
+    if (index < m_vertexAttribValue.size()) {
         m_vertexAttribValue[index].type = GraphicsContextGL::UNSIGNED_INT;
         m_vertexAttribValue[index].uiValue[0] = x;
         m_vertexAttribValue[index].uiValue[1] = y;
@@ -1447,7 +1447,7 @@ void WebGL2RenderingContext::vertexAttribI4uiv(GCGLuint index, Uint32List&& list
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4uiv", "array too small");
         return;
     }
-    if (index >= m_maxVertexAttribs) {
+    if (index >= m_vertexAttribValue.size()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribI4uiv", "index out of range");
         return;
     }
@@ -1476,7 +1476,7 @@ void WebGL2RenderingContext::vertexAttribIPointer(GCGLuint index, GCGLint size, 
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "vertexAttribIPointer", "invalid type");
         return;
     }
-    if (index >= m_maxVertexAttribs) {
+    if (index >= m_vertexAttribValue.size()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "vertexAttribIPointer", "index out of range");
         return;
     }
@@ -1571,7 +1571,7 @@ void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
             continue;
         default:
             if (bufs[i] > GraphicsContextGL::COLOR_ATTACHMENT0
-                && bufs[i] < GraphicsContextGL::COLOR_ATTACHMENT0 + getMaxColorAttachments()) {
+                && bufs[i] < GraphicsContextGL::COLOR_ATTACHMENT0 + maxColorAttachments()) {
                 continue;
             }
             synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "drawBuffers", "invalid buffer");
@@ -1592,7 +1592,7 @@ void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
         m_context->drawBuffers(value);
         setBackDrawBuffer(bufs[0]);
     } else {
-        if (n > getMaxDrawBuffers()) {
+        if (n > maxDrawBuffers()) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "drawBuffers", "more than max draw buffers");
             return;
         }
@@ -2818,7 +2818,7 @@ bool WebGL2RenderingContext::validateNonDefaultFramebufferAttachment(const char*
     case GraphicsContextGL::DEPTH_STENCIL_ATTACHMENT:
         return true;
     default:
-        if (attachment >= GraphicsContextGL::COLOR_ATTACHMENT0 && attachment < static_cast<GCGLenum>(GraphicsContextGL::COLOR_ATTACHMENT0 + getMaxColorAttachments()))
+        if (attachment >= GraphicsContextGL::COLOR_ATTACHMENT0 && attachment < static_cast<GCGLenum>(GraphicsContextGL::COLOR_ATTACHMENT0 + maxColorAttachments()))
             return true;
     }
 
@@ -2826,14 +2826,14 @@ bool WebGL2RenderingContext::validateNonDefaultFramebufferAttachment(const char*
     return false;
 }
 
-GCGLint WebGL2RenderingContext::getMaxDrawBuffers()
+GCGLint WebGL2RenderingContext::maxDrawBuffers()
 {
     if (!m_maxDrawBuffers)
         m_maxDrawBuffers = m_context->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS);
     return m_maxDrawBuffers;
 }
 
-GCGLint WebGL2RenderingContext::getMaxColorAttachments()
+GCGLint WebGL2RenderingContext::maxColorAttachments()
 {
     // DrawBuffers requires MAX_COLOR_ATTACHMENTS == MAX_DRAW_BUFFERS
     if (!m_maxColorAttachments)
@@ -3054,7 +3054,7 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     case GraphicsContextGL::MAX_CLIENT_WAIT_TIMEOUT_WEBGL:
         return static_cast<long long>(MaxClientWaitTimeout);
     case GraphicsContextGL::MAX_COLOR_ATTACHMENTS:
-        return getIntParameter(pname);
+        return maxColorAttachments();
     case GraphicsContextGL::MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS:
         return getInt64Parameter(pname);
     case GraphicsContextGL::MAX_COMBINED_UNIFORM_BLOCKS:
@@ -3062,7 +3062,7 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     case GraphicsContextGL::MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS:
         return getInt64Parameter(pname);
     case GraphicsContextGL::MAX_DRAW_BUFFERS:
-        return getIntParameter(pname);
+        return maxDrawBuffers();
     case GraphicsContextGL::MAX_ELEMENT_INDEX:
         return getInt64Parameter(pname);
     case GraphicsContextGL::MAX_ELEMENTS_INDICES:
@@ -3078,7 +3078,7 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     case GraphicsContextGL::MAX_PROGRAM_TEXEL_OFFSET:
         return getIntParameter(pname);
     case GraphicsContextGL::MAX_SAMPLES:
-        return getIntParameter(pname);
+        return maxSamples();
     case GraphicsContextGL::MAX_SERVER_WAIT_TIMEOUT:
         return getInt64Parameter(pname);
     case GraphicsContextGL::MAX_TEXTURE_LOD_BIAS:

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -278,8 +278,8 @@ private:
     WebGLBuffer* validateBufferDataParameters(const char* functionName, GCGLenum target, GCGLenum usage) final;
     WebGLBuffer* validateBufferDataTarget(const char* functionName, GCGLenum target) final;
     bool validateAndCacheBufferBinding(const AbstractLocker&, const char* functionName, GCGLenum target, WebGLBuffer*) final;
-    GCGLint getMaxDrawBuffers() final;
-    GCGLint getMaxColorAttachments() final;
+    GCGLint maxDrawBuffers() final;
+    GCGLint maxColorAttachments() final;
     bool validateBlendEquation(const char* functionName, GCGLenum mode) final;
     bool validateCapability(const char* functionName, GCGLenum cap) final;
     template<typename T, typename TypedArrayType>

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
@@ -68,7 +68,7 @@ void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
         context.graphicsContextGL()->drawBuffersEXT(value);
         context.setBackDrawBuffer(bufs[0]);
     } else {
-        if (n > context.getMaxDrawBuffers()) {
+        if (n > context.maxDrawBuffers()) {
             context.synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "drawBuffersWEBGL", "more than max draw buffers");
             return;
         }

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -320,7 +320,7 @@ long long WebGLRenderingContext::getInt64Parameter(GCGLenum pname)
     return m_context->getInteger64EXT(pname);
 }
 
-GCGLint WebGLRenderingContext::getMaxDrawBuffers()
+GCGLint WebGLRenderingContext::maxDrawBuffers()
 {
     if (!supportsDrawBuffers())
         return 0;
@@ -332,7 +332,7 @@ GCGLint WebGLRenderingContext::getMaxDrawBuffers()
     return std::min(m_maxDrawBuffers, m_maxColorAttachments);
 }
 
-GCGLint WebGLRenderingContext::getMaxColorAttachments()
+GCGLint WebGLRenderingContext::maxColorAttachments()
 {
     if (!supportsDrawBuffers())
         return 0;

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -50,8 +50,8 @@ public:
 
     long long getInt64Parameter(GCGLenum) final;
 
-    GCGLint getMaxDrawBuffers() final;
-    GCGLint getMaxColorAttachments() final;
+    GCGLint maxDrawBuffers() final;
+    GCGLint maxColorAttachments() final;
     void initializeDefaultObjects() final;
     bool validateBlendEquation(const char* functionName, GCGLenum mode) final;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -54,6 +54,7 @@
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/GenericTypedArrayView.h>
 #include <JavaScriptCore/TypedArrayAdaptors.h>
+#include <array>
 #include <limits>
 #include <memory>
 #include <wtf/CheckedArithmetic.h>
@@ -378,6 +379,11 @@ public:
 
     void viewport(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height);
 
+    virtual GCGLint maxDrawBuffers() = 0;
+    virtual GCGLint maxColorAttachments() = 0;
+    size_t maxVertexAttribs() const { return m_vertexAttribValue.size(); }
+    GCGLint maxSamples() const { return m_maxSamples; }
+
     // WEBKIT_lose_context support
     enum LostContextMode {
         // Lost context occurred at the graphics system level.
@@ -405,8 +411,6 @@ public:
 
     void removeSharedObject(WebGLObject&);
     void removeContextObject(WebGLObject&);
-
-    unsigned getMaxVertexAttribs() const { return m_maxVertexAttribs; }
 
     bool isContextUnrecoverablyLost() const;
 
@@ -598,7 +602,6 @@ protected:
         };
     };
     Vector<VertexAttribValue> m_vertexAttribValue;
-    unsigned m_maxVertexAttribs;
 
     RefPtr<WebGLProgram> m_currentProgram;
     WebGLBindingPoint<WebGLFramebuffer> m_framebufferBinding;
@@ -630,9 +633,10 @@ protected:
     GCGLint m_maxTextureSize;
     GCGLint m_maxCubeMapTextureSize;
     GCGLint m_maxRenderbufferSize;
-    GCGLint m_maxViewportDims[2] { 0, 0 };
+    std::array<GCGLint, 2> m_maxViewportDims { 0, 0 };
     GCGLint m_maxTextureLevel;
     GCGLint m_maxCubeMapTextureLevel;
+    GCGLint m_maxSamples { 0 };
 
     GCGLint m_maxDrawBuffers;
     GCGLint m_maxColorAttachments;
@@ -984,9 +988,6 @@ protected:
 
     // Clamp the width and height to GL_MAX_VIEWPORT_DIMS.
     IntSize clampedCanvasSize();
-
-    virtual GCGLint getMaxDrawBuffers() = 0;
-    virtual GCGLint getMaxColorAttachments() = 0;
 
     void setBackDrawBuffer(GCGLenum);
     void setFramebuffer(const AbstractLocker&, GCGLenum, WebGLFramebuffer*);

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
@@ -39,7 +39,7 @@ WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase(WebGLRenderingContextBase
     : WebGLObject(context, object)
     , m_type(type)
 {
-    m_vertexAttribState.resize(context.getMaxVertexAttribs());
+    m_vertexAttribState.resize(context.maxVertexAttribs());
 }
 
 void WebGLVertexArrayObjectBase::setElementArrayBuffer(const AbstractLocker& locker, WebGLBuffer* buffer)


### PR DESCRIPTION
#### a48a890fc2ef03c6b5e2764ea5d65396f5738cab
<pre>
Add max samples accessor for WebGLRenderingContextBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=264155">https://bugs.webkit.org/show_bug.cgi?id=264155</a>
<a href="https://rdar.apple.com/117903868">rdar://117903868</a>

Reviewed by Dan Glastonbury.

Add WebGLRenderingContextBase::maxSamples() to access the
GL_MAX_SAMPLES. This is used in the WebXR layer framebuffer
implementation. This will be used also in the default framebuffer
implementation.

Use uniform WebKit naming for all the similar accessors.

Use the client-side state when JS queries the state for all
similar state.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::vertexAttribI4i):
(WebCore::WebGL2RenderingContext::vertexAttribI4iv):
(WebCore::WebGL2RenderingContext::vertexAttribI4ui):
(WebCore::WebGL2RenderingContext::vertexAttribI4uiv):
(WebCore::WebGL2RenderingContext::vertexAttribIPointer):
(WebCore::WebGL2RenderingContext::drawBuffers):
(WebCore::WebGL2RenderingContext::validateNonDefaultFramebufferAttachment):
(WebCore::WebGL2RenderingContext::maxDrawBuffers):
(WebCore::WebGL2RenderingContext::maxColorAttachments):
(WebCore::WebGL2RenderingContext::getParameter):
(WebCore::WebGL2RenderingContext::getMaxDrawBuffers): Deleted.
(WebCore::WebGL2RenderingContext::getMaxColorAttachments): Deleted.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLDrawBuffers.cpp:
(WebCore::WebGLDrawBuffers::drawBuffersWEBGL):
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::maxDrawBuffers):
(WebCore::WebGLRenderingContext::maxColorAttachments):
(WebCore::WebGLRenderingContext::getMaxDrawBuffers): Deleted.
(WebCore::WebGLRenderingContext::getMaxColorAttachments): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::bindAttribLocation):
(WebCore::WebGLRenderingContextBase::disableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::enableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::getVertexAttrib):
(WebCore::WebGLRenderingContextBase::vertexAttribPointer):
(WebCore::WebGLRenderingContextBase::getWebGLIntArrayParameter):
(WebCore::WebGLRenderingContextBase::validateFramebufferFuncParameters):
(WebCore::WebGLRenderingContextBase::vertexAttribfImpl):
(WebCore::WebGLRenderingContextBase::vertexAttribfvImpl):
(WebCore::WebGLRenderingContextBase::maxDrawBuffers):
(WebCore::WebGLRenderingContextBase::maxColorAttachments):
(WebCore::WebGLRenderingContextBase::vertexAttribDivisor):
(WebCore::WebGLRenderingContextBase::getMaxDrawBuffers): Deleted.
(WebCore::WebGLRenderingContextBase::getMaxColorAttachments): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::maxVertexAttribs const):
(WebCore::WebGLRenderingContextBase::maxSamples const):
(WebCore::WebGLRenderingContextBase::getMaxVertexAttribs const): Deleted.
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase):

Canonical link: <a href="https://commits.webkit.org/270317@main">https://commits.webkit.org/270317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c385384d0fecbd5e4b8d774a604562af520a0aeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27289 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23098 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27868 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22670 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22972 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26616 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/671 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3725 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6029 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2815 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2710 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->