### PR TITLE
[WebCore] Optimize BMPImageReader

### DIFF
--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -383,8 +383,8 @@ bool BMPImageReader::processBitmasks()
         // supposed to be ignored in non-BITFIELDS cases.
         // 16 bits:    MSB <-                     xRRRRRGG GGGBBBBB -> LSB
         // 24/32 bits: MSB <- [AAAAAAAA] RRRRRRRR GGGGGGGG BBBBBBBB -> LSB
-        const int numBits = (m_infoHeader.biBitCount == 16) ? 5 : 8;
-        for (int i = 0; i <= 2; ++i)
+        const unsigned numBits = (m_infoHeader.biBitCount == 16) ? 5 : 8;
+        for (unsigned i = 0; i <= 2; ++i)
             m_bitMasks[i] = ((static_cast<uint32_t>(1) << (numBits * (3 - i))) - 1) ^ ((static_cast<uint32_t>(1) << (numBits * (2 - i))) - 1);
 
         // For Windows V4+ 32-bit RGB, don't overwrite the alpha mask from the
@@ -423,7 +423,7 @@ bool BMPImageReader::processBitmasks()
     m_needToProcessBitmasks = false;
 
     // Check masks and set shift values.
-    for (int i = 0; i < 4; ++i) {
+    for (unsigned i = 0; i < 4; ++i) {
         // Trim the mask to the allowed bit depth.  Some Windows V4+ BMPs
         // specify a bogus alpha channel in bits that don't exist in the pixel
         // data (for example, bits 25-31 in a 24-bit RGB format).
@@ -440,18 +440,18 @@ bool BMPImageReader::processBitmasks()
         }
 
         // Make sure bitmask does not overlap any other bitmasks.
-        for (int j = 0; j < i; ++j) {
+        for (unsigned j = 0; j < i; ++j) {
             if (tempMask & m_bitMasks[j])
                 return m_parent->setFailed();
         }
 
         // Count offset into pixel data.
-        for (m_bitShiftsRight[i] = 0; !(tempMask & 1); tempMask >>= 1)
-            ++m_bitShiftsRight[i];
+        unsigned rightOffset = ctz(tempMask);
+        tempMask >>= rightOffset;
 
-        // Count size of mask.
-        for (m_bitShiftsLeft[i] = 8; tempMask & 1; tempMask >>= 1)
-            --m_bitShiftsLeft[i];
+        // Count offset of mask from most significant bit
+        unsigned leftOffset = ctz(~tempMask);
+        tempMask >>= leftOffset;
 
         // Make sure bitmask is contiguous.
         if (tempMask)
@@ -459,10 +459,21 @@ bool BMPImageReader::processBitmasks()
 
         // Since RGBABuffer tops out at 8 bits per channel, adjust the shift
         // amounts to use the most significant 8 bits of the channel.
-        if (m_bitShiftsLeft[i] < 0) {
-            m_bitShiftsRight[i] -= m_bitShiftsLeft[i];
-            m_bitShiftsLeft[i] = 0;
+        if (leftOffset > 8) {
+
+            // Carry over excess shifts to rightOffset, as a negative
+            // offset to the left is a positive offset to the right.
+            rightOffset += leftOffset - 8;
+
+            // Cap leftOffset at 8
+            leftOffset = 8;
         }
+
+        m_bitShiftsRight[i] = rightOffset;
+
+        // m_bitShiftsLeft is the offset from the most significant bit,
+        // so find the mask size by subtracting the offset from 8.
+        m_bitShiftsLeft[i] = 8 - leftOffset;
     }
 
     return true;
@@ -587,14 +598,11 @@ bool BMPImageReader::processRLEData()
                 // Because processNonRLEData() expects m_decodedOffset to
                 // point to the beginning of the pixel data, bump it past
                 // the escape bytes and then reset if decoding failed.
-                m_decodedOffset += 2;
                 const ProcessingResult result = processNonRLEData(true, code);
-                if (result == Failure)
-                    return m_parent->setFailed();
-                if (result == InsufficientData) {
-                    m_decodedOffset -= 2;
-                    return false;
-                }
+                if (result != Success)
+                    return (result == Failure) ? m_parent->setFailed() : false;
+
+                m_decodedOffset += 2;
                 break;
             }
             }
@@ -623,9 +631,9 @@ bool BMPImageReader::processRLEData()
                 }
                 if ((colorIndexes[0] >= m_infoHeader.biClrUsed) || (colorIndexes[1] >= m_infoHeader.biClrUsed))
                     return m_parent->setFailed();
-                for (int which = 0; m_coord.x() < endX; ) {
+                for (unsigned which = 0; m_coord.x() < endX;) {
                     setI(colorIndexes[which]);
-                    which = !which;
+                    which ^= 1;
                 }
 
                 m_decodedOffset += 2;
@@ -706,7 +714,7 @@ BMPImageReader::ProcessingResult BMPImageReader::processNonRLEData(bool inRLE, i
                 // As an optimization, avoid setting "hasAlpha" to true for
                 // images where all alpha values are 255; opaque images are
                 // faster to draw.
-                int alpha = getAlpha(pixel);
+                unsigned alpha = getAlpha(pixel);
                 if (!m_seenNonZeroAlphaPixel && !alpha) {
                     m_seenZeroAlphaPixel = true;
                     alpha = 255;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -321,8 +321,8 @@ private:
     // could go either direction. (If only "<< -x" were equivalent to
     // ">> x"...)
     uint32_t m_bitMasks[4];
-    int m_bitShiftsRight[4];
-    int m_bitShiftsLeft[4];
+    unsigned m_bitShiftsRight[4];
+    unsigned m_bitShiftsLeft[4];
 
     // The color palette, for paletted formats.
     Vector<RGBTriple> m_colorTable;


### PR DESCRIPTION
<pre>
Optimize BMPImageReader
https://bugs.webkit.org/show_bug.cgi?id=262970

Reviewed by NOBODY (OOPS!).

The usage of compiler intrinsics will help speed up processing of BMP images.

* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
   (WebCore::BMPImageReader::processBitmasks): Use ^= 1 to toggle "which" variable
   between 0 and 1 instead of using a conditional.
(WebCore::BMPImageReader::processRLEData): Use ctz to go through bits.
(WebCore::BMPImageReader::processNonRLEData): Ditto.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6517c5d592eb45b31d7973a28d90e9889960187f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28391 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28032 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31356 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->