### PR TITLE
Add CustomStateSet and :state() selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/state-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/state-in-has-expected.txt
@@ -1,0 +1,4 @@
+Test :state() pseudo-class invalidation with :has()
+
+PASS Test :has() invalidation with :state() pseudo-classes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/state-in-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/state-in-has.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<title>:has() invalidation with :state() pseudo-class</title>
+<link rel="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational" />
+<link rel="help" href="https://github.com/whatwg/html/pull/8467" />
+<style>
+  #subject {
+    background-color: #f00;
+  }
+  #subject:has(:state(--green)) {
+    background-color: #0f0;
+  }
+  #subject:has(:state(--blue)) {
+    background-color: #00f;
+  }
+</style>
+<body>
+  Test :state() pseudo-class invalidation with :has()
+  <div id="subject">
+    <my-element id="child"></my-element>
+  </div>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script>
+    const RED = "rgb(255, 0, 0)";
+    const GREEN = "rgb(0, 255, 0)";
+    const BLUE = "rgb(0, 0, 255)";
+
+    test(() => {
+      customElements.define(
+        "my-element",
+        class MyElement extends HTMLElement {
+          connectedCallback() {
+            this.elementInternals = this.attachInternals();
+          }
+        },
+      );
+      assert_equals(getComputedStyle(subject).backgroundColor, RED);
+      child.elementInternals.states.add("--green");
+      assert_equals(getComputedStyle(subject).backgroundColor, GREEN);
+      child.elementInternals.states.clear();
+      assert_equals(getComputedStyle(subject).backgroundColor, RED);
+
+      child.elementInternals.states.add("--blue");
+      assert_equals(getComputedStyle(subject).backgroundColor, BLUE);
+      child.elementInternals.states.clear();
+      assert_equals(getComputedStyle(subject).backgroundColor, RED);
+
+      child.elementInternals.states.add("--green");
+      child.elementInternals.states.add("--blue");
+      assert_equals(getComputedStyle(subject).backgroundColor, BLUE);
+      child.elementInternals.states.delete("--blue");
+      assert_equals(getComputedStyle(subject).backgroundColor, GREEN);
+      child.elementInternals.states.delete("--green");
+      assert_equals(getComputedStyle(subject).backgroundColor, RED);
+    }, "Test :has() invalidation with :state() pseudo-classes");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL ":state(--foo)" should be a valid selector ':state(--foo)' is not a valid selector.
-FAIL ":state(bar)" should be a valid selector ':state(bar)' is not a valid selector.
-FAIL ":state(--)" should be a valid selector ':state(--)' is not a valid selector.
-FAIL ":state(--0)" should be a valid selector ':state(--0)' is not a valid selector.
-FAIL ":host(:state(--foo))" should be a valid selector ':host(:state(--foo))' is not a valid selector.
-FAIL "my-input[type=\"foo\"]:state(checked)" should be a valid selector 'my-input[type="foo"]:state(checked)' is not a valid selector.
-FAIL "my-input[type=\"foo\"]:state(--0)::before" should be a valid selector 'my-input[type="foo"]:state(--0)::before' is not a valid selector.
-FAIL "my-input[type=\"foo\"]:state(--0)::part(inner)" should be a valid selector 'my-input[type="foo"]:state(--0)::part(inner)' is not a valid selector.
-FAIL "my-input[type=\"foo\"]:state(--0)::part(inner):state(bar)" should be a valid selector 'my-input[type="foo"]:state(--0)::part(inner):state(bar)' is not a valid selector.
-FAIL "::part(inner):state(bar)::before" should be a valid selector '::part(inner):state(bar)::before' is not a valid selector.
-FAIL "::part(inner):state(bar)::after" should be a valid selector '::part(inner):state(bar)::after' is not a valid selector.
+PASS ":state(--foo)" should be a valid selector
+PASS ":state(bar)" should be a valid selector
+PASS ":state(--)" should be a valid selector
+PASS ":state(--0)" should be a valid selector
+PASS ":host(:state(--foo))" should be a valid selector
+PASS "my-input[type=\"foo\"]:state(checked)" should be a valid selector
+PASS "my-input[type=\"foo\"]:state(--0)::before" should be a valid selector
+PASS "my-input[type=\"foo\"]:state(--0)::part(inner)" should be a valid selector
+PASS "my-input[type=\"foo\"]:state(--0)::part(inner):state(bar)" should be a valid selector
+PASS "::part(inner):state(bar)::before" should be a valid selector
+PASS "::part(inner):state(bar)::after" should be a valid selector
 PASS ":state" should be an invalid selector
 PASS ":state(" should be an invalid selector
 PASS ":state()" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL CustomStateSet behavior of ElementInternals.states: Initial state Can't find variable: CustomStateSet
-FAIL CustomStateSet behavior of ElementInternals.states: Exceptions assert_throws_dom: function "() => { i.states.add(''); }" threw object "TypeError: undefined is not an object (evaluating 'i.states.add')" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
-FAIL CustomStateSet behavior of ElementInternals.states: Modifications undefined is not an object (evaluating 'i.states.add')
-FAIL Updating a CustomStateSet while iterating it should work undefined is not an object (evaluating 'i.states.add')
+PASS CustomStateSet behavior of ElementInternals.states: Initial state
+PASS CustomStateSet behavior of ElementInternals.states: Exceptions
+PASS CustomStateSet behavior of ElementInternals.states: Modifications
+PASS Updating a CustomStateSet while iterating it should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states.html
@@ -27,8 +27,6 @@ test(() => {
 test(() => {
   let i = (new TestElement()).internals;
   assert_throws_js(TypeError, () => { i.states.supports('foo'); });
-  assert_throws_dom('SyntaxError', () => { i.states.add(''); });
-  assert_throws_dom('SyntaxError', () => { i.states.add('--a\tb'); });
 }, 'CustomStateSet behavior of ElementInternals.states: Exceptions');
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL :--foo parsing passes ':--' is not a valid selector.
-PASS :--foo parsing failures
-FAIL :--foo serialization undefined is not an object (evaluating 'document.styleSheets[0].cssRules[1].cssText')
-FAIL :--foo in simple cases ':--foo' is not a valid selector.
-FAIL :--foo and other pseudo classes undefined is not an object (evaluating 'states.add')
-FAIL :--foo and ::part() undefined is not an object (evaluating 'innerStates.add')
-FAIL :--foo and :host() undefined is not an object (evaluating 'outer.i.states.add')
+PASS :state() parsing passes
+PASS :state() parsing failures
+PASS :state(foo) serialization
+PASS :state(foo) in simple cases
+PASS :state(foo) and other pseudo classes
+FAIL :state(foo) and ::part() assert_equals: ::part() followed by :state(innerFoo) expected "0.5" but got "0"
+PASS :state(foo) and :host()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class.html
@@ -5,13 +5,13 @@
 #state-and-part::part(inner) {
   opacity: 0;
 }
-#state-and-part::part(inner):--innerFoo {
+#state-and-part::part(inner):state(innerFoo) {
   opacity: 0.5;
 }
-#state-and-part:--outerFoo::part(inner) {
+#state-and-part:state(outerFoo)::part(inner) {
   opacity: 0.25;
 }
-:--\(escaped\ state {}
+:state(--\)escaped\ state) {}
 </style>
 <body>
 <script>
@@ -37,7 +37,7 @@ class ContainerElement extends HTMLElement {
 :host {
   border-style: solid;
 }
-:host(:--dotted) {
+:host(:state(dotted)) {
   border-style: dotted;
 }
 </style>
@@ -54,38 +54,44 @@ class ContainerElement extends HTMLElement {
 customElements.define('container-element', ContainerElement);
 
 test(() => {
-  document.querySelector(':--');
-  document.querySelector(':--16px');
-}, ':--foo parsing passes');
+  document.querySelector(':state(foo)');
+  document.querySelector(':state(--foo)');
+  document.querySelector(':state(--)');
+  document.querySelector(':state(--16px)');
+}, ':state() parsing passes');
 
 test(() => {
   assert_throws_dom('SyntaxError', () => { document.querySelector(':--('); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':--()'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state()'); });
   assert_throws_dom('SyntaxError', () => { document.querySelector(':--)'); });
   assert_throws_dom('SyntaxError', () => { document.querySelector(':--='); });
   assert_throws_dom('SyntaxError', () => { document.querySelector(':--name=value'); });
-}, ':--foo parsing failures');
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state(--name=value'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state(--name=value)'); });
+}, ':state() parsing failures');
 
 test(() => {
   assert_equals(document.styleSheets[0].cssRules[1].cssText,
-      '#state-and-part::part(inner):--innerFoo { opacity: 0.5; }');
+      '#state-and-part::part(inner):state(innerFoo) { opacity: 0.5; }');
   assert_equals(document.styleSheets[0].cssRules[3].selectorText,
-      ':--\\(escaped\\ state');
-}, ':--foo serialization');
+      ':state(--\\)escaped\\ state)');
+}, ':state(foo) serialization');
 
 test(() => {
   let element = new TestElement();
   let states = element.i.states;
 
-  assert_false(element.matches(':--foo'));
-  assert_true(element.matches(':not(:--foo)'));
-  states.add('--foo');
-  assert_true(element.matches(':--foo'));
-  assert_true(element.matches(':is(:--foo)'));
+  assert_false(element.matches(':state(foo)'));
+  assert_true(element.matches(':not(:state(foo))'));
+  states.add('foo');
+  assert_true(element.matches(':state(foo)'));
+  assert_true(element.matches(':is(:state(foo))'));
   element.classList.add('c1', 'c2');
-  assert_true(element.matches('.c1:--foo'));
-  assert_true(element.matches(':--foo.c1'));
-  assert_true(element.matches('.c2:--foo.c1'));
-}, ':--foo in simple cases');
+  assert_true(element.matches('.c1:state(foo)'));
+  assert_true(element.matches(':state(foo).c1'));
+  assert_true(element.matches('.c2:state(foo).c1'));
+}, ':state(foo) in simple cases');
 
 test(() => {
   let element = new TestElement();
@@ -94,10 +100,10 @@ test(() => {
   element.focus();
   let states = element.i.states;
 
-  states.add('--foo');
-  assert_true(element.matches(':focus:--foo'));
-  assert_true(element.matches(':--foo:focus'));
-}, ':--foo and other pseudo classes');
+  states.add('foo');
+  assert_true(element.matches(':focus:state(foo)'));
+  assert_true(element.matches(':state(foo):focus'));
+}, ':state(foo) and other pseudo classes');
 
 test(() => {
   let outer = new ContainerElement();
@@ -106,27 +112,27 @@ test(() => {
   let inner = outer.innerElement;
   let innerStates = inner.i.states;
 
-  innerStates.add('--innerFoo');
+  innerStates.add(':state(innerFoo)');
   assert_equals(getComputedStyle(inner).opacity, '0.5',
-      '::part() followed by :--foo');
-  innerStates.delete('--innerFoo');
-  innerStates.add('--innerfoo');
+      '::part() followed by :state(innerFoo)');
+  innerStates.delete('innerFoo');
+  innerStates.add('innerfoo');
   assert_equals(getComputedStyle(inner).opacity, '0',
-      ':--foo matching should be case-sensitive');
-  innerStates.delete('--innerfoo');
+      ':state(foo) matching should be case-sensitive');
+  innerStates.delete('innerfoo');
 
-  outer.i.states.add('--outerFoo');
+  outer.i.states.add('outerFoo');
   assert_equals(getComputedStyle(inner).opacity, '0.25',
-      ':--foo followed by ::part()');
-}, ':--foo and ::part()');
+      ':state(foo) followed by ::part()');
+}, ':state(foo) and ::part()');
 
 test(() => {
   let outer = new ContainerElement();
   document.body.appendChild(outer);
 
   assert_equals(getComputedStyle(outer).borderStyle, 'solid');
-  outer.i.states.add('--dotted');
+  outer.i.states.add('dotted');
   assert_equals(getComputedStyle(outer).borderStyle, 'dotted');
-}, ':--foo and :host()');
+}, ':state(foo) and :host()');
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/custom-state-set-strong-ref.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/custom-state-set-strong-ref.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL customstateset doesn't crash after GC on detached node promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'states.add')"
+PASS customstateset doesn't crash after GC on detached node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/idlharness.window-expected.txt
@@ -4,17 +4,17 @@ PASS idl_test validation
 PASS Partial interface ElementInternals: original interface defined
 PASS Partial interface ElementInternals: member names are unique
 PASS ElementInternals includes ARIAMixin: member names are unique
-FAIL CustomStateSet interface: existence and properties of interface object assert_own_property: self does not have own property "CustomStateSet" expected property "CustomStateSet" missing
-FAIL CustomStateSet interface object length assert_own_property: self does not have own property "CustomStateSet" expected property "CustomStateSet" missing
-FAIL CustomStateSet interface object name assert_own_property: self does not have own property "CustomStateSet" expected property "CustomStateSet" missing
-FAIL CustomStateSet interface: existence and properties of interface prototype object assert_own_property: self does not have own property "CustomStateSet" expected property "CustomStateSet" missing
-FAIL CustomStateSet interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "CustomStateSet" expected property "CustomStateSet" missing
-FAIL CustomStateSet interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "CustomStateSet" expected property "CustomStateSet" missing
-FAIL CustomStateSet interface: setlike<DOMString> undefined is not an object (evaluating 'this.get_interface_object().prototype')
-FAIL CustomStateSet interface: operation add(DOMString) assert_own_property: self does not have own property "CustomStateSet" expected property "CustomStateSet" missing
-FAIL CustomStateSet must be primary interface of customStateSet assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL Stringification of customStateSet assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL CustomStateSet interface: customStateSet must inherit property "add(DOMString)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL CustomStateSet interface: calling add(DOMString) on customStateSet with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL ElementInternals interface: attribute states assert_true: The prototype object must have a property "states" expected true got false
+PASS CustomStateSet interface: existence and properties of interface object
+PASS CustomStateSet interface object length
+PASS CustomStateSet interface object name
+PASS CustomStateSet interface: existence and properties of interface prototype object
+PASS CustomStateSet interface: existence and properties of interface prototype object's "constructor" property
+PASS CustomStateSet interface: existence and properties of interface prototype object's @@unscopables property
+PASS CustomStateSet interface: setlike<DOMString>
+PASS CustomStateSet interface: operation add(DOMString)
+PASS CustomStateSet must be primary interface of customStateSet
+PASS Stringification of customStateSet
+PASS CustomStateSet interface: customStateSet must inherit property "add(DOMString)" with the proper type
+PASS CustomStateSet interface: calling add(DOMString) on customStateSet with too few arguments must throw TypeError
+PASS ElementInternals interface: attribute states
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+PASS state selector has no influence when state is not applied
+FAIL state selector has influence when state is applied assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
+PASS state selector only applies on given ident
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="timeout" content="long" />
+    <meta
+      name="author"
+      title="Keith Cirkel"
+      href="mailto:wpt@keithcirkel.co.uk"
+    />
+    <link rel="help" href="https://wicg.github.io/custom-state-pseudo-class/" />
+    <title>:state() css selector applies in shadow roots</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <custom-state id="myCE"> I should be green </custom-state>
+    <style></style>
+    <script>
+      customElements.define(
+        "custom-state",
+        class extends HTMLElement {
+          connectedCallback() {
+            this.elementInternals = this.attachInternals();
+            const css = new CSSStyleSheet();
+            css.replaceSync(`
+              :host {
+                color: #f00;
+              }
+              :host:state(green) {
+                color: #0f0;
+              }
+            `);
+            this.attachShadow({ mode: "open" }).adoptedStyleSheets.push(css);
+          }
+        },
+      );
+
+      test(function () {
+        assert_false(myCE.elementInternals.states.has("green"));
+        assert_equals(
+          getComputedStyle(myCE).getPropertyValue("color"),
+          "rgb(255, 0, 0)",
+        );
+      }, "state selector has no influence when state is not applied");
+
+      test(function (t) {
+        myCE.elementInternals.states.add("green");
+        t.add_cleanup(() => {
+          myCE.elementInternals.states.delete("green");
+        });
+        assert_true(myCE.elementInternals.states.has("green"));
+        assert_equals(
+          getComputedStyle(myCE).getPropertyValue("color"),
+          "rgb(0, 255, 0)",
+        );
+      }, "state selector has influence when state is applied");
+
+      test(function (t) {
+        myCE.elementInternals.states.add("foo");
+        t.add_cleanup(() => {
+          myCE.elementInternals.states.delete("foo");
+        });
+        assert_false(myCE.elementInternals.states.has("green"));
+        assert_true(myCE.elementInternals.states.has("foo"));
+        assert_equals(
+          getComputedStyle(myCE).getPropertyValue("color"),
+          "rgb(255, 0, 0)",
+        );
+      }, "state selector only applies on given ident");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative-expected.txt
@@ -4,12 +4,12 @@ I should be blue
 I should be blue
 
 
-FAIL state selector has no influence when state is not applied undefined is not an object (evaluating 'myCE.elementInternals.states.has')
-FAIL state selector has no influence on sibling selectors when not applied undefined is not an object (evaluating 'myCE.elementInternals.states.has')
-FAIL state selector has influence when state is applied undefined is not an object (evaluating 'myCE.elementInternals.states.add')
-FAIL state selector influences siblings when state is applied undefined is not an object (evaluating 'myCE.elementInternals.states.add')
-FAIL state selector influences has() when state is applied undefined is not an object (evaluating 'myCE.elementInternals.states.add')
-FAIL state selector only applies on given ident undefined is not an object (evaluating 'myCE.elementInternals.states.add')
-FAIL state selector only applies to siblings on given ident undefined is not an object (evaluating 'myCE.elementInternals.states.add')
-FAIL state selector only applies to has() on given ident undefined is not an object (evaluating 'myCE.elementInternals.states.add')
+PASS state selector has no influence when state is not applied
+PASS state selector has no influence on sibling selectors when not applied
+PASS state selector has influence when state is applied
+FAIL state selector influences siblings when state is applied assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+FAIL state selector influences has() when state is applied assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS state selector only applies on given ident
+PASS state selector only applies to siblings on given ident
+PASS state selector only applies to has() on given ident
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1914,6 +1914,20 @@ CustomPasteboardDataEnabled:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WIN)": true
       default: false
 
+CustomStateSetEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "CustomStateSet"
+  humanReadableDescription: "Support for CustomStateSet in custom elements"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DNSPrefetchingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1020,6 +1020,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/ContentVisibilityAutoStateChangeEvent.idl
     dom/CustomElementRegistry.idl
     dom/CustomEvent.idl
+    dom/CustomStateSet.idl
     dom/DOMException.idl
     dom/DOMImplementation.idl
     dom/DOMPoint.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1327,6 +1327,7 @@ $(PROJECT_DIR)/dom/CompositionEvent.idl
 $(PROJECT_DIR)/dom/ContentVisibilityAutoStateChangeEvent.idl
 $(PROJECT_DIR)/dom/CustomElementRegistry.idl
 $(PROJECT_DIR)/dom/CustomEvent.idl
+$(PROJECT_DIR)/dom/CustomStateSet.idl
 $(PROJECT_DIR)/dom/DOMException.idl
 $(PROJECT_DIR)/dom/DOMImplementation.idl
 $(PROJECT_DIR)/dom/DOMPoint.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -677,6 +677,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomElementRegistry.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomElementRegistry.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomStateSet.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomStateSet.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomXPathNSResolver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomXPathNSResolver.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMApplicationCache.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1028,6 +1028,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/ContentVisibilityAutoStateChangeEvent.idl \
     $(WebCore)/dom/CustomElementRegistry.idl \
     $(WebCore)/dom/CustomEvent.idl \
+    $(WebCore)/dom/CustomStateSet.idl \
     $(WebCore)/dom/DOMException.idl \
     $(WebCore)/dom/DOMImplementation.idl \
     $(WebCore)/dom/DOMPoint.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1055,6 +1055,7 @@ dom/CustomElementDefaultARIA.cpp
 dom/CustomElementReactionQueue.cpp
 dom/CustomElementRegistry.cpp
 dom/CustomEvent.cpp
+dom/CustomStateSet.cpp
 dom/DOMException.cpp
 dom/DOMImplementation.cpp
 dom/DOMPointReadOnly.cpp
@@ -3373,6 +3374,7 @@ JSCustomEffect.cpp
 JSCustomEffectCallback.cpp
 JSCustomElementRegistry.cpp
 JSCustomEvent.cpp
+JSCustomStateSet.cpp
 JSDOMApplicationCache.cpp
 JSDOMAudioSession.cpp
 JSDOMCSSCustomPropertyDescriptor.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -169,6 +169,7 @@ namespace WebCore {
     macro(CookieStoreManager) \
     macro(CustomElementRegistry) \
     macro(CustomEffect) \
+    macro(CustomStateSet) \
     macro(Database) \
     macro(DataTransferItem) \
     macro(DataTransferItemList) \

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -716,6 +716,11 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             case CSSSelector::PseudoClassType::Scope:
                 builder.append(":scope");
                 break;
+            case CSSSelector::PseudoClassType::State:
+                builder.append(":state(");
+                serializeIdentifier(cs->argument(), builder);
+                builder.append(')');
+                break;
             case CSSSelector::PseudoClassType::HasScope:
                 // Remove the space from the start to generate a relative selector string like in ":has(> foo)".
                 return makeString(separator.substring(1), rightSide);

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -152,6 +152,7 @@ struct PossiblyQuotedIdentifier {
             Not,
             Root,
             Scope,
+            State,
             HasScope, // for internal use, matches the :has() scope
             WindowInactive,
             CornerPresent,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1072,6 +1072,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             const Node* contextualReferenceNode = !checkingContext.scope ? element.document().documentElement() : checkingContext.scope;
             return &element == contextualReferenceNode;
         }
+        case CSSSelector::PseudoClassType::State:
+            return element.hasCustomState(selector.argument());
         case CSSSelector::PseudoClassType::HasScope: {
             bool matches = &element == checkingContext.hasScope || checkingContext.matchesAllHasScopes;
 

--- a/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
@@ -66,6 +66,7 @@ read-write
 required
 root
 scope
+state
 single-button
 start
 target

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -106,6 +106,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssTextWrapPrettyEnabled { document.settings().cssTextWrapPrettyEnabled() }
     , highlightAPIEnabled { document.settings().highlightAPIEnabled() }
     , grammarAndSpellingPseudoElementsEnabled { document.settings().grammarAndSpellingPseudoElementsEnabled() }
+    , customStateSetEnabled { document.settings().customStateSetEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -142,7 +143,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssTextWrapPrettyEnabled                  << 25
         | context.highlightAPIEnabled                       << 26
         | context.grammarAndSpellingPseudoElementsEnabled   << 27
-        | (uint64_t)context.mode                            << 28; // This is multiple bits, so keep it last.
+        | context.customStateSetEnabled                     << 28
+        | (uint64_t)context.mode                            << 29; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -99,6 +99,7 @@ struct CSSParserContext {
     bool cssTextWrapPrettyEnabled : 1 { false };
     bool highlightAPIEnabled : 1 { false };
     bool grammarAndSpellingPseudoElementsEnabled : 1 { false };
+    bool customStateSetEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -724,6 +724,7 @@ static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClassType pseudoClassTy
     case CSSSelector::PseudoClassType::Lang:
     case CSSSelector::PseudoClassType::Any:
     case CSSSelector::PseudoClassType::Dir:
+    case CSSSelector::PseudoClassType::State:
         return true;
     default:
         break;
@@ -776,6 +777,8 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             if (!m_context.hasPseudoClassEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::Has)
                 return nullptr;
             if (!m_context.popoverAttributeEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::PopoverOpen)
+                return nullptr;
+            if (!m_context.customStateSetEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::State)
                 return nullptr;
             if (m_context.mode != UASheetMode && selector->pseudoClassType() == CSSSelector::PseudoClassType::HtmlDocument)
                 return nullptr;
@@ -895,6 +898,13 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             return selector;
         }
         case CSSSelector::PseudoClassType::Dir: {
+            const CSSParserToken& ident = block.consumeIncludingWhitespace();
+            if (ident.type() != IdentToken || !block.atEnd())
+                return nullptr;
+            selector->setArgument(ident.value().toAtomString());
+            return selector;
+        }
+        case CSSSelector::PseudoClassType::State: {
             const CSSParserToken& ident = block.consumeIncludingWhitespace();
             if (ident.type() != IdentToken || !block.atEnd())
                 return nullptr;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -35,6 +35,7 @@ namespace WebCore {
 CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& context)
     : mode(context.mode)
     , cssNestingEnabled(context.cssNestingEnabled)
+    , customStateSetEnabled(context.customStateSetEnabled)
     , focusVisibleEnabled(context.focusVisibleEnabled)
     , grammarAndSpellingPseudoElementsEnabled(context.grammarAndSpellingPseudoElementsEnabled)
     , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
@@ -47,6 +48,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
 CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
     , cssNestingEnabled(document.settings().cssNestingEnabled())
+    , customStateSetEnabled(document.settings().customStateSetEnabled())
     , focusVisibleEnabled(document.settings().focusVisibleEnabled())
     , grammarAndSpellingPseudoElementsEnabled(document.settings().grammarAndSpellingPseudoElementsEnabled())
     , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
@@ -61,6 +63,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
     add(hasher,
         context.mode,
         context.cssNestingEnabled,
+        context.customStateSetEnabled,
         context.focusVisibleEnabled,
         context.grammarAndSpellingPseudoElementsEnabled,
         context.hasPseudoClassEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -37,6 +37,7 @@ class Document;
 struct CSSSelectorParserContext {
     CSSParserMode mode { CSSParserMode::HTMLStandardMode };
     bool cssNestingEnabled { false };
+    bool customStateSetEnabled { false };
     bool focusVisibleEnabled { false };
     bool grammarAndSpellingPseudoElementsEnabled { false };
     bool hasPseudoClassEnabled { false };

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1229,6 +1229,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClassType::Drag:
     case CSSSelector::PseudoClassType::Has:
     case CSSSelector::PseudoClassType::HasScope:
+    case CSSSelector::PseudoClassType::State:
         return FunctionType::CannotCompile;
 
     // Optimized pseudo selectors.

--- a/Source/WebCore/dom/CustomStateSet.cpp
+++ b/Source/WebCore/dom/CustomStateSet.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CustomStateSet.h"
+
+#include "CSSParser.h"
+#include "Element.h"
+#include "PseudoClassChangeInvalidation.h"
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(CustomStateSet);
+
+bool CustomStateSet::addToSetLike(const AtomString& state)
+{
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+    if (RefPtr element = m_element.get())
+        styleInvalidation.emplace(*element, CSSSelector::PseudoClassType::State, Style::PseudoClassChangeInvalidation::AnyValue);
+
+    return m_states.add(AtomString(state)).isNewEntry;
+}
+
+bool CustomStateSet::removeFromSetLike(const AtomString& state)
+{
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+    if (RefPtr element = m_element.get())
+        styleInvalidation.emplace(*element, CSSSelector::PseudoClassType::State, Style::PseudoClassChangeInvalidation::AnyValue);
+
+    return m_states.remove(AtomString(state));
+}
+
+void CustomStateSet::clearFromSetLike()
+{
+    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
+    if (RefPtr element = m_element.get())
+        styleInvalidation.emplace(*element, CSSSelector::PseudoClassType::State, Style::PseudoClassChangeInvalidation::AnyValue);
+
+    m_states.clear();
+}
+
+bool CustomStateSet::has(const AtomString& state) const
+{
+    return m_states.contains(state);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/CustomStateSet.h
+++ b/Source/WebCore/dom/CustomStateSet.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Element.h"
+#include "JSDOMSetLike.h"
+#include "ScriptWrappable.h"
+
+namespace WebCore {
+
+class CustomStateSet final : public ScriptWrappable, public RefCounted<CustomStateSet> {
+    WTF_MAKE_ISO_ALLOCATED(CustomStateSet);
+
+public:
+    static Ref<CustomStateSet> create(Element& element)
+    {
+        return adoptRef(*new CustomStateSet(element));
+    };
+
+    bool addToSetLike(const AtomString& state);
+    bool removeFromSetLike(const AtomString& state);
+    void clearFromSetLike();
+    void initializeSetLike(DOMSetAdapter&) { };
+
+    bool has(const AtomString&) const;
+
+private:
+    explicit CustomStateSet(Element& element)
+        : m_element(element)
+    {
+    }
+
+    ListHashSet<AtomString> m_states;
+
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/CustomStateSet.idl
+++ b/Source/WebCore/dom/CustomStateSet.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Exposed=Window,
+    EnabledBySetting=CustomStateSetEnabled,
+] interface CustomStateSet {
+    setlike<[AtomString] DOMString>;
+};

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -43,6 +43,7 @@
 #include "ContentVisibilityDocumentState.h"
 #include "CustomElementReactionQueue.h"
 #include "CustomElementRegistry.h"
+#include "CustomStateSet.h"
 #include "DOMRect.h"
 #include "DOMRectList.h"
 #include "DOMTokenList.h"
@@ -5529,6 +5530,27 @@ AtomString Element::makeTargetBlankIfHasDanglingMarkup(const AtomString& target)
     if ((target.contains('\n') || target.contains('\r') || target.contains('\t')) && target.contains('<'))
         return "_blank"_s;
     return target;
+}
+
+bool Element::hasCustomState(const AtomString& state) const
+{
+    if (!document().settings().customStateSetEnabled())
+        return false;
+
+    if (hasRareData()) {
+        RefPtr customStates = elementRareData()->customStateSet();
+        return customStates && customStates->has(state);
+    }
+
+    return false;
+}
+
+CustomStateSet& Element::ensureCustomStateSet()
+{
+    auto& rareData = const_cast<Element*>(this)->ensureElementRareData();
+    if (!rareData.customStateSet())
+        rareData.setCustomStateSet(CustomStateSet::create(*this));
+    return *rareData.customStateSet();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -51,6 +51,7 @@ class Attribute;
 class AttributeIteratorAccessor;
 class CustomElementDefaultARIA;
 class CustomElementReactionQueue;
+class CustomStateSet;
 class DatasetDOMStringMap;
 class DOMRect;
 class DOMRectList;
@@ -755,6 +756,9 @@ public:
 
     std::optional<OptionSet<ContentRelevancy>> contentRelevancy() const;
     void setContentRelevancy(OptionSet<ContentRelevancy>);
+
+    bool hasCustomState(const AtomString& state) const;
+    CustomStateSet& ensureCustomStateSet();
 
 protected:
     Element(const QualifiedName&, Document&, ConstructionType);

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "ElementInternals.h"
+#include "CustomStateSet.h"
 
 #include "AXObjectCache.h"
 #include "DocumentInlines.h"
@@ -189,6 +190,11 @@ void ElementInternals::setElementsArrayAttribute(const QualifiedName& name, std:
 
     if (CheckedPtr cache = element->document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
+}
+
+CustomStateSet& ElementInternals::states()
+{
+    return m_element->ensureCustomStateSet();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -35,11 +35,13 @@
 
 namespace WebCore {
 
+class CustomStateSet;
 class HTMLFormElement;
 class FormAssociatedCustomElement;
 
 class ElementInternals final : public ScriptWrappable, public RefCounted<ElementInternals> {
     WTF_MAKE_ISO_ALLOCATED(ElementInternals);
+
 public:
     static Ref<ElementInternals> create(HTMLElement& element)
     {
@@ -70,6 +72,8 @@ public:
     void setElementAttribute(const QualifiedName&, Element*);
     std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName&) const;
     void setElementsArrayAttribute(const QualifiedName&, std::optional<Vector<RefPtr<Element>>>&&);
+
+    CustomStateSet& states();
 
 private:
     ElementInternals(HTMLElement& element)

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -44,6 +44,8 @@
 
     readonly attribute NodeList labels;
 
+    [EnabledBySetting=CustomStateSetEnabled, SameObject] readonly attribute CustomStateSet states;
+
     [Reflect, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? role;
     [Reflect=aria_activedescendant, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute Element? ariaActiveDescendantElement;
     [Reflect=aria_atomic, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaAtomic;

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -39,7 +39,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     uint8_t contentRelevancy;
     IntPoint savedLayerScrollPosition;
     Vector<std::unique_ptr<ElementAnimationRareData>> animationRareData;
-    void* pointers[16];
+    void* pointers[17];
     void* intersectionObserverData;
     void* typedOMData[2];
     void* resizeObserverData;

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -23,6 +23,7 @@
 
 #include "CustomElementDefaultARIA.h"
 #include "CustomElementReactionQueue.h"
+#include "CustomStateSet.h"
 #include "DOMTokenList.h"
 #include "DatasetDOMStringMap.h"
 #include "ElementAnimationRareData.h"
@@ -148,6 +149,9 @@ public:
     const std::optional<OptionSet<ContentRelevancy>>& contentRelevancy() const { return m_contentRelevancy; }
     void setContentRelevancy(OptionSet<ContentRelevancy>& contentRelevancy) { m_contentRelevancy = contentRelevancy; }
 
+    CustomStateSet* customStateSet() { return m_customStateSet.get(); }
+    void setCustomStateSet(Ref<CustomStateSet>&& customStateSet) { m_customStateSet = WTFMove(customStateSet); }
+
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
     {
@@ -200,6 +204,8 @@ public:
             result.add(UseType::Popover);
         if (m_childIndex)
             result.add(UseType::ChildIndex);
+        if (!m_customStateSet.isEmpty())
+            result.add(UseType::CustomStateSet);
         return result;
     }
 #endif
@@ -246,6 +252,8 @@ private:
     ExplicitlySetAttrElementsMap m_explicitlySetAttrElementsMap;
 
     std::unique_ptr<PopoverData> m_popoverData;
+
+    RefPtr<CustomStateSet> m_customStateSet;
 };
 
 inline ElementRareData::ElementRareData()

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -255,6 +255,7 @@ public:
         ExplicitlySetAttrElementsMap = 1 << 24,
         Popover = 1 << 25,
         DisplayContentsStyle = 1 << 26,
+        CustomStateSet = 1 << 27,
     };
 #endif
 


### PR DESCRIPTION
#### 59cb7cb2d9244ba77870eabe9f6a8da9249a1312
<pre>
Add CustomStateSet and :state() selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=215911">https://bugs.webkit.org/show_bug.cgi?id=215911</a>

Reviewed by Tim Nguyen.

This adds the CustomStateSet idl definitions, and the `states` getter in
the ElementInternals IDL. The gatter laziliy initialises a
CustomStateSet object in ElementRareData which behaves like a
setlike&lt;DOMString&gt;.

This also adds the `:state()` pseudo selector, which can take an ident
and matches when the ident matches one of the given states in the
CustomStateSet for the element.

Any states set by CustomStateSet need to invalidate styles for the
element, so the `:state()` pseudo can match.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/state-in-has-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/state-in-has.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/custom-state-set-strong-ref.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/idlharness.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isOnlyPseudoClassFunction):
(WebCore::CSSSelectorParser::consumePseudo):
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/dom/CustomStateSet.cpp: Added.
(WebCore::CustomStateSet::addToSetLike):
(WebCore::CustomStateSet::removeFromSetLike):
(WebCore::CustomStateSet::clearFromSetLike):
(WebCore::CustomStateSet::has):
* Source/WebCore/dom/CustomStateSet.h: Added.
* Source/WebCore/dom/CustomStateSet.idl: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hasCustomState const):
(WebCore::Element::ensureCustomStateSet):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::states):
* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/ElementInternals.idl:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::customStateSet):
(WebCore::ElementRareData::setCustomStateSet):
(WebCore::ElementRareData::useTypes const):
* Source/WebCore/dom/NodeRareData.h:

Canonical link: <a href="https://commits.webkit.org/271600@main">https://commits.webkit.org/271600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e495b9ddeba51a3f18adf54a843558ef6b9d1911

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4959 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29243 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5485 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32923 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/25014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/29243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29639 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7238 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/25679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35586 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6916 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6079 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7673 "Passed tests") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->