### PR TITLE
Implement API review feedback for WKWebExtensionAction

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
@@ -59,6 +59,9 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 NS_SWIFT_NAME(_WKWebExtension.Action)
 @interface _WKWebExtensionAction : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)new NS_UNAVAILABLE;
+
 /*! @abstract The extension context to which this action is related. */
 @property (nonatomic, readonly, weak) _WKWebExtensionContext *webExtensionContext;
 
@@ -82,10 +85,10 @@ NS_SWIFT_NAME(_WKWebExtension.Action)
 #endif
 
 /*! @abstract The localized display label for the action. */
-@property (nonatomic, readonly, copy) NSString *displayLabel;
+@property (nonatomic, readonly, copy) NSString *label;
 
 /*! @abstract The badge text for the action. */
-@property (nonatomic, nullable, readonly, copy) NSString *badgeText;
+@property (nonatomic, readonly, copy) NSString *badgeText;
 
 /*! @abstract A Boolean value indicating whether the action is enabled. */
 @property (nonatomic, readonly, getter=isEnabled) BOOL enabled;
@@ -95,7 +98,7 @@ NS_SWIFT_NAME(_WKWebExtension.Action)
  @discussion Use this property to check if the action has a popup before attempting to access the `popupWebView` property.
  @seealso popupWebView
  */
-@property (nonatomic, readonly) BOOL hasPopup;
+@property (nonatomic, readonly) BOOL presentsPopup;
 
 /*!
  @abstract A web view loaded with the popup page for this action, or `nil` if no popup is specified.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
@@ -85,9 +85,9 @@ NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification =
     return _webExtensionAction->icon(size);
 }
 
-- (NSString *)displayLabel
+- (NSString *)label
 {
-    return _webExtensionAction->displayLabel();
+    return _webExtensionAction->label();
 }
 
 - (NSString *)badgeText
@@ -100,9 +100,9 @@ NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification =
     return _webExtensionAction->isEnabled();
 }
 
-- (BOOL)hasPopup
+- (BOOL)presentsPopup
 {
-    return _webExtensionAction->hasPopup();
+    return _webExtensionAction->presentsPopup();
 }
 
 - (WKWebView *)popupWebView
@@ -144,7 +144,7 @@ NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification =
     return nil;
 }
 
-- (NSString *)displayLabel
+- (NSString *)label
 {
     return nil;
 }
@@ -159,7 +159,7 @@ NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification =
     return NO;
 }
 
-- (BOOL)hasPopup
+- (BOOL)presentsPopup
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -489,7 +489,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @discussion The returned object represents the action specific to the tab when provided; otherwise, it returns the default action. The default
  action is useful when the context is unrelated to a specific tab. When possible, specify the tab to get the most context-relevant action.
  */
-- (_WKWebExtensionAction *)actionForTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(action(for:));
+- (nullable _WKWebExtensionAction *)actionForTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(action(for:));
 
 /*!
  @abstract Performs the extension action associated with the specified tab or performs the default action if `nil` is passed.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -159,7 +159,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  called when the web view for the popup is fully loaded and ready to display. Implementing this method is needed if the app intends to support
  programmatically showing the popup by the extension, although it is recommended for handling both programmatic and user-initiated cases.
  */
-- (void)webExtensionController:(_WKWebExtensionController *)controller presentActionPopup:(_WKWebExtensionAction *)action forExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+- (void)webExtensionController:(_WKWebExtensionController *)controller presentPopupForAction:(_WKWebExtensionAction *)action forExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called when an extension context wants to send a one-time message to an application.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -106,7 +106,7 @@ void WebExtensionContext::actionGetTitle(std::optional<WebExtensionWindowIdentif
 
     ASSERT(action);
 
-    completionHandler(action->displayLabel(WebExtensionAction::FallbackWhenEmpty::No), std::nullopt);
+    completionHandler(action->label(WebExtensionAction::FallbackWhenEmpty::No), std::nullopt);
 }
 
 void WebExtensionContext::actionSetTitle(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& title, CompletionHandler<void(std::optional<String>)>&& completionHandler)
@@ -122,7 +122,7 @@ void WebExtensionContext::actionSetTitle(std::optional<WebExtensionWindowIdentif
 
     ASSERT(action);
 
-    action->setDisplayLabel(title);
+    action->setLabel(title);
 
     completionHandler(std::nullopt);
 }
@@ -196,7 +196,7 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
         }
 
         if (auto activeTab = window->activeTab()) {
-            if (getAction(activeTab.get())->hasPopup())
+            if (getAction(activeTab.get())->presentsPopup())
                 performAction(activeTab.get(), UserTriggered::No);
 
             completionHandler(std::nullopt);
@@ -211,14 +211,14 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
             return;
         }
 
-        if (getAction(tab.get())->hasPopup())
+        if (getAction(tab.get())->presentsPopup())
             performAction(tab.get(), UserTriggered::No);
 
         completionHandler(std::nullopt);
         return;
     }
 
-    if (defaultAction().hasPopup())
+    if (defaultAction().presentsPopup())
         performAction(nullptr, UserTriggered::No);
 
     completionHandler(std::nullopt);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1693,7 +1693,7 @@ void WebExtensionContext::performAction(WebExtensionTab* tab, UserTriggered user
         userGesturePerformed(*tab);
 
     auto action = getOrCreateAction(tab);
-    if (action->hasPopup()) {
+    if (action->presentsPopup()) {
         action->presentPopupWhenReady();
         return;
     }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -74,8 +74,8 @@ public:
     CocoaImage *icon(CGSize);
     void setIconsDictionary(NSDictionary *);
 
-    String displayLabel(FallbackWhenEmpty = FallbackWhenEmpty::Yes) const;
-    void setDisplayLabel(String);
+    String label(FallbackWhenEmpty = FallbackWhenEmpty::Yes) const;
+    void setLabel(String);
 
     String badgeText() const;
     void setBadgeText(String);
@@ -83,7 +83,7 @@ public:
     bool isEnabled() const;
     void setEnabled(std::optional<bool>);
 
-    bool hasPopup() const { return !popupPath().isEmpty(); }
+    bool presentsPopup() const { return !popupPath().isEmpty(); }
     bool canProgrammaticallyPresentPopup() const { return m_respondsToPresentPopup; }
 
     String popupPath() const;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -125,7 +125,7 @@ TEST(WKWebExtensionAPIAction, ClickedEvent)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIAction, PresentActionPopup)
+TEST(WKWebExtensionAPIAction, presentPopupForAction)
 {
     auto *popupPage = @"<b>Hello World!</b>";
 
@@ -146,12 +146,12 @@ TEST(WKWebExtensionAPIAction, PresentActionPopup)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
-        EXPECT_TRUE(action.hasPopup);
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
+        EXPECT_TRUE(action.presentsPopup);
         EXPECT_TRUE(action.isEnabled);
         EXPECT_NULL(action.badgeText);
 
-        EXPECT_NS_EQUAL(action.displayLabel, @"Test Action");
+        EXPECT_NS_EQUAL(action.label, @"Test Action");
 
         auto *smallIcon = [action iconForSize:CGSizeMake(16, 16)];
         EXPECT_NOT_NULL(smallIcon);
@@ -203,25 +203,25 @@ TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *defaultAction = [manager.get().context actionForTab:nil];
 
-        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_TRUE(defaultAction.presentsPopup);
         EXPECT_FALSE(defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(defaultAction.label, @"Modified Title");
         EXPECT_NS_EQUAL(defaultAction.badgeText, @"42");
 
         EXPECT_NULL(action.associatedTab);
 
         EXPECT_FALSE(action.isEnabled);
-        EXPECT_NS_EQUAL(action.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(action.label, @"Modified Title");
         EXPECT_NS_EQUAL(action.badgeText, @"42");
 
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
 
-        EXPECT_TRUE(action.hasPopup);
+        EXPECT_TRUE(action.presentsPopup);
         EXPECT_FALSE(action.isEnabled);
 
         EXPECT_NOT_NULL(action.popupWebView);
@@ -272,12 +272,12 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *defaultAction = [manager.get().context actionForTab:nil];
 
-        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_TRUE(defaultAction.presentsPopup);
         EXPECT_TRUE(defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Test Action");
+        EXPECT_NS_EQUAL(defaultAction.label, @"Test Action");
         EXPECT_NS_EQUAL(defaultAction.badgeText, @"");
 
         auto *defaultIcon = [defaultAction iconForSize:CGSizeMake(32, 32)];
@@ -285,14 +285,14 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
         EXPECT_TRUE(CGSizeEqualToSize(defaultIcon.size, CGSizeMake(32, 32)));
 
         EXPECT_FALSE(action.isEnabled);
-        EXPECT_NS_EQUAL(action.displayLabel, @"Tab Title");
+        EXPECT_NS_EQUAL(action.label, @"Tab Title");
         EXPECT_NS_EQUAL(action.badgeText, @"42");
 
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
 
-        EXPECT_TRUE(action.hasPopup);
+        EXPECT_TRUE(action.presentsPopup);
         EXPECT_FALSE(action.isEnabled);
 
         EXPECT_NOT_NULL(action.popupWebView);
@@ -304,9 +304,9 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
 
         auto *secondTabAction = [manager.get().context actionForTab:manager.get().defaultWindow.tabs.lastObject];
 
-        EXPECT_EQ(secondTabAction.hasPopup, defaultAction.hasPopup);
+        EXPECT_EQ(secondTabAction.presentsPopup, defaultAction.presentsPopup);
         EXPECT_EQ(secondTabAction.isEnabled, defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(secondTabAction.displayLabel, defaultAction.displayLabel);
+        EXPECT_NS_EQUAL(secondTabAction.label, defaultAction.label);
         EXPECT_NS_EQUAL(secondTabAction.badgeText, defaultAction.badgeText);
 
         icon = [secondTabAction iconForSize:CGSizeMake(32, 32)];
@@ -318,9 +318,9 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
         EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
 
         auto *secondWindowAction = [manager.get().context actionForTab:manager.get().windows[1].tabs[0]];
-        EXPECT_EQ(secondWindowAction.hasPopup, defaultAction.hasPopup);
+        EXPECT_EQ(secondWindowAction.presentsPopup, defaultAction.presentsPopup);
         EXPECT_EQ(secondWindowAction.isEnabled, defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(secondWindowAction.displayLabel, defaultAction.displayLabel);
+        EXPECT_NS_EQUAL(secondWindowAction.label, defaultAction.label);
         EXPECT_NS_EQUAL(secondWindowAction.badgeText, defaultAction.badgeText);
 
         icon = [secondWindowAction iconForSize:CGSizeMake(32, 32)];
@@ -375,12 +375,12 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *defaultAction = [manager.get().context actionForTab:nil];
 
-        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_TRUE(defaultAction.presentsPopup);
         EXPECT_TRUE(defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Test Action");
+        EXPECT_NS_EQUAL(defaultAction.label, @"Test Action");
         EXPECT_NS_EQUAL(defaultAction.badgeText, @"");
 
         auto *defaultIcon = [defaultAction iconForSize:CGSizeMake(32, 32)];
@@ -388,22 +388,22 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
         EXPECT_TRUE(CGSizeEqualToSize(defaultIcon.size, CGSizeMake(32, 32)));
 
         EXPECT_TRUE(action.isEnabled);
-        EXPECT_NS_EQUAL(action.displayLabel, @"Window Title");
+        EXPECT_NS_EQUAL(action.label, @"Window Title");
         EXPECT_NS_EQUAL(action.badgeText, @"W");
 
         auto *windowIcon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(windowIcon);
         EXPECT_TRUE(CGSizeEqualToSize(windowIcon.size, CGSizeMake(48, 48)));
 
-        EXPECT_TRUE(action.hasPopup);
+        EXPECT_TRUE(action.presentsPopup);
         NSURL *webViewURL = action.popupWebView.URL;
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/window-popup.html");
 
         auto *secondWindowAction = [manager.get().context actionForTab:manager.get().windows[1].tabs[0]];
-        EXPECT_EQ(secondWindowAction.hasPopup, defaultAction.hasPopup);
+        EXPECT_EQ(secondWindowAction.presentsPopup, defaultAction.presentsPopup);
         EXPECT_EQ(secondWindowAction.isEnabled, defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(secondWindowAction.displayLabel, defaultAction.displayLabel);
+        EXPECT_NS_EQUAL(secondWindowAction.label, defaultAction.label);
         EXPECT_NS_EQUAL(secondWindowAction.badgeText, defaultAction.badgeText);
 
         auto *secondWindowIcon = [secondWindowAction iconForSize:CGSizeMake(32, 32)];
@@ -443,7 +443,7 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePath)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
@@ -476,7 +476,7 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
         auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
         auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
@@ -520,7 +520,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageData)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
 
         EXPECT_NOT_NULL(icon);
@@ -555,7 +555,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
         auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
         auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
@@ -604,7 +604,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithSVGDataURL)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
@@ -646,7 +646,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon48);
 #if USE(APPKIT)
@@ -713,25 +713,25 @@ TEST(WKWebExtensionAPIAction, BrowserAction)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:browserActionManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *defaultAction = [manager.get().context actionForTab:nil];
 
-        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_TRUE(defaultAction.presentsPopup);
         EXPECT_FALSE(defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(defaultAction.label, @"Modified Title");
         EXPECT_NS_EQUAL(defaultAction.badgeText, @"42");
 
         EXPECT_NULL(action.associatedTab);
 
         EXPECT_FALSE(action.isEnabled);
-        EXPECT_NS_EQUAL(action.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(action.label, @"Modified Title");
         EXPECT_NS_EQUAL(action.badgeText, @"42");
 
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
 
-        EXPECT_TRUE(action.hasPopup);
+        EXPECT_TRUE(action.presentsPopup);
         EXPECT_FALSE(action.isEnabled);
 
         EXPECT_NOT_NULL(action.popupWebView);
@@ -797,25 +797,25 @@ TEST(WKWebExtensionAPIAction, PageAction)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:pageActionManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         auto *defaultAction = [manager.get().context actionForTab:nil];
 
-        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_TRUE(defaultAction.presentsPopup);
         EXPECT_FALSE(defaultAction.isEnabled);
-        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(defaultAction.label, @"Modified Title");
         EXPECT_NS_EQUAL(defaultAction.badgeText, @"42");
 
         EXPECT_NULL(action.associatedTab);
 
         EXPECT_FALSE(action.isEnabled);
-        EXPECT_NS_EQUAL(action.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(action.label, @"Modified Title");
         EXPECT_NS_EQUAL(action.badgeText, @"42");
 
         auto *icon = [action iconForSize:CGSizeMake(48, 48)];
         EXPECT_NOT_NULL(icon);
         EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
 
-        EXPECT_TRUE(action.hasPopup);
+        EXPECT_TRUE(action.presentsPopup);
         EXPECT_FALSE(action.isEnabled);
 
         EXPECT_NOT_NULL(action.popupWebView);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -200,7 +200,7 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromPopup)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         // Do nothing so the popup web view will stay loaded.
     };
 
@@ -383,7 +383,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForPopup)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         // Do nothing so the popup web view will stay loaded.
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -207,7 +207,7 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromPopup)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:runtimeManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         // Do nothing so the popup web view will stay loaded.
     };
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -56,7 +56,7 @@
 @property (nonatomic, copy) void (^sendMessage)(id message, NSString *applicationIdentifier, void (^)(id replyMessage, NSError *));
 @property (nonatomic, copy) void (^connectUsingMessagePort)(_WKWebExtensionMessagePort *);
 
-@property (nonatomic, copy) void (^presentActionPopup)(_WKWebExtensionAction *);
+@property (nonatomic, copy) void (^presentPopupForAction)(_WKWebExtensionAction *);
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -121,10 +121,10 @@
         completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.connectNative() not implemneted" }]);
 }
 
-- (void)webExtensionController:(_WKWebExtensionController *)controller presentActionPopup:(_WKWebExtensionAction *)action forExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+- (void)webExtensionController:(_WKWebExtensionController *)controller presentPopupForAction:(_WKWebExtensionAction *)action forExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    if (_presentActionPopup) {
-        _presentActionPopup(action);
+    if (_presentPopupForAction) {
+        _presentPopupForAction(action);
         completionHandler(nil);
     } else
         completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"action.showPopup() not implemneted" }]);


### PR DESCRIPTION
#### 9a906430f2ec386932b423dd4198202af3866126
<pre>
Implement API review feedback for WKWebExtensionAction
<a href="https://rdar.apple.com/118007942">rdar://118007942</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=264270">https://bugs.webkit.org/show_bug.cgi?id=264270</a>

Reviewed by Timothy Hatcher.

Implement feedback for the first round of review for WKWebExtensionAction. This mostly contains
mostly minor changes such as name changes.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm:
(-[_WKWebExtensionAction label]):
(-[_WKWebExtensionAction presentsPopup]):
(-[_WKWebExtensionAction displayLabel]): Deleted.
(-[_WKWebExtensionAction hasPopup]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::actionGetTitle):
(WebKit::WebExtensionContext::actionSetTitle):
(WebKit::WebExtensionContext::actionOpenPopup):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::WebExtensionAction):
(WebKit::WebExtensionAction::popupWebView):
(WebKit::WebExtensionAction::readyToPresentPopup):
(WebKit::WebExtensionAction::label const):
(WebKit::WebExtensionAction::setLabel):
(WebKit::WebExtensionAction::displayLabel const): Deleted.
(WebKit::WebExtensionAction::setDisplayLabel): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::performAction):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
(WebKit::WebExtensionAction::presentsPopup const):
(WebKit::WebExtensionAction::hasPopup const): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:presentPopupForAction:forExtensionContext:completionHandler:]):
(-[TestWebExtensionsDelegate webExtensionController:presentActionPopup:forExtensionContext:completionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/270330@main">https://commits.webkit.org/270330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84c9250a70fa089873fff9cb25eb3bdb92229ec3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23284 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27780 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28718 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26530 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/609 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3648 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2740 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3210 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2637 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->