### PR TITLE
Cache complex CSS variable values

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -859,6 +859,7 @@ css/CSSNamespaceRule.cpp
 css/CSSOffsetRotateValue.cpp
 css/CSSPageRule.cpp
 css/CSSPaintImageValue.cpp
+css/CSSPendingSubstitutionValue.cpp
 css/CSSPrimitiveValue.cpp
 css/CSSProperty.cpp
 css/CSSPropertyRule.cpp

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPendingSubstitutionValue.h"
+
+#include "CSSPropertyParser.h"
+
+namespace WebCore {
+
+RefPtr<CSSValue> CSSPendingSubstitutionValue::resolveValue(Style::BuilderState& builderState, CSSPropertyID propertyID) const
+{
+    auto cacheValue = [&](auto data) {
+        ParsedPropertyVector parsedProperties;
+        if (!CSSPropertyParser::parseValue(m_shorthandPropertyId, false, data->tokens(), data->context(), parsedProperties, StyleRuleType::Style)) {
+            m_cachedPropertyValues = { };
+            return;
+        }
+
+        m_cachedPropertyValues = parsedProperties;
+    };
+
+    if (!m_shorthandValue->resolveAndCacheValue(builderState, cacheValue))
+        return nullptr;
+
+    for (auto& property : m_cachedPropertyValues) {
+        if (property.id() == propertyID)
+            return property.value();
+    }
+
+    return nullptr;
+}
+
+}

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -34,6 +34,8 @@
 
 namespace WebCore {
 
+class CSSProperty;
+
 class CSSPendingSubstitutionValue : public CSSValue {
 public:
     static Ref<CSSPendingSubstitutionValue> create(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
@@ -47,6 +49,8 @@ public:
     bool equals(const CSSPendingSubstitutionValue& other) const { return m_shorthandValue.ptr() == other.m_shorthandValue.ptr(); }
     static String customCSSText() { return emptyString(); }
 
+    RefPtr<CSSValue> resolveValue(Style::BuilderState&, CSSPropertyID) const;
+
 private:
     CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
         : CSSValue(PendingSubstitutionValueClass)
@@ -57,6 +61,8 @@ private:
 
     const CSSPropertyID m_shorthandPropertyId;
     Ref<CSSVariableReferenceValue> m_shorthandValue;
+
+    mutable Vector<CSSProperty> m_cachedPropertyValues;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -376,7 +376,7 @@ Ref<CSSValue> Builder::resolveVariableReferences(CSSPropertyID propertyID, CSSVa
     auto variableValue = [&]() -> RefPtr<CSSValue> {
         if (is<CSSPendingSubstitutionValue>(value)) {
             auto& substitution = downcast<CSSPendingSubstitutionValue>(value);
-            return substitution.shorthandValue().resolveSubstitutionValue(m_state, propertyID, substitution.shorthandPropertyId());
+            return substitution.resolveValue(m_state, propertyID);
         }
 
         auto& variableReferenceValue = downcast<CSSVariableReferenceValue>(value);


### PR DESCRIPTION
#### 72e9a6afd35e3cbfbf80e2b3584292fe668e0b3c
<pre>
Cache complex CSS variable values
<a href="https://bugs.webkit.org/show_bug.cgi?id=264250">https://bugs.webkit.org/show_bug.cgi?id=264250</a>
<a href="https://rdar.apple.com/117996144">rdar://117996144</a>

Reviewed by Alan Baradlay.

Cache the final CSSValue for variable references in all cases.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPendingSubstitutionValue.cpp: Added.
(WebCore::CSSPendingSubstitutionValue::resolveValue const):

For shortcut references cache each individual longhand.

* Source/WebCore/css/CSSPendingSubstitutionValue.h:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::cacheSimpleReference):
(WebCore::CSSVariableReferenceValue::resolveSingleValue const):
(WebCore::CSSVariableReferenceValue::resolveAndCacheValue const): Deleted.
(WebCore::CSSVariableReferenceValue::resolveSubstitutionValue const): Deleted.
* Source/WebCore/css/CSSVariableReferenceValue.h:
(WebCore::CSSVariableReferenceValue::resolveAndCacheValue const):

Cache also in non-simple reference case. In these cases we still resolve the tokens and
use their equaivalence to test the validity of the cached value.

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveVariableReferences):

Canonical link: <a href="https://commits.webkit.org/270376@main">https://commits.webkit.org/270376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/831f663ece1c7e0e7a1782c02ec45f77e86b9ed2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27902 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28815 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23044 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26661 "Found 2 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/700 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3759 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6067 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2848 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2743 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->