### PR TITLE
[WebGPU] error: use of undeclared identifier 'inverseSqrt' opening https://threejs.org/examples/?q=webgpu#webgpu_clearcoat

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1395,6 +1395,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "dpdyFine", "dfdy"_s },
             { "fwidthCoarse", "fwidth"_s },
             { "fwidthFine", "fwidth"_s },
+            { "inverseSqrt", "rsqrt"_s },
         };
         static constexpr SortedArrayMap mappedNames { directMappings };
         if (call.isConstructor()) {

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1402,30 +1402,37 @@ fn testInsertBits()
 }
 
 // 17.5.34
+// RUN: %metal-compile testInverseSqrt
+@compute @workgroup_size(1)
 fn testInverseSqrt()
 {
     // [T < Float].(T) => T,
+    let x = 2.f;
     {
-        _ = inverseSqrt(0);
-        _ = inverseSqrt(0.0);
-        _ = inverseSqrt(1f);
+        _ = inverseSqrt(2);
+        _ = inverseSqrt(2.0);
+        _ = inverseSqrt(2f);
+        _ = inverseSqrt(x);
     }
 
     // [T < Float, N].(Vector[T, N]) => Vector[T, N],
     {
-        _ = inverseSqrt(vec2(0));
-        _ = inverseSqrt(vec2(0.0));
-        _ = inverseSqrt(vec2(1f));
+        _ = inverseSqrt(vec2(2));
+        _ = inverseSqrt(vec2(2.0));
+        _ = inverseSqrt(vec2(2f));
+        _ = inverseSqrt(vec2(x));
     }
     {
-        _ = inverseSqrt(vec3(-1));
-        _ = inverseSqrt(vec3(-1.0));
-        _ = inverseSqrt(vec3(-1f));
+        _ = inverseSqrt(vec3(2));
+        _ = inverseSqrt(vec3(2.0));
+        _ = inverseSqrt(vec3(2f));
+        _ = inverseSqrt(vec3(x));
     }
     {
-        _ = inverseSqrt(vec4(-1));
-        _ = inverseSqrt(vec4(-1.0));
-        _ = inverseSqrt(vec4(-1f));
+        _ = inverseSqrt(vec4(2));
+        _ = inverseSqrt(vec4(2.0));
+        _ = inverseSqrt(vec4(2f));
+        _ = inverseSqrt(vec4(x));
     }
 }
 


### PR DESCRIPTION
#### f1a3f7b6d47ef09369ce3a36f21615dd11338eae
<pre>
[WebGPU] error: use of undeclared identifier &apos;inverseSqrt&apos; opening <a href="https://threejs.org/examples/?q=webgpu#webgpu_clearcoat">https://threejs.org/examples/?q=webgpu#webgpu_clearcoat</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=264141">https://bugs.webkit.org/show_bug.cgi?id=264141</a>
<a href="https://rdar.apple.com/117892734">rdar://117892734</a>

Reviewed by Mike Wyrzykowski.

Add code generation for inverseSqrt, just translates directly to Metal&apos;s rsqrt

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270260@main">https://commits.webkit.org/270260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc006d13db1ab1d90c73bd7b8c1b748da03e3b4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22763 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23097 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27496 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2096 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28493 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26307 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/334 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3320 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5983 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->