### PR TITLE
Port SourceBrush::Brush::LogicalGradient to the new IPC serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2001,6 +2001,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ScreenDataOverrides.h
     platform/graphics/ShouldLocalizeAxisNames.h
     platform/graphics/SourceBrush.h
+    platform/graphics/SourceBrushLogicalGradient.h
     platform/graphics/SourceBufferPrivate.h
     platform/graphics/SourceBufferPrivateClient.h
     platform/graphics/SourceImage.h

--- a/Source/WebCore/platform/graphics/SourceBrushLogicalGradient.h
+++ b/Source/WebCore/platform/graphics/SourceBrushLogicalGradient.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Gradient.h"
+
+namespace WebCore {
+
+struct SourceBrushLogicalGradient {
+    std::variant<Ref<Gradient>, RenderingResourceIdentifier> gradient;
+    AffineTransform spaceTransform;
+
+    std::variant<Ref<Gradient>, RenderingResourceIdentifier> serializableGradient() const;
+    friend bool operator==(const SourceBrushLogicalGradient&, const SourceBrushLogicalGradient&);
+};
+
+inline std::variant<Ref<Gradient>, RenderingResourceIdentifier> SourceBrushLogicalGradient::serializableGradient() const
+{
+    return WTF::switchOn(gradient,
+        [&] (const Ref<Gradient>& gradient) -> std::variant<Ref<Gradient>, RenderingResourceIdentifier> {
+            if (gradient->hasValidRenderingResourceIdentifier())
+                return gradient->renderingResourceIdentifier();
+            return gradient;
+        },
+        [&] (RenderingResourceIdentifier renderingResourceIdentifier) -> std::variant<Ref<Gradient>, RenderingResourceIdentifier> {
+            return renderingResourceIdentifier;
+        }
+    );
+}
+
+inline bool operator==(const SourceBrushLogicalGradient& a, const SourceBrushLogicalGradient& b)
+{
+    if (a.spaceTransform != b.spaceTransform)
+        return false;
+
+    return WTF::switchOn(a.gradient,
+        [&] (const Ref<Gradient>& aGradient) {
+            if (auto* bGradient = std::get_if<Ref<Gradient>>(&b.gradient))
+                return aGradient.ptr() == bGradient->ptr();
+            return false;
+        },
+        [&] (RenderingResourceIdentifier aRenderingResourceIdentifier) {
+            if (auto* bRenderingResourceIdentifier = std::get_if<RenderingResourceIdentifier>(&b.gradient))
+                return aRenderingResourceIdentifier == *bRenderingResourceIdentifier;
+            return false;
+        }
+    );
+}
+
+} // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6557,6 +6557,11 @@ header: <WebCore/GraphicsContextState.h>
     WebCore::GraphicsContextState::Purpose m_purpose;
 };
 
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::SourceBrushLogicalGradient {
+    std::variant<Ref<WebCore::Gradient>, WebCore::RenderingResourceIdentifier> serializableGradient();
+    WebCore::AffineTransform spaceTransform;
+};
+
 #if PLATFORM(COCOA)
 struct WebCore::KeypressCommand {
     String commandName;


### PR DESCRIPTION
#### c150417332542e24c769ad4b7cd448e5aa6ab3e1
<pre>
Port SourceBrush::Brush::LogicalGradient to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264350">https://bugs.webkit.org/show_bug.cgi?id=264350</a>

Reviewed by Alex Christensen.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/SourceBrush.h:
(WebCore::SourceBrush::Brush::LogicalGradient::encode const): Deleted.
(WebCore::SourceBrush::Brush::LogicalGradient::decode): Deleted.
* Source/WebCore/platform/graphics/SourceBrushLogicalGradient.h: Added.
(WebCore::SourceBrushLogicalGradient::serializableGradient const):
(WebCore::operator==):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270369@main">https://commits.webkit.org/270369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/647375ed3761b8b0891ea4a3ab36aaca56907301

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27917 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28829 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26658 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/713 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2863 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3228 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2758 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->