### PR TITLE
Pass parent frame ID and timestamp to webNavigation handlers

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -261,7 +261,7 @@ WebExtensionController::WebExtensionSet WebExtensionController::extensions() con
 
 // MARK: Web Navigation
 
-void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, const URL& targetURL)
+void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& targetURL, WallTime timestamp)
 {
     auto eventType = WebExtensionEventListenerType::WebNavigationOnBeforeNavigate;
     auto listenerTypes = WebExtensionContext::EventListenerTypeSet { eventType };
@@ -275,16 +275,16 @@ void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentif
             continue;
 
         context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, targetURL));
+            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, parentFrameID, targetURL, timestamp));
         });
     }
 }
 
-void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, const URL& frameURL)
+void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
 {
-    auto completedEventType = WebExtensionEventListenerType::WebNavigationOnCompleted;
+    auto committedEventType = WebExtensionEventListenerType::WebNavigationOnCommitted;
     auto contentLoadedtype = WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded;
-    auto listenerTypes = WebExtensionContext::EventListenerTypeSet { completedEventType, contentLoadedtype };
+    auto listenerTypes = WebExtensionContext::EventListenerTypeSet { committedEventType, contentLoadedtype };
 
     for (auto& context : m_extensionContexts) {
         if (!context->hasPermission(frameURL))
@@ -303,13 +303,13 @@ void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID
             continue;
 
         context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(completedEventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(completedEventType, tab->identifier(), frameID, frameURL));
-            context->sendToProcessesForEvent(contentLoadedtype, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(contentLoadedtype, tab->identifier(), frameID, frameURL));
+            context->sendToProcessesForEvent(committedEventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(committedEventType, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
+            context->sendToProcessesForEvent(contentLoadedtype, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(contentLoadedtype, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
         });
     }
 }
 
-void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, const URL& frameURL)
+void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
 {
     auto eventType = WebExtensionEventListenerType::WebNavigationOnCompleted;
     auto listenerTypes = WebExtensionContext::EventListenerTypeSet { eventType };
@@ -323,12 +323,12 @@ void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID
             continue;
 
         context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, frameURL));
+            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
         });
     }
 }
 
-void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, const URL& frameURL)
+void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
 {
     auto eventType = WebExtensionEventListenerType::WebNavigationOnErrorOccurred;
     auto listenerTypes = WebExtensionContext::EventListenerTypeSet { eventType };
@@ -342,7 +342,7 @@ void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, 
             continue;
 
         context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, frameURL));
+            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
         });
     }
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -133,10 +133,10 @@ private:
     void removeUserContentController(WebUserContentControllerProxy&);
 
     // Web Navigation
-    void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, const URL&);
-    void didCommitLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, const URL&);
-    void didFinishLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, const URL&);
-    void didFailLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, const URL&);
+    void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didCommitLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didFinishLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didFailLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
 
     Ref<WebExtensionControllerConfiguration> m_configuration;
     WebExtensionControllerIdentifier m_identifier;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -28,10 +28,10 @@
 messages -> WebExtensionController {
 
     // webNavigation support.
-    DidStartProvisionalLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, URL targetURL)
-    DidCommitLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, URL targetURL)
-    DidFinishLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, URL targetURL)
-    DidFailLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, URL targetURL)
+    DidStartProvisionalLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
+    DidCommitLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
+    DidFinishLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
+    DidFailLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
 
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -99,14 +99,15 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onErrorOccurred
     return *m_onErrorOccurredEvent;
 }
 
-void WebExtensionContextProxy::dispatchWebNavigationEvent(WebExtensionEventListenerType type, WebExtensionTabIdentifier tabID, WebExtensionFrameIdentifier frameID, const URL& frameURL)
+void WebExtensionContextProxy::dispatchWebNavigationEvent(WebExtensionEventListenerType type, WebExtensionTabIdentifier tabID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
 {
     auto *navigationDetails = @{
         @"url": (NSString *)frameURL.string(),
 
-        // FIXME: <https://webkit.org/b/260160> We should be passing more arguments here.
         @"tabId": @(toWebAPI(tabID)),
-        @"frameId": @(toWebAPI(frameID))
+        @"frameId": @(toWebAPI(frameID)),
+        @"parentFrameId": @(toWebAPI(parentFrameID)),
+        @"timeStamp": @(timestamp.approximateWallTime().secondsSinceEpoch().milliseconds())
     };
 
     enumerateNamespaceObjects([&](auto& namespaceObject) {

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -108,22 +108,26 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
 
 void WebExtensionControllerProxy::didStartProvisionalLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
 {
-    WebProcess::singleton().send(Messages::WebExtensionController::DidStartProvisionalLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), url), identifier());
+    WebExtensionFrameIdentifier parentFrameID = frame.isMainFrame() ? WebExtensionFrameConstants::NoneIdentifier : toWebExtensionFrameIdentifier(*frame.parentFrame());
+    WebProcess::singleton().send(Messages::WebExtensionController::DidStartProvisionalLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), parentFrameID, url, WallTime::now()), identifier());
 }
 
 void WebExtensionControllerProxy::didCommitLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
 {
-    WebProcess::singleton().send(Messages::WebExtensionController::DidCommitLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), url), identifier());
+    WebExtensionFrameIdentifier parentFrameID = frame.isMainFrame() ? WebExtensionFrameConstants::NoneIdentifier : toWebExtensionFrameIdentifier(*frame.parentFrame());
+    WebProcess::singleton().send(Messages::WebExtensionController::DidCommitLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), parentFrameID, url, WallTime::now()), identifier());
 }
 
 void WebExtensionControllerProxy::didFinishLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
 {
-    WebProcess::singleton().send(Messages::WebExtensionController::DidFinishLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), url), identifier());
+    WebExtensionFrameIdentifier parentFrameID = frame.isMainFrame() ? WebExtensionFrameConstants::NoneIdentifier : toWebExtensionFrameIdentifier(*frame.parentFrame());
+    WebProcess::singleton().send(Messages::WebExtensionController::DidFinishLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), parentFrameID, url, WallTime::now()), identifier());
 }
 
 void WebExtensionControllerProxy::didFailLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
 {
-    WebProcess::singleton().send(Messages::WebExtensionController::DidFailLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), url), identifier());
+    WebExtensionFrameIdentifier parentFrameID = frame.isMainFrame() ? WebExtensionFrameConstants::NoneIdentifier : toWebExtensionFrameIdentifier(*frame.parentFrame());
+    WebProcess::singleton().send(Messages::WebExtensionController::DidFailLoadForFrame(page.webPageProxyIdentifier(), toWebExtensionFrameIdentifier(frame), parentFrameID, url, WallTime::now()), identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -155,7 +155,7 @@ private:
     void dispatchTabsRemovedEvent(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, WebExtensionContext::WindowIsClosing);
 
     // Web Navigation
-    void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebExtensionTabIdentifier, WebExtensionFrameIdentifier, const URL&);
+    void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebExtensionTabIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
 
     // Windows
     void dispatchWindowsEvent(WebExtensionEventListenerType, const std::optional<WebExtensionWindowParameters>&);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -62,7 +62,7 @@ messages -> WebExtensionContextProxy {
     DispatchTabsRemovedEvent(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, WebKit::WebExtensionContext::WindowIsClosing windowIsClosing)
 
     // Web Navigation
-    DispatchWebNavigationEvent(WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionTabIdentifier tabID, WebKit::WebExtensionFrameIdentifier frameID, URL targetURL)
+    DispatchWebNavigationEvent(WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionTabIdentifier tabID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
 
     // Windows
     DispatchWindowsEvent(WebKit::WebExtensionEventListenerType type, std::optional<WebKit::WebExtensionWindowParameters> windowParameters)


### PR DESCRIPTION
#### dabbc74d29e07c7a33ceb0373d72e7ea107f178a
<pre>
Pass parent frame ID and timestamp to webNavigation handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=264345">https://bugs.webkit.org/show_bug.cgi?id=264345</a>
<a href="https://rdar.apple.com/102820594">rdar://102820594</a>

Reviewed by Timothy Hatcher.

When firing the webNavigation events - make sure that we include additional information for parity with Safari. This includes:
- The parent frame ID (or none if the event is being fired for a main frame)
- The timestamp of the event

This information is all sent from WebExtensionControllerProxyCocoa -&gt; WebExtensionControllerCocoa -&gt; WebExtensionAPIWebNavigationCocoa.

This PR also fixes a bug where we were firing the wrong event (completed instead of committed in didCommitLoadForFrame).

It also fixes an issue with the web navigation tests (where we weren&apos;t spinning the run loop after loading a URL), and adding a test
verifying that all web navigation events are fired in a page load.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame): Pass the parent frame ID and timestamp along.
(WebKit::WebExtensionController::didCommitLoadForFrame): Ditto (and make sure we send the correct event!)
(WebKit::WebExtensionController::didFinishLoadForFrame): Ditto.
(WebKit::WebExtensionController::didFailLoadForFrame): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchWebNavigationEvent): Include the parent frame ID and timestamp in the details dictionary.
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::didStartProvisionalLoadForFrame): Pass the parent frame ID and timestamp along.
(WebKit::WebExtensionControllerProxy::didCommitLoadForFrame): Ditto.
(WebKit::WebExtensionControllerProxy::didFinishLoadForFrame): Ditto.
(WebKit::WebExtensionControllerProxy::didFailLoadForFrame): Ditto.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm:
(TestWebKitAPI::TEST): Fix the tests by spinning the run loop, and add some new tests.

Canonical link: <a href="https://commits.webkit.org/270345@main">https://commits.webkit.org/270345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72bed9f8a0ba897d52897e00c2acee5b752787c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23152 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1206 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27922 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22715 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26662 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/717 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3779 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6048 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2868 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2762 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->