### PR TITLE
[WebGPU] Queue::commitMTLCommandBuffer will fail if command buffer was already committed

### DIFF
--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -58,12 +58,13 @@ public:
     id<MTLCommandBuffer> commandBuffer() const { return m_commandBuffer; }
 
     Device& device() const { return m_device; }
+    void makeInvalid();
 
 private:
     CommandBuffer(id<MTLCommandBuffer>, Device&);
     CommandBuffer(Device&);
 
-    const id<MTLCommandBuffer> m_commandBuffer { nil };
+    id<MTLCommandBuffer> m_commandBuffer { nil };
 
     const Ref<Device> m_device;
 };

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -48,6 +48,11 @@ void CommandBuffer::setLabel(String&& label)
     m_commandBuffer.label = label;
 }
 
+void CommandBuffer::makeInvalid()
+{
+    m_commandBuffer = nil;
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -59,7 +59,7 @@ public:
     ~Queue();
 
     void onSubmittedWorkDone(CompletionHandler<void(WGPUQueueWorkDoneStatus)>&& callback);
-    void submit(Vector<std::reference_wrapper<const CommandBuffer>>&& commands);
+    void submit(Vector<std::reference_wrapper<CommandBuffer>>&& commands);
     void writeBuffer(const Buffer&, uint64_t bufferOffset, const void* data, size_t);
     void writeTexture(const WGPUImageCopyTexture& destination, const void* data, size_t dataSize, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize);
     void setLabel(String&&);
@@ -78,7 +78,7 @@ private:
     Queue(id<MTLCommandQueue>, Device&);
     Queue(Device&);
 
-    bool validateSubmit(const Vector<std::reference_wrapper<const CommandBuffer>>&) const;
+    bool validateSubmit(const Vector<std::reference_wrapper<CommandBuffer>>&) const;
     bool validateWriteBuffer(const Buffer&, uint64_t bufferOffset, size_t) const;
 
     void ensureBlitCommandEncoder();


### PR DESCRIPTION
#### a965533e01fa734237987cad947b3ef7c651f0c7
<pre>
[WebGPU] Queue::commitMTLCommandBuffer will fail if command buffer was already committed
<a href="https://bugs.webkit.org/show_bug.cgi?id=264339">https://bugs.webkit.org/show_bug.cgi?id=264339</a>
&lt;radar://117851924&gt;

Reviewed by Tadeu Zagallo.

Ensure that a command buffer doesn&apos;t get submitted twice and generate
a validation error if we would attempt to do so.

* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::makeInvalid):
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::validateSubmit const):
(WebGPU::Queue::commitMTLCommandBuffer):
(WebGPU::Queue::submit):
(wgpuQueueSubmit):

Canonical link: <a href="https://commits.webkit.org/270361@main">https://commits.webkit.org/270361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dce0f223bc08ee3833e38614c5fbbb7f09149254

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27316 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23125 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23364 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27895 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2450 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28813 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26654 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/693 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3752 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2841 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2736 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->