### PR TITLE
[LBSE] Unbreak clipping (regression from 270088@main)

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1597,6 +1597,10 @@ void RenderLayer::updateAncestorDependentState()
     m_enclosingSVGHiddenOrResourceContainer = nullptr;
     auto determineSVGAncestors = [&] (const RenderElement& renderer) {
         for (auto* ancestor = renderer.parent(); ancestor; ancestor = ancestor->parent()) {
+            if (auto* container = dynamicDowncast<RenderSVGResourceContainer>(ancestor)) {
+                m_enclosingSVGHiddenOrResourceContainer = container;
+                return;
+            }
             if (auto* container = dynamicDowncast<RenderSVGHiddenContainer>(ancestor)) {
                 m_enclosingSVGHiddenOrResourceContainer = container;
                 return;


### PR DESCRIPTION
#### bbebc590512613655555a348725daf9abd23e75f
<pre>
[LBSE] Unbreak clipping (last minute regression)
<a href="https://bugs.webkit.org/show_bug.cgi?id=264224">https://bugs.webkit.org/show_bug.cgi?id=264224</a>

Reviewed by Rob Buis.

SVG clipping is broken, due to a last minute change in RenderLayer.

The intention to check if a renderer inherits from either RenderSVGResourceContainer
or RenderSVGHiddenContainer was tested using only one &quot;dynamicDowncast&lt;RenderSVGHiddenContainer&quot;&gt;,
as RenderSVGResourceContainer also inherits from RenderSVGHiddenContainer.

However, the is&lt;&gt; mechanism, implemented using the RenderObject::isXYZ() methods, does not
work anymore like this, due to the introduction of the non-virtual type() method. Nowadays
is&lt;RenderSVGHiddenContainer&gt; boils down to:

    bool isSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer; }

Any renderer that inherits from RenderSVGHiddenContainer, e.g. RenderSVGResourceClipper,
therefore returns &apos;false&apos; for is&lt;RenderSVGHiddenContainer&gt;(), because RenderSVGResourceClipper
carries a different type() - here &apos;Type::SVGResourceClipper&apos;.

--&gt; One explicitly needs to check both is&lt;RenderSVGResourceClipper&gt;() || is&lt;RenderSVGResourceContainer&gt;())
to check if a renderer inherits from RenderSVGResourceClipper or RenderSVGResourceContainer -- not possible
with a single check, given the way isRenderSVGResourceContainer() is currently implemented.

Let&apos;s first fix this regression for now, and then discuss the correct future mechanism. Whether
we should respect the base-class hierarchy in is&lt;&gt; or not.

Covered by existing tests, when LBSE is activated.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateAncestorDependentState):

Canonical link: <a href="https://commits.webkit.org/270248@main">https://commits.webkit.org/270248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f84cbf0391dd5104dd0f0f05e10fc30cf2a84707

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27089 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23204 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27669 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28616 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26440 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/494 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3475 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5976 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->