### PR TITLE
[WGSL] Validate constant evaluation result

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -754,9 +754,17 @@ BINARY_OPERATION(Atan2, Float, WRAP_STD(atan2))
 UNARY_OPERATION(Ceil, Float, WRAP_STD(ceil))
 TERNARY_OPERATION(Clamp, Number, [&](auto e, auto low, auto high) { return std::min(std::max(e, low), high); })
 
-UNARY_OPERATION(CountLeadingZeros, Integer, [&](uint32_t arg) { return std::countl_zero(arg); })
-UNARY_OPERATION(CountOneBits, Integer, [&](uint32_t arg) { return std::popcount(arg); })
-UNARY_OPERATION(CountTrailingZeros, Integer, [&](uint32_t arg) { return std::countr_zero(arg); })
+UNARY_OPERATION(CountLeadingZeros, ConcreteInteger, [&]<typename T>(T arg) -> T {
+    return std::countl_zero(static_cast<unsigned>(arg));
+})
+
+UNARY_OPERATION(CountOneBits, ConcreteInteger, [&]<typename T>(T arg) -> T {
+    return std::popcount(static_cast<unsigned>(arg));
+})
+
+UNARY_OPERATION(CountTrailingZeros, ConcreteInteger, [&]<typename T>(T arg) -> T {
+    return std::countr_zero(static_cast<unsigned>(arg));
+})
 
 CONSTANT_FUNCTION(Cross)
 {
@@ -1150,8 +1158,8 @@ UNARY_OPERATION(Saturate, Float, [&](auto e) {
     return std::min(std::max(e, static_cast<decltype(e)>(0)), static_cast<decltype(e)>(1));
 })
 
-UNARY_OPERATION(Sign, Number, [&](auto e) {
-    int result;
+UNARY_OPERATION(Sign, Number, [&]<typename T>(T e) -> T {
+    T result;
     if (e > 0)
         result = 1;
     else if (e < 0)

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1350,7 +1350,7 @@ const Type* TypeChecker::chooseOverload(const char* kind, AST::Expression& expre
                 auto result = constantFunction(overload->result, WTFMove(arguments));
                 if (!result)
                     typeError(InferBottom::No, expression.span(), result.error());
-                else
+                else if (convertValue(expression.span(), overload->result, *result))
                     setConstantValue(expression, WTFMove(*result));
             }
         }

--- a/Source/WebGPU/WGSL/tests/invalid/division.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/division.wgsl
@@ -83,14 +83,13 @@ fn testU32()
 
 fn testAbstractFloat()
 {
-    // FIXME: values need to be converted after return from call
-    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
     _ = 42.0 / 0.0;
-    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
     _ = 42.0 / vec2(1.0, 0.0);
-    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
     _ = vec2(42.0) / 0.0;
-    // skip-CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
     _ = vec2(42.0) / vec2(1.0, 0.0);
 
     // CHECK-NOT-L: division by zero
@@ -122,14 +121,13 @@ fn testAbstractFloat()
 
 fn testF32()
 {
-    // FIXME: values need to be converted after return from call
-    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    // CHECK-L: value Infinity cannot be represented as 'f32'
     _ = 42f / 0f;
-    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    // CHECK-L: value Infinity cannot be represented as 'f32'
     _ = 42f / vec2(1f, 0f);
-    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    // CHECK-L: value Infinity cannot be represented as 'f32'
     _ = vec2(42f) / 0f;
-    // skip-CHECK-L: value Infinity cannot be represented as 'f32'
+    // CHECK-L: value Infinity cannot be represented as 'f32'
     _ = vec2(42f) / vec2(1f, 0f);
 
     let x = 42f;

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1499,26 +1499,26 @@ fn testLog()
 {
     // [T < Float].(T) => T,
     {
-        _ = log(0);
-        _ = log(0.0);
+        _ = log(2);
+        _ = log(1.0);
         _ = log(1f);
     }
 
     // [T < Float, N].(Vector[T, N]) => Vector[T, N],
     {
-        _ = log(vec2(0));
-        _ = log(vec2(0.0));
-        _ = log(vec2(1f));
+        _ = log(vec2(2));
+        _ = log(vec2(2.0));
+        _ = log(vec2(2f));
     }
     {
-        _ = log(vec3(-1));
-        _ = log(vec3(-1.0));
-        _ = log(vec3(-1f));
+        _ = log(vec3(-2));
+        _ = log(vec3(-2.0));
+        _ = log(vec3(-2f));
     }
     {
-        _ = log(vec4(-1));
-        _ = log(vec4(-1.0));
-        _ = log(vec4(-1f));
+        _ = log(vec4(-2));
+        _ = log(vec4(-2.0));
+        _ = log(vec4(-2f));
     }
 }
 
@@ -1526,26 +1526,26 @@ fn testLog()
 fn testLog2() {
     // [T < Float].(T) => T,
     {
-        _ = log2(0);
-        _ = log2(0.0);
-        _ = log2(1f);
+        _ = log2(2);
+        _ = log2(2.0);
+        _ = log2(2f);
     }
 
     // [T < Float, N].(Vector[T, N]) => Vector[T, N],
     {
-        _ = log2(vec2(0));
-        _ = log2(vec2(0.0));
-        _ = log2(vec2(1f));
+        _ = log2(vec2(2));
+        _ = log2(vec2(2.0));
+        _ = log2(vec2(2f));
     }
     {
-        _ = log2(vec3(-1));
-        _ = log2(vec3(-1.0));
-        _ = log2(vec3(-1f));
+        _ = log2(vec3(-2));
+        _ = log2(vec3(-2.0));
+        _ = log2(vec3(-2f));
     }
     {
-        _ = log2(vec4(-1));
-        _ = log2(vec4(-1.0));
-        _ = log2(vec4(-1f));
+        _ = log2(vec4(-2));
+        _ = log2(vec4(-2.0));
+        _ = log2(vec4(-2f));
     }
 }
 


### PR DESCRIPTION
#### f3c296b0b2ce3e55eb1ff4f35449b713c6db6f6a
<pre>
[WGSL] Validate constant evaluation result
<a href="https://bugs.webkit.org/show_bug.cgi?id=264182">https://bugs.webkit.org/show_bug.cgi?id=264182</a>
<a href="https://rdar.apple.com/117922885">rdar://117922885</a>

Reviewed by Mike Wyrzykowski.

This is necessary to catch when operations produce values that can&apos;t be represented
in their respective type, but it&apos;s also helpful to identify issues where the value
representation diverges from the type. There were already a few such cases which had
to be fixed as part of this patch.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::UNARY_OPERATION):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/tests/invalid/division.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270261@main">https://commits.webkit.org/270261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e201f93fecf84141c94052e51bdf05435eb0cdba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27134 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1000 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27714 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26478 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2236 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3517 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5988 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->