### PR TITLE
Remove remaining WebGL diagnostic logging

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -659,13 +659,10 @@ WebGLRenderingContextBase::WebGLRenderingContextBase(CanvasBase& canvas, WebGLCo
     , m_generatedImageCache(4)
     , m_attributes(attributes)
     , m_numGLErrorsToConsoleAllowed(canvas.scriptExecutionContext()->settingsValues().webGLErrorsToConsoleEnabled ? maxGLErrorsAllowedToConsole : 0)
-    , m_checkForContextLossHandlingTimer(*this, &WebGLRenderingContextBase::checkForContextLossHandling)
 #if ENABLE(WEBXR)
     , m_isXRCompatible(attributes.xrCompatible)
 #endif
 {
-    if (htmlCanvas())
-        m_checkForContextLossHandlingTimer.startOneShot(checkContextLossHandlingDelay);
 }
 
 WebGLCanvas WebGLRenderingContextBase::canvas()
@@ -687,25 +684,6 @@ OffscreenCanvas* WebGLRenderingContextBase::offscreenCanvas()
     return &downcast<OffscreenCanvas>(base);
 }
 #endif
-
-// We check for context loss handling after a few seconds to give the JS a chance to register the event listeners
-// and to discard temporary GL contexts (e.g. feature detection).
-void WebGLRenderingContextBase::checkForContextLossHandling()
-{
-    auto* canvas = htmlCanvas();
-    if (!canvas)
-        return;
-
-    if (!canvas->renderer())
-        return;
-
-    auto* page = canvas->document().page();
-    if (!page)
-        return;
-
-    bool handlesContextLoss = canvas->hasEventListeners(eventNames().webglcontextlostEvent) && canvas->hasEventListeners(eventNames().webglcontextrestoredEvent);
-    page->diagnosticLoggingClient().logDiagnosticMessage(DiagnosticLoggingKeys::pageHandlesWebGLContextLossKey(), handlesContextLoss ? DiagnosticLoggingKeys::yesKey() : DiagnosticLoggingKeys::noKey(), ShouldSample::No);
-}
 
 void WebGLRenderingContextBase::initializeNewContext(Ref<GraphicsContextGL> context)
 {

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1011,8 +1011,6 @@ private:
     void maybeRestoreContextSoon(Seconds timeout = 0_s);
     void maybeRestoreContext();
 
-    void checkForContextLossHandling();
-
     void activityStateDidChange(OptionSet<ActivityState> oldActivityState, OptionSet<ActivityState> newActivityState) override;
 
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, ImageBitmap& source);
@@ -1029,7 +1027,6 @@ private:
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, WebCodecsVideoFrame& source);
 #endif
 
-    Timer m_checkForContextLossHandlingTimer;
     bool m_isSuspended { false };
 
 #if ENABLE(WEBXR)

--- a/Source/WebCore/page/DiagnosticLoggingKeys.cpp
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.cpp
@@ -63,11 +63,6 @@ String DiagnosticLoggingKeys::postPageBackgroundingMemoryUsageKey()
     return "postPageBackgroundingMemoryUsage"_s;
 }
 
-String DiagnosticLoggingKeys::pageHandlesWebGLContextLossKey()
-{
-    return "pageHandlesWebGLContextLoss"_s;
-}
-
 String DiagnosticLoggingKeys::postPageLoadCPUUsageKey()
 {
     return "postPageLoadCPUUsage"_s;
@@ -233,11 +228,6 @@ String DiagnosticLoggingKeys::imageKey()
     return "image"_s;
 }
 
-String DiagnosticLoggingKeys::inactiveKey()
-{
-    return "inactive"_s;
-}
-
 String DiagnosticLoggingKeys::internalErrorKey()
 {
     return "internalError"_s;
@@ -346,16 +336,6 @@ String DiagnosticLoggingKeys::cpuUsageKey()
 String DiagnosticLoggingKeys::createSharedBufferFailedKey()
 {
     return "createSharedBufferFailed"_s;
-}
-
-String DiagnosticLoggingKeys::activeInForegroundTabKey()
-{
-    return "activeInForegroundTab"_s;
-}
-
-String DiagnosticLoggingKeys::activeInBackgroundTabOnlyKey()
-{
-    return "activeInBackgroundTabOnly"_s;
 }
 
 String DiagnosticLoggingKeys::applicationCacheKey()

--- a/Source/WebCore/page/DiagnosticLoggingKeys.h
+++ b/Source/WebCore/page/DiagnosticLoggingKeys.h
@@ -31,8 +31,6 @@ namespace WebCore {
 
 class DiagnosticLoggingKeys {
 public:
-    WEBCORE_EXPORT static String activeInForegroundTabKey();
-    WEBCORE_EXPORT static String activeInBackgroundTabOnlyKey();
     static String applicationCacheKey();
 #if ENABLE(APPLICATION_MANIFEST)
     static String applicationManifestKey();
@@ -77,7 +75,6 @@ public:
     static String fontKey();
     static String httpsNoStoreKey();
     static String imageKey();
-    WEBCORE_EXPORT static String inactiveKey();
     WEBCORE_EXPORT static String internalErrorKey();
     WEBCORE_EXPORT static String invalidSessionIDKey();
     WEBCORE_EXPORT static String isAttachmentKey();
@@ -115,7 +112,6 @@ public:
     static String visuallyEmptyKey();
     static String pageContainsAtLeastOneMediaEngineKey();
     static String pageContainsMediaEngineKey();
-    static String pageHandlesWebGLContextLossKey();
     static String pageLoadedKey();
     static String playedKey();
     static String postPageBackgroundingCPUUsageKey();


### PR DESCRIPTION
#### 699f679fb8a2f81f8b336f7188a73e39bd98b7a4
<pre>
Remove remaining WebGL diagnostic logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=264347">https://bugs.webkit.org/show_bug.cgi?id=264347</a>
<a href="https://rdar.apple.com/118066101">rdar://118066101</a>

Reviewed by Dan Glastonbury.

This removes the remaining pieces of WebGL diagnostic logging, in
particular for context loss and some remaining constants.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
(WebCore::WebGLRenderingContextBase::checkForContextLossHandling): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/page/DiagnosticLoggingKeys.cpp:
(WebCore::DiagnosticLoggingKeys::pageHandlesWebGLContextLossKey): Deleted.
(WebCore::DiagnosticLoggingKeys::inactiveKey): Deleted.
(WebCore::DiagnosticLoggingKeys::activeInForegroundTabKey): Deleted.
(WebCore::DiagnosticLoggingKeys::activeInBackgroundTabOnlyKey): Deleted.
* Source/WebCore/page/DiagnosticLoggingKeys.h:

Canonical link: <a href="https://commits.webkit.org/270380@main">https://commits.webkit.org/270380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3640a181c02e4a2aced684acf50fca3a3c7a8ced

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1298 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28013 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28889 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/788 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3859 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6069 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2944 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2836 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->