### PR TITLE
Build failure of AccessibilityNotificationHandler.cpp

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp
@@ -44,6 +44,7 @@ AccessibilityNotificationHandler::AccessibilityNotificationHandler(JSValueRef ca
     , m_element(element)
 {
     WKAccessibilityEnable();
+#if ENABLE(DEVELOPER_MODE)
     WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
     JSContextRef jsContext = WKBundleFrameGetJavaScriptContext(mainFrame);
     JSValueProtect(jsContext, m_callback);
@@ -89,15 +90,18 @@ AccessibilityNotificationHandler::AccessibilityNotificationHandler(JSValueRef ca
             JSObjectCallAsFunction(jsContext, const_cast<JSObjectRef>(m_callback), 0, 3, arguments, 0);
         }
     });
+#endif
 }
 
 AccessibilityNotificationHandler::~AccessibilityNotificationHandler()
 {
+#if ENABLE(DEVELOPER_MODE)
     WebCore::AccessibilityAtspi::singleton().removeNotificationObserver(this);
 
     WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
     JSContextRef jsContext = WKBundleFrameGetJavaScriptContext(mainFrame);
     JSValueUnprotect(jsContext, m_callback);
+#endif
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### 0335988960faf5c9255a4769389625cd8150392b
<pre>
Build failure of AccessibilityNotificationHandler.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264207">https://bugs.webkit.org/show_bug.cgi?id=264207</a>

Reviewed by Michael Catanzaro.

The constructor and destructor of AccessibilityNotificationHandler use methods
guarded by DEVELOPER_MODE.

* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp:
(WTR::AccessibilityNotificationHandler::AccessibilityNotificationHandler):
(WTR::AccessibilityNotificationHandler::~AccessibilityNotificationHandler):

Canonical link: <a href="https://commits.webkit.org/270333@main">https://commits.webkit.org/270333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea3bff5e42521f975a5b73206e5c661b2eee135a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23014 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23278 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27766 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28714 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/589 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3611 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6039 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2727 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2624 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->