### PR TITLE
Scroll To Text Fragement re-loads after every dynamic style sheet load, and fights user scrolls to do so.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load-expected.txt
@@ -1,0 +1,3 @@
+PASS: Page scrolls to correct Text Fragment.
+PASS: Addition of dynamic style element did not adjust scroll.
+

--- a/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - ensure that loading a stylesheet doesn't cause the page to re-scroll</title>
+<meta name="assert" content="This test checks that loading a stylesheet doesn't cause the page to re-scroll.">
+
+<head>
+<script src="/js-test-resources/ui-helper.js"></script>
+
+<script>
+
+    document.addEventListener('readystatechange', () => {
+        if (document.readyState !== 'interactive')
+            return;
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.type = 'text/css';
+        link.media = 'all';
+        link.property = 'stylesheet';
+        link.href = 'not-even-a-file.css';
+        document.body.appendChild(link);
+    });
+
+    function adjustStyle() {
+        const head = document.head || document.getElementsByTagName("head")[0];
+        const styleElement = document.createElement('style');
+
+        styleElement.type = "text/css";
+        head.appendChild(styleElement);
+        const css = '#matches-nothing-in-dom {}';
+        const cssNode = document.createTextNode(css);
+        const childNodes = styleElement.childNodes;
+        const child = childNodes[0];
+
+        if (child)
+            styleElement.replaceChild(cssNode, child);
+        else
+            styleElement.appendChild(cssNode);
+    }
+
+    if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    }
+
+  
+ async function runTest()
+ {
+    if (!testRunner.runUIScript)
+        return;
+
+    location.href = "#:~:text=Scroll%20Point";
+    var output = "";
+
+    await UIHelper.ensurePresentationUpdate();
+
+    if (window.pageYOffset > 0)
+      output += "PASS: Page scrolls to correct Text Fragment.";
+    else 
+      output += "FAIL: Page does not scroll to correct Text Fragment.";
+    output += '<br>';
+
+    var scrollOffset = window.pageYOffset;
+
+    await UIHelper.initiateUserScroll();
+
+    adjustStyle();
+
+    await UIHelper.renderingUpdate();
+
+    if (window.pageYOffset != scrollOffset)
+      output += "PASS: Addition of dynamic style element did not adjust scroll.";
+    else
+      output += "FAIL: Addition of dynamic style element causes page to re-scroll. First Scroll: " + scrollOffset + " Second Scroll: " + window.pageYOffset;
+    output += '<br>';
+
+    var target = document.getElementById('target');
+    target.innerHTML = output;
+    target.style.paddingTop = "0px";
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+  }
+
+  window.addEventListener('load', () => {
+    runTest();
+  }, false);
+</script>
+</head>
+
+<body>
+    <div id="target" style="padding-top: 10000px;">
+    
+        <p>Scroll Point</p>
+
+    </div>
+</body>
+</html>
+

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2648,6 +2648,8 @@ fast/canvas/font-family-system-ui-canvas.html [ Skip ]
 
 fast/line-grid [ Skip ]
 
+http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html [ Skip ]
+
 # Flaky tests Nov2023
 webkit.org/b/264680 compositing/transitions/transform-on-large-layer.html [ ImageOnlyFailure Pass ]
 webkit.org/b/264680 fast/canvas/offscreen-backing-store-attached.html [ ImageOnlyFailure Pass ]

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -521,6 +521,16 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => setTimeout(resolve, ms));
     }
 
+    static async initiateUserScroll()
+    {
+        if (this.isIOSFamily()) {
+            await UIHelper.scrollTo(0, 10);
+        }
+        else {
+            await UIHelper.statelessMouseWheelScrollAt(10, 10, 0, 10);
+        }
+    }
+
     static scrollTo(x, y, unconstrained)
     {
         if (!this.isWebKit2()) {

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4665,6 +4665,10 @@ void LocalFrameView::setWasScrolledByUser(bool wasScrolledByUser)
     cancelScheduledScrolls();
     if (currentScrollType() == ScrollType::Programmatic)
         return;
+
+    if (wasScrolledByUser)
+        m_frame->document()->setGotoAnchorNeededAfterStylesheetsLoad(false);
+
     m_maintainScrollPositionAnchor = nullptr;
     if (m_wasScrolledByUser == wasScrolledByUser)
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12261,6 +12261,7 @@ void WebPageProxy::detectDataInAllFrames(OptionSet<WebCore::DataDetectorType> ty
         completionHandler({ });
         return;
     }
+
     sendWithAsyncReply(Messages::WebPage::DetectDataInAllFrames(types), WTFMove(completionHandler));
 }
 


### PR DESCRIPTION
#### 2dd5d4cec216fe15f1571fda3d2b578056e5ce75
<pre>
Scroll To Text Fragement re-loads after every dynamic style sheet load, and fights user scrolls to do so.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264195">https://bugs.webkit.org/show_bug.cgi?id=264195</a>
<a href="https://rdar.apple.com/112608578">rdar://112608578</a>

Reviewed by Simon Fraser.

In order to account for style changes adjusting the scroll of the page, after each dynamic style
sheet load, we recall scrollToFragment to set the page at the correct position again.

We need to stop automatically scrolling after the user has scrolled, as user scroll should trump
all URL programatic scrolls. So we reset the flag that causes scrolls to happen when a user scroll is
detected.

* LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async initiateUserScroll):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::didRemoveAllPendingStylesheet):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragment):
(WebCore::LocalFrameView::setWasScrolledByUser):
* Source/WebCore/page/LocalFrameView.h:

Canonical link: <a href="https://commits.webkit.org/272151@main">https://commits.webkit.org/272151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e9957e1a66c7d746c07a3f862023215d8a253bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33232 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6671 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6776 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33088 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30920 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27164 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7268 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->