### PR TITLE
[WGSL] Disallow NaN as a constant value

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -142,6 +142,8 @@ std::optional<To> convertFloat(From value)
         return std::nullopt;
     if (value < std::numeric_limits<To>::lowest())
         return std::nullopt;
+    if (std::isnan(value))
+        return std::nullopt;
     if (std::abs(value) < std::numeric_limits<To>::min())
         return { 0 };
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -745,10 +745,10 @@ fn testTrigonometric()
 fn testTrigonometricHyperbolic()
 {
   {
-    _ = acosh(0.0);
-    _ = acosh(vec2(0.0, 0.0));
-    _ = acosh(vec3(0.0, 0.0, 0.0));
-    _ = acosh(vec4(0.0, 0.0, 0.0, 0.0));
+    _ = acosh(1.0);
+    _ = acosh(vec2(1.0, 1.0));
+    _ = acosh(vec3(1.0, 1.0, 1.0));
+    _ = acosh(vec4(1.0, 1.0, 1.0, 1.0));
   }
 
   {
@@ -1511,14 +1511,14 @@ fn testLog()
         _ = log(vec2(2f));
     }
     {
-        _ = log(vec3(-2));
-        _ = log(vec3(-2.0));
-        _ = log(vec3(-2f));
+        _ = log(vec3(2));
+        _ = log(vec3(2.0));
+        _ = log(vec3(2f));
     }
     {
-        _ = log(vec4(-2));
-        _ = log(vec4(-2.0));
-        _ = log(vec4(-2f));
+        _ = log(vec4(2));
+        _ = log(vec4(2.0));
+        _ = log(vec4(2f));
     }
 }
 
@@ -1538,14 +1538,14 @@ fn testLog2() {
         _ = log2(vec2(2f));
     }
     {
-        _ = log2(vec3(-2));
-        _ = log2(vec3(-2.0));
-        _ = log2(vec3(-2f));
+        _ = log2(vec3(2));
+        _ = log2(vec3(2.0));
+        _ = log2(vec3(2f));
     }
     {
-        _ = log2(vec4(-2));
-        _ = log2(vec4(-2.0));
-        _ = log2(vec4(-2f));
+        _ = log2(vec4(2));
+        _ = log2(vec4(2.0));
+        _ = log2(vec4(2f));
     }
 }
 
@@ -1673,8 +1673,8 @@ fn testNormalize()
 {
     // [T < Float, N].(Vector[T, N]) => Vector[T, N],
     {
-        _ = normalize(vec2(0));
-        _ = normalize(vec2(0.0));
+        _ = normalize(vec2(1));
+        _ = normalize(vec2(1.0));
         _ = normalize(vec2(1f));
     }
     {
@@ -1975,19 +1975,19 @@ fn testSmoothstep()
     }
     // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
     {
-        _ = smoothstep(vec2(0), vec2(0), vec2(0));
-        _ = smoothstep(vec2(0), vec2(0), vec2(0.0));
-        _ = smoothstep(vec2(0), vec2(0), vec2(0f));
+        _ = smoothstep(vec2(2), vec2(1), vec2(1));
+        _ = smoothstep(vec2(2), vec2(1), vec2(1.0));
+        _ = smoothstep(vec2(2), vec2(1), vec2(1f));
     }
     {
-        _ = smoothstep(vec3(0), vec3(0), vec3(0));
-        _ = smoothstep(vec3(0), vec3(0), vec3(0.0));
-        _ = smoothstep(vec3(0), vec3(0), vec3(0f));
+        _ = smoothstep(vec3(2), vec3(1), vec3(1));
+        _ = smoothstep(vec3(2), vec3(1), vec3(1.0));
+        _ = smoothstep(vec3(2), vec3(1), vec3(1f));
     }
     {
-        _ = smoothstep(vec4(0), vec4(0), vec4(0));
-        _ = smoothstep(vec4(0), vec4(0), vec4(0.0));
-        _ = smoothstep(vec4(0), vec4(0), vec4(0f));
+        _ = smoothstep(vec4(2), vec4(1), vec4(1));
+        _ = smoothstep(vec4(2), vec4(1), vec4(1.0));
+        _ = smoothstep(vec4(2), vec4(1), vec4(1f));
     }
 }
 
@@ -2008,14 +2008,14 @@ fn testSqrt()
         _ = sqrt(vec2(1f));
     }
     {
-        _ = sqrt(vec3(-1));
-        _ = sqrt(vec3(-1.0));
-        _ = sqrt(vec3(-1f));
+        _ = sqrt(vec3(1));
+        _ = sqrt(vec3(1.0));
+        _ = sqrt(vec3(1f));
     }
     {
-        _ = sqrt(vec4(-1));
-        _ = sqrt(vec4(-1.0));
-        _ = sqrt(vec4(-1f));
+        _ = sqrt(vec4(1));
+        _ = sqrt(vec4(1.0));
+        _ = sqrt(vec4(1f));
     }
 }
 


### PR DESCRIPTION
#### e449510e80210ea7a569b3db7f71d83df293348b
<pre>
[WGSL] Disallow NaN as a constant value
<a href="https://bugs.webkit.org/show_bug.cgi?id=264333">https://bugs.webkit.org/show_bug.cgi?id=264333</a>
<a href="https://rdar.apple.com/118055576">rdar://118055576</a>

Reviewed by Mike Wyrzykowski.

The constant value conversion/validation was missing a check for NaNs, which are
not valid constant values.

* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::convertFloat):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270326@main">https://commits.webkit.org/270326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d1ede851cdf5a0a6ec689e397b2e1d80e81be34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23112 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1165 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27882 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2439 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28801 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26627 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/682 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3739 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2828 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2723 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->