### PR TITLE
WebXROpaqueFramebuffer queries state from GPUP

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2060,6 +2060,7 @@ if (ENABLE_WEBGL)
         html/canvas/WebGLTimerQueryEXT.cpp
         html/canvas/WebGLTransformFeedback.cpp
         html/canvas/WebGLUniformLocation.cpp
+        html/canvas/WebGLUtilities.cpp
         html/canvas/WebGLVertexArrayObject.cpp
         html/canvas/WebGLVertexArrayObjectBase.cpp
         html/canvas/WebGLVertexArrayObjectOES.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1578,6 +1578,7 @@ html/canvas/WebGLTexture.cpp
 html/canvas/WebGLTimerQueryEXT.cpp
 html/canvas/WebGLTransformFeedback.cpp
 html/canvas/WebGLUniformLocation.cpp
+html/canvas/WebGLUtilities.cpp
 html/canvas/WebGLVertexArrayObject.cpp
 html/canvas/WebGLVertexArrayObjectBase.cpp
 html/canvas/WebGLVertexArrayObjectOES.cpp

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -54,6 +54,7 @@
 #include "WebGLTexture.h"
 #include "WebGLTransformFeedback.h"
 #include "WebGLUniformLocation.h"
+#include "WebGLUtilities.h"
 #include "WebGLVertexArrayObject.h"
 #include "WebGLVertexArrayObjectOES.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
@@ -1549,7 +1550,7 @@ void WebGL2RenderingContext::drawRangeElements(GCGLenum mode, GCGLuint start, GC
     clearIfComposited(CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(*this, m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { *this };
 
         m_context->drawRangeElements(mode, start, end, count, type, offset);
     }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -342,6 +342,8 @@ private:
     GCGLint m_max3DTextureSize { 0 };
     GCGLint m_max3DTextureLevel { 0 };
     GCGLint m_maxArrayTextureLayers { 0 };
+
+    friend class ScopedWebGLRestoreFramebuffer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
@@ -29,7 +29,7 @@
 #include "WebGLDrawInstancedBaseVertexBaseInstance.h"
 
 #include "InspectorInstrumentation.h"
-
+#include "WebGLUtilities.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -64,7 +64,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWE
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
     }
@@ -87,7 +87,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBa
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
     }

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -30,6 +30,7 @@
 
 #include "InspectorInstrumentation.h"
 #include "WebGLExtensionAnyInlines.h"
+#include "WebGLUtilities.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -76,7 +77,7 @@ void WebGLMultiDraw::multiDrawArraysWEBGL(GCGLenum mode, Int32List&& firstsList,
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.data() + firstsOffset, countsList.data() + countsOffset, static_cast<size_t>(drawcount) });
     }
@@ -106,7 +107,7 @@ void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List&& fi
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) });
     }
@@ -135,7 +136,7 @@ void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List&& countsLis
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, static_cast<size_t>(drawcount) }, type);
     }
@@ -165,7 +166,7 @@ void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List&& 
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) }, type);
     }

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
@@ -30,6 +30,7 @@
 
 #include "InspectorInstrumentation.h"
 #include "WebGLExtensionAnyInlines.h"
+#include "WebGLUtilities.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -77,7 +78,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBase
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, baseInstancesList.data() + baseInstancesOffset, static_cast<size_t>(drawcount) });
     }
@@ -109,7 +110,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBa
     context.clearIfComposited(WebGLRenderingContextBase::CallerTypeDrawOrClear);
 
     {
-        InspectorScopedShaderProgramHighlight scopedHighlight(context, context.m_currentProgram.get());
+        ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
         context.graphicsContextGL()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, baseVerticesList.data() + baseVerticesOffset, baseInstancesList.data() + baseInstancesOffset, static_cast<size_t>(drawcount) }, type);
     }

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -98,6 +98,7 @@
 #include "WebGLStencilTexturing.h"
 #include "WebGLTexture.h"
 #include "WebGLTransformFeedback.h"
+#include "WebGLUtilities.h"
 #include "WebGLVertexArrayObject.h"
 #include "WebGLVertexArrayObjectOES.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -104,32 +104,6 @@ using WebGLCanvas = std::variant<RefPtr<HTMLCanvasElement>>;
 class VideoFrame;
 #endif
 
-class InspectorScopedShaderProgramHighlight {
-public:
-    InspectorScopedShaderProgramHighlight(WebGLRenderingContextBase&, WebGLProgram*);
-
-    ~InspectorScopedShaderProgramHighlight();
-
-private:
-    void showHighlight();
-    void hideHighlight();
-
-    struct {
-        GCGLfloat color[4];
-        GCGLenum equationRGB;
-        GCGLenum equationAlpha;
-        GCGLenum srcRGB;
-        GCGLenum dstRGB;
-        GCGLenum srcAlpha;
-        GCGLenum dstAlpha;
-        GCGLboolean enabled;
-    } m_savedBlend;
-
-    WebGLRenderingContextBase& m_context;
-    WebGLProgram* m_program { nullptr };
-    bool m_didApply { false };
-};
-
 class WebGLRenderingContextBase : public GraphicsContextGL::Client, public GPUBasedCanvasRenderingContext, private ActivityStateChangeObserver {
     WTF_MAKE_ISO_ALLOCATED(WebGLRenderingContextBase);
 public:
@@ -479,10 +453,13 @@ protected:
     friend class WebGLVertexArrayObjectOES;
 
     // Implementation helpers.
-    friend class InspectorScopedShaderProgramHighlight;
     friend class ScopedDisableRasterizerDiscard;
-    friend class ScopedEnableBackbuffer;
     friend class ScopedDisableScissorTest;
+    friend class ScopedEnableBackbuffer;
+    friend class ScopedInspectorShaderProgramHighlight;
+    friend class ScopedWebGLRestoreFramebuffer;
+    friend class ScopedWebGLRestoreRenderbuffer;
+    friend class ScopedWebGLRestoreTexture;
 
     void initializeNewContext(Ref<GraphicsContextGL>);
     virtual void initializeContextState();

--- a/Source/WebCore/html/canvas/WebGLUtilities.cpp
+++ b/Source/WebCore/html/canvas/WebGLUtilities.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBGL)
+#include "WebGLUtilities.h"
+
+#include "InspectorInstrumentation.h"
+
+namespace WebCore {
+
+bool ScopedInspectorShaderProgramHighlight::shouldApply(WebGLRenderingContextBase& context)
+{
+    if (LIKELY(!context.m_currentProgram || !InspectorInstrumentation::isWebGLProgramHighlighted(context, *context.m_currentProgram)))
+        return false;
+    if (context.m_framebufferBinding)
+        return false;
+    return true;
+}
+
+void ScopedInspectorShaderProgramHighlight::showHighlight()
+{
+    auto& gl = *m_context->graphicsContextGL();
+    // When OES_draw_buffers_indexed extension is enabled,
+    // these state queries return the state for draw buffer 0.
+    // Constant blend color is always the same for all draw buffers.
+    gl.getFloatv(GraphicsContextGL::BLEND_COLOR, m_savedBlend.color);
+    m_savedBlend.equationRGB = gl.getInteger(GraphicsContextGL::BLEND_EQUATION_RGB);
+    m_savedBlend.equationAlpha = gl.getInteger(GraphicsContextGL::BLEND_EQUATION_ALPHA);
+    m_savedBlend.srcRGB = gl.getInteger(GraphicsContextGL::BLEND_SRC_RGB);
+    m_savedBlend.dstRGB = gl.getInteger(GraphicsContextGL::BLEND_DST_RGB);
+    m_savedBlend.srcAlpha = gl.getInteger(GraphicsContextGL::BLEND_SRC_ALPHA);
+    m_savedBlend.dstAlpha = gl.getInteger(GraphicsContextGL::BLEND_DST_ALPHA);
+    m_savedBlend.enabled = gl.isEnabled(GraphicsContextGL::BLEND);
+
+    static const GCGLfloat red = 111.0 / 255.0;
+    static const GCGLfloat green = 168.0 / 255.0;
+    static const GCGLfloat blue = 220.0 / 255.0;
+    static const GCGLfloat alpha = 2.0 / 3.0;
+    gl.blendColor(red, green, blue, alpha);
+
+    if (m_context->m_oesDrawBuffersIndexed) {
+        gl.enableiOES(GraphicsContextGL::BLEND, 0);
+        gl.blendEquationiOES(0, GraphicsContextGL::FUNC_ADD);
+        gl.blendFunciOES(0, GraphicsContextGL::CONSTANT_COLOR, GraphicsContextGL::ONE_MINUS_SRC_ALPHA);
+    } else {
+        gl.enable(GraphicsContextGL::BLEND);
+        gl.blendEquation(GraphicsContextGL::FUNC_ADD);
+        gl.blendFunc(GraphicsContextGL::CONSTANT_COLOR, GraphicsContextGL::ONE_MINUS_SRC_ALPHA);
+    }
+}
+
+void ScopedInspectorShaderProgramHighlight::hideHighlight()
+{
+    auto& gl = *m_context->graphicsContextGL();
+    gl.blendColor(m_savedBlend.color[0], m_savedBlend.color[1], m_savedBlend.color[2], m_savedBlend.color[3]);
+
+    if (m_context->m_oesDrawBuffersIndexed) {
+        gl.blendEquationSeparateiOES(0, m_savedBlend.equationRGB, m_savedBlend.equationAlpha);
+        gl.blendFuncSeparateiOES(0, m_savedBlend.srcRGB, m_savedBlend.dstRGB, m_savedBlend.srcAlpha, m_savedBlend.dstAlpha);
+        if (!m_savedBlend.enabled)
+            gl.disableiOES(GraphicsContextGL::BLEND, 0);
+    } else {
+        gl.blendEquationSeparate(m_savedBlend.equationRGB, m_savedBlend.equationAlpha);
+        gl.blendFuncSeparate(m_savedBlend.srcRGB, m_savedBlend.dstRGB, m_savedBlend.srcAlpha, m_savedBlend.dstAlpha);
+        if (!m_savedBlend.enabled)
+            gl.disable(GraphicsContextGL::BLEND);
+    }
+}
+
+}
+
+#endif

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBGL)
+#include "WebGL2RenderingContext.h"
+
+namespace WebCore {
+
+class ScopedInspectorShaderProgramHighlight {
+    WTF_MAKE_NONCOPYABLE(ScopedInspectorShaderProgramHighlight);
+public:
+    ScopedInspectorShaderProgramHighlight(WebGLRenderingContextBase& context)
+       : m_context(shouldApply(context) ? &context : nullptr) // NOLINT
+    {
+        if (LIKELY(!m_context))
+            return;
+        showHighlight();
+    }
+
+    ~ScopedInspectorShaderProgramHighlight()
+    {
+        if (LIKELY(!m_context))
+            return;
+        hideHighlight();
+    }
+private:
+    static bool shouldApply(WebGLRenderingContextBase&);
+    void showHighlight();
+    void hideHighlight();
+
+    struct {
+        GCGLfloat color[4];
+        GCGLenum equationRGB;
+        GCGLenum equationAlpha;
+        GCGLenum srcRGB;
+        GCGLenum dstRGB;
+        GCGLenum srcAlpha;
+        GCGLenum dstAlpha;
+        GCGLboolean enabled;
+    } m_savedBlend;
+
+    WebGLRenderingContextBase* const m_context;
+};
+
+// Set UNPACK_ALIGNMENT to 1, all other parameters to 0.
+class ScopedTightUnpackParameters {
+    WTF_MAKE_NONCOPYABLE(ScopedTightUnpackParameters);
+public:
+    explicit ScopedTightUnpackParameters(WebGLRenderingContextBase& context, bool enabled = true)
+        : m_context(enabled ? &context : nullptr)
+    {
+        if (!m_context)
+            return;
+        set(m_context->unpackPixelStoreParameters(), tightUnpack);
+    }
+
+    ~ScopedTightUnpackParameters()
+    {
+        if (!m_context)
+            return;
+        set(tightUnpack, m_context->unpackPixelStoreParameters());
+    }
+private:
+    using PixelStoreParameters =  WebGLRenderingContextBase::PixelStoreParameters;
+    static constexpr PixelStoreParameters tightUnpack { 1, 0, 0, 0, 0 };
+    void set(const PixelStoreParameters& oldValues, const PixelStoreParameters& newValues)
+    {
+        auto* context = m_context->graphicsContextGL();
+        if (oldValues.alignment != newValues.alignment)
+            context->pixelStorei(GraphicsContextGL::UNPACK_ALIGNMENT, newValues.alignment);
+        if (oldValues.rowLength != newValues.rowLength)
+            context->pixelStorei(GraphicsContextGL::UNPACK_ROW_LENGTH, newValues.rowLength);
+        if (oldValues.imageHeight != newValues.imageHeight)
+            context->pixelStorei(GraphicsContextGL::UNPACK_IMAGE_HEIGHT, newValues.imageHeight);
+        if (oldValues.skipPixels != newValues.skipPixels)
+            context->pixelStorei(GraphicsContextGL::UNPACK_SKIP_PIXELS, newValues.skipPixels);
+        if (oldValues.skipRows != newValues.skipRows)
+            context->pixelStorei(GraphicsContextGL::UNPACK_SKIP_ROWS, newValues.skipRows);
+        if (oldValues.skipImages != newValues.skipImages)
+            context->pixelStorei(GraphicsContextGL::UNPACK_SKIP_IMAGES, newValues.skipImages);
+    }
+    WebGLRenderingContextBase* const m_context;
+};
+
+class ScopedDisableRasterizerDiscard {
+    WTF_MAKE_NONCOPYABLE(ScopedDisableRasterizerDiscard);
+public:
+    explicit ScopedDisableRasterizerDiscard(WebGLRenderingContextBase& context)
+        : m_context(context.m_rasterizerDiscardEnabled ? &context : nullptr)
+    {
+        if (!m_context)
+            return;
+        m_context->graphicsContextGL()->disable(GraphicsContextGL::RASTERIZER_DISCARD);
+    }
+
+    ~ScopedDisableRasterizerDiscard()
+    {
+        if (!m_context)
+            return;
+        m_context->graphicsContextGL()->enable(GraphicsContextGL::RASTERIZER_DISCARD);
+    }
+
+private:
+    WebGLRenderingContextBase* const m_context;
+};
+
+class ScopedEnableBackbuffer {
+    WTF_MAKE_NONCOPYABLE(ScopedEnableBackbuffer);
+public:
+    explicit ScopedEnableBackbuffer(WebGLRenderingContextBase& context)
+        : m_context(context.m_backDrawBuffer == GraphicsContextGL::NONE ? &context : nullptr)
+    {
+        if (!m_context)
+            return;
+        GCGLenum value[1] { GraphicsContextGL::COLOR_ATTACHMENT0 };
+        if (m_context->isWebGL2())
+            m_context->graphicsContextGL()->drawBuffers(value);
+        else
+            m_context->graphicsContextGL()->drawBuffersEXT(value);
+    }
+
+    ~ScopedEnableBackbuffer()
+    {
+        if (!m_context)
+            return;
+        GCGLenum value[1] { GraphicsContextGL::NONE };
+        if (m_context->isWebGL2())
+            m_context->graphicsContextGL()->drawBuffers(value);
+        else
+            m_context->graphicsContextGL()->drawBuffersEXT(value);
+    }
+
+private:
+    WebGLRenderingContextBase* const m_context;
+};
+
+class ScopedDisableScissorTest {
+    WTF_MAKE_NONCOPYABLE(ScopedDisableScissorTest);
+public:
+    explicit ScopedDisableScissorTest(WebGLRenderingContextBase& context)
+        : m_context(context.m_scissorEnabled ? &context : nullptr)
+    {
+        if (!m_context)
+            return;
+        m_context->graphicsContextGL()->disable(GraphicsContextGL::SCISSOR_TEST);
+    }
+
+    ~ScopedDisableScissorTest()
+    {
+        if (!m_context)
+            return;
+        m_context->graphicsContextGL()->enable(GraphicsContextGL::SCISSOR_TEST);
+    }
+
+private:
+    WebGLRenderingContextBase* const m_context;
+};
+
+class ScopedWebGLRestoreFramebuffer {
+    WTF_MAKE_NONCOPYABLE(ScopedWebGLRestoreFramebuffer);
+public:
+    explicit ScopedWebGLRestoreFramebuffer(WebGLRenderingContextBase& context)
+        : m_context(context)
+    {
+    }
+
+    ~ScopedWebGLRestoreFramebuffer()
+    {
+        auto* gl = m_context.graphicsContextGL();
+        if (m_context.isWebGL2()) {
+            auto& context2 = downcast<WebGL2RenderingContext>(m_context);
+            gl->bindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER_BINDING, objectOrZero(context2.m_readFramebufferBinding));
+            gl->bindFramebuffer(GraphicsContextGL::DRAW_FRAMEBUFFER_BINDING, objectOrZero(context2.m_framebufferBinding));
+        } else
+            gl->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER_BINDING, objectOrZero(m_context.m_framebufferBinding));
+    }
+
+private:
+    WebGLRenderingContextBase& m_context;
+};
+
+class ScopedWebGLRestoreRenderbuffer {
+    WTF_MAKE_NONCOPYABLE(ScopedWebGLRestoreRenderbuffer);
+public:
+    explicit ScopedWebGLRestoreRenderbuffer(WebGLRenderingContextBase& context)
+        : m_context(context)
+    {
+    }
+
+    ~ScopedWebGLRestoreRenderbuffer()
+    {
+        auto* gl = m_context.graphicsContextGL();
+        gl->bindRenderbuffer(GraphicsContextGL::RENDERBUFFER, objectOrZero(m_context.m_renderbufferBinding));
+    }
+    WebGLRenderingContextBase& m_context;
+};
+
+class ScopedWebGLRestoreTexture {
+    WTF_MAKE_NONCOPYABLE(ScopedWebGLRestoreTexture);
+public:
+    explicit ScopedWebGLRestoreTexture(WebGLRenderingContextBase& context, GCGLenum textureTarget)
+        : m_context(context)
+        , m_target(textureTarget)
+    {
+    }
+
+    ~ScopedWebGLRestoreTexture()
+    {
+        auto& textureUnit = m_context.m_textureUnits[m_context.m_activeTextureUnit];
+        PlatformGLObject texture = 0;
+        switch (m_target) {
+        case GraphicsContextGL::TEXTURE_2D:
+            texture = objectOrZero(textureUnit.textureCubeMapBinding);
+            break;
+        case GraphicsContextGL::TEXTURE_CUBE_MAP:
+            texture = objectOrZero(textureUnit.textureCubeMapBinding);
+            break;
+        case GraphicsContextGL::TEXTURE_3D:
+            texture = objectOrZero(textureUnit.texture3DBinding);
+            break;
+        case GraphicsContextGL::TEXTURE_2D_ARRAY:
+            texture = objectOrZero(textureUnit.texture2DArrayBinding);
+            break;
+        default:
+            // Not part of WebGL, does not need to be restored.
+            return;
+        }
+        auto* gl = m_context.graphicsContextGL();
+        gl->bindTexture(m_target, texture);
+    }
+private:
+    WebGLRenderingContextBase& m_context;
+    const GCGLenum m_target;
+};
+
+
+}
+
+#endif


### PR DESCRIPTION
#### 05bd97a27164d3373bd61101c2f995d292bc36f0
<pre>
WebXROpaqueFramebuffer queries state from GPUP
<a href="https://bugs.webkit.org/show_bug.cgi?id=264248">https://bugs.webkit.org/show_bug.cgi?id=264248</a>
<a href="https://rdar.apple.com/117992444">rdar://117992444</a>

Reviewed by Dan Glastonbury.

The context state is available in WebGLRenderingContextBase, and thus
it should not be queried from the underlying OpenGL context.

Add Scoped*Restore classes to encapsulate restoring the state from
the WebGL context. These will also be used when default framebuffer
implementation is moved from the underlying context to the webgl context
level.

Move all the scoped helpers to WebGLUtilities.h so they&apos;re available
to all the WebGL implementation files.

This is work towards supporting premultipliedAlpha=false compositing.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::drawRangeElements):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::multiDrawArraysWEBGL):
(WebCore::WebGLMultiDraw::multiDrawArraysInstancedWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsInstancedWEBGL):
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::drawArrays):
(WebCore::WebGLRenderingContextBase::drawElements):
(WebCore::WebGLRenderingContextBase::drawArraysInstanced):
(WebCore::WebGLRenderingContextBase::drawElementsInstanced):
(WebCore::ScopedTightUnpackParameters::ScopedTightUnpackParameters): Deleted.
(WebCore::ScopedTightUnpackParameters::~ScopedTightUnpackParameters): Deleted.
(WebCore::ScopedTightUnpackParameters::set): Deleted.
(WebCore::ScopedDisableRasterizerDiscard::ScopedDisableRasterizerDiscard): Deleted.
(WebCore::ScopedDisableRasterizerDiscard::~ScopedDisableRasterizerDiscard): Deleted.
(WebCore::ScopedEnableBackbuffer::ScopedEnableBackbuffer): Deleted.
(WebCore::ScopedEnableBackbuffer::~ScopedEnableBackbuffer): Deleted.
(WebCore::ScopedDisableScissorTest::ScopedDisableScissorTest): Deleted.
(WebCore::ScopedDisableScissorTest::~ScopedDisableScissorTest): Deleted.
(WebCore::InspectorScopedShaderProgramHighlight::InspectorScopedShaderProgramHighlight): Deleted.
(WebCore::InspectorScopedShaderProgramHighlight::~InspectorScopedShaderProgramHighlight): Deleted.
(WebCore::InspectorScopedShaderProgramHighlight::showHighlight): Deleted.
(WebCore::InspectorScopedShaderProgramHighlight::hideHighlight): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/270886@main">https://commits.webkit.org/270886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee2bd990a85fc465252453b2960eaf4aeea501be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23348 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/2470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28798 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26624 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3736 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6417 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->