### PR TITLE
[Cocoa] Thread-unsafe use of Vector in WebAVSampleBufferErrorListener

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -52,7 +52,7 @@ OBJC_CLASS AVSampleBufferDisplayLayer;
 OBJC_CLASS NSData;
 OBJC_CLASS NSError;
 OBJC_CLASS NSObject;
-OBJC_CLASS WebAVSampleBufferErrorListener;
+OBJC_CLASS WebAVSampleBufferListener;
 
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 typedef const struct opaqueCMFormatDescription *CMFormatDescriptionRef;
@@ -219,7 +219,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     HashMap<uint64_t, RetainPtr<AVSampleBufferAudioRenderer>, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_audioRenderers;
 ALLOW_NEW_API_WITHOUT_GUARDS_END
-    RetainPtr<WebAVSampleBufferErrorListener> m_errorListener;
+    RetainPtr<WebAVSampleBufferListener> m_listener;
 #if PLATFORM(IOS_FAMILY)
     bool m_displayLayerWasInterrupted { false };
 #endif


### PR DESCRIPTION
#### 66793be1c5e22d471fd3c57d64be06b46f012fcd
<pre>
[Cocoa] Thread-unsafe use of Vector in WebAVSampleBufferErrorListener
<a href="https://bugs.webkit.org/show_bug.cgi?id=264217">https://bugs.webkit.org/show_bug.cgi?id=264217</a>
<a href="https://rdar.apple.com/117950166">rdar://117950166</a>

Reviewed by Eric Carlson.

WebAVSampleBufferErrorListener contains two Vectors (_layers and _renderers) that are accessed from
the main thread as well as whichever thread AVFoundation uses to post notifications and key-value
observation callbacks; this is unsafe.

Addressed this by ensuring both Vectors are accessed on the main thread. Also did the following:
- Renamed WebAVSampleBufferErrorListener to WebAVSampleBufferListener since it observes more than
just errors.
- Made use of context pointers in the key-value observer to make WebAVSampleBufferListener safe for
subclassing.
- Fixed some style issues.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(-[WebAVSampleBufferListener initWithParent:]):
(-[WebAVSampleBufferListener invalidate]):
(-[WebAVSampleBufferListener beginObservingLayer:]):
(-[WebAVSampleBufferListener stopObservingLayer:]):
(-[WebAVSampleBufferListener beginObservingRenderer:]):
(-[WebAVSampleBufferListener stopObservingRenderer:]):
(-[WebAVSampleBufferListener observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVSampleBufferListener layerFailedToDecode:]):
(-[WebAVSampleBufferListener layerRequiresFlushToResumeDecodingChanged:]):
(-[WebAVSampleBufferListener audioRendererWasAutomaticallyFlushed:]):
(WebCore::SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::destroyRenderers):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::setVideoLayer):
(-[WebAVSampleBufferErrorListener initWithParent:]): Deleted.
(-[WebAVSampleBufferErrorListener dealloc]): Deleted.
(-[WebAVSampleBufferErrorListener invalidate]): Deleted.
(-[WebAVSampleBufferErrorListener beginObservingLayer:]): Deleted.
(-[WebAVSampleBufferErrorListener stopObservingLayer:]): Deleted.
(-[WebAVSampleBufferErrorListener beginObservingRenderer:]): Deleted.
(-[WebAVSampleBufferErrorListener stopObservingRenderer:]): Deleted.
(-[WebAVSampleBufferErrorListener observeValueForKeyPath:ofObject:change:context:]): Deleted.
(-[WebAVSampleBufferErrorListener layerFailedToDecode:]): Deleted.
(-[WebAVSampleBufferErrorListener layerRequiresFlushToResumeDecodingChanged:]): Deleted.
(-[WebAVSampleBufferErrorListener layerReadyForDisplayChanged:]): Deleted.
(-[WebAVSampleBufferErrorListener audioRendererWasAutomaticallyFlushed:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/270237@main">https://commits.webkit.org/270237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30e85c11a86ffff877af7aad56d5ff0491bc0e78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24947 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23187 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27643 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28598 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26422 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/466 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3450 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->