### PR TITLE
Replace std::isnan/isinf/isfinite UB overloads for time classes with member functions

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -286,7 +286,7 @@ void InspectorHeapAgent::didGarbageCollect(CollectionScope scope)
         return;
     }
 
-    if (std::isnan(m_gcStartTime)) {
+    if (m_gcStartTime.isNaN()) {
         // We were not enabled when the GC began.
         return;
     }

--- a/Source/WTF/wtf/ApproximateTime.cpp
+++ b/Source/WTF/wtf/ApproximateTime.cpp
@@ -34,14 +34,14 @@ namespace WTF {
 
 WallTime ApproximateTime::approximateWallTime() const
 {
-    if (std::isinf(*this))
+    if (isInfinity())
         return WallTime::fromRawSeconds(m_value);
     return *this - now() + WallTime::now();
 }
 
 MonotonicTime ApproximateTime::approximateMonotonicTime() const
 {
-    if (std::isinf(*this))
+    if (isInfinity())
         return MonotonicTime::fromRawSeconds(m_value);
     return *this - now() + MonotonicTime::now();
 }

--- a/Source/WTF/wtf/ApproximateTime.h
+++ b/Source/WTF/wtf/ApproximateTime.h
@@ -69,7 +69,7 @@ static_assert(sizeof(ApproximateTime) == sizeof(double));
 struct ApproximateTime::MarkableTraits {
     static bool isEmptyValue(ApproximateTime time)
     {
-        return std::isnan(time.m_value);
+        return time.isNaN();
     }
 
     static constexpr ApproximateTime emptyValue()
@@ -79,24 +79,5 @@ struct ApproximateTime::MarkableTraits {
 };
 
 } // namespace WTF
-
-namespace std {
-
-inline bool isnan(WTF::ApproximateTime time)
-{
-    return std::isnan(time.secondsSinceEpoch().value());
-}
-
-inline bool isinf(WTF::ApproximateTime time)
-{
-    return std::isinf(time.secondsSinceEpoch().value());
-}
-
-inline bool isfinite(WTF::ApproximateTime time)
-{
-    return std::isfinite(time.secondsSinceEpoch().value());
-}
-
-} // namespace std
 
 using WTF::ApproximateTime;

--- a/Source/WTF/wtf/GenericTimeMixin.h
+++ b/Source/WTF/wtf/GenericTimeMixin.h
@@ -43,6 +43,10 @@ public:
     static constexpr DerivedTime infinity() { return fromRawSeconds(std::numeric_limits<double>::infinity()); }
     static constexpr DerivedTime nan() { return fromRawSeconds(std::numeric_limits<double>::quiet_NaN()); }
 
+    bool isNaN() const { return std::isnan(m_value); }
+    bool isInfinity() const { return std::isinf(m_value); }
+    bool isFinite() const { return std::isfinite(m_value); }
+
     constexpr Seconds secondsSinceEpoch() const { return Seconds(m_value); }
 
     explicit constexpr operator bool() const { return !!m_value; }
@@ -113,7 +117,7 @@ public:
 
     static constexpr DerivedTime timePointFromNow(Seconds relativeTimeFromNow)
     {
-        if (std::isinf(relativeTimeFromNow))
+        if (relativeTimeFromNow.isInfinity())
             return DerivedTime::fromRawSeconds(relativeTimeFromNow.value());
         return DerivedTime::now() + relativeTimeFromNow;
     }

--- a/Source/WTF/wtf/MonotonicTime.cpp
+++ b/Source/WTF/wtf/MonotonicTime.cpp
@@ -33,7 +33,7 @@ namespace WTF {
 
 WallTime MonotonicTime::approximateWallTime() const
 {
-    if (std::isinf(*this))
+    if (isInfinity())
         return WallTime::fromRawSeconds(m_value);
     return *this - now() + WallTime::now();
 }

--- a/Source/WTF/wtf/MonotonicTime.h
+++ b/Source/WTF/wtf/MonotonicTime.h
@@ -81,22 +81,3 @@ struct MonotonicTime::MarkableTraits {
 };
 
 } // namespace WTF
-
-namespace std {
-
-inline bool isnan(WTF::MonotonicTime time)
-{
-    return std::isnan(time.secondsSinceEpoch().value());
-}
-
-inline bool isinf(WTF::MonotonicTime time)
-{
-    return std::isinf(time.secondsSinceEpoch().value());
-}
-
-inline bool isfinite(WTF::MonotonicTime time)
-{
-    return std::isfinite(time.secondsSinceEpoch().value());
-}
-
-} // namespace std

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -98,6 +98,10 @@ public:
         return Seconds(std::numeric_limits<double>::quiet_NaN());
     }
     
+    bool isNaN() const { return std::isnan(m_value); }
+    bool isInfinity() const { return std::isinf(m_value); }
+    bool isFinite() const { return std::isfinite(m_value); }
+
     explicit constexpr operator bool() const { return !!m_value; }
     
     constexpr Seconds operator+(Seconds other) const
@@ -228,7 +232,7 @@ WTF_EXPORT_PRIVATE void sleep(Seconds);
 struct Seconds::MarkableTraits {
     static bool isEmptyValue(Seconds seconds)
     {
-        return std::isnan(seconds.value());
+        return seconds.isNaN();
     }
 
     static constexpr Seconds emptyValue()
@@ -316,25 +320,6 @@ WTF_EXPORT_PRIVATE TextStream& operator<<(TextStream&, Seconds);
 } // namespace WTF
 
 using WTF::sleep;
-
-namespace std {
-
-inline bool isnan(WTF::Seconds seconds)
-{
-    return std::isnan(seconds.value());
-}
-
-inline bool isinf(WTF::Seconds seconds)
-{
-    return std::isinf(seconds.value());
-}
-
-inline bool isfinite(WTF::Seconds seconds)
-{
-    return std::isfinite(seconds.value());
-}
-
-} // namespace std
 
 using namespace WTF::seconds_literals;
 using WTF::Seconds;

--- a/Source/WTF/wtf/Stopwatch.h
+++ b/Source/WTF/wtf/Stopwatch.h
@@ -49,7 +49,7 @@ public:
 
     std::optional<Seconds> fromMonotonicTime(MonotonicTime) const;
 
-    bool isActive() const { return !std::isnan(m_lastStartTime); }
+    bool isActive() const { return !m_lastStartTime.isNaN(); }
 private:
     Stopwatch() { reset(); }
 
@@ -66,14 +66,14 @@ inline void Stopwatch::reset()
 
 inline void Stopwatch::start()
 {
-    ASSERT_WITH_MESSAGE(std::isnan(m_lastStartTime), "Tried to start the stopwatch, but it is already running.");
+    ASSERT_WITH_MESSAGE(m_lastStartTime.isNaN(), "Tried to start the stopwatch, but it is already running.");
 
     m_lastStartTime = MonotonicTime::now();
 }
 
 inline void Stopwatch::stop()
 {
-    ASSERT_WITH_MESSAGE(!std::isnan(m_lastStartTime), "Tried to stop the stopwatch, but it is not running.");
+    ASSERT_WITH_MESSAGE(!m_lastStartTime.isNaN(), "Tried to stop the stopwatch, but it is not running.");
 
     auto stopTime = MonotonicTime::now();
     m_pastInternals.append({ m_lastStartTime, stopTime });
@@ -105,7 +105,7 @@ inline Seconds Stopwatch::elapsedTimeSince(MonotonicTime timeStamp) const
 
 inline std::optional<Seconds> Stopwatch::fromMonotonicTime(MonotonicTime timeStamp) const
 {
-    if (!std::isnan(m_lastStartTime) && m_lastStartTime < timeStamp)
+    if (!m_lastStartTime.isNaN() && m_lastStartTime < timeStamp)
         return Stopwatch::elapsedTimeSince(timeStamp);
 
     Seconds elapsedTime;

--- a/Source/WTF/wtf/TimeWithDynamicClockType.cpp
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.cpp
@@ -146,7 +146,7 @@ bool hasElapsed(const TimeWithDynamicClockType& time)
     // Avoid doing now().
     if (!(time > time.withSameClockAndRawSeconds(0)))
         return true;
-    if (std::isinf(time.secondsSinceEpoch().value()))
+    if (time.secondsSinceEpoch().isInfinity())
         return false;
     
     return time <= time.nowWithSameClock();

--- a/Source/WTF/wtf/TimeWithDynamicClockType.h
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.h
@@ -85,6 +85,10 @@ public:
     WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
     WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
     
+    bool isNaN() const { return std::isnan(m_value); }
+    bool isInfinity() const { return std::isinf(m_value); }
+    bool isFinite() const { return std::isfinite(m_value); }
+
     explicit operator bool() const { return !!m_value; }
     
     TimeWithDynamicClockType operator+(Seconds other) const
@@ -136,25 +140,6 @@ WTF_EXPORT_PRIVATE void sleep(const TimeWithDynamicClockType&);
 WTF_EXPORT_PRIVATE bool hasElapsed(const TimeWithDynamicClockType&);
 
 } // namespace WTF
-
-namespace std {
-
-inline bool isnan(WTF::TimeWithDynamicClockType time)
-{
-    return std::isnan(time.secondsSinceEpoch().value());
-}
-
-inline bool isinf(WTF::TimeWithDynamicClockType time)
-{
-    return std::isinf(time.secondsSinceEpoch().value());
-}
-
-inline bool isfinite(WTF::TimeWithDynamicClockType time)
-{
-    return std::isfinite(time.secondsSinceEpoch().value());
-}
-
-} // namespace std
 
 using WTF::TimeWithDynamicClockType;
 using WTF::hasElapsed;

--- a/Source/WTF/wtf/WallTime.cpp
+++ b/Source/WTF/wtf/WallTime.cpp
@@ -33,7 +33,7 @@ namespace WTF {
 
 MonotonicTime WallTime::approximateMonotonicTime() const
 {
-    if (std::isinf(*this))
+    if (isInfinity())
         return MonotonicTime::fromRawSeconds(m_value);
     return *this - now() + MonotonicTime::now();
 }

--- a/Source/WTF/wtf/WallTime.h
+++ b/Source/WTF/wtf/WallTime.h
@@ -67,7 +67,7 @@ static_assert(sizeof(WallTime) == sizeof(double));
 struct WallTime::MarkableTraits {
     static bool isEmptyValue(WallTime time)
     {
-        return std::isnan(time.m_value);
+        return time.isNaN();
     }
 
     static constexpr WallTime emptyValue()
@@ -79,24 +79,5 @@ struct WallTime::MarkableTraits {
 WTF_EXPORT_PRIVATE Int128 currentTimeInNanoseconds();
 
 } // namespace WTF
-
-namespace std {
-
-inline bool isnan(WTF::WallTime time)
-{
-    return std::isnan(time.secondsSinceEpoch().value());
-}
-
-inline bool isinf(WTF::WallTime time)
-{
-    return std::isinf(time.secondsSinceEpoch().value());
-}
-
-inline bool isfinite(WTF::WallTime time)
-{
-    return std::isfinite(time.secondsSinceEpoch().value());
-}
-
-} // namespace std
 
 using WTF::WallTime;

--- a/Source/WTF/wtf/WorkerPool.cpp
+++ b/Source/WTF/wtf/WorkerPool.cpp
@@ -107,11 +107,11 @@ WorkerPool::~WorkerPool()
 
 bool WorkerPool::shouldSleep(const AbstractLocker&)
 {
-    if (m_timeout > 0_s && std::isinf(m_timeout))
+    if (m_timeout > 0_s && m_timeout.isInfinity())
         return false;
 
     MonotonicTime currentTime = MonotonicTime::now();
-    if (std::isnan(m_lastTimeoutTime) || (currentTime >= (m_lastTimeoutTime  + m_timeout))) {
+    if (m_lastTimeoutTime.isNaN() || (currentTime >= (m_lastTimeoutTime  + m_timeout))) {
         m_lastTimeoutTime = currentTime;
         return true;
     }

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -653,7 +653,7 @@ void ThreadCondition::wait(Mutex& mutex)
 
 bool ThreadCondition::timedWait(Mutex& mutex, WallTime absoluteTime)
 {
-    if (std::isinf(absoluteTime)) {
+    if (absoluteTime.isInfinity()) {
         if (absoluteTime == -WallTime::infinity())
             return false;
         wait(mutex);

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -351,7 +351,7 @@ void Mutex::unlock()
 // Returns an interval in milliseconds suitable for passing to one of the Win32 wait functions (e.g., ::WaitForSingleObject).
 static DWORD absoluteTimeToWaitTimeoutInterval(WallTime absoluteTime)
 {
-    if (std::isinf(absoluteTime)) {
+    if (absoluteTime.isInfinity()) {
         if (absoluteTime == -WallTime::infinity())
             return 0;
         return INFINITE;

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -239,7 +239,7 @@ ExceptionOr<void> ApplePayDeferredPaymentRequest::validate() const
     if (!URL { managementURL }.isValid())
         return Exception(TypeError, makeString('"', managementURL, "\" is not a valid URL."));
 
-    if (std::isnan(freeCancellationDate)) {
+    if (freeCancellationDate.isNaN()) {
         if (!freeCancellationDateTimeZone.isEmpty())
             return Exception(TypeError, "Unexpected 'freeCancellationDateTimeZone' when 'freeCancellationDate' is not set."_s);
     } else if (freeCancellationDateTimeZone.isEmpty())

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -89,11 +89,11 @@ PKRecurringPaymentSummaryItem *platformRecurringSummaryItem(const ApplePayLineIt
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Recurring);
     PKRecurringPaymentSummaryItem *summaryItem = [PAL::getPKRecurringPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
-    if (!std::isnan(lineItem.recurringPaymentStartDate))
+    if (!lineItem.recurringPaymentStartDate.isNaN())
         summaryItem.startDate = toDate(lineItem.recurringPaymentStartDate);
     summaryItem.intervalUnit = toCalendarUnit(lineItem.recurringPaymentIntervalUnit);
     summaryItem.intervalCount = lineItem.recurringPaymentIntervalCount;
-    if (!std::isnan(lineItem.recurringPaymentEndDate))
+    if (!lineItem.recurringPaymentEndDate.isNaN())
         summaryItem.endDate = toDate(lineItem.recurringPaymentEndDate);
     return summaryItem;
 }
@@ -106,7 +106,7 @@ PKDeferredPaymentSummaryItem *platformDeferredSummaryItem(const ApplePayLineItem
 {
     ASSERT(lineItem.paymentTiming == ApplePayPaymentTiming::Deferred);
     PKDeferredPaymentSummaryItem *summaryItem = [PAL::getPKDeferredPaymentSummaryItemClass() summaryItemWithLabel:lineItem.label amount:toDecimalNumber(lineItem.amount) type:toPKPaymentSummaryItemType(lineItem.type)];
-    if (!std::isnan(lineItem.deferredPaymentDate))
+    if (!lineItem.deferredPaymentDate.isNaN())
         summaryItem.deferredDate = toDate(lineItem.deferredPaymentDate);
     return summaryItem;
 }

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -274,7 +274,7 @@ template<typename T> struct IDLTypedArray : IDLBufferSource<T> { };
 struct IDLDate : IDLType<WallTime> { 
     using NullableType = WallTime;
     static WallTime nullValue() { return WallTime::nan(); }
-    static bool isNullValue(WallTime value) { return std::isnan(value); }
+    static bool isNullValue(WallTime value) { return value.isNaN(); }
     static WallTime extractValueFromNullable(WallTime value) { return value; }
 };
 

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -210,7 +210,7 @@ static RefPtr<IDBKey> createIDBKeyFromValue(JSGlobalObject& lexicalGlobalObject,
     if (value.inherits<DateInstance>()) {
         auto dateValue = valueToDate(lexicalGlobalObject, value);
         RETURN_IF_EXCEPTION(scope, { });
-        if (!std::isnan(dateValue))
+        if (!dateValue.isNaN())
             return IDBKey::createDate(dateValue.secondsSinceEpoch().milliseconds());
     }
 

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -163,7 +163,7 @@ void FileReader::didReceiveData()
 {
     enqueueTask([this] {
         auto now = MonotonicTime::now();
-        if (std::isnan(m_lastProgressNotificationTime)) {
+        if (m_lastProgressNotificationTime.isNaN()) {
             m_lastProgressNotificationTime = now;
             return;
         }

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -772,7 +772,7 @@ void InspectorCanvas::finalizeFrame()
 {
     appendActionSnapshotIfNeeded();
 
-    if (m_frames && m_frames->length() && !std::isnan(m_currentFrameStartTime)) {
+    if (m_frames && m_frames->length() && !m_currentFrameStartTime.isNaN()) {
         auto currentFrame = static_reference_cast<Protocol::Recording::Frame>(m_frames->get(m_frames->length() - 1));
         currentFrame->setDuration((MonotonicTime::now() - m_currentFrameStartTime).milliseconds());
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1613,7 +1613,7 @@ bool LocalDOMWindow::consumeTransientActivation()
 
 void LocalDOMWindow::consumeLastActivationIfNecessary()
 {
-    if (!std::isinf(m_lastActivationTimestamp))
+    if (!m_lastActivationTimestamp.isInfinity())
         m_lastActivationTimestamp = -MonotonicTime::infinity();
 }
 

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -441,7 +441,7 @@ static String formatByteNumber(size_t number)
 
 static String gcTimerString(MonotonicTime timerFireDate, MonotonicTime now)
 {
-    if (std::isnan(timerFireDate))
+    if (timerFireDate.isNaN())
         return "[not scheduled]"_s;
     return String::numberToStringFixedPrecision((timerFireDate - now).seconds());
 }

--- a/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
@@ -62,7 +62,7 @@ static String formatByteNumber(size_t number)
 
 static String gcTimerString(MonotonicTime timerFireDate, MonotonicTime now)
 {
-    if (std::isnan(timerFireDate))
+    if (timerFireDate.isNaN())
         return "[not scheduled]"_s;
     return String::numberToStringFixedPrecision((timerFireDate - now).seconds());
 }

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -466,11 +466,11 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
     RELEASE_ASSERT(canCurrentThreadAccessThreadLocalData(m_thread) || shouldSuppressThreadSafetyCheck());
-    bool timerHasBeenDeleted = std::isnan(m_unalignedNextFireTime);
+    bool timerHasBeenDeleted = m_unalignedNextFireTime.isNaN();
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!timerHasBeenDeleted);
 
     if (m_unalignedNextFireTime != newTime) {
-        RELEASE_ASSERT(!std::isnan(newTime));
+        RELEASE_ASSERT(!newTime.isNaN());
         m_unalignedNextFireTime = newTime;
     }
 
@@ -518,7 +518,7 @@ Seconds TimerBase::nextUnalignedFireInterval() const
 {
     ASSERT(isActive());
     auto result = std::max(m_unalignedNextFireTime - MonotonicTime::now(), 0_s);
-    RELEASE_ASSERT(std::isfinite(result));
+    RELEASE_ASSERT(result.isFinite());
     return result;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -1114,7 +1114,7 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const S
     // Rough bandwidth calculation. We ignore here the first data package because we would have to reset the counters when we issue the request and
     // that first package delivery would include the time of sending out the request and getting the data back. Since we can't distinguish the
     // sending time from the receiving time, it is better to ignore it.
-    if (!std::isnan(members->downloadStartTime)) {
+    if (!members->downloadStartTime.isNaN()) {
         members->totalDownloadedBytes += data.size();
         double timeSinceStart = (WallTime::now() - members->downloadStartTime).seconds();
         GST_TRACE_OBJECT(src, "R%u: downloaded %" G_GUINT64_FORMAT " bytes in %f seconds =~ %1.0f bytes/second", m_requestNumber, members->totalDownloadedBytes, timeSinceStart

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -195,7 +195,7 @@ void DisplayCaptureSourceCocoa::stopProducingData()
 
 Seconds DisplayCaptureSourceCocoa::elapsedTime()
 {
-    if (std::isnan(m_startTime))
+    if (m_startTime.isNaN())
         return m_elapsedTime;
 
     return m_elapsedTime + (MonotonicTime::now() - m_startTime);

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -165,7 +165,7 @@ void MockRealtimeAudioSource::stopProducingData()
 
 void MockRealtimeAudioSource::tick()
 {
-    if (std::isnan(m_lastRenderTime))
+    if (m_lastRenderTime.isNaN())
         m_lastRenderTime = MonotonicTime::now();
 
     MonotonicTime now = MonotonicTime::now();

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -340,7 +340,7 @@ void MockRealtimeVideoSource::stopProducingData()
 
 Seconds MockRealtimeVideoSource::elapsedTime()
 {
-    if (std::isnan(m_startTime))
+    if (m_startTime.isNaN())
         return m_elapsedTime;
 
     return m_elapsedTime + (MonotonicTime::now() - m_startTime);

--- a/Source/WebKit/Platform/IPC/Timeout.h
+++ b/Source/WebKit/Platform/IPC/Timeout.h
@@ -34,12 +34,12 @@ namespace IPC {
 class Timeout {
 public:
     Timeout(Seconds timeDelta)
-        : m_deadline(std::isinf(timeDelta) ? ApproximateTime::infinity() : ApproximateTime::now() + timeDelta)
+        : m_deadline(timeDelta.isInfinity() ? ApproximateTime::infinity() : ApproximateTime::now() + timeDelta)
     {
     }
 
     static constexpr Timeout infinity() { return Timeout { }; }
-    bool isInfinity() const { return std::isinf(m_deadline); }
+    bool isInfinity() const { return m_deadline.isInfinity(); }
     static Timeout now() { return 0_s; }
     Seconds secondsUntilDeadline() const { return std::max(m_deadline - ApproximateTime::now(), 0_s ); }
     constexpr ApproximateTime deadline() const { return m_deadline; }

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -383,10 +383,10 @@ NSString *escapeCharactersInString(NSString *string, NSString *charactersToEscap
 
 NSDate *toAPI(const WallTime& time)
 {
-    if (std::isnan(time))
+    if (time.isNaN())
         return nil;
 
-    if (std::isinf(time))
+    if (time.isInfinity())
         return NSDate.distantFuture;
 
     return [NSDate dateWithTimeIntervalSince1970:time.secondsSinceEpoch().value()];

--- a/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
@@ -45,7 +45,7 @@ RetainPtr<PKDeferredPaymentRequest> platformDeferredPaymentRequest(const ApplePa
         managementURL:[NSURL URLWithString:webDeferredPaymentRequest.managementURL]]);
     if (auto& billingAgreement = webDeferredPaymentRequest.billingAgreement; !billingAgreement.isNull())
         [pkDeferredPaymentRequest setBillingAgreement:billingAgreement];
-    if (auto& freeCancellationDate = webDeferredPaymentRequest.freeCancellationDate; !std::isnan(freeCancellationDate)) {
+    if (auto& freeCancellationDate = webDeferredPaymentRequest.freeCancellationDate; !freeCancellationDate.isNaN()) {
         if (auto& freeCancellationDateTimeZone = webDeferredPaymentRequest.freeCancellationDateTimeZone; !freeCancellationDateTimeZone.isNull()) {
             if (auto timeZone = [NSTimeZone timeZoneWithName:freeCancellationDateTimeZone]) {
                 [pkDeferredPaymentRequest setFreeCancellationDate:[NSDate dateWithTimeIntervalSince1970:freeCancellationDate.secondsSinceEpoch().value()]];

--- a/Tools/TestWebKitAPI/Tests/WTF/Time.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Time.cpp
@@ -408,8 +408,8 @@ static const bool GreaterThanOrEqual = Zero >= Zero;
 
 TEST(WTF_Time, constexprMonotonicTime)
 {
-    EXPECT_TRUE(std::isnan(NaN));
-    EXPECT_TRUE(std::isinf(Infinity));
+    EXPECT_TRUE(NaN.isNaN());
+    EXPECT_TRUE(Infinity.isInfinity());
     EXPECT_TRUE(Zero.secondsSinceEpoch().value() == 0.0);
     EXPECT_TRUE(One.secondsSinceEpoch().value() == 1.0);
     EXPECT_TRUE(NegativeOne.secondsSinceEpoch().value() == -1.0);


### PR DESCRIPTION
#### acfb618b4d5ad0bc49791190588cfa125d198c6c
<pre>
Replace std::isnan/isinf/isfinite UB overloads for time classes with member functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=264241">https://bugs.webkit.org/show_bug.cgi?id=264241</a>
<a href="https://rdar.apple.com/problem/117986797">rdar://problem/117986797</a>

Reviewed by Dan Glastonbury.

Time types under WTF (MonotonicTime, etc.) add overloads of std::isnan, isinf, and isfinite,
but it is generally UB to add declarations&amp;definitions to `namespace std`:
<a href="https://en.cppreference.com/w/cpp/language/extending_std">https://en.cppreference.com/w/cpp/language/extending_std</a>

Instead, these functions should be class member functions, or free functions outside of `std`.
I don&apos;t believe these functions are used in generic code, so I think member functions are more
appropriate here.

* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
(Inspector::InspectorHeapAgent::didGarbageCollect):
* Source/WTF/wtf/ApproximateTime.cpp:
(WTF::ApproximateTime::approximateWallTime const):
(WTF::ApproximateTime::approximateMonotonicTime const):
* Source/WTF/wtf/ApproximateTime.h:
(WTF::ApproximateTime::MarkableTraits::isEmptyValue):
(std::isnan): Deleted.
(std::isinf): Deleted.
(std::isfinite): Deleted.
* Source/WTF/wtf/GenericTimeMixin.h:
(WTF::GenericTimeMixin::isNaN const):
(WTF::GenericTimeMixin::isInfinity const):
(WTF::GenericTimeMixin::isFinite const):
(WTF::GenericTimeMixin::timePointFromNow):
* Source/WTF/wtf/MonotonicTime.cpp:
(WTF::MonotonicTime::approximateWallTime const):
* Source/WTF/wtf/MonotonicTime.h:
(std::isnan): Deleted.
(std::isinf): Deleted.
(std::isfinite): Deleted.
* Source/WTF/wtf/Seconds.h:
(WTF::Seconds::MarkableTraits::isEmptyValue):
(std::isnan): Deleted.
(std::isinf): Deleted.
(std::isfinite): Deleted.
* Source/WTF/wtf/Stopwatch.h:
(WTF::Stopwatch::start):
(WTF::Stopwatch::stop):
(WTF::Stopwatch::fromMonotonicTime const):
* Source/WTF/wtf/TimeWithDynamicClockType.cpp:
(WTF::hasElapsed):
* Source/WTF/wtf/TimeWithDynamicClockType.h:
(std::isnan): Deleted.
(std::isinf): Deleted.
(std::isfinite): Deleted.
* Source/WTF/wtf/WallTime.cpp:
(WTF::WallTime::approximateMonotonicTime const):
* Source/WTF/wtf/WallTime.h:
(WTF::WallTime::MarkableTraits::isEmptyValue):
(std::isnan): Deleted.
(std::isinf): Deleted.
(std::isfinite): Deleted.
* Source/WTF/wtf/WorkerPool.cpp:
(WTF::WorkerPool::shouldSleep):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::ThreadCondition::timedWait):
* Source/WTF/wtf/win/ThreadingWin.cpp:
(WTF::absoluteTimeToWaitTimeoutInterval):
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::ApplePayDeferredPaymentRequest::validate const):
* Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm:
(WebCore::platformRecurringSummaryItem):
(WebCore::platformDeferredSummaryItem):
* Source/WebCore/bindings/IDLTypes.h:
(WebCore::IDLDate::isNullValue):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::createIDBKeyFromValue):
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::didReceiveData):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::finalizeFrame):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::consumeLastActivationIfNecessary):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::gcTimerString):
* Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp:
(WebCore::gcTimerString):
* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::setNextFireTime):
(WebCore::TimerBase::nextUnalignedFireInterval const):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(CachedResourceStreamingClient::dataReceived):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::elapsedTime):
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::tick):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::elapsedTime):
* Source/WebKit/Platform/IPC/Timeout.h:
(IPC::Timeout::Timeout):
(IPC::Timeout::isInfinity const):
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toAPI):
* Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm:
(WebKit::platformDeferredPaymentRequest):
* Tools/TestWebKitAPI/Tests/WTF/Time.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270366@main">https://commits.webkit.org/270366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4826ff6c830e34fb7461439c9cbc21644fdcf5e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23290 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27781 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28722 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21817 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26534 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24332 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/603 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31742 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3649 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6952 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6059 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2741 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2638 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->