### PR TITLE
Update html.css to use logical properties for form controls

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -439,7 +439,8 @@ input {
     border-radius: 5px;
     border: 1px solid -apple-system-secondary-label;
     font: 11px system-ui;
-    padding: 0.2em 0.5em 0.3em 0.5em;
+    padding-block: 0.2em 0.3em;
+    padding-inline: 0.5em;
 #else
     border: 2px inset gray;
     padding: 1px;
@@ -482,7 +483,8 @@ input[type="search"]::-webkit-search-results-decoration {
     display: block;
     flex: none;
     align-self: flex-start;
-    margin: auto 0;
+    margin-block: auto;
+    margin-inline: 0;
 }
 
 input[type="search"]::-webkit-search-results-button {
@@ -491,7 +493,8 @@ input[type="search"]::-webkit-search-results-button {
     flex: none;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     align-self: flex-start;
-    margin: auto 0;
+    margin-block: auto;
+    margin-inline: 0;
 #endif
 }
 
@@ -534,9 +537,11 @@ input::-webkit-date-and-time-value {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     margin: 0px;
     text-align: center;
-    width: 100%;
+    inline-size: 100%;
 #else
-    margin: 1px 24px 1px 4px;
+    margin-block: 1px;
+    margin-inline-start: 4px;
+    margin-inline-end: 24px;
     white-space: pre;
 #endif
 }
@@ -738,13 +743,13 @@ input::-webkit-list-button {
     flex: none;
     -webkit-user-select: none;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
-    width: 11px;
+    inline-size: 11px;
     /* Make it easier to hit the button on iOS */
     padding: 7px;
     margin: -7px;
 #else
-    width: 16px;
-    height: 100%;
+    inline-size: 16px;
+    block-size: 100%;
 #endif
 }
 #endif
@@ -769,8 +774,7 @@ textarea {
     /* On iOS we want to inherit the left and right padding for consistency with
      other form controls (e.g. <input type="text">). We want to override the top
      and bottom padding to ensure we have a symmetric look for text areas. */
-    padding-top: 2px;
-    padding-bottom: 2px;
+    padding-block: 2px;
 #endif
     flex-direction: column;
     resize: auto;
@@ -1070,7 +1074,8 @@ select {
     letter-spacing: normal;
     word-spacing: normal;
     line-height: normal;
-    padding: 0 0.4em 0 0.4em;
+    padding-block: 0;
+    padding-inline: 0.4em;
     color: -apple-system-blue;
     font: 11px system-ui;
     border: 1px solid -webkit-control-background;


### PR DESCRIPTION
#### 55af19e16ebb473a7a4f4d5a4fe07c23179c5259
<pre>
Update html.css to use logical properties for form controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=264236">https://bugs.webkit.org/show_bug.cgi?id=264236</a>
<a href="https://rdar.apple.com/117983666">rdar://117983666</a>

Reviewed by Tim Nguyen.

This is necessary in order to support vertical form controls.

* Source/WebCore/css/html.css:
(input):
(input[type=&quot;search&quot;]::-webkit-search-cancel-button,input[type=&quot;search&quot;]::-webkit-search-decoration,input[type=&quot;search&quot;]::-webkit-search-results-decoration):
(input[type=&quot;search&quot;]::-webkit-search-results-button):
(input::-webkit-date-and-time-value:
(input::-webkit-list-button):
(textarea):
(select):

Canonical link: <a href="https://commits.webkit.org/270277@main">https://commits.webkit.org/270277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78261c5891ed2e2e4e998ea580e0caa71360b2b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27739 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2325 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22553 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26502 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/560 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3540 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->