### PR TITLE
Assign generic role to aside tag within the sectioning content elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
@@ -12,15 +12,17 @@ x
 x
 x
 x
+x
 
 PASS el-a
 PASS el-aside-in-section-with-name
+PASS el-aside-in-section-with-role
 PASS el-aside-ancestorbodymain
 PASS el-footer-ancestorbody
 PASS el-header-ancestorbody
 PASS el-section
 PASS el-a-no-href
-FAIL el-aside-in-section-without-name assert_false: Computed Role: "complementary" does not match any of the acceptable role strings in ["generic", "", "none"]: <aside data-testname="el-aside-in-section-without-name" class="ex-generic">x</aside> expected false got true
+PASS el-aside-in-section-without-name
 PASS el-footer
 PASS el-header
 PASS el-section-no-name

--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual.html
@@ -25,6 +25,7 @@
 <nav>
   <aside data-testname="el-aside-in-section-with-name" data-expectedrole="complementary" aria-label="x" class="ex">x</aside>
   <aside data-testname="el-aside-in-section-without-name" class="ex-generic">x</aside>
+  <aside data-testname="el-aside-in-section-with-role" data-expectedrole="complementary" class="ex" role="complementary">x</aside>
 </nav>
 <aside data-testname="el-aside-ancestorbodymain" data-expectedrole="complementary" class="ex">x</aside>
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -440,8 +440,20 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return AccessibilityRole::LandmarkMain;
     if (node()->hasTagName(navTag))
         return AccessibilityRole::LandmarkNavigation;
-    if (node()->hasTagName(asideTag))
+    if (node()->hasTagName(asideTag)) {
+        if (ariaRoleAttribute() == AccessibilityRole::LandmarkComplementary)
+            return AccessibilityRole::LandmarkComplementary;
+        // The aside element should not assume the complementary role when nested
+        // within the sectioning content elements.
+        // https://w3c.github.io/html-aam/#el-aside
+        if (isDescendantOfElementType({ asideTag, articleTag, sectionTag, navTag })) {
+            // Return LandmarkComplementary if the aside element has an accessible name.
+            if (hasAttribute(aria_labelAttr) || hasAttribute(aria_labelledbyAttr) || hasAttribute(aria_descriptionAttr) || hasAttribute(aria_describedbyAttr))
+                return AccessibilityRole::LandmarkComplementary;
+            return AccessibilityRole::Generic;
+        }
         return AccessibilityRole::LandmarkComplementary;
+    }
     if (node()->hasTagName(searchTag))
         return AccessibilityRole::LandmarkSearch;
 


### PR DESCRIPTION
#### 47f7deca4cff8a33ff3881f7d2801030f87c1d03
<pre>
Assign generic role to aside tag within the sectioning content elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=235065">https://bugs.webkit.org/show_bug.cgi?id=235065</a>
<a href="https://rdar.apple.com/problem/87391915">rdar://problem/87391915</a>

Reviewed by Tyler Wilcock.

This change assigns a generic ARIA role to &lt;aside&gt; elements when they are nested
within &lt;aside&gt;, &lt;article&gt;, &lt;section&gt;, or &lt;nav&gt; elements, aligning with the spec
(<a href="https://w3c.github.io/html-aam/#el-aside).">https://w3c.github.io/html-aam/#el-aside).</a>
This follows the discussion in <a href="https://github.com/w3c/html-aam/issues/512">https://github.com/w3c/html-aam/issues/512</a>

Additionally, it introduces a check to return LandmarkComplementary when an &lt;aside&gt;
tag has an explicit accessible name.

* LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual.html:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):

Canonical link: <a href="https://commits.webkit.org/270509@main">https://commits.webkit.org/270509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/131b7bc303aba6292969f5b466fee6831d318c1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1697 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28337 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29145 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27000 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1061 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->