### PR TITLE
Deprecate _WKFrameHandle.frameID

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.h
@@ -29,6 +29,6 @@
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface _WKFrameHandle : NSObject <NSCopying, NSSecureCoding>
 
-@property (nonatomic, readonly) uint64_t frameID WK_API_AVAILABLE(macos(12.0), ios(15.0));
+@property (nonatomic, readonly) uint64_t frameID WK_API_DEPRECATED("With site isolation, this identifier may collide with frame identifiers generated in another process", macos(12.0, WK_MAC_TBA), ios(15.0, WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
@@ -103,7 +103,7 @@
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-    [coder encodeObject:@(self.frameID) forKey:@"frameID"];
+    [coder encodeObject:@(_frameHandle->frameID().object().toUInt64()) forKey:@"frameID"];
     [coder encodeObject:@(_frameHandle->frameID().processIdentifier().toUInt64()) forKey:@"processID"];
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -116,7 +116,12 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WKFrameInfo *fr
     if (frameInfo.isMainFrame)
         return WebExtensionFrameConstants::MainFrameIdentifier;
 
+    // FIXME: <rdar://117932176> Stop using FrameIdentifier/_WKFrameHandle for WebExtensionFrameIdentifier,
+    // which needs to be just one number and probably should only be generated in the UI process
+    // to prevent collisions with numbers generated in different web content processes, especially with site isolation.
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WebExtensionFrameIdentifier result { frameInfo._handle.frameID };
+ALLOW_DEPRECATED_DECLARATIONS_END
     ASSERT(result.isValid());
     return result;
 }

--- a/Source/WebKit/UIProcess/API/C/WKFrameHandleRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKFrameHandleRef.h
@@ -34,7 +34,7 @@ extern "C" {
 
 WK_EXPORT WKTypeID WKFrameHandleGetTypeID();
 
-WK_EXPORT uint64_t WKFrameHandleGetFrameID(WKFrameHandleRef);
+WK_EXPORT uint64_t WKFrameHandleGetFrameID(WKFrameHandleRef) WK_C_API_DEPRECATED_WITH_MESSAGE("With site isolation, this identifier may collide with frame identifiers generated in another process");
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1175,10 +1175,8 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
     }
     
     std::optional<WebCore::FrameIdentifier> frameID;
-    if (frame) {
-        if (frame._handle.frameID)
-            frameID = frame._handle->_frameHandle->frameID();
-    }
+    if (frame && frame._handle && frame._handle->_frameHandle->frameID())
+        frameID = frame._handle->_frameHandle->frameID();
 
     auto removeTransientActivation = WebKit::shouldEvaluateJavaScriptWithoutTransientActivation() ? WebCore::RemoveTransientActivation::Yes : WebCore::RemoveTransientActivation::No;
     _page->runJavaScriptInFrameInScriptWorld({ javaScriptString, JSC::SourceTaintedOrigin::Untainted, sourceURL, !!asAsyncFunction, WTFMove(argumentsMap), !!forceUserGesture, removeTransientActivation }, frameID, *world->_contentWorld.get(), [handler] (auto&& result) {

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2739,7 +2739,9 @@ String TestController::saltForOrigin(WKFrameRef frame, String originHash)
     auto& settings = settingsForOrigin(originHash);
     auto& ephemeralSalts = settings.ephemeralSalts();
     auto frameHandle = adoptWK(WKFrameCreateFrameHandle(frame));
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     uint64_t frameIdentifier = WKFrameHandleGetFrameID(frameHandle.get());
+ALLOW_DEPRECATED_DECLARATIONS_END
     String frameSalt = ephemeralSalts.get(frameIdentifier);
 
     if (settings.persistentPermission()) {


### PR DESCRIPTION
#### 30f6d58c1ad8d7059ff4536c00081fb7520f3f1d
<pre>
Deprecate _WKFrameHandle.frameID
<a href="https://bugs.webkit.org/show_bug.cgi?id=264199">https://bugs.webkit.org/show_bug.cgi?id=264199</a>
<a href="https://rdar.apple.com/117936267">rdar://117936267</a>

Reviewed by Timothy Hatcher.

With site isolation, different processes can generate the number that is returned by this SPI,
which means it is no longer guaranteed to be unique within a page.  Deprecate it to discourage
future adoption and to allow me to catalog the work it will take to migrate.  I filed <a href="https://rdar.apple.com/117936088">rdar://117936088</a>
and <a href="https://rdar.apple.com/117932176">rdar://117932176</a> to track that work.

* Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.h:
* Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm:
(-[_WKFrameHandle encodeWithCoder:]):
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
(WebKit::toWebExtensionFrameIdentifier):
* Source/WebKit/UIProcess/API/C/WKFrameHandleRef.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::saltForOrigin):

Canonical link: <a href="https://commits.webkit.org/270269@main">https://commits.webkit.org/270269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff39afba72a125e24f13a2f9bc4306716c6acfa5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27608 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28572 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2580 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3184 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->