### PR TITLE
[JSC] Add Int52 integer parsing fast path to JSON.parse

### DIFF
--- a/JSTests/stress/json-int52.js
+++ b/JSTests/stress/json-int52.js
@@ -1,0 +1,8 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+shouldBe(JSON.parse("999999999999999"), 999999999999999);
+shouldBe(JSON.parse("9999999999999999"), 9999999999999999);
+shouldBe(JSON.parse("-999999999999999"), -999999999999999);
+shouldBe(JSON.parse("-9999999999999999"), -9999999999999999);

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1029,41 +1029,71 @@ TokenType LiteralParser<CharType>::Lexer::lexNumber(LiteralParserToken<CharType>
     }
 
     // ('.' [0-9]+)?
-    const int NumberOfDigitsForSafeInt32 = 9;  // The numbers from -99999999 to 999999999 are always in range of Int32.
-    if (m_ptr < m_end && *m_ptr == '.') {
-        ++m_ptr;
-        // [0-9]+
-        if (m_ptr >= m_end || !isASCIIDigit(*m_ptr)) {
-            m_lexErrorMessage = "Invalid digits after decimal point"_s;
-            return TokError;
-        }
-
-        ++m_ptr;
-        while (m_ptr < m_end && isASCIIDigit(*m_ptr))
+    if (LIKELY(m_ptr < m_end)) {
+        if (*m_ptr == '.') {
             ++m_ptr;
-    } else if (m_ptr < m_end && (*m_ptr != 'e' && *m_ptr != 'E') && (m_ptr - start) <= NumberOfDigitsForSafeInt32) {
-        int32_t result = 0;
-        token.type = TokNumber;
-        const CharType* digit = start;
-        bool negative = false;
-        if (*digit == '-') {
-            negative = true;
-            digit++;
-        }
-        
-        ASSERT((m_ptr - digit) <= NumberOfDigitsForSafeInt32);
-        while (digit < m_ptr)
-            result = result * 10 + (*digit++) - '0';
+            // [0-9]+
+            if (m_ptr >= m_end || !isASCIIDigit(*m_ptr)) {
+                m_lexErrorMessage = "Invalid digits after decimal point"_s;
+                return TokError;
+            }
 
-        if (!negative)
-            token.numberToken = result;
-        else {
-            if (!result)
-                token.numberToken = -0.0;
-            else
-                token.numberToken = -result;
+            ++m_ptr;
+            while (m_ptr < m_end && isASCIIDigit(*m_ptr))
+                ++m_ptr;
+        } else if (*m_ptr != 'e' && *m_ptr != 'E') {
+            constexpr int numberOfDigitsForSafeInt32 = 9; // The numbers from -99999999 to 999999999 are always in range of Int32.
+            if (LIKELY((m_ptr - start) <= numberOfDigitsForSafeInt32)) {
+                int32_t result = 0;
+                token.type = TokNumber;
+                const CharType* digit = start;
+                bool negative = false;
+                if (*digit == '-') {
+                    negative = true;
+                    digit++;
+                }
+
+                ASSERT((m_ptr - digit) <= numberOfDigitsForSafeInt32);
+                while (digit < m_ptr)
+                    result = result * 10 + (*digit++) - '0';
+
+                if (!negative)
+                    token.numberToken = result;
+                else {
+                    if (!result)
+                        token.numberToken = -0.0;
+                    else
+                        token.numberToken = -result;
+                }
+                return TokNumber;
+            }
+
+            constexpr int numberOfDigitsForSafeInt52 = 15; // The numbers from -99999999999999 to 999999999999999 are always in range of Int52.
+            if ((m_ptr - start) <= numberOfDigitsForSafeInt52) {
+                int64_t result = 0;
+                token.type = TokNumber;
+                const CharType* digit = start;
+                bool negative = false;
+                if (*digit == '-') {
+                    negative = true;
+                    digit++;
+                }
+
+                ASSERT((m_ptr - digit) <= numberOfDigitsForSafeInt52);
+                while (digit < m_ptr)
+                    result = result * 10 + (*digit++) - '0';
+
+                if (!negative)
+                    token.numberToken = result;
+                else {
+                    if (!result)
+                        token.numberToken = -0.0;
+                    else
+                        token.numberToken = -result;
+                }
+                return TokNumber;
+            }
         }
-        return TokNumber;
     }
 
     //  ([eE][+-]? [0-9]+)?


### PR DESCRIPTION
#### e57a3976e076b3128f1f2464a71faf4b6e2bdfdd
<pre>
[JSC] Add Int52 integer parsing fast path to JSON.parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=264324">https://bugs.webkit.org/show_bug.cgi?id=264324</a>
<a href="https://rdar.apple.com/118038556">rdar://118038556</a>

Reviewed by NOBODY (OOPS!).

This patch adds a fast path for parsing Int52 integers, they are safely represented in double.
We found that sometimes we encounter out-of-int32 range integers from JSON, while they are within Int52
range. We can parse it quickly by using int64_t.

* JSTests/stress/json-int52.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexNumber):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e57a3976e076b3128f1f2464a71faf4b6e2bdfdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27272 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23082 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23329 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25400 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2723 "Found 1 new test failure: fast/forms/datalist/datalist-option-labels.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27851 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28768 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21875 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26591 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24395 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/653 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31811 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3708 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6964 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2799 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2694 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->