### PR TITLE
NetworkRTCProvider::doSocketTaskOnRTCNetworkThread should protect iself

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -208,7 +208,7 @@ void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identif
             signalSocketIsClosed(identifier);
             return;
         }
-        callOnRTCNetworkThread([this, identifier, localAddress = RTC::Network::SocketAddress::isolatedCopy(localAddress.rtcAddress()), remoteAddress = RTC::Network::SocketAddress::isolatedCopy(remoteAddress.rtcAddress()), proxyInfo = proxyInfoFromSession(remoteAddress, *session), userAgent = WTFMove(userAgent).isolatedCopy(), options]() mutable {
+        callOnRTCNetworkThread([this, protectedThis = Ref { *this }, identifier, localAddress = RTCNetwork::isolatedCopy(localAddress.value), remoteAddress = RTCNetwork::isolatedCopy(remoteAddress.value), proxyInfo = proxyInfoFromSession(remoteAddress, *session), userAgent = WTFMove(userAgent).isolatedCopy(), options]() mutable {
 
             rtc::PacketSocketTcpOptions tcpOptions;
             tcpOptions.opts = options;
@@ -247,7 +247,7 @@ void NetworkRTCProvider::closeSocket(LibWebRTCSocketIdentifier identifier)
 
 void NetworkRTCProvider::doSocketTaskOnRTCNetworkThread(LibWebRTCSocketIdentifier identifier, Function<void(Socket&)>&& callback)
 {
-    callOnRTCNetworkThread([this, identifier, callback = WTFMove(callback)]() mutable {
+    callOnRTCNetworkThread([this, protectedThis = Ref { *this }, identifier, callback = WTFMove(callback)]() mutable {
         auto iterator = m_sockets.find(identifier);
         if (iterator == m_sockets.end())
             return;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -76,7 +76,7 @@ struct SocketComparator {
     }
 };
 
-class NetworkRTCProvider : private FunctionDispatcher, private IPC::MessageReceiver, public ThreadSafeRefCounted<NetworkRTCProvider> {
+class NetworkRTCProvider : private FunctionDispatcher, private IPC::MessageReceiver, public ThreadSafeRefCounted<NetworkRTCProvider, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<NetworkRTCProvider> create(NetworkConnectionToWebProcess& connection)
     {


### PR DESCRIPTION
#### 8a1af03c50aa7ecc70a9746bd49fe5248cb6deb7
<pre>
NetworkRTCProvider::doSocketTaskOnRTCNetworkThread should protect iself
<a href="https://bugs.webkit.org/show_bug.cgi?id=261200">https://bugs.webkit.org/show_bug.cgi?id=261200</a>
<a href="https://rdar.apple.com/112521277">rdar://112521277</a>

Reviewed by Eric Carlson.

Make sure to ref NetworkRTCProvider before hopping to another thread.
We mark NetworkRTCProvider as DestructionThread::MainRunLoop to ensure it gets destroyed in main run loop.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::createClientTCPSocket):
(WebKit::NetworkRTCProvider::doSocketTaskOnRTCNetworkThread):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:

Originally-landed-as: 5dd0bac29991. rdar://117808918
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a1af03c50aa7ecc70a9746bd49fe5248cb6deb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24884 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3428 "Hash 8a1af03c for PR 19986 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26137 "Hash 8a1af03c for PR 19986 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22839 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5112 "Hash 8a1af03c for PR 19986 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/865 "Hash 8a1af03c for PR 19986 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23149 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25128 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/5112 "Hash 8a1af03c for PR 19986 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/26137 "Hash 8a1af03c for PR 19986 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27580 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/5112 "Hash 8a1af03c for PR 19986 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/26137 "Hash 8a1af03c for PR 19986 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28556 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/5112 "Hash 8a1af03c for PR 19986 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/26137 "Hash 8a1af03c for PR 19986 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2113 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/865 "Hash 8a1af03c for PR 19986 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3397 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/26137 "Hash 8a1af03c for PR 19986 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->