### PR TITLE
Add notifyd telemetry

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -517,18 +517,26 @@
         (literal "/private/var/run/syslog"))
 )
 
+(define (notifyd-message-numbers) (message-number 1002 1011 1012 1016 1017 1018 1021 1025 1026 1028 1029 1030 1031 1032))
+
 (allow mach-lookup (global-name "com.apple.system.notification_center")
     (apply-message-filter
         (deny mach-message-send)
         (deny mach-message-send (with no-report) (message-number 1023))
-        (allow mach-message-send (message-number
-            1002 1011 1012 1016 1017 1018 1021 1025 1026 1028 1029 1030 1031 1032))))
+        (allow mach-message-send (notifyd-message-numbers))))
 
 (allow ipc-posix-shm-read*
     (ipc-posix-name "apple.shm.notification_center"))
 
+(with-filter (webcontent-process-launched)
+    (apply-message-filter
+        (deny mach-message-send)
+        (deny mach-message-send (with no-report) (message-number 1023))
+        (allow mach-message-send (with telemetry-backtrace) (notifyd-message-numbers))))
+
 (with-filter (state-flag "EnableExperimentalSandbox")
-    (deny mach-lookup (global-name "com.apple.system.notification_center")))
+    (allow mach-lookup (global-name "com.apple.system.notification_center")
+        (apply-message-filter (deny mach-message-send))))
 
 
 (managed-configuration-read-public)


### PR DESCRIPTION
#### c84d6bc150f33fdc9f44f6e53a680dd408e712e1
<pre>
Add notifyd telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=264256">https://bugs.webkit.org/show_bug.cgi?id=264256</a>
<a href="https://rdar.apple.com/117998431">rdar://117998431</a>

Reviewed by Brent Fulgham.

Add notifyd telemetry in the WebContent process sandbox on iOS.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/270289@main">https://commits.webkit.org/270289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d36a82668b9b597880c78c9c910220bbc946a432

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22979 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23262 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2304 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28666 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22898 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26492 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/549 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3529 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6006 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->