### PR TITLE
Add assertions to make sure RenderObject type checks stay accurate

### DIFF
--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -49,6 +49,7 @@ RenderAttachment::RenderAttachment(HTMLAttachmentElement& element, RenderStyle&&
     : RenderReplaced(Type::Attachment, element, WTFMove(style), LayoutSize())
     , m_isWideLayout(element.isWideLayout())
 {
+    ASSERT(isAttachment());
 #if ENABLE(SERVICE_CONTROLS)
     m_hasShadowControls = element.isImageMenuEnabled();
 #endif

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -307,11 +307,13 @@ private:
 RenderBlock::RenderBlock(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderBox(type, element, WTFMove(style), baseTypeFlags | RenderBlockFlag)
 {
+    ASSERT(isRenderBlock());
 }
 
 RenderBlock::RenderBlock(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderBox(type, document, WTFMove(style), baseTypeFlags | RenderBlockFlag)
 {
+    ASSERT(isRenderBlock());
 }
 
 static void removeBlockFromPercentageDescendantAndContainerMaps(RenderBlock& block)

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -122,6 +122,7 @@ RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& styl
     , m_lineCountForTextAutosizing(NOT_SET)
 #endif
 {
+    ASSERT(isRenderBlockFlow());
     setChildrenInline(true);
 }
 
@@ -132,6 +133,7 @@ RenderBlockFlow::RenderBlockFlow(Type type, Document& document, RenderStyle&& st
     , m_lineCountForTextAutosizing(NOT_SET)
 #endif
 {
+    ASSERT(isRenderBlockFlow());
     setChildrenInline(true);
 }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -156,12 +156,14 @@ RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, BaseTypeF
     : RenderBoxModelObject(type, element, WTFMove(style), baseTypeFlags)
 {
     setIsBox();
+    ASSERT(isBox());
 }
 
 RenderBox::RenderBox(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderBoxModelObject(type, document, WTFMove(style), baseTypeFlags)
 {
     setIsBox();
+    ASSERT(isBox());
 }
 
 RenderBox::~RenderBox()

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -170,11 +170,13 @@ bool RenderBoxModelObject::hasAcceleratedCompositing() const
 RenderBoxModelObject::RenderBoxModelObject(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderLayerModelObject(type, element, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
 {
+    ASSERT(isBoxModelObject());
 }
 
 RenderBoxModelObject::RenderBoxModelObject(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderLayerModelObject(type, document, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
 {
+    ASSERT(isBoxModelObject());
 }
 
 RenderBoxModelObject::~RenderBoxModelObject()

--- a/Source/WebCore/rendering/RenderButton.cpp
+++ b/Source/WebCore/rendering/RenderButton.cpp
@@ -48,6 +48,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderButton);
 RenderButton::RenderButton(HTMLFormControlElement& element, RenderStyle&& style)
     : RenderFlexibleBox(Type::Button, element, WTFMove(style))
 {
+    ASSERT(isRenderButton());
 }
 
 RenderButton::~RenderButton() = default;

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -38,6 +38,7 @@ RenderCombineText::RenderCombineText(Text& textNode, const String& string)
     , m_isCombined(false)
     , m_needsFontUpdate(false)
 {
+    ASSERT(isCombineText());
 }
 
 void RenderCombineText::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -435,6 +435,7 @@ RenderCounter::RenderCounter(Document& document, const CounterContent& counter)
     : RenderText(Type::Counter, document, emptyString())
     , m_counter(counter)
 {
+    ASSERT(isCounter());
     view().addCounterNeedingUpdate(*this);
 }
 

--- a/Source/WebCore/rendering/RenderDetailsMarker.cpp
+++ b/Source/WebCore/rendering/RenderDetailsMarker.cpp
@@ -40,6 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderDetailsMarker);
 RenderDetailsMarker::RenderDetailsMarker(DetailsMarkerControl& element, RenderStyle&& style)
     : RenderBlockFlow(Type::DetailsMarker, element, WTFMove(style))
 {
+    ASSERT(isDetailsMarker());
 }
 
 static Path createPath(const FloatPoint* path)

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -137,6 +137,7 @@ inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument,
     , m_didContributeToVisuallyNonEmptyPixelCount(false)
     , m_style(WTFMove(style))
 {
+    ASSERT(RenderObject::isRenderElement());
 }
 
 RenderElement::RenderElement(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -86,6 +86,7 @@ RenderEmbeddedObject::RenderEmbeddedObject(HTMLFrameOwnerElement& element, Rende
     , m_unavailablePluginIndicatorIsPressed(false)
     , m_mouseDownWasInUnavailablePluginIndicator(false)
 {
+    ASSERT(isEmbeddedObject());
 }
 
 RenderEmbeddedObject::~RenderEmbeddedObject()

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -72,6 +72,7 @@ RenderFileUploadControl::RenderFileUploadControl(HTMLInputElement& input, Render
     : RenderBlockFlow(Type::FileUploadControl, input, WTFMove(style))
     , m_canReceiveDroppedFiles(input.canReceiveDroppedFiles())
 {
+    ASSERT(isFileUploadControl());
 }
 
 RenderFileUploadControl::~RenderFileUploadControl() = default;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -83,12 +83,14 @@ struct RenderFlexibleBox::LineState {
 RenderFlexibleBox::RenderFlexibleBox(Type type, Element& element, RenderStyle&& style)
     : RenderBlock(type, element, WTFMove(style), RenderFlexibleBoxFlag)
 {
+    ASSERT(isRenderFlexibleBox());
     setChildrenInline(false); // All of our children must be block-level.
 }
 
 RenderFlexibleBox::RenderFlexibleBox(Type type, Document& document, RenderStyle&& style)
     : RenderBlock(type, document, WTFMove(style), RenderFlexibleBoxFlag)
 {
+    ASSERT(isRenderFlexibleBox());
     setChildrenInline(false); // All of our children must be block-level.
 }
 

--- a/Source/WebCore/rendering/RenderFragmentContainerSet.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainerSet.cpp
@@ -38,6 +38,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFragmentContainerSet);
 RenderFragmentContainerSet::RenderFragmentContainerSet(Type type, Document& document, RenderStyle&& style, RenderFragmentedFlow& fragmentedFlow)
     : RenderFragmentContainer(type, document, WTFMove(style), &fragmentedFlow)
 {
+    ASSERT(is<RenderFragmentContainerSet>(*this));
 }
 
 void RenderFragmentContainerSet::installFragmentedFlow()

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -64,6 +64,7 @@ RenderFragmentedFlow::RenderFragmentedFlow(Type type, Document& document, Render
     , m_pageLogicalSizeChanged(false)
 {
     setIsRenderFragmentedFlow(true);
+    ASSERT(isRenderFragmentedFlow());
 }
 
 void RenderFragmentedFlow::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderFrame.cpp
+++ b/Source/WebCore/rendering/RenderFrame.cpp
@@ -37,6 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFrame);
 RenderFrame::RenderFrame(HTMLFrameElement& frame, RenderStyle&& style)
     : RenderFrameBase(Type::Frame, frame, WTFMove(style))
 {
+    ASSERT(isFrame());
 }
 
 HTMLFrameElement& RenderFrame::frameElement() const

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -58,6 +58,7 @@ RenderFrameSet::RenderFrameSet(HTMLFrameSetElement& frameSet, RenderStyle&& styl
     : RenderBox(Type::FrameSet, frameSet, WTFMove(style), 0)
     , m_isResizing(false)
 {
+    ASSERT(isFrameSet());
     setInline(false);
 }
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -56,6 +56,7 @@ RenderGrid::RenderGrid(Element& element, RenderStyle&& style)
     , m_trackSizingAlgorithm(this, currentGrid())
     , m_masonryLayout(*this)
 {
+    ASSERT(isRenderGrid());
     // All of our children must be block level.
     setChildrenInline(false);
 }

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -52,6 +52,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderHTMLCanvas);
 RenderHTMLCanvas::RenderHTMLCanvas(HTMLCanvasElement& element, RenderStyle&& style)
     : RenderReplaced(Type::HTMLCanvas, element, WTFMove(style), element.size())
 {
+    ASSERT(isCanvas());
 }
 
 HTMLCanvasElement& RenderHTMLCanvas::canvasElement() const

--- a/Source/WebCore/rendering/RenderIFrame.cpp
+++ b/Source/WebCore/rendering/RenderIFrame.cpp
@@ -47,6 +47,7 @@ using namespace HTMLNames;
 RenderIFrame::RenderIFrame(HTMLIFrameElement& element, RenderStyle&& style)
     : RenderFrameBase(Type::IFrame, element, WTFMove(style))
 {
+    ASSERT(isRenderIFrame());
 }
 
 HTMLIFrameElement& RenderIFrame::iframeElement() const

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -68,12 +68,14 @@ RenderInline::RenderInline(Type type, Element& element, RenderStyle&& style)
     : RenderBoxModelObject(type, element, WTFMove(style), RenderInlineFlag)
 {
     setChildrenInline(true);
+    ASSERT(isRenderInline());
 }
 
 RenderInline::RenderInline(Type type, Document& document, RenderStyle&& style)
     : RenderBoxModelObject(type, document, WTFMove(style), RenderInlineFlag)
 {
     setChildrenInline(true);
+    ASSERT(isRenderInline());
 }
 
 void RenderInline::willBeDestroyed()

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -60,11 +60,13 @@ bool RenderLayerModelObject::s_layerWasSelfPainting = false;
 RenderLayerModelObject::RenderLayerModelObject(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderElement(type, element, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
 {
+    ASSERT(isRenderLayerModelObject());
 }
 
 RenderLayerModelObject::RenderLayerModelObject(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderElement(type, document, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
 {
+    ASSERT(isRenderLayerModelObject());
 }
 
 RenderLayerModelObject::~RenderLayerModelObject()

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -55,6 +55,7 @@ RenderLineBreak::RenderLineBreak(HTMLElement& element, RenderStyle&& style)
     , m_cachedLineHeight(invalidLineHeight)
     , m_isWBR(is<HTMLWBRElement>(element))
 {
+    ASSERT(isLineBreak());
 }
 
 RenderLineBreak::~RenderLineBreak()

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -52,6 +52,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderListItem);
 RenderListItem::RenderListItem(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::ListItem, element, WTFMove(style))
 {
+    ASSERT(isListItem());
     setInline(false);
 }
 

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -55,6 +55,7 @@ RenderListMarker::RenderListMarker(RenderListItem& listItem, RenderStyle&& style
 {
     setInline(true);
     setReplacedOrInlineBlock(true); // pretend to be replaced
+    ASSERT(isListMarker());
 }
 
 RenderListMarker::~RenderListMarker()

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -89,6 +89,7 @@ RenderMenuList::RenderMenuList(HTMLSelectElement& element, RenderStyle&& style)
     , m_popupIsVisible(false)
 #endif
 {
+    ASSERT(isMenuList());
 }
 
 RenderMenuList::~RenderMenuList()

--- a/Source/WebCore/rendering/RenderMeter.cpp
+++ b/Source/WebCore/rendering/RenderMeter.cpp
@@ -37,6 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMeter);
 RenderMeter::RenderMeter(HTMLElement& element, RenderStyle&& style)
     : RenderBlockFlow(Type::Meter, element, WTFMove(style))
 {
+    ASSERT(isMeter());
 }
 
 RenderMeter::~RenderMeter() = default;

--- a/Source/WebCore/rendering/RenderModel.cpp
+++ b/Source/WebCore/rendering/RenderModel.cpp
@@ -39,6 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderModel);
 RenderModel::RenderModel(HTMLModelElement& element, RenderStyle&& style)
     : RenderReplaced { Type::Model, element, WTFMove(style) }
 {
+    ASSERT(isRenderModel());
 }
 
 // Do not add any code to the destructor, instead, add it to willBeDestroyed().

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -49,6 +49,7 @@ RenderMultiColumnFlow::RenderMultiColumnFlow(Document& document, RenderStyle&& s
     , m_spannerMap(makeUnique<SpannerMap>())
 {
     setFragmentedFlowState(InsideInFragmentedFlow);
+    ASSERT(isRenderMultiColumnFlow());
 }
 
 RenderMultiColumnFlow::~RenderMultiColumnFlow() = default;

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -49,6 +49,7 @@ RenderMultiColumnSet::RenderMultiColumnSet(RenderFragmentedFlow& fragmentedFlow,
     , m_maxColumnHeight(RenderFragmentedFlow::maxLogicalHeight())
     , m_minSpaceShortage(RenderFragmentedFlow::maxLogicalHeight())
 {
+    ASSERT(isRenderMultiColumnSet());
 }
 
 RenderMultiColumnSet* RenderMultiColumnSet::nextSiblingMultiColumnSet() const

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
@@ -53,6 +53,7 @@ RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder(RenderM
     , m_spanner(spanner)
     , m_fragmentedFlow(fragmentedFlow)
 {
+    ASSERT(isRenderMultiColumnSpannerPlaceholder());
 }
 
 ASCIILiteral RenderMultiColumnSpannerPlaceholder::renderName() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -422,7 +422,7 @@ public:
 
 #if ENABLE(MATHML)
     virtual bool isRenderMathMLBlock() const { return false; }
-    virtual bool isRenderMathMLTable() const { return type() == Type::MathMLTable; }
+    bool isRenderMathMLTable() const { return type() == Type::MathMLTable; }
     virtual bool isRenderMathMLOperator() const { return false; }
     bool isRenderMathMLRow() const;
     bool isRenderMathMLMath() const { return type() == Type::MathMLMath; }

--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -37,6 +37,7 @@ RenderProgress::RenderProgress(HTMLElement& element, RenderStyle&& style)
     , m_position(HTMLProgressElement::InvalidPosition)
     , m_animationTimer(*this, &RenderProgress::animationTimerFired)
 {
+    ASSERT(isProgress());
 }
 
 RenderProgress::~RenderProgress() = default;

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -41,6 +41,7 @@ RenderQuote::RenderQuote(Document& document, RenderStyle&& style, QuoteType quot
     , m_type(quote)
     , m_text(emptyString())
 {
+    ASSERT(isQuote());
 }
 
 RenderQuote::~RenderQuote()

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -70,6 +70,7 @@ RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style)
     , m_intrinsicSize(cDefaultWidth, cDefaultHeight)
 {
     setReplacedOrInlineBlock(true);
+    ASSERT(isRenderReplaced());
 }
 
 RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize)
@@ -77,6 +78,7 @@ RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style,
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);
+    ASSERT(isRenderReplaced());
 }
 
 RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize)
@@ -84,6 +86,7 @@ RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& styl
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);
+    ASSERT(isRenderReplaced());
 }
 
 RenderReplaced::~RenderReplaced() = default;

--- a/Source/WebCore/rendering/RenderRuby.cpp
+++ b/Source/WebCore/rendering/RenderRuby.cpp
@@ -51,6 +51,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyAsBlock);
 RenderRubyAsInline::RenderRubyAsInline(Element& element, RenderStyle&& style)
     : RenderInline(Type::RubyAsInline, element, WTFMove(style))
 {
+    ASSERT(isRubyInline());
 }
 
 RenderRubyAsInline::~RenderRubyAsInline() = default;
@@ -66,6 +67,7 @@ void RenderRubyAsInline::styleDidChange(StyleDifference diff, const RenderStyle*
 RenderRubyAsBlock::RenderRubyAsBlock(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::RubyAsBlock, element, WTFMove(style))
 {
+    ASSERT(isRubyBlock());
 }
 
 RenderRubyAsBlock::~RenderRubyAsBlock() = default;

--- a/Source/WebCore/rendering/RenderRubyBase.cpp
+++ b/Source/WebCore/rendering/RenderRubyBase.cpp
@@ -49,6 +49,7 @@ RenderRubyBase::RenderRubyBase(Document& document, RenderStyle&& style)
     , m_isAfterExpansion(true)
 {
     setInline(false);
+    ASSERT(isRubyBase());
 }
 
 RenderRubyBase::~RenderRubyBase() = default;

--- a/Source/WebCore/rendering/RenderRubyRun.cpp
+++ b/Source/WebCore/rendering/RenderRubyRun.cpp
@@ -56,6 +56,7 @@ RenderRubyRun::RenderRubyRun(Document& document, RenderStyle&& style)
 {
     setReplacedOrInlineBlock(true);
     setInline(true);
+    ASSERT(isRubyRun());
 }
 
 RenderRubyRun::~RenderRubyRun() = default;

--- a/Source/WebCore/rendering/RenderRubyText.cpp
+++ b/Source/WebCore/rendering/RenderRubyText.cpp
@@ -44,6 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyText);
 RenderRubyText::RenderRubyText(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::RubyText, element, WTFMove(style))
 {
+    ASSERT(isRubyText());
 }
 
 RenderRubyText::~RenderRubyText() = default;

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -45,6 +45,7 @@ RenderScrollbarPart::RenderScrollbarPart(Document& document, RenderStyle&& style
     , m_scrollbar(scrollbar)
     , m_part(part)
 {
+    ASSERT(isRenderScrollbarPart());
 }
 
 RenderScrollbarPart::~RenderScrollbarPart() = default;

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -61,6 +61,7 @@ RenderSearchField::RenderSearchField(HTMLInputElement& element, RenderStyle&& st
     , m_searchPopup(nullptr)
 {
     ASSERT(element.isSearchField());
+    ASSERT(isSearchField());
 }
 
 RenderSearchField::~RenderSearchField()

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -55,6 +55,7 @@ RenderSlider::RenderSlider(HTMLInputElement& element, RenderStyle&& style)
 {
     // We assume RenderSlider works only with <input type=range>.
     ASSERT(element.isRangeControl());
+    ASSERT(isSlider());
 }
 
 RenderSlider::~RenderSlider() = default;

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -84,6 +84,7 @@ RenderTable::RenderTable(Type type, Element& element, RenderStyle&& style)
     , m_columnOffsetHeight(-1)
 {
     setChildrenInline(false);
+    ASSERT(isTable());
 }
 
 RenderTable::RenderTable(Type type, Document& document, RenderStyle&& style)
@@ -101,6 +102,7 @@ RenderTable::RenderTable(Type type, Document& document, RenderStyle&& style)
     , m_borderEnd(0)
 {
     setChildrenInline(false);
+    ASSERT(isTable());
 }
 
 RenderTable::~RenderTable() = default;

--- a/Source/WebCore/rendering/RenderTableCaption.cpp
+++ b/Source/WebCore/rendering/RenderTableCaption.cpp
@@ -32,6 +32,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableCaption);
 RenderTableCaption::RenderTableCaption(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::TableCaption, element, WTFMove(style))
 {
+    ASSERT(isTableCaption());
 }
 
 RenderTableCaption::~RenderTableCaption() = default;

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -81,6 +81,7 @@ RenderTableCell::RenderTableCell(Element& element, RenderStyle&& style)
     // We only update the flags when notified of DOM changes in colSpanOrRowSpanChanged()
     // so we need to set their initial values here in case something asks for colSpan()/rowSpan() before then.
     updateColAndRowSpanFlags();
+    ASSERT(isTableCell());
 }
 
 RenderTableCell::RenderTableCell(Document& document, RenderStyle&& style)
@@ -94,6 +95,7 @@ RenderTableCell::RenderTableCell(Document& document, RenderStyle&& style)
     , m_hasEmptyCollapsedStartBorder(false)
     , m_hasEmptyCollapsedEndBorder(false)
 {
+    ASSERT(isTableCell());
 }
 
 void RenderTableCell::willBeRemovedFromTree(IsInternalMove isInternalMove)

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -51,12 +51,14 @@ RenderTableCol::RenderTableCol(Element& element, RenderStyle&& style)
     // init RenderObject attributes
     setInline(true); // our object is not Inline
     updateFromElement();
+    ASSERT(isRenderTableCol());
 }
 
 RenderTableCol::RenderTableCol(Document& document, RenderStyle&& style)
     : RenderBox(Type::TableCol, document, WTFMove(style), 0)
 {
     setInline(true);
+    ASSERT(isRenderTableCol());
 }
 
 void RenderTableCol::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -52,6 +52,7 @@ RenderTableRow::RenderTableRow(Element& element, RenderStyle&& style)
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
+    ASSERT(isTableRow());
 }
 
 RenderTableRow::RenderTableRow(Document& document, RenderStyle&& style)
@@ -59,6 +60,7 @@ RenderTableRow::RenderTableRow(Document& document, RenderStyle&& style)
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
+    ASSERT(isTableRow());
 }
 
 void RenderTableRow::willBeRemovedFromTree(IsInternalMove isInternalMove)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -94,12 +94,14 @@ RenderTableSection::RenderTableSection(Element& element, RenderStyle&& style)
     : RenderBox(Type::TableSection, element, WTFMove(style), 0)
 {
     setInline(false);
+    ASSERT(isTableSection());
 }
 
 RenderTableSection::RenderTableSection(Document& document, RenderStyle&& style)
     : RenderBox(Type::TableSection, document, WTFMove(style), 0)
 {
     setInline(false);
+    ASSERT(isTableSection());
 }
 
 RenderTableSection::~RenderTableSection() = default;

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -251,6 +251,7 @@ inline RenderText::RenderText(Type type, Node& node, const String& text)
     ASSERT(!m_text.isNull());
     setIsText();
     m_canUseSimpleFontCodePath = computeCanUseSimpleFontCodePath();
+    ASSERT(isText());
 }
 
 RenderText::RenderText(Type type, Text& textNode, const String& text)

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -46,6 +46,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlInnerContainer);
 RenderTextControl::RenderTextControl(Type type, HTMLTextFormControlElement& element, RenderStyle&& style)
     : RenderBlockFlow(type, element, WTFMove(style), RenderTextControlFlag)
 {
+    ASSERT(isRenderTextControl());
 }
 
 RenderTextControl::~RenderTextControl() = default;

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -40,6 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlMultiLine);
 RenderTextControlMultiLine::RenderTextControlMultiLine(HTMLTextAreaElement& element, RenderStyle&& style)
     : RenderTextControl(Type::TextControlMultiLine, element, WTFMove(style))
 {
+    ASSERT(isTextArea());
 }
 
 RenderTextControlMultiLine::~RenderTextControlMultiLine()

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -489,6 +489,7 @@ HTMLInputElement& RenderTextControlSingleLine::inputElement() const
 RenderTextControlInnerBlock::RenderTextControlInnerBlock(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::TextControlInnerBlock, element, WTFMove(style))
 {
+    ASSERT(isTextControlInnerBlock());
 }
 
 }

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -49,6 +49,7 @@ RenderVTTCue::RenderVTTCue(VTTCueBox& element, RenderStyle&& style)
     , m_cue(downcast<VTTCue>(element.getCue()))
 {
     ASSERT(m_cue);
+    ASSERT(isRenderVTTCue());
 }
 
 void RenderVTTCue::layout()

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -55,6 +55,7 @@ RenderVideo::RenderVideo(HTMLVideoElement& element, RenderStyle&& style)
     : RenderMedia(Type::Video, element, WTFMove(style))
 {
     setIntrinsicSize(calculateIntrinsicSize());
+    ASSERT(isVideo());
 }
 
 RenderVideo::~RenderVideo()

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -95,6 +95,8 @@ RenderView::RenderView(Document& document, RenderStyle&& style)
     setPreferredLogicalWidthsDirty(true, MarkOnlyThis);
     
     setPositionState(PositionType::Absolute); // to 0,0 :)
+
+    ASSERT(isRenderView());
 }
 
 RenderView::~RenderView()

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
@@ -39,6 +39,7 @@ inline RenderMathMLTable::RenderMathMLTable(MathMLElement& element, RenderStyle&
     : RenderTable(Type::MathMLTable, element, WTFMove(style))
     , m_mathMLStyle(MathMLStyle::create())
 {
+    ASSERT(isRenderMathMLTable());
 }
 
 inline LayoutUnit RenderMathMLBlock::ascentForChild(const RenderBox& child)

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
@@ -53,6 +53,7 @@ static constexpr auto gClosingBraceChar = ")"_s;
 RenderMathMLFenced::RenderMathMLFenced(MathMLRowElement& element, RenderStyle&& style)
     : RenderMathMLRow(Type::MathMLFenced, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLFenced());
 }
 
 void RenderMathMLFenced::updateFromElement()

--- a/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
@@ -47,6 +47,7 @@ RenderMathMLFencedOperator::RenderMathMLFencedOperator(Document& document, Rende
     , m_operatorFlags(flags)
 {
     updateOperatorContent(operatorString);
+    ASSERT(isRenderMathMLFencedOperator());
 }
 
 void RenderMathMLFencedOperator::updateOperatorContent(const String& operatorString)

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -44,6 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLFraction);
 RenderMathMLFraction::RenderMathMLFraction(MathMLFractionElement& element, RenderStyle&& style)
     : RenderMathMLBlock(Type::MathMLFraction, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLFraction());
 }
 
 bool RenderMathMLFraction::isValid() const

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
@@ -44,6 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLMath);
 RenderMathMLMath::RenderMathMLMath(MathMLRowElement& element, RenderStyle&& style)
     : RenderMathMLRow(Type::MathMLMath, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLMath());
 }
 
 void RenderMathMLMath::centerChildren(LayoutUnit contentWidth)

--- a/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
@@ -51,6 +51,7 @@ const unsigned short longDivLeftSpace = 10;
 RenderMathMLMenclose::RenderMathMLMenclose(MathMLMencloseElement& element, RenderStyle&& style)
     : RenderMathMLRow(Type::MathMLMenclose, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLMenclose());
 }
 
 // This arbitrary thickness value is used for the parameter \xi_8 from the MathML in HTML5 implementation note.

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
@@ -39,6 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLPadded);
 RenderMathMLPadded::RenderMathMLPadded(MathMLPaddedElement& element, RenderStyle&& style)
     : RenderMathMLRow(Type::MathMLPadded, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLPadded());
 }
 
 LayoutUnit RenderMathMLPadded::voffset() const

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -51,6 +51,7 @@ RenderMathMLRoot::RenderMathMLRoot(MathMLRootElement& element, RenderStyle&& sty
     : RenderMathMLRow(Type::MathMLRoot, element, WTFMove(style))
 {
     m_radicalOperator.setOperator(RenderMathMLRoot::style(), gRadicalCharacter, MathOperator::Type::VerticalOperator);
+    ASSERT(isRenderMathMLRoot());
 }
 
 MathMLRootElement& RenderMathMLRoot::element() const

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -47,6 +47,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLRow);
 RenderMathMLRow::RenderMathMLRow(Type type, MathMLRowElement& element, RenderStyle&& style)
     : RenderMathMLBlock(type, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLRow());
 }
 
 MathMLRowElement& RenderMathMLRow::element() const

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -40,6 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLSpace);
 RenderMathMLSpace::RenderMathMLSpace(MathMLSpaceElement& element, RenderStyle&& style)
     : RenderMathMLBlock(Type::MathMLSpace, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLSpace());
 }
 
 void RenderMathMLSpace::computePreferredLogicalWidths()

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -44,6 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLUnderOver);
 RenderMathMLUnderOver::RenderMathMLUnderOver(MathMLUnderOverElement& element, RenderStyle&& style)
     : RenderMathMLScripts(Type::MathMLUnderOver, element, WTFMove(style))
 {
+    ASSERT(isRenderMathMLUnderOver());
 }
 
 MathMLUnderOverElement& RenderMathMLUnderOver::element() const

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -49,6 +49,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGForeignObject);
 RenderSVGForeignObject::RenderSVGForeignObject(SVGForeignObjectElement& element, RenderStyle&& style)
     : RenderSVGBlock(Type::SVGForeignObject, element, WTFMove(style))
 {
+    ASSERT(isSVGForeignObject());
 }
 
 RenderSVGForeignObject::~RenderSVGForeignObject() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -40,6 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGGradientStop);
 RenderSVGGradientStop::RenderSVGGradientStop(SVGStopElement& element, RenderStyle&& style)
     : RenderElement(Type::SVGGradientStop, element, WTFMove(style), 0)
 {
+    ASSERT(isSVGGradientStop());
 }
 
 RenderSVGGradientStop::~RenderSVGGradientStop() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
@@ -33,6 +33,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGHiddenContainer);
 RenderSVGHiddenContainer::RenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style)
     : RenderSVGContainer(type, element, WTFMove(style))
 {
+    ASSERT(isSVGHiddenContainer());
 }
 
 void RenderSVGHiddenContainer::layout()

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -59,6 +59,7 @@ RenderSVGImage::RenderSVGImage(SVGImageElement& element, RenderStyle&& style)
     : RenderSVGModelObject(Type::SVGImage, element, WTFMove(style))
     , m_imageResource(makeUnique<RenderImageResource>())
 {
+    ASSERT(isSVGImage());
     imageResource().initialize(*this);
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -40,6 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGInline);
 RenderSVGInline::RenderSVGInline(Type type, SVGGraphicsElement& element, RenderStyle&& style)
     : RenderInline(type, element, WTFMove(style))
 {
+    ASSERT(isSVGInline());
 }
 
 std::unique_ptr<LegacyInlineFlowBox> RenderSVGInline::createInlineFlowBox()

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -76,6 +76,7 @@ RenderSVGInlineText::RenderSVGInlineText(Text& textNode, const String& string)
     , m_scalingFactor(1)
     , m_layoutAttributes(*this)
 {
+    ASSERT(isSVGInlineText());
 }
 
 String RenderSVGInlineText::originalText() const

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -47,6 +47,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGPath);
 RenderSVGPath::RenderSVGPath(SVGGraphicsElement& element, RenderStyle&& style)
     : RenderSVGShape(Type::SVGPath, element, WTFMove(style))
 {
+    ASSERT(isSVGPath());
 }
 
 RenderSVGPath::~RenderSVGPath() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -61,6 +61,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceClipper);
 RenderSVGResourceClipper::RenderSVGResourceClipper(SVGClipPathElement& element, RenderStyle&& style)
     : RenderSVGResourceContainer(Type::SVGResourceClipper, element, WTFMove(style))
 {
+    ASSERT(isSVGResourceClipper());
 }
 
 RenderSVGResourceClipper::~RenderSVGResourceClipper() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -39,6 +39,7 @@ RenderSVGResourceContainer::RenderSVGResourceContainer(Type type, SVGElement& el
     : RenderSVGHiddenContainer(type, element, WTFMove(style))
     , m_id(element.getIdAttribute())
 {
+    ASSERT(isSVGResourceContainer());
 }
 
 RenderSVGResourceContainer::~RenderSVGResourceContainer() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -69,6 +69,7 @@ const int defaultHeight = 150;
 RenderSVGRoot::RenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
     : RenderReplaced(Type::SVGRoot, element, WTFMove(style))
 {
+    ASSERT(isSVGRoot());
     LayoutSize intrinsicSize(calculateIntrinsicSize());
     if (!intrinsicSize.width())
         intrinsicSize.setWidth(defaultWidth);

--- a/Source/WebCore/rendering/svg/RenderSVGTSpan.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTSpan.h
@@ -33,8 +33,8 @@ public:
     explicit RenderSVGTSpan(SVGTextPositioningElement& element, RenderStyle&& style)
         : RenderSVGInline(Type::SVGTSpan, element, WTFMove(style))
     {
+        ASSERT(isSVGTSpan());
     }
-
 
 private:
     void graphicsElement() const = delete;

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -62,6 +62,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGText);
 RenderSVGText::RenderSVGText(SVGTextElement& element, RenderStyle&& style)
     : RenderSVGBlock(Type::SVGText, element, WTFMove(style))
 {
+    ASSERT(isSVGText());
 }
 
 RenderSVGText::~RenderSVGText()

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -43,6 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGTextPath);
 RenderSVGTextPath::RenderSVGTextPath(SVGTextPathElement& element, RenderStyle&& style)
     : RenderSVGInline(Type::SVGTextPath, element, WTFMove(style))
 {
+    ASSERT(isSVGTextPath());
 }
 
 SVGTextPathElement& RenderSVGTextPath::textPathElement() const

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -39,6 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGTransformableContainer);
 RenderSVGTransformableContainer::RenderSVGTransformableContainer(SVGGraphicsElement& element, RenderStyle&& style)
     : RenderSVGContainer(Type::SVGTransformableContainer, element, WTFMove(style))
 {
+    ASSERT(isSVGTransformableContainer());
 }
 
 SVGGraphicsElement& RenderSVGTransformableContainer::graphicsElement() const

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -41,11 +41,13 @@ RenderSVGViewportContainer::RenderSVGViewportContainer(RenderSVGRoot& parent, Re
     : RenderSVGContainer(Type::SVGViewportContainer, parent.document(), WTFMove(style))
     , m_owningSVGRoot(parent)
 {
+    ASSERT(isSVGViewportContainer());
 }
 
 RenderSVGViewportContainer::RenderSVGViewportContainer(SVGSVGElement& element, RenderStyle&& style)
     : RenderSVGContainer(Type::SVGViewportContainer, element, WTFMove(style))
 {
+    ASSERT(isSVGViewportContainer());
 }
 
 SVGSVGElement& RenderSVGViewportContainer::svgSVGElement() const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -46,6 +46,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGForeignObject);
 LegacyRenderSVGForeignObject::LegacyRenderSVGForeignObject(SVGForeignObjectElement& element, RenderStyle&& style)
     : RenderSVGBlock(Type::LegacySVGForeignObject, element, WTFMove(style))
 {
+    ASSERT(isLegacySVGForeignObject());
 }
 
 LegacyRenderSVGForeignObject::~LegacyRenderSVGForeignObject() = default;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -55,6 +55,7 @@ LegacyRenderSVGImage::LegacyRenderSVGImage(SVGImageElement& element, RenderStyle
     , m_imageResource(makeUnique<RenderImageResource>())
 {
     imageResource().initialize(*this);
+    ASSERT(isLegacySVGImage());
 }
 
 LegacyRenderSVGImage::~LegacyRenderSVGImage() = default;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -45,6 +45,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGPath);
 LegacyRenderSVGPath::LegacyRenderSVGPath(SVGGraphicsElement& element, RenderStyle&& style)
     : LegacyRenderSVGShape(Type::LegacySVGPath, element, WTFMove(style))
 {
+    ASSERT(isLegacySVGPath());
 }
 
 LegacyRenderSVGPath::~LegacyRenderSVGPath() = default;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -65,6 +65,7 @@ LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& s
     , m_needsBoundariesOrTransformUpdate(true)
     , m_hasBoxDecorations(false)
 {
+    ASSERT(isLegacySVGRoot());
     LayoutSize intrinsicSize(calculateIntrinsicSize());
     if (!intrinsicSize.width())
         intrinsicSize.setWidth(defaultWidth);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -39,6 +39,7 @@ LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer(SVG
     , m_needsTransformUpdate(true)
     , m_didTransformToRootUpdate(false)
 {
+    ASSERT(isLegacySVGTransformableContainer());
 }
 
 bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
@@ -39,6 +39,7 @@ LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer(SVGSVGElement
     , m_isLayoutSizeChanged(false)
     , m_needsTransformUpdate(true)
 {
+    ASSERT(isLegacySVGViewportContainer());
 }
 
 SVGSVGElement& LegacyRenderSVGViewportContainer::svgSVGElement() const


### PR DESCRIPTION
#### 5f6e0965d1a0b9f13a1e7391c93cc031af69ffee
<pre>
Add assertions to make sure RenderObject type checks stay accurate
<a href="https://bugs.webkit.org/show_bug.cgi?id=264319">https://bugs.webkit.org/show_bug.cgi?id=264319</a>

Reviewed by Simon Fraser.

* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::RenderAttachment):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::RenderBlock):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::RenderBlockFlow):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::RenderBox):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::RenderBoxModelObject):
* Source/WebCore/rendering/RenderButton.cpp:
(WebCore::RenderButton::RenderButton):
* Source/WebCore/rendering/RenderCombineText.cpp:
(WebCore::RenderCombineText::RenderCombineText):
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::RenderCounter::RenderCounter):
* Source/WebCore/rendering/RenderDetailsMarker.cpp:
(WebCore::RenderDetailsMarker::RenderDetailsMarker):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::RenderEmbeddedObject):
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::RenderFileUploadControl):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::RenderFlexibleBox):
* Source/WebCore/rendering/RenderFragmentContainerSet.cpp:
(WebCore::RenderFragmentContainerSet::RenderFragmentContainerSet):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::RenderFragmentedFlow):
* Source/WebCore/rendering/RenderFrame.cpp:
(WebCore::RenderFrame::RenderFrame):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::RenderFrameSet):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::RenderGrid):
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::RenderHTMLCanvas):
* Source/WebCore/rendering/RenderIFrame.cpp:
(WebCore::RenderIFrame::RenderIFrame):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::RenderInline):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::RenderLayerModelObject):
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::RenderLineBreak):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::RenderListItem):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::RenderListMarker):
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::RenderMenuList):
* Source/WebCore/rendering/RenderMeter.cpp:
(WebCore::RenderMeter::RenderMeter):
* Source/WebCore/rendering/RenderModel.cpp:
* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(WebCore::RenderMultiColumnFlow::RenderMultiColumnFlow):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::RenderMultiColumnSet):
* Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp:
(WebCore::RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderMathMLTable const):
* Source/WebCore/rendering/RenderProgress.cpp:
(WebCore::RenderProgress::RenderProgress):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::RenderQuote::RenderQuote):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::RenderReplaced):
* Source/WebCore/rendering/RenderRuby.cpp:
(WebCore::RenderRubyAsInline::RenderRubyAsInline):
(WebCore::RenderRubyAsBlock::RenderRubyAsBlock):
* Source/WebCore/rendering/RenderRubyBase.cpp:
(WebCore::RenderRubyBase::RenderRubyBase):
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::RenderRubyRun):
* Source/WebCore/rendering/RenderRubyText.cpp:
(WebCore::RenderRubyText::RenderRubyText):
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(WebCore::RenderScrollbarPart::RenderScrollbarPart):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::RenderSearchField):
* Source/WebCore/rendering/RenderSlider.cpp:
(WebCore::RenderSlider::RenderSlider):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::RenderTable):
* Source/WebCore/rendering/RenderTableCaption.cpp:
(WebCore::RenderTableCaption::RenderTableCaption):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::RenderTableCell):
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::RenderTableCol):
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::RenderTableRow):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::RenderTableSection):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::RenderText):
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::RenderTextControl):
* Source/WebCore/rendering/RenderTextControlMultiLine.cpp:
(WebCore::RenderTextControlMultiLine::RenderTextControlMultiLine):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlInnerBlock::RenderTextControlInnerBlock):
* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::RenderVTTCue):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::RenderVideo):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::RenderView):
* Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h:
(WebCore::RenderMathMLTable::RenderMathMLTable):
* Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp:
(WebCore::RenderMathMLFenced::RenderMathMLFenced):
* Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp:
(WebCore::RenderMathMLFencedOperator::RenderMathMLFencedOperator):
* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::RenderMathMLFraction):
* Source/WebCore/rendering/mathml/RenderMathMLMath.cpp:
(WebCore::RenderMathMLMath::RenderMathMLMath):
* Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp:
(WebCore::RenderMathMLMenclose::RenderMathMLMenclose):
* Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp:
(WebCore::RenderMathMLPadded::RenderMathMLPadded):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::RenderMathMLRoot):
* Source/WebCore/rendering/mathml/RenderMathMLRow.cpp:
(WebCore::RenderMathMLRow::RenderMathMLRow):
* Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp:
(WebCore::RenderMathMLSpace::RenderMathMLSpace):
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
(WebCore::RenderMathMLUnderOver::RenderMathMLUnderOver):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(WebCore::RenderSVGForeignObject::RenderSVGForeignObject):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::RenderSVGGradientStop):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp:
(WebCore::RenderSVGHiddenContainer::RenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::RenderSVGImage):
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::RenderSVGInline):
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::RenderSVGInlineText):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::RenderSVGPath):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::RenderSVGResourceClipper):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::RenderSVGResourceContainer):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::RenderSVGRoot):
* Source/WebCore/rendering/svg/RenderSVGTSpan.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::RenderSVGText):
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
(WebCore::RenderSVGTextPath::RenderSVGTextPath):
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::RenderSVGTransformableContainer::RenderSVGTransformableContainer):
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::RenderSVGViewportContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::LegacyRenderSVGForeignObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::LegacyRenderSVGImage):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::LegacyRenderSVGPath):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::LegacyRenderSVGRoot):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp:
(WebCore::LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer):

Canonical link: <a href="https://commits.webkit.org/270353@main">https://commits.webkit.org/270353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2c4d25317c44413d611273475cd86750d2d4508

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23073 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23323 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27842 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28763 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26586 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/644 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2790 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3222 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2685 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->