### PR TITLE
[content-visibility] Property should not apply to tables

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-094-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-094-expected.html
@@ -1,0 +1,23 @@
+<!doctype HTML>
+<html>
+<meta charset="utf8">
+<title>Content Visibility: hidden table types</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+
+<style>
+table {
+  width: 150px;
+  height: 150px;
+  background: lightblue;
+}
+</style>
+
+<table id=table>
+  <tr id=tr>
+    <td id=td>
+      <div>Test passes if this text is visible.</div>
+    </td>
+  </tr>
+</table>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-094.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-094.html
@@ -1,0 +1,44 @@
+<!doctype HTML>
+<html class="reftest-wait">
+<meta charset="utf8">
+<title>Content Visibility: hidden table types</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="match" href="container-ref.html">
+<meta name="assert" content="content-visibility effect on hidden table types">
+
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+table {
+  width: 150px;
+  height: 150px;
+  background: lightblue;
+}
+.hidden {
+  content-visibility: hidden;
+}
+</style>
+
+<table id=table>
+  <caption id=caption>
+    <div>Test fails if this text is visible.</div>
+  </caption>
+  <tr id=tr>
+    <td id=td>
+      <div>Test passes if this text is visible.</div>
+    </td>
+  </tr>
+</table>
+
+<script>
+function runTest() {
+  document.getElementById("table").classList.add("hidden");
+  document.getElementById("tr").classList.add("hidden");
+  document.getElementById("caption").classList.add("hidden");
+  requestAnimationFrame(takeScreenshot);
+}
+
+window.onload = () => requestAnimationFrame(runTest);
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-095-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-095-expected.html
@@ -1,0 +1,24 @@
+<!doctype HTML>
+<html>
+<meta charset="utf8">
+<title>CSS Content Visibility: container (reference)</title>
+<link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+
+<style>
+#table {
+  width: 150px;
+  height: 150px;
+  background: lightblue;
+}
+#positioned {
+  position: absolute;
+}
+</style>
+
+<table id=table>
+  <td>
+    <div id=positioned>Test passes if this text is visible.</div>
+  </td>
+</table>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-095.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-095.html
@@ -1,0 +1,47 @@
+<!doctype HTML>
+<html class="reftest-wait">
+<meta charset="utf8">
+<title>Content Visibility: hidden table with positioned child</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="match" href="container-ref.html">
+<meta name="assert" content="content-visibility hidden table does paint the subtree">
+
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+table {
+  width: 150px;
+  height: 150px;
+  background: lightblue;
+}
+#positioned {
+  position: absolute;
+}
+.hidden {
+  content-visibility: hidden;
+}
+</style>
+
+<table id=table>
+  <caption id=caption>
+      <div id=positioned>Test fails if this text is visible.</div>
+  </caption>
+  <tr id=tr>
+    <td id=td>
+      <div id=positioned>Test passes if this text is visible.</div>
+    </td>
+  </tr>
+</table>
+
+<script>
+function runTest() {
+  document.getElementById("table").classList.add("hidden");
+  document.getElementById("tr").classList.add("hidden");
+  document.getElementById("caption").classList.add("hidden");
+  requestAnimationFrame(takeScreenshot);
+}
+
+window.onload = () => requestAnimationFrame(runTest);
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -90,12 +90,12 @@ inline bool RenderElement::shouldApplyLayoutOrPaintContainment(bool containsAcco
 
 inline bool RenderElement::shouldApplyLayoutOrPaintContainment() const
 {
-    return shouldApplyLayoutOrPaintContainment(style().containsLayoutOrPaint() || style().contentVisibility() != ContentVisibility::Visible);
+    return shouldApplyLayoutOrPaintContainment(style().containsLayoutOrPaint()) || shouldApplySizeOrStyleContainment(style().contentVisibility() != ContentVisibility::Visible);
 }
 
 inline bool RenderElement::shouldApplyPaintContainment() const
 {
-    return shouldApplyLayoutOrPaintContainment(style().containsPaint() || style().contentVisibility() != ContentVisibility::Visible);
+    return shouldApplyLayoutOrPaintContainment(style().containsPaint()) || shouldApplySizeOrStyleContainment(style().contentVisibility() != ContentVisibility::Visible);
 }
 
 inline bool RenderElement::shouldApplySizeContainment() const
@@ -108,6 +108,7 @@ inline bool RenderElement::shouldApplySizeOrInlineSizeContainment() const
     return isSkippedContentRoot() || shouldApplySizeOrStyleContainment(style().containsSizeOrInlineSize());
 }
 
+// FIXME: try to avoid duplication with isSkippedContentRoot.
 inline bool RenderElement::shouldApplySizeOrStyleContainment(bool containsAccordingToStyle) const
 {
     return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRenderRubyText() && (!isTablePart() || isRenderTableCaption()) && !isRenderTable();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -937,17 +937,16 @@ inline TypographicMode RenderStyle::typographicMode() const
 
 inline bool isSkippedContentRoot(const RenderStyle& style, const Element* element)
 {
-    switch (style.contentVisibility()) {
-    case ContentVisibility::Visible:
+    if (style.contentVisibility() == ContentVisibility::Visible)
         return false;
-    case ContentVisibility::Hidden:
+    // FIXME (https://bugs.webkit.org/show_bug.cgi?id=265020): check more display types.
+    // FIXME: try to avoid duplication with shouldApplySizeOrStyleContainment.
+    if (style.isDisplayTableOrTablePart() && style.display() != DisplayType::TableCaption)
+        return false;
+    if (style.contentVisibility() == ContentVisibility::Hidden)
         return true;
-    case ContentVisibility::Auto:
-        return element && !element->isRelevantToUser();
-    };
-
-    ASSERT_NOT_REACHED();
-    return false;
+    ASSERT(style.contentVisibility() == ContentVisibility::Auto);
+    return element && !element->isRelevantToUser();
 }
 
 inline float adjustFloatForAbsoluteZoom(float value, const RenderStyle& style)


### PR DESCRIPTION
#### eea0af365e1cca71d12a328eee4398d5f2db9745
<pre>
[content-visibility] Property should not apply to tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=264163">https://bugs.webkit.org/show_bug.cgi?id=264163</a>

Reviewed by Tim Nguyen.

The content-visibility property applied to elements for which size containment can apply [1].
However, size containment does not apply to tables [2], so change the code to make content-visibility
not have a direct effect on tables.

[1] <a href="https://drafts.csswg.org/css-contain/#content-visibility">https://drafts.csswg.org/css-contain/#content-visibility</a>
[2] <a href="https://drafts.csswg.org/css-contain/#containment-size">https://drafts.csswg.org/css-contain/#containment-size</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-094-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-094.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-095-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-095.html: Added.
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::shouldApplyLayoutOrPaintContainment const):
(WebCore::RenderElement::shouldApplyPaintContainment const):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::isSkippedContentRoot):

Canonical link: <a href="https://commits.webkit.org/270888@main">https://commits.webkit.org/270888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e516d4fecc302708354898cf76a96b02474a5bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29412 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29954 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27855 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23664 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6418 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->