### PR TITLE
[WebGPU] requestAdapterInfo test expects (r) to be removed from adapterInfo.vendor and  adapterInfo.device

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2620,6 +2620,4 @@ webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallbac
 [ Sonoma+ ] svg/custom/svg-fonts-in-html.html [ Pass ImageOnlyFailure Failure ]
 [ Sonoma+ ] tables/mozilla/bugs/bug2479-2.html [ Pass ImageOnlyFailure Failure ]
 
-webkit.org/b/264165 http/tests/webgpu/webgpu/api/operation/adapter/requestAdapterInfo.html [ Failure ]
-
 webkit.org/b/264177 requestidlecallback/requestidlecallback-deadline-shortened-by-rendering-update.html [ Pass Failure ]

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/ASCIICType.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -38,16 +39,17 @@ public:
         return adoptRef(*new GPUAdapterInfo(WTFMove(name)));
     }
 
-    String vendor() const { auto v = m_name.split(' '); return v.size() ? v[0].convertToLowercaseWithoutLocale() : ""_s; }
-    String architecture() const { return ""_s; }
-    String device() const { return vendor(); }
-    String description() const { return ""_s; }
+    String vendor() const { auto v = m_name.split(' '); return v.size() ? normalizedIdentifier(v[0]) : ""_s; }
+    String architecture() const { return normalizedIdentifier(m_name); }
+    String device() const { return normalizedIdentifier(m_name); }
+    String description() const { return normalizedIdentifier(m_name); }
 
 private:
     GPUAdapterInfo(String&& name)
         : m_name(name)
     {
     }
+    static String normalizedIdentifier(const String& s) { return s.convertToLowercaseWithoutLocale().removeCharacters([](auto c) { return !isASCIIAlphanumeric(c); }); }
 
     String m_name;
 };


### PR DESCRIPTION
#### 94804f286a49540dadad3efd02be79111b29006c
<pre>
[WebGPU] requestAdapterInfo test expects (r) to be removed from adapterInfo.vendor and  adapterInfo.device
<a href="https://bugs.webkit.org/show_bug.cgi?id=264168">https://bugs.webkit.org/show_bug.cgi?id=264168</a>
&lt;radar://117912370&gt;

Reviewed by Tadeu Zagallo.

Strings returned by requestAdapterInfo should only contain letters and numbers.

Intel was returning &quot;Intel(r)&quot; and the &quot;(&quot; and &quot;)&quot; caused the test expectation to fail.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h:
(WebCore::GPUAdapterInfo::vendor const):
(WebCore::GPUAdapterInfo::architecture const):
(WebCore::GPUAdapterInfo::device const):
(WebCore::GPUAdapterInfo::description const):
(WebCore::GPUAdapterInfo::normalizedIdentifier):

Canonical link: <a href="https://commits.webkit.org/270213@main">https://commits.webkit.org/270213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e309da4b06f6c3409e8c570b60940567aef90ac8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26979 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/844 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2446 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27559 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22393 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26361 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2092 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3376 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5954 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->