### PR TITLE
[JSC] Fix addImmediateShouldSpeculateInt32 for case int32 + constant double

### DIFF
--- a/JSTests/stress/dfg-add-int32-var-with-const-double.js
+++ b/JSTests/stress/dfg-add-int32-var-with-const-double.js
@@ -1,0 +1,18 @@
+let expected = 0;
+
+function foo(arg) {
+    let x = /\s/;
+    const a = 0 | arg;
+    const b = a + 0.1;
+    const c = b >> x;
+    if (expected != 0 && c != expected)
+        throw new Error("bad c " + c + " expected " + expected);
+    return c;
+}
+noInline(foo);
+
+let y = -2147483647;
+expected = foo(y);
+for (let i = 0; i < 1e4; i++) {
+    foo(y);
+}


### PR DESCRIPTION
#### 79a659d55c63c76abcb5c54b02dffe7631b68e6b
<pre>
[JSC] Fix addImmediateShouldSpeculateInt32 for case int32 + constant double
<a href="https://bugs.webkit.org/show_bug.cgi?id=264278">https://bugs.webkit.org/show_bug.cgi?id=264278</a>
<a href="https://rdar.apple.com/117563215">rdar://117563215</a>

Reviewed by Yusuke Suzuki.

Current fixup phase would convert the DFG node

    ValueAdd(Int32, DoubleConstant)

to

    ArithAdd(Int32, JSConstant(DoubleConstant))

if the node is OK to be truncated to Int32. This is
wrong. For example, let Int32 be -1 and DoubleConstant
be 0.1 where

    ToInt32(-1 + 0.1) == 0

but

    -1 + ToInt32(0.1) == -1

. So, we should not speculate that node with Int32 in this case.

* JSTests/stress/dfg-int32-add-non-int-double.js: Added.
(foo):
* Source/JavaScriptCore/dfg/DFGGraph.h:

Canonical link: <a href="https://commits.webkit.org/270481@main">https://commits.webkit.org/270481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a829549f79c5af876644abe711428a9298ec45b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23319 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23495 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28116 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28993 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22125 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26820 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24658 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/875 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32088 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3994 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->