### PR TITLE
[Async text interaction] Enable selection autoscrolling, and reveal the edit menu after scrolling

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1169,6 +1169,7 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 - (void)pasteAndMatchStyle:(id)sender;
 - (void)makeTextWritingDirectionNatural:(id)sender;
 @property (nonatomic, setter=_setSuppressSoftwareKeyboard:) BOOL _suppressSoftwareKeyboard;
+@property (nonatomic, readonly) UITextInteractionAssistant *interactionAssistant;
 @end
 
 @interface _UINavigationInteractiveTransitionBase ()

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -480,6 +480,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _waitingForKeyboardAppearanceAnimationToStart;
     BOOL _isHidingKeyboard;
     BOOL _isPreparingEditMenu;
+    BOOL _isPresentingEditMenu;
 
     BOOL _focusRequiresStrongPasswordAssistance;
     BOOL _waitingForEditDragSnapshot;
@@ -608,6 +609,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly) UIGestureRecognizer *imageAnalysisGestureRecognizer;
 @property (nonatomic, readonly, getter=isKeyboardScrollingAnimationRunning) BOOL keyboardScrollingAnimationRunning;
 @property (nonatomic, readonly) UIView *unscaledView;
+@property (nonatomic, readonly) BOOL isPresentingEditMenu;
 
 #if ENABLE(DATALIST_ELEMENT)
 @property (nonatomic, strong) UIView <WKFormControl> *dataListTextSuggestionsInputView;


### PR DESCRIPTION
#### 92399f9f2ddd89a024d1d9549a5945cea4c1b605
<pre>
[Async text interaction] Enable selection autoscrolling, and reveal the edit menu after scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=264337">https://bugs.webkit.org/show_bug.cgi?id=264337</a>

Reviewed by Megan Gardner.

This patch works towards additional support for async text interaction (and input client), by
adding plumbing for the following:

1.  Plumbing to autoscroll to a given `point` in content view coordinates.
2.  Logic to reveal the edit menu after scrolling or zooming, only if the edit menu was previously
    presented. To know this, we add a new flag on the content view to keep track of whether the edit
    menu has been fully presented.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Add an SPI method declaration here, only so that we can call super in our existing implementation of
`-interactionAssistant`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView interactionAssistant]):
(-[WKContentView willPresentEditMenuWithAnimator:]):
(-[WKContentView willDismissEditMenuWithAnimator:]):

Keep track of `_isPresentingEditMenu`, so that we can consult it in the `WKTextInteractionWrapper`
below to conditionally restore edit menu visibility.

(-[WKContentView isPresentingEditMenu]):
(-[WKContentView autoscrollToPoint:]):
(-[WKContentView cancelAutoscroll]):

Implement a new method to hook into platform selection autoscrolling support using
`UIAsyncTextInputClient`.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(SOFT_LINK_CLASS_OPTIONAL):
(-[WKTextInteractionWrapper initWithView:]):
(-[WKTextInteractionWrapper willStartScrollingOverflow]):
(-[WKTextInteractionWrapper didEndScrollingOverflow]):
(-[WKTextInteractionWrapper willStartScrollingOrZooming]):
(-[WKTextInteractionWrapper didEndScrollingOrZooming]):

Canonical link: <a href="https://commits.webkit.org/270343@main">https://commits.webkit.org/270343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e1e9f3913355ee35841d36f070b04eceee3719b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27332 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23141 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1195 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27911 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2462 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26652 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3768 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6046 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2857 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2752 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->