### PR TITLE
Align with Chrome on SpeechRecognition policy handling

### DIFF
--- a/LayoutTests/http/tests/media/media-stream/resources/speechRecognition-iframe.html
+++ b/LayoutTests/http/tests/media/media-stream/resources/speechRecognition-iframe.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<body>
+<script>
+    var isRunning = true;
+    function reportResult(result)
+    {
+        if (!isRunning)
+            return;
+        isRunning = false;
+        parent.postMessage(result, "*");
+    }
+
+    onload = () => {
+        const recognition = new webkitSpeechRecognition();
+        recognition.onerror = () => {
+            reportResult("error");
+        }
+        recognition.onstart = () => {
+            reportResult("start");
+        }
+        recognition.start();
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/media-stream/speech-recognition-iframe-allow-attribute-expected.txt
+++ b/LayoutTests/http/tests/media/media-stream/speech-recognition-iframe-allow-attribute-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS speech recognition in iframe without microphone feature policy should fail
+PASS speech recognition in iframe with microphone feature policy should start
+

--- a/LayoutTests/http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html
+++ b/LayoutTests/http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+    <iframe id="none"></iframe>
+    <iframe id="microphone" allow="microphone"></iframe>
+
+    <script>
+promise_test(async () => {
+   none.src = "http://localhost:8000/media/media-stream/resources/speechRecognition-iframe.html";
+   const result = await new Promise((resolve, reject) => {
+       window.addEventListener("message", event => resolve(event.data));
+       setTimeout(() => reject("time out"), 5000);
+   });
+   assert_equals(result, "error");
+}, "speech recognition in iframe without microphone feature policy should fail");
+
+promise_test(async () => {
+   microphone.src = "http://localhost:8000/media/media-stream/resources/speechRecognition-iframe.html";
+   const result = await new Promise((resolve, reject) => {
+       window.addEventListener("message", event => resolve(event.data));
+       setTimeout(() => reject("time out"), 5000);
+   });
+   assert_equals(result, "start");
+}, "speech recognition in iframe with microphone feature policy should start");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2546,6 +2546,7 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html [ WontFix ]
 
 # Missing WebSpeech implementation
 webkit.org/b/136224 fast/speechrecognition [ Skip ]
+http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html [ Skip ]
 
 # Depends on HTTP Live Streaming (non-supported in non-Apple ports).
 fast/url/data-url-mediatype.html [ Skip ]

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -29,6 +29,7 @@
 #include "ClientOrigin.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "FeaturePolicy.h"
 #include "FrameDestructionObserverInlines.h"
 #include "Page.h"
 #include "SpeechRecognitionError.h"
@@ -77,6 +78,11 @@ ExceptionOr<void> SpeechRecognition::startRecognition()
         return Exception { UnknownError, "Recognition is not in a valid frame"_s };
 
     auto optionalFrameIdentifier = document->frameID();
+    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, document.get(), LogFeaturePolicyFailure::No)) {
+        didError({ SpeechRecognitionErrorType::NotAllowed, "Permission is denied"_s });
+        return { };
+    }
+
     auto frameIdentifier = optionalFrameIdentifier ? *optionalFrameIdentifier : FrameIdentifier { };
     m_connection->start(identifier(), m_lang, m_continuous, m_interimResults, m_maxAlternatives, ClientOrigin { document->topOrigin().data(), document->securityOrigin().data() }, frameIdentifier);
     m_state = State::Starting;


### PR DESCRIPTION
#### 7d0464cc2e949ffdee3232aff7f358d3996d06f1
<pre>
Align with Chrome on SpeechRecognition policy handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=264338">https://bugs.webkit.org/show_bug.cgi?id=264338</a>
<a href="https://rdar.apple.com/117598690">rdar://117598690</a>

Reviewed by Jean-Yves Avenard.

To improve interop, we apply microphone feature policy to SpeechRecognition.
Covered by newly added test.

* LayoutTests/http/tests/media/media-stream/resources/speechRecognition-iframe.html: Added.
* LayoutTests/http/tests/media/media-stream/speech-recognition-iframe-allow-attribute-expected.txt: Added.
* LayoutTests/http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::startRecognition):

Canonical link: <a href="https://commits.webkit.org/270432@main">https://commits.webkit.org/270432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cd376dda2bac7c77f1d3b4ca6ce2b851fcc1bd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1549 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28206 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22953 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26881 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/944 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22701 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6104 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->