### PR TITLE
AirPods removed from ears should not disturb and ongoing video call

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -116,6 +116,7 @@ protected:
 
     virtual void isProducingMicrophoneSamplesChanged() { }
     virtual void validateOutputDevice(uint32_t /* currentOutputDeviceID */) { }
+    virtual bool migrateToNewDefaultDevice(const CaptureDevice&) { return false; }
 
 private:
     OSStatus startUnit();
@@ -140,6 +141,7 @@ private:
     Vector<CheckedPtr<CoreAudioCaptureSource>> m_audioThreadClients WTF_GUARDED_BY_LOCK(m_audioThreadClientsLock);
     Lock m_audioThreadClientsLock;
 
+    bool m_isCapturingWithDefaultMicrophone { false };
     bool m_isProducingMicrophoneSamples { true };
     Vector<Function<void()>> m_whenNotRunningCallbacks;
 };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -118,6 +118,9 @@ private:
     bool isProducingData() const final { return m_ioUnitStarted; }
     void isProducingMicrophoneSamplesChanged() final;
     void validateOutputDevice(uint32_t deviceID) final;
+#if PLATFORM(MAC)
+    bool migrateToNewDefaultDevice(const CaptureDevice&) final;
+#endif
     int actualSampleRate() const final;
     void resetSampleRate();
 


### PR DESCRIPTION
#### 71ef02a300c45e9080fe75177c6c5a3dc18a0cd1
<pre>
AirPods removed from ears should not disturb and ongoing video call
<a href="https://bugs.webkit.org/show_bug.cgi?id=264334">https://bugs.webkit.org/show_bug.cgi?id=264334</a>
<a href="https://rdar.apple.com/116091083">rdar://116091083</a>

Reviewed by Eric Carlson.

When AirPods are removed from ears, AirPods are disappearing from the list of existing devices.
Before the patch, it would trigger capture failure. But web pages do not handle well capture failure.
To help web pages, if capturing with the default microphone and the microphone is disappearing, we are now
migrating to the new default microphone.
We make sure to trigger a configurationchange event on the MediaStreamTrack, which exposes the change to the web page.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::setCaptureDevice):
(WebCore::BaseAudioSharedUnit::devicesChanged):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::migrateToNewDefaultDevice):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::migrateToNewDefaultDevice):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:

Canonical link: <a href="https://commits.webkit.org/270433@main">https://commits.webkit.org/270433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1347427af649adb7ce9668dd317441bee21b41f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23355 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27891 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28807 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/689 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3748 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6105 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->