### PR TITLE
Support content security policy in Web Extensions.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -481,6 +481,9 @@
 /* WKWebExtensionErrorInvalidManifestEntry description for content_scripts */
 "Empty or invalid `content_scripts` manifest entry." = "Empty or invalid `content_scripts` manifest entry.";
 
+/* WKWebExtensionErrorInvalidManifestEntry description for content_security_policy */
+"Empty or invalid `content_security_policy` manifest entry." = "Empty or invalid `content_security_policy` manifest entry.";
+
 /* WKWebExtensionErrorInvalidManifestEntry description for default_icon in action only */
 "Empty or invalid `default_icon` for the `action` manifest entry." = "Empty or invalid `default_icon` for the `action` manifest entry.";
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1850,7 +1850,10 @@ WKWebViewConfiguration *WebExtensionContext::webViewConfiguration(WebViewPurpose
     if (!isLoaded())
         return nil;
 
+    bool isManifestVersion3 = extension().supportsManifestVersion(3);
+
     WKWebViewConfiguration *configuration = [extensionController()->configuration().webViewConfiguration() copy];
+    configuration._contentSecurityPolicyModeForExtension = isManifestVersion3 ? _WKContentSecurityPolicyModeForExtensionManifestV3 : _WKContentSecurityPolicyModeForExtensionManifestV2;
     configuration._corsDisablingPatterns = corsDisablingPatterns();
     configuration._crossOriginAccessControlCheckEnabled = NO;
     configuration._processDisplayName = processDisplayName();

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -129,9 +129,9 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
             fileData = [stylesheetContents dataUsingEncoding:NSUTF8StringEncoding];
         }
 
-        // FIXME: <https://webkit.org/b/246490> Include the Content-Security-Policy header for the extension.
         NSHTTPURLResponse *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:requestURL statusCode:200 HTTPVersion:nil headerFields:@{
             @"Access-Control-Allow-Origin": @"*",
+            @"Content-Security-Policy": extensionContext->extension().contentSecurityPolicy(),
             @"Content-Length": [NSString stringWithFormat:@"%zu", (size_t)fileData.length],
             @"Content-Type": mimeType
         }];

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -96,6 +96,7 @@ public:
         InvalidBackgroundContent,
         InvalidBackgroundPersistence,
         InvalidContentScripts,
+        InvalidContentSecurityPolicy,
         InvalidDeclarativeNetRequest,
         InvalidDescription,
         InvalidExternallyConnectable,
@@ -175,6 +176,8 @@ public:
     NSString *displayDescription();
     NSString *version();
 
+    NSString *contentSecurityPolicy();
+
     CocoaImage *icon(CGSize idealSize);
 
     CocoaImage *actionIcon(CGSize idealSize);
@@ -241,6 +244,7 @@ private:
     void populateContentScriptPropertiesIfNeeded();
     void populatePermissionsPropertiesIfNeeded();
     void populatePagePropertiesIfNeeded();
+    void populateContentSecurityPolicyStringsIfNeeded();
 
     InjectedContentVector m_staticInjectedContents;
 
@@ -277,18 +281,21 @@ private:
     RetainPtr<NSString> m_displayActionLabel;
     RetainPtr<NSString> m_actionPopupPath;
 
+    RetainPtr<NSString> m_contentSecurityPolicy;
+
     RetainPtr<NSArray> m_backgroundScriptPaths;
     RetainPtr<NSString> m_backgroundPagePath;
     RetainPtr<NSString> m_backgroundServiceWorkerPath;
     RetainPtr<NSString> m_generatedBackgroundContent;
-    bool m_backgroundContentIsPersistent : 1 { false };
-    bool m_backgroundPageUsesModules : 1 { false };
 
     RetainPtr<NSString> m_optionsPagePath;
     RetainPtr<NSString> m_overrideNewTabPagePath;
 
+    bool m_backgroundContentIsPersistent : 1 { false };
+    bool m_backgroundPageUsesModules : 1 { false };
     bool m_parsedManifest : 1 { false };
     bool m_parsedManifestDisplayStrings : 1 { false };
+    bool m_parsedManifestContentSecurityPolicyStrings : 1 { false };
     bool m_parsedManifestActionProperties : 1 { false };
     bool m_parsedManifestBackgroundProperties : 1 { false };
     bool m_parsedManifestContentScriptProperties : 1 { false };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -83,7 +83,7 @@ static inline void parseTargetInjectionOptions(NSDictionary *targetInfo, WebExte
         Vector<WebExtensionFrameIdentifier> frames;
         for (NSNumber *frameID in frameIDs) {
             auto identifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
-            if (!identifier) {
+            if (!isValid(identifier)) {
                 *outExceptionString = toErrorString(nil, frameIDsKey, @"'%@' is not a frame identifier", frameID);
                 return;
             }
@@ -302,7 +302,7 @@ bool WebExtensionAPIScripting::validateTarget(NSDictionary *targetInfo, NSString
 
     for (NSNumber *frameID in targetInfo[frameIDsKey]) {
         auto identifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
-        if (!identifier) {
+        if (!isValid(identifier)) {
             *outExceptionString = toErrorString(nil, frameIDsKey, @"'%@' is not a frame identifier", frameID);
             return false;
         }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -462,9 +462,9 @@ bool WebExtensionAPITabs::parseSendMessageOptions(NSDictionary *options, std::op
     if (!validateDictionary(options, sourceKey, nil, types, outExceptionString))
         return false;
 
-    if (NSNumber *frameNumber = objectForKey<NSNumber>(options, frameIdKey)) {
-        auto identifier = toWebExtensionFrameIdentifier(frameNumber.doubleValue);
-        if (!identifier) {
+    if (NSNumber *frameID = objectForKey<NSNumber>(options, frameIdKey)) {
+        auto identifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
+        if (!isValid(identifier)) {
             *outExceptionString = toErrorString(nil, frameIdKey, @"it is not a frame identifier");
             return false;
         }
@@ -524,7 +524,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
 
     if (NSNumber *frameID = options[frameIdKey]) {
         auto frameIdentifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
-        if (!frameIdentifier) {
+        if (!isValid(frameIdentifier)) {
             *outExceptionString = toErrorString(nil, frameIdKey, @"it is not a frame identifier");
             return false;
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -94,7 +94,7 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0");
     EXPECT_NS_EQUAL(testExtension.version, @"1.0");
     EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary[@"short_name"] = @"Tst";
     testManifestDictionary[@"version_name"] = @"1.0 Final";
@@ -105,78 +105,78 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0 Final");
     EXPECT_NS_EQUAL(testExtension.version, @"1.0");
     EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 }
 
 TEST(WKWebExtension, ActionParsing)
 {
     NSDictionary *testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" };
     auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ }, @"page_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"safari_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // action should be ignored in manifest v2.
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Manifest v3 looks for the "action" key.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Manifest v3 should never find a browser_action.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Or a page action.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
@@ -184,19 +184,19 @@ TEST(WKWebExtension, ActionParsing)
 
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title", @"default_icon": @"test.png" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title", @"default_icon": @{ @"16": @"test.png" } } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"icons": @{ @"16": @"test.png" }, @"action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 }
@@ -211,21 +211,21 @@ TEST(WKWebExtension, ContentScriptsParsing)
     auto webkitURL = [NSURL URLWithString:@"https://webkit.org/"];
     auto exampleURL = [NSURL URLWithString:@"https://example.com/"];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ], @"exclude_matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
@@ -470,14 +470,14 @@ TEST(WKWebExtension, BackgroundParsing)
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
 #endif
     EXPECT_FALSE(testExtension._backgroundContentUsesModules);
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary[@"background"] = @{ @"page": @"test.html", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
 #if TARGET_OS_IPHONE
     testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test-1.js", @"", @"test-2.js" ], @"persistent": @NO };
@@ -493,21 +493,21 @@ TEST(WKWebExtension, BackgroundParsing)
 #else
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
 #endif
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js" };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     // Invalid cases
 
@@ -620,14 +620,14 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension._backgroundContentUsesModules);
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test.js", @"test2.js" ], @"type": @"module", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension._backgroundContentUsesModules);
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 }
 
 TEST(WKWebExtension, OptionsPageParsing)
@@ -641,7 +641,7 @@ TEST(WKWebExtension, OptionsPageParsing)
     };
 
     auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE(testExtension.hasOptionsPage);
 
     testManifestDictionary = @{
@@ -679,7 +679,7 @@ TEST(WKWebExtension, OptionsPageParsing)
     };
 
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE(testExtension.hasOptionsPage);
 
     testManifestDictionary = @{
@@ -750,7 +750,7 @@ TEST(WKWebExtension, URLOverridesParsing)
     };
 
     auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE(testExtension.hasOverrideNewTabPage);
 
     testManifestDictionary = @{
@@ -764,7 +764,7 @@ TEST(WKWebExtension, URLOverridesParsing)
     };
 
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE(testExtension.hasOverrideNewTabPage);
 
     testManifestDictionary = @{
@@ -818,7 +818,7 @@ TEST(WKWebExtension, URLOverridesParsing)
     };
 
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_EQ(testExtension.errors.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE(testExtension.hasOverrideNewTabPage);
 
     testManifestDictionary = @{
@@ -860,6 +860,53 @@ TEST(WKWebExtension, URLOverridesParsing)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     EXPECT_EQ(testExtension.errors.count, 1ul);
     EXPECT_FALSE(testExtension.hasOverrideNewTabPage);
+}
+
+TEST(WKWebExtension, ContentSecurityPolicyParsing)
+{
+    NSMutableDictionary *testManifestDictionaryV2 = [@{
+        @"manifest_version": @2,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"content_security_policy": @"script-src 'self'; object-src 'self'"
+    } mutableCopy];
+
+    NSMutableDictionary *testManifestDictionaryV3 = [@{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"content_security_policy": @{
+            @"extension_pages": @"script-src 'self'; object-src 'self'"
+        }
+    } mutableCopy];
+
+    auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionaryV2];
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionaryV3];
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionaryV3[@"content_security_policy"] = @{ @"sandbox": @"sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self'" };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionaryV3];
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionaryV3[@"content_security_policy"] = @{ };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionaryV3];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    testManifestDictionaryV2[@"content_security_policy"] = @123;
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionaryV2];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    testManifestDictionaryV2[@"content_security_policy"] = @[ @"invalid", @"type" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionaryV2];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    testManifestDictionaryV3[@"content_security_policy"] = @{ @"extension_pages": @123 };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionaryV3];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -50,7 +50,6 @@ static auto *manifest = @{
 TEST(WKWebExtensionAPIScripting, Errors)
 {
     auto *backgroundScript = Util::constructScript(@[
-
         @"browser.test.assertThrows(() => browser.scripting.executeScript(), /a required argument is missing/i)",
         @"browser.test.assertThrows(() => browser.scripting.executeScript({}), /missing required keys: 'target'./i)",
         @"browser.test.assertThrows(() => browser.scripting.executeScript({'target' : {}}), /missing required keys: 'tabId'./i)",

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -45,7 +45,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -66,7 +66,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -87,7 +87,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -108,7 +108,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -131,7 +131,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -153,7 +153,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -174,7 +174,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -195,7 +195,7 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
@@ -222,7 +222,7 @@ TEST(WKWebExtensionContext, PermissionGranting)
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -148,7 +148,7 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
     _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     NSError *error;
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
@@ -158,19 +158,19 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     manifest[@"background"] = @{ @"service_worker": @"background.js" };
 
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
@@ -179,12 +179,12 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     testContext.baseURL = [NSURL URLWithString:@"test-extension://aaabbbcccddd"];
 
@@ -195,12 +195,12 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 }
 
 TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
@@ -216,7 +216,7 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
     _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
     _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     NSError *error;
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
@@ -226,19 +226,19 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     manifest[@"background"] = @{ @"service_worker": @"main.js", @"type": @"module" };
 
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
@@ -247,7 +247,7 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_EQ(testExtension.errors.count, 0ul);;
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 }
 
 TEST(WKWebExtensionController, ContentScriptLoading)
@@ -294,6 +294,94 @@ TEST(WKWebExtensionController, ContentScriptLoading)
     [webView loadRequest:server.requestWithLocalhost()];
 
     [manager loadAndRun];
+}
+
+TEST(WKWebExtensionController, ContentSecurityPolicyV2BlockingImageLoad)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/image.svg"_s, { { { "Content-Type"_s, "image/svg+xml"_s } }, "<svg xmlns='http://www.w3.org/2000/svg'></svg>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"var img = document.createElement('img')",
+        [NSString stringWithFormat:@"img.src = '%@image.svg'", urlRequest.URL.absoluteString],
+
+        @"img.onerror = () => {",
+        @"  browser.test.notifyPass()",
+        @"}",
+
+        @"img.onload = () => {",
+        @"  browser.test.notifyFail('The image should not load')",
+        @"}",
+
+        @"document.body.appendChild(img)"
+    ]);
+
+    auto *manifest = @{
+        @"manifest_version": @2,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"content_security_policy": @"script-src 'self'; img-src 'none'"
+    };
+
+    Util::loadAndRunExtension(manifest, @{
+        @"background.js": backgroundScript
+    });
+}
+
+TEST(WKWebExtensionController, ContentSecurityPolicyV3BlockingImageLoad)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/image.svg"_s, { { { "Content-Type"_s, "image/svg+xml"_s } }, "<svg xmlns='http://www.w3.org/2000/svg'></svg>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"var img = document.createElement('img')",
+        [NSString stringWithFormat:@"img.src = '%@image.svg'", urlRequest.URL.absoluteString],
+
+        @"img.onerror = () => {",
+        @"  browser.test.notifyPass()",
+        @"}",
+
+        @"img.onload = () => {",
+        @"  browser.test.notifyFail('The image should not load')",
+        @"}",
+
+        @"document.body.appendChild(img)"
+    ]);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"content_security_policy": @{
+            @"extension_pages": @"script-src 'self'; img-src 'none'"
+        }
+    };
+
+    Util::loadAndRunExtension(manifest, @{
+        @"background.js": backgroundScript
+    });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8e6019e50661673605b8787796af42bc1f89805c
<pre>
Support content security policy in Web Extensions.
<a href="https://webkit.org/b/246490">https://webkit.org/b/246490</a>
<a href="https://rdar.apple.com/problem/114823298">rdar://problem/114823298</a>

Reviewed by Brent Fulgham.

* Source/WebCore/en.lproj/Localizable.strings: Updated.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::toAPI):
(WebKit::WebExtension::createError):
(WebKit::WebExtension::errors):
(WebKit::WebExtension::contentSecurityPolicy): Added.
(WebKit::WebExtension::populateContentSecurityPolicyStringsIfNeeded): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::webViewConfiguration): Set _contentSecurityPolicyModeForExtension.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask): Set Content-Security-Policy header.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270225@main">https://commits.webkit.org/270225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d024cff4f4ba33c1721a4502c9f66c01eafcdfd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/872 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27587 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28558 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26380 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3400 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5962 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->