### PR TITLE
Make UnifiedPDFEnabled setting work on iOS

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6744,6 +6744,7 @@ UnifiedPDFEnabled:
   category: security
   humanReadableName: "Unified PDF Viewer"
   humanReadableDescription: "Enable Unified PDF Viewer"
+  condition: ENABLE(UNIFIED_PDF)
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -53,12 +53,6 @@ public:
 
     virtual void layerHostingStrategyDidChange() { }
 
-#if PLATFORM(IOS_FAMILY)
-    virtual bool willProvidePluginLayer() const { return false; }
-    virtual void attachPluginLayer() { }
-    virtual void detachPluginLayer() { }
-#endif
-
     virtual bool scroll(ScrollDirection, ScrollGranularity) { return false; }
     virtual ScrollPosition scrollPositionForTesting() const { return { }; }
 

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -107,12 +107,7 @@ bool RenderEmbeddedObject::requiresAcceleratedCompositing() const
     auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
     if (!pluginViewBase)
         return false;
-#if PLATFORM(IOS_FAMILY)
-    // The timing of layer creation is different on the phone, since the plugin can only be manipulated from the main thread.
-    return pluginViewBase->willProvidePluginLayer();
-#else
     return pluginViewBase->layerHostingStrategy() != PluginLayerHostingStrategy::None;
-#endif
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2387,14 +2387,6 @@ void RenderLayer::beginTransparencyLayers(GraphicsContext& context, const LayerP
     }
 }
 
-#if PLATFORM(IOS_FAMILY)
-void RenderLayer::willBeDestroyed()
-{
-    if (RenderLayerBacking* layerBacking = backing())
-        layerBacking->layerWillBeDestroyed();
-}
-#endif
-
 bool RenderLayer::isDescendantOf(const RenderLayer& layer) const
 {
     for (auto* ancestor = this; ancestor; ancestor = ancestor->parent()) {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -167,10 +167,6 @@ public:
     WEBCORE_EXPORT RenderLayerScrollableArea* scrollableArea() const;
     WEBCORE_EXPORT RenderLayerScrollableArea* ensureLayerScrollableArea();
 
-#if PLATFORM(IOS_FAMILY)
-    // Called before the renderer's widget (if any) has been nulled out.
-    void willBeDestroyed();
-#endif
     String name() const;
 
     Page& page() const { return renderer().page(); }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -582,16 +582,6 @@ bool RenderLayerBacking::shouldSetContentsDisplayDelegate() const
 }
 
 #if PLATFORM(IOS_FAMILY)
-void RenderLayerBacking::layerWillBeDestroyed()
-{
-    auto& renderer = this->renderer();
-    if (RenderLayerCompositor::isCompositedPlugin(renderer)) {
-        auto* pluginViewBase = downcast<PluginViewBase>(downcast<RenderWidget>(renderer).widget());
-        if (pluginViewBase && m_graphicsLayer->contentsLayerForMedia())
-            pluginViewBase->detachPluginLayer();
-    }
-}
-
 bool RenderLayerBacking::needsIOSDumpRenderTreeMainFrameRenderViewLayerIsAlwaysOpaqueHack(const GraphicsLayer& layer) const
 {
     if (m_isMainFrameRenderViewLayer && IOSApplication::isDumpRenderTree()) {
@@ -1155,13 +1145,6 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         if (!pluginViewBase)
             return;
 
-#if PLATFORM(IOS_FAMILY)
-        // FIXME: This code can probably be removed: webkit.org/b/262808
-        if (pluginViewBase && !m_graphicsLayer->contentsLayerForMedia()) {
-            pluginViewBase->detachPluginLayer();
-            pluginViewBase->attachPluginLayer();
-        }
-#else
         switch (pluginViewBase->layerHostingStrategy()) {
         case PluginLayerHostingStrategy::None:
             break;
@@ -1172,7 +1155,6 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
             // layer is parented in RenderLayerCompositor::updateBackingAndHierarchy().
             break;
         }
-#endif
     };
 
     if (RenderLayerCompositor::isCompositedPlugin(renderer()))

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -62,10 +62,6 @@ public:
     explicit RenderLayerBacking(RenderLayer&);
     ~RenderLayerBacking();
 
-#if PLATFORM(IOS_FAMILY)
-    void layerWillBeDestroyed();
-#endif
-
     // Do cleanup while layer->backing() is still valid.
     void willBeDestroyed();
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -100,9 +100,6 @@ void RenderLayerModelObject::destroyLayer()
 {
     ASSERT(!hasLayer());
     ASSERT(m_layer);
-#if PLATFORM(IOS_FAMILY)
-    m_layer->willBeDestroyed();
-#endif
     m_layer = nullptr;
 }
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -103,11 +103,6 @@ RenderWidget::RenderWidget(Type type, HTMLFrameOwnerElement& element, RenderStyl
 
 void RenderWidget::willBeDestroyed()
 {
-#if PLATFORM(IOS_FAMILY)
-    if (hasLayer())
-        layer()->willBeDestroyed();
-#endif
-
     if (AXObjectCache* cache = document().existingAXObjectCache()) {
         cache->childrenChanged(this->parent());
         cache->remove(this);

--- a/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "WKPDFView.h"
+#import "WKPreferencesInternal.h"
 #import "WKUSDPreviewView.h"
 #import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
@@ -51,9 +52,10 @@
         return nil;
 
 #if ENABLE(WKPDFVIEW)
-    // FIXME: When the UnifiedPDF Plugin is available, we need to undo this registration.
-    for (auto& type : WebCore::MIMETypeRegistry::pdfMIMETypes())
-        [self registerProvider:[WKPDFView class] forMIMEType:@(type.characters())];
+    if (!configuration.preferences->_preferences->unifiedPDFEnabled()) {
+        for (auto& type : WebCore::MIMETypeRegistry::pdfMIMETypes())
+            [self registerProvider:[WKPDFView class] forMIMEType:@(type.characters())];
+    }
 #endif
 
 #if USE(SYSTEM_PREVIEW)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1732,49 +1732,6 @@ private:
     }
 };
 
-#if PLATFORM(IOS_FAMILY)
-@interface WAKView (UIKitSecretsWebKitKnowsAboutSeeUIWebPlugInView)
-- (PlatformLayer *)pluginLayer;
-- (BOOL)willProvidePluginLayer;
-- (void)attachPluginLayer;
-- (void)detachPluginLayer;
-@end
-
-class PluginWidgetIOS : public PluginWidget {
-public:
-    PluginWidgetIOS(WAKView *view)
-        : PluginWidget(view)
-    {
-    }
-
-    virtual PlatformLayer* platformLayer() const
-    {
-        if (![platformWidget() respondsToSelector:@selector(pluginLayer)])
-            return nullptr;
-
-        return [platformWidget() pluginLayer];   
-    }
-
-    virtual bool willProvidePluginLayer() const
-    {
-        return [platformWidget() respondsToSelector:@selector(willProvidePluginLayer)]
-            && [platformWidget() willProvidePluginLayer];
-    }
-
-    virtual void attachPluginLayer()
-    {
-        if ([platformWidget() respondsToSelector:@selector(attachPluginLayer)])
-            [platformWidget() attachPluginLayer];
-    }
-
-    virtual void detachPluginLayer()
-    {
-        if ([platformWidget() respondsToSelector:@selector(detachPluginLayer)])
-            [platformWidget() detachPluginLayer];
-    }
-};
-#endif // PLATFORM(IOS_FAMILY)
-
 static bool shouldBlockPlugin(WebBasePluginPackage *)
 {
     return true;
@@ -1876,11 +1833,7 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(const WebCore::IntSiz
     }
     
     ASSERT(view);
-#if PLATFORM(IOS_FAMILY)
-    return adoptRef(new PluginWidgetIOS(view));
-#else
     return adoptRef(new PluginWidget(view));
-#endif
 
     END_BLOCK_OBJC_EXCEPTIONS
 


### PR DESCRIPTION
#### e2dca80373448e8bc6604c065ebf86d6244ee563
<pre>
Make UnifiedPDFEnabled setting work on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=264341">https://bugs.webkit.org/show_bug.cgi?id=264341</a>
<a href="https://rdar.apple.com/118062175">rdar://118062175</a>

Reviewed by Richard Robinson.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
Don&apos;t show the Unified PDF preference if the compile-time flag isn&apos;t enabled.

* Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm:
(-[WKWebViewContentProviderRegistry initWithConfiguration:]):
Don&apos;t register WKPDFView as a custom content provider when Unified PDF is enabled.

* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::willProvidePluginLayer const): Deleted.
(WebCore::PluginViewBase::attachPluginLayer): Deleted.
(WebCore::PluginViewBase::detachPluginLayer): Deleted.
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::requiresAcceleratedCompositing const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::layerWillBeDestroyed): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::createPlugin):
(PluginWidgetIOS::PluginWidgetIOS): Deleted.
(PluginWidgetIOS::platformLayer const): Deleted.
(PluginWidgetIOS::willProvidePluginLayer const): Deleted.
(PluginWidgetIOS::attachPluginLayer): Deleted.
(PluginWidgetIOS::detachPluginLayer): Deleted.
Remove WebKitLegacy-specific plugin compositing code, which is both unused
and conflicting with our desire to use the Unified PDF plugin in modern WebKit
on iOS. Removing this will make iOS WebKit respect layerHostingStrategy(), which
the Unified PDF plugin depends on.

Canonical link: <a href="https://commits.webkit.org/270339@main">https://commits.webkit.org/270339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bad9488d1a3c77802e0b2e1e17bf81a83fbcb74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1184 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27901 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2453 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22702 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21923 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26647 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24445 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/698 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31869 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3758 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6972 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2847 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2742 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->