### PR TITLE
REGRESSION(269235@main?):[ Monterey+ ] http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html is flaky recently

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6778,8 +6778,6 @@ imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-whe
 
 webkit.org/b/263413 media/media-source/media-source-first-sample-pts-non-zero-canplay-without-renderer.html [ Timeout ]
 
-webkit.org/b/263879 http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html [ Pass Failure ]
-
 # webkit.org/b/263870 [scroll-animations] lots of scroll-animations WPT tests are timing out
 imported/w3c/web-platform-tests/scroll-animations/css/animation-fill-outside-range-test.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/animation-inactive-outside-range-test.html [ Skip ]

--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson-expected.txt
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson-expected.txt
@@ -1,1 +1,2 @@
+CONSOLE MESSAGE: Victim loaded.
 This page doesn't do anything special.

--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html
@@ -38,8 +38,8 @@ if (document.location.search.indexOf("?actually-attack") !== -1) {
 
 function checkDidLoadVictim()
 {
-    if (openerDocument.location.href == "http://127.0.0.1:8000/security/xss-DENIED-script-inject-into-inactive-window2-pson.html") {
-        // Victim loaded.
+    if (window.internals && !window.internals.isFullyActive(openerDocument)) {
+        console.log("Victim loaded.");
         window.clearInterval(intervalId);
 
         // Run code in victim.

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1098,7 +1098,7 @@ public:
     const URL& firstPartyForCookies() const { return m_firstPartyForCookies; }
     void setFirstPartyForCookies(const URL& url) { m_firstPartyForCookies = url; }
 
-    bool isFullyActive() const;
+    WEBCORE_EXPORT bool isFullyActive() const;
 
     // The full URL corresponding to the "site for cookies" in the Same-Site Cookies spec.,
     // <https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00>. It is either

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1365,6 +1365,12 @@ bool Internals::hasPausedImageAnimations(Element& element)
 {
     return element.renderer() && element.renderer()->hasPausedImageAnimations();
 }
+
+bool Internals::isFullyActive(Document& document)
+{
+    return document.isFullyActive();
+}
+
     
 bool Internals::isPaintingFrequently(Element& element)
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -199,6 +199,7 @@ public:
     ExceptionOr<String> elementRenderTreeAsText(Element&);
     bool hasPausedImageAnimations(Element&);
 
+    bool isFullyActive(Document&);
     bool isPaintingFrequently(Element&);
     void incrementFrequentPaintCounter(Element&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -373,6 +373,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     // Animated image pausing testing.
     boolean hasPausedImageAnimations(Element element);
 
+    boolean isFullyActive(Document document);
     // Must be called on an element whose enclosingLayer() is self-painting.
     boolean isPaintingFrequently(Element element);
     undefined incrementFrequentPaintCounter(Element element);


### PR DESCRIPTION
#### c586c6d289d7c653602ddadbdb6ccab49671ba34
<pre>
REGRESSION(269235@main?):[ Monterey+ ] http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html is flaky recently
<a href="https://bugs.webkit.org/show_bug.cgi?id=263879">https://bugs.webkit.org/show_bug.cgi?id=263879</a>

Reviewed by Chris Dumez.

This change updates the
http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html
test to ensure it consistently passes.

The change adds a new isFullyActive(Document&amp;) function to window.internals,
and uses that function in the test.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson-expected.txt:
* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html:
* Source/WebCore/dom/Document.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isFullyActive):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/270737@main">https://commits.webkit.org/270737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91ca8f47780108a9bebadff3ecf98bd3702224df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28152 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23857 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23920 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28728 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23400 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23780 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1390 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23148 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6311 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->