### PR TITLE
REGRESSION (264419@main): [ Sonoma wk2 ] fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html  is a constant failure

### DIFF
--- a/LayoutTests/fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html
+++ b/LayoutTests/fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>This tests that parent clipping is applied properly when ancestor border-radius is present.</title>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4">
 <style>
   .outer {
     overflow: hidden;

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1966,8 +1966,6 @@ webkit.org/b/261356 [ Debug ] fast/mediastream/device-change-event-2.html [ Pass
 
 webkit.org/b/263396 css3/color/text.html [ Skip ]
 
-webkit.org/b/263738 fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html [ ImageOnlyFailure ]
-
 webkit.org/b/263754 [ Sonoma+ x86_64 ] css3/filters/effect-drop-shadow-clip-abspos.html [ ImageOnlyFailure ]
 
 # WebGPU


### PR DESCRIPTION
#### d5dc3aac1d2bb608b116b56263e66bbd5554c2de
<pre>
REGRESSION (264419@main): [ Sonoma wk2 ] fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html  is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263738">https://bugs.webkit.org/show_bug.cgi?id=263738</a>
<a href="https://rdar.apple.com/117547357">rdar://117547357</a>

Unreviewed test gardening.

Add a tiny amount of pixel tolerance.

* LayoutTests/fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270232@main">https://commits.webkit.org/270232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea54377ae0a09c338b9e452a3b04bd156a911787

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27564 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22401 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28548 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/metadata/generated/audioworklet.https.sub.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26370 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/400 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5967 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->