### PR TITLE
Unified PDF plugin contents do not scroll

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -32,7 +32,6 @@
 #include "PDFPluginIdentifier.h"
 #include "WebMouseEvent.h"
 #include <WebCore/NetscapePlugInStreamLoader.h>
-#include <WebCore/ScrollableArea.h>
 #include <wtf/HashMap.h>
 #include <wtf/Identified.h>
 #include <wtf/Range.h>
@@ -71,7 +70,6 @@ class FloatSize;
 class FragmentedSharedBuffer;
 class GraphicsContext;
 class HTMLPlugInElement;
-class Scrollbar;
 struct PluginInfo;
 }
 
@@ -88,7 +86,7 @@ class WebWheelEvent;
 struct FrameInfoData;
 struct WebHitTestResultData;
 
-class PDFPlugin final : public PDFPluginBase, public WebCore::ScrollableArea {
+class PDFPlugin final : public PDFPluginBase {
 public:
     static bool pdfKitLayerControllerIsAvailable();
 
@@ -146,46 +144,20 @@ public:
     size_t decrementThreadsWaitingOnCallback() { return --m_threadsWaitingOnCallback; }
 #endif
 
-    WebCore::ScrollPosition scrollPositionForTesting() const { return scrollPosition(); }
-    WebCore::Scrollbar* horizontalScrollbar() { return m_horizontalScrollbar.get(); }
-    WebCore::Scrollbar* verticalScrollbar() { return m_verticalScrollbar.get(); }
-
 private:
     explicit PDFPlugin(WebCore::HTMLPlugInElement&);
     bool isLegacyPDFPlugin() const override { return true; }
 
     PDFSelection *nextMatchForString(const String& target, bool searchForward, bool caseSensitive, bool wrapSearch, PDFSelection *initialSelection, bool startInSelection);
 
-    // ScrollableArea functions.
-    WebCore::IntRect scrollCornerRect() const override;
-    WebCore::ScrollableArea* enclosingScrollableArea() const override;
-    bool isScrollableOrRubberbandable() override { return true; }
-    bool hasScrollableOrRubberbandableAncestor() override { return true; }
-    WebCore::IntRect scrollableAreaBoundingBox(bool* = nullptr) const override;
-    void setScrollOffset(const WebCore::ScrollOffset&) override;
+    void didChangeScrollOffset() override;
+
     void invalidateScrollbarRect(WebCore::Scrollbar&, const WebCore::IntRect&) override;
     void invalidateScrollCornerRect(const WebCore::IntRect&) override;
+    void updateScrollbars() override;
     WebCore::IntPoint lastKnownMousePositionInView() const override { return m_lastMousePositionInPluginCoordinates; }
-    bool isActive() const override;
-    bool isScrollCornerVisible() const override { return false; }
-    WebCore::ScrollPosition scrollPosition() const override;
-    WebCore::ScrollPosition minimumScrollPosition() const override;
-    WebCore::ScrollPosition maximumScrollPosition() const override;
-    WebCore::IntSize visibleSize() const override { return m_size; }
-    WebCore::IntSize contentsSize() const override { return m_pdfDocumentSize; }
-    float deviceScaleFactor() const override;
-    WebCore::Scrollbar* horizontalScrollbar() const override { return m_horizontalScrollbar.get(); }
-    WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
-    bool shouldSuspendScrollAnimations() const override { return false; } // If we return true, ScrollAnimatorMac will keep cycling a timer forever, waiting for a good time to animate.
-    void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
-    WebCore::IntRect convertFromScrollbarToContainingView(const WebCore::Scrollbar&, const WebCore::IntRect& scrollbarRect) const override;
-    WebCore::IntRect convertFromContainingViewToScrollbar(const WebCore::Scrollbar&, const WebCore::IntRect& parentRect) const override;
-    WebCore::IntPoint convertFromScrollbarToContainingView(const WebCore::Scrollbar&, const WebCore::IntPoint& scrollbarPoint) const override;
-    WebCore::IntPoint convertFromContainingViewToScrollbar(const WebCore::Scrollbar&, const WebCore::IntPoint& parentPoint) const override;
-    bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const override;
-    bool hudEnabled() const;
-    bool shouldPlaceVerticalScrollbarOnLeft() const override { return false; }
-    String debugDescription() const override;
+    Ref<Scrollbar> createScrollbar(WebCore::ScrollbarOrientation) override;
+    void destroyScrollbar(WebCore::ScrollbarOrientation) override;
 
     // PDFPluginBase
     WebCore::PluginLayerHostingStrategy layerHostingStrategy() const override { return WebCore::PluginLayerHostingStrategy::PlatformLayer; }
@@ -193,7 +165,6 @@ private:
 
     void setView(PluginView&) override;
     void teardown() override;
-    void willDetachRenderer() override;
     bool isComposited() const override { return true; }
 
     void createPDFDocument() override;
@@ -209,11 +180,13 @@ private:
     void visibilityDidChange(bool) override;
     void contentsScaleFactorChanged(float) override;
 
-    void updateControlTints(WebCore::GraphicsContext&) override;
+    WebCore::IntSize contentsSize() const override;
+    unsigned firstPageHeight() const override;
+
+    bool isLocked() const override;
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
-    bool wantsWheelEvents() const override { return true; }
     bool handleMouseEvent(const WebMouseEvent&) override;
     bool handleWheelEvent(const WebWheelEvent&) override;
     bool handleMouseEnterEvent(const WebMouseEvent&) override;
@@ -243,10 +216,7 @@ private:
     bool incrementalPDFStreamDidFinishLoading() override;
     void incrementalPDFStreamDidFail() override;
 
-    void updateScrollbars();
-    Ref<WebCore::Scrollbar> createScrollbar(WebCore::ScrollbarOrientation);
-    void destroyScrollbar(WebCore::ScrollbarOrientation);
-    void calculateSizes();
+    void updatePDFHUDLocation();
 
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
     WebCore::IntPoint convertFromPluginToPDFView(const WebCore::IntPoint&) const;
@@ -261,8 +231,7 @@ private:
 
     void createPasswordEntryForm();
 
-    WebCore::IntSize pdfDocumentSize() const { return m_pdfDocumentSize; }
-    void setPDFDocumentSize(WebCore::IntSize size) { m_pdfDocumentSize = size; }
+    bool hudEnabled() const;
 
 #ifdef __OBJC__
     NSData *liveData() const;
@@ -275,8 +244,6 @@ private:
 
 
     bool m_pdfDocumentWasMutated { false };
-
-    WebCore::IntSize m_scrollOffset;
 
     RetainPtr<CALayer> m_containerLayer;
     RetainPtr<CALayer> m_contentLayer;
@@ -301,12 +268,6 @@ private:
     URL m_sourceURL;
 
     RetainPtr<PDFDocument> m_pdfDocument;
-
-    unsigned m_firstPageHeight { 0 };
-    WebCore::IntSize m_pdfDocumentSize; // All pages, including gaps.
-
-    RefPtr<WebCore::Scrollbar> m_horizontalScrollbar;
-    RefPtr<WebCore::Scrollbar> m_verticalScrollbar;
 
 #if HAVE(INCREMENTAL_PDF_APIS)
     void threadEntry(Ref<PDFPlugin>&&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -23,23 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "PDFPluginBase.h"
+#import "config.h"
+#import "PDFPluginBase.h"
 
 #if ENABLE(PDF_PLUGIN)
 
-#include "PluginView.h"
-#include "WebFrame.h"
-#include <CoreFoundation/CoreFoundation.h>
-#include <WebCore/ArchiveResource.h>
-#include <WebCore/Document.h>
-#include <WebCore/Frame.h>
-#include <WebCore/HTMLPlugInElement.h>
-#include <WebCore/LoaderNSURLExtras.h>
-#include <WebCore/LocalizedStrings.h>
-#include <WebCore/PluginDocument.h>
-#include <WebCore/ResourceResponse.h>
-#include <WebCore/SharedBuffer.h>
+#import "PluginView.h"
+#import "WebEventConversion.h"
+#import "WebFrame.h"
+#import <CoreFoundation/CoreFoundation.h>
+#import <WebCore/ArchiveResource.h>
+#import <WebCore/Document.h>
+#import <WebCore/FocusController.h>
+#import <WebCore/Frame.h>
+#import <WebCore/GraphicsContext.h>
+#import <WebCore/HTMLPlugInElement.h>
+#import <WebCore/LoaderNSURLExtras.h>
+#import <WebCore/LocalizedStrings.h>
+#import <WebCore/PluginDocument.h>
+#import <WebCore/ResourceResponse.h>
+#import <WebCore/ScrollAnimator.h>
+#import <WebCore/SharedBuffer.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -195,6 +199,247 @@ void PDFPluginBase::invalidateRect(const IntRect& rect)
 IntPoint PDFPluginBase::convertFromRootViewToPlugin(const IntPoint& point) const
 {
     return m_rootViewToPluginTransform.mapPoint(point);
+}
+
+void PDFPluginBase::updateControlTints(GraphicsContext& graphicsContext)
+{
+    ASSERT(graphicsContext.invalidatingControlTints());
+
+    if (RefPtr horizontalScrollbar = m_horizontalScrollbar)
+        horizontalScrollbar->invalidate();
+    if (RefPtr verticalScrollbar = m_verticalScrollbar)
+        verticalScrollbar->invalidate();
+    invalidateScrollCorner(scrollCornerRect());
+}
+
+IntRect PDFPluginBase::scrollCornerRect() const
+{
+    if (!m_horizontalScrollbar || !m_verticalScrollbar)
+        return IntRect();
+    if (m_horizontalScrollbar->isOverlayScrollbar()) {
+        ASSERT(m_verticalScrollbar->isOverlayScrollbar());
+        return IntRect();
+    }
+    return IntRect(m_view->width() - m_verticalScrollbar->width(), m_view->height() - m_horizontalScrollbar->height(), m_verticalScrollbar->width(), m_horizontalScrollbar->height());
+}
+
+ScrollableArea* PDFPluginBase::enclosingScrollableArea() const
+{
+    // FIXME: Walk up the frame tree and look for a scrollable parent frame or RenderLayer.
+    return nullptr;
+}
+
+IntRect PDFPluginBase::scrollableAreaBoundingBox(bool*) const
+{
+    return m_view->frameRect();
+}
+
+void PDFPluginBase::setScrollOffset(const ScrollOffset& offset)
+{
+    m_scrollOffset = IntSize(offset.x(), offset.y());
+
+    didChangeScrollOffset();
+}
+
+bool PDFPluginBase::isActive() const
+{
+    if (RefPtr coreFrame = m_frame ? m_frame->coreLocalFrame() : nullptr) {
+        if (CheckedPtr page = coreFrame->page())
+            return page->focusController().isActive();
+    }
+
+    return false;
+}
+
+bool PDFPluginBase::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const
+{
+    if (RefPtr coreFrame = m_frame ? m_frame->coreLocalFrame() : nullptr) {
+        if (CheckedPtr page = coreFrame->page())
+            return page->settings().scrollingPerformanceTestingEnabled();
+    }
+
+    return false;
+}
+
+ScrollPosition PDFPluginBase::scrollPosition() const
+{
+    return IntPoint(m_scrollOffset.width(), m_scrollOffset.height());
+}
+
+ScrollPosition PDFPluginBase::minimumScrollPosition() const
+{
+    return IntPoint();
+}
+
+ScrollPosition PDFPluginBase::maximumScrollPosition() const
+{
+    IntSize scrollbarSpace = scrollbarIntrusion();
+    auto pdfDocumentSize = contentsSize();
+
+    IntPoint maximumOffset(pdfDocumentSize.width() - m_size.width() + scrollbarSpace.width(), pdfDocumentSize.height() - m_size.height() + scrollbarSpace.height());
+    maximumOffset.clampNegativeToZero();
+    return maximumOffset;
+}
+
+float PDFPluginBase::deviceScaleFactor() const
+{
+    if (m_frame) {
+        if (RefPtr coreFrame = m_frame->coreLocalFrame()) {
+            if (CheckedPtr page = coreFrame->page())
+                return page->deviceScaleFactor();
+        }
+    }
+    return 1;
+}
+
+void PDFPluginBase::scrollbarStyleChanged(ScrollbarStyle style, bool forceUpdate)
+{
+    if (!forceUpdate)
+        return;
+
+    if (m_hasBeenDestroyed)
+        return;
+
+    // If the PDF was scrolled all the way to bottom right and scrollbars change to overlay style, we don't want to display white rectangles where scrollbars were.
+    IntPoint newScrollOffset = IntPoint(m_scrollOffset).shrunkTo(maximumScrollPosition());
+    setScrollOffset(newScrollOffset);
+
+    ScrollableArea::scrollbarStyleChanged(style, forceUpdate);
+    // As size of the content area changes, scrollbars may need to appear or to disappear.
+    updateScrollbars();
+}
+
+IntRect PDFPluginBase::convertFromScrollbarToContainingView(const Scrollbar& scrollbar, const IntRect& scrollbarRect) const
+{
+    IntRect rect = scrollbarRect;
+    rect.move(scrollbar.location() - m_view->location());
+
+    return m_view->frame()->protectedView()->convertFromRendererToContainingView(m_view->pluginElement().renderer(), rect);
+}
+
+IntRect PDFPluginBase::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntRect& parentRect) const
+{
+    IntRect rect = m_view->frame()->protectedView()->convertFromContainingViewToRenderer(m_view->pluginElement().renderer(), parentRect);
+    rect.move(m_view->location() - scrollbar.location());
+
+    return rect;
+}
+
+IntPoint PDFPluginBase::convertFromScrollbarToContainingView(const Scrollbar& scrollbar, const IntPoint& scrollbarPoint) const
+{
+    IntPoint point = scrollbarPoint;
+    point.move(scrollbar.location() - m_view->location());
+
+    return m_view->frame()->protectedView()->convertFromRendererToContainingView(m_view->pluginElement().renderer(), point);
+}
+
+IntPoint PDFPluginBase::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntPoint& parentPoint) const
+{
+    IntPoint point = m_view->frame()->protectedView()->convertFromContainingViewToRenderer(m_view->pluginElement().renderer(), parentPoint);
+    point.move(m_view->location() - scrollbar.location());
+
+    return point;
+}
+
+String PDFPluginBase::debugDescription() const
+{
+    return makeString("PDFPluginBase 0x", hex(reinterpret_cast<uintptr_t>(this), Lowercase));
+}
+
+void PDFPluginBase::willDetachRenderer()
+{
+    if (!m_frame || !m_frame->coreLocalFrame())
+        return;
+    if (RefPtr frameView = m_frame->coreLocalFrame()->view())
+        frameView->removeScrollableArea(this);
+}
+
+void PDFPluginBase::updateScrollbars()
+{
+    if (m_hasBeenDestroyed)
+        return;
+
+    bool hadScrollbars = m_horizontalScrollbar || m_verticalScrollbar;
+    auto pdfDocumentSize = contentsSize();
+
+    if (m_horizontalScrollbar) {
+        if (m_size.width() >= pdfDocumentSize.width())
+            destroyScrollbar(ScrollbarOrientation::Horizontal);
+    } else if (m_size.width() < pdfDocumentSize.width())
+        m_horizontalScrollbar = createScrollbar(ScrollbarOrientation::Horizontal);
+
+    if (m_verticalScrollbar) {
+        if (m_size.height() >= pdfDocumentSize.height())
+            destroyScrollbar(ScrollbarOrientation::Vertical);
+    } else if (m_size.height() < pdfDocumentSize.height())
+        m_verticalScrollbar = createScrollbar(ScrollbarOrientation::Vertical);
+
+    IntSize scrollbarSpace = scrollbarIntrusion();
+
+    if (m_horizontalScrollbar) {
+        m_horizontalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
+        m_horizontalScrollbar->setProportion(m_size.width() - scrollbarSpace.width(), pdfDocumentSize.width());
+        IntRect scrollbarRect(m_view->x(), m_view->y() + m_size.height() - m_horizontalScrollbar->height(), m_size.width(), m_horizontalScrollbar->height());
+        if (m_verticalScrollbar)
+            scrollbarRect.contract(m_verticalScrollbar->width(), 0);
+        m_horizontalScrollbar->setFrameRect(scrollbarRect);
+    }
+
+    if (m_verticalScrollbar) {
+        m_verticalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
+        m_verticalScrollbar->setProportion(m_size.height() - scrollbarSpace.height(), pdfDocumentSize.height());
+        IntRect scrollbarRect(IntRect(m_view->x() + m_size.width() - m_verticalScrollbar->width(), m_view->y(), m_verticalScrollbar->width(), m_size.height()));
+        if (m_horizontalScrollbar)
+            scrollbarRect.contract(0, m_horizontalScrollbar->height());
+        m_verticalScrollbar->setFrameRect(scrollbarRect);
+    }
+
+    RefPtr frameView = m_frame ? m_frame->coreLocalFrame()->view() : nullptr;
+    if (!frameView)
+        return;
+
+    bool hasScrollbars = m_horizontalScrollbar || m_verticalScrollbar;
+    if (hadScrollbars != hasScrollbars) {
+        if (hasScrollbars)
+            frameView->addScrollableArea(this);
+        else
+            frameView->removeScrollableArea(this);
+
+        frameView->setNeedsLayoutAfterViewConfigurationChange();
+    }
+}
+
+Ref<Scrollbar> PDFPluginBase::createScrollbar(ScrollbarOrientation orientation)
+{
+    Ref widget = Scrollbar::createNativeScrollbar(*this, orientation, ScrollbarWidth::Auto);
+    didAddScrollbar(widget.ptr(), orientation);
+
+    if (RefPtr frame = m_frame ? m_frame->coreLocalFrame() : nullptr) {
+        if (CheckedPtr page = frame->page()) {
+            if (page->isMonitoringWheelEvents())
+                scrollAnimator().setWheelEventTestMonitor(page->wheelEventTestMonitor());
+        }
+    }
+
+    // Is it ever possible that the code above and the code below can ever get at different Frames?
+    // Can't we settle on one Frame accessor?
+    if (RefPtr frame = m_view->frame()) {
+        if (RefPtr frameView = frame->view())
+            frameView->addChild(widget);
+    }
+
+    return widget;
+}
+
+void PDFPluginBase::destroyScrollbar(ScrollbarOrientation orientation)
+{
+    RefPtr<Scrollbar>& scrollbar = orientation == ScrollbarOrientation::Horizontal ? m_horizontalScrollbar : m_verticalScrollbar;
+    if (!scrollbar)
+        return;
+
+    willRemoveScrollbar(scrollbar.get(), orientation);
+    scrollbar->removeFromParent();
+    scrollbar = nullptr;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -53,9 +53,17 @@ private:
 
     CGFloat scaleFactor() const override;
 
+    WebCore::IntSize contentsSize() const override;
+    unsigned firstPageHeight() const override;
+
+    bool isLocked() const override;
+
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const override;
     WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
 
+    void scheduleRenderingUpdate();
+
+    void updateLayout();
     void geometryDidChange(const WebCore::IntSize&, const WebCore::AffineTransform&) override;
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
@@ -88,6 +96,11 @@ private:
     float deviceScaleFactor() const override;
 
     void updateLayerHierarchy();
+
+    void didChangeScrollOffset() override;
+
+    void invalidateScrollbarRect(WebCore::Scrollbar&, const WebCore::IntRect&) override;
+    void invalidateScrollCornerRect(const WebCore::IntRect&) override;
 
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, GraphicsLayer::Type);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -200,6 +200,11 @@ WebPage* WebFrame::page() const
     return page ? WebPage::fromCorePage(*page) : nullptr;
 }
 
+RefPtr<WebPage> WebFrame::protectedPage() const
+{
+    return page();
+}
+
 RefPtr<WebFrame> WebFrame::fromCoreFrame(const Frame& frame)
 {
     if (auto* localFrame = dynamicDowncast<LocalFrame>(frame)) {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -93,6 +93,7 @@ public:
     ScopeExit<Function<void()>> makeInvalidator();
 
     WebPage* page() const;
+    RefPtr<WebPage> protectedPage() const;
 
     static RefPtr<WebFrame> fromCoreFrame(const WebCore::Frame&);
     WebCore::LocalFrame* coreLocalFrame() const;


### PR DESCRIPTION
#### cbf8b324d90f14ca4483446c751202a6e40b86a8
<pre>
Unified PDF plugin contents do not scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=264359">https://bugs.webkit.org/show_bug.cgi?id=264359</a>

Reviewed by Simon Fraser.

Hoist PDFPlugin ScrollableArea implementation to PDFPluginBase.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::installPDFDocument):
(WebKit::PDFPlugin::attemptToUnlockPDF):
(WebKit::PDFPlugin::isLocked const):
(WebKit::PDFPlugin::handleMouseEvent):
(WebKit::PDFPlugin::snapshot):
Add and adopt isLocked().

(WebKit::PDFPlugin::contentsSize const):
(WebKit::PDFPlugin::firstPageHeight const):
Add methods to pull the contents and first page sizes instead of depending
on recomputing them at various times.

(WebKit::PDFPlugin::geometryDidChange):
(WebKit::PDFPlugin::updatePDFHUDLocation):
Rename calculateSizes() to updatePDFHUDLocation() since that&apos;s the last thing it does.

(WebKit::PDFPlugin::didChangeScrollOffset):
(WebKit::PDFPlugin::notifyContentScaleFactorChanged):
(WebKit::PDFPlugin::notifyDisplayModeChanged):
(WebKit::PDFPlugin::convertFromScrollbarToContainingView const): Deleted.
(WebKit::PDFPlugin::convertFromContainingViewToScrollbar const): Deleted.
(WebKit::PDFPlugin::debugDescription const): Deleted.
(WebKit::PDFPlugin::scrollCornerRect const): Deleted.
(WebKit::PDFPlugin::enclosingScrollableArea const): Deleted.
(WebKit::PDFPlugin::scrollableAreaBoundingBox const): Deleted.
(WebKit::PDFPlugin::isActive const): Deleted.
(WebKit::PDFPlugin::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const): Deleted.
(WebKit::PDFPlugin::scrollPosition const): Deleted.
(WebKit::PDFPlugin::minimumScrollPosition const): Deleted.
(WebKit::PDFPlugin::maximumScrollPosition const): Deleted.
(WebKit::PDFPlugin::scrollbarStyleChanged): Deleted.
(WebKit::PDFPlugin::deviceScaleFactor const): Deleted.
(WebKit::PDFPlugin::calculateSizes): Deleted.
(WebKit::PDFPlugin::willDetachRenderer): Deleted.
(WebKit::PDFPlugin::updateControlTints): Deleted.
(WebKit::PDFPlugin::setScrollOffset): Deleted.
Move ScrollableArea implementation to PDFPluginBase.

(WebKit::PDFPlugin::updateScrollbars):
(WebKit::PDFPlugin::createScrollbar):
(WebKit::PDFPlugin::destroyScrollbar):
Keep scrollbar *layer* code in PDFPlugin.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::scrollPositionForTesting const):
(WebKit::PDFPluginBase::willDetachRenderer): Deleted.
(WebKit::PDFPluginBase::updateControlTints): Deleted.

(WebKit::PDFPluginBase::wantsWheelEvents const):
Turn on wantsWheelEvents, since both subclasses do.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::updateControlTints):
(WebKit::PDFPluginBase::scrollCornerRect const):
(WebKit::PDFPluginBase::enclosingScrollableArea const):
(WebKit::PDFPluginBase::scrollableAreaBoundingBox const):
(WebKit::PDFPluginBase::setScrollOffset):
(WebKit::PDFPluginBase::isActive const):
(WebKit::PDFPluginBase::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const):
(WebKit::PDFPluginBase::scrollPosition const):
(WebKit::PDFPluginBase::minimumScrollPosition const):
(WebKit::PDFPluginBase::maximumScrollPosition const):
(WebKit::PDFPluginBase::deviceScaleFactor const):
(WebKit::PDFPluginBase::scrollbarStyleChanged):
(WebKit::PDFPluginBase::convertFromScrollbarToContainingView const):
(WebKit::PDFPluginBase::convertFromContainingViewToScrollbar const):
(WebKit::PDFPluginBase::debugDescription const):
(WebKit::PDFPluginBase::willDetachRenderer):
(WebKit::PDFPluginBase::updateScrollbars):
(WebKit::PDFPluginBase::createScrollbar):
(WebKit::PDFPluginBase::destroyScrollbar):
Hoist ScrollableArea implementation to here from PDFPlugin.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::geometryDidChange):
(WebKit::UnifiedPDFPlugin::updateLayout):
Fold updateLayout/updateLayerHierarchy into updateLayout(), and also update scrollbars from there.

(WebKit::UnifiedPDFPlugin::scheduleRenderingUpdate):
Added; triggers a layer flush.

(WebKit::UnifiedPDFPlugin::isLocked const):
(WebKit::UnifiedPDFPlugin::contentsSize const):
(WebKit::UnifiedPDFPlugin::firstPageHeight const):
Implement these new getters.

(WebKit::UnifiedPDFPlugin::didChangeScrollOffset):
Move the contents layer around (for now) when the scroll offset changes.

(WebKit::UnifiedPDFPlugin::invalidateScrollbarRect):
(WebKit::UnifiedPDFPlugin::invalidateScrollCornerRect):
For now, ignor scrollbar invalidation; we don&apos;t have scrollbar layers yet.

(WebKit::UnifiedPDFPlugin::handleWheelEvent):
Pass wheel events to ScrollableArea.

Canonical link: <a href="https://commits.webkit.org/270358@main">https://commits.webkit.org/270358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4c95a8523f5a8282c806e414692eb39cd900caa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23173 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1229 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27944 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23041 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23084 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/26680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/734 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3800 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6053 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2889 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2783 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->