### PR TITLE
Rename InjectedScript

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -833,7 +833,6 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/ConsoleMessage.h
     inspector/ContentSearchUtilities.h
     inspector/IdentifiersFactory.h
-    inspector/InjectedScript.h
     inspector/InjectedScriptBase.h
     inspector/InjectedScriptHost.h
     inspector/InjectedScriptManager.h
@@ -842,6 +841,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/InspectorAgentRegistry.h
     inspector/InspectorBackendDispatcher.h
     inspector/InspectorEnvironment.h
+    inspector/InspectorInjectedScript.h
     inspector/InspectorFrontendChannel.h
     inspector/InspectorFrontendRouter.h
     inspector/InspectorProtocolTypes.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1505,7 +1505,7 @@
 		A50E4B6218809DD50068A46D /* InspectorRuntimeAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A50E4B5E18809DD50068A46D /* InspectorRuntimeAgent.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A50E4B6418809DD50068A46D /* JSGlobalObjectRuntimeAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A50E4B6018809DD50068A46D /* JSGlobalObjectRuntimeAgent.h */; };
 		A51007C1187CC3C600B38879 /* JSGlobalObjectInspectorController.h in Headers */ = {isa = PBXBuildFile; fileRef = A51007BF187CC3C600B38879 /* JSGlobalObjectInspectorController.h */; };
-		A513E5B8185B8BD3007E95AD /* InjectedScript.h in Headers */ = {isa = PBXBuildFile; fileRef = A513E5B6185B8BD3007E95AD /* InjectedScript.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A513E5B8185B8BD3007E95AD /* InspectorInjectedScript.h in Headers */ = {isa = PBXBuildFile; fileRef = A513E5B6185B8BD3007E95AD /* InspectorInjectedScript.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A513E5BE185BFACC007E95AD /* InjectedScriptHost.h in Headers */ = {isa = PBXBuildFile; fileRef = A513E5B9185BFACC007E95AD /* InjectedScriptHost.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A513E5C0185BFACC007E95AD /* JSInjectedScriptHost.h in Headers */ = {isa = PBXBuildFile; fileRef = A513E5BB185BFACC007E95AD /* JSInjectedScriptHost.h */; };
 		A513E5C2185BFACC007E95AD /* JSInjectedScriptHostPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A513E5BD185BFACC007E95AD /* JSInjectedScriptHostPrototype.h */; };
@@ -4867,8 +4867,8 @@
 		A50E4B6018809DD50068A46D /* JSGlobalObjectRuntimeAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGlobalObjectRuntimeAgent.h; sourceTree = "<group>"; };
 		A51007BE187CC3C600B38879 /* JSGlobalObjectInspectorController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGlobalObjectInspectorController.cpp; sourceTree = "<group>"; };
 		A51007BF187CC3C600B38879 /* JSGlobalObjectInspectorController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGlobalObjectInspectorController.h; sourceTree = "<group>"; };
-		A513E5B5185B8BD3007E95AD /* InjectedScript.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InjectedScript.cpp; sourceTree = "<group>"; };
-		A513E5B6185B8BD3007E95AD /* InjectedScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedScript.h; sourceTree = "<group>"; };
+		A513E5B5185B8BD3007E95AD /* InspectorInjectedScript.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorInjectedScript.cpp; sourceTree = "<group>"; };
+		A513E5B6185B8BD3007E95AD /* InspectorInjectedScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorInjectedScript.h; sourceTree = "<group>"; };
 		A513E5B9185BFACC007E95AD /* InjectedScriptHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedScriptHost.h; sourceTree = "<group>"; };
 		A513E5BA185BFACC007E95AD /* JSInjectedScriptHost.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSInjectedScriptHost.cpp; sourceTree = "<group>"; };
 		A513E5BB185BFACC007E95AD /* JSInjectedScriptHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSInjectedScriptHost.h; sourceTree = "<group>"; };
@@ -9659,8 +9659,6 @@
 				A57D23F01891B5B40031C7FA /* ContentSearchUtilities.h */,
 				A5FD0072189B038C00633231 /* IdentifiersFactory.cpp */,
 				A5FD0073189B038C00633231 /* IdentifiersFactory.h */,
-				A513E5B5185B8BD3007E95AD /* InjectedScript.cpp */,
-				A513E5B6185B8BD3007E95AD /* InjectedScript.h */,
 				A514B2C0185A684400F3C7CB /* InjectedScriptBase.cpp */,
 				A514B2C1185A684400F3C7CB /* InjectedScriptBase.h */,
 				A58E35901860DEC7001F24FE /* InjectedScriptHost.cpp */,
@@ -9679,6 +9677,8 @@
 				A5945594182479EB00CC3843 /* InspectorFrontendChannel.h */,
 				99F1A6FC1B8E6D9400463B26 /* InspectorFrontendRouter.cpp */,
 				99F1A7001B98FBEC00463B26 /* InspectorFrontendRouter.h */,
+				A513E5B5185B8BD3007E95AD /* InspectorInjectedScript.cpp */,
+				A513E5B6185B8BD3007E95AD /* InspectorInjectedScript.h */,
 				A55D93AB18514F7900400DED /* InspectorProtocolTypes.h */,
 				F3459D7423973ABD00DCD27A /* InspectorTarget.cpp */,
 				A555FF382159D2D600FCD826 /* InspectorTarget.h */,
@@ -10923,7 +10923,6 @@
 				0FF8BDEB1AD4CF7100DFE884 /* InferredValue.h in Headers */,
 				0F4AE0431FE0D25700E20839 /* InferredValueInlines.h in Headers */,
 				BC18C4100E16F5CD00B34460 /* InitializeThreading.h in Headers */,
-				A513E5B8185B8BD3007E95AD /* InjectedScript.h in Headers */,
 				A514B2C3185A684400F3C7CB /* InjectedScriptBase.h in Headers */,
 				A513E5BE185BFACC007E95AD /* InjectedScriptHost.h in Headers */,
 				A513E5CB185F9624007E95AD /* InjectedScriptManager.h in Headers */,
@@ -10950,6 +10949,7 @@
 				A532438A18568335002ED692 /* InspectorFrontendDispatchers.h in Headers */,
 				99F1A7011B98FBEC00463B26 /* InspectorFrontendRouter.h in Headers */,
 				A5339EC61BB399A60054F005 /* InspectorHeapAgent.h in Headers */,
+				A513E5B8185B8BD3007E95AD /* InspectorInjectedScript.h in Headers */,
 				A532438C18568335002ED692 /* InspectorProtocolObjects.h in Headers */,
 				A55D93AC18514F7900400DED /* InspectorProtocolTypes.h in Headers */,
 				A50E4B6218809DD50068A46D /* InspectorRuntimeAgent.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -591,7 +591,7 @@ inspector/AsyncStackTrace.cpp
 inspector/ConsoleMessage.cpp
 inspector/ContentSearchUtilities.cpp
 inspector/IdentifiersFactory.cpp
-inspector/InjectedScript.cpp
+inspector/InspectorInjectedScript.cpp
 inspector/InjectedScriptBase.cpp
 inspector/InjectedScriptHost.cpp
 inspector/InjectedScriptManager.cpp

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -32,9 +32,9 @@
 #include "ConsoleMessage.h"
 
 #include "IdentifiersFactory.h"
-#include "InjectedScript.h"
 #include "InjectedScriptManager.h"
 #include "InspectorFrontendDispatchers.h"
+#include "InspectorInjectedScript.h"
 #include "ScriptArguments.h"
 #include "ScriptCallFrame.h"
 #include "ScriptCallStack.h"
@@ -259,7 +259,7 @@ void ConsoleMessage::addToFrontend(ConsoleFrontendDispatcher& consoleFrontendDis
         messageObject->setTimestamp(m_timestamp.secondsSinceEpoch().value());
 
     if ((m_arguments && m_arguments->argumentCount()) || m_jsonLogValues.size()) {
-        InjectedScript injectedScript = injectedScriptManager.injectedScriptFor(globalObject());
+        InspectorInjectedScript injectedScript = injectedScriptManager.injectedScriptFor(globalObject());
         if (!injectedScript.hasNoValue()) {
             auto argumentsObject = JSON::ArrayOf<Protocol::Runtime::RemoteObject>::create();
             if (m_arguments && m_arguments->argumentCount()) {

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -75,7 +75,7 @@ InjectedScriptHost& InjectedScriptManager::injectedScriptHost()
     return m_injectedScriptHost.get();
 }
 
-InjectedScript InjectedScriptManager::injectedScriptForId(int id)
+InspectorInjectedScript InjectedScriptManager::injectedScriptForId(int id)
 {
     auto it = m_idToInjectedScript.find(id);
     if (it != m_idToInjectedScript.end())
@@ -86,7 +86,7 @@ InjectedScript InjectedScriptManager::injectedScriptForId(int id)
             return injectedScriptFor(it->key);
     }
 
-    return InjectedScript();
+    return InspectorInjectedScript();
 }
 
 int InjectedScriptManager::injectedScriptIdFor(JSGlobalObject* globalObject)
@@ -100,19 +100,19 @@ int InjectedScriptManager::injectedScriptIdFor(JSGlobalObject* globalObject)
     return id;
 }
 
-InjectedScript InjectedScriptManager::injectedScriptForObjectId(const String& objectId)
+InspectorInjectedScript InjectedScriptManager::injectedScriptForObjectId(const String& objectId)
 {
     auto parsedObjectId = JSON::Value::parseJSON(objectId);
     if (!parsedObjectId)
-        return InjectedScript();
+        return InspectorInjectedScript();
 
     auto resultObject = parsedObjectId->asObject();
     if (!resultObject)
-        return InjectedScript();
+        return InspectorInjectedScript();
 
     auto injectedScriptId = resultObject->getInteger("injectedScriptId"_s);
     if (!injectedScriptId)
-        return InjectedScript();
+        return InspectorInjectedScript();
 
     return m_idToInjectedScript.get(*injectedScriptId);
 }
@@ -163,7 +163,7 @@ Expected<JSObject*, NakedPtr<Exception>> InjectedScriptManager::createInjectedSc
     return result.getObject();
 }
 
-InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalObject)
+InspectorInjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalObject)
 {
     auto it = m_scriptStateToId.find(globalObject);
     if (it != m_scriptStateToId.end()) {
@@ -173,7 +173,7 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
     }
 
     if (!m_environment.canAccessInspectedScriptState(globalObject))
-        return InjectedScript();
+        return InspectorInjectedScript();
 
     int id = injectedScriptIdFor(globalObject);
     auto createResult = createInjectedScript(globalObject, id);
@@ -182,7 +182,7 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
         ASSERT(error);
 
         if (globalObject->vm().isTerminationException(error))
-            return InjectedScript();
+            return InspectorInjectedScript();
 
         unsigned line = 0;
         unsigned column = 0;
@@ -197,13 +197,13 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    InjectedScript result(globalObject, createResult.value(), &m_environment);
+    InspectorInjectedScript result(globalObject, createResult.value(), &m_environment);
     m_idToInjectedScript.set(id, result);
     didCreateInjectedScript(result);
     return result;
 }
 
-void InjectedScriptManager::didCreateInjectedScript(const InjectedScript&)
+void InjectedScriptManager::didCreateInjectedScript(const InspectorInjectedScript&)
 {
     // Intentionally empty. This allows for subclasses to inject additional scripts.
 }

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.h
@@ -30,8 +30,8 @@
 #pragma once
 
 #include "Exception.h"
-#include "InjectedScript.h"
 #include "InspectorEnvironment.h"
+#include "InspectorInjectedScript.h"
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -60,18 +60,18 @@ public:
     InjectedScriptHost& injectedScriptHost();
     InspectorEnvironment& inspectorEnvironment() const { return m_environment; }
 
-    InjectedScript injectedScriptFor(JSC::JSGlobalObject*);
-    InjectedScript injectedScriptForId(int);
+    InspectorInjectedScript injectedScriptFor(JSC::JSGlobalObject*);
+    InspectorInjectedScript injectedScriptForId(int);
     int injectedScriptIdFor(JSC::JSGlobalObject*);
-    InjectedScript injectedScriptForObjectId(const String& objectId);
+    InspectorInjectedScript injectedScriptForObjectId(const String& objectId);
     void releaseObjectGroup(const String& objectGroup);
     void clearEventValue();
     void clearExceptionValue();
 
 protected:
-    virtual void didCreateInjectedScript(const InjectedScript&);
+    virtual void didCreateInjectedScript(const InspectorInjectedScript&);
 
-    HashMap<int, InjectedScript> m_idToInjectedScript;
+    HashMap<int, InspectorInjectedScript> m_idToInjectedScript;
     HashMap<JSC::JSGlobalObject*, int> m_scriptStateToId;
 
 private:

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -32,8 +32,8 @@
 #include "config.h"
 #include "InjectedScriptModule.h"
 
-#include "InjectedScript.h"
 #include "InjectedScriptManager.h"
+#include "InspectorInjectedScript.h"
 #include "ScriptFunctionCall.h"
 
 namespace Inspector {
@@ -49,17 +49,17 @@ InjectedScriptModule::~InjectedScriptModule()
 
 void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptManager, JSC::JSGlobalObject* globalObject)
 {
-    InjectedScript injectedScript = injectedScriptManager->injectedScriptFor(globalObject);
+    InspectorInjectedScript injectedScript = injectedScriptManager->injectedScriptFor(globalObject);
     ensureInjected(injectedScriptManager, injectedScript);
 }
 
-void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptManager, const InjectedScript& injectedScript)
+void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptManager, const InspectorInjectedScript& injectedScript)
 {
     ASSERT(!injectedScript.hasNoValue());
     if (injectedScript.hasNoValue())
         return;
 
-    // FIXME: Make the InjectedScript a module itself.
+    // FIXME: Make the InspectorInjectedScript a module itself.
     JSC::JSLockHolder locker(injectedScript.globalObject());
     ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "hasInjectedModule"_s, injectedScriptManager->inspectorEnvironment().functionCallHandler());
     function.appendArgument(name());

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.h
@@ -40,7 +40,7 @@ class JSValue;
 
 namespace Inspector {
 
-class InjectedScript;
+class InspectorInjectedScript;
 class InjectedScriptManager;
 
 class JS_EXPORT_PRIVATE InjectedScriptModule : public InjectedScriptBase {
@@ -55,7 +55,7 @@ protected:
     // and call its ensureInjected() method immediately.
     explicit InjectedScriptModule(const String& name);
     void ensureInjected(InjectedScriptManager*, JSC::JSGlobalObject*);
-    void ensureInjected(InjectedScriptManager*, const InjectedScript&);
+    void ensureInjected(InjectedScriptManager*, const InspectorInjectedScript&);
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -130,7 +130,7 @@ function max(a, b) {
 
 // -------
 
-let InjectedScript = class InjectedScript extends PrototypelessObjectBase
+let InspectorInjectedScript = class InspectorInjectedScript extends PrototypelessObjectBase
 {
     constructor()
     {
@@ -145,7 +145,7 @@ let InjectedScript = class InjectedScript extends PrototypelessObjectBase
         this._savedResults = @createArrayWithoutPrototype();
     }
 
-    // InjectedScript C++ API
+    // InspectorInjectedScript C++ API
 
     execute(functionString, objectGroup, includeCommandLineAPI, returnByValue, generatePreview, saveResult, args)
     {

--- a/Source/JavaScriptCore/inspector/InspectorInjectedScript.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorInjectedScript.cpp
@@ -30,7 +30,7 @@
  */
 
 #include "config.h"
-#include "InjectedScript.h"
+#include "InspectorInjectedScript.h"
 
 #include "JSCInlines.h"
 #include "JSLock.h"
@@ -41,21 +41,21 @@
 
 namespace Inspector {
 
-InjectedScript::InjectedScript()
+InspectorInjectedScript::InspectorInjectedScript()
     : InjectedScriptBase("InjectedScript"_s)
 {
 }
 
-InjectedScript::InjectedScript(JSC::JSGlobalObject* globalObject, JSC::JSObject* injectedScriptObject, InspectorEnvironment* environment)
+InspectorInjectedScript::InspectorInjectedScript(JSC::JSGlobalObject* globalObject, JSC::JSObject* injectedScriptObject, InspectorEnvironment* environment)
     : InjectedScriptBase("InjectedScript"_s, globalObject, injectedScriptObject, environment)
 {
 }
 
-InjectedScript::~InjectedScript()
+InspectorInjectedScript::~InspectorInjectedScript()
 {
 }
 
-void InjectedScript::execute(Protocol::ErrorString& errorString, const String& functionString, ExecuteOptions&& options, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
+void InspectorInjectedScript::execute(Protocol::ErrorString& errorString, const String& functionString, ExecuteOptions&& options, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "execute"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(functionString);
@@ -68,7 +68,7 @@ void InjectedScript::execute(Protocol::ErrorString& errorString, const String& f
     makeEvalCall(errorString, function, result, wasThrown, savedResultIndex);
 }
 
-void InjectedScript::evaluate(Protocol::ErrorString& errorString, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
+void InspectorInjectedScript::evaluate(Protocol::ErrorString& errorString, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluate"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(expression);
@@ -80,7 +80,7 @@ void InjectedScript::evaluate(Protocol::ErrorString& errorString, const String& 
     makeEvalCall(errorString, function, result, wasThrown, savedResultIndex);
 }
 
-void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByValue, bool generatePreview, bool saveResult, AsyncCallCallback&& callback)
+void InspectorInjectedScript::awaitPromise(const String& promiseObjectId, bool returnByValue, bool generatePreview, bool saveResult, AsyncCallCallback&& callback)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "awaitPromise"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(promiseObjectId);
@@ -90,7 +90,7 @@ void InjectedScript::awaitPromise(const String& promiseObjectId, bool returnByVa
     makeAsyncCall(function, WTFMove(callback));
 }
 
-void InjectedScript::callFunctionOn(Protocol::ErrorString& errorString, const String& objectId, const String& expression, const String& arguments, bool returnByValue, bool generatePreview, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown)
+void InspectorInjectedScript::callFunctionOn(Protocol::ErrorString& errorString, const String& objectId, const String& expression, const String& arguments, bool returnByValue, bool generatePreview, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "callFunctionOn"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
@@ -104,7 +104,7 @@ void InjectedScript::callFunctionOn(Protocol::ErrorString& errorString, const St
     ASSERT(!savedResultIndex);
 }
 
-void InjectedScript::evaluateOnCallFrame(Protocol::ErrorString& errorString, JSC::JSValue callFrames, const String& callFrameId, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
+void InspectorInjectedScript::evaluateOnCallFrame(Protocol::ErrorString& errorString, JSC::JSValue callFrames, const String& callFrameId, const String& expression, const String& objectGroup, bool includeCommandLineAPI, bool returnByValue, bool generatePreview, bool saveResult, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "evaluateOnCallFrame"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(callFrames);
@@ -118,7 +118,7 @@ void InjectedScript::evaluateOnCallFrame(Protocol::ErrorString& errorString, JSC
     makeEvalCall(errorString, function, result, wasThrown, savedResultIndex);
 }
 
-void InjectedScript::getFunctionDetails(Protocol::ErrorString& errorString, const String& functionId, RefPtr<Protocol::Debugger::FunctionDetails>& result)
+void InspectorInjectedScript::getFunctionDetails(Protocol::ErrorString& errorString, const String& functionId, RefPtr<Protocol::Debugger::FunctionDetails>& result)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getFunctionDetails"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(functionId);
@@ -134,7 +134,7 @@ void InjectedScript::getFunctionDetails(Protocol::ErrorString& errorString, cons
     result = Protocol::BindingTraits<Protocol::Debugger::FunctionDetails>::runtimeCast(resultValue.releaseNonNull());
 }
 
-void InjectedScript::functionDetails(Protocol::ErrorString& errorString, JSC::JSValue value, RefPtr<Protocol::Debugger::FunctionDetails>& result)
+void InspectorInjectedScript::functionDetails(Protocol::ErrorString& errorString, JSC::JSValue value, RefPtr<Protocol::Debugger::FunctionDetails>& result)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "functionDetails"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(value);
@@ -150,7 +150,7 @@ void InjectedScript::functionDetails(Protocol::ErrorString& errorString, JSC::JS
     result = Protocol::BindingTraits<Protocol::Debugger::FunctionDetails>::runtimeCast(resultValue.releaseNonNull());
 }
 
-void InjectedScript::getPreview(Protocol::ErrorString& errorString, const String& objectId, RefPtr<Protocol::Runtime::ObjectPreview>& result)
+void InspectorInjectedScript::getPreview(Protocol::ErrorString& errorString, const String& objectId, RefPtr<Protocol::Runtime::ObjectPreview>& result)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getPreview"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
@@ -166,7 +166,7 @@ void InjectedScript::getPreview(Protocol::ErrorString& errorString, const String
     result = Protocol::BindingTraits<Protocol::Runtime::ObjectPreview>::runtimeCast(resultValue.releaseNonNull());
 }
 
-void InjectedScript::getProperties(Protocol::ErrorString& errorString, const String& objectId, bool ownProperties, int fetchStart, int fetchCount, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>& properties)
+void InspectorInjectedScript::getProperties(Protocol::ErrorString& errorString, const String& objectId, bool ownProperties, int fetchStart, int fetchCount, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>& properties)
 {
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
@@ -187,7 +187,7 @@ void InjectedScript::getProperties(Protocol::ErrorString& errorString, const Str
     properties = Protocol::BindingTraits<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>::runtimeCast(result.releaseNonNull());
 }
 
-void InjectedScript::getDisplayableProperties(Protocol::ErrorString& errorString, const String& objectId, int fetchStart, int fetchCount, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>& properties)
+void InspectorInjectedScript::getDisplayableProperties(Protocol::ErrorString& errorString, const String& objectId, int fetchStart, int fetchCount, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>& properties)
 {
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
@@ -207,7 +207,7 @@ void InjectedScript::getDisplayableProperties(Protocol::ErrorString& errorString
     properties = Protocol::BindingTraits<JSON::ArrayOf<Protocol::Runtime::PropertyDescriptor>>::runtimeCast(result.releaseNonNull());
 }
 
-void InjectedScript::getInternalProperties(Protocol::ErrorString& errorString, const String& objectId, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::InternalPropertyDescriptor>>& properties)
+void InspectorInjectedScript::getInternalProperties(Protocol::ErrorString& errorString, const String& objectId, bool generatePreview, RefPtr<JSON::ArrayOf<Protocol::Runtime::InternalPropertyDescriptor>>& properties)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "getInternalProperties"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
@@ -224,7 +224,7 @@ void InjectedScript::getInternalProperties(Protocol::ErrorString& errorString, c
         properties = WTFMove(array);
 }
 
-void InjectedScript::getCollectionEntries(Protocol::ErrorString& errorString, const String& objectId, const String& objectGroup, int fetchStart, int fetchCount, RefPtr<JSON::ArrayOf<Protocol::Runtime::CollectionEntry>>& entries)
+void InspectorInjectedScript::getCollectionEntries(Protocol::ErrorString& errorString, const String& objectId, const String& objectGroup, int fetchStart, int fetchCount, RefPtr<JSON::ArrayOf<Protocol::Runtime::CollectionEntry>>& entries)
 {
     ASSERT(fetchStart >= 0);
     ASSERT(fetchCount >= 0);
@@ -244,7 +244,7 @@ void InjectedScript::getCollectionEntries(Protocol::ErrorString& errorString, co
     entries = Protocol::BindingTraits<JSON::ArrayOf<Protocol::Runtime::CollectionEntry>>::runtimeCast(result.releaseNonNull());
 }
 
-void InjectedScript::saveResult(Protocol::ErrorString& errorString, const String& callArgumentJSON, std::optional<int>& savedResultIndex)
+void InspectorInjectedScript::saveResult(Protocol::ErrorString& errorString, const String& callArgumentJSON, std::optional<int>& savedResultIndex)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "saveResult"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(callArgumentJSON);
@@ -258,7 +258,7 @@ void InjectedScript::saveResult(Protocol::ErrorString& errorString, const String
     savedResultIndex = result->asInteger();
 }
 
-Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> InjectedScript::wrapCallFrames(JSC::JSValue callFrames) const
+Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> InspectorInjectedScript::wrapCallFrames(JSC::JSValue callFrames) const
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "wrapCallFrames"_s, inspectorEnvironment()->functionCallHandler());
@@ -276,7 +276,7 @@ Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> InjectedScript::wrapCallFrames
     return JSON::ArrayOf<Protocol::Debugger::CallFrame>::create();
 }
 
-RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapObject(JSC::JSValue value, const String& groupName, bool generatePreview) const
+RefPtr<Protocol::Runtime::RemoteObject> InspectorInjectedScript::wrapObject(JSC::JSValue value, const String& groupName, bool generatePreview) const
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapObject"_s, inspectorEnvironment()->functionCallHandler());
@@ -300,7 +300,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapObject(JSC::JSValue 
     return Protocol::BindingTraits<Protocol::Runtime::RemoteObject>::runtimeCast(resultObject.releaseNonNull());
 }
 
-RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapJSONString(const String& json, const String& groupName, bool generatePreview) const
+RefPtr<Protocol::Runtime::RemoteObject> InspectorInjectedScript::wrapJSONString(const String& json, const String& groupName, bool generatePreview) const
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapJSONString"_s, inspectorEnvironment()->functionCallHandler());
@@ -326,7 +326,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapJSONString(const Str
     return Protocol::BindingTraits<Protocol::Runtime::RemoteObject>::runtimeCast(resultObject.releaseNonNull());
 }
 
-RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapTable(JSC::JSValue table, JSC::JSValue columns) const
+RefPtr<Protocol::Runtime::RemoteObject> InspectorInjectedScript::wrapTable(JSC::JSValue table, JSC::JSValue columns) const
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "wrapTable"_s, inspectorEnvironment()->functionCallHandler());
@@ -352,7 +352,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapTable(JSC::JSValue t
     return Protocol::BindingTraits<Protocol::Runtime::RemoteObject>::runtimeCast(resultObject.releaseNonNull());
 }
 
-RefPtr<Protocol::Runtime::ObjectPreview> InjectedScript::previewValue(JSC::JSValue value) const
+RefPtr<Protocol::Runtime::ObjectPreview> InspectorInjectedScript::previewValue(JSC::JSValue value) const
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall wrapFunction(globalObject(), injectedScriptObject(), "previewValue"_s, inspectorEnvironment()->functionCallHandler());
@@ -373,7 +373,7 @@ RefPtr<Protocol::Runtime::ObjectPreview> InjectedScript::previewValue(JSC::JSVal
     return Protocol::BindingTraits<Protocol::Runtime::ObjectPreview>::runtimeCast(resultObject.releaseNonNull());
 }
 
-void InjectedScript::setEventValue(JSC::JSValue value)
+void InspectorInjectedScript::setEventValue(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setEventValue"_s, inspectorEnvironment()->functionCallHandler());
@@ -381,14 +381,14 @@ void InjectedScript::setEventValue(JSC::JSValue value)
     makeCall(function);
 }
 
-void InjectedScript::clearEventValue()
+void InspectorInjectedScript::clearEventValue()
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearEventValue"_s, inspectorEnvironment()->functionCallHandler());
     makeCall(function);
 }
 
-void InjectedScript::setExceptionValue(JSC::JSValue value)
+void InspectorInjectedScript::setExceptionValue(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "setExceptionValue"_s, inspectorEnvironment()->functionCallHandler());
@@ -396,14 +396,14 @@ void InjectedScript::setExceptionValue(JSC::JSValue value)
     makeCall(function);
 }
 
-void InjectedScript::clearExceptionValue()
+void InspectorInjectedScript::clearExceptionValue()
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "clearExceptionValue"_s, inspectorEnvironment()->functionCallHandler());
     makeCall(function);
 }
 
-JSC::JSValue InjectedScript::findObjectById(const String& objectId) const
+JSC::JSValue InspectorInjectedScript::findObjectById(const String& objectId) const
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "findObjectById"_s, inspectorEnvironment()->functionCallHandler());
@@ -416,7 +416,7 @@ JSC::JSValue InjectedScript::findObjectById(const String& objectId) const
     return callResult.value();
 }
 
-void InjectedScript::inspectObject(JSC::JSValue value)
+void InspectorInjectedScript::inspectObject(JSC::JSValue value)
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "inspectObject"_s, inspectorEnvironment()->functionCallHandler());
@@ -424,14 +424,14 @@ void InjectedScript::inspectObject(JSC::JSValue value)
     makeCall(function);
 }
 
-void InjectedScript::releaseObject(const String& objectId)
+void InspectorInjectedScript::releaseObject(const String& objectId)
 {
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "releaseObject"_s, inspectorEnvironment()->functionCallHandler());
     function.appendArgument(objectId);
     makeCall(function);
 }
 
-void InjectedScript::releaseObjectGroup(const String& objectGroup)
+void InspectorInjectedScript::releaseObjectGroup(const String& objectGroup)
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall releaseFunction(globalObject(), injectedScriptObject(), "releaseObjectGroup"_s, inspectorEnvironment()->functionCallHandler());
@@ -441,7 +441,7 @@ void InjectedScript::releaseObjectGroup(const String& objectGroup)
     ASSERT_UNUSED(callResult, callResult);
 }
 
-JSC::JSObject* InjectedScript::createCommandLineAPIObject(JSC::JSValue callFrame) const
+JSC::JSObject* InspectorInjectedScript::createCommandLineAPIObject(JSC::JSValue callFrame) const
 {
     ASSERT(!hasNoValue());
     ScriptFunctionCall function(globalObject(), injectedScriptObject(), "createCommandLineAPIObject"_s, inspectorEnvironment()->functionCallHandler());
@@ -452,7 +452,7 @@ JSC::JSObject* InjectedScript::createCommandLineAPIObject(JSC::JSValue callFrame
     return callResult ? asObject(callResult.value()) : nullptr;
 }
 
-JSC::JSValue InjectedScript::arrayFromVector(Vector<JSC::JSValue>&& vector)
+JSC::JSValue InspectorInjectedScript::arrayFromVector(Vector<JSC::JSValue>&& vector)
 {
     JSC::JSGlobalObject* globalObject = this->globalObject();
     if (!globalObject)

--- a/Source/JavaScriptCore/inspector/InspectorInjectedScript.h
+++ b/Source/JavaScriptCore/inspector/InspectorInjectedScript.h
@@ -45,11 +45,11 @@ namespace Inspector {
 class InjectedScriptModule;
 class InspectorEnvironment;
 
-class JS_EXPORT_PRIVATE InjectedScript final : public InjectedScriptBase {
+class JS_EXPORT_PRIVATE InspectorInjectedScript final : public InjectedScriptBase {
 public:
-    InjectedScript();
-    InjectedScript(JSC::JSGlobalObject*, JSC::JSObject*, InspectorEnvironment*);
-    ~InjectedScript() final;
+    InspectorInjectedScript();
+    InspectorInjectedScript(JSC::JSGlobalObject*, JSC::JSObject*, InspectorEnvironment*);
+    ~InspectorInjectedScript() final;
 
     struct ExecuteOptions {
         String objectGroup;

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
@@ -27,7 +27,7 @@
 #include "InspectorAuditAgent.h"
 
 #include "Debugger.h"
-#include "InjectedScript.h"
+#include "InspectorInjectedScript.h"
 #include "JSLock.h"
 #include "ObjectConstructor.h"
 #include <wtf/RefPtr.h>
@@ -63,7 +63,7 @@ Protocol::ErrorStringOr<void> InspectorAuditAgent::setup(std::optional<Protocol:
     if (hasActiveAudit())
         return makeUnexpected("Must call teardown before calling setup again"_s);
 
-    InjectedScript injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
+    InspectorInjectedScript injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
     if (injectedScript.hasNoValue())
         return makeUnexpected(errorString);
 
@@ -88,13 +88,13 @@ Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::op
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
+    InspectorInjectedScript injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
     if (injectedScript.hasNoValue())
         return makeUnexpected(errorString);
 
     auto functionString = makeString("(function(WebInspectorAudit) { \"use strict\"; return eval(`("_s, makeStringByReplacingAll(test, '`', "\\`"_s), ")`)(WebInspectorAudit); })"_s);
 
-    InjectedScript::ExecuteOptions options;
+    InspectorInjectedScript::ExecuteOptions options;
     options.objectGroup = "audit"_s;
     if (m_injectedWebInspectorAuditValue)
         options.args = { m_injectedWebInspectorAuditValue.get() };

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
@@ -38,7 +38,7 @@ class Debugger;
 
 namespace Inspector {
 
-class InjectedScript;
+class InspectorInjectedScript;
 class InjectedScriptManager;
 
 class JS_EXPORT_PRIVATE InspectorAuditAgent : public InspectorAgentBase, public AuditBackendDispatcherHandler {
@@ -63,7 +63,7 @@ protected:
 
     InjectedScriptManager& injectedScriptManager() { return m_injectedScriptManager; }
 
-    virtual InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
+    virtual InspectorInjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
 
     virtual void populateAuditObject(JSC::JSGlobalObject*, JSC::Strong<JSC::JSObject>& auditObject);
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -47,7 +47,7 @@
 namespace Inspector {
 
 class AsyncStackTrace;
-class InjectedScript;
+class InspectorInjectedScript;
 class InjectedScriptManager;
 
 class JS_EXPORT_PRIVATE InspectorDebuggerAgent
@@ -165,10 +165,10 @@ protected:
     virtual void internalEnable();
     virtual void internalDisable(bool isBeingDestroyed);
 
-    Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> evaluateOnCallFrame(InjectedScript&, const Protocol::Debugger::CallFrameId&, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture);
+    Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> evaluateOnCallFrame(InspectorInjectedScript&, const Protocol::Debugger::CallFrameId&, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture);
 
     InjectedScriptManager& injectedScriptManager() const { return m_injectedScriptManager; }
-    virtual InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
+    virtual InspectorInjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
 
     JSC::Debugger& debugger() { return m_debugger; }
 
@@ -183,7 +183,7 @@ protected:
 private:
     bool shouldBlackboxURL(const String&) const;
 
-    Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> currentCallFrames(const InjectedScript&);
+    Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> currentCallFrames(const InspectorInjectedScript&);
 
     class ProtocolBreakpoint {
         WTF_MAKE_FAST_ALLOCATED;
@@ -239,7 +239,7 @@ private:
     void updatePauseReasonAndData(DebuggerFrontendDispatcher::Reason, RefPtr<JSON::Object>&& data);
 
     RefPtr<JSON::Object> buildBreakpointPauseReason(JSC::BreakpointID);
-    RefPtr<JSON::Object> buildExceptionPauseReason(JSC::JSValue exception, const InjectedScript&);
+    RefPtr<JSON::Object> buildExceptionPauseReason(JSC::JSValue exception, const InspectorInjectedScript&);
 
     using AsyncCallIdentifier = std::pair<unsigned, uint64_t>;
     static AsyncCallIdentifier asyncCallIdentifier(AsyncCallType, uint64_t callbackId);

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -28,9 +28,9 @@
 
 #include "HeapProfiler.h"
 #include "HeapSnapshot.h"
-#include "InjectedScript.h"
 #include "InjectedScriptManager.h"
 #include "InspectorEnvironment.h"
+#include "InspectorInjectedScript.h"
 #include "JSBigInt.h"
 #include "VM.h"
 #include <wtf/Stopwatch.h>
@@ -208,7 +208,7 @@ Protocol::ErrorStringOr<std::tuple<String, RefPtr<Protocol::Debugger::FunctionDe
     if (!globalObject)
         return makeUnexpected("Unable to get object details - GlobalObject"_s);
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Unable to get object details - InjectedScript"_s);
 
@@ -248,7 +248,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorHeapAgent
     if (!globalObject)
         return makeUnexpected("Unable to get object details - GlobalObject"_s);
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptFor(globalObject);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Unable to get object details - InjectedScript"_s);
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -35,9 +35,9 @@
 #include "Completion.h"
 #include "ControlFlowProfiler.h"
 #include "Debugger.h"
-#include "InjectedScript.h"
 #include "InjectedScriptHost.h"
 #include "InjectedScriptManager.h"
+#include "InspectorInjectedScript.h"
 #include "JSLock.h"
 #include "ParserError.h"
 #include "SourceCode.h"
@@ -125,14 +125,14 @@ Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::op
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
+    InspectorInjectedScript injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
     if (injectedScript.hasNoValue())
         return makeUnexpected(errorString);
 
     return evaluate(injectedScript, expression, objectGroup, WTFMove(includeCommandLineAPI), WTFMove(doNotPauseOnExceptionsAndMuteConsole), WTFMove(returnByValue), WTFMove(generatePreview), WTFMove(saveResult), WTFMove(emulateUserGesture));
 }
 
-Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> InspectorRuntimeAgent::evaluate(InjectedScript& injectedScript, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& /* emulateUserGesture */)
+Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> InspectorRuntimeAgent::evaluate(InspectorInjectedScript& injectedScript, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& /* emulateUserGesture */)
 {
     ASSERT(!injectedScript.hasNoValue());
 
@@ -163,7 +163,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::op
 
 void InspectorRuntimeAgent::awaitPromise(const Protocol::Runtime::RemoteObjectId& promiseObjectId, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, Ref<AwaitPromiseCallback>&& callback)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(promiseObjectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(promiseObjectId);
     if (injectedScript.hasNoValue()) {
         callback->sendFailure("Missing injected script for given promiseObjectId"_s);
         return;
@@ -179,14 +179,14 @@ void InspectorRuntimeAgent::awaitPromise(const Protocol::Runtime::RemoteObjectId
 
 Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */>> InspectorRuntimeAgent::callFunctionOn(const Protocol::Runtime::RemoteObjectId& objectId, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
     return callFunctionOn(injectedScript, objectId, functionDeclaration, WTFMove(arguments), WTFMove(doNotPauseOnExceptionsAndMuteConsole), WTFMove(returnByValue), WTFMove(generatePreview), WTFMove(emulateUserGesture));
 }
 
-Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */>> InspectorRuntimeAgent::callFunctionOn(InjectedScript& injectedScript, const Protocol::Runtime::RemoteObjectId& objectId, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& /* emulateUserGesture */)
+Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */>> InspectorRuntimeAgent::callFunctionOn(InspectorInjectedScript& injectedScript, const Protocol::Runtime::RemoteObjectId& objectId, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& /* emulateUserGesture */)
 {
     ASSERT(!injectedScript.hasNoValue());
 
@@ -218,7 +218,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::ObjectPreview>> InspectorRuntimeA
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -243,7 +243,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Protocol::Runtime::Property
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -281,7 +281,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<JSON::ArrayOf<Protocol::Runtime::Property
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -319,7 +319,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Runtime::CollectionEntry>>> 
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return makeUnexpected("Missing injected script for given objectId"_s);
 
@@ -345,7 +345,7 @@ Protocol::ErrorStringOr<std::optional<int> /* saveResultIndex */> InspectorRunti
 {
     Protocol::ErrorString errorString;
 
-    InjectedScript injectedScript;
+    InspectorInjectedScript injectedScript;
 
     auto objectId = callArgument->getString(Protocol::Runtime::CallArgument::objectIdKey);
     if (!objectId) {
@@ -377,7 +377,7 @@ Protocol::ErrorStringOr<void> InspectorRuntimeAgent::setSavedResultAlias(const S
 
 Protocol::ErrorStringOr<void> InspectorRuntimeAgent::releaseObject(const Protocol::Runtime::RemoteObjectId& objectId)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (!injectedScript.hasNoValue())
         injectedScript.releaseObject(objectId);
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
@@ -43,7 +43,7 @@ class VM;
 
 namespace Inspector {
 
-class InjectedScript;
+class InspectorInjectedScript;
 class InjectedScriptManager;
 
 class JS_EXPORT_PRIVATE InspectorRuntimeAgent : public InspectorAgentBase, public RuntimeBackendDispatcherHandler {
@@ -81,12 +81,12 @@ public:
 protected:
     InspectorRuntimeAgent(AgentContext&);
 
-    Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> evaluate(InjectedScript&, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture);
-    Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */>> callFunctionOn(InjectedScript&, const Protocol::Runtime::RemoteObjectId&, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture);
+    Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> evaluate(InspectorInjectedScript&, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture);
+    Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */>> callFunctionOn(InspectorInjectedScript&, const Protocol::Runtime::RemoteObjectId&, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture);
 
     InjectedScriptManager& injectedScriptManager() { return m_injectedScriptManager; }
 
-    virtual InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
+    virtual InspectorInjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) = 0;
 
     virtual void muteConsole() = 0;
     virtual void unmuteConsole() = 0;

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.cpp
@@ -26,8 +26,8 @@
 #include "config.h"
 #include "JSGlobalObjectAuditAgent.h"
 
-#include "InjectedScript.h"
 #include "InjectedScriptManager.h"
+#include "InspectorInjectedScript.h"
 
 namespace Inspector {
 
@@ -41,14 +41,14 @@ JSGlobalObjectAuditAgent::JSGlobalObjectAuditAgent(JSAgentContext& context)
 
 JSGlobalObjectAuditAgent::~JSGlobalObjectAuditAgent() = default;
 
-InjectedScript JSGlobalObjectAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript JSGlobalObjectAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for JSContexts as there is only one execution context"_s;
-        return InjectedScript();
+        return InspectorInjectedScript();
     }
 
-    InjectedScript injectedScript = injectedScriptManager().injectedScriptFor(&m_globalObject);
+    InspectorInjectedScript injectedScript = injectedScriptManager().injectedScriptFor(&m_globalObject);
     if (injectedScript.hasNoValue())
         errorString = "Internal error: main world execution context not found"_s;
 

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.h
@@ -41,7 +41,7 @@ public:
     ~JSGlobalObjectAuditAgent() final;
 
 private:
-    InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) final;
+    InspectorInjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) final;
 
     JSC::JSGlobalObject& m_globalObject;
 };

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.cpp
@@ -44,11 +44,11 @@ JSGlobalObjectDebuggerAgent::JSGlobalObjectDebuggerAgent(JSAgentContext& context
 
 JSGlobalObjectDebuggerAgent::~JSGlobalObjectDebuggerAgent() = default;
 
-InjectedScript JSGlobalObjectDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript JSGlobalObjectDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for JSContexts as there is only one execution context"_s;
-        return InjectedScript();
+        return InspectorInjectedScript();
     }
 
     JSGlobalObject& globalObject = static_cast<JSGlobalObjectDebugger&>(debugger()).globalObject();

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.h
@@ -42,7 +42,7 @@ public:
     void breakpointActionLog(JSC::JSGlobalObject*, const String& data) final;
 
 private:
-    InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) final;
+    InspectorInjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) final;
 
     // NOTE: JavaScript inspector does not yet need to mute a console because no messages
     // are sent to the console outside of the API boundary or console object.

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
@@ -26,8 +26,8 @@
 #include "config.h"
 #include "JSGlobalObjectRuntimeAgent.h"
 
-#include "InjectedScript.h"
 #include "InjectedScriptManager.h"
+#include "InspectorInjectedScript.h"
 
 namespace Inspector {
 
@@ -43,14 +43,14 @@ JSGlobalObjectRuntimeAgent::JSGlobalObjectRuntimeAgent(JSAgentContext& context)
 
 JSGlobalObjectRuntimeAgent::~JSGlobalObjectRuntimeAgent() = default;
 
-InjectedScript JSGlobalObjectRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript JSGlobalObjectRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for JSContexts as there is only one execution context"_s;
-        return InjectedScript();
+        return InspectorInjectedScript();
     }
 
-    InjectedScript injectedScript = injectedScriptManager().injectedScriptFor(&m_globalObject);
+    InspectorInjectedScript injectedScript = injectedScriptManager().injectedScriptFor(&m_globalObject);
     if (injectedScript.hasNoValue())
         errorString = "Missing execution context for given executionContextId."_s;
 

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h
@@ -42,7 +42,7 @@ public:
     ~JSGlobalObjectRuntimeAgent() final;
 
 private:
-    InjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) final;
+    InspectorInjectedScript injectedScriptForEval(Protocol::ErrorString&, std::optional<Protocol::Runtime::ExecutionContextId>&&) final;
 
     // NOTE: JavaScript inspector does not yet need to mute a console because no messages
     // are sent to the console outside of the API boundary or console object.

--- a/Source/WebCore/inspector/CommandLineAPIModule.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIModule.cpp
@@ -30,14 +30,14 @@
 #include "WebCoreJSBuiltinInternals.h"
 #include "WebInjectedScriptManager.h"
 #include <JavaScriptCore/HeapInlines.h>
-#include <JavaScriptCore/InjectedScript.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 
 namespace WebCore {
 
 using namespace JSC;
 using namespace Inspector;
 
-void CommandLineAPIModule::injectIfNeeded(InjectedScriptManager* injectedScriptManager, const InjectedScript& injectedScript)
+void CommandLineAPIModule::injectIfNeeded(InjectedScriptManager* injectedScriptManager, const InspectorInjectedScript& injectedScript)
 {
     CommandLineAPIModule module;
     module.ensureInjected(injectedScriptManager, injectedScript);

--- a/Source/WebCore/inspector/CommandLineAPIModule.h
+++ b/Source/WebCore/inspector/CommandLineAPIModule.h
@@ -36,7 +36,7 @@ public:
     JSC::JSFunction* injectModuleFunction(JSC::JSGlobalObject*) const override;
     JSC::JSValue host(Inspector::InjectedScriptManager*, JSC::JSGlobalObject*) const override;
 
-    static void injectIfNeeded(Inspector::InjectedScriptManager*, const Inspector::InjectedScript&);
+    static void injectIfNeeded(Inspector::InjectedScriptManager*, const Inspector::InspectorInjectedScript&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/WebInjectedScriptManager.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.cpp
@@ -64,7 +64,7 @@ void WebInjectedScriptManager::discardInjectedScripts()
         m_commandLineAPIHost->clearAllWrappers();
 }
 
-void WebInjectedScriptManager::didCreateInjectedScript(const Inspector::InjectedScript& injectedScript)
+void WebInjectedScriptManager::didCreateInjectedScript(const Inspector::InspectorInjectedScript& injectedScript)
 {
     CommandLineAPIModule::injectIfNeeded(this, injectedScript);
 }

--- a/Source/WebCore/inspector/WebInjectedScriptManager.h
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.h
@@ -49,7 +49,7 @@ public:
     void discardInjectedScriptsFor(LocalDOMWindow&);
 
 private:
-    void didCreateInjectedScript(const Inspector::InjectedScript&) override;
+    void didCreateInjectedScript(const Inspector::InspectorInjectedScript&) override;
 
     RefPtr<CommandLineAPIHost> m_commandLineAPIHost;
 };

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -66,8 +66,8 @@
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/IdentifiersFactory.h>
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrays.h>

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -113,9 +113,9 @@
 #include "XPathResult.h"
 #include "markup.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorDebuggerAgent.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/Function.h>
@@ -3038,7 +3038,7 @@ Node* InspectorDOMAgent::nodeForPath(const String& path)
 
 Node* InspectorDOMAgent::nodeForObjectId(const Protocol::Runtime::RemoteObjectId& objectId)
 {
-    InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
+    InspectorInjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
         return nullptr;
 

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -42,9 +42,9 @@
 #include "ScriptDisallowedScope.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/ContentSearchUtilities.h>
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/RegularExpression.h>
 #include <wtf/JSONValues.h>
 

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -60,10 +60,10 @@
 #include "SecurityOrigin.h"
 #include "WindowOrWorkerGlobalScopeIndexedDatabase.h"
 #include <JavaScriptCore/HeapInlines.h>
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <wtf/JSONValues.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Vector.h>
@@ -329,7 +329,7 @@ static RefPtr<IDBKeyRange> idbKeyRangeFromKeyRange(JSON::Object& keyRange)
 
 class OpenCursorCallback final : public EventListener {
 public:
-    static Ref<OpenCursorCallback> create(InjectedScript injectedScript, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, int skipCount, unsigned pageSize)
+    static Ref<OpenCursorCallback> create(InspectorInjectedScript injectedScript, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, int skipCount, unsigned pageSize)
     {
         return adoptRef(*new OpenCursorCallback(injectedScript, WTFMove(requestCallback), skipCount, pageSize));
     }
@@ -407,7 +407,7 @@ public:
     }
 
 private:
-    OpenCursorCallback(InjectedScript injectedScript, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, int skipCount, unsigned pageSize)
+    OpenCursorCallback(InspectorInjectedScript injectedScript, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, int skipCount, unsigned pageSize)
         : EventListener(EventListener::CPPEventListenerType)
         , m_injectedScript(injectedScript)
         , m_requestCallback(WTFMove(requestCallback))
@@ -416,7 +416,7 @@ private:
         , m_pageSize(pageSize)
     {
     }
-    InjectedScript m_injectedScript;
+    InspectorInjectedScript m_injectedScript;
     Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback> m_requestCallback;
     Ref<JSON::ArrayOf<Protocol::IndexedDB::DataEntry>> m_result;
     int m_skipCount;
@@ -425,7 +425,7 @@ private:
 
 class DataLoader final : public ExecutableWithDatabase {
 public:
-    static Ref<DataLoader> create(ScriptExecutionContext* context, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, const InjectedScript& injectedScript, const String& objectStoreName, const String& indexName, RefPtr<IDBKeyRange>&& idbKeyRange, int skipCount, unsigned pageSize)
+    static Ref<DataLoader> create(ScriptExecutionContext* context, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, const InspectorInjectedScript& injectedScript, const String& objectStoreName, const String& indexName, RefPtr<IDBKeyRange>&& idbKeyRange, int skipCount, unsigned pageSize)
     {
         return adoptRef(*new DataLoader(context, WTFMove(requestCallback), injectedScript, objectStoreName, indexName, WTFMove(idbKeyRange), skipCount, pageSize));
     }
@@ -477,7 +477,7 @@ public:
     }
 
     BackendDispatcher::CallbackBase& requestCallback() override { return m_requestCallback.get(); }
-    DataLoader(ScriptExecutionContext* scriptExecutionContext, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, const InjectedScript& injectedScript, const String& objectStoreName, const String& indexName, RefPtr<IDBKeyRange> idbKeyRange, int skipCount, unsigned pageSize)
+    DataLoader(ScriptExecutionContext* scriptExecutionContext, Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback>&& requestCallback, const InspectorInjectedScript& injectedScript, const String& objectStoreName, const String& indexName, RefPtr<IDBKeyRange> idbKeyRange, int skipCount, unsigned pageSize)
         : ExecutableWithDatabase(scriptExecutionContext)
         , m_requestCallback(WTFMove(requestCallback))
         , m_injectedScript(injectedScript)
@@ -487,7 +487,7 @@ public:
         , m_skipCount(skipCount)
         , m_pageSize(pageSize) { }
     Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback> m_requestCallback;
-    InjectedScript m_injectedScript;
+    InspectorInjectedScript m_injectedScript;
     String m_objectStoreName;
     String m_indexName;
     RefPtr<IDBKeyRange> m_idbKeyRange;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -77,8 +77,8 @@
 #include "WebSocketFrame.h"
 #include <JavaScriptCore/ContentSearchUtilities.h>
 #include <JavaScriptCore/IdentifiersFactory.h>
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptCallStack.h>

--- a/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
@@ -36,8 +36,8 @@
 #include "Page.h"
 #include "PageConsoleClient.h"
 #include <JavaScriptCore/CallFrame.h>
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/JSLock.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
@@ -56,18 +56,18 @@ PageAuditAgent::PageAuditAgent(PageAgentContext& context)
 
 PageAuditAgent::~PageAuditAgent() = default;
 
-InjectedScript PageAuditAgent::injectedScriptForEval(std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript PageAuditAgent::injectedScriptForEval(std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId)
         return injectedScriptManager().injectedScriptForId(*executionContextId);
     if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame()))
         return injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(*localMainFrame));
-    return InjectedScript();
+    return InspectorInjectedScript();
 }
 
-InjectedScript PageAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript PageAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
-    InjectedScript injectedScript = injectedScriptForEval(WTFMove(executionContextId));
+    InspectorInjectedScript injectedScript = injectedScriptForEval(WTFMove(executionContextId));
     if (injectedScript.hasNoValue()) {
         if (executionContextId)
             errorString = "Missing injected script for given executionContextId"_s;

--- a/Source/WebCore/inspector/agents/page/PageAuditAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageAuditAgent.h
@@ -42,8 +42,8 @@ public:
     Page& inspectedPage() const { return m_inspectedPage; }
 
 private:
-    Inspector::InjectedScript injectedScriptForEval(std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
-    Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
+    Inspector::InspectorInjectedScript injectedScriptForEval(std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
+    Inspector::InspectorInjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
 
     void populateAuditObject(JSC::JSGlobalObject*, JSC::Strong<JSC::JSObject>& auditObject);
 

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -45,8 +45,8 @@
 #include "PageDebugger.h"
 #include "ScriptExecutionContext.h"
 #include "UserGestureEmulationScope.h"
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <wtf/NeverDestroyed.h>
@@ -142,16 +142,16 @@ void PageDebuggerAgent::breakpointActionLog(JSC::JSGlobalObject* lexicalGlobalOb
     m_inspectedPage.console().addMessage(MessageSource::JS, MessageLevel::Log, message, createScriptCallStack(lexicalGlobalObject));
 }
 
-InjectedScript PageDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript PageDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
     if (!localMainFrame)
-        return InjectedScript();
+        return InspectorInjectedScript();
 
     if (!executionContextId)
         return injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(*localMainFrame));
 
-    InjectedScript injectedScript = injectedScriptManager().injectedScriptForId(*executionContextId);
+    InspectorInjectedScript injectedScript = injectedScriptManager().injectedScriptForId(*executionContextId);
     if (injectedScript.hasNoValue())
         errorString = "Missing injected script for given executionContextId."_s;
 

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.h
@@ -78,7 +78,7 @@ private:
     void muteConsole();
     void unmuteConsole();
 
-    Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
+    Inspector::InspectorInjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
 
     Page& m_inspectedPage;
     Vector<UniqueRef<UserGestureEmulationScope>> m_breakpointActionUserGestureEmulationScopeStack;

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -44,8 +44,8 @@
 #include "ScriptController.h"
 #include "SecurityOrigin.h"
 #include "UserGestureEmulationScope.h"
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 
 namespace WebCore {
@@ -103,20 +103,20 @@ void PageRuntimeAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapper
     notifyContextCreated(pageAgent->frameId(&frame), frame.script().globalObject(world), world);
 }
 
-InjectedScript PageRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript PageRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (!executionContextId) {
         auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
         if (!localMainFrame)
-            return InjectedScript();
+            return InspectorInjectedScript();
 
-        InjectedScript result = injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(*localMainFrame));
+        InspectorInjectedScript result = injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(*localMainFrame));
         if (result.hasNoValue())
             errorString = "Internal error: main world execution context not found"_s;
         return result;
     }
 
-    InjectedScript injectedScript = injectedScriptManager().injectedScriptForId(*executionContextId);
+    InspectorInjectedScript injectedScript = injectedScriptManager().injectedScriptForId(*executionContextId);
     if (injectedScript.hasNoValue())
         errorString = "Missing injected script for given executionContextId"_s;
     return injectedScript;

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
@@ -64,7 +64,7 @@ public:
     void didClearWindowObjectInWorld(LocalFrame&, DOMWrapperWorld&);
 
 private:
-    Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
+    Inspector::InspectorInjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
     void muteConsole();
     void unmuteConsole();
     void reportExecutionContextCreation();

--- a/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp
@@ -29,8 +29,8 @@
 #include "JSDOMGlobalObject.h"
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerOrWorkletScriptController.h"
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/JSCInlines.h>
 
 namespace WebCore {
@@ -46,11 +46,11 @@ WorkerAuditAgent::WorkerAuditAgent(WorkerAgentContext& context)
 
 WorkerAuditAgent::~WorkerAuditAgent() = default;
 
-InjectedScript WorkerAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript WorkerAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for workers as there is only one execution context"_s;
-        return InjectedScript();
+        return InspectorInjectedScript();
     }
 
     // FIXME: What guarantees m_globalScope.script() is non-null?

--- a/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.h
@@ -40,7 +40,7 @@ public:
     ~WorkerAuditAgent();
 
 private:
-    Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
+    Inspector::InspectorInjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
 
     WorkerOrWorkletGlobalScope& m_globalScope;
 };

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
@@ -30,8 +30,8 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerOrWorkletScriptController.h"
 #include <JavaScriptCore/ConsoleMessage.h>
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 
@@ -54,11 +54,11 @@ void WorkerDebuggerAgent::breakpointActionLog(JSGlobalObject* lexicalGlobalObjec
     m_globalScope.addConsoleMessage(makeUnique<ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Log, message, createScriptCallStack(lexicalGlobalObject)));
 }
 
-InjectedScript WorkerDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript WorkerDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for workers as there is only one execution context"_s;
-        return InjectedScript();
+        return InspectorInjectedScript();
     }
 
     // FIXME: What guarantees m_globalScope.script() is non-null?

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h
@@ -46,7 +46,7 @@ private:
     void muteConsole() { }
     void unmuteConsole() { }
 
-    Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
+    Inspector::InspectorInjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
 
     WorkerOrWorkletGlobalScope& m_globalScope;
 };

--- a/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
@@ -35,8 +35,8 @@
 #include "JSDOMGlobalObject.h"
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerOrWorkletScriptController.h"
-#include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorInjectedScript.h>
 
 namespace WebCore {
 
@@ -52,11 +52,11 @@ WorkerRuntimeAgent::WorkerRuntimeAgent(WorkerAgentContext& context)
 
 WorkerRuntimeAgent::~WorkerRuntimeAgent() = default;
 
-InjectedScript WorkerRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InspectorInjectedScript WorkerRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for workers as there is only one execution context"_s;
-        return InjectedScript();
+        return InspectorInjectedScript();
     }
 
     // FIXME: What guarantees m_globalScope.script() is non-null?

--- a/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h
@@ -46,7 +46,7 @@ public:
     ~WorkerRuntimeAgent();
 
 private:
-    Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
+    Inspector::InspectorInjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
 
     // We don't need to mute console for workers.
     void muteConsole() { }


### PR DESCRIPTION
#### 069e9a9a066b15d0531e69ea5481e768975ae0a3
<pre>
Rename InjectedScript
<a href="https://bugs.webkit.org/show_bug.cgi?id=33615">https://bugs.webkit.org/show_bug.cgi?id=33615</a>

Reviewed by NOBODY (OOPS!).

Rename &quot;InjectedScript&quot; to &quot;InspectorInjectedScript&quot; for clarity because
&quot;InjectedScript&quot; should only be used within the inspector.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
(Inspector::ConsoleMessage::addToFrontend):
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::injectedScriptForId):
(Inspector::InjectedScriptManager::injectedScriptForObjectId):
(Inspector::InjectedScriptManager::injectedScriptFor):
(Inspector::InjectedScriptManager::didCreateInjectedScript):
* Source/JavaScriptCore/inspector/InjectedScriptManager.h:
* Source/JavaScriptCore/inspector/InjectedScriptModule.cpp:
(Inspector::InjectedScriptModule::ensureInjected):
* Source/JavaScriptCore/inspector/InjectedScriptModule.h:
* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(let.InjectedScript): Deleted.
(let.InjectedScript.prototype.execute): Deleted.
(let.InjectedScript.prototype.evaluate): Deleted.
(let.InjectedScript.prototype.awaitPromise): Deleted.
(let.InjectedScript.prototype.evaluateOnCallFrame): Deleted.
(let.InjectedScript.prototype.callFunctionOn): Deleted.
(let.InjectedScript.prototype.getFunctionDetails): Deleted.
(let.InjectedScript.prototype.functionDetails): Deleted.
(let.InjectedScript.prototype.getPreview): Deleted.
(let.InjectedScript.prototype.getProperties): Deleted.
(let.InjectedScript.prototype.getDisplayableProperties): Deleted.
(let.InjectedScript.prototype.getInternalProperties): Deleted.
(let.InjectedScript.prototype.getCollectionEntries): Deleted.
(let.InjectedScript.prototype.saveResult): Deleted.
(let.InjectedScript.prototype.wrapCallFrames): Deleted.
(let.InjectedScript.prototype.wrapObject): Deleted.
(let.InjectedScript.prototype.wrapJSONString): Deleted.
(let.InjectedScript.prototype.wrapTable): Deleted.
(let.InjectedScript.prototype.previewValue): Deleted.
(let.InjectedScript.prototype.setEventValue): Deleted.
(let.InjectedScript.prototype.clearEventValue): Deleted.
(let.InjectedScript.prototype.setExceptionValue): Deleted.
(let.InjectedScript.prototype.clearExceptionValue): Deleted.
(let.InjectedScript.prototype.findObjectById): Deleted.
(let.InjectedScript.prototype.releaseObject): Deleted.
(let.InjectedScript.prototype.releaseObjectGroup): Deleted.
(let.InjectedScript.prototype.createCommandLineAPIObject): Deleted.
(let.InjectedScript.prototype.inspectObject): Deleted.
(let.InjectedScript.prototype.hasInjectedModule): Deleted.
(let.InjectedScript.prototype.injectModule): Deleted.
(let.InjectedScript.prototype.isPrimitiveValue): Deleted.
(let.InjectedScript.prototype._parseObjectId): Deleted.
(let.InjectedScript.prototype._objectForId): Deleted.
(let.InjectedScript.prototype._bind): Deleted.
(let.InjectedScript.prototype._releaseObject): Deleted.
(let.InjectedScript.prototype._fallbackWrapper): Deleted.
(let.InjectedScript.prototype._resolveCallArgument): Deleted.
(let.InjectedScript.prototype._createThrownValue): Deleted.
(let.InjectedScript.prototype._evaluateAndWrap): Deleted.
(let.InjectedScript.prototype._wrapAndSaveCall): Deleted.
(let.InjectedScript.prototype._wrapCall): Deleted.
(let.InjectedScript.prototype._evaluateOn): Deleted.
(let.InjectedScript.prototype._callFrameForId): Deleted.
(let.InjectedScript.prototype._getProperties): Deleted.
(let.InjectedScript.prototype._internalPropertyDescriptors): Deleted.
(let.InjectedScript.prototype._forEachPropertyDescriptor.createFakeValueDescriptor): Deleted.
(let.InjectedScript.prototype._forEachPropertyDescriptor.processDescriptor): Deleted.
(let.InjectedScript.prototype._forEachPropertyDescriptor.processProperty): Deleted.
(let.InjectedScript.prototype._forEachPropertyDescriptor): Deleted.
(let.InjectedScript.prototype._getSetEntries): Deleted.
(let.InjectedScript.prototype._getMapEntries): Deleted.
(let.InjectedScript.prototype._getWeakMapEntries): Deleted.
(let.InjectedScript.prototype._getWeakSetEntries): Deleted.
(let.InjectedScript.prototype._getIteratorEntries): Deleted.
(let.InjectedScript.prototype._entries): Deleted.
(let.InjectedScript.prototype._saveResult): Deleted.
* Source/JavaScriptCore/inspector/InspectorInjectedScript.cpp: Renamed from Source/JavaScriptCore/inspector/InjectedScript.cpp.
(Inspector::InspectorInjectedScript::InspectorInjectedScript):
(Inspector::InspectorInjectedScript::~InspectorInjectedScript):
(Inspector::InspectorInjectedScript::execute):
(Inspector::InspectorInjectedScript::evaluate):
(Inspector::InspectorInjectedScript::awaitPromise):
(Inspector::InspectorInjectedScript::callFunctionOn):
(Inspector::InspectorInjectedScript::evaluateOnCallFrame):
(Inspector::InspectorInjectedScript::getFunctionDetails):
(Inspector::InspectorInjectedScript::functionDetails):
(Inspector::InspectorInjectedScript::getPreview):
(Inspector::InspectorInjectedScript::getProperties):
(Inspector::InspectorInjectedScript::getDisplayableProperties):
(Inspector::InspectorInjectedScript::getInternalProperties):
(Inspector::InspectorInjectedScript::getCollectionEntries):
(Inspector::InspectorInjectedScript::saveResult):
(Inspector::InspectorInjectedScript::wrapCallFrames const):
(Inspector::InspectorInjectedScript::wrapObject const):
(Inspector::InspectorInjectedScript::wrapJSONString const):
(Inspector::InspectorInjectedScript::wrapTable const):
(Inspector::InspectorInjectedScript::previewValue const):
(Inspector::InspectorInjectedScript::setEventValue):
(Inspector::InspectorInjectedScript::clearEventValue):
(Inspector::InspectorInjectedScript::setExceptionValue):
(Inspector::InspectorInjectedScript::clearExceptionValue):
(Inspector::InspectorInjectedScript::findObjectById const):
(Inspector::InspectorInjectedScript::inspectObject):
(Inspector::InspectorInjectedScript::releaseObject):
(Inspector::InspectorInjectedScript::releaseObjectGroup):
(Inspector::InspectorInjectedScript::createCommandLineAPIObject const):
(Inspector::InspectorInjectedScript::arrayFromVector):
* Source/JavaScriptCore/inspector/InspectorInjectedScript.h: Renamed from Source/JavaScriptCore/inspector/InjectedScript.h.
* Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp:
(Inspector::InspectorAuditAgent::setup):
(Inspector::InspectorAuditAgent::run):
* Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::buildExceptionPauseReason):
(Inspector::InspectorDebuggerAgent::getFunctionDetails):
(Inspector::InspectorDebuggerAgent::evaluateOnCallFrame):
(Inspector::InspectorDebuggerAgent::currentCallFrames):
(Inspector::InspectorDebuggerAgent::didPause):
(Inspector::InspectorDebuggerAgent::breakpointActionProbe):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
(Inspector::InspectorHeapAgent::getPreview):
(Inspector::InspectorHeapAgent::getRemoteObject):
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp:
(Inspector::InspectorRuntimeAgent::evaluate):
(Inspector::InspectorRuntimeAgent::awaitPromise):
(Inspector::InspectorRuntimeAgent::callFunctionOn):
(Inspector::InspectorRuntimeAgent::getPreview):
(Inspector::InspectorRuntimeAgent::getProperties):
(Inspector::InspectorRuntimeAgent::getDisplayableProperties):
(Inspector::InspectorRuntimeAgent::getCollectionEntries):
(Inspector::InspectorRuntimeAgent::releaseObject):
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.cpp:
(Inspector::JSGlobalObjectAuditAgent::injectedScriptForEval):
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.h:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.cpp:
(Inspector::JSGlobalObjectDebuggerAgent::injectedScriptForEval):
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp:
(Inspector::JSGlobalObjectRuntimeAgent::injectedScriptForEval):
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h:
* Source/WebCore/inspector/CommandLineAPIModule.cpp:
(WebCore::CommandLineAPIModule::injectIfNeeded):
* Source/WebCore/inspector/CommandLineAPIModule.h:
* Source/WebCore/inspector/WebInjectedScriptManager.cpp:
(WebCore::WebInjectedScriptManager::didCreateInjectedScript):
* Source/WebCore/inspector/WebInjectedScriptManager.h:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::nodeForObjectId):
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
* Source/WebCore/inspector/agents/page/PageAuditAgent.cpp:
(WebCore::PageAuditAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/page/PageAuditAgent.h:
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.h:
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp:
(WebCore::WorkerAuditAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/worker/WorkerAuditAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp:
(WebCore::WorkerDebuggerAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp:
(WebCore::WorkerRuntimeAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/069e9a9a066b15d0531e69ea5481e768975ae0a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23061 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23317 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2703 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21690 "Found 3 new API test failures: TestWebKitAPI.WKInspectorExtension.EvaluateScriptOnPage, TestWebKitAPI.WKInspectorDelegate.InspectorConfiguration, TestWebKitAPI.WKInspectorExtension.ExtensionTabIsPersistent (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27828 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2385 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22630 "Found 60 new test failures: fast/css/transform-function-perspective-crash.html, fast/frames/lots-of-objects.html, http/tests/inspector/dom/cross-domain-inspected-node-access.html, http/tests/inspector/dom/didFireEvent.html, http/tests/inspector/network/copy-as-curl.html, http/tests/inspector/network/copy-as-fetch.html, http/tests/inspector/network/eventsource-type.html, http/tests/inspector/network/fetch-network-data.html, http/tests/inspector/network/fetch-response-body.html, http/tests/inspector/network/getSerializedCertificate.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28753 "Failure limit exceed. At least found 369 new test failures: http/tests/inspector/dom/cross-domain-inspected-node-access.html, http/tests/inspector/dom/didFireEvent.html, http/tests/inspector/dom/disconnect-dom-tree-after-main-frame-navigation.html, http/tests/inspector/network/beacon-type.html, http/tests/inspector/network/contentextensions/blocked-websocket-crash.html, http/tests/inspector/network/copy-as-curl.html, http/tests/inspector/network/eventsource-type.html, http/tests/inspector/network/fetch-network-data.html, http/tests/inspector/network/fetch-response-body.html, http/tests/inspector/network/har/har-basic.html ... (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21854 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22927 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22976 "Found 60 new test failures: http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py, http/tests/inspector/dom/cross-domain-inspected-node-access.html, http/tests/inspector/dom/didFireEvent.html, http/tests/inspector/network/beacon-type.html, http/tests/inspector/network/copy-as-curl.html, http/tests/inspector/network/copy-as-fetch.html, http/tests/inspector/network/eventsource-type.html, http/tests/inspector/network/fetch-network-data.html, http/tests/inspector/network/fetch-response-body-304.html, http/tests/inspector/network/fetch-response-body.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26573 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2341 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/633 "Found 60 new test failures: compositing/layer-creation/scale-rotation-animation-overlap.html, css1/box_properties/acid_test.html, fast/css/aspect-ratio-min-height-replaced.html, fast/media/media-query-dynamic-with-font-face.html, fast/mediastream/mediastreamtrack-video-torch.html, fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html, http/tests/inspector/dom/cross-domain-inspected-node-access.html, http/tests/inspector/dom/didFireEvent.html, http/tests/inspector/network/beacon-type.html, http/tests/inspector/network/copy-as-curl.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31788 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3685 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6961 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2778 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2673 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->