### PR TITLE
[iOS] Render <hr>-in-<select> as separator

### DIFF
--- a/LayoutTests/fast/forms/ios/select-multiple-options-with-hr-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-multiple-options-with-hr-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that choosing options in a <select multiple> with an <hr> child works as expected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectValues is ""
+PASS selectValues is "D"
+PASS selectValues is "D,E"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-multiple-options-with-hr.html
+++ b/LayoutTests/fast/forms/ios/select-multiple-options-with-hr.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select multiple id="select">
+    <option>A</option>
+    <option>B</option>
+    <option>C</option>
+    <hr>
+    <option>D</option>
+    <option>E</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+function valuesForSelectElement(element)
+{
+    return Array.from(element.selectedOptions).map(o => o.value).toString();
+}
+
+async function selectRowAndAssertValues(row, values)
+{
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.selectFormAccessoryPickerRow(row);
+    await UIHelper.ensurePresentationUpdate();
+
+    selectValues = valuesForSelectElement(select);
+    shouldBeEqualToString("selectValues", values);
+}
+
+addEventListener("load", async () => {
+    description("This test verifies that choosing options in a &lt;select multiple&gt; with an &lt;hr&gt; child works as expected.");
+
+    selectValues = valuesForSelectElement(select);
+    shouldBeEqualToString("selectValues", "");
+
+    await UIHelper.activateElement(select);
+    await selectRowAndAssertValues(3, "D");
+    await selectRowAndAssertValues(4, "D,E");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/fast/forms/ios/select-options-with-hr-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-options-with-hr-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that choosing options in a <select> with an <hr> child works as expected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.value is "A"
+PASS select.value is "D"
+PASS select.value is "E"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-options-with-hr.html
+++ b/LayoutTests/fast/forms/ios/select-options-with-hr.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select id="select">
+    <option>A</option>
+    <option>B</option>
+    <option>C</option>
+    <hr>
+    <option>D</option>
+    <option>E</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that choosing options in a &lt;select&gt; with an &lt;hr&gt; child works as expected.");
+
+    shouldBeEqualToString("select.value", "A");
+
+    await UIHelper.activateElement(select);
+    await UIHelper.waitForContextMenuToShow();
+    await UIHelper.selectFormAccessoryPickerRow(3);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "D");
+
+    await UIHelper.activateElement(select);
+    await UIHelper.waitForContextMenuToShow();
+    await UIHelper.selectFormAccessoryPickerRow(4);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "E");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -99,6 +99,7 @@
 #import <WebCore/HTMLElement.h>
 #import <WebCore/HTMLElementTypeHelpers.h>
 #import <WebCore/HTMLFormElement.h>
+#import <WebCore/HTMLHRElement.h>
 #import <WebCore/HTMLIFrameElement.h>
 #import <WebCore/HTMLImageElement.h>
 #import <WebCore/HTMLInputElement.h>
@@ -3633,6 +3634,10 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
 
                 parentGroupID++;
                 information.selectOptions.append(OptionItem(optGroupElement->groupLabelText(), true, false, optGroupElement->hasAttributeWithoutSynchronization(WebCore::HTMLNames::disabledAttr), parentGroupID));
+            } else if (selectPickerUsesMenu && is<HTMLHRElement>(item.get())) {
+                parentGroupID++;
+                parentGroup = nullptr;
+                information.selectOptions.append(OptionItem(emptyString(), true, false, false, parentGroupID));
             }
         }
         information.selectedIndex = element.selectedIndex();


### PR DESCRIPTION
#### 6e4ae062086ea05880c62c7313096daba801b4d5
<pre>
[iOS] Render &lt;hr&gt;-in-&lt;select&gt; as separator
<a href="https://bugs.webkit.org/show_bug.cgi?id=264232">https://bugs.webkit.org/show_bug.cgi?id=264232</a>
<a href="https://rdar.apple.com/108783915">rdar://108783915</a>

Reviewed by Wenson Hsieh.

263624@main added support for &lt;hr&gt;-in-&lt;select&gt; at a parser level. macOS has
long supporting rendering a separator in this scenario but iOS does not.

Render a separator when an &lt;hr&gt; is encountered by adding an empty group to the
data model sent to the UI process. UIKit only supports showing a separator when
using sub-menus with `UIMenuOptionsDisplayInline`. Since this is the default
option used for &lt;optgroup&gt;s in WebKit, an empty group is all that&apos;s needed to
display a separator.

It is not possible to test the appearance of the native picker, but tests that
verify selection still works as expected in this scenario have been added.

* LayoutTests/fast/forms/ios/select-multiple-options-with-hr-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-multiple-options-with-hr.html: Added.
* LayoutTests/fast/forms/ios/select-options-with-hr-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-options-with-hr.html: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):

Canonical link: <a href="https://commits.webkit.org/270293@main">https://commits.webkit.org/270293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c55d354df8469ae33e08ee97cf6f73354de259a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23220 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27689 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28631 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26456 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/512 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22253 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2658 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3198 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->