### PR TITLE
[ITP] Port ThirdPartyData / ThirdPartyDataForSpecificFirstParty to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -364,6 +364,9 @@ set(WebKit_SERIALIZATION_IN_FILES
     NetworkProcess/NetworkProcessCreationParameters.serialization.in
     NetworkProcess/NetworkResourceLoadParameters.serialization.in
 
+    NetworkProcess/Classifier/ITPThirdPartyData.serialization.in
+    NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.serialization.in
+
     Platform/IPC/StreamServerConnection.serialization.in
 
     Platform/SharedMemory.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -114,6 +114,8 @@ $(PROJECT_DIR)/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
 $(PROJECT_DIR)/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.messages.in
 $(PROJECT_DIR)/Modules/OSX_Private.modulemap
 $(PROJECT_DIR)/Modules/iOS_Private.modulemap
+$(PROJECT_DIR)/NetworkProcess/Classifier/ITPThirdPartyData.serialization.in
+$(PROJECT_DIR)/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.serialization.in
 $(PROJECT_DIR)/NetworkProcess/Cookies/WebCookieManager.messages.in
 $(PROJECT_DIR)/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in
 $(PROJECT_DIR)/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -518,6 +518,8 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in \
 	NetworkProcess/NetworkProcessCreationParameters.serialization.in \
 	NetworkProcess/NetworkResourceLoadParameters.serialization.in \
+        NetworkProcess/Classifier/ITPThirdPartyData.serialization.in \
+	NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.serialization.in \
 	Platform/IPC/StreamServerConnection.serialization.in \
 	Platform/SharedMemory.serialization.in \
 	Shared/AuxiliaryProcessCreationParameters.serialization.in \

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,39 +23,28 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
 
-#include "APIObject.h"
-#include "ITPThirdPartyDataForSpecificFirstParty.h"
-#include <wtf/RunLoop.h>
-#include <wtf/text/WTFString.h>
+#if ENABLE(TRACKING_PREVENTION)
+#include "ITPThirdPartyData.h"
 
-namespace API {
+namespace WebKit {
 
-class ResourceLoadStatisticsFirstParty final : public ObjectImpl<Object::Type::ResourceLoadStatisticsFirstParty> {
-public:
-    static Ref<ResourceLoadStatisticsFirstParty> create(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-        return adoptRef(*new ResourceLoadStatisticsFirstParty(firstPartyData));
-    }
+String ITPThirdPartyData::toString() const
+{
+    StringBuilder stringBuilder;
+    stringBuilder.append("Third Party Registrable Domain: ", thirdPartyDomain.string(), "\n    {");
+    for (auto firstParty : underFirstParties)
+        stringBuilder.append("{ ", firstParty.toString(), " },");
+    stringBuilder.append('}');
+    return stringBuilder.toString();
+}
 
-    ~ResourceLoadStatisticsFirstParty()
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-    }
+bool ITPThirdPartyData::operator<(const ITPThirdPartyData& other) const
+{
+    return underFirstParties.size() < other.underFirstParties.size();
+}
 
-    const WTF::String& firstPartyDomain() const { return m_firstPartyData.firstPartyDomain.string(); }
-    bool storageAccess() const { return m_firstPartyData.storageAccessGranted; }
-    double timeLastUpdated() const { return m_firstPartyData.timeLastUpdated.value(); }
+} // namespace WebKit
 
-private:
-    explicit ResourceLoadStatisticsFirstParty(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-        : m_firstPartyData(firstPartyData)
-    {
-    }
-
-    const WebKit::ITPThirdPartyDataForSpecificFirstParty m_firstPartyData;
-};
-
-} // namespace API
+#endif // ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,37 +25,24 @@
 
 #pragma once
 
-#include "APIObject.h"
+#if ENABLE(TRACKING_PREVENTION)
+
 #include "ITPThirdPartyDataForSpecificFirstParty.h"
-#include <wtf/RunLoop.h>
-#include <wtf/text/WTFString.h>
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/Forward.h>
 
-namespace API {
+namespace WebKit {
 
-class ResourceLoadStatisticsFirstParty final : public ObjectImpl<Object::Type::ResourceLoadStatisticsFirstParty> {
-public:
-    static Ref<ResourceLoadStatisticsFirstParty> create(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-        return adoptRef(*new ResourceLoadStatisticsFirstParty(firstPartyData));
-    }
+struct ITPThirdPartyData {
+    WebCore::RegistrableDomain thirdPartyDomain;
+    Vector<ITPThirdPartyDataForSpecificFirstParty> underFirstParties;
 
-    ~ResourceLoadStatisticsFirstParty()
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-    }
+    String toString() const;
 
-    const WTF::String& firstPartyDomain() const { return m_firstPartyData.firstPartyDomain.string(); }
-    bool storageAccess() const { return m_firstPartyData.storageAccessGranted; }
-    double timeLastUpdated() const { return m_firstPartyData.timeLastUpdated.value(); }
-
-private:
-    explicit ResourceLoadStatisticsFirstParty(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-        : m_firstPartyData(firstPartyData)
-    {
-    }
-
-    const WebKit::ITPThirdPartyDataForSpecificFirstParty m_firstPartyData;
+    // FIXME: This sorts by number of underFirstParties, so it probably should be a named function, not operator<.
+    bool operator<(const ITPThirdPartyData&) const;
 };
 
-} // namespace API
+} // namespace WebKit
+
+#endif // ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.serialization.in
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.serialization.in
@@ -1,0 +1,30 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(TRACKING_PREVENTION)
+
+struct WebKit::ITPThirdPartyData {
+    WebCore::RegistrableDomain thirdPartyDomain;
+    Vector<WebKit::ITPThirdPartyDataForSpecificFirstParty> underFirstParties;
+}
+
+#endif

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,39 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
 
-#include "APIObject.h"
+#if ENABLE(TRACKING_PREVENTION)
 #include "ITPThirdPartyDataForSpecificFirstParty.h"
-#include <wtf/RunLoop.h>
-#include <wtf/text/WTFString.h>
 
-namespace API {
+namespace WebKit {
 
-class ResourceLoadStatisticsFirstParty final : public ObjectImpl<Object::Type::ResourceLoadStatisticsFirstParty> {
-public:
-    static Ref<ResourceLoadStatisticsFirstParty> create(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-        return adoptRef(*new ResourceLoadStatisticsFirstParty(firstPartyData));
-    }
+String ITPThirdPartyDataForSpecificFirstParty::toString() const
+{
+    return makeString("Has been granted storage access under ", firstPartyDomain.string(), ": ", storageAccessGranted ? '1' : '0', "; Has been seen under ", firstPartyDomain.string(), " in the last 24 hours: ", WallTime::now().secondsSinceEpoch() - timeLastUpdated < 24_h ? '1' : '0');
+}
 
-    ~ResourceLoadStatisticsFirstParty()
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-    }
+bool ITPThirdPartyDataForSpecificFirstParty::operator==(const ITPThirdPartyDataForSpecificFirstParty& other) const
+{
+    return firstPartyDomain == other.firstPartyDomain && storageAccessGranted == other.storageAccessGranted;
+}
 
-    const WTF::String& firstPartyDomain() const { return m_firstPartyData.firstPartyDomain.string(); }
-    bool storageAccess() const { return m_firstPartyData.storageAccessGranted; }
-    double timeLastUpdated() const { return m_firstPartyData.timeLastUpdated.value(); }
+} // namespace WebKit
 
-private:
-    explicit ResourceLoadStatisticsFirstParty(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-        : m_firstPartyData(firstPartyData)
-    {
-    }
-
-    const WebKit::ITPThirdPartyDataForSpecificFirstParty m_firstPartyData;
-};
-
-} // namespace API
+#endif // ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,37 +25,24 @@
 
 #pragma once
 
-#include "APIObject.h"
-#include "ITPThirdPartyDataForSpecificFirstParty.h"
-#include <wtf/RunLoop.h>
-#include <wtf/text/WTFString.h>
+#if ENABLE(TRACKING_PREVENTION)
 
-namespace API {
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/Forward.h>
 
-class ResourceLoadStatisticsFirstParty final : public ObjectImpl<Object::Type::ResourceLoadStatisticsFirstParty> {
-public:
-    static Ref<ResourceLoadStatisticsFirstParty> create(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-        return adoptRef(*new ResourceLoadStatisticsFirstParty(firstPartyData));
-    }
+namespace WebKit {
 
-    ~ResourceLoadStatisticsFirstParty()
-    {
-        RELEASE_ASSERT(RunLoop::isMain());
-    }
+struct ITPThirdPartyDataForSpecificFirstParty {
+    WebCore::RegistrableDomain firstPartyDomain;
+    bool storageAccessGranted;
+    Seconds timeLastUpdated;
 
-    const WTF::String& firstPartyDomain() const { return m_firstPartyData.firstPartyDomain.string(); }
-    bool storageAccess() const { return m_firstPartyData.storageAccessGranted; }
-    double timeLastUpdated() const { return m_firstPartyData.timeLastUpdated.value(); }
+    String toString() const;
 
-private:
-    explicit ResourceLoadStatisticsFirstParty(const WebKit::ITPThirdPartyDataForSpecificFirstParty& firstPartyData)
-        : m_firstPartyData(firstPartyData)
-    {
-    }
-
-    const WebKit::ITPThirdPartyDataForSpecificFirstParty m_firstPartyData;
+    // FIXME: Since this ignores differences in decodedTimeLastUpdated it probably should be a named function, not operator==.
+    bool operator==(const ITPThirdPartyDataForSpecificFirstParty&) const;
 };
 
-} // namespace API
+} // namespace WebKit
+
+#endif // ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.serialization.in
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(TRACKING_PREVENTION)
+
+struct WebKit::ITPThirdPartyDataForSpecificFirstParty {
+    WebCore::RegistrableDomain firstPartyDomain;
+    bool storageAccessGranted;
+    Seconds timeLastUpdated;
+}
+
+#endif

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
@@ -61,7 +61,7 @@ public:
     void clear(CompletionHandler<void()>&&) override;
     bool isEmpty() const override;
 
-    Vector<WebResourceLoadStatisticsStore::ThirdPartyData> aggregatedThirdPartyData() const override;
+    Vector<ITPThirdPartyData> aggregatedThirdPartyData() const override;
     void updateCookieBlocking(CompletionHandler<void()>&&) override;
 
     void classifyPrevalentResources() override;
@@ -141,7 +141,7 @@ private:
     void destroyStatements() final;
 
     bool hasStorageAccess(const TopFrameDomain&, const SubFrameDomain&) const;
-    Vector<WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty> getThirdPartyDataForSpecificFirstPartyDomains(unsigned, const RegistrableDomain&) const;
+    Vector<ITPThirdPartyDataForSpecificFirstParty> getThirdPartyDataForSpecificFirstPartyDomains(unsigned, const RegistrableDomain&) const;
     void openAndUpdateSchemaIfNecessary();
     String getDomainStringFromDomainID(unsigned) const final;
     ASCIILiteral getSubStatisticStatement(ASCIILiteral) const;

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsMemoryStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsMemoryStore.h
@@ -51,7 +51,7 @@ public:
     void clear(CompletionHandler<void()>&&) override;
     bool isEmpty() const override;
 
-    Vector<WebResourceLoadStatisticsStore::ThirdPartyData> aggregatedThirdPartyData() const override;
+    Vector<ITPThirdPartyData> aggregatedThirdPartyData() const override;
     const HashMap<RegistrableDomain, UniqueRef<WebCore::ResourceLoadStatistics>>& data() const { return m_resourceStatisticsMap; }
 
     std::unique_ptr<WebCore::KeyedEncoder> createEncoderFromData() const;

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -104,7 +104,7 @@ public:
 
     void clear(CompletionHandler<void()>&&);
     bool isEmpty() const;
-    Vector<WebResourceLoadStatisticsStore::ThirdPartyData> aggregatedThirdPartyData() const;
+    Vector<ITPThirdPartyData> aggregatedThirdPartyData() const;
     void updateCookieBlocking(CompletionHandler<void()>&&);
     void processStatisticsAndDataRecords();
     void cancelPendingStatisticsProcessingRequest();
@@ -232,7 +232,7 @@ private:
     bool shouldExemptFromWebsiteDataDeletion(const RegistrableDomain&) const;
 
     bool hasStorageAccess(const TopFrameDomain&, const SubFrameDomain&) const;
-    Vector<WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty> getThirdPartyDataForSpecificFirstPartyDomains(unsigned, const RegistrableDomain&) const;
+    Vector<ITPThirdPartyDataForSpecificFirstParty> getThirdPartyDataForSpecificFirstPartyDomains(unsigned, const RegistrableDomain&) const;
     String getDomainStringFromDomainID(unsigned) const final;
     void resourceToString(StringBuilder&, const String&) const;
     ASCIILiteral getSubStatisticStatement(ASCIILiteral) const;

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -69,6 +69,8 @@ enum class ShouldGrandfatherStatistics : bool;
 enum class ShouldIncludeLocalhost : bool { No, Yes };
 enum class EnableResourceLoadStatisticsDebugMode : bool { No, Yes };
 
+struct ITPThirdPartyData;
+
 using TopFrameDomain = WebCore::RegistrableDomain;
 using SubResourceDomain = WebCore::RegistrableDomain;
 
@@ -112,31 +114,6 @@ public:
     static Ref<WebResourceLoadStatisticsStore> create(NetworkSession&, const String& resourceLoadStatisticsDirectory, ShouldIncludeLocalhost, ResourceLoadStatistics::IsEphemeral);
 
     ~WebResourceLoadStatisticsStore();
-
-    struct ThirdPartyDataForSpecificFirstParty {
-        WebCore::RegistrableDomain firstPartyDomain;
-        bool storageAccessGranted;
-        Seconds timeLastUpdated;
-
-        String toString() const;
-        void encode(IPC::Encoder&) const;
-        static std::optional<ThirdPartyDataForSpecificFirstParty> decode(IPC::Decoder&);
-
-        // FIXME: Since this ignores differences in decodedTimeLastUpdated it probably should be a named function, not operator==.
-        bool operator==(const ThirdPartyDataForSpecificFirstParty&) const;
-    };
-
-    struct ThirdPartyData {
-        WebCore::RegistrableDomain thirdPartyDomain;
-        Vector<ThirdPartyDataForSpecificFirstParty> underFirstParties;
-
-        String toString() const;
-        void encode(IPC::Encoder&) const;
-        static std::optional<ThirdPartyData> decode(IPC::Decoder&);
-
-        // FIXME: This sorts by number of underFirstParties, so it probably should be a named function, not operator<.
-        bool operator<(const ThirdPartyData&) const;
-    };
 
     void didDestroyNetworkSession(CompletionHandler<void()>&&);
 
@@ -239,7 +216,7 @@ public:
 
     void resourceLoadStatisticsUpdated(Vector<WebCore::ResourceLoadStatistics>&&, CompletionHandler<void()>&&);
     void requestStorageAccessUnderOpener(DomainInNeedOfStorageAccess&&, WebCore::PageIdentifier openerID, OpenerDomain&&);
-    void aggregatedThirdPartyData(CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&&);
+    void aggregatedThirdPartyData(CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&&);
     static void suspend(CompletionHandler<void()>&&);
     static void resume();
     

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -35,6 +35,7 @@
 #include "DataReference.h"
 #include "Download.h"
 #include "DownloadProxyMessages.h"
+#include "ITPThirdPartyData.h"
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
 #include "LegacyCustomProtocolManager.h"
 #endif
@@ -780,7 +781,7 @@ void NetworkProcess::scheduleClearInMemoryAndPersistent(PAL::SessionID sessionID
     }
 }
 
-void NetworkProcess::getResourceLoadStatisticsDataSummary(PAL::SessionID sessionID, CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&& completionHandler)
+void NetworkProcess::getResourceLoadStatisticsDataSummary(PAL::SessionID sessionID, CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&& completionHandler)
 {
     if (auto* session = networkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -245,7 +245,7 @@ public:
     void resetCacheMaxAgeCapForPrevalentResources(PAL::SessionID, CompletionHandler<void()>&&);
     void resetParametersToDefaultValues(PAL::SessionID, CompletionHandler<void()>&&);
     void scheduleClearInMemoryAndPersistent(PAL::SessionID, std::optional<WallTime> modifiedSince, ShouldGrandfatherStatistics, CompletionHandler<void()>&&);
-    void getResourceLoadStatisticsDataSummary(PAL::SessionID, CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&&);
+    void getResourceLoadStatisticsDataSummary(PAL::SessionID, CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&&);
     void scheduleCookieBlockingUpdate(PAL::SessionID, CompletionHandler<void()>&&);
     void scheduleStatisticsAndDataRecordsProcessing(PAL::SessionID, CompletionHandler<void()>&&);
     void statisticsDatabaseHasAllTables(PAL::SessionID, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -118,7 +118,7 @@ messages -> NetworkProcess LegacyReceiver {
     StatisticsDatabaseHasAllTables(PAL::SessionID sessionID) -> (bool hasAllTables)
     SetCacheMaxAgeCapForPrevalentResources(PAL::SessionID sessionID, Seconds seconds) -> ()
     SetGrandfathered(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain, bool isGrandfathered) -> ()
-    GetResourceLoadStatisticsDataSummary(PAL::SessionID sessionID) -> (Vector<WebKit::WebResourceLoadStatisticsStore::ThirdPartyData> thirdPartyData)
+    GetResourceLoadStatisticsDataSummary(PAL::SessionID sessionID) -> (Vector<WebKit::ITPThirdPartyData> thirdPartyData)
     SetGrandfatheringTime(PAL::SessionID sessionID, Seconds seconds) -> ()
     SetMaxStatisticsEntries(PAL::SessionID sessionID, uint64_t maximumEntryCount) -> ()
     SetMinimumTimeBetweenDataRecordsRemoval(PAL::SessionID sessionID, Seconds seconds) -> ()

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -116,6 +116,8 @@ NetworkProcess/NetworkSocketChannel.cpp
 NetworkProcess/PingLoad.cpp
 NetworkProcess/PreconnectTask.cpp
 
+NetworkProcess/Classifier/ITPThirdPartyData.cpp
+NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
 
 NetworkProcess/Cookies/WebCookieManager.cpp

--- a/Source/WebKit/UIProcess/API/APIResourceLoadStatisticsThirdParty.h
+++ b/Source/WebKit/UIProcess/API/APIResourceLoadStatisticsThirdParty.h
@@ -26,14 +26,15 @@
 #pragma once
 
 #include "APIObject.h"
-#include "WebResourceLoadStatisticsStore.h"
+#include "ITPThirdPartyData.h"
+#include <wtf/RunLoop.h>
 #include <wtf/text/WTFString.h>
 
 namespace API {
 
 class ResourceLoadStatisticsThirdParty final : public ObjectImpl<Object::Type::ResourceLoadStatisticsThirdParty> {
 public:
-    static Ref<ResourceLoadStatisticsThirdParty> create(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData&& thirdPartyData)
+    static Ref<ResourceLoadStatisticsThirdParty> create(WebKit::ITPThirdPartyData&& thirdPartyData)
     {
         RELEASE_ASSERT(RunLoop::isMain());
         return adoptRef(*new ResourceLoadStatisticsThirdParty(WTFMove(thirdPartyData)));
@@ -45,15 +46,15 @@ public:
     }
 
     const WTF::String& thirdPartyDomain() const { return m_thirdPartyData.thirdPartyDomain.string(); }
-    const Vector<WebKit::WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty>& underFirstParties() const { return m_thirdPartyData.underFirstParties; }
+    const Vector<WebKit::ITPThirdPartyDataForSpecificFirstParty>& underFirstParties() const { return m_thirdPartyData.underFirstParties; }
 
 private:
-    explicit ResourceLoadStatisticsThirdParty(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData&& thirdPartyData)
+    explicit ResourceLoadStatisticsThirdParty(WebKit::ITPThirdPartyData&& thirdPartyData)
         : m_thirdPartyData(WTFMove(thirdPartyData))
     {
     }
 
-    const WebKit::WebResourceLoadStatisticsStore::ThirdPartyData m_thirdPartyData;
+    const WebKit::ITPThirdPartyData m_thirdPartyData;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -805,8 +805,8 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 - (void)_getResourceLoadStatisticsDataSummary:(void (^)(NSArray<_WKResourceLoadStatisticsThirdParty *> *))completionHandler
 {
 #if ENABLE(TRACKING_PREVENTION)
-    _websiteDataStore->getResourceLoadStatisticsDataSummary([completionHandler = makeBlockPtr(completionHandler)] (Vector<WebKit::WebResourceLoadStatisticsStore::ThirdPartyData>&& thirdPartyDomains) {
-        completionHandler(createNSArray(WTFMove(thirdPartyDomains), [] (WebKit::WebResourceLoadStatisticsStore::ThirdPartyData&& domain) {
+    _websiteDataStore->getResourceLoadStatisticsDataSummary([completionHandler = makeBlockPtr(completionHandler)] (Vector<WebKit::ITPThirdPartyData>&& thirdPartyDomains) {
+        completionHandler(createNSArray(WTFMove(thirdPartyDomains), [] (WebKit::ITPThirdPartyData&& domain) {
             return wrapper(API::ResourceLoadStatisticsThirdParty::create(WTFMove(domain)));
         }).get());
     });

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -572,7 +572,7 @@ void webkit_network_session_get_itp_summary(WebKitNetworkSession* session, GCanc
 
     auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
     GRefPtr<GTask> task = adoptGRef(g_task_new(session, cancellable, callback, userData));
-    websiteDataStore.getResourceLoadStatisticsDataSummary([task = WTFMove(task)](Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&& thirdPartyList) {
+    websiteDataStore.getResourceLoadStatisticsDataSummary([task = WTFMove(task)](Vector<ITPThirdPartyData>&& thirdPartyList) {
         GList* result = nullptr;
         while (!thirdPartyList.isEmpty())
             result = g_list_prepend(result, webkitITPThirdPartyCreate(thirdPartyList.takeLast()));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "WebKitWebsiteDataManager.h"
 
+#include "ITPThirdPartyData.h"
+#include "ITPThirdPartyDataForSpecificFirstParty.h"
 #include "WebKitCookieManagerPrivate.h"
 #include "WebKitInitialize.h"
 #include "WebKitMemoryPressureSettings.h"
@@ -1377,7 +1379,7 @@ gboolean webkit_website_data_manager_clear_finish(WebKitWebsiteDataManager* mana
  */
 struct _WebKitITPFirstParty {
 #if ENABLE(TRACKING_PREVENTION)
-    explicit _WebKitITPFirstParty(WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty&& data)
+    explicit _WebKitITPFirstParty(ITPThirdPartyDataForSpecificFirstParty&& data)
         : domain(data.firstPartyDomain.string().utf8())
         , storageAccessGranted(data.storageAccessGranted)
         , lastUpdated(adoptGRef(g_date_time_new_from_unix_utc(data.timeLastUpdated.secondsAs<gint64>())))
@@ -1422,7 +1424,7 @@ void webkit_website_data_manager_set_memory_pressure_settings(WebKitMemoryPressu
 G_DEFINE_BOXED_TYPE(WebKitITPFirstParty, webkit_itp_first_party, webkit_itp_first_party_ref, webkit_itp_first_party_unref)
 
 #if ENABLE(TRACKING_PREVENTION)
-static WebKitITPFirstParty* webkitITPFirstPartyCreate(WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty&& data)
+static WebKitITPFirstParty* webkitITPFirstPartyCreate(ITPThirdPartyDataForSpecificFirstParty&& data)
 {
     auto* firstParty = static_cast<WebKitITPFirstParty*>(fastMalloc(sizeof(WebKitITPFirstParty)));
     new (firstParty) WebKitITPFirstParty(WTFMove(data));
@@ -1540,7 +1542,7 @@ GDateTime* webkit_itp_first_party_get_last_update_time(WebKitITPFirstParty* firs
 
 struct _WebKitITPThirdParty {
 #if ENABLE(TRACKING_PREVENTION)
-    explicit _WebKitITPThirdParty(WebResourceLoadStatisticsStore::ThirdPartyData&& data)
+    explicit _WebKitITPThirdParty(ITPThirdPartyData&& data)
         : domain(data.thirdPartyDomain.string().utf8())
     {
         while (!data.underFirstParties.isEmpty())
@@ -1561,7 +1563,7 @@ struct _WebKitITPThirdParty {
 G_DEFINE_BOXED_TYPE(WebKitITPThirdParty, webkit_itp_third_party, webkit_itp_third_party_ref, webkit_itp_third_party_unref)
 
 #if ENABLE(TRACKING_PREVENTION)
-WebKitITPThirdParty* webkitITPThirdPartyCreate(WebResourceLoadStatisticsStore::ThirdPartyData&& data)
+WebKitITPThirdParty* webkitITPThirdPartyCreate(ITPThirdPartyData&& data)
 {
     auto* thirdParty = static_cast<WebKitITPThirdParty*>(fastMalloc(sizeof(WebKitITPThirdParty)));
     new (thirdParty) WebKitITPThirdParty(WTFMove(data));
@@ -1668,7 +1670,7 @@ void webkit_website_data_manager_get_itp_summary(WebKitWebsiteDataManager* manag
     g_return_if_fail(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager));
 
     GRefPtr<GTask> task = adoptGRef(g_task_new(manager, cancellable, callback, userData));
-    manager->priv->websiteDataStore->getResourceLoadStatisticsDataSummary([task = WTFMove(task)](Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&& thirdPartyList) {
+    manager->priv->websiteDataStore->getResourceLoadStatisticsDataSummary([task = WTFMove(task)](Vector<ITPThirdPartyData>&& thirdPartyList) {
         GList* result = nullptr;
         while (!thirdPartyList.isEmpty())
             result = g_list_prepend(result, webkitITPThirdPartyCreate(thirdPartyList.takeLast()));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h
@@ -30,5 +30,5 @@ WebKitWebsiteDataManager* webkitWebsiteDataManagerCreate(CString&&, CString&&);
 WebKit::WebsiteDataStore& webkitWebsiteDataManagerGetDataStore(WebKitWebsiteDataManager*);
 
 #if ENABLE(TRACKING_PREVENTION)
-WebKitITPThirdParty* webkitITPThirdPartyCreate(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData&&);
+WebKitITPThirdParty* webkitITPThirdPartyCreate(WebKit::ITPThirdPartyData&&);
 #endif

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1030,7 +1030,7 @@ void NetworkProcessProxy::getAllStorageAccessEntries(PAL::SessionID sessionID, C
     sendWithAsyncReply(Messages::NetworkProcess::GetAllStorageAccessEntries(sessionID), WTFMove(completionHandler));
 }
 
-void NetworkProcessProxy::getResourceLoadStatisticsDataSummary(PAL::SessionID sessionID, CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&& completionHandler)
+void NetworkProcessProxy::getResourceLoadStatisticsDataSummary(PAL::SessionID sessionID, CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&& completionHandler)
 {
     if (!canSendMessage()) {
         completionHandler({ });

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -176,7 +176,7 @@ public:
     void setPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
     void setPrevalentResourceForDebugMode(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
     void setVeryPrevalentResource(PAL::SessionID, const RegistrableDomain&, CompletionHandler<void()>&&);
-    void getResourceLoadStatisticsDataSummary(PAL::SessionID, CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&&);
+    void getResourceLoadStatisticsDataSummary(PAL::SessionID, CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&&);
     void getAllStorageAccessEntries(PAL::SessionID, CompletionHandler<void(Vector<String> domains)>&&);
     void requestStorageAccessConfirm(WebPageProxyIdentifier, WebCore::FrameIdentifier, const SubFrameDomain&, const TopFrameDomain&, CompletionHandler<void(bool)>&&);
     void resetParametersToDefaultValues(PAL::SessionID, CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1177,13 +1177,13 @@ void WebsiteDataStore::scheduleClearInMemoryAndPersistent(WallTime modifiedSince
     protectedNetworkProcess()->scheduleClearInMemoryAndPersistent(m_sessionID, modifiedSince, shouldGrandfather, WTFMove(completionHandler));
 }
 
-void WebsiteDataStore::getResourceLoadStatisticsDataSummary(CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&& completionHandler)
+void WebsiteDataStore::getResourceLoadStatisticsDataSummary(CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
 
     class LocalCallbackAggregator : public RefCounted<LocalCallbackAggregator> {
     public:
-        static Ref<LocalCallbackAggregator> create(CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&& completionHandler)
+        static Ref<LocalCallbackAggregator> create(CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&& completionHandler)
         {
             return adoptRef(*new LocalCallbackAggregator(WTFMove(completionHandler)));
         }
@@ -1195,26 +1195,26 @@ void WebsiteDataStore::getResourceLoadStatisticsDataSummary(CompletionHandler<vo
             m_completionHandler(WTFMove(m_results));
         }
 
-        void addResult(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&& results)
+        void addResult(Vector<ITPThirdPartyData>&& results)
         {
             m_results.appendVector(WTFMove(results));
         }
 
     private:
-        LocalCallbackAggregator(CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&& completionHandler)
+        LocalCallbackAggregator(CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&& completionHandler)
             : m_completionHandler(WTFMove(completionHandler))
         {
             ASSERT(RunLoop::isMain());
         }
 
-        CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)> m_completionHandler;
-        Vector<WebResourceLoadStatisticsStore::ThirdPartyData> m_results;
+        CompletionHandler<void(Vector<ITPThirdPartyData>&&)> m_completionHandler;
+        Vector<ITPThirdPartyData> m_results;
     };
     
     Ref localCallbackAggregator = LocalCallbackAggregator::create(WTFMove(completionHandler));
     
     Ref wtfCallbackAggregator = CallbackAggregator::create([this, protectedThis = Ref { *this }, localCallbackAggregator] {
-        protectedNetworkProcess()->getResourceLoadStatisticsDataSummary(m_sessionID, [localCallbackAggregator](Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&& data) {
+        protectedNetworkProcess()->getResourceLoadStatisticsDataSummary(m_sessionID, [localCallbackAggregator](Vector<ITPThirdPartyData>&& data) {
             localCallbackAggregator->addResult(WTFMove(data));
         });
     });

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -108,6 +108,7 @@ enum class UnifiedOriginStorageLevel : uint8_t;
 enum class WebsiteDataFetchOption : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
+struct ITPThirdPartyData;
 struct NetworkProcessConnectionInfo;
 struct WebPushMessage;
 struct WebsiteDataRecord;
@@ -220,7 +221,7 @@ public:
     void scheduleCookieBlockingUpdate(CompletionHandler<void()>&&);
     void scheduleClearInMemoryAndPersistent(WallTime modifiedSince, ShouldGrandfatherStatistics, CompletionHandler<void()>&&);
     void scheduleClearInMemoryAndPersistent(ShouldGrandfatherStatistics, CompletionHandler<void()>&&);
-    void getResourceLoadStatisticsDataSummary(CompletionHandler<void(Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&&)>&&);
+    void getResourceLoadStatisticsDataSummary(CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&&);
     void scheduleStatisticsAndDataRecordsProcessing(CompletionHandler<void()>&&);
     void setGrandfathered(const URL&, bool, CompletionHandler<void()>&&);
     void isGrandfathered(const URL&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1033,6 +1033,8 @@
 		46C916AA2799D0A2001A4E7C /* WebSharedWorkerServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 46C916A92799D09D001A4E7C /* WebSharedWorkerServer.h */; };
 		46CE3B1123D8C8490016A96A /* WebBackForwardListCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 46CE3B1023D8C83D0016A96A /* WebBackForwardListCounts.h */; };
 		46D48FCE2799D7E1007D2014 /* WebSharedWorkerServerToContextConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 46D48FCD2799D7DE007D2014 /* WebSharedWorkerServerToContextConnection.h */; };
+		46DBC28C2AF96B9F00E6B63A /* ITPThirdPartyData.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DBC28A2AF96B9700E6B63A /* ITPThirdPartyData.h */; };
+		46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DBC28B2AF96B9700E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h */; };
 		46DC53C328EB3D99005376B0 /* WebScreenOrientationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DC53C028EB3D90005376B0 /* WebScreenOrientationManager.h */; };
 		46DC53C728EB3DC8005376B0 /* WebScreenOrientationManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DC53C628EB3DBE005376B0 /* WebScreenOrientationManagerProxy.h */; };
 		46DF063C1F3905F8001980BB /* NetworkCORSPreflightChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DF063A1F3905E5001980BB /* NetworkCORSPreflightChecker.h */; };
@@ -4922,6 +4924,12 @@
 		46D48FCC2799D7DD007D2014 /* WebSharedWorkerServerToContextConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSharedWorkerServerToContextConnection.cpp; sourceTree = "<group>"; };
 		46D48FCD2799D7DE007D2014 /* WebSharedWorkerServerToContextConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSharedWorkerServerToContextConnection.h; sourceTree = "<group>"; };
 		46DA285727B73E760089D339 /* WebGeolocationManagerProxyCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGeolocationManagerProxyCocoa.cpp; sourceTree = "<group>"; };
+		46DBC2862AF96B9600E6B63A /* ITPThirdPartyDataForSpecificFirstParty.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = ITPThirdPartyDataForSpecificFirstParty.serialization.in; path = Classifier/ITPThirdPartyDataForSpecificFirstParty.serialization.in; sourceTree = "<group>"; };
+		46DBC2872AF96B9600E6B63A /* ITPThirdPartyData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ITPThirdPartyData.cpp; path = Classifier/ITPThirdPartyData.cpp; sourceTree = "<group>"; };
+		46DBC2882AF96B9600E6B63A /* ITPThirdPartyData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = ITPThirdPartyData.serialization.in; path = Classifier/ITPThirdPartyData.serialization.in; sourceTree = "<group>"; };
+		46DBC2892AF96B9700E6B63A /* ITPThirdPartyDataForSpecificFirstParty.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ITPThirdPartyDataForSpecificFirstParty.cpp; path = Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp; sourceTree = "<group>"; };
+		46DBC28A2AF96B9700E6B63A /* ITPThirdPartyData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ITPThirdPartyData.h; path = Classifier/ITPThirdPartyData.h; sourceTree = "<group>"; };
+		46DBC28B2AF96B9700E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ITPThirdPartyDataForSpecificFirstParty.h; path = Classifier/ITPThirdPartyDataForSpecificFirstParty.h; sourceTree = "<group>"; };
 		46DC53C028EB3D90005376B0 /* WebScreenOrientationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebScreenOrientationManager.h; sourceTree = "<group>"; };
 		46DC53C128EB3D90005376B0 /* WebScreenOrientationManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebScreenOrientationManager.cpp; sourceTree = "<group>"; };
 		46DC53C228EB3D90005376B0 /* WebScreenOrientationManager.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebScreenOrientationManager.messages.in; sourceTree = "<group>"; };
@@ -11841,6 +11849,12 @@
 		7A843A1D21E41FD900DEF663 /* Classifier */ = {
 			isa = PBXGroup;
 			children = (
+				46DBC2872AF96B9600E6B63A /* ITPThirdPartyData.cpp */,
+				46DBC28A2AF96B9700E6B63A /* ITPThirdPartyData.h */,
+				46DBC2882AF96B9600E6B63A /* ITPThirdPartyData.serialization.in */,
+				46DBC2892AF96B9700E6B63A /* ITPThirdPartyDataForSpecificFirstParty.cpp */,
+				46DBC28B2AF96B9700E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h */,
+				46DBC2862AF96B9600E6B63A /* ITPThirdPartyDataForSpecificFirstParty.serialization.in */,
 				7ACE82E8221CAE07000DA94C /* ResourceLoadStatisticsStore.cpp */,
 				7ACE82E7221CAE06000DA94C /* ResourceLoadStatisticsStore.h */,
 				7A41E9FA21F81DAC00B88CDB /* ShouldGrandfatherStatistics.h */,
@@ -14907,6 +14921,8 @@
 				A73E66BD2AB107C3005FC327 /* IPCEvent.h in Headers */,
 				A31F60A425CC7DB900AF14F4 /* IPCSemaphore.h in Headers */,
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
+				46DBC28C2AF96B9F00E6B63A /* ITPThirdPartyData.h in Headers */,
+				46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,
 				1CC94E542AC92F190045F269 /* JSWebExtensionAPIAction.h in Headers */,
 				1C386F352AF409F9004108F0 /* JSWebExtensionAPINotifications.h in Headers */,


### PR DESCRIPTION
#### 1a06a71f905770f92eb46d4cc693f8a5b9d2feda
<pre>
[ITP] Port ThirdPartyData / ThirdPartyDataForSpecificFirstParty to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264271">https://bugs.webkit.org/show_bug.cgi?id=264271</a>

Reviewed by Alex Christensen.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.cpp: Added.
(WebKit::ITPThirdPartyData::toString const):
(WebKit::ITPThirdPartyData::operator&lt; const):
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.h: Added.
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.serialization.in: Added.
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.cpp: Added.
(WebKit::ITPThirdPartyDataForSpecificFirstParty::toString const):
(WebKit::ITPThirdPartyDataForSpecificFirstParty::operator== const):
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h: Added.
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.serialization.in: Added.
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsMemoryStore.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::getThirdPartyDataForSpecificFirstPartyDomains const):
(WebKit::ResourceLoadStatisticsStore::aggregatedThirdPartyData const):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::aggregatedThirdPartyData):
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty::toString const): Deleted.
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty::encode const): Deleted.
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty::decode): Deleted.
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty::operator== const): Deleted.
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData::toString const): Deleted.
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData::encode const): Deleted.
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData::decode): Deleted.
(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData::operator&lt; const): Deleted.
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::getResourceLoadStatisticsDataSummary):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APIResourceLoadStatisticsFirstParty.h:
* Source/WebKit/UIProcess/API/APIResourceLoadStatisticsThirdParty.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _getResourceLoadStatisticsDataSummary:]):
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkit_network_session_get_itp_summary):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(_WebKitITPFirstParty::_WebKitITPFirstParty):
(webkitITPFirstPartyCreate):
(_WebKitITPThirdParty::_WebKitITPThirdParty):
(webkitITPThirdPartyCreate):
(webkit_website_data_manager_get_itp_summary):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getResourceLoadStatisticsDataSummary):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::getResourceLoadStatisticsDataSummary):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270310@main">https://commits.webkit.org/270310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26be6bae6d32df0da6209a66d939b77a4370205c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25108 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23043 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27802 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28733 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26548 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/615 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3666 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6022 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2759 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2655 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->