### PR TITLE
Fix some i18n (localization) issues with Web Extensions.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, copy) NSDictionary *localizationDictionary;
 
 - (instancetype)initWithWebExtension:(WebKit::WebExtension&)webExtension;
+- (instancetype)initWithLocalizedDictionary:(nullable NSDictionary<NSString *, NSDictionary *> *)localizedDictionary uniqueIdentifier:(NSString *)uniqueIdentifier;
 - (instancetype)initWithRegionalLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)regionalLocalization languageLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)languageLocalization defaultLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)defaultLocalization withBestLocale:(nullable NSString *)localeString uniqueIdentifier:(nullable NSString *)uniqueIdentifier NS_DESIGNATED_INITIALIZER;
 
 - (NSDictionary<NSString *, id> *)localizedDictionaryForDictionary:(NSDictionary<NSString *, id> *)dictionary;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -101,7 +101,7 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
             }
         }
 
-        NSData *fileData = extensionContext->extension().resourceDataForPath(requestURL.path().toString());
+        auto *fileData = extensionContext->extension().resourceDataForPath(requestURL.path().toString());
         if (!fileData) {
             task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil]);
             return;
@@ -114,22 +114,19 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
             }
         }
 
-        NSString *mimeType = [UTType typeWithFilenameExtension:((NSURL *)requestURL).pathExtension].preferredMIMEType;
+        auto *mimeType = [UTType typeWithFilenameExtension:((NSURL *)requestURL).pathExtension].preferredMIMEType;
         if (!mimeType)
             mimeType = @"application/octet-stream";
 
         if ([mimeType isEqualToString:@"text/css"]) {
-            _WKWebExtensionLocalization *localization = extensionContext->extension().localization();
-            if (!localization.uniqueIdentifier)
-                localization.uniqueIdentifier = extensionContext->uniqueIdentifier();
-
             // FIXME: <https://webkit.org/b/252628> Only attempt to localize CSS files if we notice a localization wildcard in the file's NSData.
-            NSString *stylesheetContents = [[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding];
+            auto *localization = extensionContext->extension().localization();
+            auto *stylesheetContents = [[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding];
             stylesheetContents = [localization localizedStringForString:stylesheetContents];
             fileData = [stylesheetContents dataUsingEncoding:NSUTF8StringEncoding];
         }
 
-        NSHTTPURLResponse *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:requestURL statusCode:200 HTTPVersion:nil headerFields:@{
+        auto *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:requestURL statusCode:200 HTTPVersion:nil headerFields:@{
             @"Access-Control-Allow-Origin": @"*",
             @"Content-Security-Policy": extensionContext->extension().contentSecurityPolicy(),
             @"Content-Length": [NSString stringWithFormat:@"%zu", (size_t)fileData.length],

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -84,6 +84,7 @@ public:
 
     enum class CacheResult : bool { No, Yes };
     enum class SuppressNotification : bool { No, Yes };
+    enum class SuppressNotFoundErrors : bool { No, Yes };
 
     enum class Error : uint8_t {
         Unknown = 1,
@@ -164,8 +165,8 @@ public:
 
     UTType *resourceTypeForPath(NSString *);
 
-    NSString *resourceStringForPath(NSString *, CacheResult = CacheResult::No);
-    NSData *resourceDataForPath(NSString *, CacheResult = CacheResult::No);
+    NSString *resourceStringForPath(NSString *, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
+    NSData *resourceDataForPath(NSString *, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
 
     _WKWebExtensionLocalization *localization();
     NSLocale *defaultLocale();

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -75,7 +75,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
     auto updateProperties = [&](WebExtensionContextProxy& context) {
         context.m_baseURL = parameters.baseURL;
         context.m_uniqueIdentifier = parameters.uniqueIdentifier;
-        context.m_localization = parseLocalization(parameters.localizationJSON.get());
+        context.m_localization = parseLocalization(parameters.localizationJSON.get(), parameters.baseURL);
         context.m_manifest = parseJSON(parameters.manifestJSON.get());
         context.m_manifestVersion = parameters.manifestVersion;
         context.m_testingMode = parameters.testingMode;
@@ -120,13 +120,9 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
     return result.releaseNonNull();
 }
 
-_WKWebExtensionLocalization *WebExtensionContextProxy::parseLocalization(API::Data& json)
+_WKWebExtensionLocalization *WebExtensionContextProxy::parseLocalization(API::Data& json, const URL& baseURL)
 {
-    NSDictionary *localizedDictionary = parseJSON(json);
-    if (!localizedDictionary)
-        return nil;
-
-    return [[_WKWebExtensionLocalization alloc] initWithRegionalLocalization:localizedDictionary languageLocalization:nil defaultLocalization:nil withBestLocale:localizedDictionary[@"@@ui_locale"][@"message"] uniqueIdentifier:nil];
+    return [[_WKWebExtensionLocalization alloc] initWithLocalizedDictionary:parseJSON(json) uniqueIdentifier:baseURL.host().toString()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -80,8 +80,6 @@ public:
 
     _WKWebExtensionLocalization *localization() { return m_localization.get(); }
 
-    static _WKWebExtensionLocalization *parseLocalization(API::Data&);
-
     bool inTestingMode() { return m_testingMode; }
 
     static WebCore::DOMWrapperWorld& mainWorld() { return WebCore::mainThreadNormalWorld(); }
@@ -116,6 +114,8 @@ public:
 
 private:
     explicit WebExtensionContextProxy(const WebExtensionContextParameters&);
+
+    static _WKWebExtensionLocalization *parseLocalization(API::Data&, const URL& baseURL);
 
     // Action
     void dispatchActionClickedEvent(const std::optional<WebExtensionTabParameters>&);


### PR DESCRIPTION
#### ad7f91327f7f464c852905d7545926b5d352c97b
<pre>
Fix some i18n (localization) issues with Web Extensions.
<a href="https://webkit.org/b/264211">https://webkit.org/b/264211</a>
<a href="https://rdar.apple.com/problem/117948039">rdar://problem/117948039</a>

Reviewed by Brian Weinstein.

* Remove a FIXME for &lt;<a href="https://webkit.org/b/261047">https://webkit.org/b/261047</a>&gt; Handle multiple unique identifiers for localization.
  This wasn&apos;t needed after all since the @@extension_id message can&apos;t be used in the manifest.
* Supply the @@extension_id key with the extension&apos;s base URL host in the WebProcess.
* Suppress errors for file not found when attempting to discover localization message files.
* Don&apos;t attempt to read the same file twice if the default_locale matches the language or regional name.
* Don&apos;t support locale predefined messages when there is no default_locale.
* Bail early in more places if there are no localized strings.
* Removed some unused NSCoding key strings.
* Added more tests to cover these changes.

* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm:
(-[_WKWebExtensionLocalization initWithWebExtension:]):
(-[_WKWebExtensionLocalization initWithLocalizedDictionary:uniqueIdentifier:]): Added.
(-[_WKWebExtensionLocalization initWithRegionalLocalization:languageLocalization:defaultLocalization:withBestLocale:uniqueIdentifier:]):
(-[_WKWebExtensionLocalization localizedDictionaryForDictionary:]):
(-[_WKWebExtensionLocalization localizedStringForKey:withPlaceholders:]):
(-[_WKWebExtensionLocalization _localizedArrayForArray:]):
(-[_WKWebExtensionLocalization _localizationDictionaryForWebExtension:withLocale:]):
(-[_WKWebExtensionLocalization _predefinedMessages]):
(-[_WKWebExtensionLocalization _predefinedMessagesForLocale:]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceStringForPath):
(WebKit::WebExtension::resourceDataForPath):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
(WebKit::WebExtensionContextProxy::parseLocalization):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270279@main">https://commits.webkit.org/270279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68b546ca342afec08ef1229c5e3fd7cb30913557

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23180 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27634 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28592 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/458 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2606 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3190 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->