### PR TITLE
[iOS] Remove the image analysis timeout gesture

### DIFF
--- a/Source/WebKit/Shared/ios/InteractionInformationRequest.cpp
+++ b/Source/WebKit/Shared/ios/InteractionInformationRequest.cpp
@@ -56,9 +56,6 @@ bool InteractionInformationRequest::isValidForRequest(const InteractionInformati
     if (other.linkIndicatorShouldHaveLegacyMargins != linkIndicatorShouldHaveLegacyMargins)
         return false;
 
-    if (other.disallowUserAgentShadowContent != disallowUserAgentShadowContent)
-        return false;
-
     return (other.point - point).diagonalLengthSquared() <= radius * radius;
 }
     

--- a/Source/WebKit/Shared/ios/InteractionInformationRequest.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationRequest.h
@@ -47,7 +47,6 @@ struct InteractionInformationRequest {
 
     bool gatherAnimations { false };
     bool linkIndicatorShouldHaveLegacyMargins { false };
-    bool disallowUserAgentShadowContent { false };
 
     InteractionInformationRequest() { }
     explicit InteractionInformationRequest(WebCore::IntPoint point)
@@ -56,7 +55,7 @@ struct InteractionInformationRequest {
     }
 
     explicit InteractionInformationRequest(WebCore::IntPoint point, bool includeSnapshot, bool includeLinkIndicator, bool includeCaretContext, bool includeHasDoubleClickHandler,
-        bool includeImageData, bool gatherAnimations, bool linkIndicatorShouldHaveLegacyMargins, bool disallowUserAgentShadowContent)
+        bool includeImageData, bool gatherAnimations, bool linkIndicatorShouldHaveLegacyMargins)
         : point(point)
         , includeSnapshot(includeSnapshot)
         , includeLinkIndicator(includeLinkIndicator)
@@ -65,7 +64,6 @@ struct InteractionInformationRequest {
         , includeImageData(includeImageData)
         , gatherAnimations(gatherAnimations)
         , linkIndicatorShouldHaveLegacyMargins(linkIndicatorShouldHaveLegacyMargins)
-        , disallowUserAgentShadowContent(disallowUserAgentShadowContent)
     {
     }
 

--- a/Source/WebKit/Shared/ios/InteractionInformationRequest.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationRequest.serialization.in
@@ -33,7 +33,6 @@ struct WebKit::InteractionInformationRequest {
 
     bool gatherAnimations;
     bool linkIndicatorShouldHaveLegacyMargins;
-    bool disallowUserAgentShadowContent;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -534,13 +534,9 @@ struct ImageAnalysisContextMenuActionData {
 
 #if ENABLE(IMAGE_ANALYSIS)
     RetainPtr<WKImageAnalysisGestureRecognizer> _imageAnalysisGestureRecognizer;
-    RetainPtr<UILongPressGestureRecognizer> _imageAnalysisTimeoutGestureRecognizer;
     std::optional<WebKit::ImageAnalysisRequestIdentifier> _pendingImageAnalysisRequestIdentifier;
     std::optional<WebCore::ElementContext> _elementPendingImageAnalysis;
     Vector<BlockPtr<void(WebKit::ProceedWithTextSelectionInImage)>> _actionsToPerformAfterPendingImageAnalysis;
-#if USE(UICONTEXTMENU)
-    BOOL _contextMenuWasTriggeredByImageAnalysisTimeout;
-#endif // USE(UICONTEXTMENU)
     BOOL _isProceedingWithTextSelectionInImage;
     RetainPtr<CocoaImageAnalyzer> _imageAnalyzer;
 #if USE(QUICK_LOOK)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7417,6 +7417,7 @@
 		F410A19329AAC81E0082D554 /* RemoteGPURequestAdapterResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGPURequestAdapterResponse.h; sourceTree = "<group>"; };
 		F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CompactContextMenuPresenter.h; path = ios/CompactContextMenuPresenter.h; sourceTree = "<group>"; };
 		F41795A52AC619A2007F5F12 /* CompactContextMenuPresenter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = CompactContextMenuPresenter.mm; path = ios/CompactContextMenuPresenter.mm; sourceTree = "<group>"; };
+		F425374F2AF9A25A00873864 /* InteractionInformationRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = InteractionInformationRequest.serialization.in; path = ios/InteractionInformationRequest.serialization.in; sourceTree = "<group>"; };
 		F4299506270E234C0032298B /* StreamMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamMessageReceiver.h; sourceTree = "<group>"; };
 		F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionData.h; path = ios/WebAutocorrectionData.h; sourceTree = "<group>"; };
 		F430E941224732A9005FE053 /* WebsiteMetaViewportPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebsiteMetaViewportPolicy.h; sourceTree = "<group>"; };
@@ -9944,6 +9945,7 @@
 				86DA60CA28EB11830044FE4D /* InteractionInformationAtPosition.serialization.in */,
 				2D4D2C801DF60BF3002EB10C /* InteractionInformationRequest.cpp */,
 				2D4D2C7F1DF60BF3002EB10C /* InteractionInformationRequest.h */,
+				F425374F2AF9A25A00873864 /* InteractionInformationRequest.serialization.in */,
 				2DA944971884E4F000ED86DB /* NativeWebKeyboardEventIOS.mm */,
 				1C9EBA5B2087E74E00054429 /* NativeWebMouseEventIOS.mm */,
 				2DA944981884E4F000ED86DB /* NativeWebTouchEventIOS.mm */,

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3334,9 +3334,6 @@ InteractionInformationAtPosition WebPage::positionInformation(const InteractionI
         HitTestRequest::Type::AllowVisibleChildFrameContentOnly,
     };
 
-    if (request.disallowUserAgentShadowContent)
-        hitTestRequestTypes.add(HitTestRequest::Type::DisallowUserAgentShadowContent);
-
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     if (request.gatherAnimations) {
         hitTestRequestTypes.add(HitTestRequest::Type::IncludeAllElementsUnderPoint);


### PR DESCRIPTION
#### 84ccf0d321e00273f10ac00bf94d8d11d416bb76
<pre>
[iOS] Remove the image analysis timeout gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=264289">https://bugs.webkit.org/show_bug.cgi?id=264289</a>

Reviewed by NOBODY (OOPS!).

Remove the image analysis timeout gesture, along with the `disallowUserAgentShadowContent` position
information request flag (which was only set in this scenario). The timeout gesture currently allows
the user to show an image context menu after selecting Live Text, by continuing to hold down over
the image for 2 seconds after making a selection.

This was originally devised to make it possible to invoke the context menu over an image that is
completely covered by selectable Live Text; however:

1.  This scenario is extremely rare, and doesn&apos;t come up in practice; screenshots filled with text
    generally still contain enough space before or after lines, or in between paragraphs that it&apos;s
    possible to invoke the image context menu.

2.  The very long, 2 second delay made this fallback mechanism very difficult to discover in the
    first place.

For consistency with Live Text on the rest of the platform (e.g. Photos), and because it&apos;ll soon
become untennable to programmatically present context menus outside of the context of UI controls,
let&apos;s experiment with removing this fallback mechanism.

* Source/WebKit/Shared/ios/InteractionInformationRequest.cpp:
(WebKit::InteractionInformationRequest::isValidForRequest const):
* Source/WebKit/Shared/ios/InteractionInformationRequest.h:
(WebKit::InteractionInformationRequest::InteractionInformationRequest):
* Source/WebKit/Shared/ios/InteractionInformationRequest.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
(-[WKContentView cleanUpInteraction]):
(-[WKContentView gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKContentView gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]):
(-[WKContentView gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):
(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
(-[WKContentView _setUpImageAnalysis]):
(-[WKContentView _tearDownImageAnalysis]):
(-[WKContentView _internalContextMenuInteraction:configurationForMenuAtLocation:completion:]):
(-[WKContentView imageAnalysisGestureDidTimeOut:]): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Drive-by fix: add `InteractionInformationRequest.serialization.in` to the Xcode project.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::positionInformation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84ccf0d321e00273f10ac00bf94d8d11d416bb76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23038 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1079 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27796 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28730 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26544 "Passed tests") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2319 "Failed to checkout and rebase branch from PR 20063") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3661 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6015 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2754 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2650 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->