### PR TITLE
[WGSL] error: use of undeclared identifier 'textureSampleCompareLevel' opening https://spookyball.com/

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1049,7 +1049,6 @@ static void emitTextureSampleCompare(FunctionDefinitionWriter* writer, AST::Call
     visitArguments(writer, call, 1);
 }
 
-
 static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     bool isArray = false;
@@ -1357,6 +1356,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "textureSample", emitTextureSample },
             { "textureSampleBaseClampToEdge", emitTextureSampleClampToEdge },
             { "textureSampleCompare", emitTextureSampleCompare },
+            { "textureSampleCompareLevel", emitTextureSampleCompare },
             { "textureSampleLevel", emitTextureSampleLevel },
             { "textureStore", emitTextureStore },
             { "workgroupBarrier", emitWorkgroupBarrier },

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2653,6 +2653,8 @@ fn testTextureSampleCompare()
 }
 
 // 16.7.11
+// RUN: %metal-compile testTextureSampleCompareLevel
+@compute @workgroup_size(1)
 fn testTextureSampleCompareLevel()
 {
     // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,


### PR DESCRIPTION
#### 144459dcdc40e9cee3b589f0781f584aafe3c43e
<pre>
[WGSL] error: use of undeclared identifier &apos;textureSampleCompareLevel&apos; opening <a href="https://spookyball.com/">https://spookyball.com/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=264140">https://bugs.webkit.org/show_bug.cgi?id=264140</a>
<a href="https://rdar.apple.com/117891882">rdar://117891882</a>

Reviewed by Mike Wyrzykowski.

Add code generation for textureSampleCompareLevel. Fow now, it just call the same
generator as textureSampleCompare, as both take the same arguments and translate
to the same call in Metal.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270257@main">https://commits.webkit.org/270257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4219f30c2529e5e36f319db76214c6f95f318af1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22762 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23095 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27495 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2091 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28491 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26305 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/333 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3319 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5982 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->