### PR TITLE
WebXRSession should not hold a unique ptr to WebXRViewerSpace which is ref counted

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -64,7 +64,7 @@ WebXRSession::WebXRSession(Document& document, WebXRSystem& system, XRSessionMod
     , m_device(device)
     , m_requestedFeatures(WTFMove(requestedFeatures))
     , m_activeRenderState(WebXRRenderState::create(mode))
-    , m_viewerReferenceSpace(makeUnique<WebXRViewerSpace>(document, *this))
+    , m_viewerReferenceSpace(WebXRViewerSpace::create(document, *this))
     , m_timeOrigin(MonotonicTime::now())
     , m_views(device.views(mode))
 {

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -99,7 +99,7 @@ public:
 
     const Vector<PlatformXR::Device::ViewData>& views() const { return m_views; }
     const PlatformXR::Device::FrameData& frameData() const { return m_frameData; }
-    const WebXRViewerSpace& viewerReferenceSpace() const { return *m_viewerReferenceSpace; }
+    const WebXRViewerSpace& viewerReferenceSpace() const { return m_viewerReferenceSpace; }
     bool posesCanBeReported(const Document&) const;
     
 #if ENABLE(WEBXR_HANDS)
@@ -147,7 +147,7 @@ private:
     FeatureList m_requestedFeatures;
     RefPtr<WebXRRenderState> m_activeRenderState;
     RefPtr<WebXRRenderState> m_pendingRenderState;
-    std::unique_ptr<WebXRViewerSpace> m_viewerReferenceSpace;
+    Ref<WebXRViewerSpace> m_viewerReferenceSpace;
     MonotonicTime m_timeOrigin;
 
     unsigned m_nextCallbackId { 1 };

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -73,18 +73,26 @@ private:
 // https://immersive-web.github.io/webxr/#xrsession-viewer-reference-space
 // This is a helper class to implement the viewer space owned by a WebXRSession.
 // It avoids a circular reference between the session and the reference space.
-class WebXRViewerSpace : public WebXRSpace {
+class WebXRViewerSpace : public RefCounted<WebXRViewerSpace>, public WebXRSpace {
     WTF_MAKE_ISO_ALLOCATED(WebXRViewerSpace);
 public:
-    WebXRViewerSpace(Document&, WebXRSession&);
+    static Ref< WebXRViewerSpace> create(Document& document, WebXRSession& session)
+    {
+        return adoptRef(*new WebXRViewerSpace(document, session));
+    }
     virtual ~WebXRViewerSpace();
 
+    using RefCounted::ref;
+    using RefCounted::deref;
+
 private:
+    WebXRViewerSpace(Document&, WebXRSession&);
+
     WebXRSession* session() const final { return m_session.get(); }
     std::optional<TransformationMatrix> nativeOrigin() const final;
 
-    void refEventTarget() final { RELEASE_ASSERT_NOT_REACHED(); }
-    void derefEventTarget() final { RELEASE_ASSERT_NOT_REACHED(); }
+    void refEventTarget() final { ref(); }
+    void derefEventTarget() final { deref(); }
 
     WeakPtr<WebXRSession> m_session;
 };


### PR DESCRIPTION
#### 67e35fd334d59ec2e9d3294b843884dcecdca493
<pre>
WebXRSession should not hold a unique ptr to WebXRViewerSpace which is ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=264200">https://bugs.webkit.org/show_bug.cgi?id=264200</a>
<a href="https://rdar.apple.com/115180471">rdar://115180471</a>

Reviewed by Chris Dumez.

WebXRViewerSpace subclasses EventTarget and therefore should be ref-counted.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::WebXRSession):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSpace.h:
(WebCore::WebXRViewerSpace::create):

Canonical link: <a href="https://commits.webkit.org/270230@main">https://commits.webkit.org/270230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d5d803a9022e6e38fc4d714514f7cab810e40cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23164 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27611 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28575 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26400 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/437 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3419 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5966 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->