### PR TITLE
Make ::backdrop inherit from parent element

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6825,10 +6825,6 @@ webkit.org/b/263873 imported/w3c/web-platform-tests/scroll-animations/css/printi
 
 webkit.org/b/263923 animations/transition-and-animation-2.html [ Failure Pass ]
 
-# <dialog> element failures
-
-webkit.org/b/263834 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-inherits.html [ ImageOnlyFailure ]
-
 # CloseWatcher related timeouts
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-events.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-preventDefault.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create.html
@@ -15,6 +15,7 @@
     visibility: hidden;
   }
   dialog::backdrop {
+    visibility: visible;
     display: none;
     background-color: green;
   }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -200,8 +200,7 @@ void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& 
         return;
     }
 
-    // ::backdrop does not inherit style, hence using the view style as parent style
-    auto style = renderer.getCachedPseudoStyle(PseudoId::Backdrop, &renderer.view().style());
+    auto style = renderer.getCachedPseudoStyle(PseudoId::Backdrop, &renderer.style());
     if (!style || style->display() == DisplayType::None) {
         destroyBackdropIfNeeded();
         return;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -515,9 +515,6 @@ ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const Elem
             if (auto* firstLineStyle = elementUpdate.style->getCachedPseudoStyle(PseudoId::FirstLine))
                 return firstLineStyle;
         }
-        // ::backdrop does not inherit style, hence using the view style as parent style
-        if (pseudoId == PseudoId::Backdrop)
-            return &m_document.renderView()->style();
         return elementUpdate.style.get();
     };
 


### PR DESCRIPTION
#### d23e04b12f7944b899fc46f1abba89e300c2887d
<pre>
Make ::backdrop inherit from parent element
<a href="https://bugs.webkit.org/show_bug.cgi?id=263834">https://bugs.webkit.org/show_bug.cgi?id=263834</a>

Reviewed by Tim Nguyen.

StyleTreeResolver/RenterTreeUpdate explicitly checked for ::backdrop
elements to remove their inheritance chain, per the spec at the time.
<a href="https://github.com/whatwg/fullscreen/issues/124">https://github.com/whatwg/fullscreen/issues/124</a> was created to query
this and it was resolved that ::backdrop _should_ inherit.

This commit addresses the change by removing the check in
StyleTreeResolve to allow ::backdrop to inherit from its parent element,
and altering the check in RenderTreeUpdate to call renderer.style()
instead of renderer.view.style(). This aligns behaviour with the other
browsers and WPT.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create.html:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):

Canonical link: <a href="https://commits.webkit.org/270246@main">https://commits.webkit.org/270246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aef5b14f82dc6b1e4bf701d6d218a6f350c7f7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23203 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27668 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28615 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26439 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22236 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2638 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3180 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->