### PR TITLE
Do not promote WebRTC video conference web pages to NowPlaying

### DIFF
--- a/LayoutTests/media/now-playing-status-for-video-conference-web-page-expected.txt
+++ b/LayoutTests/media/now-playing-status-for-video-conference-web-page-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Check NowPlaying status on a VC page
+

--- a/LayoutTests/media/now-playing-status-for-video-conference-web-page.html
+++ b/LayoutTests/media/now-playing-status-for-video-conference-web-page.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+        <script src="../webrtc/routines.js"></script>
+    </head>
+    <body>
+        <video id="localVideo" autoplay playsinline muted></video>
+        <video id="remoteVideo" autoplay playsinline></video>
+        <script>
+promise_test(async (t) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    localVideo.srcObject = localStream;
+    await localVideo.play();
+
+    const remoteStream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+            firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
+        }, (secondConnection) => {
+            pc2 = secondConnection;
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    remoteVideo.srcObject = remoteStream;
+    await remoteVideo.play();
+
+    if (!window.internals)
+        return;
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+    assert_false(internals.nowPlayingState.haveEverRegisteredAsNowPlayingApplication);
+
+    internals.setMediaStreamTrackMuted(localStream.getAudioTracks()[0], false); 
+    internals.setMediaStreamTrackMuted(localStream.getVideoTracks()[0], false); 
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+    assert_false(internals.nowPlayingState.haveEverRegisteredAsNowPlayingApplication);
+}, "Check NowPlaying status on a VC page");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -74,6 +74,7 @@ media/audio-session-category-at-most-recent-playback.html [ Skip ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-constructor.https.html [ Skip ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-setsinkid.https.html [ Skip ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-state-change.https.html [ Skip ]
+media/now-playing-status-for-video-conference-web-page.html [ Skip ]
 
 # Payment request API is not supported on WK1.
 imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html [ Skip ]


### PR DESCRIPTION
#### 44519e1f0b97a33fd1020f9c9909ea993ebb9e0d
<pre>
Do not promote WebRTC video conference web pages to NowPlaying
<a href="https://bugs.webkit.org/show_bug.cgi?id=264335">https://bugs.webkit.org/show_bug.cgi?id=264335</a>
<a href="https://rdar.apple.com/118057213">rdar://118057213</a>

Reviewed by Eric Carlson.

When a web page becomes the NowPlaying app, it might receive Pause and Play commands.
This for instance happens when AirPods are removed from ears.
There are cases where the Pause command will be received but the Play command will not be sent when AirPods are back in ears.

Given video conference web pages currently do not handle well pause/play, we are, by default, no longer making web pages that do capture
and play several media streams the now playing app, except for web pages that use MediaSession since they are then responsible to handle play/pause commands.

* LayoutTests/media/now-playing-status-for-video-conference-web-page-expected.txt: Added.
* LayoutTests/media/now-playing-status-for-video-conference-web-page.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isDocumentPlayingSeveralMediaStreamsAndCapturing):
(WebCore::processRemoteControlCommandIfPlayingMediaStreams):
(WebCore::MediaElementSession::nowPlayingInfo const):
(WebCore::isDocumentPlayingSeveralMediaStreams): Deleted.

Canonical link: <a href="https://commits.webkit.org/270459@main">https://commits.webkit.org/270459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50764f2c69c2fd9bf3de51147aa50bec5864f473

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27646 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1582 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28228 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29065 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26900 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6129 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->