### PR TITLE
[GPU Process] Ensure that only supported image decoders run in the WebProcess

### DIFF
--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
@@ -146,6 +146,20 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
+Vector<String> allowableImageTypes()
+{
+    auto allowableImageTypes = copyToVector(defaultSupportedImageTypes());
+    auto additionalImageTypes = copyToVector(additionalSupportedImageTypes());
+    allowableImageTypes.appendVector(additionalImageTypes);
+#if HAVE(AVIF)
+    // AVIF might be embedded in a HEIF container. So HEIF/HEIC decoding have
+    // to be allowed to get AVIF decoded.
+    allowableImageTypes.append("public.heif"_s);
+    allowableImageTypes.append("public.heic"_s);
+#endif
+    return allowableImageTypes;
 }
 
-#endif
+} // namespace WebCore
+
+#endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.h
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.h
@@ -35,8 +35,9 @@ MemoryCompactRobinHoodHashSet<String>& additionalSupportedImageTypes();
 WEBCORE_EXPORT void setAdditionalSupportedImageTypes(const Vector<String>&);
 WEBCORE_EXPORT void setAdditionalSupportedImageTypesForTesting(const String&);
 WEBCORE_EXPORT bool isSupportedImageType(const String&);
+WEBCORE_EXPORT Vector<String> allowableImageTypes();
 bool isGIFImageType(StringView);
 String preferredExtensionForImageType(const String& type);
 String MIMETypeForImageType(const String& type);
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/network/mac/UTIUtilities.h
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.h
@@ -35,4 +35,6 @@ RetainPtr<CFStringRef> mimeTypeFromUTITree(CFStringRef);
 WEBCORE_EXPORT String UTIFromMIMEType(const String&);
 bool isDeclaredUTI(const String&);
 WEBCORE_EXPORT String UTIFromTag(const String& tagClass, const String& tag, const String& conformingToUTI);
-}
+WEBCORE_EXPORT void setImageSourceAllowableTypes(const Vector<String>&);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -33,9 +33,14 @@
 #import <wtf/TinyLRUCache.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/WTFString.h>
+#include <wtf/cocoa/VectorCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <MobileCoreServices/MobileCoreServices.h>
+#endif
+
+#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
+#include <pal/spi/cg/ImageIOSPI.h>
 #endif
 
 namespace WebCore {
@@ -149,4 +154,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return u.get();
 }
 
+void setImageSourceAllowableTypes(const Vector<String>& supportedImageTypes)
+{
+#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
+    auto allowableTypes = createNSArray(supportedImageTypes);
+    CGImageSourceSetAllowableTypes((__bridge CFArrayRef)allowableTypes.get());
+#else
+    UNUSED_PARAM(supportedImageTypes);
+#endif
 }
+
+} // namespace WebCore

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -74,11 +74,8 @@
 #if PLATFORM(COCOA)
 #include "ArgumentCodersCocoa.h"
 #include <WebCore/CoreAudioSharedUnit.h>
+#include <WebCore/UTIUtilities.h>
 #include <WebCore/VP9UtilitiesCocoa.h>
-#endif
-
-#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
-#include <pal/spi/cg/ImageIOSPI.h>
 #endif
 
 #if HAVE(SCREEN_CAPTURE_KIT)
@@ -268,9 +265,8 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
     SandboxExtension::consumePermanently(parameters.gpuToolsExtensionHandles);
 #endif
 
-#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
-    auto emptyArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks));
-    CGImageSourceSetAllowableTypes(emptyArray.get());
+#if PLATFORM(COCOA)
+    WebCore::setImageSourceAllowableTypes({ });
 #endif
 
 #if USE(GBM)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -72,6 +72,8 @@
 #import <WebCore/RenderLayer.h>
 #import <WebCore/RenderedDocumentMarker.h>
 #import <WebCore/TextIterator.h>
+#import <WebCore/UTIRegistry.h>
+#import <WebCore/UTIUtilities.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 
@@ -112,6 +114,8 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
 #if PLATFORM(IOS_FAMILY)
     setInsertionPointColor(parameters.insertionPointColor);
 #endif
+    WebCore::setAdditionalSupportedImageTypes(parameters.additionalSupportedImageTypes);
+    WebCore::setImageSourceAllowableTypes(WebCore::allowableImageTypes());
 }
 
 void WebPage::platformDidReceiveLoadParameters(const LoadParameters& parameters)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -336,7 +336,6 @@
 #include "WKStringCF.h"
 #include "WebRemoteObjectRegistry.h"
 #include <WebCore/LegacyWebArchive.h>
-#include <WebCore/UTIRegistry.h>
 #include <pal/spi/cg/ImageIOSPI.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/spi/darwin/SandboxSPI.h>
@@ -964,7 +963,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
 #if PLATFORM(COCOA)
     setSmartInsertDeleteEnabled(parameters.smartInsertDeleteEnabled);
-    WebCore::setAdditionalSupportedImageTypes(parameters.additionalSupportedImageTypes);
 #endif
 
 #if HAVE(APP_ACCENT_COLORS)


### PR DESCRIPTION
#### e2934b9029d0fb8381f11a719a8c33e7df5b18f8
<pre>
[GPU Process] Ensure that only supported image decoders run in the WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=256852">https://bugs.webkit.org/show_bug.cgi?id=256852</a>
<a href="https://rdar.apple.com/109414332">rdar://109414332</a>

Reviewed by Brent Fulgham.

Ensure that ImageIO is allowed to decode only the (default + additional) supported
image types even outside WebKit rendering code path for example displaying a bitmap
image in a PDF document.

This work will be done for WK2 only. WK1 allows setting the prefrences only after
creating the WebView. And we use the prefrences to set the additional supported
image types. So there is no way to pass to know additional supported image types
when the WebView is created. And ImageIO expects CGImageSourceSetAllowableTypes()
to be called only once.

* Source/WebCore/platform/graphics/cg/UTIRegistry.cpp:
(WebCore::allowableImageTypes):
* Source/WebCore/platform/graphics/cg/UTIRegistry.h:
* Source/WebCore/platform/network/mac/UTIUtilities.h:
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::setImageSourceAllowableTypes):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):

Canonical link: <a href="https://commits.webkit.org/270228@main">https://commits.webkit.org/270228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0be58d0a1349909984c834bc86cf364b7a3ccf7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23147 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27576 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28554 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26376 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/411 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3393 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5965 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2555 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->