### PR TITLE
Drop workaround added in 270248@main and fix the bug properly

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1597,10 +1597,6 @@ void RenderLayer::updateAncestorDependentState()
     m_enclosingSVGHiddenOrResourceContainer = nullptr;
     auto determineSVGAncestors = [&] (const RenderElement& renderer) {
         for (auto* ancestor = renderer.parent(); ancestor; ancestor = ancestor->parent()) {
-            if (auto* container = dynamicDowncast<RenderSVGResourceContainer>(ancestor)) {
-                m_enclosingSVGHiddenOrResourceContainer = container;
-                return;
-            }
             if (auto* container = dynamicDowncast<RenderSVGHiddenContainer>(ancestor)) {
                 m_enclosingSVGHiddenOrResourceContainer = container;
                 return;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -452,7 +452,7 @@ public:
     bool isLegacySVGViewportContainer() const { return type() == Type::LegacySVGViewportContainer; }
     bool isSVGGradientStop() const { return type() == Type::SVGGradientStop; }
     virtual bool isLegacySVGHiddenContainer() const { return false; }
-    bool isSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer; }
+    bool isSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer || isSVGResourceContainer(); }
     bool isLegacySVGPath() const { return type() == Type::LegacySVGPath; }
     bool isSVGPath() const { return type() == Type::SVGPath; }
     virtual bool isSVGShape() const { return false; }
@@ -467,7 +467,7 @@ public:
     bool isLegacySVGForeignObject() const { return type() == Type::LegacySVGForeignObject; }
     bool isSVGForeignObject() const { return type() == Type::SVGForeignObject; }
     virtual bool isLegacySVGResourceContainer() const { return false; }
-    virtual bool isSVGResourceContainer() const { return false; }
+    bool isSVGResourceContainer() const { return type() == Type::SVGResourceClipper; }
     bool isSVGResourceFilter() const { return type() == Type::SVGResourceFilter; }
     bool isLegacySVGResourceClipper() const { return type() == Type::LegacySVGResourceClipper; }
     bool isSVGResourceClipper() const { return type() == Type::SVGResourceClipper; }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -37,8 +37,6 @@ public:
 
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
-    bool isSVGResourceContainer() const final { return true; }
-
     void idChanged();
 
 protected:


### PR DESCRIPTION
#### 26ef6e92d328cb5dd1314873b52e3f5ab1b592f6
<pre>
Drop workaround added in 270248@main and fix the bug properly
<a href="https://bugs.webkit.org/show_bug.cgi?id=264279">https://bugs.webkit.org/show_bug.cgi?id=264279</a>

Reviewed by Nikolas Zimmermann and Said Abou-Hallawa.

The implementation of `isSVGHiddenContainer()` was incorrect and was returning
false for RenderSVGResourceContainer types, even though RenderSVGResourceContainer
subclasses RenderSVGHiddenContainer.

Fix the isSVGHiddenContainer() implementation and drop the workaround recently
introduced in 270248@main.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateAncestorDependentState):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isSVGHiddenContainer const):
(WebCore::RenderObject::isSVGResourceContainer const):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h:

Canonical link: <a href="https://commits.webkit.org/270302@main">https://commits.webkit.org/270302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f41893b853422ee57081d6e6eb27c32dbaf0a2f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27194 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1058 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27775 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28717 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26529 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/597 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3644 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6014 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2735 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2632 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->