### PR TITLE
[Apple Pay] Remove `PKDeferredPaymentRequest.freeCancellationDateTimeZone` staging code

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -335,12 +335,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^PKCanMakePaymentsCompletion)(BOOL isValid, NSError *);
 
-#if HAVE(PASSKIT_DEFERRED_PAYMENTS)
-@interface PKDeferredPaymentRequest (Staging_104652810)
-@property (nonatomic, strong, nullable) NSTimeZone *freeCancellationDateTimeZone;
-@end
-#endif
-
 #if HAVE(PKPAYMENTREQUEST_USERAGENT)
 // FIXME: <rdar://116640656> Remove `PKPaymentRequest.userAgent` staging code
 @interface PKPaymentRequest (Staging_110687914)

--- a/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
@@ -49,8 +49,7 @@ RetainPtr<PKDeferredPaymentRequest> platformDeferredPaymentRequest(const ApplePa
         if (auto& freeCancellationDateTimeZone = webDeferredPaymentRequest.freeCancellationDateTimeZone; !freeCancellationDateTimeZone.isNull()) {
             if (auto timeZone = [NSTimeZone timeZoneWithName:freeCancellationDateTimeZone]) {
                 [pkDeferredPaymentRequest setFreeCancellationDate:[NSDate dateWithTimeIntervalSince1970:freeCancellationDate.secondsSinceEpoch().value()]];
-                if ([pkDeferredPaymentRequest respondsToSelector:@selector(setFreeCancellationDateTimeZone:)])
-                    [pkDeferredPaymentRequest setFreeCancellationDateTimeZone:timeZone];
+                [pkDeferredPaymentRequest setFreeCancellationDateTimeZone:timeZone];
             }
         }
     }


### PR DESCRIPTION
#### 550f36d18b62cd1cba12a36033474d98d667c0e4
<pre>
[Apple Pay] Remove `PKDeferredPaymentRequest.freeCancellationDateTimeZone` staging code
<a href="https://bugs.webkit.org/show_bug.cgi?id=264305">https://bugs.webkit.org/show_bug.cgi?id=264305</a>
<a href="https://rdar.apple.com/118027435">rdar://118027435</a>

Reviewed by Megan Gardner.

`freeCancellationDateTimeZone` has been in builds for long enough to
warrant removal of the staging declaration, and the associated selector
check in DeferredPaymentRequestCocoa.mm.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm:
(WebKit::platformDeferredPaymentRequest):

Canonical link: <a href="https://commits.webkit.org/270352@main">https://commits.webkit.org/270352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77808347057c7bc28191a6e64be8eefa43530801

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25244 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/3785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/26500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/27358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/23165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25513 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/5502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/27358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25487 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/5502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/26500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/5502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/26500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/27936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/5502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/26500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/27936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/26500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/2881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3221 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->