### PR TITLE
Generate IPC serialization for WebKit::PrintInfo

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -403,6 +403,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/Pasteboard.serialization.in
     Shared/PlatformPopupMenuData.serialization.in
     Shared/PolicyDecision.serialization.in
+    Shared/PrintInfo.serialization.in
     Shared/RTCNetwork.serialization.in
     Shared/RemoteWorkerInitializationData.serialization.in
     Shared/RemoteWorkerType.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -242,6 +242,7 @@ $(PROJECT_DIR)/Shared/Pasteboard.serialization.in
 $(PROJECT_DIR)/Shared/PlatformPopupMenuData.serialization.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
 $(PROJECT_DIR)/Shared/PolicyDecision.serialization.in
+$(PROJECT_DIR)/Shared/PrintInfo.serialization.in
 $(PROJECT_DIR)/Shared/PushMessageForTesting.serialization.in
 $(PROJECT_DIR)/Shared/RTCNetwork.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -584,6 +584,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Pasteboard.serialization.in \
 	Shared/PlatformPopupMenuData.serialization.in \
 	Shared/PolicyDecision.serialization.in \
+	Shared/PrintInfo.serialization.in \
 	Shared/PushMessageForTesting.serialization.in \
 	Shared/RTCNetwork.serialization.in \
 	Shared/RemoteWorkerInitializationData.serialization.in \

--- a/Source/WebKit/Shared/PrintInfo.cpp
+++ b/Source/WebKit/Shared/PrintInfo.cpp
@@ -26,58 +26,29 @@
 #include "config.h"
 #include "PrintInfo.h"
 
-#include "WebCoreArgumentCoders.h"
-
-#if PLATFORM(GTK)
-#include "ArgumentCodersGtk.h"
-#endif
-
 namespace WebKit {
 
-void PrintInfo::encode(IPC::Encoder& encoder) const
-{
-    encoder << pageSetupScaleFactor;
-    encoder << availablePaperWidth;
-    encoder << availablePaperHeight;
-    encoder << margin;
-
-#if PLATFORM(GTK)
-    IPC::encode(encoder, printSettings.get());
-    IPC::encode(encoder, pageSetup.get());
-    encoder << printMode;
-#endif
-
+PrintInfo::PrintInfo(float pageSetupScaleFactor, float availablePaperWidth, float availablePaperHeight, WebCore::FloatBoxExtent margin
 #if PLATFORM(IOS_FAMILY)
-    encoder << snapshotFirstPage;
+    , bool snapshotFirstPage
 #endif
-}
-
-bool PrintInfo::decode(IPC::Decoder& decoder, PrintInfo& info)
-{
-    if (!decoder.decode(info.pageSetupScaleFactor))
-        return false;
-    if (!decoder.decode(info.availablePaperWidth))
-        return false;
-    if (!decoder.decode(info.availablePaperHeight))
-        return false;
-    if (!decoder.decode(info.margin))
-        return false;
-
 #if PLATFORM(GTK)
-    if (!IPC::decode(decoder, info.printSettings))
-        return false;
-    if (!IPC::decode(decoder, info.pageSetup))
-        return false;
-    if (!decoder.decode(info.printMode))
-        return false;
+    , GRefPtr<GtkPrintSettings>&& printSettings, GRefPtr<GtkPageSetup>&& pageSetup, PrintMode printMode
 #endif
-
+    )
+    : pageSetupScaleFactor(pageSetupScaleFactor)
+    , availablePaperWidth(availablePaperWidth)
+    , availablePaperHeight(availablePaperHeight)
+    , margin(margin)
 #if PLATFORM(IOS_FAMILY)
-    if (!decoder.decode(info.snapshotFirstPage))
-        return false;
+    , snapshotFirstPage(snapshotFirstPage)
 #endif
-
-    return true;
+#if PLATFORM(GTK)
+    , printSettings(WTFMove(printSettings))
+    , pageSetup(WTFMove(pageSetup))
+    , printMode(printMode)
+#endif
+{
 }
 
 }

--- a/Source/WebKit/Shared/PrintInfo.serialization.in
+++ b/Source/WebKit/Shared/PrintInfo.serialization.in
@@ -1,0 +1,49 @@
+# Copyright (C) 2020 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "ArgumentCoders.h"
+#if PLATFORM(GTK)
+header: "ArgumentCodersGtk.h"
+#endif
+
+#if PLATFORM(GTK)
+[Nested] enum class WebKit::PrintInfo::PrintMode : uint8_t {
+    Async,
+    Sync
+}
+#endif
+
+struct WebKit::PrintInfo {
+    float pageSetupScaleFactor;
+    float availablePaperWidth;
+    float availablePaperHeight;
+    WebCore::FloatBoxExtent margin;
+#if PLATFORM(IOS_FAMILY)
+    bool snapshotFirstPage;
+#endif
+
+#if PLATFORM(GTK)
+    GRefPtr<GtkPrintSettings> printSettings;
+    GRefPtr<GtkPageSetup> pageSetup;
+    WebKit::PrintInfo::PrintMode printMode;
+#endif
+}

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
@@ -195,50 +195,50 @@ static WARN_UNUSED_RETURN bool decodeGKeyFile(Decoder& decoder, GUniquePtr<GKeyF
     return true;
 }
 
-void encode(Encoder& encoder, GtkPrintSettings* settings)
+void ArgumentCoder<GRefPtr<GtkPrintSettings>>::encode(Encoder& encoder, const GRefPtr<GtkPrintSettings>& argument)
 {
-    GRefPtr<GtkPrintSettings> printSettings = settings ? settings : adoptGRef(gtk_print_settings_new());
+    GRefPtr<GtkPrintSettings> printSettings = argument ? argument : adoptGRef(gtk_print_settings_new());
     GUniquePtr<GKeyFile> keyFile(g_key_file_new());
     gtk_print_settings_to_key_file(printSettings.get(), keyFile.get(), "Print Settings");
     encodeGKeyFile(encoder, keyFile.get());
 }
 
-bool decode(Decoder& decoder, GRefPtr<GtkPrintSettings>& printSettings)
+std::optional<GRefPtr<GtkPrintSettings>> ArgumentCoder<GRefPtr<GtkPrintSettings>>::decode(Decoder& decoder)
 {
     GUniquePtr<GKeyFile> keyFile;
     if (!decodeGKeyFile(decoder, keyFile))
-        return false;
+        return std::nullopt;
 
-    printSettings = adoptGRef(gtk_print_settings_new());
+    GRefPtr<GtkPrintSettings> printSettings = adoptGRef(gtk_print_settings_new());
     if (!keyFile)
-        return true;
+        return printSettings;
 
     if (!gtk_print_settings_load_key_file(printSettings.get(), keyFile.get(), "Print Settings", nullptr))
-        printSettings = nullptr;
+        return std::nullopt;
 
     return printSettings;
 }
 
-void encode(Encoder& encoder, GtkPageSetup* setup)
+void ArgumentCoder<GRefPtr<GtkPageSetup>>::encode(Encoder& encoder, const GRefPtr<GtkPageSetup>& argument)
 {
-    GRefPtr<GtkPageSetup> pageSetup = setup ? setup : adoptGRef(gtk_page_setup_new());
+    GRefPtr<GtkPageSetup> pageSetup = argument ? argument : adoptGRef(gtk_page_setup_new());
     GUniquePtr<GKeyFile> keyFile(g_key_file_new());
     gtk_page_setup_to_key_file(pageSetup.get(), keyFile.get(), "Page Setup");
     encodeGKeyFile(encoder, keyFile.get());
 }
 
-bool decode(Decoder& decoder, GRefPtr<GtkPageSetup>& pageSetup)
+std::optional<GRefPtr<GtkPageSetup>> ArgumentCoder<GRefPtr<GtkPageSetup>>::decode(Decoder& decoder)
 {
     GUniquePtr<GKeyFile> keyFile;
     if (!decodeGKeyFile(decoder, keyFile))
-        return false;
+        return std::nullopt;
 
-    pageSetup = adoptGRef(gtk_page_setup_new());
+    GRefPtr<GtkPageSetup> pageSetup = adoptGRef(gtk_page_setup_new());
     if (!keyFile)
-        return true;
+        return pageSetup;
 
     if (!gtk_page_setup_load_key_file(pageSetup.get(), keyFile.get(), "Page Setup", nullptr))
-        pageSetup = nullptr;
+        return std::nullopt;
 
     return pageSetup;
 }

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.h
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.h
@@ -37,11 +37,15 @@ class SelectionData;
 
 namespace IPC {
 
-void encode(Encoder&, GtkPrintSettings*);
-WARN_UNUSED_RETURN bool decode(Decoder&, GRefPtr<GtkPrintSettings>&);
+template<> struct ArgumentCoder<GRefPtr<GtkPrintSettings>> {
+    static void encode(Encoder&, const GRefPtr<GtkPrintSettings>&);
+    static std::optional<GRefPtr<GtkPrintSettings>> decode(Decoder&);
+};
 
-void encode(Encoder&, GtkPageSetup*);
-WARN_UNUSED_RETURN bool decode(Decoder&, GRefPtr<GtkPageSetup>&);
+template<> struct ArgumentCoder<GRefPtr<GtkPageSetup>> {
+    static void encode(Encoder&, const GRefPtr<GtkPageSetup>&);
+    static std::optional<GRefPtr<GtkPageSetup>> decode(Decoder&);
+};
 
 template<> struct ArgumentCoder<WebCore::SelectionData> {
     static void encode(Encoder&, const WebCore::SelectionData&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -2750,7 +2750,7 @@ void webkitWebViewMouseTargetChanged(WebKitWebView* webView, const WebHitTestRes
 void webkitWebViewPrintFrame(WebKitWebView* webView, WebFrameProxy* frame)
 {
     auto printOperation = adoptGRef(webkit_print_operation_new(webView));
-    webkitPrintOperationSetPrintMode(printOperation.get(), PrintInfo::PrintModeSync);
+    webkitPrintOperationSetPrintMode(printOperation.get(), PrintInfo::PrintMode::Sync);
     gboolean returnValue;
     g_signal_emit(webView, signals[PRINT], 0, printOperation.get(), &returnValue);
     if (returnValue)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -364,7 +364,7 @@ static void webkitPrintOperationPrintPagesForFrame(WebKitPrintOperation* printOp
     page.drawPagesForPrinting(webFrame, printInfo, [printOperation = GRefPtr<WebKitPrintOperation>(printOperation)](std::optional<SharedMemory::Handle>&& data, WebCore::ResourceError&& error) mutable {
         auto* priv = printOperation->priv;
         // When running synchronously, WebPageProxy::printFrame() calls endPrinting().
-        if (priv->printMode == PrintInfo::PrintModeAsync && priv->webView)
+        if (priv->printMode == PrintInfo::PrintMode::Async && priv->webView)
             webkitWebViewGetPage(priv->webView.get()).endPrinting();
 
         if (!data || !error.isNull()) {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4142,6 +4142,7 @@
 		2D4AF0882044C3C4006C8817 /* FrontBoardServicesSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FrontBoardServicesSPI.h; sourceTree = "<group>"; };
 		2D4D2C7F1DF60BF3002EB10C /* InteractionInformationRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InteractionInformationRequest.h; path = ios/InteractionInformationRequest.h; sourceTree = "<group>"; };
 		2D4D2C801DF60BF3002EB10C /* InteractionInformationRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InteractionInformationRequest.cpp; path = ios/InteractionInformationRequest.cpp; sourceTree = "<group>"; };
+		2D4EDA892AFA220B003396F7 /* PrintInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PrintInfo.serialization.in; sourceTree = "<group>"; };
 		2D50365D1BCC793F00E20BB3 /* NativeWebGestureEventMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NativeWebGestureEventMac.mm; sourceTree = "<group>"; };
 		2D50366A1BCDE17900E20BB3 /* NativeWebGestureEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebGestureEvent.h; sourceTree = "<group>"; };
 		2D5036731BCED19F00E20BB3 /* WebGestureEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGestureEvent.cpp; sourceTree = "<group>"; };
@@ -8347,6 +8348,7 @@
 				86D1967229A4E25F0083B077 /* PolicyDecision.serialization.in */,
 				E18C92F312DB9E7100CF2AEB /* PrintInfo.cpp */,
 				E1CC1B8E12D7EADF00625838 /* PrintInfo.h */,
+				2D4EDA892AFA220B003396F7 /* PrintInfo.serialization.in */,
 				5C05FDF227AB4FA5003A2487 /* PrivateRelayed.h */,
 				0FEC6E05280915CF008082AC /* ProcessTerminationReason.cpp */,
 				463FD4811EB94EAD00A2982C /* ProcessTerminationReason.h */,

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -54,7 +54,7 @@ namespace WebKit {
 WebPrintOperationGtk::PrintPagesData::PrintPagesData(WebPrintOperationGtk* printOperation)
     : printOperation(printOperation)
 {
-    if (printOperation->m_printMode == PrintInfo::PrintModeSync)
+    if (printOperation->m_printMode == PrintInfo::PrintMode::Sync)
         mainLoop = adoptGRef(g_main_loop_new(0, FALSE));
 
     if (printOperation->m_collateCopies) {
@@ -597,10 +597,10 @@ void WebPrintOperationGtk::print(cairo_surface_t* surface, double xDPI, double y
     // Make sure the print pages idle has more priority than IPC messages comming from
     // the IO thread, so that the EndPrinting message is always handled once the print
     // operation has finished. See https://bugs.webkit.org/show_bug.cgi?id=122801.
-    unsigned idlePriority = m_printMode == PrintInfo::PrintModeSync ? G_PRIORITY_DEFAULT - 10 : G_PRIORITY_DEFAULT_IDLE + 10;
+    unsigned idlePriority = m_printMode == PrintInfo::PrintMode::Sync ? G_PRIORITY_DEFAULT - 10 : G_PRIORITY_DEFAULT_IDLE + 10;
     GMainLoop* mainLoop = data->mainLoop.get();
     m_printPagesIdleId = g_idle_add_full(idlePriority, printPagesIdle, data.release(), printPagesIdleDone);
-    if (m_printMode == PrintInfo::PrintModeSync) {
+    if (m_printMode == PrintInfo::PrintMode::Sync) {
         ASSERT(mainLoop);
         g_main_loop_run(mainLoop);
     }

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
@@ -103,7 +103,7 @@ private:
 
     GRefPtr<GtkPrintSettings> m_printSettings;
     GRefPtr<GtkPageSetup> m_pageSetup;
-    PrintInfo::PrintMode m_printMode { PrintInfo::PrintMode::PrintModeAsync };
+    PrintInfo::PrintMode m_printMode { PrintInfo::PrintMode::Async };
     WebCore::PrintContext* m_printContext { nullptr };
     CompletionHandler<void(RefPtr<WebCore::FragmentedSharedBuffer>&&, WebCore::ResourceError&&)> m_completionHandler;
     RefPtr<cairo_t> m_cairoContext;


### PR DESCRIPTION
#### c2381fe366932db961b453199ca80d162f0e40a0
<pre>
Generate IPC serialization for WebKit::PrintInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=264274">https://bugs.webkit.org/show_bug.cgi?id=264274</a>

Reviewed by Michael Catanzaro.

Provide serialization input file for the WebKit::PrintInfo struct, removing the
need for custom encode/decode methods.

For the GTK port, the PrintMode enumeration is turned into the scoped equivalent
along with the necessary changes at points of use. ArgumentCoder specializations
are also provided for the two types that are GRefPtr-wrapped.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/Shared/PrintInfo.cpp:
(WebKit::PrintInfo::PrintInfo):
(WebKit::PrintInfo::encode const): Deleted.
(WebKit::PrintInfo::decode): Deleted.
* Source/WebKit/Shared/PrintInfo.h:
* Source/WebKit/Shared/PrintInfo.serialization.in: Added.
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPrintSettings&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPrintSettings&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPageSetup&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPageSetup&gt;&gt;::decode):
(IPC::encode): Deleted.
(IPC::decode): Deleted.
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewPrintFrame):
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
(webkitPrintOperationPrintPagesForFrame):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp:
(WebKit::WebPrintOperationGtk::PrintPagesData::PrintPagesData):
(WebKit::WebPrintOperationGtk::print):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h:

Canonical link: <a href="https://commits.webkit.org/270377@main">https://commits.webkit.org/270377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12050149b11bb76f753624e5db92022f6f0faf5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25172 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27287 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23340 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27866 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2426 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28786 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/668 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3723 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2813 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2708 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->