### PR TITLE
Multiple iframes in same isolated process results in one of them not being drawn.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/double-iframe-expected.html
+++ b/LayoutTests/http/tests/site-isolation/double-iframe-expected.html
@@ -1,0 +1,4 @@
+<body bgcolor=blue>
+<div style="width:300px;height:150px;background-color:green;display:inline-block"></div>
+<div style="width:300px;height:150px;background-color:green;display:inline-block"></div>
+</body>

--- a/LayoutTests/http/tests/site-isolation/double-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/double-iframe.html
@@ -1,0 +1,6 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head><meta name="fuzzy" content="maxDifference=112; totalPixels=900"/></head>
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0></iframe>
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0></iframe>
+</body>

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -64,6 +64,7 @@ public:
     bool paintReachableBackingStoreContents();
 
     void willFlushLayers();
+    void willBuildTransaction();
     void willCommitLayerTree(RemoteLayerTreeTransaction&);
     Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> didFlushLayers(RemoteLayerTreeTransaction&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -75,6 +75,10 @@ void RemoteLayerBackingStoreCollection::willFlushLayers()
 
     m_inLayerFlush = true;
     m_reachableBackingStoreInLatestFlush.clear();
+}
+
+void RemoteLayerBackingStoreCollection::willBuildTransaction()
+{
     m_backingStoresNeedingDisplay.clear();
 }
 


### PR DESCRIPTION
#### bb4da53917de7e7e3788b43bf8b9aba9ee81d718
<pre>
Multiple iframes in same isolated process results in one of them not being drawn.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264356">https://bugs.webkit.org/show_bug.cgi?id=264356</a>
&lt;<a href="https://rdar.apple.com/118034981">rdar://118034981</a>&gt;

Reviewed by Alex Christensen.

RemoteLayerBackingStoreCollection::willCommitLayerTree collects all the backing stores that were unreachable,
and includes that list in the transaction so that the UI process can ensure the buffer references are removed.

This changes moves that call until we&apos;ve finished building all the transactions, so that were not considering
buffers only used in latter transactions to be unreachable for the first transaction.

It also adds a new &apos;willBuildTransaction&apos; function. The set of backing stores that need display is a property
of the transaction (where we call prepareBuffersForDisplay, and then paint them), so we want to clear this
state per-transaction, not per rendering update.

* LayoutTests/http/tests/site-isolation/double-iframe-expected.html: Added.
* LayoutTests/http/tests/site-isolation/double-iframe.html: Added.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::willFlushLayers):
(WebKit::RemoteLayerBackingStoreCollection::willBuildTransaction):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/270399@main">https://commits.webkit.org/270399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/127406db9f7907cf4ed99cf618940ebe7ad9ff08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23381 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25474 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2793 "Found 1 new test failure: http/tests/site-isolation/double-iframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27924 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2477 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28835 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23067 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26674 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/appcache (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/721 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22465 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2870 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3242 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2764 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->