### PR TITLE
[WebGPU] Error opening https://threejs.org/examples/?q=webgpu#webgpu_backdrop_area

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -878,7 +878,7 @@ CONSTANT_FUNCTION(Length)
     ASSERT(arguments.size() == 1);
     const auto& arg = arguments[0];
     if (!arg.isVector())
-        return arg;
+        return constantAbs(resultType, arguments);
 
     ConstantValue result = zeroValue(resultType);
     for (auto& element : arg.toVector().elements) {

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1275,6 +1275,22 @@ static void emitArrayLength(FunctionDefinitionWriter* writer, AST::CallExpressio
     writer->stringBuilder().append(".size()");
 }
 
+static void emitDistance(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    auto* argumentType = call.arguments()[0].inferredType();
+    if (std::holds_alternative<Types::Primitive>(*argumentType)) {
+        writer->stringBuilder().append("abs(");
+        writer->visit(call.arguments()[0]);
+        writer->stringBuilder().append(" - ");
+        writer->visit(call.arguments()[1]);
+        writer->stringBuilder().append(")");
+        return;
+    }
+    writer->visit(call.target());
+    visitArguments(writer, call);
+}
+
+
 static void emitDynamicOffset(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     auto* targetType = call.target().inferredType();
@@ -1349,6 +1365,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "atomicStore", emitAtomicStore },
             { "atomicSub", emitAtomicSub },
             { "atomicXor", emitAtomicXor },
+            { "distance", emitDistance },
             { "storageBarrier", emitStorageBarrier },
             { "textureDimensions", emitTextureDimensions },
             { "textureLoad", emitTextureLoad },

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1001,9 +1001,13 @@ fn testDeterminant()
 }
 
 // 17.5.19
+// RUN: %metal-compile testDistance
+@compute @workgroup_size(1)
 fn testDistance()
 {
     // [T < Float].(T, T) => T,
+    var a = 1.f;
+    let b = 2.f;
     {
         _ = distance(0, 1);
         _ = distance(0, 1.0);
@@ -1011,6 +1015,7 @@ fn testDistance()
         _ = distance(0.0, 1.0);
         _ = distance(1.0, 2f);
         _ = distance(1f, 2f);
+        _ = distance(a, b);
     }
     // [T < Float, N].(Vector[T, N], Vector[T, N]) => T,
     {
@@ -1020,6 +1025,7 @@ fn testDistance()
         _ = distance(vec2(0.0), vec2(0.0));
         _ = distance(vec2(0.0), vec2(0f) );
         _ = distance(vec2(1f),  vec2(1f) );
+        _ = distance(vec2(a), vec2(b));
     }
     {
         _ = distance(vec3(0),   vec3(1)  );
@@ -1028,6 +1034,7 @@ fn testDistance()
         _ = distance(vec3(0.0), vec3(0.0));
         _ = distance(vec3(0.0), vec3(0f) );
         _ = distance(vec3(1f),  vec3(1f) );
+        _ = distance(vec3(a), vec3(b));
     }
     {
         _ = distance(vec4(0),   vec4(1)  );
@@ -1036,6 +1043,7 @@ fn testDistance()
         _ = distance(vec4(0.0), vec4(0.0));
         _ = distance(vec4(0.0), vec4(0f) );
         _ = distance(vec4(1f),  vec4(1f) );
+        _ = distance(vec4(a), vec4(b));
     }
 }
 


### PR DESCRIPTION
#### 8d5247e667b6ebf6d84297d0bc9b4b55aca0d221
<pre>
[WebGPU] Error opening <a href="https://threejs.org/examples/?q=webgpu#webgpu_backdrop_area">https://threejs.org/examples/?q=webgpu#webgpu_backdrop_area</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=264143">https://bugs.webkit.org/show_bug.cgi?id=264143</a>
<a href="https://rdar.apple.com/117893591">rdar://117893591</a>

Reviewed by Mike Wyrzykowski.

Metal&apos;s `distance` function doesn&apos;t support floats as arguments (only vectors),
so `distance(a: float, b: float)` must be translate to `a - b `.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitDistance):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270259@main">https://commits.webkit.org/270259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc2c607b9cfc091a75d503b1d4b021cefd4a959d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26974 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23134 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27554 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2142 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28539 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26369 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/391 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3372 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5984 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->