### PR TITLE
REGRESSION (269897@main): [ Sonoma wk2 ] 2 tests in imported/w3c/web-platform-tests/css/cssom-view/ are a constant failure

### DIFF
--- a/LayoutTests/platform/mac-ventura-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-ventura-wk2/TestExpectations
@@ -34,3 +34,6 @@ webkit.org/b/261444 [ Debug x86_64 ] http/tests/security/referrer-policy-header.
 
 # Asserts on pre-Sonoma macOS: rdar://116291539
 [ Debug ] http/tests/site-isolation/window-properties.html [ Skip ]
+
+# webkit.org/b/263955 Twelve css WPTs are failing with async overflow scrolling enabled on macOS
+imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -614,7 +614,6 @@ imported/w3c/web-platform-tests/css/css-ui/outline-negative-offset-composited-sc
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-inline-block.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Failure ]
-imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.html [ Failure ]
 
 ### END OF (1) Classified failures with bug reports
 ########################################
@@ -1986,7 +1985,3 @@ http/tests/webgpu/webgpu/api/operation/render_pipeline/overrides.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/render_pipeline/primitive_topology.html [ Pass ]
 
 webkit.org/b/263920 svg/transforms/transformed-text-fill-gradient.html [ ImageOnlyFailure ]
-
-# rdar://117706782 (REGRESSION (269897@main): [ Sonoma wk2 ] 2 tests in imported/w3c/web-platform-t ests/css/cssom-view/ are a constant failure
-[ Sonoma+ ] imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-window.html [ Failure ]
-[ Sonoma+ ] imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html [ Failure ]

--- a/LayoutTests/tiled-drawing/scrolling/clamp-out-of-bounds-scrolls-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/clamp-out-of-bounds-scrolls-expected.txt
@@ -3,6 +3,7 @@ Attempted scroll to -5000, 0
 (Frame scrolling node
   (scrollable area size 785 585)
   (contents size 5008 5021)
+  (requested scroll position represents programmatic scroll 1)
   (scrollable area parameters
     (horizontal scroll elasticity 2)
     (vertical scroll elasticity 2)
@@ -21,6 +22,7 @@ Attempted scroll to 0, -5000
 (Frame scrolling node
   (scrollable area size 785 585)
   (contents size 5008 5021)
+  (requested scroll position represents programmatic scroll 1)
   (scrollable area parameters
     (horizontal scroll elasticity 2)
     (vertical scroll elasticity 2)
@@ -39,6 +41,7 @@ Attempted scroll to -5000, -5000
 (Frame scrolling node
   (scrollable area size 785 585)
   (contents size 5008 5021)
+  (requested scroll position represents programmatic scroll 1)
   (scrollable area parameters
     (horizontal scroll elasticity 2)
     (vertical scroll elasticity 2)

--- a/LayoutTests/tiled-drawing/scrolling/fixed/negative-scroll-offset-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/fixed/negative-scroll-offset-expected.txt
@@ -2,6 +2,7 @@
 (Frame scrolling node
   (scrollable area size 785 600)
   (contents size 785 2221)
+  (requested scroll position represents programmatic scroll 1)
   (scrollable area parameters
     (horizontal scroll elasticity 2)
     (vertical scroll elasticity 2)

--- a/LayoutTests/tiled-drawing/scrolling/fixed/negative-scroll-offset-in-view-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/fixed/negative-scroll-offset-in-view-expected.txt
@@ -2,6 +2,7 @@
 (Frame scrolling node
   (scrollable area size 785 600)
   (contents size 785 2221)
+  (requested scroll position represents programmatic scroll 1)
   (scrollable area parameters
     (horizontal scroll elasticity 2)
     (vertical scroll elasticity 2)

--- a/LayoutTests/tiled-drawing/scrolling/sticky/negative-scroll-offset-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/sticky/negative-scroll-offset-expected.txt
@@ -2,6 +2,7 @@
 (Frame scrolling node
   (scrollable area size 785 600)
   (contents size 785 2216)
+  (requested scroll position represents programmatic scroll 1)
   (scrollable area parameters
     (horizontal scroll elasticity 2)
     (vertical scroll elasticity 2)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -301,11 +301,11 @@ void ScrollingTreeScrollingNode::requestKeyboardScroll(const RequestedKeyboardSc
 
 void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScrollData& requestedScrollData)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " handleScrollPositionRequest()" << " animated " << (requestedScrollData.animated == ScrollIsAnimated::Yes) << " requestedScrollData: " << requestedScrollData);
-
     stopAnimatedScroll();
 
     if (requestedScrollData.requestType == ScrollRequestType::CancelAnimatedScroll) {
+        ASSERT(!requestedScrollData.requestedDataBeforeAnimatedScroll);
+        LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " handleScrollPositionRequest() - cancel animated scroll");
         scrollingTree().removePendingScrollAnimationForNode(scrollingNodeID());
         return;
     }
@@ -313,7 +313,7 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
     if (scrollingTree().scrollingTreeNodeRequestsScroll(scrollingNodeID(), requestedScrollData))
         return;
 
-    auto currentScrollPosition = this->currentScrollPosition();
+    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " handleScrollPositionRequest() with data " << requestedScrollData);
 
     if (requestedScrollData.requestedDataBeforeAnimatedScroll) {
         auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *requestedScrollData.requestedDataBeforeAnimatedScroll;
@@ -321,7 +321,7 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
         switch (requestType) {
         case ScrollRequestType::PositionUpdate:
         case ScrollRequestType::DeltaUpdate: {
-            auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
+            auto intermediatePosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition(), requestType, positionOrDeltaBeforeAnimatedScroll);
             scrollTo(intermediatePosition, scrollType, clamping);
             break;
         }
@@ -331,8 +331,7 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
         }
     }
 
-    auto destinationPosition = requestedScrollData.destinationPosition(currentScrollPosition);
-
+    auto destinationPosition = requestedScrollData.destinationPosition(currentScrollPosition());
     if (requestedScrollData.animated == ScrollIsAnimated::Yes) {
         startAnimatedScrollToPosition(destinationPosition);
         return;

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -552,8 +552,10 @@ void ScrollView::setScrollPosition(const ScrollPosition& scrollPosition, const S
         return;
     }
 
-    ScrollPosition newScrollPosition = (!delegatesScrollingToNativeView() && options.clamping == ScrollClamping::Clamped) ? adjustScrollPositionWithinRange(scrollPosition) : scrollPosition;
-    if ((!delegatesScrollingToNativeView() || currentScrollType() == ScrollType::User) && newScrollPosition == this->scrollPosition()) {
+    auto newScrollPosition = (!delegatesScrollingToNativeView() && options.clamping == ScrollClamping::Clamped) ? adjustScrollPositionWithinRange(scrollPosition) : scrollPosition;
+    bool scrollPositionChanged = newScrollPosition != this->scrollPosition();
+
+    if (currentScrollType() == ScrollType::User && !scrollPositionChanged) {
         LOG_WITH_STREAM(Scrolling, stream << "ScrollView::setScrollPosition " << scrollPosition << " return for no change");
         return;
     }


### PR DESCRIPTION
#### a53d9e00eb65bcb56d2d24b1edde139091027c63
<pre>
REGRESSION (269897@main): [ Sonoma wk2 ] 2 tests in imported/w3c/web-platform-tests/css/cssom-view/ are a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263925">https://bugs.webkit.org/show_bug.cgi?id=263925</a>
<a href="https://rdar.apple.com/117706782">rdar://117706782</a>

Reviewed by Richard Robinson.

Fix a bug introduced in 269897@main, and an older bug that prevented scroll-behavior-main-frame* tests from passing.

In 269897@main the intermediate scrollTo() that we do when we have `requestedDataBeforeAnimatedScroll` data needs
to also contribute its destination position to the animated scroll that happens second, but both
`ScrollingTreeScrollingNode::handleScrollPositionRequest()` and `RemoteScrollingTreeMac::startPendingScrollAnimations()`
failed to do this.

Even wit this fix, two WPT tests were failing when they made the following sequence of programmatic scrolls:
    scrollBy(0, X, animated)
    scrollTo(0, 0)
    scrollBy(0, Y, animated)

We&apos;d end up scrolling to X + Y because `ScrollView::setScrollPosition()` early returned if there was no position
change for the `scrollTo(0, 0)`. But we need to hit `requestScrollToPosition()` so that we have a chance to
cancel the enqueued animated scroll, so remove the `!delegatesScrollingToNativeView()` check.

* LayoutTests/platform/mac-ventura-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::setScrollPosition):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::startPendingScrollAnimations):

Canonical link: <a href="https://commits.webkit.org/270243@main">https://commits.webkit.org/270243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca73c6d185be535b775b03821b2025843b845c23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23175 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27628 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28587 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/452 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3436 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5974 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->