### PR TITLE
REGRESSION(268354@main): Text gets shadow if its container has a filter drop-shadow

### DIFF
--- a/LayoutTests/fast/text/text-container-filter-drop-shadow-expected.html
+++ b/LayoutTests/fast/text/text-container-filter-drop-shadow-expected.html
@@ -1,0 +1,26 @@
+<style>
+    .text-with-null-shadow {
+        text-shadow: rgba(0, 0, 0, 0) 0px 0px 0.000001px;
+    }
+    .box {
+        font: 1.5em serif;
+        filter: drop-shadow(8px 8px 8px green);
+        width: 400px;
+        height: 400px;
+        background: AliceBlue;
+        display: inline-block;
+        margin: 10px;
+        padding: 20px;
+    }
+</style>
+<body>
+    <div class="box">
+        <span class="text-with-null-shadow">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+            labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+            laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+            voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+            non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </span>
+    </div>
+</body>

--- a/LayoutTests/fast/text/text-container-filter-drop-shadow.html
+++ b/LayoutTests/fast/text/text-container-filter-drop-shadow.html
@@ -1,0 +1,23 @@
+<style>
+    .box {
+        font: 1.5em serif;
+        filter: drop-shadow(8px 8px 8px green);
+        width: 400px;
+        height: 400px;
+        background: AliceBlue;
+        display: inline-block;
+        margin: 10px;
+        padding: 20px;
+    }
+</style>
+<body>
+    <div class="box">
+        <span>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
+            labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+            laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+            voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+            non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </span>
+    </div>
+</body>

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -633,42 +633,6 @@ Vector<FloatPoint> GraphicsContext::centerLineAndCutOffCorners(bool isVerticalLi
     return { point1, point2 };
 }
 
-void GraphicsContext::clearShadow()
-{
-    if (!m_state.style())
-        return;
-
-    if (!std::holds_alternative<GraphicsDropShadow>(*m_state.style()))
-        return;
-
-    m_state.setStyle(std::nullopt);
-    didUpdateState(m_state);
-}
-
-bool GraphicsContext::hasVisibleShadow() const
-{
-    if (const auto shadow = dropShadow())
-        return shadow->isVisible();
-
-    return false;
-}
-
-bool GraphicsContext::hasBlurredShadow() const
-{
-    if (const auto shadow = dropShadow())
-        return shadow->isBlurred();
-
-    return false;
-}
-
-bool GraphicsContext::hasShadow() const
-{
-    if (const auto shadow = dropShadow())
-        return shadow->hasOutsets();
-
-    return false;
-}
-
 #if ENABLE(VIDEO)
 void GraphicsContext::paintFrameForMedia(MediaPlayer& player, const FloatRect& destination)
 {

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -124,11 +124,10 @@ public:
     void setStrokeStyle(StrokeStyle style) { m_state.setStrokeStyle(style); didUpdateState(m_state); }
 
     std::optional<GraphicsDropShadow> dropShadow() const { return m_state.dropShadow(); }
-    void setDropShadow(const GraphicsDropShadow& dropShadow) { m_state.setStyle(dropShadow); didUpdateState(m_state); }
-    WEBCORE_EXPORT void clearShadow();
-    bool hasVisibleShadow() const;
-    bool hasBlurredShadow() const;
-    bool hasShadow() const;
+    void setDropShadow(const GraphicsDropShadow& dropShadow) { m_state.setDropShadow(dropShadow); didUpdateState(m_state); }
+    void clearDropShadow() { m_state.setDropShadow(std::nullopt); didUpdateState(m_state); }
+    bool hasBlurredDropShadow() const { return dropShadow() && dropShadow()->isBlurred(); }
+    bool hasDropShadow() const { return dropShadow() && dropShadow()->hasOutsets(); }
 
     std::optional<GraphicsStyle> style() const { return m_state.style(); }
     void setStyle(const std::optional<GraphicsStyle>& style) { m_state.setStyle(style); didUpdateState(m_state); }

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -58,17 +58,6 @@ GraphicsContextState GraphicsContextState::clone(Purpose purpose) const
     return clone;
 }
 
-std::optional<GraphicsDropShadow> GraphicsContextState::dropShadow() const
-{
-    if (!m_style)
-        return std::nullopt;
-
-    if (!std::holds_alternative<GraphicsDropShadow>(*m_style))
-        return std::nullopt;
-
-    return std::get<GraphicsDropShadow>(*m_style);
-}
-
 bool GraphicsContextState::containsOnlyInlineChanges() const
 {
     if (m_changeFlags.isEmpty() || m_changeFlags != (m_changeFlags & basicChangeFlags))
@@ -130,6 +119,9 @@ void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state, c
         case toIndex(Change::CompositeMode):
             mergeChange(&GraphicsContextState::m_compositeMode);
             break;
+        case toIndex(Change::DropShadow):
+            mergeChange(&GraphicsContextState::m_dropShadow);
+            break;
         case toIndex(Change::Style):
             mergeChange(&GraphicsContextState::m_style);
             break;
@@ -187,6 +179,8 @@ void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
     mergeChange(Change::StrokeStyle,                 &GraphicsContextState::m_strokeStyle);
 
     mergeChange(Change::CompositeMode,               &GraphicsContextState::m_compositeMode);
+    mergeChange(Change::DropShadow,                  &GraphicsContextState::m_dropShadow);
+    mergeChange(Change::Style,                       &GraphicsContextState::m_style);
 
     mergeChange(Change::Alpha,                       &GraphicsContextState::m_alpha);
     mergeChange(Change::ImageInterpolationQuality,   &GraphicsContextState::m_textDrawingMode);
@@ -222,6 +216,9 @@ static const char* stateChangeName(GraphicsContextState::Change change)
 
     case GraphicsContextState::Change::CompositeMode:
         return "composite-mode";
+
+    case GraphicsContextState::Change::DropShadow:
+        return "drop-shadow";
 
     case GraphicsContextState::Change::Style:
         return "style";
@@ -276,6 +273,7 @@ TextStream& GraphicsContextState::dump(TextStream& ts) const
     dump(Change::StrokeStyle,                   &GraphicsContextState::m_strokeStyle);
 
     dump(Change::CompositeMode,                 &GraphicsContextState::m_compositeMode);
+    dump(Change::DropShadow,                    &GraphicsContextState::m_dropShadow);
     dump(Change::Style,                         &GraphicsContextState::m_style);
 
     dump(Change::Alpha,                         &GraphicsContextState::m_alpha);

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -46,19 +46,20 @@ public:
         StrokeStyle                 = 1 << 4,
 
         CompositeMode               = 1 << 5,
-        Style                       = 1 << 6,
+        DropShadow                  = 1 << 6,
+        Style                       = 1 << 7,
 
-        Alpha                       = 1 << 7,
-        TextDrawingMode             = 1 << 8,
-        ImageInterpolationQuality   = 1 << 9,
+        Alpha                       = 1 << 8,
+        TextDrawingMode             = 1 << 9,
+        ImageInterpolationQuality   = 1 << 10,
 
-        ShouldAntialias             = 1 << 10,
-        ShouldSmoothFonts           = 1 << 11,
-        ShouldSubpixelQuantizeFonts = 1 << 12,
-        ShadowsIgnoreTransforms     = 1 << 13,
-        DrawLuminanceMask           = 1 << 14,
+        ShouldAntialias             = 1 << 11,
+        ShouldSmoothFonts           = 1 << 12,
+        ShouldSubpixelQuantizeFonts = 1 << 13,
+        ShadowsIgnoreTransforms     = 1 << 14,
+        DrawLuminanceMask           = 1 << 15,
 #if HAVE(OS_DARK_MODE_SUPPORT)
-        UseDarkAppearance           = 1 << 15,
+        UseDarkAppearance           = 1 << 16,
 #endif
     };
     using ChangeFlags = OptionSet<Change>;
@@ -106,7 +107,8 @@ public:
     const CompositeMode& compositeMode() const { return m_compositeMode; }
     void setCompositeMode(CompositeMode compositeMode) { setProperty(Change::CompositeMode, &GraphicsContextState::m_compositeMode, compositeMode); }
 
-    WEBCORE_EXPORT std::optional<GraphicsDropShadow> dropShadow() const;
+    const std::optional<GraphicsDropShadow>& dropShadow() const { return m_dropShadow; }
+    void setDropShadow(const std::optional<GraphicsDropShadow>& dropShadow) { setProperty(Change::DropShadow, &GraphicsContextState::m_dropShadow, dropShadow); }
 
     const std::optional<GraphicsStyle>& style() const { return m_style; }
     void setStyle(const std::optional<GraphicsStyle>& style) { setProperty(Change::Style, &GraphicsContextState::m_style, style); }
@@ -184,6 +186,7 @@ private:
     StrokeStyle m_strokeStyle { StrokeStyle::SolidStroke };
 
     CompositeMode m_compositeMode { CompositeOperator::SourceOver, BlendMode::Normal };
+    std::optional<GraphicsDropShadow> m_dropShadow;
     std::optional<GraphicsStyle> m_style;
 
     float m_alpha { 1 };
@@ -220,6 +223,7 @@ template<> struct EnumTraits<WebCore::GraphicsContextState::Change> {
         WebCore::GraphicsContextState::Change::StrokeStyle,
 
         WebCore::GraphicsContextState::Change::CompositeMode,
+        WebCore::GraphicsContextState::Change::DropShadow,
         WebCore::GraphicsContextState::Change::Style,
 
         WebCore::GraphicsContextState::Change::Alpha,

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -469,7 +469,7 @@ void ShadowBlur::drawShadowBuffer(GraphicsContext& graphicsContext, ImageBuffer&
     graphicsContext.clipToImageBuffer(layerImage, FloatRect(layerOrigin, bufferSize));
     graphicsContext.setFillColor(m_color);
 
-    graphicsContext.clearShadow();
+    graphicsContext.clearDropShadow();
     graphicsContext.fillRect(FloatRect(layerOrigin, layerSize));
 }
 
@@ -507,13 +507,13 @@ void ShadowBlur::drawRectShadow(GraphicsContext& graphicsContext, const FloatRou
         },
         [&graphicsContext](ImageBuffer& image, const FloatRect& destRect, const FloatRect& srcRect) {
             GraphicsContextStateSaver stateSaver(graphicsContext);
-            graphicsContext.clearShadow();
+            graphicsContext.clearDropShadow();
             graphicsContext.drawImageBuffer(image, destRect, srcRect);
         },
         [&graphicsContext](const FloatRect& rect, const Color& color) {
             GraphicsContextStateSaver stateSaver(graphicsContext);
             graphicsContext.setFillColor(color);
-            graphicsContext.clearShadow();
+            graphicsContext.clearDropShadow();
             graphicsContext.fillRect(rect);
         });
 }
@@ -528,7 +528,7 @@ void ShadowBlur::drawInsetShadow(GraphicsContext& graphicsContext, const FloatRe
             // Note that drawing the ImageBuffer is faster than creating a Image and drawing that,
             // because ImageBuffer::draw() knows that it doesn't have to copy the image bits.
             GraphicsContextStateSaver stateSaver(graphicsContext);
-            graphicsContext.clearShadow();
+            graphicsContext.clearDropShadow();
             graphicsContext.drawImageBuffer(image, destRect, srcRect);
         },
         [&graphicsContext](const FloatRect& rect, const FloatRect& holeRect, const Color& color) {
@@ -539,7 +539,7 @@ void ShadowBlur::drawInsetShadow(GraphicsContext& graphicsContext, const FloatRe
             GraphicsContextStateSaver fillStateSaver(graphicsContext);
             graphicsContext.setFillRule(WindRule::EvenOdd);
             graphicsContext.setFillColor(color);
-            graphicsContext.clearShadow();
+            graphicsContext.clearDropShadow();
             graphicsContext.fillPath(exteriorPath);
         });
 }

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -268,12 +268,12 @@ void GraphicsContextCairo::didUpdateState(GraphicsContextState& state)
         Cairo::State::setStrokeStyle(*this, state.strokeStyle());
 
     // FIXME: m_state should not be changed to flip the shadow offset. This can happen when the shadow is applied to the platform context.
-    if (state.changes().contains(GraphicsContextState::Change::Style)) {
+    if (state.changes().contains(GraphicsContextState::Change::DropShadow)) {
         auto dropShadow = state.dropShadow();
         if (dropShadow && state.shadowsIgnoreTransforms()) {
             // Meaning that this graphics context is associated with a CanvasRenderingContext
             // We flip the height since CG and HTML5 Canvas have opposite Y axis
-            m_state.m_style = GraphicsDropShadow { { dropShadow->offset.width(), -dropShadow->offset.height() }, dropShadow->radius, dropShadow->color, dropShadow->radiusMode };
+            m_state.m_dropShadow = GraphicsDropShadow { { dropShadow->offset.width(), -dropShadow->offset.height() }, dropShadow->radius, dropShadow->color, dropShadow->radiusMode };
         }
     }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -140,7 +140,7 @@ public:
     bool consumeHasDrawn();
 
 protected:
-    virtual void setCGShadow(const GraphicsDropShadow&, bool shadowsIgnoreTransforms);
+    void setCGShadow(const std::optional<GraphicsDropShadow>&, bool shadowsIgnoreTransforms);
     void setCGStyle(const std::optional<GraphicsStyle>&, bool shadowsIgnoreTransforms);
 
 private:

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -130,7 +130,7 @@ void DrawGlyphsRecorder::populateInternalContext(const GraphicsContextState& con
     if (m_originalState.dropShadow)
         m_internalContext->setDropShadow(*m_originalState.dropShadow);
     else
-        m_internalContext->clearShadow();
+        m_internalContext->clearDropShadow();
 
     m_internalContext->setTextDrawingMode(contextState.textDrawingMode());
 }
@@ -217,7 +217,7 @@ void DrawGlyphsRecorder::updateShadow(const std::optional<GraphicsDropShadow>& d
     if (dropShadow)
         m_owner.setDropShadow(*dropShadow);
     else
-        m_owner.clearShadow();
+        m_owner.clearDropShadow();
 
     m_owner.setShadowsIgnoreTransforms(shadowsIgnoreTransforms == ShadowsIgnoreTransforms::Yes);
 }

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -364,7 +364,7 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const G
     bool hasSimpleShadow = context.textDrawingMode() == TextDrawingMode::Fill && shadow && shadow->color.isValid() && !shadow->radius && !platformData.isColorBitmapFont() && (!context.shadowsIgnoreTransforms() || contextCTM.isIdentityOrTranslationOrFlipped()) && !context.isInTransparencyLayer();
     if (hasSimpleShadow) {
         // Paint simple shadows ourselves instead of relying on CG shadows, to avoid losing subpixel antialiasing.
-        context.clearShadow();
+        context.clearDropShadow();
         Color fillColor = context.fillColor();
         Color shadowFillColor = shadow->color.colorWithAlphaMultipliedBy(fillColor.alphaAsFloat());
         context.setFillColor(shadowFillColor);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -44,7 +44,7 @@ class ResourceHeap;
 class ApplyDeviceScaleFactor;
 class BeginTransparencyLayer;
 class ClearRect;
-class ClearShadow;
+class ClearDropShadow;
 class Clip;
 class ClipRoundedRect;
 class ClipOut;
@@ -119,7 +119,7 @@ using Item = std::variant
     < ApplyDeviceScaleFactor
     , BeginTransparencyLayer
     , ClearRect
-    , ClearShadow
+    , ClearDropShadow
     , Clip
     , ClipRoundedRect
     , ClipOut

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -181,9 +181,9 @@ void SetMiterLimit::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("mitre-limit", miterLimit());
 }
 
-void ClearShadow::apply(GraphicsContext& context) const
+void ClearDropShadow::apply(GraphicsContext& context) const
 {
-    context.clearShadow();
+    context.clearDropShadow();
 }
 
 void Clip::apply(GraphicsContext& context) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -308,9 +308,9 @@ private:
     float m_miterLimit;
 };
 
-class ClearShadow {
+class ClearDropShadow {
 public:
-    static constexpr char name[] = "set-clear-shadow";
+    static constexpr char name[] = "clear-drop-shadow";
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const { }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -84,7 +84,7 @@ protected:
     virtual void recordSetLineDash(const DashArray&, float dashOffset) = 0;
     virtual void recordSetLineJoin(LineJoin) = 0;
     virtual void recordSetMiterLimit(float) = 0;
-    virtual void recordClearShadow() = 0;
+    virtual void recordClearDropShadow() = 0;
     virtual void recordResetClip() = 0;
     virtual void recordClip(const FloatRect&) = 0;
     virtual void recordClipRoundedRect(const FloatRoundedRect&) = 0;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -124,9 +124,9 @@ void RecorderImpl::recordSetMiterLimit(float limit)
     append(SetMiterLimit(limit));
 }
 
-void RecorderImpl::recordClearShadow()
+void RecorderImpl::recordClearDropShadow()
 {
-    append(ClearShadow());
+    append(ClearDropShadow());
 }
 
 void RecorderImpl::recordResetClip()

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -55,7 +55,7 @@ private:
     void recordSetLineDash(const DashArray&, float dashOffset) final;
     void recordSetLineJoin(LineJoin) final;
     void recordSetMiterLimit(float) final;
-    void recordClearShadow() final;
+    void recordClearDropShadow() final;
     void recordResetClip() final;
     void recordClip(const FloatRect&) final;
     void recordClipRoundedRect(const FloatRoundedRect&) final;

--- a/Source/WebCore/rendering/EllipsisBoxPainter.cpp
+++ b/Source/WebCore/rendering/EllipsisBoxPainter.cpp
@@ -77,7 +77,7 @@ void EllipsisBoxPainter::paint()
         context.setFillColor(textColor);
 
     if (setShadow)
-        context.clearShadow();
+        context.clearDropShadow();
 }
 
 void EllipsisBoxPainter::paintSelection()

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -298,7 +298,7 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
     if (clipping)
         m_context.restore();
     else if (m_shadow)
-        m_context.clearShadow();
+        m_context.clearDropShadow();
 }
 
 void TextDecorationPainter::paintForegroundDecorations(const ForegroundDecorationGeometry& foregroundDecorationGeometry, const Styles& decorationStyle)

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -94,7 +94,7 @@ ShadowApplier::~ShadowApplier()
     if (m_onlyDrawsShadow)
         m_context.restore();
     else if (!m_avoidDrawingShadow)
-        m_context.clearShadow();
+        m_context.clearDropShadow();
 }
 
 TextPainter::TextPainter(GraphicsContext& context, const FontCascade& font, const RenderStyle& renderStyle)

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -108,9 +108,9 @@ void RenderSVGRect::fillShape(GraphicsContext& context) const
     // shadow drawing method, which draws an extra shadow.
     // This is a workaround for switching off the extra shadow.
     // https://bugs.webkit.org/show_bug.cgi?id=68899
-    if (context.hasShadow()) {
+    if (context.hasDropShadow()) {
         GraphicsContextStateSaver stateSaver(context);
-        context.clearShadow();
+        context.clearDropShadow();
         context.fillRect(m_fillBoundingBox);
         return;
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -105,9 +105,9 @@ void LegacyRenderSVGRect::fillShape(GraphicsContext& context) const
     // shadow drawing method, which draws an extra shadow.
     // This is a workaround for switching off the extra shadow.
     // https://bugs.webkit.org/show_bug.cgi?id=68899
-    if (context.hasShadow()) {
+    if (context.hasDropShadow()) {
         GraphicsContextStateSaver stateSaver(context);
-        context.clearShadow();
+        context.clearDropShadow();
         context.fillRect(m_fillBoundingBox);
         return;
     }

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -190,9 +190,9 @@ void RemoteDisplayListRecorder::setMiterLimit(float limit)
     handleItem(DisplayList::SetMiterLimit(limit));
 }
 
-void RemoteDisplayListRecorder::clearShadow()
+void RemoteDisplayListRecorder::clearDropShadow()
 {
-    handleItem(DisplayList::ClearShadow());
+    handleItem(DisplayList::ClearDropShadow());
 }
 
 void RemoteDisplayListRecorder::clip(const FloatRect& rect)

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -69,7 +69,7 @@ public:
     void setLineDash(WebCore::DisplayList::SetLineDash&&);
     void setLineJoin(WebCore::LineJoin);
     void setMiterLimit(float);
-    void clearShadow();
+    void clearDropShadow();
     void clip(const WebCore::FloatRect&);
     void clipRoundedRect(const WebCore::FloatRoundedRect&);
     void clipOut(const WebCore::FloatRect&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -37,7 +37,7 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     SetLineDash(WebCore::DisplayList::SetLineDash item) StreamBatched
     SetLineJoin(enum:uint8_t WebCore::LineJoin lineJoin) StreamBatched
     SetMiterLimit(float limit) StreamBatched
-    ClearShadow()
+    ClearDropShadow()
     Clip(WebCore::FloatRect rect)
     ClipRoundedRect(WebCore::FloatRoundedRect rect)
     ClipOut(WebCore::FloatRect rect)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6516,6 +6516,7 @@ header: <WebCore/GraphicsContextState.h>
     StrokeThickness,
     StrokeStyle,
     CompositeMode,
+    DropShadow,
     Style,
     Alpha,
     TextDrawingMode,
@@ -6545,6 +6546,7 @@ header: <WebCore/GraphicsContextState.h>
     float m_strokeThickness;
     WebCore::StrokeStyle m_strokeStyle;
     WebCore::CompositeMode m_compositeMode;
+    std::optional<WebCore::GraphicsDropShadow> m_dropShadow;
     std::optional<WebCore::GraphicsStyle> m_style;
     float m_alpha;
     WebCore::InterpolationQuality m_imageInterpolationQuality;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -153,9 +153,9 @@ void RemoteDisplayListRecorderProxy::recordSetMiterLimit(float limit)
     send(Messages::RemoteDisplayListRecorder::SetMiterLimit(limit));
 }
 
-void RemoteDisplayListRecorderProxy::recordClearShadow()
+void RemoteDisplayListRecorderProxy::recordClearDropShadow()
 {
-    send(Messages::RemoteDisplayListRecorder::ClearShadow());
+    send(Messages::RemoteDisplayListRecorder::ClearDropShadow());
 }
 
 void RemoteDisplayListRecorderProxy::recordClip(const FloatRect& rect)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -72,7 +72,7 @@ private:
     void recordSetLineDash(const WebCore::DashArray&, float dashOffset) final;
     void recordSetLineJoin(WebCore::LineJoin) final;
     void recordSetMiterLimit(float) final;
-    void recordClearShadow() final;
+    void recordClearDropShadow() final;
     void recordClip(const WebCore::FloatRect&) final;
     void recordClipRoundedRect(const WebCore::FloatRoundedRect&) final;
     void recordClipOut(const WebCore::FloatRect&) final;

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -594,7 +594,7 @@ void FindController::drawRect(PageOverlay&, GraphicsContext& graphicsContext, co
     for (auto& path : whiteFramePaths)
         graphicsContext.strokePath(path);
 
-    graphicsContext.clearShadow();
+    graphicsContext.clearDropShadow();
 
     // Clear out the holes.
     graphicsContext.setCompositeOperation(CompositeOperator::Clear);

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -288,7 +288,7 @@ void WebFoundTextRangeController::drawRect(WebCore::PageOverlay&, WebCore::Graph
     for (auto& path : foundFramePaths)
         graphicsContext.strokePath(path);
 
-    graphicsContext.clearShadow();
+    graphicsContext.clearDropShadow();
 
     graphicsContext.setCompositeOperation(WebCore::CompositeOperator::Clear);
     for (auto& path : foundFramePaths)


### PR DESCRIPTION
#### f4c2de375a56df1d82f6701bb98623996f26c9a6
<pre>
REGRESSION(268354@main): Text gets shadow if its container has a filter drop-shadow
<a href="https://bugs.webkit.org/show_bug.cgi?id=264354">https://bugs.webkit.org/show_bug.cgi?id=264354</a>
<a href="https://rdar.apple.com/117987393">rdar://117987393</a>

Reviewed by Simon Fraser.

GraphicsContextState used to have two different entities one for drop-shadow and
and another one for filter-effect-style. After 266544@main they became one entity
represented by GraphicsStyle.

This change did not consider the drop-shadow and the filter-effect-style can be
two different states and can coexist. So it caused the following problem: If the
text does not have text-shadow but its ancestor has filter drop-shadow, the text
will rendered with the drop-shadow of its ancestor.

To fix this bug, these two states have to be split again so rendering the text
does not get confused by the filter effect style. The drop-shadow can still be
represented as GraphicsDropShadow.

* LayoutTests/fast/text/text-container-filter-drop-shadow-expected.html: Added.
* LayoutTests/fast/text/text-container-filter-drop-shadow.html: Added.
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::clearShadow): Deleted.
(WebCore::GraphicsContext::hasVisibleShadow const): Deleted.
(WebCore::GraphicsContext::hasBlurredShadow const): Deleted.
(WebCore::GraphicsContext::hasShadow const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::setDropShadow):
(WebCore::GraphicsContext::clearDropShadow):
(WebCore::GraphicsContext::hasBlurredDropShadow const):
(WebCore::GraphicsContext::hasDropShadow const):
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::mergeLastChanges):
(WebCore::GraphicsContextState::mergeAllChanges):
(WebCore::stateChangeName):
(WebCore::GraphicsContextState::dump const):
(WebCore::GraphicsContextState::dropShadow const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::dropShadow const):
(WebCore::GraphicsContextState::setDropShadow):
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::ShadowBlur::drawShadowBuffer):
(WebCore::ShadowBlur::drawRectShadow):
(WebCore::ShadowBlur::drawInsetShadow):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::didUpdateState):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::fillPath):
(WebCore::GraphicsContextCG::strokePath):
(WebCore::GraphicsContextCG::fillRect):
(WebCore::GraphicsContextCG::setCGShadow):
(WebCore::GraphicsContextCG::didUpdateState):
(WebCore::GraphicsContextCG::strokeRect):
(WebCore::GraphicsContextCG::canUseShadowBlur const):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::populateInternalContext):
(WebCore::DrawGlyphsRecorder::updateShadow):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::ClearDropShadow::apply const):
(WebCore::DisplayList::ClearShadow::apply const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::ClearShadow::dump const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordClearDropShadow):
(WebCore::DisplayList::RecorderImpl::recordClearShadow): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/rendering/EllipsisBoxPainter.cpp:
(WebCore::EllipsisBoxPainter::paint):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::paintBackgroundDecorations):
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::ShadowApplier::~ShadowApplier):
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::fillShape const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::fillShape const):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::clearDropShadow):
(WebKit::RemoteDisplayListRecorder::clearShadow): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordClearDropShadow):
(WebKit::RemoteDisplayListRecorderProxy::recordClearShadow): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::drawRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::drawRect):

Canonical link: <a href="https://commits.webkit.org/270414@main">https://commits.webkit.org/270414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afc2f1041509d0be28a87011705f49e9e1fdcab2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23312 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1456 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28107 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28991 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26811 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/870 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22620 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6091 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3065 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2955 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->