### PR TITLE
Temporal API should throw TypeErrors for unexpected primitives

### DIFF
--- a/JSTests/stress/temporal-duration.js
+++ b/JSTests/stress/temporal-duration.js
@@ -67,7 +67,7 @@ shouldBe(pos.blank, false);
 shouldBe(neg.blank, false);
 
 shouldBe(Temporal.Duration.from.length, 1);
-shouldThrow(() => Temporal.Duration.from(), RangeError);
+shouldThrow(() => Temporal.Duration.from(), TypeError);
 shouldThrow(() => Temporal.Duration.from({}), TypeError);
 {
     const badStrings = [
@@ -102,9 +102,9 @@ shouldBe(Temporal.Duration.from('PT1.03125M').toString(), 'PT1M1.875S');
 const posAbsolute = new Temporal.Duration(0,0,0,1,2,3,4,5,6,7);
 
 shouldBe(Temporal.Duration.compare.length, 2);
-shouldThrow(() => Temporal.Duration.compare(), RangeError);
+shouldThrow(() => Temporal.Duration.compare(), TypeError);
 shouldThrow(() => Temporal.Duration.compare({}), TypeError);
-shouldThrow(() => Temporal.Duration.compare(zero), RangeError);
+shouldThrow(() => Temporal.Duration.compare(zero), TypeError);
 shouldThrow(() => Temporal.Duration.compare(zero, {}), TypeError);
 shouldThrow(() => Temporal.Duration.compare({ years: 1 }, zero), RangeError);
 shouldThrow(() => Temporal.Duration.compare({ months: 1 }, zero), RangeError);
@@ -160,7 +160,7 @@ shouldThrow(() => Temporal.Duration.prototype.abs.call({}), TypeError);
 for (const method of ['add', 'subtract']) {
     shouldBe(Temporal.Duration.prototype[method].length, 1);
     shouldThrow(() => Temporal.Duration.prototype[method].call({ hours: 1 }), TypeError);
-    shouldThrow(() => zero[method](), RangeError);
+    shouldThrow(() => zero[method](), TypeError);
     shouldThrow(() => zero[method]({}), TypeError);
     shouldThrow(() => zero[method]({ years: 1 }), RangeError);
     shouldThrow(() => zero[method]({ months: 1 }), RangeError);

--- a/JSTests/stress/temporal-plaindatetime.js
+++ b/JSTests/stress/temporal-plaindatetime.js
@@ -75,7 +75,7 @@ shouldBe(Temporal.PlainDateTime.prototype.getISOFields.length, 0);
 shouldBe(JSON.stringify(pdt.getISOFields()), `{"calendar":"iso8601","isoDay":3,"isoHour":4,"isoMicrosecond":8,"isoMillisecond":7,"isoMinute":5,"isoMonth":2,"isoNanosecond":9,"isoSecond":6,"isoYear":1}`);
 
 shouldBe(Temporal.PlainDateTime.from.length, 1);
-shouldThrow(() => Temporal.PlainDateTime.from(), RangeError);
+shouldThrow(() => Temporal.PlainDateTime.from(), TypeError);
 shouldBe(Temporal.PlainDateTime.from('0001-02-03T04:05:06.007008009').toString(), '0001-02-03T04:05:06.007008009');
 {
     const dateTime = Temporal.PlainDateTime.from('2007-01-09T03:24:30+01:00[Europe/Brussels]');
@@ -278,7 +278,7 @@ shouldBe(pdt.with({ day: 30 }).toString(), '0001-02-28T04:05:06.007008009');
 shouldThrow(() => { pdt.with({ day: 30 }, { overflow: 'reject' }); }, RangeError);
 
 shouldBe(Temporal.PlainDateTime.prototype.withPlainDate.length, 1);
-shouldThrow(() => { pdt.withPlainDate(); }, RangeError);
+shouldThrow(() => { pdt.withPlainDate(); }, TypeError);
 shouldBe(pdt.withPlainDate({ year: 2000, month: 10, day: 30 }).toString(), '2000-10-30T04:05:06.007008009');
 
 shouldBe(Temporal.PlainDateTime.prototype.withPlainTime.length, 0);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -194,6 +194,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/calendar-possibly-required.js
     - test/built-ins/Temporal/Duration/prototype/round/calendar-temporal-object.js
     - test/built-ins/Temporal/Duration/prototype/round/dateuntil-field.js
+    - test/built-ins/Temporal/Duration/prototype/round/duration-out-of-range-added-to-relativeto.js
     - test/built-ins/Temporal/Duration/prototype/round/february-leap-year.js
     - test/built-ins/Temporal/Duration/prototype/round/largestunit-smallestunit-default.js
     - test/built-ins/Temporal/Duration/prototype/round/nanoseconds-to-days-loop-indefinitely-1.js
@@ -304,6 +305,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/total/calendar-possibly-required.js
     - test/built-ins/Temporal/Duration/prototype/total/calendar-temporal-object.js
     - test/built-ins/Temporal/Duration/prototype/total/dateuntil-field.js
+    - test/built-ins/Temporal/Duration/prototype/total/duration-out-of-range-added-to-relativeto.js
     - test/built-ins/Temporal/Duration/prototype/total/nanoseconds-to-days-loop-indefinitely-1.js
     - test/built-ins/Temporal/Duration/prototype/total/nanoseconds-to-days-loop-indefinitely-2.js
     - test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -121,12 +121,6 @@ test/built-ins/Temporal/Duration/compare/relativeto-propertybag-invalid-offset-s
 test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-string.js:
   default: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
-test/built-ins/Temporal/Duration/from/argument-non-string.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-test/built-ins/Temporal/Duration/prototype/add/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Duration/prototype/add/nanoseconds-to-days-loop-indefinitely.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
@@ -152,9 +146,6 @@ test/built-ins/Temporal/Duration/prototype/round/constructor-in-calendar-fields.
   default: 'Test262Error: Expected a RangeError but got a Error'
   strict mode: 'Test262Error: Expected a RangeError but got a Error'
 test/built-ins/Temporal/Duration/prototype/round/duplicate-calendar-fields.js:
-  default: 'Test262Error: Expected a RangeError but got a Error'
-  strict mode: 'Test262Error: Expected a RangeError but got a Error'
-test/built-ins/Temporal/Duration/prototype/round/duration-out-of-range-added-to-relativeto.js:
   default: 'Test262Error: Expected a RangeError but got a Error'
   strict mode: 'Test262Error: Expected a RangeError but got a Error'
 test/built-ins/Temporal/Duration/prototype/round/largestunit-correct-rebalancing.js:
@@ -193,9 +184,6 @@ test/built-ins/Temporal/Duration/prototype/round/roundingincrement-out-of-range.
 test/built-ins/Temporal/Duration/prototype/round/zero-day-length.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, tz, \"iso8601\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, tz, \"iso8601\")')"
-test/built-ins/Temporal/Duration/prototype/subtract/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Duration/prototype/subtract/nanoseconds-to-days-loop-indefinitely.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
@@ -226,9 +214,6 @@ test/built-ins/Temporal/Duration/prototype/toString/order-of-operations.js:
 test/built-ins/Temporal/Duration/prototype/toString/precision-exact-mathematical-values.js:
   default: 'Test262Error: Expected SameValue(«PT10000000000000.004096S», «PT10000000000000.004097S») to be true'
   strict mode: 'Test262Error: Expected SameValue(«PT10000000000000.004096S», «PT10000000000000.004097S») to be true'
-test/built-ins/Temporal/Duration/prototype/total/duration-out-of-range-added-to-relativeto.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/total/nanoseconds-to-days-loop-indefinitely.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone)')"
@@ -259,21 +244,12 @@ test/built-ins/Temporal/Duration/prototype/total/zero-day-length.js:
 test/built-ins/Temporal/Instant/compare/argument-string-date-with-utc-offset.js:
   default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
   strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-test/built-ins/Temporal/Instant/compare/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/from/argument-string-date-with-utc-offset.js:
   default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
   strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-test/built-ins/Temporal/Instant/from/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/from/instant-string-sub-minute-offset.js:
   default: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/Instant/prototype/add/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/prototype/epochMicroseconds/basic.js:
   default: 'Test262Error: epochMicroseconds pre epoch Expected SameValue(«-217175010876543», «-217175010876544») to be true'
   strict mode: 'Test262Error: epochMicroseconds pre epoch Expected SameValue(«-217175010876543», «-217175010876544») to be true'
@@ -286,18 +262,12 @@ test/built-ins/Temporal/Instant/prototype/epochSeconds/basic.js:
 test/built-ins/Temporal/Instant/prototype/equals/argument-string-date-with-utc-offset.js:
   default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
   strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-test/built-ins/Temporal/Instant/prototype/equals/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/prototype/equals/instant-string-sub-minute-offset.js:
   default: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Instant/prototype/since/argument-string-date-with-utc-offset.js:
   default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
   strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-test/built-ins/Temporal/Instant/prototype/since/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/prototype/since/instant-string-sub-minute-offset.js:
   default: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
@@ -334,9 +304,6 @@ test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfTrunc.js:
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-trunc.js:
   default: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
   strict mode: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
-test/built-ins/Temporal/Instant/prototype/subtract/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-non-integer.js:
   default: 'Test262Error: fractionalSecondDigits -0.6 floors to -1 and is out of range Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: fractionalSecondDigits -0.6 floors to -1 and is out of range Expected a RangeError to be thrown but no exception was thrown at all'
@@ -349,9 +316,6 @@ test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js:
 test/built-ins/Temporal/Instant/prototype/until/argument-string-date-with-utc-offset.js:
   default: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
   strict mode: "RangeError: '1970-01-01T00Z[!UTC]' is not a valid Temporal.Instant string"
-test/built-ins/Temporal/Instant/prototype/until/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/Instant/prototype/until/instant-string-sub-minute-offset.js:
   default: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: ISO strings cannot have sub-minute offsets in time zone annotations: 2021-08-19T17:30-07:00:01[-07:00:01] Expected a RangeError to be thrown but no exception was thrown at all'
@@ -403,9 +367,6 @@ test/built-ins/Temporal/Now/timeZoneId/prop-desc.js:
 test/built-ins/Temporal/Now/timeZoneId/return-value.js:
   default: "TypeError: Temporal.Now.timeZoneId is not a function. (In 'Temporal.Now.timeZoneId()', 'Temporal.Now.timeZoneId' is undefined)"
   strict mode: "TypeError: Temporal.Now.timeZoneId is not a function. (In 'Temporal.Now.timeZoneId()', 'Temporal.Now.timeZoneId' is undefined)"
-test/built-ins/Temporal/PlainDate/argument-convert.js:
-  default: 'Test262Error: year undefined Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: year undefined Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/calendar-case-insensitive.js:
   default: 'Test262Error: Calendar is case-insensitive Expected SameValue(«undefined», «iso8601») to be true'
   strict mode: 'Test262Error: Calendar is case-insensitive Expected SameValue(«undefined», «iso8601») to be true'
@@ -421,9 +382,6 @@ test/built-ins/Temporal/PlainDate/compare/argument-constructor-in-calendar-field
 test/built-ins/Temporal/PlainDate/compare/argument-duplicate-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDate/compare/argument-number.js:
-  default: 'Test262Error: A number is not a valid ISO string for PlainDate (first argument) Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number is not a valid ISO string for PlainDate (first argument) Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-case-insensitive.js:
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
@@ -433,18 +391,12 @@ test/built-ins/Temporal/PlainDate/compare/argument-proto-in-calendar-fields.js:
 test/built-ins/Temporal/PlainDate/compare/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDate/compare/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/from/argument-constructor-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/from/argument-duplicate-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDate/from/argument-number.js:
-  default: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-string.js:
   default: 'Test262Error: calendar slot stores a string Expected SameValue(«iso8601», «iso8601») to be true'
   strict mode: 'Test262Error: calendar slot stores a string Expected SameValue(«iso8601», «iso8601») to be true'
@@ -454,9 +406,6 @@ test/built-ins/Temporal/PlainDate/from/argument-proto-in-calendar-fields.js:
 test/built-ins/Temporal/PlainDate/from/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDate/from/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/from/observable-get-overflow-argument-primitive.js:
   default: 'Test262Error: Expected [get options.overflow, get options.overflow.toString, call options.overflow.toString] and [ownKeys options, getOwnPropertyDescriptor options.overflow, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. Successful call'
   strict mode: 'Test262Error: Expected [get options.overflow, get options.overflow.toString, call options.overflow.toString] and [ownKeys options, getOwnPropertyDescriptor options.overflow, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. Successful call'
@@ -466,9 +415,6 @@ test/built-ins/Temporal/PlainDate/from/observable-get-overflow-argument-string-i
 test/built-ins/Temporal/PlainDate/from/order-of-operations.js:
   default: 'RangeError: unimplemented: from non-ISO8601 calendar'
   strict mode: 'RangeError: unimplemented: from non-ISO8601 calendar'
-test/built-ins/Temporal/PlainDate/prototype/add/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/add/order-of-operations.js:
   default: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
@@ -502,18 +448,12 @@ test/built-ins/Temporal/PlainDate/prototype/equals/argument-constructor-in-calen
 test/built-ins/Temporal/PlainDate/prototype/equals/argument-duplicate-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDate/prototype/equals/argument-number.js:
-  default: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/equals/argument-proto-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDate/prototype/equals/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/getCalendar/branding.js:
   default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
   strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
@@ -553,36 +493,21 @@ test/built-ins/Temporal/PlainDate/prototype/since/argument-constructor-in-calend
 test/built-ins/Temporal/PlainDate/prototype/since/argument-duplicate-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDate/prototype/since/argument-number.js:
-  default: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/since/argument-proto-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/prototype/since/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDate/prototype/since/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement-out-of-range.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDate/prototype/subtract/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/subtract/order-of-operations.js:
   default: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid time string'
   strict mode: 'RangeError: invalid time string'
-test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-wrong-type.js:
-  default: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/toString/order-of-operations.js:
   default: 'Test262Error: Expected [] and [get options.calendarName, get options.calendarName.toString, call options.calendarName.toString, get this.calendar.id] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [] and [get options.calendarName, get options.calendarName.toString, call options.calendarName.toString, get this.calendar.id] to have the same contents. order of operations'
@@ -592,18 +517,12 @@ test/built-ins/Temporal/PlainDate/prototype/until/argument-constructor-in-calend
 test/built-ins/Temporal/PlainDate/prototype/until/argument-duplicate-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDate/prototype/until/argument-number.js:
-  default: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/until/argument-proto-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDate/prototype/until/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDate/prototype/until/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDate/prototype/until/roundingincrement-out-of-range.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
@@ -652,18 +571,12 @@ test/built-ins/Temporal/PlainDateTime/calendar-string.js:
 test/built-ins/Temporal/PlainDateTime/calendar-undefined.js:
   default: 'Test262Error: Expected SameValue(«undefined», «iso8601») to be true'
   strict mode: 'Test262Error: Expected SameValue(«undefined», «iso8601») to be true'
-test/built-ins/Temporal/PlainDateTime/compare/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainDateTime (first argument) Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainDateTime (first argument) Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-case-insensitive.js:
   default: 'RangeError: invalid calendar ID'
   strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDateTime/compare/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDateTime/compare/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/compare/constructor-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
@@ -673,18 +586,12 @@ test/built-ins/Temporal/PlainDateTime/compare/duplicate-calendar-fields.js:
 test/built-ins/Temporal/PlainDateTime/compare/proto-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDateTime/from/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainDateTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainDateTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-string.js:
   default: 'Test262Error: calendar slot stores a string Expected SameValue(«iso8601», «iso8601») to be true'
   strict mode: 'Test262Error: calendar slot stores a string Expected SameValue(«iso8601», «iso8601») to be true'
 test/built-ins/Temporal/PlainDateTime/from/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDateTime/from/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/from/constructor-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
@@ -703,9 +610,6 @@ test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js:
 test/built-ins/Temporal/PlainDateTime/from/proto-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDateTime/prototype/add/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/prototype/add/order-of-operations.js:
   default: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
@@ -733,15 +637,9 @@ test/built-ins/Temporal/PlainDateTime/prototype/daysInWeek/builtin-calendar-no-o
 test/built-ins/Temporal/PlainDateTime/prototype/daysInYear/builtin-calendar-no-observable-calls.js:
   default: 'TypeError: Property description must be an object.'
   strict mode: 'TypeError: Property description must be an object.'
-test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainDateTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainDateTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/prototype/equals/constructor-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
@@ -784,9 +682,6 @@ test/built-ins/Temporal/PlainDateTime/prototype/monthCode/builtin-calendar-no-ob
 test/built-ins/Temporal/PlainDateTime/prototype/monthsInYear/builtin-calendar-no-observable-calls.js:
   default: 'TypeError: Property description must be an object.'
   strict mode: 'TypeError: Property description must be an object.'
-test/built-ins/Temporal/PlainDateTime/prototype/subtract/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/prototype/subtract/order-of-operations.js:
   default: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get options.overflow, get options.overflow.toString, call options.overflow.toString] and [get fields.days, get fields.days.valueOf, call fields.days.valueOf, get fields.hours, get fields.hours.valueOf, call fields.hours.valueOf, get fields.microseconds, get fields.microseconds.valueOf, call fields.microseconds.valueOf, get fields.milliseconds, get fields.milliseconds.valueOf, call fields.milliseconds.valueOf, get fields.minutes, get fields.minutes.valueOf, call fields.minutes.valueOf, get fields.months, get fields.months.valueOf, call fields.months.valueOf, get fields.nanoseconds, get fields.nanoseconds.valueOf, call fields.nanoseconds.valueOf, get fields.seconds, get fields.seconds.valueOf, call fields.seconds.valueOf, get fields.weeks, get fields.weeks.valueOf, call fields.weeks.valueOf, get fields.years, get fields.years.valueOf, call fields.years.valueOf, get this.calendar.dateAdd, call this.calendar.dateAdd, get options.overflow, get options.overflow.toString, call options.overflow.toString] to have the same contents. order of operations'
@@ -817,27 +712,15 @@ test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-construct
 test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-duplicate-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-number.js:
-  default: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-proto-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid time string'
   strict mode: 'RangeError: invalid time string'
-test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-wrong-type.js:
-  default: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainDateTime/prototype/year/builtin-calendar-no-observable-calls.js:
   default: 'TypeError: Property description must be an object.'
   strict mode: 'TypeError: Property description must be an object.'
@@ -859,30 +742,15 @@ test/built-ins/Temporal/PlainDateTime/prototype/yearOfWeek/prop-desc.js:
 test/built-ins/Temporal/PlainDateTime/prototype/yearOfWeek/validate-calendar-value.js:
   default: 'Test262Error: undefined undefined not converted to integer Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: undefined undefined not converted to integer Expected a TypeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainTime/compare/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainTime (first argument) Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainTime (first argument) Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/compare/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid time string'
   strict mode: 'RangeError: invalid time string'
-test/built-ins/Temporal/PlainTime/compare/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string (first argument) Expected a TypeError but got a RangeError'
-test/built-ins/Temporal/PlainTime/from/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/from/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid time string'
   strict mode: 'RangeError: invalid time string'
-test/built-ins/Temporal/PlainTime/from/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/from/order-of-operations.js:
   default: 'Test262Error: Expected [get options.overflow, get options.overflow.toString, call options.overflow.toString, get fields.calendar, get fields.calendar.toString, call fields.calendar.toString, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf] and [get options.overflow, get options.overflow.toString, call options.overflow.toString, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get options.overflow, get options.overflow.toString, call options.overflow.toString, get fields.calendar, get fields.calendar.toString, call fields.calendar.toString, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf] and [get options.overflow, get options.overflow.toString, call options.overflow.toString, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainTime/prototype/add/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/add/precision-exact-mathematical-values-1.js:
   default: 'Test262Error:  microsecond result Expected SameValue(«992», «993») to be true'
   strict mode: 'Test262Error:  microsecond result Expected SameValue(«992», «993») to be true'
@@ -892,33 +760,18 @@ test/built-ins/Temporal/PlainTime/prototype/add/precision-exact-mathematical-val
 test/built-ins/Temporal/PlainTime/prototype/add/precision-exact-mathematical-values-3.js:
   default: 'RangeError: hour is out of range'
   strict mode: 'RangeError: hour is out of range'
-test/built-ins/Temporal/PlainTime/prototype/equals/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid time string'
   strict mode: 'RangeError: invalid time string'
-test/built-ins/Temporal/PlainTime/prototype/equals/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/getISOFields/field-traversal-order.js:
   default: 'Test262Error: Expected [calendar, isoHour, isoMicrosecond, isoMillisecond, isoMinute, isoNanosecond, isoSecond] and [isoHour, isoMicrosecond, isoMillisecond, isoMinute, isoNanosecond, isoSecond] to have the same contents. '
   strict mode: 'Test262Error: Expected [calendar, isoHour, isoMicrosecond, isoMillisecond, isoMinute, isoNanosecond, isoSecond] and [isoHour, isoMicrosecond, isoMillisecond, isoMinute, isoNanosecond, isoSecond] to have the same contents. '
-test/built-ins/Temporal/PlainTime/prototype/since/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/since/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid time string'
   strict mode: 'RangeError: invalid time string'
-test/built-ins/Temporal/PlainTime/prototype/since/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/since/order-of-operations.js:
   default: 'Test262Error: Expected [get other.calendar, get other.calendar.toString, call other.calendar.toString, get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and [get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, ownKeys options, getOwnPropertyDescriptor options.roundingIncrement, get options.roundingIncrement, getOwnPropertyDescriptor options.roundingMode, get options.roundingMode, getOwnPropertyDescriptor options.largestUnit, get options.largestUnit, getOwnPropertyDescriptor options.smallestUnit, get options.smallestUnit, getOwnPropertyDescriptor options.additional, get options.additional, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get other.calendar, get other.calendar.toString, call other.calendar.toString, get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and [get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, ownKeys options, getOwnPropertyDescriptor options.roundingIncrement, get options.roundingIncrement, getOwnPropertyDescriptor options.roundingMode, get options.roundingMode, getOwnPropertyDescriptor options.largestUnit, get options.largestUnit, getOwnPropertyDescriptor options.smallestUnit, get options.smallestUnit, getOwnPropertyDescriptor options.additional, get options.additional, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainTime/prototype/subtract/argument-not-object.js:
-  default: 'Test262Error: undefined Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/subtract/precision-exact-mathematical-values-1.js:
   default: 'Test262Error:  microsecond result Expected SameValue(«992», «993») to be true'
   strict mode: 'Test262Error:  microsecond result Expected SameValue(«992», «993») to be true'
@@ -934,33 +787,21 @@ test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-constructor
 test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-duplicate-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-number.js:
-  default: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: Numbers cannot be used in place of an ISO string for PlainDate Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-proto-in-calendar-fields.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid date string'
   strict mode: 'RangeError: invalid date string'
-test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-non-integer.js:
   default: 'Test262Error: fractionalSecondDigits -0.6 floors to -1 and is out of range Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: fractionalSecondDigits -0.6 floors to -1 and is out of range Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/PlainTime/prototype/toString/order-of-operations.js:
   default: 'Test262Error: Expected [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainTime/prototype/until/argument-number.js:
-  default: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: A number (1) is not a valid ISO string for PlainTime Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/until/argument-string-date-with-utc-offset.js:
   default: 'RangeError: invalid time string'
   strict mode: 'RangeError: invalid time string'
-test/built-ins/Temporal/PlainTime/prototype/until/argument-wrong-type.js:
-  default: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: undefined does not convert to a valid ISO string Expected a TypeError but got a RangeError'
 test/built-ins/Temporal/PlainTime/prototype/until/order-of-operations.js:
   default: 'Test262Error: Expected [get other.calendar, get other.calendar.toString, call other.calendar.toString, get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and [get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, ownKeys options, getOwnPropertyDescriptor options.roundingIncrement, get options.roundingIncrement, getOwnPropertyDescriptor options.roundingMode, get options.roundingMode, getOwnPropertyDescriptor options.largestUnit, get options.largestUnit, getOwnPropertyDescriptor options.smallestUnit, get options.smallestUnit, getOwnPropertyDescriptor options.additional, get options.additional, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get other.calendar, get other.calendar.toString, call other.calendar.toString, get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and [get other.hour, get other.hour.valueOf, call other.hour.valueOf, get other.microsecond, get other.microsecond.valueOf, call other.microsecond.valueOf, get other.millisecond, get other.millisecond.valueOf, call other.millisecond.valueOf, get other.minute, get other.minute.valueOf, call other.minute.valueOf, get other.nanosecond, get other.nanosecond.valueOf, call other.nanosecond.valueOf, get other.second, get other.second.valueOf, call other.second.valueOf, ownKeys options, getOwnPropertyDescriptor options.roundingIncrement, get options.roundingIncrement, getOwnPropertyDescriptor options.roundingMode, get options.roundingMode, getOwnPropertyDescriptor options.largestUnit, get options.largestUnit, getOwnPropertyDescriptor options.smallestUnit, get options.smallestUnit, getOwnPropertyDescriptor options.additional, get options.additional, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit.toString, call options.smallestUnit.toString] to have the same contents. order of operations'

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -299,7 +299,7 @@ public:
 
     // Integer conversions.
     JS_EXPORT_PRIVATE double toIntegerPreserveNaN(JSGlobalObject*) const;
-    double toIntegerWithoutRounding(JSGlobalObject*) const;
+    double toIntegerWithTruncation(JSGlobalObject*) const;
     double toIntegerOrInfinity(JSGlobalObject*) const;
     int32_t toInt32(JSGlobalObject*) const;
     uint32_t toUInt32(JSGlobalObject*) const;

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -112,19 +112,21 @@ inline size_t JSValue::toTypedArrayIndex(JSGlobalObject* globalObject, ASCIILite
     RELEASE_AND_RETURN(scope, outputOffset + static_cast<size_t>(static_cast<uint32_t>(JSC::toInt32(d - inputOffset))));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-tointegerwithoutrounding
-inline double JSValue::toIntegerWithoutRounding(JSGlobalObject* globalObject) const
+// https://tc39.es/proposal-temporal/#sec-tointegerwithtruncation
+inline double JSValue::toIntegerWithTruncation(JSGlobalObject* globalObject) const
 {
     if (isInt32())
         return asInt32();
-    double d = toNumber(globalObject);
-    return std::isnan(d) ? 0.0 : d + 0.0;
+    return trunc(toNumber(globalObject) + 0.0);
 }
 
 // https://tc39.es/ecma262/#sec-tointegerorinfinity
 inline double JSValue::toIntegerOrInfinity(JSGlobalObject* globalObject) const
 {
-    return trunc(toIntegerWithoutRounding(globalObject));
+    if (isInt32())
+        return asInt32();
+    double d = toNumber(globalObject);
+    return trunc(std::isnan(d) ? 0.0 : d + 0.0);
 }
 
 inline bool JSValue::isUInt32() const

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -92,7 +92,7 @@ ISO8601::Duration TemporalDuration::fromDurationLike(JSGlobalObject* globalObjec
             continue;
 
         hasRelevantProperty = true;
-        result[unit] = value.toIntegerWithoutRounding(globalObject);
+        result[unit] = value.toNumber(globalObject) + 0.0;
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!isInteger(result[unit])) {
@@ -121,6 +121,11 @@ ISO8601::Duration TemporalDuration::toISO8601Duration(JSGlobalObject* globalObje
         duration = fromDurationLike(globalObject, asObject(itemValue));
         RETURN_IF_EXCEPTION(scope, { });
     } else {
+        if (!itemValue.isString()) {
+            throwTypeError(globalObject, scope, "can only convert to Duration from object or string values"_s);
+            return { };
+        }
+
         String string = itemValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
@@ -96,7 +96,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalDuration, (JSGlobalObject* globalObjec
         if (value.isUndefined())
             continue;
 
-        result[i] = value.toIntegerWithoutRounding(globalObject);
+        result[i] = value.toNumber(globalObject) + 0.0;
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!isInteger(result[i]))

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -141,6 +141,11 @@ TemporalInstant* TemporalInstant::toInstant(JSGlobalObject* globalObject, JSValu
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    if (!itemValue.isObject() && !itemValue.isString()) {
+        throwTypeError(globalObject, scope, "can only convert to Instant from object or string values"_s);
+        return nullptr;
+    }
+
     if (itemValue.inherits<TemporalInstant>())
         return jsCast<TemporalInstant*>(itemValue);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -185,6 +185,11 @@ TemporalPlainDate* TemporalPlainDate::from(JSGlobalObject* globalObject, JSValue
         return TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTFMove(plainDate));
     }
 
+    if (!itemValue.isString()) {
+        throwTypeError(globalObject, scope, "can only convert to PlainDate from object or string values"_s);
+        return { };
+    }
+
     auto string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
     auto argumentCount = callFrame->argumentCount();
 
     if (argumentCount > 0) {
-        auto value = callFrame->uncheckedArgument(0).toIntegerOrInfinity(globalObject);
+        auto value = callFrame->uncheckedArgument(0).toIntegerWithTruncation(globalObject);
         if (!std::isfinite(value))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate year property must be finite"_s);
         duration.setYears(value);
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
     }
 
     if (argumentCount > 1) {
-        auto value = callFrame->uncheckedArgument(1).toIntegerOrInfinity(globalObject);
+        auto value = callFrame->uncheckedArgument(1).toIntegerWithTruncation(globalObject);
         if (!std::isfinite(value))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate month property must be finite"_s);
         duration.setMonths(value);
@@ -109,7 +109,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
     }
 
     if (argumentCount > 2) {
-        auto value = callFrame->uncheckedArgument(2).toIntegerOrInfinity(globalObject);
+        auto value = callFrame->uncheckedArgument(2).toIntegerWithTruncation(globalObject);
         if (!std::isfinite(value))
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate day property must be finite"_s);
         duration.setDays(value);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -145,6 +145,11 @@ TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject,
         RELEASE_AND_RETURN(scope, TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTFMove(plainDate), WTFMove(plainTime)));
     }
 
+    if (!itemValue.isString()) {
+        throwTypeError(globalObject, scope, "can only convert to PlainDateTime from object or string values"_s);
+        return { };
+    }
+
     auto string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -414,6 +414,11 @@ TemporalPlainTime* TemporalPlainTime::from(JSGlobalObject* globalObject, JSValue
         return TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTFMove(plainTime));
     }
 
+    if (!itemValue.isString()) {
+        throwTypeError(globalObject, scope, "can only convert to PlainTime from object or string values"_s);
+        return { };
+    }
+
     // https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimestring
     // TemporalTimeString :
     //    CalendarTime


### PR DESCRIPTION
#### 681701c7e39b6750bdd27c95497e8dcbc361176b
<pre>
Temporal API should throw TypeErrors for unexpected primitives
<a href="https://bugs.webkit.org/show_bug.cgi?id=264240">https://bugs.webkit.org/show_bug.cgi?id=264240</a>

Reviewed by Yusuke Suzuki.

As of the latest Temporal spec, we should never convert non-object, non-string values to a Temporal object.
At our current stage of implementation, this applies to Duration, Instant, PlainDate, PlainTime, and PlainDateTime.

Relatedly (namely, for the case of handling explicit undefined values),
toIntegerOrInfinity is no longer used by Temporal and toIntegerWithoutRounding has been removed entirely.
Spec-side, these have been replaced by toIntegerWithTruncation and toIntegerIfIntegral;
here, we implement the former and inline the latter.

* JSTests/test262/config.yaml:
Move two tests over from expectations.yaml;
even before this patch, these are hitting an assertion due to unimplemented parts of Temporal.

* JSTests/test262/expectations.yaml:
Mark 102 test cases passing.

* JSTests/stress/temporal-duration.js:
* JSTests/stress/temporal-plaindatetime.js:
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toIntegerWithTruncation const):
(JSC::JSValue::toIntegerOrInfinity const):
(JSC::JSValue::toIntegerWithoutRounding const): Deleted.
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::TemporalDuration::fromDurationLike):
(JSC::TemporalDuration::toISO8601Duration):
* Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalInstant.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
(JSC::TemporalPlainDate::from):
* Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp:
(JSC::TemporalPlainDateTime::from):
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::TemporalPlainTime::from):

Canonical link: <a href="https://commits.webkit.org/270262@main">https://commits.webkit.org/270262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/098a474ba0007a77640e2a8ceaf04cf1a7ae2d44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27131 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22964 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/997 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25259 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27711 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22527 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/21751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26479 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24263 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/534 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31670 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3514 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6942 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5987 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2678 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31655 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2576 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/6620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->