### PR TITLE
Add support for runtime.getFrameId() in Web Extensions.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -44,8 +44,10 @@ using WebExtensionFrameIdentifier = ObjectIdentifier<WebExtensionFrameIdentifier
 namespace WebExtensionFrameConstants {
 
 static constexpr double MainFrame { 0 };
+static constexpr double None { -1 };
 
 static constexpr const WebExtensionFrameIdentifier MainFrameIdentifier { std::numeric_limits<uint64_t>::max() - 1 };
+static constexpr const WebExtensionFrameIdentifier NoneIdentifier { std::numeric_limits<uint64_t>::max() - 2 };
 
 }
 
@@ -57,6 +59,21 @@ inline bool isMainFrame(WebExtensionFrameIdentifier identifier)
 inline bool isMainFrame(std::optional<WebExtensionFrameIdentifier> identifier)
 {
     return identifier && isMainFrame(identifier.value());
+}
+
+inline bool isNone(WebExtensionFrameIdentifier identifier)
+{
+    return identifier == WebExtensionFrameConstants::NoneIdentifier;
+}
+
+inline bool isNone(std::optional<WebExtensionFrameIdentifier> identifier)
+{
+    return identifier && isNone(identifier.value());
+}
+
+inline bool isValid(std::optional<WebExtensionFrameIdentifier> identifier)
+{
+    return identifier && !isNone(identifier.value());
 }
 
 inline WebCore::FrameIdentifier toWebCoreFrameIdentifier(const WebExtensionFrameIdentifier& identifier, const WebPage& page)
@@ -110,7 +127,10 @@ inline std::optional<WebExtensionFrameIdentifier> toWebExtensionFrameIdentifier(
     if (identifier == WebExtensionFrameConstants::MainFrame)
         return WebExtensionFrameConstants::MainFrameIdentifier;
 
-    if (!std::isfinite(identifier) || identifier <= 0 || identifier >= static_cast<double>(WebExtensionFrameConstants::MainFrameIdentifier.toUInt64()))
+    if (identifier == WebExtensionFrameConstants::None)
+        return WebExtensionFrameConstants::NoneIdentifier;
+
+    if (!std::isfinite(identifier) || identifier <= 0 || identifier >= static_cast<double>(WebExtensionFrameConstants::NoneIdentifier.toUInt64()))
         return std::nullopt;
 
     double integral;
@@ -130,6 +150,9 @@ inline double toWebAPI(const WebExtensionFrameIdentifier& identifier)
 
     if (isMainFrame(identifier))
         return WebExtensionFrameConstants::MainFrame;
+
+    if (isNone(identifier))
+        return WebExtensionFrameConstants::None;
 
     return static_cast<double>(identifier.toUInt64());
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -39,6 +39,7 @@
 #import "WebExtensionAPINamespace.h"
 #import "WebExtensionAPIPort.h"
 #import "WebExtensionContextMessages.h"
+#import "WebExtensionFrameIdentifier.h"
 #import "WebExtensionMessageSenderParameters.h"
 #import "WebExtensionUtilities.h"
 #import "WebProcess.h"
@@ -201,6 +202,20 @@ void WebExtensionAPIRuntime::getBackgroundPage(Ref<WebExtensionCallbackHandler>&
 
         callback->call(toWindowObject(callback->globalContext(), *page));
     }, extensionContext().identifier());
+}
+
+double WebExtensionAPIRuntime::getFrameId(JSValue *target)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getFrameId
+
+    if (!target)
+        return WebExtensionFrameConstants::None;
+
+    auto frame = WebFrame::contentFrameForWindowOrFrameElement(target.context.JSGlobalContextRef, target.JSValueRef);
+    if (!frame)
+        return WebExtensionFrameConstants::None;
+
+    return toWebAPI(toWebExtensionFrameIdentifier(*frame));
 }
 
 void WebExtensionAPIRuntime::setUninstallURL(URL, Ref<WebExtensionCallbackHandler>&& callback)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -68,6 +68,7 @@ public:
     NSDictionary *getManifest();
     void getPlatformInfo(Ref<WebExtensionCallbackHandler>&&);
     void getBackgroundPage(Ref<WebExtensionCallbackHandler>&&);
+    double getFrameId(JSValue *);
 
     void setUninstallURL(URL, Ref<WebExtensionCallbackHandler>&&);
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
@@ -28,11 +28,11 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIRuntime {
 
-    [URL, ConvertNullStringTo=Null, RaisesException] DOMString getURL(DOMString resourcePath);
-
-    [NSDictionary] any getManifest();
-
     [ImplementedAs=runtimeIdentifier] readonly attribute DOMString id;
+
+    [URL, ConvertNullStringTo=Null, RaisesException] DOMString getURL(DOMString resourcePath);
+    [NSDictionary] any getManifest();
+    double getFrameId(any target);
 
     [MainWorldOnly] void getPlatformInfo([Optional, CallbackHandler] function callback);
     [MainWorldOnly] void getBackgroundPage([Optional, CallbackHandler] function callback);


### PR DESCRIPTION
#### 790c5d5a8195e9cb80e585221fd12045643b718d
<pre>
Add support for runtime.getFrameId() in Web Extensions.
<a href="https://webkit.org/b/264172">https://webkit.org/b/264172</a>
<a href="https://rdar.apple.com/problem/117916101">rdar://problem/117916101</a>

Reviewed by Brady Eidson.

* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
(WebKit::isNone): Added.
(WebKit::isValid): Added.
(WebKit::toWebExtensionFrameIdentifier): Handle None case.
(WebKit::toWebAPI): Ditto.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getFrameId): Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270205@main">https://commits.webkit.org/270205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d5cb3e6c73d2593142299a66c2158209619a943

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24856 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3400 "Failed to checkout and rebase branch from PR 19965") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26109 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/26972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25124 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/5084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/26972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25100 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/5084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/5084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/22386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/27552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/5084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3170 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->