### PR TITLE
Support web accessible resources in Web Extensions.

### DIFF
--- a/Source/WebCore/page/UserContentURLPattern.cpp
+++ b/Source/WebCore/page/UserContentURLPattern.cpp
@@ -324,4 +324,9 @@ bool UserContentURLPattern::matchesPath(const String& path) const
     return MatchTester(m_path, path).test();
 }
 
+bool matchesWildcardPattern(const String& pattern, const String& testString)
+{
+    return MatchTester(pattern, testString).test();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/UserContentURLPattern.h
+++ b/Source/WebCore/page/UserContentURLPattern.h
@@ -99,4 +99,6 @@ private:
     bool m_matchSubdomains { false };
 };
 
+WEBCORE_EXPORT bool matchesWildcardPattern(const String& pattern, const String& testString);
+
 } // namespace WebCore

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -39,6 +39,9 @@ static NSString * const privacyPreservingDescriptionKey = @"privacyPreservingDes
 template<>
 NSArray *filterObjects<NSArray>(NSArray *array, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
 {
+    if (!array)
+        return nil;
+
     switch (array.count) {
     case 0:
         return @[ ];
@@ -56,6 +59,9 @@ NSArray *filterObjects<NSArray>(NSArray *array, bool NS_NOESCAPE (^block)(__kind
 template<>
 NSDictionary *filterObjects<NSDictionary>(NSDictionary *dictionary, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
 {
+    if (!dictionary)
+        return nil;
+
     if (!dictionary.count)
         return @{ };
 
@@ -72,6 +78,9 @@ NSDictionary *filterObjects<NSDictionary>(NSDictionary *dictionary, bool NS_NOES
 template<>
 NSSet *filterObjects<NSSet>(NSSet *set, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
 {
+    if (!set)
+        return nil;
+
     if (!set.count)
         return [NSSet set];
 
@@ -83,6 +92,9 @@ NSSet *filterObjects<NSSet>(NSSet *set, bool NS_NOESCAPE (^block)(__kindof id ke
 template<>
 NSArray *mapObjects<NSArray>(NSArray *array, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
 {
+    if (!array)
+        return nil;
+
     switch (array.count) {
     case 0:
         return @[ ];
@@ -108,6 +120,9 @@ NSArray *mapObjects<NSArray>(NSArray *array, __kindof id NS_NOESCAPE (^block)(__
 template<>
 NSDictionary *mapObjects<NSDictionary>(NSDictionary *dictionary, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
 {
+    if (!dictionary)
+        return nil;
+
     if (!dictionary.count)
         return @{ };
 
@@ -124,6 +139,9 @@ NSDictionary *mapObjects<NSDictionary>(NSDictionary *dictionary, __kindof id NS_
 template<>
 NSSet *mapObjects<NSSet>(NSSet *set, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
 {
+    if (!set)
+        return nil;
+
     switch (set.count) {
     case 0:
         return [NSSet set];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -235,8 +235,7 @@ bool WebExtensionTab::matches(const WebExtensionTabQueryParameters& parameters, 
     }
 
     if (parameters.titlePattern) {
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF LIKE %@", (NSString *)parameters.titlePattern.value()];
-        if (![predicate evaluateWithObject:title()])
+        if (!WebCore::matchesWildcardPattern(parameters.titlePattern.value(), title()))
             return false;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -59,7 +59,7 @@ WebExtensionURLSchemeHandler::WebExtensionURLSchemeHandler(WebExtensionControlle
 
 void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLSchemeTask& task)
 {
-    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([this, &task, &page, protectedThis = Ref { *this }, protectedTask = Ref { task }, protectedPage = Ref { page }]() {
+    auto *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([this, &task, &page, protectedThis = Ref { *this }, protectedTask = Ref { task }, protectedPage = Ref { page }]() {
         // If a frame is loading, the frame request URL will be an empty string, since the request is actually the frame URL being loaded.
         // In this case, consider the firstPartyForCookies() to be the document including the frame. This fails for nested frames, since
         // it is always the main frame URL, not the immediate parent frame.
@@ -84,7 +84,7 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
         // FIXME: <https://webkit.org/b/246485> Support devtools' exception to web accessible resources.
 
         if (!protocolHostAndPortAreEqual(frameDocumentURL, requestURL)) {
-            if (!extensionContext->extension().isAccessibleResourcePath(requestURL.path().toString(), frameDocumentURL)) {
+            if (!extensionContext->extension().isWebAccessibleResource(requestURL, frameDocumentURL)) {
                 task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:noPermissionErrorCode userInfo:nil]);
                 return;
             }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -139,7 +139,13 @@ public:
         NSArray *expandedExcludeMatchPatternStrings() const;
     };
 
+    struct WebAccessibleResourceData {
+        MatchPatternSet matchPatterns;
+        Vector<String> resourcePathPatterns;
+    };
+
     using InjectedContentVector = Vector<InjectedContentData>;
+    using WebAccessibleResourcesVector = Vector<WebAccessibleResourceData>;
 
     static const PermissionsSet& supportedPermissions();
 
@@ -159,7 +165,7 @@ public:
     bool validateResourceData(NSURL *, NSData *, NSError **);
 #endif
 
-    bool isAccessibleResourcePath(NSString *, NSURL *frameDocumentURL);
+    bool isWebAccessibleResource(const URL& resourceURL, const URL& pageURL);
 
     NSURL *resourceFileURLForPath(NSString *);
 
@@ -246,8 +252,10 @@ private:
     void populatePermissionsPropertiesIfNeeded();
     void populatePagePropertiesIfNeeded();
     void populateContentSecurityPolicyStringsIfNeeded();
+    void populateWebAccessibleResourcesIfNeeded();
 
     InjectedContentVector m_staticInjectedContents;
+    WebAccessibleResourcesVector m_webAccessibleResources;
 
     MatchPatternSet m_permissionMatchPatterns;
     MatchPatternSet m_optionalPermissionMatchPatterns;
@@ -302,6 +310,7 @@ private:
     bool m_parsedManifestContentScriptProperties : 1 { false };
     bool m_parsedManifestPermissionProperties : 1 { false };
     bool m_parsedManifestPageProperties : 1 { false };
+    bool m_parsedManifestWebAccessibleResources : 1 { false };
 };
 
 #ifdef __OBJC__

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -909,6 +909,91 @@ TEST(WKWebExtension, ContentSecurityPolicyParsing)
     EXPECT_EQ(testExtension.errors.count, 1ul);
 }
 
+TEST(WKWebExtension, WebAccessibleResourcesV2)
+{
+    NSMutableDictionary *testManifestDictionary = [@{
+        @"manifest_version": @2,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"web_accessible_resources": @[ @"images/*.png", @"styles/*.css" ]
+    } mutableCopy];
+
+    auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"web_accessible_resources"] = @[ ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"web_accessible_resources"] = @"bad";
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    testManifestDictionary[@"web_accessible_resources"] = @{ };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+}
+
+TEST(WKWebExtension, WebAccessibleResourcesV3)
+{
+    NSMutableDictionary *testManifestDictionary = [@{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"web_accessible_resources": @[ @{
+            @"resources": @[ @"images/*.png", @"styles/*.css" ],
+            @"matches": @[ @"<all_urls>" ]
+        },
+        @{
+            @"resources": @[ @"scripts/*.js" ],
+            @"matches": @[ @"*://localhost/*" ]
+        } ]
+    } mutableCopy];
+
+    auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"web_accessible_resources"] = @[ @{
+        @"resources": @[ ],
+        @"matches": @[ ]
+    } ];
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"web_accessible_resources"] = @[ @{
+        @"resources": @"bad",
+        @"matches": @[ @"<all_urls>" ]
+    } ];
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    testManifestDictionary[@"web_accessible_resources"] = @[ @{
+        @"resources": @[ @"images/*.png" ],
+        @"matches": @"bad"
+    } ];
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    testManifestDictionary[@"web_accessible_resources"] = @[ @{
+        @"matches": @[ @"<all_urls>" ]
+    } ];
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    testManifestDictionary[@"web_accessible_resources"] = @[ @{
+        @"resources": @[ ]
+    } ];
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### dc77e1b0e4196b9e88040f5749b88b5bdce8bfc5
<pre>
Support web accessible resources in Web Extensions.
<a href="https://webkit.org/b/246489">https://webkit.org/b/246489</a>
<a href="https://rdar.apple.com/problem/114823315">rdar://problem/114823315</a>

Reviewed by Brent Fulgham.

* Source/WebCore/page/UserContentURLPattern.cpp:
(WebCore::matchesWildcardPattern): Added.
* Source/WebCore/page/UserContentURLPattern.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::filterObjects&lt;NSArray&gt;): Return nil if the input is nil.
(WebKit::filterObjects&lt;NSDictionary&gt;): Ditto.
(WebKit::filterObjects&lt;NSSet&gt;): Ditto.
(WebKit::mapObjects&lt;NSArray&gt;): Ditto.
(WebKit::mapObjects&lt;NSDictionary&gt;): Ditto.
(WebKit::mapObjects&lt;NSSet&gt;): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::isWebAccessibleResource): Added.
(WebKit::WebExtension::populateWebAccessibleResourcesIfNeeded): Added.
(WebKit::WebExtension::errors): Call populateWebAccessibleResourcesIfNeeded().
(WebKit::WebExtension::isAccessibleResourcePath): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::matches const): Use matchesWildcardPattern instead of NSPredicate.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask): Call isWebAccessibleResource.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270298@main">https://commits.webkit.org/270298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ce161619bd4c5efe19ba07da4ff94808e2639f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27167 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23270 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2632 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21621 "Failed to checkout and rebase branch from PR 20044") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27747 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28689 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26507 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2708 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3200 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->