### PR TITLE
Fix system-mac-syscall sandbox violation

### DIFF
--- a/Source/WebKit/Shared/Sandbox/iOS/common.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/common.sb
@@ -32,7 +32,7 @@
     (allow system-mac-syscall (mac-syscall-number 2 4 6 7 67)))
 
 (with-filter (mac-policy-name "AMFI")
-    (allow system-mac-syscall (mac-syscall-number 90)))
+    (allow system-mac-syscall (mac-syscall-number 90 102)))
 #endif
 
 (define-once (allow-read-and-issue-generic-extensions . filters)


### PR DESCRIPTION
#### 5f0070517012bf121ac9be34cc46004c51b75d1e
<pre>
Fix system-mac-syscall sandbox violation
<a href="https://bugs.webkit.org/show_bug.cgi?id=264186">https://bugs.webkit.org/show_bug.cgi?id=264186</a>
<a href="https://rdar.apple.com/117927636">rdar://117927636</a>

Reviewed by Brent Fulgham.

* Source/WebKit/Shared/Sandbox/iOS/common.sb:

Canonical link: <a href="https://commits.webkit.org/270300@main">https://commits.webkit.org/270300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3063a7627c6af584aa73314197be9e62a596328

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22833 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23144 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27573 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2158 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28551 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26373 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/412 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3390 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6013 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->