### PR TITLE
Build failure of AccessibilityNotificationHandler.cpp

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp
@@ -43,6 +43,7 @@ AccessibilityNotificationHandler::AccessibilityNotificationHandler(JSValueRef ca
     : m_callback(callback)
     , m_element(element)
 {
+#if ENABLE(DEVELOPER_MODE)
     WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
     JSContextRef jsContext = WKBundleFrameGetJavaScriptContext(mainFrame);
     JSValueProtect(jsContext, m_callback);
@@ -88,15 +89,18 @@ AccessibilityNotificationHandler::AccessibilityNotificationHandler(JSValueRef ca
             JSObjectCallAsFunction(jsContext, const_cast<JSObjectRef>(m_callback), 0, 3, arguments, 0);
         }
     });
+#endif
 }
 
 AccessibilityNotificationHandler::~AccessibilityNotificationHandler()
 {
+#if ENABLE(DEVELOPER_MODE)
     WebCore::AccessibilityAtspi::singleton().removeNotificationObserver(this);
 
     WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
     JSContextRef jsContext = WKBundleFrameGetJavaScriptContext(mainFrame);
     JSValueUnprotect(jsContext, m_callback);
+#endif
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### 81c9728fe7d7b969963cbcad390c188526df558a
<pre>
Build failure of AccessibilityNotificationHandler.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264207">https://bugs.webkit.org/show_bug.cgi?id=264207</a>

Reviewed by NOBODY (OOPS!).

The constructor and destructor of AccessibilityNotificationHandler use the
methods guarded by DEVELOPER_MODE.

* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp:
(WTR::AccessibilityNotificationHandler::AccessibilityNotificationHandler):
(WTR::AccessibilityNotificationHandler::~AccessibilityNotificationHandler):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81c9728fe7d7b969963cbcad390c188526df558a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24930 "Failed to checkout and rebase branch from PR 19999") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/3473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26183 "Failed to checkout and rebase branch from PR 19999") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/27046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22882 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/25198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/5164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/27046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25174 "Failed to checkout and rebase branch from PR 19999") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/5164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/26183 "Failed to checkout and rebase branch from PR 19999") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/5164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/26183 "Failed to checkout and rebase branch from PR 19999") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/27626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/5164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/26183 "Failed to checkout and rebase branch from PR 19999") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/26183 "Failed to checkout and rebase branch from PR 19999") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->