### PR TITLE
Add vertical writing mode support to `RenderMenuList`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS select[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width
+FAIL select[style="writing-mode: vertical-lr"] block size should match width and inline size should match height assert_equals: expected "77px" but got "18px"
+FAIL select[style="writing-mode: vertical-rl"] block size should match width and inline size should match height assert_equals: expected "77px" but got "18px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow">
+<title>Select appearance native writing mode computed style</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<select style="writing-mode: horizontal-tb">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>
+
+<select style="writing-mode: vertical-lr">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>
+
+<select style="writing-mode: vertical-rl">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>
+
+<script>
+test(() => {
+  const select = document.querySelector(`select[style="writing-mode: horizontal-tb"]`);
+  const style = getComputedStyle(select);
+  const blockSize = parseInt(style.blockSize, 10);
+  const inlineSize = parseInt(style.inlineSize, 10);
+  assert_not_equals(blockSize, 0);
+  assert_not_equals(inlineSize, 0);
+  assert_greater_than(inlineSize, blockSize);
+  assert_equals(style.blockSize, style.height);
+  assert_equals(style.inlineSize, style.width);
+}, `select[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width`);
+
+for (const writingMode of ["vertical-lr", "vertical-rl"]) {
+  test(() => {
+    const select = document.querySelector(`select[style="writing-mode: ${writingMode}"]`);
+    const style = getComputedStyle(select);
+    const blockSize = parseInt(style.blockSize, 10);
+    const inlineSize = parseInt(style.inlineSize, 10);
+    assert_not_equals(blockSize, 0);
+    assert_not_equals(inlineSize, 0);
+    assert_greater_than(inlineSize, blockSize);
+    assert_equals(style.blockSize, style.width);
+    assert_equals(style.inlineSize, style.height);
+  }, `select[style="writing-mode: ${writingMode}"] block size should match width and inline size should match height`);
+};
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-horizontal.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-horizontal.optional-expected-mismatch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance none writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-lr.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-rl.optional.html">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: horizontal-tb; appearance: none;">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-horizontal.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-horizontal.optional.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance native writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-lr.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-rl.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: horizontal-tb">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-vertical.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-vertical.optional-expected-mismatch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance none writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+<link rel="match" href="select-appearance-none-vertical-rl.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: vertical-lr; appearance: none;">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-vertical.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-vertical.optional.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance native writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-none-vertical-lr.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-rl.optional.html">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: vertical-lr">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-horizontal.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-horizontal.optional-expected-mismatch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance native writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-lr.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-rl.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: horizontal-tb">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-horizontal.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-horizontal.optional.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance none writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-lr.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-rl.optional.html">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: horizontal-tb; appearance: none;">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-lr.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-lr.optional-expected-mismatch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance native writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-none-vertical-lr.optional.html">
+<link rel="mismatch" href="select-appearance-none-vertical-rl.optional.html">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: vertical-lr">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-lr.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-lr.optional.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance none writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+<link rel="match" href="select-appearance-none-vertical-rl.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: vertical-lr; appearance: none;">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-rl.optional-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-rl.optional-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance none writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+<link rel="match" href="select-appearance-none-vertical-rl.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: vertical-lr; appearance: none;">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-rl.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-rl.optional.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Select appearance none writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="match" href="select-appearance-none-vertical-lr.optional.html">
+<link rel="mismatch" href="select-appearance-native-vertical.optional.html">
+<link rel="mismatch" href="select-appearance-none-horizontal.optional.html">
+<link rel="mismatch" href="select-appearance-native-horizontal.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The select element below should match the correct writing mode.</p>
+<select style="writing-mode: vertical-rl; appearance: none;">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS select[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width
+FAIL select[style="writing-mode: vertical-lr"] block size should match width and inline size should match height assert_equals: expected "88px" but got "30px"
+FAIL select[style="writing-mode: vertical-rl"] block size should match width and inline size should match height assert_equals: expected "88px" but got "30px"
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS select[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width
+FAIL select[style="writing-mode: vertical-lr"] block size should match width and inline size should match height assert_equals: expected "70px" but got "20px"
+FAIL select[style="writing-mode: vertical-rl"] block size should match width and inline size should match height assert_equals: expected "70px" but got "20px"
+

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3272,6 +3272,36 @@ void RenderStyle::setMarginEnd(Length&& margin)
     }
 }
 
+void RenderStyle::setMarginBefore(Length&& margin)
+{
+    if (isHorizontalWritingMode()) {
+        if (isFlippedBlocksWritingMode())
+            setMarginBottom(WTFMove(margin));
+        else
+            setMarginTop(WTFMove(margin));
+    } else {
+        if (isFlippedBlocksWritingMode())
+            setMarginRight(WTFMove(margin));
+        else
+            setMarginLeft(WTFMove(margin));
+    }
+}
+
+void RenderStyle::setMarginAfter(Length&& margin)
+{
+    if (isHorizontalWritingMode()) {
+        if (isFlippedBlocksWritingMode())
+            setMarginTop(WTFMove(margin));
+        else
+            setMarginBottom(WTFMove(margin));
+    } else {
+        if (isFlippedBlocksWritingMode())
+            setMarginLeft(WTFMove(margin));
+        else
+            setMarginRight(WTFMove(margin));
+    }
+}
+
 TextEmphasisMark RenderStyle::textEmphasisMark() const
 {
     auto mark = static_cast<TextEmphasisMark>(m_rareInheritedData->textEmphasisMark);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1096,6 +1096,9 @@ public:
     inline void setMinHeight(Length&&);
     inline void setMaxHeight(Length&&);
 
+    inline void setLogicalMinWidth(Length&&);
+    inline void setLogicalMaxWidth(Length&&);
+
     inline void resetBorder();
     inline void resetBorderExceptRadius();
     inline void resetBorderTop();
@@ -1301,6 +1304,8 @@ public:
     inline void setMarginRight(Length&&);
     void setMarginStart(Length&&);
     void setMarginEnd(Length&&);
+    void setMarginBefore(Length&&);
+    void setMarginAfter(Length&&);
 
     inline void resetPadding();
     inline void setPaddingBox(LengthBox&&);

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -490,6 +490,22 @@ inline void RenderStyle::setLogicalWidth(Length&& width)
         setHeight(WTFMove(width));
 }
 
+inline void RenderStyle::setLogicalMinWidth(Length&& width)
+{
+    if (isHorizontalWritingMode())
+        setMinWidth(WTFMove(width));
+    else
+        setMinHeight(WTFMove(width));
+}
+
+inline void RenderStyle::setLogicalMaxWidth(Length&& width)
+{
+    if (isHorizontalWritingMode())
+        setMaxWidth(WTFMove(width));
+    else
+        setMaxHeight(WTFMove(width));
+}
+
 inline void RenderStyle::setOpacity(float opacity)
 {
     float clampedOpacity = clampTo(opacity, 0.f, 1.f);


### PR DESCRIPTION
#### 6caf36aefca6b4a87410238aa7b3bf7e6cdad668
<pre>
Add vertical writing mode support to `RenderMenuList`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264267">https://bugs.webkit.org/show_bug.cgi?id=264267</a>
<a href="https://rdar.apple.com/118007185">rdar://118007185</a>

Reviewed by Alan Baradlay and Tim Nguyen.

Update `RenderMenuList` to use logical properties and values where applicable.

Add WPTs for `&lt;select&gt;` with a vertical writing mode, similar to other controls.
Note that the computed style test will only pass in WebKit once `&lt;select&gt;` has
been marked testable.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-horizontal.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-horizontal.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-vertical.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-vertical.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-horizontal.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-horizontal.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-lr.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-lr.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-rl.optional-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-none-vertical-rl.optional.html: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt: Added.
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::adjustInnerStyle):
(RenderMenuList::computeIntrinsicLogicalWidths const):
(RenderMenuList::computePreferredLogicalWidths):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setMarginBefore):
(WebCore::RenderStyle::setMarginAfter):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setLogicalMinWidth):
(WebCore::RenderStyle::setLogicalMaxWidth):

Canonical link: <a href="https://commits.webkit.org/270309@main">https://commits.webkit.org/270309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aef65cc4703858c1a75fb70c59cae6ba6422a3c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1081 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27798 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28739 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2316 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/612 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-content-use-007.svg (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22352 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6020 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2755 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2651 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->