### PR TITLE
[iOS] Range inputs have an incorrect appearance in vertical writing mode with a left-to-right-direction

### DIFF
--- a/LayoutTests/fast/forms/ios/range-vertical-rl-dir-ltr-expected-mismatch.html
+++ b/LayoutTests/fast/forms/ios/range-vertical-rl-dir-ltr-expected-mismatch.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+
+input {
+    writing-mode: vertical-rl;
+    direction: rtl;
+}
+
+</style>
+</head>
+<body>
+<input type="range" min="0" max="100" value="50">
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/range-vertical-rl-dir-ltr.html
+++ b/LayoutTests/fast/forms/ios/range-vertical-rl-dir-ltr.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+
+input {
+    writing-mode: vertical-rl;
+    direction: ltr;
+}
+
+</style>
+</head>
+<body>
+<input type="range" min="0" max="100" value="50">
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -2373,7 +2373,9 @@ bool RenderThemeIOS::paintSliderTrackWithFormControlRefresh(const RenderObject& 
     } else {
         float height = trackClip.height();
         trackClip.setHeight(height * valueRatio);
-        trackClip.setY(trackClip.y() + height - trackClip.height());
+
+        if (box.style().isHorizontalWritingMode() || !box.style().isLeftToRightDirection())
+            trackClip.setY(trackClip.y() + height - trackClip.height());
     }
 
     FloatRoundedRect fillRect(trackClip, cornerRadii);


### PR DESCRIPTION
#### 1ce2532648afb8177d3f669049c097cbbdd557e1
<pre>
[iOS] Range inputs have an incorrect appearance in vertical writing mode with a left-to-right-direction
<a href="https://bugs.webkit.org/show_bug.cgi?id=264352">https://bugs.webkit.org/show_bug.cgi?id=264352</a>
<a href="https://rdar.apple.com/118067444">rdar://118067444</a>

Reviewed by Wenson Hsieh.

In the left-to-right direction, in vertical writing mode, the track should be
filled from top to bottom. Currently, it is filled from bottom to top, resulting
in the thumb being detached from the fill.

Fix by adjusting the clip used in this scenario.

* LayoutTests/fast/forms/ios/range-vertical-rl-dir-ltr-expected-mismatch.html: Added.
* LayoutTests/fast/forms/ios/range-vertical-rl-dir-ltr.html: Added.

Added a ref-mismatch test to verify that the track fills in different directions
based on the direction value. This is not a WPT, since it is not the case that
all platforms have a fill (example: macOS).

* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintSliderTrackWithFormControlRefresh):

Canonical link: <a href="https://commits.webkit.org/270355@main">https://commits.webkit.org/270355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d906799efec494954f3b14a74c5ae696b582df03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27918 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28830 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26659 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/714 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22459 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2864 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3223 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2759 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->