### PR TITLE
[LBSE] Update some test results after 270302@main

### DIFF
--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-intro-01-f-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-intro-01-f-expected.txt
@@ -9,9 +9,7 @@ layer at (63.55,18.50) size 352x21
     RenderSVGInlineText {#text} at (0,0) size 353x21
       chunk 1 (middle anchor) text run 1 at (63.55,35.00) startOffset 0 endOffset 51 width 352.90: "Testing stroke inclusion for 'clip-path' and 'mask'"
 layer at (0.09,0.30) size 1x1
-  RenderSVGHiddenContainer {defs} at (0.09,0.30) size 0.81x0.41
-layer at (0.09,0.30) size 1x1
-  RenderSVGResourceClipper {clipPath} at (0,0) size 0.81x0.41
+  RenderSVGResourceClipper {clipPath} at (0.09,0.30) size 0.81x0.41
 layer at (0.09,0.30) size 1x1
   RenderSVGEllipse {circle} at (0,0) size 0.41x0.41 [stroke={[type=SOLID] [color=#FF0000] [stroke width=0.15]}] [cx=0.30] [cy=0.50] [r=0.20]
 layer at (0.50,0.30) size 1x1

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-path-01-b-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-path-01-b-expected.txt
@@ -6,14 +6,12 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,20) size 440x267
   RenderSVGTransformableContainer {g} at (20,20) size 440x266.36
-layer at (90,10) size 230x240
-  RenderSVGHiddenContainer {defs} at (70,-10) size 230x240
 layer at (200,10) size 60x100
-  RenderSVGResourceClipper {clipPath} at (110,0) size 60x100
+  RenderSVGResourceClipper {clipPath} at (200,10) size 60x100
 layer at (200,10) size 60x100
   RenderSVGRect {rect} at (0,0) size 60x100 [fill={[type=SOLID] [color=#000000]}] [x=200.00] [y=10.00] [width=60.00] [height=100.00]
 layer at (90,150) size 230x100
-  RenderSVGResourceClipper {clipPath} at (0,140) size 230x100
+  RenderSVGResourceClipper {clipPath} at (90,150) size 230x100
 layer at (90,150) size 175x100
   RenderSVGRect {rect} at (0,0) size 175x100 [fill={[type=SOLID] [color=#000000]}] [x=90.00] [y=150.00] [width=175.00] [height=100.00]
 layer at (225,160) size 95x75

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-path-04-b-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-path-04-b-expected.txt
@@ -7,9 +7,7 @@ layer at (0,0) size 480x360
 layer at (20,20) size 420x310
   RenderSVGTransformableContainer {g} at (20,20) size 420x310
 layer at (45,169.11) size 355x123
-  RenderSVGHiddenContainer {defs} at (25,149.11) size 354.45x121.98
-layer at (45,169.11) size 355x122
-  RenderSVGResourceClipper {clipPath} at (0,0) size 354.45x121.98
+  RenderSVGResourceClipper {clipPath} at (45,169.11) size 354.45x121.98
 layer at (45,169.11) size 354x122
   RenderSVGText {text} at (0,0) size 355x122 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 355x122

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/painting-marker-02-f-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/painting-marker-02-f-expected.txt
@@ -6,8 +6,6 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (0,0) size 416x273
   RenderSVGTransformableContainer {g} at (0,0) size 415.03x272.13
-layer at (0,0) size 4x4
-  RenderSVGHiddenContainer {defs} at (0,0) size 4x4
 layer at (0,0) size 2x2
   RenderSVGResourceClipper {clipPath} at (0,0) size 2x2
 layer at (0,0) size 2x2

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/batik/text/textEffect2-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/batik/text/textEffect2-expected.txt
@@ -14,16 +14,14 @@ layer at (104.50,35.52) size 241x18
   RenderSVGText {text} at (4,20) size 242x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 241x18
       chunk 1 (middle anchor) text run 1 at (104.50,50.00) startOffset 0 endOffset 32 width 240.99: "(Using System font and SVG font)"
-layer at (100,151.72) size 155x160
-  RenderSVGHiddenContainer {defs} at (0,136.20) size 154.13x159.59
-layer at (100,151.72) size 155x60
-  RenderSVGResourceClipper {clipPath} at (0,0) size 154.13x59.59
+layer at (100,151.72) size 155x61
+  RenderSVGResourceClipper {clipPath} at (100,151.72) size 154.13x59.59
 layer at (100,151.72) size 154x60
   RenderSVGText {text} at (0,0) size 155x60 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 155x60
       chunk 1 text run 1 at (100.00,200.00) startOffset 0 endOffset 5 width 154.11: "BATIK"
-layer at (100,251.72) size 155x60
-  RenderSVGResourceClipper {clipPath} at (0,100) size 154.13x59.59
+layer at (100,251.72) size 155x61
+  RenderSVGResourceClipper {clipPath} at (100,251.72) size 154.13x59.59
 layer at (100,251.72) size 154x60
   RenderSVGText {text} at (0,0) size 155x60 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 155x60

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/batik/text/textProperties-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/batik/text/textProperties-expected.txt
@@ -181,9 +181,7 @@ layer at (-75.48,11) size 151x18 backgroundClip at (0,0) size 450x500 clip at (0
     RenderSVGInlineText {#text} at (0,0) size 151x18
       chunk 1 (middle anchor) text run 1 at (-75.48,25.00) startOffset 0 endOffset 21 width 150.97: "stroke=\"MidnightBlue\""
 layer at (-42.50,-27.50) size 86x36 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGHiddenContainer {defs} at (44.08,8.50) size 85x35
-layer at (-42.50,-27.50) size 85x35 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGResourceClipper {clipPath} at (0,0) size 85x35
+  RenderSVGResourceClipper {clipPath} at (-42.50,-27.50) size 85x35
 layer at (-42.50,-27.50) size 85x35 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
   RenderSVGText {text} at (0,0) size 85x35 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 85x35

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/text-clip-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/text-clip-expected.txt
@@ -5,9 +5,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (200,200) size 100x200
-  RenderSVGHiddenContainer {defs} at (200,200) size 100x200
-layer at (200,200) size 100x200
-  RenderSVGResourceClipper {clipPath} at (0,0) size 100x200
+  RenderSVGResourceClipper {clipPath} at (200,200) size 100x200
 layer at (200,200) size 100x200
   RenderSVGPath {path} at (0,0) size 100x200 [fill={[type=SOLID] [color=#000000]}] [data="M 200 200 L 300 200 L 300 400 L 200 400 Z"]
 layer at (0,75.75) size 645x64

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/filters/filter-clip-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/filters/filter-clip-expected.txt
@@ -5,9 +5,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (20,20) size 100x100
-  RenderSVGHiddenContainer {defs} at (20,20) size 100x100
-layer at (20,20) size 100x100
-  RenderSVGResourceClipper {clipPath} at (0,0) size 100x100
+  RenderSVGResourceClipper {clipPath} at (20,20) size 100x100
 layer at (20,20) size 100x100
   RenderSVGEllipse {circle} at (0,0) size 100x100 [fill={[type=SOLID] [color=#000000]}] [cx=70.00] [cy=70.00] [r=50.00]
 layer at (20,20) size 100x100

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/foreignObject/clip-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/foreignObject/clip-expected.txt
@@ -9,8 +9,6 @@ layer at (0,0) size 300x150
 layer at (0,0) size 300x150
   RenderSVGViewportContainer at (0,0) size 300x150
 layer at (0,0) size 200x50
-  RenderSVGHiddenContainer {defs} at (0,0) size 200x50
-layer at (0,0) size 200x50
   RenderSVGResourceClipper {clipPath} at (0,0) size 200x50
 layer at (0,0) size 200x50
   RenderSVGRect {rect} at (0,0) size 200x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=200.00] [height=50.00]

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/repaint/mask-clip-target-transform-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/repaint/mask-clip-target-transform-expected.txt
@@ -5,9 +5,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (-50,50) size 100x100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderSVGHiddenContainer {defs} at (-50,50) size 100x100
-layer at (-50,50) size 100x100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderSVGResourceClipper {clipPath} at (0,0) size 100x100
+  RenderSVGResourceClipper {clipPath} at (-50,50) size 100x100
 layer at (-50,50) size 100x100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderSVGEllipse {circle} at (0,0) size 100x100 [fill={[type=SOLID] [color=#000000]}] [cx=0.00] [cy=100.00] [r=50.00]
 layer at (50,-50) size 100x100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600


### PR DESCRIPTION
#### 647284f7496da1a508fb755705fdd4dadb8965d2
<pre>
[LBSE] Update some test results after 270302@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=264332">https://bugs.webkit.org/show_bug.cgi?id=264332</a>

Reviewed by Nikolas Zimmermann.

Update some test results after 270302@main.

* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-intro-01-f-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-path-01-b-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/masking-path-04-b-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/W3C-SVG-1.1/painting-marker-02-f-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/batik/text/textEffect2-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/batik/text/textProperties-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/text-clip-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/filters/filter-clip-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/foreignObject/clip-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/repaint/mask-clip-target-transform-expected.txt:

Canonical link: <a href="https://commits.webkit.org/270389@main">https://commits.webkit.org/270389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d39e69c3fc9938acaf3613c672dbe3390875eb7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23253 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1325 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28040 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22816 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23128 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26756 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/812 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3886 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2971 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3235 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2863 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->