### PR TITLE
Resync the invokers Web-Platform-Tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
@@ -20,7 +20,7 @@
     assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
     assert_equals(event.type, "invoke", "type");
     assert_equals(event.bubbles, false, "bubbles");
-    assert_equals(event.composed, false, "composed");
+    assert_equals(event.composed, true, "composed");
     assert_equals(event.isTrusted, true, "isTrusted");
     assert_equals(event.action, "auto", "action");
     assert_equals(event.target, invokee, "target");
@@ -35,7 +35,7 @@
     assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
     assert_equals(event.type, "invoke", "type");
     assert_equals(event.bubbles, false, "bubbles");
-    assert_equals(event.composed, false, "composed");
+    assert_equals(event.composed, true, "composed");
     assert_equals(event.isTrusted, true, "isTrusted");
     assert_equals(event.action, "fooBar", "action");
     assert_equals(event.target, invokee, "target");
@@ -50,7 +50,7 @@
     assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
     assert_equals(event.type, "invoke", "type");
     assert_equals(event.bubbles, false, "bubbles");
-    assert_equals(event.composed, false, "composed");
+    assert_equals(event.composed, true, "composed");
     assert_equals(event.isTrusted, true, "isTrusted");
     assert_equals(event.action, "BaRbAz", "action");
     assert_equals(event.target, invokee, "target");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative-expected.txt
@@ -1,0 +1,14 @@
+Fullscreen content
+
+PASS invoking div with auto action is no-op
+FAIL invoking div with toggleFullscreen action makes div fullscreen assert_true: expected true got false
+PASS invoking div with toggleFullscreen action and preventDefault is a no-op
+FAIL invoking fullscreen div with toggleFullscreen action exits fullscreen assert_false: expected false got true
+FAIL invoking fullscreen div with toggleFullscreen (case-insensitive) action exits fullscreen assert_false: expected false got true
+FAIL invoking div with requestFullscreen action makes div fullscreen assert_true: expected true got false
+PASS invoking div with requestFullscreen action and preventDefault is a no-op
+PASS invoking fullscreen div with requestFullscreen action is a no-op
+PASS invoking div with exitFullscreen action is a no-op
+FAIL invoking fullscreen div with exitFullscreen action exits fullscreen assert_false: expected false got true
+PASS invoking fullscreen div with exitFullscreen action and preventDefault is a no-op
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="invokee">
+  Fullscreen content
+  <button id="invokerbutton" invoketarget="invokee"></button>
+</div>
+
+<script>
+  // auto
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    assert_false(invokee.matches(":fullscreen"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking div with auto action is no-op");
+
+  // toggleFullscreen
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    assert_false(invokee.matches(":fullscreen"));
+    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches(":fullscreen"));
+  }, "invoking div with toggleFullscreen action makes div fullscreen");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_false(invokee.matches(":fullscreen"));
+    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking div with toggleFullscreen action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    await test_driver.bless('go fullscreen');
+    await invokee.requestFullscreen();
+    assert_true(invokee.matches(":fullscreen"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking fullscreen div with toggleFullscreen action exits fullscreen");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    invokerbutton.setAttribute("invokeaction", "tOgGlEFullscreen");
+    await test_driver.bless('go fullscreen');
+    await invokee.requestFullscreen();
+    assert_true(invokee.matches(":fullscreen"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking fullscreen div with toggleFullscreen (case-insensitive) action exits fullscreen");
+
+  // requestFullscreen
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    assert_false(invokee.matches(":fullscreen"));
+    invokerbutton.setAttribute("invokeaction", "requestFullscreen");
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches(":fullscreen"));
+  }, "invoking div with requestFullscreen action makes div fullscreen");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_false(invokee.matches(":fullscreen"));
+    invokerbutton.setAttribute("invokeaction", "requestFullscreen");
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking div with requestFullscreen action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    invokerbutton.setAttribute("invokeaction", "requestFullscreen");
+    await test_driver.bless('go fullscreen');
+    await invokee.requestFullscreen();
+    assert_true(invokee.matches(":fullscreen"));
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches(":fullscreen"));
+  }, "invoking fullscreen div with requestFullscreen action is a no-op");
+
+  // exitFullscreen
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    assert_false(invokee.matches(":fullscreen"));
+    invokerbutton.setAttribute("invokeaction", "exitFullscreen");
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking div with exitFullscreen action is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    invokerbutton.setAttribute("invokeaction", "exitFullscreen");
+    await test_driver.bless('go fullscreen');
+    await invokee.requestFullscreen();
+    assert_true(invokee.matches(":fullscreen"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking fullscreen div with exitFullscreen action exits fullscreen");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    invokerbutton.setAttribute("invokeaction", "exitFullscreen");
+    await test_driver.bless('go fullscreen');
+    await invokee.requestFullscreen();
+    assert_true(invokee.matches(":fullscreen"));
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches(":fullscreen"));
+  }, "invoking fullscreen div with exitFullscreen action and preventDefault is a no-op");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative-expected.txt
@@ -1,0 +1,20 @@
+
+
+FAIL invoking closed details with auto action opens assert_true: expected true got false
+PASS invoking closed details with auto action and preventDefault does not open
+FAIL invoking open details with auto action opens assert_false: expected false got true
+PASS invoking open details with auto action and preventDefault does not close
+FAIL invoking closed details with toggle action opens assert_true: expected true got false
+FAIL invoking closed details with toggle (case-insensitive) action opens assert_true: expected true got false
+PASS invoking closed details with toggle action and preventDefault does not open
+FAIL invoking open details with toggle action closes assert_false: expected false got true
+PASS invoking open details with toggle action and preventDefault does not close
+FAIL invoking closed details with open action opens assert_true: expected true got false
+FAIL invoking closed details with open (case insensitive) action opens assert_true: expected true got false
+PASS invoking open details with open action is noop
+PASS invoking closed popover with open action and preventDefault does not open
+PASS invoking closed details with close action is noop
+FAIL invoking open details with close action closes assert_false: expected false got true
+FAIL invoking open details with close (case insensitive) action closes assert_false: expected false got true
+PASS invoking open details with close action with preventDefault does not close
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<details id="invokee">
+  Details Contents
+</details>
+<button id="invokerbutton" invoketarget="invokee"></button>
+
+<script>
+  // auto
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_true(invokee.matches("[open]"));
+  }, "invoking closed details with auto action opens");
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches("[open]"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_false(invokee.matches("[open]"));
+  }, "invoking closed details with auto action and preventDefault does not open");
+
+  promise_test(async function (t) {
+    invokee.setAttribute('open', '');
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches("[open]"));
+  }, "invoking open details with auto action opens");
+
+  promise_test(async function (t) {
+    invokee.setAttribute('open', '');
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches("[open]"));
+  }, "invoking open details with auto action and preventDefault does not close");
+
+  // toggle
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches("[open]"));
+    invokerbutton.setAttribute("invokeaction", "toggle");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_true(invokee.matches("[open]"));
+  }, "invoking closed details with toggle action opens");
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches("[open]"));
+    invokerbutton.setAttribute("invokeaction", "tOgGlE");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_true(invokee.matches("[open]"));
+  }, "invoking closed details with toggle (case-insensitive) action opens");
+
+  promise_test(async function (t) {
+    assert_false(invokee.matches("[open]"));
+    invokerbutton.setAttribute("invokeaction", "toggle");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_false(invokee.matches("[open]"));
+  }, "invoking closed details with toggle action and preventDefault does not open");
+
+  promise_test(async function (t) {
+    invokee.setAttribute('open', '');
+    invokerbutton.setAttribute("invokeaction", "toggle");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches("[open]"));
+  }, "invoking open details with toggle action closes");
+
+  promise_test(async function (t) {
+    invokee.setAttribute('open', '');
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    invokerbutton.setAttribute("invokeaction", "toggle");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches("[open]"));
+  }, "invoking open details with toggle action and preventDefault does not close");
+
+  // open
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "open");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_true(invokee.matches("[open]"));
+  }, "invoking closed details with open action opens");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "oPeN");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_true(invokee.matches("[open]"));
+  }, "invoking closed details with open (case insensitive) action opens");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "open");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.setAttribute('open', '');
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_true(invokee.matches("[open]"));
+  }, "invoking open details with open action is noop");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "open");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches("[open]"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_false(invokee.matches("[open]"));
+  }, "invoking closed popover with open action and preventDefault does not open");
+
+  // close
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "close");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    assert_false(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches("[open]"));
+  }, "invoking closed details with close action is noop");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "close");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.setAttribute('open', '');
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_false(invokee.matches("[open]"));
+  }, "invoking open details with close action closes");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "cLoSe");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.setAttribute('open', '');
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_false(invokee.matches("[open]"));
+  }, "invoking open details with close (case insensitive) action closes");
+
+  promise_test(async function (t) {
+    invokerbutton.setAttribute("invokeaction", "close");
+    t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+    invokee.setAttribute('open', '');
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    assert_true(invokee.matches("[open]"));
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches("[open]"));
+  }, "invoking open details with close action with preventDefault does not close");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
@@ -19,3 +19,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-actual.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-actual.txt
@@ -1,0 +1,20 @@
+
+
+FAIL invoking (as auto) closed popover opens assert_true: expected true got false
+PASS invoking (as auto) closed popover with preventDefault does not open
+FAIL invoking (as auto) open popover closes assert_false: expected false got true
+PASS invoking (as auto) open popover with preventDefault does not close
+FAIL invoking (as togglepopover) closed popover opens assert_true: expected true got false
+FAIL invoking (as togglepopover - case insensitive) closed popover opens assert_true: expected true got false
+PASS invoking (as togglepopover) closed popover with preventDefault does not open
+FAIL invoking (as togglepopover) open popover closes assert_false: expected false got true
+PASS invoking (as togglepopover) open popover with preventDefault does not close
+FAIL invoking (as showpopover) closed popover opens assert_true: expected true got false
+FAIL invoking (as showpopover - case insensitive) closed popover opens assert_true: expected true got false
+PASS invoking (as showpopover) open popover is noop
+PASS invoking (as showpopover) closed popover with preventDefault does not open
+PASS invoking (as hidepopover) closed popover is noop
+FAIL invoking (as hidepopover) open popover closes assert_false: expected false got true
+FAIL invoking (as hidepopover - case insensitive) open popover closes assert_false: expected false got true
+PASS invoking (as hidepopover) open popover with preventDefault does not close
+


### PR DESCRIPTION
#### 286cbf78d0795063da15eb0aebaa7ba85e24d654
<pre>
Resync the invokers Web-Platform-Tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=264282">https://bugs.webkit.org/show_bug.cgi?id=264282</a>

Reviewed by Tim Nguyen.

This re-syncs and rebaselines the Web Platform Tests, and rebaselines a
test that&apos;s coincidentally passing on iOS. The failure on other
platforms relates to an as-yet implemented feature.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/c570935108b66e32347afaaa95fc79b0c2c8c8df">https://github.com/web-platform-tests/wpt/commit/c570935108b66e32347afaaa95fc79b0c2c8c8df</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-actual.txt: Added.

Canonical link: <a href="https://commits.webkit.org/270365@main">https://commits.webkit.org/270365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97a4c3ec4b029d0bbf987691a25d2246e5b1e0d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23104 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23343 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27874 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28793 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26619 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6060 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2820 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2715 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->