### PR TITLE
[cssom-view] Rename / alias options for element.checkVisibility()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
@@ -68,6 +68,9 @@ test(() => {
   assert_false(visibilityhidden.checkVisibility({
     checkVisibilityCSS: true
   }), 'checkVisibilityCSS:true');
+  assert_false(visibilityhidden.checkVisibility({
+    visibilityProperty: true
+  }), 'visibilityProperty:true');
   assert_true(visibilityhidden.checkVisibility({
     checkVisibilityCSS: false
   }), 'checkVisibilityCSS:false');
@@ -84,20 +87,20 @@ test(() => {
 promise_test(async () => {
   await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
   assert_true(cvauto.checkVisibility({
-    checkContentVisibilityAuto: false
-  }), 'checkContentVisibilityAuto: false');
+    contentVisibilityAuto: false
+  }), 'contentVisibilityAuto: false');
   assert_true(cvauto.checkVisibility({
-    checkContentVisibilityAuto: true
-  }), 'checkContentVisibilityAuto: true');
+    contentVisibilityAuto: true
+  }), 'contentVisibilityAuto: true');
 }, 'checkVisibility on content-visibility:auto element.');
 
 test(() => {
   assert_true(cvautooffscreen.checkVisibility({
-    checkContentVisibilityAuto: false
-  }), 'checkContentVisibilityAuto: false');
+    contentVisibilityAuto: false
+  }), 'contentVisibilityAuto: false');
   assert_false(cvautooffscreen.checkVisibility({
-    checkContentVisibilityAuto: true
-  }), 'checkContentVisibilityAuto: true');
+    contentVisibilityAuto: true
+  }), 'contentVisibilityAuto: true');
 }, 'checkVisibility on content-visibility:auto element which is outside the viewport.');
 
 test(() => {
@@ -117,6 +120,9 @@ test(() => {
   assert_false(opacityzero.checkVisibility({
     checkOpacity: true
   }), 'checkOpacity:true');
+  assert_false(opacityzero.checkVisibility({
+    opacityProperty: true
+  }), 'opacityProperty:true');
   assert_true(opacityzero.checkVisibility({
     checkOpacity: false
   }), 'checkOpacity:false');
@@ -135,11 +141,11 @@ test(() => {
   cvautocontainer.style.contentVisibility = 'auto';
   cvautochild.style.visibility = 'hidden';
   assert_false(cvautochild.checkVisibility({checkVisibilityCSS: true}));
-  assert_false(cvautochild.checkVisibility({checkContentVisibilityAuto: true}));
+  assert_false(cvautochild.checkVisibility({contentVisibilityAuto: true}));
   assert_true(cvautochild.checkVisibility());
   cvautochild.style.visibility = 'visible';
   assert_true(cvautochild.checkVisibility({checkVisibilityCSS: true}));
-  assert_false(cvautochild.checkVisibility({checkContentVisibilityAuto: true}));
+  assert_false(cvautochild.checkVisibility({contentVisibilityAuto: true}));
   assert_true(cvautochild.checkVisibility());
 }, 'checkVisibility on content-visibility:auto with visibility:hidden inside.');
 

--- a/Source/WebCore/dom/CheckVisibilityOptions.h
+++ b/Source/WebCore/dom/CheckVisibilityOptions.h
@@ -28,9 +28,13 @@
 namespace WebCore {
 
 struct CheckVisibilityOptions {
+    bool opacityProperty { false };
+    bool visibilityProperty { false };
+    bool contentVisibilityAuto { false };
+
+    // Historical aliases.
     bool checkOpacity { false };
     bool checkVisibilityCSS { false };
-    bool checkContentVisibilityAuto { false };
 };
 
 }

--- a/Source/WebCore/dom/CheckVisibilityOptions.idl
+++ b/Source/WebCore/dom/CheckVisibilityOptions.idl
@@ -25,7 +25,10 @@
 
 // https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface
 dictionary CheckVisibilityOptions {
-    boolean checkOpacity = false;
-    boolean checkVisibilityCSS = false;
-    boolean checkContentVisibilityAuto = false;
+    boolean opacityProperty = false;
+    boolean visibilityProperty = false;
+    boolean contentVisibilityAuto = false;
+
+    boolean checkOpacity = false; // Historical alias of .opacityProperty.
+    boolean checkVisibilityCSS = false; // Historical alias of .visibilityProperty.
 };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5472,7 +5472,7 @@ bool Element::checkVisibility(const CheckVisibilityOptions& options)
     if (style->display() == DisplayType::Contents)
         return false;
 
-    if (options.checkVisibilityCSS && style->visibility() != Visibility::Visible)
+    if ((options.visibilityProperty || options.checkVisibilityCSS) && style->visibility() != Visibility::Visible)
         return false;
 
     RefPtr parent = parentElementInComposedTree();
@@ -5491,7 +5491,7 @@ bool Element::checkVisibility(const CheckVisibilityOptions& options)
     if (isSkippedContentWithReason(ContentVisibility::Hidden))
         return false;
 
-    if (options.checkContentVisibilityAuto && isSkippedContentWithReason(ContentVisibility::Auto))
+    if (options.contentVisibilityAuto && isSkippedContentWithReason(ContentVisibility::Auto))
         return false;
 
     for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
@@ -5499,7 +5499,7 @@ bool Element::checkVisibility(const CheckVisibilityOptions& options)
         if (ancestorStyle->display() == DisplayType::None)
             return false;
 
-        if (options.checkOpacity && ancestorStyle->opacity() == 0.0f)
+        if ((options.opacityProperty || options.checkOpacity) && ancestorStyle->opacity() == 0.0f)
             return false;
     }
 


### PR DESCRIPTION
#### 2d9a96581fafa907ffd9ddfb4d8ca2bb24ae0692
<pre>
[cssom-view] Rename / alias options for element.checkVisibility()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264062">https://bugs.webkit.org/show_bug.cgi?id=264062</a>
<a href="https://rdar.apple.com/117821444">rdar://117821444</a>

Reviewed by Tim Nguyen.

Implement <a href="https://github.com/w3c/csswg-drafts/pull/9549.">https://github.com/w3c/csswg-drafts/pull/9549.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html:
* Source/WebCore/dom/CheckVisibilityOptions.h:
* Source/WebCore/dom/CheckVisibilityOptions.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::checkVisibility):

Canonical link: <a href="https://commits.webkit.org/270283@main">https://commits.webkit.org/270283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c372a8351c832957de10449b5bdf45a304b6377

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1024 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27740 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2326 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html, imported/w3c/web-platform-tests/screen-orientation/active-lock.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28686 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/569 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22306 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6003 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->