### PR TITLE
[CSS Highlight API] REGRESSION(270146@main): Crash trying to serialize `::highlight`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt
@@ -3,6 +3,7 @@ PASS "::highlight(foo)" should be a valid selector
 PASS ".a::highlight(foo)" should be a valid selector
 PASS "div ::highlight(foo)" should be a valid selector
 PASS "::part(my-part)::highlight(foo)" should be a valid selector
+PASS "::highlight" should be an invalid selector
 PASS "::before::highlight(foo)" should be an invalid selector
 PASS "::highlight(foo).a" should be an invalid selector
 PASS "::highlight(foo) div" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing.html
@@ -7,11 +7,12 @@
 <script src="/css/support/parsing-testcommon.js"></script>
 <script>
   const pseudo = "::highlight(foo)";
-  test_valid_selector(`${pseudo}`);
+  test_valid_selector(pseudo);
   test_valid_selector(`.a${pseudo}`);
   test_valid_selector(`div ${pseudo}`);
   test_valid_selector(`::part(my-part)${pseudo}`);
 
+  test_invalid_selector("::highlight");
   test_invalid_selector(`::before${pseudo}`);
   test_invalid_selector(`${pseudo}.a`);
   test_invalid_selector(`${pseudo} div`);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements-expected.txt
@@ -1,0 +1,3 @@
+
+PASS CSSOM: Test that rules with invalid pseudo elements are not found
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: Test that rules with invalid pseudo elements are not found</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    ::part {}
+    ::slotted {}
+    ::highlight {}
+</style>
+<script>
+    test(() => {
+        assert_equals(document.styleSheets[0].cssRules[0]?.selectorText, undefined, "No associated selectorText");
+        assert_equals(document.styleSheets[0].cssRules[0], undefined, "No invalid pseudo element rule should be found");
+    });
+</script>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -764,10 +764,11 @@ static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClassType pseudoClassTy
     
 static bool isOnlyPseudoElementFunction(CSSSelector::PseudoElementType pseudoElementType)
 {
-    // Note that we omit cue since it can be either an ident or a function.
+    // Note that we omit ::cue since it can be either an ident or a function.
     switch (pseudoElementType) {
     case CSSSelector::PseudoElementPart:
     case CSSSelector::PseudoElementSlotted:
+    case CSSSelector::PseudoElementHighlight:
         return true;
     default:
         break;


### PR DESCRIPTION
#### f3dcaa105e40967837c37e998f2383c22ec0b99c
<pre>
[CSS Highlight API] REGRESSION(270146@main): Crash trying to serialize `::highlight`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264204">https://bugs.webkit.org/show_bug.cgi?id=264204</a>
<a href="https://rdar.apple.com/117943689">rdar://117943689</a>

Reviewed by Simon Fraser.

270146@main made the correct assumption that `::highlight` should not parse without a function argument...

Except it does parse successfully, this leads to this testcase crashing:
```
&lt;style&gt;
    ::highlight {}
&lt;/style&gt;
&lt;script&gt;
  onload = () =&gt; {
    document.styleSheets[0].cssRules[0].selectorText;
  };
&lt;/script&gt;
```

In this testcase, document.styleSheets[0].cssRules[0] should be undefined.

Reject `::highlight` with no argument at parse-time and add related WPTs.

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements.html: Added.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isOnlyPseudoElementFunction):

Canonical link: <a href="https://commits.webkit.org/270229@main">https://commits.webkit.org/270229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eba19ae35517732ee0c4161e88ff6065d977b6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23170 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27619 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28582 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/443 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22187 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2591 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3177 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->