### PR TITLE
[macOS] Toggling AX preferences does not update form control appearance

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
@@ -152,6 +152,8 @@ extern CFStringRef kAXInterfaceReduceMotionStatusDidChangeNotification;
 
 extern CFStringRef kAXInterfaceIncreaseContrastKey;
 
+extern CFStringRef kAXInterfaceDifferentiateWithoutColorKey;
+
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -149,6 +149,8 @@ protected:
     virtual void preferenceDidUpdate(const String& domain, const String& key, const std::optional<String>& encodedValue);
     virtual void handlePreferenceChange(const String& domain, const String& key, id value);
     virtual void dispatchSimulatedNotificationsForPreferenceChange(const String& key) { }
+
+    virtual void accessibilitySettingsDidChange() { }
 #endif
     void applyProcessCreationParameters(const AuxiliaryProcessCreationParameters&);
 
@@ -169,6 +171,10 @@ protected:
     bool allowsFirstPartyForCookies(const WebCore::RegistrableDomain&, HashSet<WebCore::RegistrableDomain>&);
 
 private:
+#if ENABLE(CFPREFS_DIRECT_MODE)
+    void handleAXPreferenceChange(const String& domain, const String& key, id value);
+#endif
+
     virtual bool shouldOverrideQuarantine() { return true; }
 
     // IPC::MessageSender

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -46,6 +46,7 @@
 #endif
 
 #if PLATFORM(MAC)
+#import "AppKitSPI.h"
 #import <pal/spi/mac/HIServicesSPI.h>
 #endif
 
@@ -208,7 +209,15 @@ static const WTF::String& increaseContrastPreferenceKey()
 }
 #endif
 
-static void handleAXPreferenceChange(const String& domain, const String& key, id value)
+#if USE(APPKIT)
+static const WTF::String& invertColorsPreferenceKey()
+{
+    static NeverDestroyed<WTF::String> key(MAKE_STATIC_STRING_IMPL("whiteOnBlack"));
+    return key;
+}
+#endif
+
+void AuxiliaryProcess::handleAXPreferenceChange(const String& domain, const String& key, id value)
 {
 #if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS)
     if (!libAccessibilityLibrary())
@@ -228,6 +237,14 @@ static void handleAXPreferenceChange(const String& domain, const String& key, id
             _AXSSetDarkenSystemColors([(NSNumber *)value boolValue]);
 #endif
     }
+
+#if USE(APPKIT)
+    auto cfKey = key.createCFString();
+    if (CFEqual(cfKey.get(), kAXInterfaceReduceMotionKey) || CFEqual(cfKey.get(), kAXInterfaceIncreaseContrastKey) || CFEqual(cfKey.get(), kAXInterfaceDifferentiateWithoutColorKey) || key == invertColorsPreferenceKey()) {
+        [NSWorkspace _invalidateAccessibilityDisplayValues];
+        accessibilitySettingsDidChange();
+    }
+#endif
 }
 
 void AuxiliaryProcess::handlePreferenceChange(const String& domain, const String& key, id value)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -649,6 +649,8 @@ private:
 #if ENABLE(CFPREFS_DIRECT_MODE)
     void handlePreferenceChange(const String& domain, const String& key, id value) final;
     void dispatchSimulatedNotificationsForPreferenceChange(const String& key) final;
+
+    void accessibilitySettingsDidChange() final;
 #endif
 
     void setNetworkProcessConnectionID(IPC::Connection::UniqueID);

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1294,12 +1294,6 @@ static const WTF::String& userHighlightColorPreferenceKey()
     static NeverDestroyed<WTF::String> userHighlightColorPreferenceKey(MAKE_STATIC_STRING_IMPL("AppleHighlightColor"));
     return userHighlightColorPreferenceKey;
 }
-
-static const WTF::String& invertColorsPreferenceKey()
-{
-    static NeverDestroyed<WTF::String> key(MAKE_STATIC_STRING_IMPL("whiteOnBlack"));
-    return key;
-}
 #endif
 
 static const WTF::String& captionProfilePreferenceKey()
@@ -1344,21 +1338,18 @@ void WebProcess::handlePreferenceChange(const String& domain, const String& key,
         WTF::languageDidChange();
     }
 
-#if USE(APPKIT)
-    auto cfKey = key.createCFString();
-    if (CFEqual(cfKey.get(), kAXInterfaceReduceMotionKey) || CFEqual(cfKey.get(), kAXInterfaceIncreaseContrastKey) || key == invertColorsPreferenceKey()) {
-        [NSWorkspace _invalidateAccessibilityDisplayValues];
-        for (auto& page : m_pageMap.values())
-            page->accessibilitySettingsDidChange();
-    }
-#endif
-
     AuxiliaryProcess::handlePreferenceChange(domain, key, value);
 }
 
 void WebProcess::notifyPreferencesChanged(const String& domain, const String& key, const std::optional<String>& encodedValue)
 {
     preferenceDidUpdate(domain, key, encodedValue);
+}
+
+void WebProcess::accessibilitySettingsDidChange()
+{
+    for (auto& page : m_pageMap.values())
+        page->accessibilitySettingsDidChange();
 }
 #endif
 


### PR DESCRIPTION
#### f8db1385c264d8fcc07744663f502a066e838acd
<pre>
[macOS] Toggling AX preferences does not update form control appearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=264170">https://bugs.webkit.org/show_bug.cgi?id=264170</a>
<a href="https://rdar.apple.com/117914468">rdar://117914468</a>

Reviewed by Wenson Hsieh.

cfprefsd is blocked in the GPU process. Consequently, any changes to
preferences are not automatically reflected to the process. For this reason,
there is existing logic for the UI process to notify the child processes of
preference changes.

Note that AppKit caches the value of some accessibility settings. The WebContent
process already works around this by invalidating the cache whenever an
accessibility setting is modified. However, the GPU process does not currently
use the same logic. Consequently, the AppKit&apos;s cache of accessibility settings
remains frozen in the GPU process.

To fix, ensure the cache is invalidated, by moving logic from `WebProcessCocoa`
into `AuxiliaryProcessCocoa`. This approach ensures that all child processes
invalidate the relevant cache.

* Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h:
* Source/WebKit/Shared/AuxiliaryProcess.h:
(WebKit::AuxiliaryProcess::accessibilitySettingsDidChange):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::invertColorsPreferenceKey):
(WebKit::AuxiliaryProcess::handleAXPreferenceChange):

Additionally invalidate the cache when the &quot;Differentiate without color&quot;
setting is toggled.

(WebKit::handleAXPreferenceChange): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::handlePreferenceChange):
(WebKit::WebProcess::accessibilitySettingsDidChange):
(WebKit::invertColorsPreferenceKey): Deleted.

Canonical link: <a href="https://commits.webkit.org/270221@main">https://commits.webkit.org/270221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94fdee73e2d6ef9d00bea27092e875df54558955

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/851 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25114 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27566 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28547 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26368 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/403 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2545 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3174 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->