### PR TITLE
Use GlyphData.isValid() consistently for checking whether GlyphData is valid.

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1556,7 +1556,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     UChar32 baseCharacter = *stringView.codePoints().begin();
     GlyphData baseCharacterGlyphData = glyphDataForCharacter(baseCharacter, false, NormalVariant);
 
-    if (!baseCharacterGlyphData.glyph)
+    if (!baseCharacterGlyphData.isValid())
         return nullptr;
     return baseCharacterGlyphData.font.get();
 }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -87,7 +87,7 @@ GlyphData FontCascadeFonts::GlyphPageCacheEntry::glyphDataForCharacter(UChar32 c
 
 void FontCascadeFonts::GlyphPageCacheEntry::setGlyphDataForCharacter(UChar32 character, GlyphData glyphData)
 {
-    ASSERT(!glyphDataForCharacter(character).glyph);
+    ASSERT(!glyphDataForCharacter(character).isValid());
     if (!m_mixedFont) {
         m_mixedFont = makeUnique<MixedFontGlyphPage>(m_singleFont.get());
         m_singleFont = nullptr;
@@ -380,7 +380,7 @@ GlyphData FontCascadeFonts::glyphDataForSystemFallback(UChar32 character, const 
     }
 
     // Keep the system fallback fonts we use alive.
-    if (fallbackGlyphData.glyph)
+    if (fallbackGlyphData.isValid())
         m_systemFallbackFontSet.add(WTFMove(systemFallbackFont));
 
     return fallbackGlyphData;
@@ -418,7 +418,7 @@ GlyphData FontCascadeFonts::glyphDataForVariant(UChar32 character, const FontCas
             break;
 
         GlyphData data = fontRanges.glyphDataForCharacter(character, policy);
-        if (!data.font)
+        if (!data.isValid())
             continue;
 
         if (resolvedEmojiPolicy == ResolvedEmojiPolicy::RequireText && data.colorGlyphType == ColorGlyphType::Color)
@@ -430,7 +430,7 @@ GlyphData FontCascadeFonts::glyphDataForVariant(UChar32 character, const FontCas
             policy = ExternalResourceDownloadPolicy::Forbid;
             if (fallbackVisibility == FallbackVisibility::Immaterial)
                 fallbackVisibility = data.font->visibility() == Font::Visibility::Visible ? FallbackVisibility::Visible : FallbackVisibility::Invisible;
-            if (!loadingResult.font && data.glyph)
+            if (!loadingResult.isValid() && data.glyph)
                 loadingResult = data;
             continue;
         }
@@ -459,7 +459,7 @@ GlyphData FontCascadeFonts::glyphDataForVariant(UChar32 character, const FontCas
         return data;
     }
 
-    if (loadingResult.font)
+    if (loadingResult.isValid())
         return loadingResult;
     // https://drafts.csswg.org/css-fonts-4/#char-handling-issues
     // "If a given character is a Private-Use Area Unicode codepoint, user agents must only match font families named in the font-family list that are not generic families. If none of the families named in the font-family list contain a glyph for that codepoint, user agents must display some form of missing glyph symbol for that character rather than attempting installed font fallback for that codepoint."
@@ -523,7 +523,7 @@ GlyphData FontCascadeFonts::glyphDataForCharacter(UChar32 c, const FontCascadeDe
     }).iterator->value;
 
     GlyphData glyphData = cacheEntry.glyphDataForCharacter(c);
-    if (!glyphData.font) {
+    if (!glyphData.isValid()) {
         // No glyph, resolve per-character.
         ASSERT(variant == NormalVariant);
         glyphData = glyphDataForVariant(c, description, variant, resolvedEmojiPolicy);

--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -94,7 +94,7 @@ GlyphData FontRanges::glyphDataForCharacter(UChar32 character, ExternalResourceD
                         resultFont = font;
                 } else {
                     auto glyphData = font->glyphDataForCharacter(character);
-                    if (glyphData.font) {
+                    if (glyphData.isValid()) {
                         CheckedPtr glyphDataFont = glyphData.font;
                         if (glyphDataFont && glyphDataFont->visibility() == Font::Visibility::Visible && resultFont && resultFont->visibility() == Font::Visibility::Invisible)
                             return GlyphData(glyphData.glyph, &glyphDataFont->invisibleFont());

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -51,7 +51,7 @@ struct GlyphData {
     {
     }
 
-    bool isValid() const { return glyph || font; }
+    bool isValid() const { return font; }
 
     Glyph glyph;
     ColorGlyphType colorGlyphType;


### PR DESCRIPTION
#### ef2295446d89276b712fcd8eee2494c622c5ee18
<pre>
Use GlyphData.isValid() consistently for checking whether GlyphData is valid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264130">https://bugs.webkit.org/show_bug.cgi?id=264130</a>
<a href="https://rdar.apple.com/117905809">rdar://117905809</a>

Reviewed by Tim Nguyen.

Replace GlyphData validity checks using .glyph and .font directly with .isValid().
Make .isValid() return false even if .glyph is non-zero and .font is null
(which should never happen) since a .font null check isn&apos;t expensive anyway.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::fontForCombiningCharacterSequence const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::GlyphPageCacheEntry::setGlyphDataForCharacter):
(WebCore::FontCascadeFonts::glyphDataForSystemFallback):
(WebCore::FontCascadeFonts::glyphDataForVariant):
(WebCore::FontCascadeFonts::glyphDataForCharacter):
* Source/WebCore/platform/graphics/FontRanges.cpp:
(WebCore::FontRanges::glyphDataForCharacter const):
* Source/WebCore/platform/graphics/GlyphPage.h:
(WebCore::GlyphData::isValid const):

Canonical link: <a href="https://commits.webkit.org/270299@main">https://commits.webkit.org/270299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a400a0867a8af2df0ac6c762896e2c731bf52f2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23032 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1072 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27789 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22594 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26540 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/605 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3655 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6008 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2748 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2644 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->