### PR TITLE
Remove diagnostic logging from CachedResourceLoader

### DIFF
--- a/Source/WebCore/page/DiagnosticLoggingKeys.cpp
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.cpp
@@ -168,24 +168,9 @@ String DiagnosticLoggingKeys::noKey()
     return "no"_s;
 }
 
-String DiagnosticLoggingKeys::noCacheKey()
-{
-    return "noCache"_s;
-}
-
-String DiagnosticLoggingKeys::noStoreKey()
-{
-    return "noStore"_s;
-}
-
 String DiagnosticLoggingKeys::nonVisibleStateKey()
 {
     return "nonVisibleState"_s;
-}
-
-String DiagnosticLoggingKeys::notInMemoryCacheKey()
-{
-    return "notInMemoryCache"_s;
 }
 
 String DiagnosticLoggingKeys::backForwardCacheKey()
@@ -228,11 +213,6 @@ String DiagnosticLoggingKeys::isErrorPageKey()
     return "isErrorPage"_s;
 }
 
-String DiagnosticLoggingKeys::isExpiredKey()
-{
-    return "isExpired"_s;
-}
-
 String DiagnosticLoggingKeys::isReloadIgnoringCacheDataKey()
 {
     return "isReloadIgnoringCacheData"_s;
@@ -251,11 +231,6 @@ String DiagnosticLoggingKeys::httpsNoStoreKey()
 String DiagnosticLoggingKeys::imageKey()
 {
     return "image"_s;
-}
-
-String DiagnosticLoggingKeys::inMemoryCacheKey()
-{
-    return "inMemoryCache"_s;
 }
 
 String DiagnosticLoggingKeys::inactiveKey()
@@ -490,11 +465,6 @@ String DiagnosticLoggingKeys::retrievalKey()
     return "retrieval"_s;
 }
 
-String DiagnosticLoggingKeys::revalidatingKey()
-{
-    return "revalidating"_s;
-}
-
 String DiagnosticLoggingKeys::reloadFromOriginKey()
 {
     return "reloadFromOrigin"_s;
@@ -663,41 +633,6 @@ String DiagnosticLoggingKeys::unsuspendableDOMObjectKey()
 String DiagnosticLoggingKeys::unusedKey()
 {
     return "unused"_s;
-}
-
-String DiagnosticLoggingKeys::unusedReasonCredentialSettingsKey()
-{
-    return "unused.reason.credentialSettings"_s;
-}
-
-String DiagnosticLoggingKeys::unusedReasonErrorKey()
-{
-    return "unused.reason.error"_s;
-}
-
-String DiagnosticLoggingKeys::unusedReasonMustRevalidateNoValidatorKey()
-{
-    return "unused.reason.mustRevalidateNoValidator"_s;
-}
-
-String DiagnosticLoggingKeys::unusedReasonNoStoreKey()
-{
-    return "unused.reason.noStore"_s;
-}
-
-String DiagnosticLoggingKeys::unusedReasonRedirectChainKey()
-{
-    return "unused.reason.redirectChain"_s;
-}
-
-String DiagnosticLoggingKeys::unusedReasonReloadKey()
-{
-    return "unused.reason.reload"_s;
-}
-
-String DiagnosticLoggingKeys::unusedReasonTypeMismatchKey()
-{
-    return "unused.reason.typeMismatch"_s;
 }
 
 String DiagnosticLoggingKeys::usedKey()

--- a/Source/WebCore/page/DiagnosticLoggingKeys.h
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.h
@@ -77,7 +77,6 @@ public:
     static String fontKey();
     static String httpsNoStoreKey();
     static String imageKey();
-    static String inMemoryCacheKey();
     WEBCORE_EXPORT static String inactiveKey();
     WEBCORE_EXPORT static String internalErrorKey();
     WEBCORE_EXPORT static String invalidSessionIDKey();
@@ -85,7 +84,6 @@ public:
     WEBCORE_EXPORT static String isConditionalRequestKey();
     static String isDisabledKey();
     static String isErrorPageKey();
-    static String isExpiredKey();
     WEBCORE_EXPORT static String isReloadIgnoringCacheDataKey();
     static String loadingKey();
     static String isLoadingKey();
@@ -105,14 +103,11 @@ public:
     WEBCORE_EXPORT static String networkProcessCrashedKey();
     WEBCORE_EXPORT static String neverSeenBeforeKey();
     static String noKey();
-    static String noCacheKey();
     static String noCurrentHistoryItemKey();
     static String noDocumentLoaderKey();
     WEBCORE_EXPORT static String noLongerInCacheKey();
-    static String noStoreKey();
     WEBCORE_EXPORT static String nonVisibleStateKey();
     WEBCORE_EXPORT static String notHTTPFamilyKey();
-    static String notInMemoryCacheKey();
     WEBCORE_EXPORT static String occurredKey();
     WEBCORE_EXPORT static String otherKey();
     static String backForwardCacheKey();
@@ -142,7 +137,6 @@ public:
     static String resourceResponseSourceKey();
     WEBCORE_EXPORT static String retrievalKey();
     WEBCORE_EXPORT static String retrievalRequestKey();
-    WEBCORE_EXPORT static String revalidatingKey();
     static String sameLoadKey();
     static String scriptKey();
     static String serviceWorkerKey();
@@ -166,13 +160,6 @@ public:
     WEBCORE_EXPORT static String unsupportedHTTPMethodKey();
     static String unsuspendableDOMObjectKey();
     WEBCORE_EXPORT static String unusedKey();
-    static String unusedReasonCredentialSettingsKey();
-    static String unusedReasonErrorKey();
-    static String unusedReasonMustRevalidateNoValidatorKey();
-    static String unusedReasonNoStoreKey();
-    static String unusedReasonRedirectChainKey();
-    static String unusedReasonReloadKey();
-    static String unusedReasonTypeMismatchKey();
     static String usedKey();
     WEBCORE_EXPORT static String userZoomActionKey();
     WEBCORE_EXPORT static String varyingHeaderMismatchKey();


### PR DESCRIPTION
#### c1ff3177cf14b7662ac2ec9ec59930604ac5c075
<pre>
Remove diagnostic logging from CachedResourceLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=264340">https://bugs.webkit.org/show_bug.cgi?id=264340</a>
<a href="https://rdar.apple.com/118061900">rdar://118061900</a>

Reviewed by Chris Dumez.

These loggings are no longer used. And it turned out that they are very
costly when we are just hitting memory-cached resource path. We are sampling
with 5%, which means we hit this every 20 image elements for example.
This patch drops it from CachedResourceLoader. We should consider removing
the other loggings too in the subsequent patch.

* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::determineRevalidationPolicy const):
(WebCore::logMemoryCacheResourceRequest): Deleted.
(WebCore::logRevalidation): Deleted.
(WebCore::logResourceRevalidationDecision): Deleted.
* Source/WebCore/page/DiagnosticLoggingKeys.cpp:
(WebCore::DiagnosticLoggingKeys::noCacheKey): Deleted.
(WebCore::DiagnosticLoggingKeys::noStoreKey): Deleted.
(WebCore::DiagnosticLoggingKeys::notInMemoryCacheKey): Deleted.
(WebCore::DiagnosticLoggingKeys::isExpiredKey): Deleted.
(WebCore::DiagnosticLoggingKeys::inMemoryCacheKey): Deleted.
(WebCore::DiagnosticLoggingKeys::reloadKey): Deleted.
(WebCore::DiagnosticLoggingKeys::revalidatingKey): Deleted.
(WebCore::DiagnosticLoggingKeys::unusedReasonCredentialSettingsKey): Deleted.
(WebCore::DiagnosticLoggingKeys::unusedReasonErrorKey): Deleted.
(WebCore::DiagnosticLoggingKeys::unusedReasonMustRevalidateNoValidatorKey): Deleted.
(WebCore::DiagnosticLoggingKeys::unusedReasonNoStoreKey): Deleted.
(WebCore::DiagnosticLoggingKeys::unusedReasonRedirectChainKey): Deleted.
(WebCore::DiagnosticLoggingKeys::unusedReasonReloadKey): Deleted.
(WebCore::DiagnosticLoggingKeys::unusedReasonTypeMismatchKey): Deleted.
* Source/WebCore/page/DiagnosticLoggingKeys.h:

Canonical link: <a href="https://commits.webkit.org/270338@main">https://commits.webkit.org/270338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83a513c13866787cbc4837c4247d0d12ace23ab4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1194 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2775 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27910 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22699 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26650 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2856 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3214 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2751 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->