### PR TITLE
Web Inspector: Font Panel: CSS font property values marked !important don't get overridden when using the interactive editing controls.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/CSSProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSProperty.js
@@ -366,7 +366,6 @@ WI.CSSProperty = class CSSProperty extends WI.Object
         return this._canonicalName;
     }
 
-    // FIXME: Remove current value getter and rename rawValue to value once the old styles sidebar is removed.
     get value()
     {
         if (!this._value)

--- a/Source/WebInspectorUI/UserInterface/Models/FontStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/FontStyles.js
@@ -145,7 +145,7 @@ WI.FontStyles = class FontStyles
                 axes.push(`"${tag}" ${value}`);
             }
 
-            let targetPropertyValue = axes.join(', ');
+            let targetPropertyValue = axes.join(", ");
 
             const createIfMissing = true;
             cssProperty = this._effectiveWritablePropertyForName(targetPropertyName, createIfMissing);


### PR DESCRIPTION
#### e6f0e73090f834ff021ff7e702a179f11b827e08
<pre>
Web Inspector: Font Panel: CSS font property values marked !important don&apos;t get overridden when using the interactive editing controls.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258975">https://bugs.webkit.org/show_bug.cgi?id=258975</a>

Review by NOBODY (OOPS!).

Fix the font-weight slider as the !important declaration causes the slider to to not slide and be overridden.

Address the case of having multiple of the same property of multiple font-weights and a !important declaration in the inline style.

FontStyles.js, writeFontVariation(): check if the target property exists, check if the existing target property contains !important,
check if the existing property is font-weight, update the value as !important if not already,
create the font-weight property if it doesn&apos;t exist, and set the CSSProperty raw value without marking it as !important.

Remove FixMe in CSSProperty.js, as there are intentional calls to the CSSProperty.value getter in use.

* Source/WebInspectorUI/UserInterface/Models/CSSProperty.js:
* Source/WebInspectorUI/UserInterface/Models/FontStyles.js:
(WI.FontStyles.prototype.writeFontVariation):
</pre>
----------------------------------------------------------------------
#### 3138cc78b5df4d3f4d3c67f9484639d93b0acb34
<pre>
Web Inspector: Font Panel: CSS font property values marked !important don&apos;t get overridden when using the interactive editing controls.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258975">https://bugs.webkit.org/show_bug.cgi?id=258975</a>

Review by NOBODY (OOPS!).

Fix the font-weight slider as the !important declaration causes the slider to to not slide and be overridden.

Address the case of having multiple of the same property of multiple font-weights and a !important declaration in the inline style.

FontStyles.js, writeFontVariation(): check if the target property exists, check if the existing target property contains !important,
check if the existing property is font-weight, update the value as !important if not already,
create the font-weight property if it doesn&apos;t exist, and set the CSSProperty raw value without marking it as !important.

Remove FixMe in CSSProperty.js, as there are intentional calls to the CSSProperty.value getter in use.

* Source/WebInspectorUI/UserInterface/Models/CSSProperty.js:
* Source/WebInspectorUI/UserInterface/Models/FontStyles.js:
(WI.FontStyles.prototype.writeFontVariation):
</pre>
----------------------------------------------------------------------
#### f4a59075e299452a3cf03ea66fb35edc01acf215
<pre>
Web Inspector: Font Panel: CSS font property values marked !important don&apos;t get overridden when using the interactive editing controls.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258975">https://bugs.webkit.org/show_bug.cgi?id=258975</a>

Review by NOBODY (OOPS!).

Fix the font-weight slider as the !important declaration causes the slider to to not slide and be overridden.

Address the case of having multiple of the same property of multiple font-weights and a !important declaration in the inline style.

FontStyles.js, writeFontVariation(): check if the target property exists, check if the existing target property contains !important,
check if the existing property is font-weight, update the value as !important if not already,
create the font-weight property if it doesn&apos;t exist, and set the CSSProperty raw value without marking it as !important.

Add FixMe for font-weight being renamed to font-variation-settings under style attributes.
Remove FixMe in CSSProperty.js, as there are intentional calls to the CSSProperty.value getter in use.

* Source/WebInspectorUI/UserInterface/Models/CSSProperty.js:
* Source/WebInspectorUI/UserInterface/Models/FontStyles.js:
(WI.FontStyles.prototype.writeFontVariation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6f0e73090f834ff021ff7e702a179f11b827e08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24330 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2624 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4046 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3565 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23840 "Found 2 new test failures: inspector/model/font-styles-write-variation.html, platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24260 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24240 "Found 1 new test failure: inspector/model/font-styles-write-variation.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3640 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27769 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5079 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->