### PR TITLE
[TextureMapper] Pass size to BitmapTexture constructor

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3264,8 +3264,7 @@ void MediaPlayerPrivateGStreamer::pushTextureToCompositor()
         } else {
             layerBuffer = proxy.getAvailableBuffer(frameHolder->size(), GL_DONT_CARE);
             if (UNLIKELY(!layerBuffer)) {
-                auto texture = BitmapTexture::create();
-                texture->reset(frameHolder->size(), frameHolder->hasAlphaChannel() ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag);
+                auto texture = BitmapTexture::create(frameHolder->size(), frameHolder->hasAlphaChannel() ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag);
                 layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(texture));
             }
             frameHolder->updateTexture(layerBuffer->texture());

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
@@ -71,8 +71,7 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
                 if (!proxy.isActive())
                     return;
 
-                auto texture = BitmapTexture::create();
-
+                RefPtr<BitmapTexture> texture;
                 {
                     Locker locker { m_imageBufferLock };
 
@@ -84,8 +83,7 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
                         return;
 
                     auto size = nativeImage->size();
-
-                    texture->reset(size, nativeImage->hasAlpha() ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag);
+                    texture = BitmapTexture::create(size, nativeImage->hasAlpha() ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag);
 #if USE(CAIRO)
                     auto* surface = nativeImage->platformImage().get();
                     auto* imageData = cairo_image_surface_get_data(surface);

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -60,15 +60,14 @@ public:
 
     typedef unsigned Flags;
 
-    static Ref<BitmapTexture> create(const Flags flags = NoFlag, GLint internalFormat = GL_DONT_CARE)
+    static Ref<BitmapTexture> create(const IntSize& size, const Flags flags = NoFlag, GLint internalFormat = GL_DONT_CARE)
     {
-        return adoptRef(*new BitmapTexture(flags, internalFormat));
+        return adoptRef(*new BitmapTexture(size, flags, internalFormat));
     }
 
     WEBCORE_EXPORT ~BitmapTexture();
 
-    IntSize size() const;
-    bool isValid() const;
+    const IntSize& size() const { return m_size; };
     Flags flags() const { return m_flags; }
     GLint internalFormat() const { return m_internalFormat; }
     bool isOpaque() const { return !(m_flags & SupportsAlpha); }
@@ -77,22 +76,13 @@ public:
     void initializeStencil();
     void initializeDepthBuffer();
     uint32_t id() const { return m_id; }
-    uint32_t textureTarget() const { return GL_TEXTURE_2D; }
-    IntSize textureSize() const { return m_textureSize; }
 
     void updateContents(NativeImage*, const IntRect&, const IntPoint& offset);
     void updateContents(GraphicsLayer*, const IntRect& target, const IntPoint& offset, float scale = 1);
     void updateContents(const void*, const IntRect& target, const IntPoint& offset, int bytesPerLine);
 
-    void reset(const IntSize& size, Flags flags = 0)
-    {
-        m_flags = flags;
-        m_contentSize = size;
-        didReset();
-    }
-    void didReset();
+    void reset(const IntSize&, Flags = NoFlag);
 
-    const IntSize& contentSize() const { return m_contentSize; }
     int numberOfBytes() const { return size().width() * size().height() * 32 >> 3; }
 
     RefPtr<BitmapTexture> applyFilters(TextureMapper&, const FilterOperations&, bool defersLastFilterPass);
@@ -113,15 +103,14 @@ public:
     OptionSet<TextureMapperFlags> colorConvertFlags() const { return m_colorConvertFlags; }
 
 private:
-    BitmapTexture(const Flags, GLint internalFormat);
+    BitmapTexture(const IntSize&, const Flags, GLint internalFormat);
 
     void clearIfNeeded();
     void createFboIfNeeded();
 
     Flags m_flags { 0 };
-    IntSize m_contentSize;
+    IntSize m_size;
     GLuint m_id { 0 };
-    IntSize m_textureSize;
     GLuint m_fbo { 0 };
 #if !USE(TEXMAP_DEPTH_STENCIL_BUFFER)
     GLuint m_rbo { 0 };
@@ -133,13 +122,6 @@ private:
     FilterInfo m_filterInfo;
     GLint m_internalFormat { 0 };
     GLenum m_format { 0 };
-    GLenum m_type {
-#if OS(DARWIN)
-        GL_UNSIGNED_INT_8_8_8_8_REV
-#else
-        GL_UNSIGNED_BYTE
-#endif
-    };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -50,9 +50,10 @@ RefPtr<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, con
         });
 
     if (selectedEntry == m_textures.end()) {
-        m_textures.append(Entry(BitmapTexture::create(flags)));
+        m_textures.append(Entry(BitmapTexture::create(size, flags)));
         selectedEntry = &m_textures.last();
-    }
+    } else
+        selectedEntry->m_texture->reset(size, flags);
 
     scheduleReleaseUnusedTextures();
     selectedEntry->markIsInUse();

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -185,9 +185,7 @@ TextureMapper::TextureMapper()
 
 RefPtr<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size, const BitmapTexture::Flags flags)
 {
-    RefPtr<BitmapTexture> selectedTexture = m_texturePool->acquireTexture(size, flags);
-    selectedTexture->reset(size, flags);
-    return selectedTexture;
+    return m_texturePool->acquireTexture(size, flags);
 }
 
 #if USE(GRAPHICS_LAYER_WC)
@@ -454,9 +452,6 @@ static void prepareRoundedRectClip(TextureMapperShaderProgram& program, const fl
 
 void TextureMapper::drawTexture(const BitmapTexture& texture, const FloatRect& targetRect, const TransformationMatrix& matrix, float opacity, AllEdgesExposed allEdgesExposed)
 {
-    if (!texture.isValid())
-        return;
-
     if (clipStack().isCurrentScissorBoxEmpty())
         return;
 
@@ -839,19 +834,19 @@ void TextureMapper::drawTexturedQuadWithProgram(TextureMapperShaderProgram& prog
 void TextureMapper::drawTextureCopy(const BitmapTexture& sourceTexture, const FloatRect& sourceRect, const FloatRect& targetRect)
 {
     Ref<TextureMapperShaderProgram> program = data().getShaderProgram({ TextureMapperShaderProgram::TextureCopy });
-    IntSize textureSize = sourceTexture.contentSize();
+    const auto& textureSize = sourceTexture.size();
 
     glUseProgram(program->programID());
 
     auto textureCopyMatrix = TransformationMatrix::identity;
 
     textureCopyMatrix.scale3d(
-        double(sourceRect.width()) / sourceTexture.contentSize().width(),
-        double(sourceRect.height()) / sourceTexture.contentSize().height(),
+        double(sourceRect.width()) / textureSize.width(),
+        double(sourceRect.height()) / textureSize.height(),
         1
     ).translate3d(
-        double(sourceRect.x()) / sourceTexture.contentSize().width(),
-        double(sourceRect.y()) / sourceTexture.contentSize().height(),
+        double(sourceRect.x()) / textureSize.width(),
+        double(sourceRect.y()) / textureSize.height(),
         0
     );
 
@@ -872,7 +867,7 @@ void TextureMapper::drawBlurred(const BitmapTexture& sourceTexture, const FloatR
         alphaBlur ? TextureMapperShaderProgram::AlphaBlur : TextureMapperShaderProgram::BlurFilter,
     });
 
-    IntSize textureSize = sourceTexture.contentSize();
+    const auto& textureSize = sourceTexture.size();
 
     glUseProgram(program->programID());
 
@@ -911,7 +906,7 @@ void TextureMapper::drawBlurred(const BitmapTexture& sourceTexture, const FloatR
 
 RefPtr<BitmapTexture> TextureMapper::applyBlurFilter(RefPtr<BitmapTexture> sourceTexture, const BlurFilterOperation& blurFilter)
 {
-    IntSize textureSize = sourceTexture->contentSize();
+    const auto& textureSize = sourceTexture->size();
     float radiusX = floatValueForLength(blurFilter.stdDeviation(), textureSize.width());
     float radiusY = floatValueForLength(blurFilter.stdDeviation(), textureSize.height());
 
@@ -993,7 +988,7 @@ RefPtr<BitmapTexture> TextureMapper::applyBlurFilter(RefPtr<BitmapTexture> sourc
 
 RefPtr<BitmapTexture> TextureMapper::applyDropShadowFilter(RefPtr<BitmapTexture> sourceTexture, const DropShadowFilterOperation& dropShadowFilter)
 {
-    IntSize textureSize = sourceTexture->contentSize();
+    const auto& textureSize = sourceTexture->size();
     RefPtr<BitmapTexture> resultTexture = acquireTextureFromPool(textureSize, BitmapTexture::SupportsAlpha);
     RefPtr<BitmapTexture> contentTexture = acquireTextureFromPool(textureSize, BitmapTexture::SupportsAlpha);
     IntSize currentSize = textureSize;
@@ -1121,7 +1116,7 @@ RefPtr<BitmapTexture> TextureMapper::applySinglePassFilter(RefPtr<BitmapTexture>
         return sourceTexture;
     }
 
-    RefPtr<BitmapTexture> resultTexture = acquireTextureFromPool(sourceTexture->contentSize(), BitmapTexture::SupportsAlpha);
+    RefPtr<BitmapTexture> resultTexture = acquireTextureFromPool(sourceTexture->size(), BitmapTexture::SupportsAlpha);
 
     bindSurface(resultTexture.get());
 
@@ -1130,7 +1125,7 @@ RefPtr<BitmapTexture> TextureMapper::applySinglePassFilter(RefPtr<BitmapTexture>
     Ref<TextureMapperShaderProgram> program = data().getShaderProgram(options);
 
     prepareFilterProgram(program.get(), *filter);
-    FloatRect targetRect(FloatPoint::zero(), sourceTexture->contentSize());
+    FloatRect targetRect(FloatPoint::zero(), sourceTexture->size());
     drawTexturedQuadWithProgram(program.get(), sourceTexture->id(), { }, targetRect, TransformationMatrix(), 1);
 
     return resultTexture;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -78,8 +78,7 @@ std::unique_ptr<TextureMapperPlatformLayerBuffer> TextureMapperPlatformLayerBuff
                 return nullptr;
             }
 
-            auto clonedTexture = BitmapTexture::create(BitmapTexture::NoFlag, m_internalFormat);
-            clonedTexture->reset(m_size);
+            auto clonedTexture = BitmapTexture::create(m_size, BitmapTexture::NoFlag, m_internalFormat);
             clonedTexture->copyFromExternalTexture(texture.id);
             return makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(clonedTexture), m_extraFlags);
         },

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp
@@ -57,10 +57,8 @@ void TextureMapperTile::updateContents(Image* image, const IntRect& dirtyRect)
 
     // Normalize targetRect to the texture's coordinates.
     targetRect.move(-m_rect.x(), -m_rect.y());
-    if (!m_texture) {
-        m_texture = BitmapTexture::create();
-        m_texture->reset(targetRect.size(), image->currentFrameKnownToBeOpaque() ? 0 : BitmapTexture::SupportsAlpha);
-    }
+    if (!m_texture)
+        m_texture = BitmapTexture::create(targetRect.size(), image->currentFrameKnownToBeOpaque() ? 0 : BitmapTexture::SupportsAlpha);
 
     auto nativeImage = image->nativeImageForCurrentFrame();
     m_texture->updateContents(nativeImage.get(), targetRect, sourceOffset);
@@ -77,10 +75,8 @@ void TextureMapperTile::updateContents(GraphicsLayer* sourceLayer, const IntRect
     // Normalize targetRect to the texture's coordinates.
     targetRect.move(-m_rect.x(), -m_rect.y());
 
-    if (!m_texture) {
-        m_texture = BitmapTexture::create();
-        m_texture->reset(targetRect.size(), BitmapTexture::SupportsAlpha);
-    }
+    if (!m_texture)
+        m_texture = BitmapTexture::create(targetRect.size(), BitmapTexture::SupportsAlpha);
 
     m_texture->updateContents(sourceLayer, targetRect, sourceOffset, scale);
 }


### PR DESCRIPTION
#### 0cf3ba971a8968d4bc0638a70d3535730c3f703d
<pre>
[TextureMapper] Pass size to BitmapTexture constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=264157">https://bugs.webkit.org/show_bug.cgi?id=264157</a>

Reviewed by Fujii Hironori.

This way we can create a BitmapTexture without having to call reset
right after the creation to set the size and flags (that are passed but
ignored in the constructor).

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushTextureToCompositor):
* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:
(Nicosia::NicosiaImageBufferPipeSource::handle):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::updateContents):
(WebCore::BitmapTexture::initializeStencil):
(WebCore::BitmapTexture::initializeDepthBuffer):
(WebCore::BitmapTexture::clearIfNeeded):
(WebCore::BitmapTexture::bindAsSurface):
(WebCore::BitmapTexture::~BitmapTexture):
(WebCore::BitmapTexture::copyFromExternalTexture):
(WebCore::BitmapTexture::didReset): Deleted.
(WebCore::BitmapTexture::isValid const): Deleted.
(WebCore::BitmapTexture::size const): Deleted.
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::acquireTexture):
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::acquireTextureFromPool):
(WebCore::TextureMapper::drawTexture):
(WebCore::TextureMapper::drawTextureCopy):
(WebCore::TextureMapper::drawBlurred):
(WebCore::TextureMapper::applyBlurFilter):
(WebCore::TextureMapper::applyDropShadowFilter):
(WebCore::TextureMapper::applySinglePassFilter):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp:
(WebCore::TextureMapperPlatformLayerBuffer::clone):
* Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp:
(WebCore::TextureMapperTile::updateContents):

Canonical link: <a href="https://commits.webkit.org/270227@main">https://commits.webkit.org/270227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e9ee0577f08bec22dca58c5a56f75621058768d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26906 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23093 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27489 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28487 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26301 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/327 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2474 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3176 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->