### PR TITLE
Rewrite Python CGI under http/tests/xmlhttprequest to use binary mode for stdout for Windows Python

### DIFF
--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-allow-lists.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-allow-lists.py
@@ -14,30 +14,27 @@ split_query = {}
 for pair in query.split('&'):
     split_query[unquote(pair.split('=')[0])] = '='.join(pair.split('=')[1:])
 
-sys.stdout.write('Content-Type: text/html\r\n')
+sys.stdout.buffer.write(b'Content-Type: text/html\r\n')
 
 origin = split_query.get('origin', 'none')
 if origin != 'none' and '%00' not in origin:
-    sys.stdout.write('Access-Control-Allow-Origin: ')
-    sys.stdout.flush()
+    sys.stdout.buffer.write(b'Access-Control-Allow-Origin: ')
     sys.stdout.buffer.write(unquote_to_bytes(origin))
-    sys.stdout.write('\r\n')
+    sys.stdout.buffer.write(b'\r\n')
 
 headers = split_query.get('headers')
 if headers:
-    sys.stdout.write('Access-Control-Allow-Headers: ')
-    sys.stdout.flush()
+    sys.stdout.buffer.write(b'Access-Control-Allow-Headers: ')
     sys.stdout.buffer.write(unquote_to_bytes(headers))
-    sys.stdout.write('\r\n')
+    sys.stdout.buffer.write(b'\r\n')
 
 methods = split_query.get('methods')
 if methods:
-    sys.stdout.write('Access-Control-Allow-Methods: ')
-    sys.stdout.flush()
+    sys.stdout.buffer.write(b'Access-Control-Allow-Methods: ')
     sys.stdout.buffer.write(unquote_to_bytes(methods))
-    sys.stdout.write('\r\n')
+    sys.stdout.buffer.write(b'\r\n')
 
-sys.stdout.write('\r\n')
+sys.stdout.buffer.write(b'\r\n')
 
 headers = {}
 headers['get_value'] = unquote(split_query.get('get_value', ''))
@@ -48,4 +45,4 @@ for headername, headervalue in os.environ.items():
         continue
     headers[headername[5:].lower().replace('_', '-')] = headervalue
 
-sys.stdout.write(json.dumps(headers))
+sys.stdout.buffer.write(json.dumps(headers).encode())

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-allow-with-body.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-allow-with-body.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 import sys
 
-sys.stdout.write(
-    'Content-Type: text/html\r\n'
-    'Access-control-allow-headers: X-Requested-With\r\n'
-    'Access-control-max-age: 0\r\n'
-    'Access-control-allow-origin: *\r\n'
-    'Access-control-allow-methods: *\r\n'
-    'Vary: Accept-Encoding\r\n'
-    'Content-Type: text/plain\r\n'
-    '\r\n'
-    'echo'
+sys.stdout.buffer.write(
+    b'Content-Type: text/html\r\n'
+    b'Access-control-allow-headers: X-Requested-With\r\n'
+    b'Access-control-max-age: 0\r\n'
+    b'Access-control-allow-origin: *\r\n'
+    b'Access-control-allow-methods: *\r\n'
+    b'Vary: Accept-Encoding\r\n'
+    b'Content-Type: text/plain\r\n'
+    b'\r\n'
+    b'echo'
 )
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir1/basic-auth.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir1/basic-auth.py
@@ -3,20 +3,20 @@ import base64
 import os
 import sys
 
-sys.stdout.write('Content-Type: text/html\r\n')
+sys.stdout.buffer.write(b'Content-Type: text/html\r\n')
 if os.environ.get('HTTP_AUTHORIZATION'):
     credentials = base64.b64decode(os.environ['HTTP_AUTHORIZATION'].split(' ')[1]).decode().split(':')
     username = credentials[0]
     password = ':'.join(credentials[1:])
-    sys.stdout.write(
+    sys.stdout.buffer.write(
         '\r\n'
-        'User: {}, password: {}.'.format(username, password)
+        'User: {}, password: {}.'.format(username, password).encode()
     )
 
 else:
-    sys.stdout.write(
-        'WWW-Authenticate: Basic realm="xhr basic-auth-default"\r\n'
-        'status: 401\r\n'
-        '\r\n'
-        'Authentication canceled'
+    sys.stdout.buffer.write(
+        b'WWW-Authenticate: Basic realm="xhr basic-auth-default"\r\n'
+        b'status: 401\r\n'
+        b'\r\n'
+        b'Authentication canceled'
     )

--- a/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir2/basic-auth.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir2/basic-auth.py
@@ -3,20 +3,20 @@ import base64
 import os
 import sys
 
-sys.stdout.write('Content-Type: text/html\r\n')
+sys.stdout.buffer.write(b'Content-Type: text/html\r\n')
 if os.environ.get('HTTP_AUTHORIZATION'):
     credentials = base64.b64decode(os.environ['HTTP_AUTHORIZATION'].split(' ')[1]).decode().split(':')
     username = credentials[0]
     password = ':'.join(credentials[1:])
-    sys.stdout.write(
+    sys.stdout.buffer.write(
         '\r\n'
-        'User: {}, password: {}.'.format(username, password)
+        'User: {}, password: {}.'.format(username, password).encode()
     )
 
 else:
-    sys.stdout.write(
-        'WWW-Authenticate: Basic realm="xhr basic-auth-default"\r\n'
-        'status: 401\r\n'
-        '\r\n'
-        'Authentication canceled'
+    sys.stdout.buffer.write(
+        b'WWW-Authenticate: Basic realm="xhr basic-auth-default"\r\n'
+        b'status: 401\r\n'
+        b'\r\n'
+        b'Authentication canceled'
     )

--- a/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir2/catch.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir2/catch.py
@@ -3,21 +3,21 @@ import base64
 import os
 import sys
 
-sys.stdout.write('Content-Type: text/html\r\n')
+sys.stdout.buffer.write(b'Content-Type: text/html\r\n')
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]
 password = ':'.join(credentials[1:]) if len(credentials) > 1 else ''
 
 if username:
-    sys.stdout.write(
+    sys.stdout.buffer.write(
         '\r\n'
-        'User: {}, password: {}.'.format(username, password)
+        'User: {}, password: {}.'.format(username, password).encode()
     )
 
 else:
-    sys.stdout.write(
-        'status: 500\r\n'
-        '\r\n'
-        'Where is my default auth?'
+    sys.stdout.buffer.write(
+        b'status: 500\r\n'
+        b'\r\n'
+        b'Where is my default auth?'
     )

--- a/LayoutTests/http/tests/xmlhttprequest/resources/chunked-transfer.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/chunked-transfer.py
@@ -2,14 +2,14 @@
 import os
 import sys
 
-sys.stdout.write(
-    'Content-Type: text/html\r\n'
-    'Transfer-encoding: chunked\r\n'
-    'Cache-Control: no-cache, no-store\r\n'
-    '\r\n'
+sys.stdout.buffer.write(
+    b'Content-Type: text/html\r\n'
+    b'Transfer-encoding: chunked\r\n'
+    b'Cache-Control: no-cache, no-store\r\n'
+    b'\r\n'
 )
 
 sys.stdout.flush()
-sys.stdout.write("4\r\n<a/>\r\n")
+sys.stdout.buffer.write(b"4\r\n<a/>\r\n")
 sys.stdout.flush()
-sys.stdout.write("0\r\n\r\n")
+sys.stdout.buffer.write(b"0\r\n\r\n")

--- a/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-authorization.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-authorization.py
@@ -3,27 +3,27 @@ import base64
 import os
 import sys
 
-sys.stdout.write(
-    'Content-Type: text/html\r\n'
-    'Set-Cookie: WK-cross-origin=1\r\n'
-    'Cache-Control: no-store\r\n'
-    'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
-    'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
-    'Access-Control-Allow-Credentials: true\r\n'
-    'Connection: close\r\n'
+sys.stdout.buffer.write(
+    b'Content-Type: text/html\r\n'
+    b'Set-Cookie: WK-cross-origin=1\r\n'
+    b'Cache-Control: no-store\r\n'
+    b'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
+    b'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
+    b'Access-Control-Allow-Credentials: true\r\n'
+    b'Connection: close\r\n'
 )
 
 if os.environ.get('HTTP_AUTHORIZATION'):
-    sys.stdout.write('\r\n')
+    sys.stdout.buffer.write(b'\r\n')
     username, _ = base64.b64decode(os.environ['HTTP_AUTHORIZATION'].split(' ')[1]).split(b':')
-    sys.stdout.write("log('PASS: Loaded, user {}');\n".format(username.decode('utf-8')))
+    sys.stdout.buffer.write("log('PASS: Loaded, user {}');\n".format(username.decode('utf-8')).encode())
 
 else:
-    sys.stdout.write(
-        'WWW-Authenticate: Basic realm="WebKit xmlhttprequest/cross-origin-no-authorization"\r\n'
-        'status: 401\r\n'
-        '\r\n'
-        'Authentication canceled'
+    sys.stdout.buffer.write(
+        b'WWW-Authenticate: Basic realm="WebKit xmlhttprequest/cross-origin-no-authorization"\r\n'
+        b'status: 401\r\n'
+        b'\r\n'
+        b'Authentication canceled'
     )
 
 sys.stdout.flush()

--- a/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-check-cookies.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-check-cookies.py
@@ -8,14 +8,14 @@ cookies = {
     pair.split('=')[0]: '='.join(pair.split('=')[1:]) for pair in os.environ.get('HTTP_COOKIE', '').split(';')
 }
 
-sys.stdout.write(
-    'Content-Type: text/html\r\n'
-    'Cache-Control: no-store\r\n'
-    'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
-    'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
-    'Access-Control-Allow-Credentials: true\r\n'
-    'Connection: close\r\n'
-    '\r\n'
+sys.stdout.buffer.write(
+    b'Content-Type: text/html\r\n'
+    b'Cache-Control: no-store\r\n'
+    b'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
+    b'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
+    b'Access-Control-Allow-Credentials: true\r\n'
+    b'Connection: close\r\n'
+    b'\r\n'
 )
 
 cookie = query.get('cookie')
@@ -25,6 +25,6 @@ if not cookie:
     cookie = 'WK-cross-origin'
 
 if cookies.get(cookie):
-    sys.stdout.write('{}: {}'.format(cookie, cookies.get(cookie)))
+    sys.stdout.buffer.write('{}: {}'.format(cookie, cookies.get(cookie)).encode())
 else:
-    sys.stdout.write('Cookie was not sent')
+    sys.stdout.buffer.write(b'Cookie was not sent')

--- a/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-no-authorization.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-no-authorization.py
@@ -3,24 +3,25 @@ import base64
 import os
 import sys
 
-sys.stdout.write(
-    'Content-Type: text/html\r\n'
-    'Set-Cookie: WK-cross-origin=1\r\n'
-    'Cache-Control: no-store\r\n'
-    'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
-    'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
-    'Connection: close\r\n'
+sys.stdout.buffer.write(
+    b'Content-Type: text/html\r\n'
+    b'Set-Cookie: WK-cross-origin=1\r\n'
+    b'Cache-Control: no-store\r\n'
+    b'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
+    b'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
+    b'Connection: close\r\n'
 )
 
 if os.environ.get('HTTP_AUTHORIZATION'):
-    sys.stdout.write('\r\n')
+    sys.stdout.buffer.write(b'\r\n')
     username, _ = base64.b64decode(os.environ['HTTP_AUTHORIZATION'].split(' ')[1]).split(b':')
-    sys.stdout.write("log('PASS: Loaded, user {}');\n".format(username.decode('utf-8')))
+
+    sys.stdout.buffer.write("log('PASS: Loaded, user {}');\n".format(username.decode('utf-8')).encode())
 
 else:
-    sys.stdout.write(
-        'WWW-Authenticate: Basic realm="WebKit xmlhttprequest/cross-origin-no-authorization"\r\n'
-        'status: 401\r\n'
-        '\r\n'
-        'Authentication canceled'
+    sys.stdout.buffer.write(
+        b'WWW-Authenticate: Basic realm="WebKit xmlhttprequest/cross-origin-no-authorization"\r\n'
+        b'status: 401\r\n'
+        b'\r\n'
+        b'Authentication canceled'
     )    

--- a/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-preflight-get.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-preflight-get.py
@@ -2,17 +2,17 @@
 import os
 import sys
 
-sys.stdout.write('Content-Type: text/html\r\n')
+sys.stdout.buffer.write(b'Content-Type: text/html\r\n')
 
 if os.environ.get('HTTP_ORIGIN'):
-    sys.stdout.write(
-        'Access-Control-Allow-Origin: *\r\n'
-        'Access-Control-Allow-Headers: X-Proprietary-Header\r\n'
-        '\r\n'
-        'PASS: Origin header correctly sent'
+    sys.stdout.buffer.write(
+        b'Access-Control-Allow-Origin: *\r\n'
+        b'Access-Control-Allow-Headers: X-Proprietary-Header\r\n'
+        b'\r\n'
+        b'PASS: Origin header correctly sent'
     )
 else:
-    sys.stdout.write(
-        '\r\n'
-        'FAIL: No origin header sent'
+    sys.stdout.buffer.write(
+        b'\r\n'
+        b'FAIL: No origin header sent'
     )

--- a/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-set-cookies.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-set-cookies.py
@@ -6,17 +6,17 @@ from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Content-Type: text/html\r\n'
     'Set-Cookie: WK-xhr-cookie-storage=MySpecialValue;{}\r\n'.format(
     'expires=Thu, 19 Mar 1982 11:22:11 GMT' if query.get('clear') is not None else '',
-))
+    ).encode())
 
-sys.stdout.write(
-    'Cache-Control: no-store\r\n'
-    'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
-    'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
-    'Access-Control-Allow-Credentials: true\r\n'
-    '\r\n'
-    'log(\'PASS: Loaded\')\n'
+sys.stdout.buffer.write(
+    b'Cache-Control: no-store\r\n'
+    b'Last-Modified: Thu, 19 Mar 2009 11:22:11 GMT\r\n'
+    b'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'
+    b'Access-Control-Allow-Credentials: true\r\n'
+    b'\r\n'
+    b'log(\'PASS: Loaded\')\n'
 )

--- a/LayoutTests/http/tests/xmlhttprequest/resources/logout/resource.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/logout/resource.py
@@ -3,9 +3,9 @@ import base64
 import os
 import sys
 
-sys.stdout.write(
-    'Content-Type: text/html\r\n'
-    'Cache-Control: no-cache, no-store\r\n'
+sys.stdout.buffer.write(
+    b'Content-Type: text/html\r\n'
+    b'Cache-Control: no-cache, no-store\r\n'
 )
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
@@ -13,15 +13,15 @@ username = credentials[0]
 password = ':'.join(credentials[1:])
 
 if (username, password) == ('user', 'pass'):
-    sys.stdout.write(
+    sys.stdout.buffer.write(
         '\r\n'
-        'User: {}, password: {}.'.format(username, password)
+        'User: {}, password: {}.'.format(username, password).encode()
     )
 
 else:
-    sys.stdout.write(
-        'WWW-Authenticate: Basic realm="Please cancel this authentication dialog"\r\n'
-        'status: 401\r\n'
-        '\r\n'
-        'Authentication canceled'
+    sys.stdout.buffer.write(
+        b'WWW-Authenticate: Basic realm="Please cancel this authentication dialog"\r\n'
+        b'status: 401\r\n'
+        b'\r\n'
+        b'Authentication canceled'
     )

--- a/LayoutTests/http/tests/xmlhttprequest/resources/re-login/resource.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/re-login/resource.py
@@ -3,9 +3,9 @@ import base64
 import os
 import sys
 
-sys.stdout.write(
-    'Content-Type: text/html\r\n'
-    'Cache-Control: no-cache, no-store\r\n'
+sys.stdout.buffer.write(
+    b'Content-Type: text/html\r\n'
+    b'Cache-Control: no-cache, no-store\r\n'
 )
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
@@ -13,15 +13,15 @@ username = credentials[0]
 password = ':'.join(credentials[1:])
 
 if username and password:
-    sys.stdout.write(
+    sys.stdout.buffer.write(
         '\r\n'
-        'User: {}, password: {}.'.format(username, password)
+        'User: {}, password: {}.'.format(username, password).encode()
     )
 
 else:
-    sys.stdout.write(
-        'WWW-Authenticate: Basic realm="WebKit test re-login"\r\n'
-        'status: 401\r\n'
-        '\r\n'
-        'Authentication canceled'
+    sys.stdout.buffer.write(
+        b'WWW-Authenticate: Basic realm="WebKit test re-login"\r\n'
+        b'status: 401\r\n'
+        b'\r\n'
+        b'Authentication canceled'
     )

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -896,7 +896,6 @@ http/tests/xmlhttprequest/abort-should-cancel-load.html [ Failure ]
 http/tests/xmlhttprequest/access-control-basic-allow-list-request-headers.html [ Failure ]
 http/tests/xmlhttprequest/basic-auth-default.html [ Failure ]
 http/tests/xmlhttprequest/basic-auth-nopassword.html [ Failure ]
-http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html [ Failure ]
 http/tests/xmlhttprequest/cross-origin-authorization.html [ Failure ]
 http/tests/xmlhttprequest/cross-origin-cookie-storage.html [ Failure ]
 http/tests/xmlhttprequest/cross-origin-no-authorization.html [ Failure ]
@@ -907,7 +906,6 @@ http/tests/xmlhttprequest/re-login-async.html [ Failure ]
 http/tests/xmlhttprequest/re-login.html [ Failure ]
 http/tests/xmlhttprequest/redirect-credentials-responseURL.html [ Failure ]
 http/tests/xmlhttprequest/simple-cross-origin-denied-events-post.html [ Failure ]
-http/tests/xmlhttprequest/upload-progress-events-gc.html [ Skip ] # Timeout
 
 # Fails on Buildbot
 http/tests/xmlhttprequest/resetting-timeout-to-zero.html [ Failure Pass ]


### PR DESCRIPTION
#### 824e7a817082c9aa5ce165ce62bf7db87cbb3478
<pre>
Rewrite Python CGI under http/tests/xmlhttprequest to use binary mode for stdout for Windows Python
<a href="https://bugs.webkit.org/show_bug.cgi?id=264238">https://bugs.webkit.org/show_bug.cgi?id=264238</a>

Reviewed by Ross Kirsling.

Windows Python automatically converts &apos;\n&apos; to &apos;\r\n&apos; in text mode.
Use sys.stdout.buffer.write instead of sys.stdout.write.

* LayoutTests/http/tests/xmlhttprequest/resources/access-control-allow-lists.py:
* LayoutTests/http/tests/xmlhttprequest/resources/access-control-allow-with-body.py:
* LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir1/basic-auth.py:
* LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir2/basic-auth.py:
* LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-default/dir2/catch.py:
* LayoutTests/http/tests/xmlhttprequest/resources/chunked-transfer.py:
* LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-authorization.py:
* LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-check-cookies.py:
* LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-no-authorization.py:
* LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-preflight-get.py:
* LayoutTests/http/tests/xmlhttprequest/resources/cross-origin-set-cookies.py:
* LayoutTests/http/tests/xmlhttprequest/resources/logout/resource.py:
* LayoutTests/http/tests/xmlhttprequest/resources/re-login/resource.py:
* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270258@main">https://commits.webkit.org/270258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1247821c1dfc1fa10c3dca7262654276f51bd2e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/981 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27695 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28640 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26465 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/519 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3500 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5986 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->