### PR TITLE
macOS: Text cursor in HTML note is black, regardless of set Accent Color

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1893,7 +1893,13 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
         return { };
     return elementStyle.colorResolvingCurrentColor(elementStyle.caretColor());
 #elif HAVE(REDESIGNED_TEXT_CURSOR)
-    if (elementStyle.hasAutoCaretColor() && !elementStyle.hasExplicitlySetColor()) {
+#if HAVE(APP_ACCENT_COLORS) && PLATFORM(MAC)
+    auto appUsesCustomAccentColor = node && node->document().page() && node->document().page()->appUsesCustomAccentColor();
+#else
+    auto appUsesCustomAccentColor = false;
+#endif
+
+    if (elementStyle.hasAutoCaretColor() && (!elementStyle.hasExplicitlySetColor() || appUsesCustomAccentColor)) {
 #if PLATFORM(MAC)
         auto cssColorValue = CSSValueAppleSystemControlAccent;
 #else

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3096,6 +3096,18 @@ Color Page::sampledPageTopColor() const
     return valueOrDefault(m_sampledPageTopColor);
 }
 
+#if HAVE(APP_ACCENT_COLORS) && PLATFORM(MAC)
+void Page::setAppUsesCustomAccentColor(bool appUsesCustomAccentColor)
+{
+    m_appUsesCustomAccentColor = appUsesCustomAccentColor;
+}
+
+bool Page::appUsesCustomAccentColor() const
+{
+    return m_appUsesCustomAccentColor;
+}
+#endif
+
 void Page::setUnderPageBackgroundColorOverride(Color&& underPageBackgroundColorOverride)
 {
     if (underPageBackgroundColorOverride == m_underPageBackgroundColorOverride)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -777,6 +777,11 @@ public:
     WEBCORE_EXPORT Color pageExtendedBackgroundColor() const;
     WEBCORE_EXPORT Color sampledPageTopColor() const;
 
+#if HAVE(APP_ACCENT_COLORS) && PLATFORM(MAC)
+    WEBCORE_EXPORT void setAppUsesCustomAccentColor(bool);
+    WEBCORE_EXPORT bool appUsesCustomAccentColor() const;
+#endif
+
     Color underPageBackgroundColorOverride() const { return m_underPageBackgroundColorOverride; }
     WEBCORE_EXPORT void setUnderPageBackgroundColorOverride(Color&&);
 
@@ -1459,6 +1464,10 @@ private:
 
 #if PLATFORM(IOS_FAMILY)
     String m_sceneIdentifier;
+#endif
+
+#if HAVE(APP_ACCENT_COLORS) && PLATFORM(MAC)
+    bool m_appUsesCustomAccentColor { false };
 #endif
 };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -201,6 +201,9 @@ struct WebPageCreationParameters {
 #endif
 #if HAVE(APP_ACCENT_COLORS)
     WebCore::Color accentColor;
+#if PLATFORM(MAC)
+    bool appUsesCustomAccentColor;
+#endif
 #endif
 #if USE(WPE_RENDERER)
     UnixFileDescriptor hostFileDescriptor;

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -141,6 +141,9 @@ headers: "ArgumentCoders.h"
 #if HAVE(APP_ACCENT_COLORS)
     WebCore::Color accentColor;
 #endif
+#if HAVE(APP_ACCENT_COLORS) && PLATFORM(MAC)
+    bool appUsesCustomAccentColor;
+#endif
 #if USE(WPE_RENDERER)
     UnixFileDescriptor hostFileDescriptor;
 #endif

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -415,6 +415,9 @@ public:
 
 #if HAVE(APP_ACCENT_COLORS)
     virtual WebCore::Color accentColor() = 0;
+#if PLATFORM(MAC)
+    virtual bool appUsesCustomAccentColor() = 0;
+#endif
 #endif
 
     virtual bool effectiveAppearanceIsDark() const { return false; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9650,6 +9650,9 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 #endif
 #if HAVE(APP_ACCENT_COLORS)
     parameters.accentColor = pageClient().accentColor();
+#if PLATFORM(MAC)
+    parameters.appUsesCustomAccentColor = pageClient().appUsesCustomAccentColor();
+#endif
 #endif
     parameters.shouldScaleViewToFitDocument = m_shouldScaleViewToFitDocument;
     parameters.userInterfaceLayoutDirection = pageClient().userInterfaceLayoutDirection();

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -290,6 +290,9 @@ private:
 
 #if HAVE(APP_ACCENT_COLORS)
     WebCore::Color accentColor() override;
+#if PLATFORM(MAC)
+    bool appUsesCustomAccentColor() override;
+#endif
 #endif
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1043,6 +1043,24 @@ WebCore::Color PageClientImpl::accentColor()
 {
     return WebCore::colorFromCocoaColor([NSApp _effectiveAccentColor]);
 }
+
+bool PageClientImpl::appUsesCustomAccentColor()
+{
+    static dispatch_once_t once;
+    static BOOL usesCustomAppAccentColor = NO;
+    dispatch_once(&once, ^{
+        NSBundle *bundleForAccentColor = [NSBundle mainBundle];
+        NSDictionary *info = [bundleForAccentColor infoDictionary];
+        NSString *accentColorName = info[@"NSAccentColorName"];
+        if ([accentColorName length])
+            usesCustomAppAccentColor = !!adoptNS([NSColor colorNamed:accentColorName bundle:bundleForAccentColor]).get();
+
+        if (!usesCustomAppAccentColor && [(accentColorName = info[@"NSAppAccentColorName"]) length])
+            usesCustomAppAccentColor = !!adoptNS([NSColor colorNamed:accentColorName bundle:bundleForAccentColor]).get();
+    });
+
+    return usesCustomAppAccentColor;
+}
 #endif
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -967,6 +967,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
 #if HAVE(APP_ACCENT_COLORS)
     setAccentColor(parameters.accentColor);
+#if PLATFORM(MAC)
+    setAppUsesCustomAccentColor(parameters.appUsesCustomAccentColor);
+#endif
 #endif
 
     m_needsFontAttributes = parameters.needsFontAttributes;
@@ -1220,6 +1223,9 @@ void WebPage::reinitializeWebPage(WebPageCreationParameters&& parameters)
 
 #if HAVE(APP_ACCENT_COLORS)
     setAccentColor(parameters.accentColor);
+#if PLATFORM(MAC)
+    setAppUsesCustomAccentColor(parameters.appUsesCustomAccentColor);
+#endif
 #endif
 
     effectiveAppearanceDidChange(parameters.useDarkAppearance, parameters.useElevatedUserInterfaceLevel);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1922,6 +1922,10 @@ private:
 
 #if HAVE(APP_ACCENT_COLORS)
     void setAccentColor(WebCore::Color);
+#if PLATFORM(MAC)
+    void setAppUsesCustomAccentColor(bool);
+    bool appUsesCustomAccentColor();
+#endif
 #endif
 
     void setMainFrameIsScrollable(bool);
@@ -2591,6 +2595,10 @@ private:
 #endif
 #if HAVE(SCENEKIT)
     bool m_useSceneKitForModel { false };
+#endif
+
+#if HAVE(APP_ACCENT_COLORS)
+    bool m_appUsesCustomAccentColor { false };
 #endif
 
     bool m_textManipulationIncludesSubframes { false };

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1092,6 +1092,13 @@ void WebPage::setAccentColor(WebCore::Color color)
     [NSApp _setAccentColor:cocoaColorOrNil(color).get()];
 }
 
+#if PLATFORM(MAC)
+void WebPage::setAppUsesCustomAccentColor(bool appUsesCustomAccentColor)
+{
+    corePage()->setAppUsesCustomAccentColor(appUsesCustomAccentColor);
+}
+#endif
+
 #endif // HAVE(APP_ACCENT_COLORS)
 
 #if ENABLE(PDF_PLUGIN)


### PR DESCRIPTION
#### ee3805278f958bea3cdf8e44233e870f569b4b44
<pre>
macOS: Text cursor in HTML note is black, regardless of set Accent Color
<a href="https://bugs.webkit.org/show_bug.cgi?id=264189">https://bugs.webkit.org/show_bug.cgi?id=264189</a>
<a href="https://rdar.apple.com/117909679">rdar://117909679</a>

Reviewed by Aditya Keerthi and Tim Horton.

266070@main changed the behavior of the caret color to more closely follow the spec, and improve
web compat. However, this behavior change also affected HTML Notes, which sets `color` on
an ancestor of the editable div. As a result, the caret color is black. However, it should match
the accent color of the app it is in, if it sets a custom accent color.

To fix, implement the same solution as 269314@main effectively, but on macOS.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::paintCaret):
(WebCore::CaretBase::computeCaretColor):
(WebCore::CaretBase::paintCaret const):
(WebCore::DragCaretController::paintDragCaret const):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setAppUsesCustomAccentColor):
(WebCore::Page::appUsesCustomAccentColor const):
* Source/WebCore/page/Page.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::autocorrectionReplacementMarkerColor const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::cachedAppUsesCustomAccentColor):
(WebKit::PageClientImpl::appUsesCustomAccentColor):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):
(WebKit::WebPage::reinitializeWebPage):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::setAppUsesCustomAccentColor):

Canonical link: <a href="https://commits.webkit.org/270325@main">https://commits.webkit.org/270325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05854714e4e8b478220607b700a1fd3fa7ee2770

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23047 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23304 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27807 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28740 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26556 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/619 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3670 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6034 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2763 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2659 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->