### PR TITLE
Update WebGPU code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -215,11 +215,10 @@ wpe/ @WebKit/glib-reviewers @zdobersek
 # ================================================================================
 # WebGPU
 
-/Source/WebCore/Modules/webgpu @litherum @mwyrzykowski
-/Source/WebCore/PAL/pal/graphics/WebGPU @litherum @mwyrzykowski
-/Source/WebGPU @litherum @mwyrzykowski
-/Source/WebKit/Shared/WebGPU @litherum @mwyrzykowski
-/Source/WebKit/WebProcess/GPU/graphics/WebGPU @litherum @mwyrzykowski
-/Source/WebKit/GPUProcess/graphics/WebGPU @litherum @mwyrzykowski
+/Source/WebCore/Modules/webgpu @tadeuzagallo @mwyrzykowski
+/Source/WebGPU @tadeuzagallo @mwyrzykowski
+/Source/WebKit/Shared/WebGPU @tadeuzagallo @mwyrzykowski
+/Source/WebKit/WebProcess/GPU/graphics/WebGPU @tadeuzagallo @mwyrzykowski
+/Source/WebKit/GPUProcess/graphics/WebGPU @tadeuzagallo @mwyrzykowski
 
-/Source/WebGPU/WGSL @litherum @djg @tadeuzagallo
+/Source/WebGPU/WGSL @mwyrzykowski @djg @tadeuzagallo


### PR DESCRIPTION
#### f10120537f7c23f4986a509a2ee58dd480b9ffb6
<pre>
Update WebGPU code owners file
<a href="https://bugs.webkit.org/show_bug.cgi?id=264342">https://bugs.webkit.org/show_bug.cgi?id=264342</a>
&lt;<a href="https://rdar.apple.com/problem/118062239">rdar://problem/118062239</a>&gt;

Reviewed by Alexey Proskuryakov.

Myles is no longer reviewing patches, update the default assignees for PRs.

* .github/CODEOWNERS:

Canonical link: <a href="https://commits.webkit.org/270336@main">https://commits.webkit.org/270336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64f884fe283ef181ae0f55765a9b4fd5abd3d981

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23128 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1181 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27898 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2452 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22999 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26648 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/695 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3755 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6040 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2844 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2739 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->