### PR TITLE
[iOS] <option> elements outside of an <optgroup> are added to the preceding group

### DIFF
--- a/LayoutTests/fast/forms/ios/select-multiple-options-after-optgroup-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-multiple-options-after-optgroup-expected.txt
@@ -1,0 +1,14 @@
+This test verifies that choosing multiple options which have preceding optgroup siblings works as expected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectValues is ""
+PASS selectValues is "B"
+PASS selectValues is "B,2"
+PASS selectValues is "B,2,D"
+PASS selectValues is "B,2,D,E"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-multiple-options-after-optgroup.html
+++ b/LayoutTests/fast/forms/ios/select-multiple-options-after-optgroup.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select multiple id="select">
+    <option>A</option>
+    <option>B</option>
+    <option>C</option>
+    <optgroup label="Numbers">
+        <option>1</option>
+        <option>2</option>
+        <option>3</option>
+    </optgroup>
+    <option>D</option>
+    <option>E</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+function valuesForSelectElement(element)
+{
+    return Array.from(element.selectedOptions).map(o => o.value).toString();
+}
+
+async function selectRowAndAssertValues(row, values)
+{
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.selectFormAccessoryPickerRow(row);
+    await UIHelper.ensurePresentationUpdate();
+
+    selectValues = valuesForSelectElement(select);
+    shouldBeEqualToString("selectValues", values);
+}
+
+addEventListener("load", async () => {
+    description("This test verifies that choosing multiple options which have preceding optgroup siblings works as expected.");
+
+    selectValues = valuesForSelectElement(select);
+    shouldBeEqualToString("selectValues", "");
+
+    await UIHelper.activateElement(select);
+    await selectRowAndAssertValues(1, "B");
+    await selectRowAndAssertValues(4, "B,2");
+    await selectRowAndAssertValues(6, "B,2,D");
+    await selectRowAndAssertValues(7, "B,2,D,E");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/fast/forms/ios/select-options-after-optgroup-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-options-after-optgroup-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that choosing options which have preceding optgroup siblings works as expected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.value is "A"
+PASS select.value is "B"
+PASS select.value is "2"
+PASS select.value is "D"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-options-after-optgroup.html
+++ b/LayoutTests/fast/forms/ios/select-options-after-optgroup.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select id="select">
+    <option>A</option>
+    <option>B</option>
+    <option>C</option>
+    <optgroup label="Numbers">
+        <option>1</option>
+        <option>2</option>
+        <option>3</option>
+    </optgroup>
+    <option>D</option>
+    <option>E</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that choosing options which have preceding optgroup siblings works as expected.");
+
+    shouldBeEqualToString("select.value", "A");
+
+    await UIHelper.activateElement(select);
+    await UIHelper.waitForContextMenuToShow();
+    await UIHelper.selectFormAccessoryPickerRow(1);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "B");
+
+    await UIHelper.activateElement(select);
+    await UIHelper.waitForContextMenuToShow();
+    await UIHelper.selectFormAccessoryPickerRow(4);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "2");
+
+    await UIHelper.activateElement(select);
+    await UIHelper.waitForContextMenuToShow();
+    await UIHelper.selectFormAccessoryPickerRow(6);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "D");
+
+    finishJSTest();
+});
+</script>
+</html>


### PR DESCRIPTION
#### 4d943d6f341e8a1d5f76e171805e7add1c4e9af9
<pre>
[iOS] &lt;option&gt; elements outside of an &lt;optgroup&gt; are added to the preceding group
<a href="https://bugs.webkit.org/show_bug.cgi?id=264192">https://bugs.webkit.org/show_bug.cgi?id=264192</a>
<a href="https://rdar.apple.com/117930480">rdar://117930480</a>

Reviewed by Wenson Hsieh.

&lt;option&gt; elements are displayed in the UI process by sending over a vector of
options that includes a minimal data representation of &lt;optgroup&gt; and &lt;option&gt;
elements. Currently, &lt;options&gt; are associated with an &lt;optgroup&gt; by incrementing
a counter whenever an &lt;optgroup&gt; is encountered, and then storing the current
counter value on the &lt;option&gt; representation.

The current approach is flawed when an &lt;optgroup&gt; terminates, and is followed by
&lt;option&gt; elements outside of a group. In this case, the counter is not incremented,
and the options are associated with the preceding group.

To fix, keep track of the current &lt;optgroup&gt; element, and when an option that no
longer belongs to the current &lt;optgroup&gt; is encountered, insert a &quot;fake&quot; group and
increment the counter. This approach ensures that trailing &lt;options&gt; do not appear
as part of the preceding group. This fix is not applied for the picker wheel UI
used in bincompat scenarios, as the UI does not allow for ungrouped options to be
distinguished.

Additionally, fix the appearance of groups with no items and groups missing a title,
to exclude a disclosure button, and remove padding, respectively.

* LayoutTests/fast/forms/ios/select-multiple-options-after-optgroup-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-multiple-options-after-optgroup.html: Added.
* LayoutTests/fast/forms/ios/select-options-after-optgroup-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-options-after-optgroup.html: Added.
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker createMenu]):
(-[WKSelectPickerGroupHeaderView initWithGroupName:section:isCollapsible:]):
(-[WKSelectPickerGroupHeaderView setCollapsed:animated:]):
(-[WKSelectPickerTableViewController tableView:heightForHeaderInSection:]):

Groups without a title should appear as a smaller amount of padding, rather
than a full size header.

(-[WKSelectPickerTableViewController tableView:viewForHeaderInSection:]):

Empty groups are not collapsible, and should not show a disclosure button.

(-[WKSelectPickerTableViewController didTapSelectPickerGroupHeaderView:]):
(-[WKSelectPickerGroupHeaderView initWithGroupName:section:]): Deleted.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):

Keep track of the current &lt;optgroup&gt; element when one is encountered. If the
next &lt;option&gt; does not belong to the same group, make it part of a new group
with an empty title.

Canonical link: <a href="https://commits.webkit.org/270235@main">https://commits.webkit.org/270235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40e501ef89020c137b7e0ec0f72587ec1d1e667

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22855 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23157 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27598 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2172 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28566 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22769 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26388 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/425 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22171 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2572 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3179 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->