### PR TITLE
Regression(270013@main) RELEASE_ASSERT(!m_count); in WebCore::Font::~Font()

### DIFF
--- a/LayoutTests/fast/text/Font-destructor-crash-expected.txt
+++ b/LayoutTests/fast/text/Font-destructor-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash. 

--- a/LayoutTests/fast/text/Font-destructor-crash.html
+++ b/LayoutTests/fast/text/Font-destructor-crash.html
@@ -1,0 +1,18 @@
+<style>
+</style>
+<script>
+  if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+  }
+  onload = () => {
+    document.styleSheets[0].insertRule(`body { font: caption; }`);
+    document.styleSheets[0].insertRule(`body { transition-duration: 200ms; }`);
+    document.body.append(`\ue000`);
+    setTimeout(() => {
+      if (window.testRunner)
+          testRunner.notifyDone();
+    }, 100);
+  };
+</script>
+This test passes if it doesn't crash.

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -30,7 +30,6 @@
 #include "RenderingResourceIdentifier.h"
 #include <variant>
 #include <wtf/BitVector.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Hasher.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
@@ -75,7 +74,7 @@ bool fontHasEitherTable(CTFontRef, unsigned tableTag1, unsigned tableTag2);
 #endif
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Font);
-class Font : public RefCounted<Font>, public CanMakeWeakPtr<Font>, public CanMakeCheckedPtr {
+class Font : public RefCounted<Font>, public CanMakeWeakPtr<Font> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Font);
 public:
     // Used to create platform fonts.

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1224,7 +1224,7 @@ int FontCascade::emphasisMarkAscent(const AtomString& mark) const
     if (!markGlyphData)
         return 0;
 
-    CheckedPtr markFontData = markGlyphData.value().font;
+    WeakPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return 0;
@@ -1238,7 +1238,7 @@ int FontCascade::emphasisMarkDescent(const AtomString& mark) const
     if (!markGlyphData)
         return 0;
 
-    CheckedPtr markFontData = markGlyphData.value().font;
+    WeakPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return 0;
@@ -1402,7 +1402,7 @@ void FontCascade::drawEmphasisMarks(GraphicsContext& context, const GlyphBuffer&
     if (!markGlyphData)
         return;
 
-    CheckedPtr markFontData = markGlyphData.value().font;
+    WeakPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return;

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -67,7 +67,7 @@ private:
     }
 
     Glyph m_glyphs[GlyphPage::size] { };
-    CheckedPtr<const Font> m_fonts[GlyphPage::size] { };
+    WeakPtr<const Font> m_fonts[GlyphPage::size] { };
 };
 
 inline FontCascadeFonts::GlyphPageCacheEntry::GlyphPageCacheEntry(RefPtr<GlyphPage>&& singleFont)
@@ -338,12 +338,12 @@ static const Font* findBestFallbackFont(FontCascadeFonts& fontCascadeFonts, cons
         auto& fontRanges = fontCascadeFonts.realizeFallbackRangesAt(description, fallbackIndex);
         if (fontRanges.isNull())
             break;
-        CheckedPtr currentFont = fontRanges.glyphDataForCharacter(character, ExternalResourceDownloadPolicy::Forbid).font;
+        auto* currentFont = fontRanges.glyphDataForCharacter(character, ExternalResourceDownloadPolicy::Forbid).font.get();
         if (!currentFont)
             currentFont = &fontRanges.fontForFirstRange();
 
         if (!currentFont->isInterstitial())
-            return currentFont.get();
+            return currentFont;
     }
 
     return nullptr;

--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -95,7 +95,7 @@ GlyphData FontRanges::glyphDataForCharacter(UChar32 character, ExternalResourceD
                 } else {
                     auto glyphData = font->glyphDataForCharacter(character);
                     if (glyphData.isValid()) {
-                        CheckedPtr glyphDataFont = glyphData.font;
+                        auto* glyphDataFont = glyphData.font.get();
                         if (glyphDataFont && glyphDataFont->visibility() == Font::Visibility::Visible && resultFont && resultFont->visibility() == Font::Visibility::Invisible)
                             return GlyphData(glyphData.glyph, &glyphDataFont->invisibleFont());
                         return glyphData;

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -51,11 +51,11 @@ struct GlyphData {
     {
     }
 
-    bool isValid() const { return font; }
+    bool isValid() const { return !!font; }
 
     Glyph glyph;
     ColorGlyphType colorGlyphType;
-    CheckedPtr<const Font> font;
+    WeakPtr<const Font> font;
 };
 
 // A GlyphPage contains a fixed-size set of GlyphData mappings for a contiguous

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -123,14 +123,14 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     else if (characters[length - 1] == 0xFE0F)
         preferColoredFont = true;
 
-    CheckedPtr baseFont = glyphDataForCharacter(character, false, NormalVariant).font;
+    WeakPtr baseFont = glyphDataForCharacter(character, false, NormalVariant).font;
     if (baseFont
         && (clusterLength == length || baseFont->canRenderCombiningCharacterSequence(normalizedString.view))
         && (!preferColoredFont || baseFont->platformData().isColorBitmapFont()))
         return baseFont.get();
 
     for (unsigned i = 0; !fallbackRangesAt(i).isNull(); ++i) {
-        CheckedPtr fallbackFont = fallbackRangesAt(i).fontForCharacter(character);
+        WeakPtr fallbackFont = fallbackRangesAt(i).fontForCharacter(character);
         if (!fallbackFont || fallbackFont == baseFont)
             continue;
 


### PR DESCRIPTION
#### 647046ce608e4be46cb91c7a345572925de0d5a1
<pre>
Regression(270013@main) RELEASE_ASSERT(!m_count); in WebCore::Font::~Font()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264313">https://bugs.webkit.org/show_bug.cgi?id=264313</a>
<a href="https://rdar.apple.com/117847851">rdar://117847851</a>

Reviewed by Ryosuke Niwa.

Use WeakPtr instead of CheckedPtr for the Font objects so that they get
nulled out when the font cache gets cleared.

* LayoutTests/fast/text/Font-destructor-crash-expected.txt: Added.
* LayoutTests/fast/text/Font-destructor-crash.html: Added.
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::emphasisMarkAscent const):
(WebCore::FontCascade::emphasisMarkDescent const):
(WebCore::FontCascade::drawEmphasisMarks const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::findBestFallbackFont):
* Source/WebCore/platform/graphics/FontRanges.cpp:
(WebCore::FontRanges::glyphDataForCharacter const):
* Source/WebCore/platform/graphics/GlyphPage.h:
(WebCore::GlyphData::isValid const):

Canonical link: <a href="https://commits.webkit.org/270320@main">https://commits.webkit.org/270320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/743ec3ba769d6ceb04d080ad38928495bd16d814

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23324 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27843 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28765 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26601 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/645 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22390 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2791 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3207 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2686 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->