### PR TITLE
Regression(268700@main) ~0.6% regression on Speedometer 2 on iPhone

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -229,7 +229,7 @@ protected:
             numCandidates--;
             if (!hasBeenSimplified(adjacentTmpIndex) && m_degrees[adjacentTmpIndex] >= registerCount()) {
                 ASSERT(std::find(highOrderAdjacents.begin(), highOrderAdjacents.end(), adjacentTmpIndex) == highOrderAdjacents.end());
-                highOrderAdjacents.append(adjacentTmpIndex);
+                highOrderAdjacents.unsafeAppendWithoutCapacityCheck(adjacentTmpIndex);
                 if (highOrderAdjacents.size() >= registerCount())
                     return false;
             } else if (highOrderAdjacents.size() + numCandidates < registerCount())
@@ -246,7 +246,7 @@ protected:
                 && m_degrees[adjacentTmpIndex] >= registerCount()
                 && std::find(highOrderAdjacents.begin(), iteratorEndHighOrderAdjacentsOfU, adjacentTmpIndex) == iteratorEndHighOrderAdjacentsOfU) {
                 ASSERT(std::find(iteratorEndHighOrderAdjacentsOfU, highOrderAdjacents.end(), adjacentTmpIndex) == highOrderAdjacents.end());
-                highOrderAdjacents.append(adjacentTmpIndex);
+                highOrderAdjacents.unsafeAppendWithoutCapacityCheck(adjacentTmpIndex);
                 if (highOrderAdjacents.size() >= registerCount())
                     return false;
             } else if (highOrderAdjacents.size() + numCandidates < registerCount())

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -2336,7 +2336,7 @@ void BytecodeGenerator::prepareLexicalScopeForNextForLoopIteration(VariableEnvir
             RegisterID* transitionValue = newBlockScopeVariable();
             transitionValue->ref();
             emitGetFromScope(transitionValue, loopScope, variableForLocalEntry(identifier, ptr->value, loopSymbolTable->index(), true), DoNotThrowIfNotFound);
-            activationValuesToCopyOver.append(std::make_pair(transitionValue, identifier));
+            activationValuesToCopyOver.unsafeAppendWithoutCapacityCheck(std::make_pair(transitionValue, identifier));
         }
     }
 

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -5545,7 +5545,7 @@ RegisterID* ArrayPatternNode::emitDirectBinding(BytecodeGenerator& generator, Re
     Vector<RefPtr<RegisterID>> registers;
     registers.reserveInitialCapacity(m_targetPatterns.size());
     for (size_t i = 0; i < m_targetPatterns.size(); i++) {
-        registers.append(generator.newTemporary());
+        registers.unsafeAppendWithoutCapacityCheck(generator.newTemporary());
         generator.emitNode(registers.last().get(), elements[i]);
         if (m_targetPatterns[i].defaultValue)
             assignDefaultValueIfUndefined(generator, registers.last().get(), m_targetPatterns[i].defaultValue);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -7852,7 +7852,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 Node* value = addToGraph(ExtractCatchLocal, OpInfo(numberOfLocals), OpInfo(localPredictions[numberOfLocals]));
                 ++numberOfLocals;
                 addToGraph(MovHint, OpInfo(operand), value);
-                localsToSet.append(std::make_pair(operand, value));
+                localsToSet.unsafeAppendWithoutCapacityCheck(std::make_pair(operand, value));
             });
             if (numberOfLocals)
                 addToGraph(ClearCatchLocals);

--- a/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
@@ -98,7 +98,7 @@ inline Ref<SharedTask<void(Visitor&)>> MarkedSpace::forEachWeakInParallel()
                     m_current = m_current->next();
                     if (block->isEmpty())
                         continue;
-                    results.append(block);
+                    results.unsafeAppendWithoutCapacityCheck(block);
                     if (results.size() == batchSize)
                         return;
                     continue;

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -423,7 +423,7 @@ public:
                 auto* nativeCallee = visitor->callee().asNativeCallee();
                 switch (nativeCallee->category()) {
                 case NativeCallee::Category::Wasm: {
-                    m_results.append(StackFrame(visitor->wasmFunctionIndexOrName()));
+                    m_results.unsafeAppendWithoutCapacityCheck(StackFrame(visitor->wasmFunctionIndexOrName()));
                     break;
                 }
                 case NativeCallee::Category::InlineCache: {
@@ -431,10 +431,10 @@ public:
                 }
                 }
             } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction()) {
-                m_results.append(
+                m_results.unsafeAppendWithoutCapacityCheck(
                     StackFrame(m_vm, m_owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
             } else {
-                m_results.append(
+                m_results.unsafeAppendWithoutCapacityCheck(
                     StackFrame(m_vm, m_owner, visitor->callee().asCell()));
             }
             return IterationStatus::Continue;

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1904,7 +1904,7 @@ const Vector<String>& intlAvailableTimeZones()
             return StringImpl::createStaticStringImpl(string.characters16(), string.length());
         };
         for (auto iterator = temporary.begin(); iterator != end; ++iterator)
-            availableTimeZones->append(createImmortalThreadSafeString(WTFMove(*iterator)));
+            availableTimeZones->unsafeAppendWithoutCapacityCheck(createImmortalThreadSafeString(WTFMove(*iterator)));
     });
     return availableTimeZones;
 }

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -4073,7 +4073,7 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl
             PropertyOffset offset;
             if (Structure* newStructure = Structure::addPropertyTransitionToExistingStructure(structure, propertyName, 0, offset)) {
                 structure = newStructure;
-                offsets.append(offset);
+                offsets.unsafeAppendWithoutCapacityCheck(offset);
                 continue;
             }
 
@@ -4081,7 +4081,7 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl
             offset = structure->get(vm, propertyName, currentAttributes);
             if (offset != invalidOffset) {
                 structure->didReplaceProperty(offset);
-                offsets.append(offset);
+                offsets.unsafeAppendWithoutCapacityCheck(offset);
                 continue;
             }
 
@@ -4101,7 +4101,7 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl
             ASSERT(newStructure->isValidOffset(offset));
 
             structure = newStructure;
-            offsets.append(offset);
+            offsets.unsafeAppendWithoutCapacityCheck(offset);
         }
 
         // Flush batching here. Note that it is possible that offsets.size() is not equal to size, if we stop batching due to transition-watchpoint-firing.

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -195,7 +195,7 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncHypot, (JSGlobalObject* globalObject, Call
     for (unsigned i = 0; i < argsCount; ++i) {
         double argument = callFrame->uncheckedArgument(i).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        args.append(argument);
+        args.unsafeAppendWithoutCapacityCheck(argument);
     }
 
     double max = 0;

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -447,10 +447,10 @@ void SamplingProfiler::takeSample(Seconds& stackTraceProcessingTime)
                 Vector<UnprocessedStackFrame> stackTrace;
                 stackTrace.reserveInitialCapacity(walkSize + !!shouldAppendTopFrameAsCCode);
                 if (shouldAppendTopFrameAsCCode)
-                    stackTrace.append(UnprocessedStackFrame { machinePC });
+                    stackTrace.unsafeAppendWithoutCapacityCheck(UnprocessedStackFrame { machinePC });
                 for (size_t i = 0; i < walkSize; i++) {
                     UnprocessedStackFrame frame = m_currentFrames[i];
-                    stackTrace.append(frame);
+                    stackTrace.unsafeAppendWithoutCapacityCheck(frame);
                 }
 
                 m_unprocessedStackTraces.append(UnprocessedStackTrace { timestamp, nowTime, machinePC, topFrameIsLLInt, llintPC, regExp, WTFMove(stackTrace) });

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -515,7 +515,7 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearchWithCache(VM& vm, JSGloba
         RETURN_IF_EXCEPTION(scope, nullptr);
         auto string = jsResult.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, nullptr);
-        replacements.append(WTFMove(string));
+        replacements.unsafeAppendWithoutCapacityCheck(WTFMove(string));
 
         lastIndex = end;
     }

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -1333,7 +1333,7 @@ auto B3IRGenerator::addLocal(Type type, uint32_t count) -> PartialResult
 
     for (uint32_t i = 0; i < count; ++i) {
         Variable* local = m_proc.addVariable(toB3Type(type));
-        m_locals.append(local);
+        m_locals.unsafeAppendWithoutCapacityCheck(local);
         if (type.isV128())
             m_currentBlock->appendNew<VariableValue>(m_proc, Set, Origin(), local, constant(toB3Type(type), v128_t { }, Origin()));
         else {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -7516,7 +7516,7 @@ public:
 
             for (unsigned index = 0; index < targets.size(); ++index) {
                 Box<CCallHelpers::Label> label = Box<CCallHelpers::Label>::create(m_jit.label());
-                labels.append(label);
+                labels.unsafeAppendWithoutCapacityCheck(label);
                 bool isCodeEmitted = currentControlData().addExit(*this, targets[index]->targetLocations(), results);
                 if (isCodeEmitted)
                     targets[index]->addBranch(m_jit.jump());

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -138,7 +138,7 @@ void EntryPlan::prepare()
             }
             RELEASE_ASSERT_NOT_REACHED();
         }
-        m_wasmToWasmExitStubs.append(binding.value());
+        m_wasmToWasmExitStubs.unsafeAppendWithoutCapacityCheck(binding.value());
     }
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -59,7 +59,7 @@ void splitStack(BlockSignature originalSignature, EnclosingStack& enclosingStack
     ASSERT(enclosingStack.size() >= signature->as<FunctionSignature>()->argumentCount());
     unsigned offset = enclosingStack.size() - signature->as<FunctionSignature>()->argumentCount();
     for (unsigned i = 0; i < signature->as<FunctionSignature>()->argumentCount(); ++i)
-        newStack.append(enclosingStack.at(i + offset));
+        newStack.unsafeAppendWithoutCapacityCheck(enclosingStack.at(i + offset));
     enclosingStack.shrink(offset);
 }
 
@@ -336,7 +336,7 @@ auto FunctionParser<Context>::parse() -> Result
 
     WASM_PARSER_FAIL_IF(!m_locals.tryReserveCapacity(signature.argumentCount()), "can't allocate enough memory for function's ", signature.argumentCount(), " arguments");
     for (uint32_t i = 0; i < signature.argumentCount(); ++i)
-        m_locals.append(signature.argumentType(i));
+        m_locals.unsafeAppendWithoutCapacityCheck(signature.argumentType(i));
 
     uint64_t totalNumberOfLocals = signature.argumentCount();
     uint64_t totalNonDefaultableLocals = 0;
@@ -362,7 +362,7 @@ auto FunctionParser<Context>::parse() -> Result
 
         WASM_PARSER_FAIL_IF(!m_locals.tryReserveCapacity(totalNumberOfLocals), "can't allocate enough memory for function's ", totalNumberOfLocals, " locals");
         for (uint32_t i = 0; i < numberOfLocals; ++i)
-            m_locals.append(typeOfLocal);
+            m_locals.unsafeAppendWithoutCapacityCheck(typeOfLocal);
 
         WASM_TRY_ADD_TO_CONTEXT(addLocal(typeOfLocal, numberOfLocals));
     }
@@ -2958,7 +2958,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t target;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(target), "can't get ", i, "th target for br_table");
             WASM_PARSER_FAIL_IF(target >= m_controlStack.size(), "br_table's ", i, "th target ", target, " exceeds control stack size ", m_controlStack.size());
-            targets.append(&m_controlStack[m_controlStack.size() - 1 - target].controlData);
+            targets.unsafeAppendWithoutCapacityCheck(&m_controlStack[m_controlStack.size() - 1 - target].controlData);
         }
 
         WASM_PARSER_FAIL_IF(!parseVarUInt32(defaultTargetIndex), "can't get default target for br_table");

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -118,20 +118,20 @@ auto SectionParser::parseType() -> PartialResult
                     RefPtr<TypeDefinition> group = TypeInformation::typeDefinitionForRecursionGroup(types);
                     RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(group->index(), 0);
                     TypeInformation::registerCanonicalRTTForType(projection->index());
-                    m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
+                    m_info->rtts.unsafeAppendWithoutCapacityCheck(TypeInformation::getCanonicalRTT(projection->index()));
                     if (signature->is<Subtype>())
                         WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(projection->unroll(), group));
-                    m_info->typeSignatures.append(projection.releaseNonNull());
+                    m_info->typeSignatures.unsafeAppendWithoutCapacityCheck(projection.releaseNonNull());
                 } else {
                     TypeInformation::registerCanonicalRTTForType(signature->index());
-                    m_info->rtts.append(TypeInformation::getCanonicalRTT(signature->index()));
+                    m_info->rtts.unsafeAppendWithoutCapacityCheck(TypeInformation::getCanonicalRTT(signature->index()));
                     if (signature->is<Subtype>())
                         WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(signature->unroll(), { }));
-                    m_info->typeSignatures.append(signature.releaseNonNull());
+                    m_info->typeSignatures.unsafeAppendWithoutCapacityCheck(signature.releaseNonNull());
                 }
             }
         } else
-            m_info->typeSignatures.append(signature.releaseNonNull());
+            m_info->typeSignatures.unsafeAppendWithoutCapacityCheck(signature.releaseNonNull());
     }
     return { };
 }
@@ -172,7 +172,7 @@ auto SectionParser::parseImport() -> PartialResult
             WASM_PARSER_FAIL_IF(functionTypeIndex >= m_info->typeCount(), "invalid function signature for ", importNumber, "th Import, ", functionTypeIndex, " is out of range of ", m_info->typeCount(), " in module '", moduleString, "' field '", fieldString, "'");
             kindIndex = m_info->importFunctionTypeIndices.size();
             TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[functionTypeIndex]);
-            m_info->importFunctionTypeIndices.append(typeIndex);
+            m_info->importFunctionTypeIndices.unsafeAppendWithoutCapacityCheck(typeIndex);
             break;
         }
         case ExternalKind::Table: {
@@ -197,7 +197,7 @@ auto SectionParser::parseImport() -> PartialResult
             if (global.mutability == Mutability::Mutable)
                 global.bindingMode = GlobalInformation::BindingMode::Portable;
             kindIndex = m_info->globals.size();
-            m_info->globals.append(WTFMove(global));
+            m_info->globals.unsafeAppendWithoutCapacityCheck(WTFMove(global));
             break;
         }
         case ExternalKind::Exception: {
@@ -210,12 +210,12 @@ auto SectionParser::parseImport() -> PartialResult
             WASM_PARSER_FAIL_IF(exceptionSignatureIndex >= m_info->typeCount(), "invalid exception signature for ", importNumber, "th Import, ", exceptionSignatureIndex, " is out of range of ", m_info->typeCount(), " in module '", moduleString, "' field '", fieldString, "'");
             kindIndex = m_info->importExceptionTypeIndices.size();
             TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[exceptionSignatureIndex]);
-            m_info->importExceptionTypeIndices.append(typeIndex);
+            m_info->importExceptionTypeIndices.unsafeAppendWithoutCapacityCheck(typeIndex);
             break;
         }
         }
 
-        m_info->imports.append({ WTFMove(moduleString), WTFMove(fieldString), kind, kindIndex });
+        m_info->imports.unsafeAppendWithoutCapacityCheck({ WTFMove(moduleString), WTFMove(fieldString), kind, kindIndex });
     }
 
     m_info->firstInternalGlobal = m_info->globals.size();
@@ -241,8 +241,8 @@ auto SectionParser::parseFunction() -> PartialResult
         // The Code section fixes up start and end.
         size_t start = 0;
         size_t end = 0;
-        m_info->internalFunctionTypeIndices.append(typeIndex);
-        m_info->functions.append({ start, end, Vector<uint8_t>() });
+        m_info->internalFunctionTypeIndices.unsafeAppendWithoutCapacityCheck(typeIndex);
+        m_info->functions.unsafeAppendWithoutCapacityCheck({ start, end, Vector<uint8_t>() });
     }
 
     // Note that `initializeFunctionTrackers` should only be used after both parseImport and parseFunction
@@ -433,7 +433,7 @@ auto SectionParser::parseGlobal() -> PartialResult
             m_info->addDeclaredFunction(global.initialBits.initialBitsOrImportNumber);
         }
 
-        m_info->globals.append(WTFMove(global));
+        m_info->globals.unsafeAppendWithoutCapacityCheck(WTFMove(global));
     }
 
     return { };
@@ -492,7 +492,7 @@ auto SectionParser::parseExport() -> PartialResult
         }
         }
 
-        m_info->exports.append({ WTFMove(fieldString), kind, kindIndex });
+        m_info->exports.unsafeAppendWithoutCapacityCheck({ WTFMove(fieldString), kind, kindIndex });
     }
 
     return { };
@@ -538,7 +538,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         case 0x01: {
@@ -551,7 +551,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         case 0x02: {
@@ -573,7 +573,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         case 0x03: {
@@ -586,7 +586,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         case 0x04: {
@@ -604,7 +604,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(TableElementType::Funcref, element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         case 0x05: {
@@ -623,7 +623,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(tableElementType, element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         case 0x06: {
@@ -653,7 +653,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(tableElementType, element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         case 0x07: {
@@ -668,7 +668,7 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_PARSER_FAIL_IF(!element.functionIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element indices");
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(TableElementType::Funcref, element.functionIndices, indexCount, elementNum));
-            m_info->elements.append(WTFMove(element));
+            m_info->elements.unsafeAppendWithoutCapacityCheck(WTFMove(element));
             break;
         }
         default:
@@ -858,7 +858,7 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
     for (unsigned i = 0; i < argumentCount; ++i) {
         Type argumentType;
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, argumentType), "can't get ", i, "th argument Type");
-        argumentTypes.append(argumentType);
+        argumentTypes.unsafeAppendWithoutCapacityCheck(argumentType);
     }
 
     uint32_t returnCount;
@@ -870,7 +870,7 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
     for (unsigned i = 0; i < returnCount; ++i) {
         Type value;
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, value), "can't get ", i, "th Type's return value");
-        returnTypes.append(value);
+        returnTypes.unsafeAppendWithoutCapacityCheck(value);
     }
 
     functionSignature = TypeInformation::typeDefinitionForFunction(returnTypes, argumentTypes);
@@ -929,7 +929,7 @@ auto SectionParser::parseStructType(uint32_t position, RefPtr<TypeDefinition>& s
         WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get ", fieldIndex, "th field mutability");
         WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid Field's mutability: 0x", hex(mutability, 2, Lowercase));
 
-        fields.append(FieldType { fieldType, static_cast<Mutability>(mutability) });
+        fields.unsafeAppendWithoutCapacityCheck(FieldType { fieldType, static_cast<Mutability>(mutability) });
         structInstancePayloadSize += typeSizeInBytes(fieldType);
         WASM_PARSER_FAIL_IF(structInstancePayloadSize.hasOverflowed(), "struct layout is too big");
     }
@@ -993,7 +993,7 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
         }
 
         WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for recursion group's ", i, "th signature");
-        types.append(signature->index());
+        types.unsafeAppendWithoutCapacityCheck(signature->index());
 
         if (!i)
             firstSignature = signature;
@@ -1011,8 +1011,8 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
             RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(recursionGroup->index(), i);
             WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's ", i, "th projection");
             TypeInformation::registerCanonicalRTTForType(projection->index());
-            m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
-            m_info->typeSignatures.append(projection.releaseNonNull());
+            m_info->rtts.unsafeAppendWithoutCapacityCheck(TypeInformation::getCanonicalRTT(projection->index()));
+            m_info->typeSignatures.unsafeAppendWithoutCapacityCheck(projection.releaseNonNull());
         }
         // Checking subtyping requirements has to be deferred until we construct projections in case recursive references show up in the type.
         for (uint32_t i = 0; i < typeCount; ++i) {
@@ -1023,18 +1023,18 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
     } else {
         if (!firstSignature->hasRecursiveReference()) {
             TypeInformation::registerCanonicalRTTForType(firstSignature->index());
-            m_info->rtts.append(TypeInformation::getCanonicalRTT(firstSignature->index()));
+            m_info->rtts.unsafeAppendWithoutCapacityCheck(TypeInformation::getCanonicalRTT(firstSignature->index()));
             if (firstSignature->is<Subtype>())
                 WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(*firstSignature, { }));
-            m_info->typeSignatures.append(firstSignature.releaseNonNull());
+            m_info->typeSignatures.unsafeAppendWithoutCapacityCheck(firstSignature.releaseNonNull());
         } else {
             RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(recursionGroup->index(), 0);
             WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's 0th projection");
             TypeInformation::registerCanonicalRTTForType(projection->index());
-            m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
+            m_info->rtts.unsafeAppendWithoutCapacityCheck(TypeInformation::getCanonicalRTT(projection->index()));
             if (firstSignature->is<Subtype>())
                 WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(projection->unroll(), recursionGroup));
-            m_info->typeSignatures.append(projection.releaseNonNull());
+            m_info->typeSignatures.unsafeAppendWithoutCapacityCheck(projection.releaseNonNull());
         }
     }
 
@@ -1235,7 +1235,7 @@ auto SectionParser::parseElementSegmentVectorOfExpressions(TableElementType tabl
         WASM_PARSER_FAIL_IF(!parseUInt8(opcode), "can't get opcode for exp end in element section's ", elementNum, "th element's ", index, "th index");
         WASM_PARSER_FAIL_IF(opcode != End, "malformed expr in element section's", elementNum, "th element's ", index, "th index");
 
-        result.append(functionIndex);
+        result.unsafeAppendWithoutCapacityCheck(functionIndex);
     }
 
     return { };
@@ -1249,7 +1249,7 @@ auto SectionParser::parseElementSegmentVectorOfIndexes(Vector<uint32_t>& result,
         WASM_PARSER_FAIL_IF(functionIndex >= m_info->functionIndexSpaceSize(), "Element section's ", elementNum, "th element's ", index, "th index is ", functionIndex, " which exceeds the function index space size of ", m_info->functionIndexSpaceSize());
 
         m_info->addDeclaredFunction(functionIndex);
-        result.append(functionIndex);
+        result.unsafeAppendWithoutCapacityCheck(functionIndex);
     }
 
     return { };
@@ -1302,7 +1302,7 @@ auto SectionParser::parseData() -> PartialResult
                 WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", dataByte, "th data byte from ", segmentNumber, "th Data segment");
                 segment->byte(dataByte) = byte;
             }
-            m_info->data.append(WTFMove(segment));
+            m_info->data.unsafeAppendWithoutCapacityCheck(WTFMove(segment));
             continue;
         }
 
@@ -1319,7 +1319,7 @@ auto SectionParser::parseData() -> PartialResult
                 WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", dataByte, "th data byte from ", segmentNumber, "th Data segment");
                 segment->byte(dataByte) = byte;
             }
-            m_info->data.append(WTFMove(segment));
+            m_info->data.unsafeAppendWithoutCapacityCheck(WTFMove(segment));
             continue;
 
         }
@@ -1343,7 +1343,7 @@ auto SectionParser::parseData() -> PartialResult
                 WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", dataByte, "th data byte from ", segmentNumber, "th Data segment");
                 segment->byte(dataByte) = byte;
             }
-            m_info->data.append(WTFMove(segment));
+            m_info->data.unsafeAppendWithoutCapacityCheck(WTFMove(segment));
             continue;
         }
 
@@ -1382,7 +1382,7 @@ auto SectionParser::parseException() -> PartialResult
         TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[typeNumber]);
         auto signature = TypeInformation::getFunctionSignature(typeIndex);
         WASM_PARSER_FAIL_IF(!signature.returnsVoid(), exceptionNumber, "th Exception type cannot have a non-void return type ", typeNumber);
-        m_info->internalExceptionTypeIndices.append(typeIndex);
+        m_info->internalExceptionTypeIndices.unsafeAppendWithoutCapacityCheck(typeIndex);
     }
 
     return { };
@@ -1401,7 +1401,7 @@ auto SectionParser::parseCustom() -> PartialResult
     for (uint32_t byteNumber = 0; byteNumber < payloadBytes; ++byteNumber) {
         uint8_t byte;
         WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", byteNumber, "th data byte from ", customSectionNumber, "th custom section");
-        section.payload.append(byte);
+        section.payload.unsafeAppendWithoutCapacityCheck(byte);
     }
 
     Name nameName = { 'n', 'a', 'm', 'e' };
@@ -1418,7 +1418,7 @@ auto SectionParser::parseCustom() -> PartialResult
         branchHintsSectionParser.parse();
     }
 
-    m_info->customSections.append(WTFMove(section));
+    m_info->customSections.unsafeAppendWithoutCapacityCheck(WTFMove(section));
 
     return { };
 }

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -155,7 +155,7 @@ public:
                 auto& controlBlock = pair.value;
                 auto* objectOfCorrectType = pair.key;
                 if (auto refPtr = controlBlock->template makeStrongReferenceIfPossible<T>(objectOfCorrectType)) {
-                    strongReferences.append(refPtr.releaseNonNull());
+                    strongReferences.unsafeAppendWithoutCapacityCheck(refPtr.releaseNonNull());
                     return false;
                 }
                 return true;

--- a/Source/WTF/wtf/TinyLRUCache.h
+++ b/Source/WTF/wtf/TinyLRUCache.h
@@ -55,7 +55,7 @@ public:
             if (index != m_cache.size() - 1) {
                 auto entry = WTFMove(m_cache[index]);
                 m_cache.remove(index);
-                m_cache.append(WTFMove(entry));
+                m_cache.unsafeAppendWithoutCapacityCheck(WTFMove(entry));
             }
             return m_cache[m_cache.size() - 1].second;
         }
@@ -64,7 +64,7 @@ public:
         if (m_cache.size() == capacity)
             m_cache.remove(0);
 
-        m_cache.append(std::pair { Policy::createKeyForStorage(key), Policy::createValueForKey(key) });
+        m_cache.unsafeAppendWithoutCapacityCheck(std::pair { Policy::createKeyForStorage(key), Policy::createValueForKey(key) });
         return m_cache.last().second;
     }
 

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -926,6 +926,10 @@ public:
 
     bool isHashTableDeletedValue() const { return m_size == std::numeric_limits<decltype(m_size)>::max(); }
 
+    void unsafeAppendWithoutCapacityCheck(ValueType&& value) { unsafeAppendWithoutCapacityCheck<ValueType>(std::forward<ValueType>(value)); }
+    template<typename U> void unsafeAppendWithoutCapacityCheck(U&&);
+    template<typename U> bool unsafeAppendWithoutCapacityCheck(const U*, size_t);
+
 private:
     template<FailureAction> bool reserveCapacity(size_t newCapacity);
     template<FailureAction> bool reserveInitialCapacity(size_t initialCapacity);
@@ -947,10 +951,6 @@ private:
     template<typename Collection> friend Vector<typename CopyOrMoveToVectorResult<Collection>::Type> copyToVector(const Collection&);
     template<typename U, size_t otherInlineCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc> friend class Vector;
     template<typename DestinationVector, typename Collection> friend DestinationVector copyToVectorSpecialization(const Collection&);
-
-    void unsafeAppendWithoutCapacityCheck(ValueType&& value) { unsafeAppendWithoutCapacityCheck<ValueType>(std::forward<ValueType>(value)); }
-    template<typename U> void unsafeAppendWithoutCapacityCheck(U&&);
-    template<FailureAction, typename U> bool unsafeAppendWithoutCapacityCheck(const U*, size_t);
 
     template<size_t position, typename U, typename... Items>
     void uncheckedInitialize(U&& item, Items&&... items)
@@ -1434,10 +1434,9 @@ ALWAYS_INLINE bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Mallo
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<FailureAction action, typename U>
+template<typename U>
 ALWAYS_INLINE bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::unsafeAppendWithoutCapacityCheck(const U* data, size_t dataSize)
 {
-    static_assert(action == FailureAction::Crash || action == FailureAction::Report);
     if (!dataSize)
         return true;
 


### PR DESCRIPTION
#### 9b178a5d519ff05904b54be473fb52fc3694968e
<pre>
Regression(268700@main) ~0.6% regression on Speedometer 2 on iPhone
<a href="https://bugs.webkit.org/show_bug.cgi?id=264231">https://bugs.webkit.org/show_bug.cgi?id=264231</a>
<a href="https://rdar.apple.com/116706935">rdar://116706935</a>

Reviewed by Darin Adler.

This is a partial revert where we start using again uncheckedAppend() (now named
unsafeAppendWithoutCapacityCheck()) in some parts of JSC and WTF. This has been
verified by A/B testing as a ~0.6% progression on Speedometer 2 on the same
iPhone hardware as the regression.

I&apos;m doing a revert for now but my plan is still to get rid of explicit usage of
unsafeAppendWithoutCapacityCheck() in the future.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::prepareLexicalScopeForNextForLoopIteration):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ArrayPatternNode::emitDirectBinding):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::specializedSweep):
* Source/JavaScriptCore/heap/MarkedSpaceInlines.h:
(JSC::MarkedSpace::forEachWeakInParallel):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::GetStackTraceFunctor::operator() const):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::intlAvailableTimeZones):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putOwnDataPropertyBatching):
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::takeSample):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::replaceUsingRegExpSearchWithCache):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addLocal):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSwitch):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::prepare):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::splitStack):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parse):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseImport):
(JSC::Wasm::SectionParser::parseFunction):
(JSC::Wasm::SectionParser::parseGlobal):
(JSC::Wasm::SectionParser::parseExport):
(JSC::Wasm::SectionParser::parseElement):
(JSC::Wasm::SectionParser::parseFunctionType):
(JSC::Wasm::SectionParser::parseStructType):
(JSC::Wasm::SectionParser::parseRecursionGroup):
(JSC::Wasm::SectionParser::parseElementSegmentVectorOfExpressions):
(JSC::Wasm::SectionParser::parseElementSegmentVectorOfIndexes):
(JSC::Wasm::SectionParser::parseData):
(JSC::Wasm::SectionParser::parseException):
(JSC::Wasm::SectionParser::parseCustom):
* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/TinyLRUCache.h:
(WTF::TinyLRUCache::get):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::unsafeAppendWithoutCapacityCheck):
(WTF::Malloc&gt;::unsafeAppendWithoutCapacityCheck):

Canonical link: <a href="https://commits.webkit.org/270254@main">https://commits.webkit.org/270254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8a47a4019b625c0e6bcf9c15d756b0b22f2ebab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23219 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25233 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2566 "Found 1 new test failure: fast/dom/focus-dialog-blur-input-type-change-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27685 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28633 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21729 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26458 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24239 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/509 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31645 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3490 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5980 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2654 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31630 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2552 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6609 "Passed tests") | 
<!--EWS-Status-Bubble-End-->