### PR TITLE
Add support for os_signpost for WebContent on iOS

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -513,6 +513,8 @@ JSC_DEFINE_HOST_FUNCTION(tracePointStop, (JSGlobalObject* globalObject, CallFram
     return JSValue::encode(jsUndefined());
 }
 
+#if HAVE(OS_SIGNPOST)
+
 static String asSignpostString(JSGlobalObject* globalObject, JSValue v)
 {
     if (v.isUndefined())
@@ -528,7 +530,7 @@ JSC_DEFINE_HOST_FUNCTION(signpostStart, (JSGlobalObject* globalObject, CallFrame
     auto message = asSignpostString(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, EncodedJSValue());
 
-    WTFBeginSignpostAlways(globalObject, "JSGlobalObject signpost", "%" PUBLIC_LOG_STRING, message.ascii().data());
+    os_signpost_interval_begin(WTFSignpostLogHandle(), os_signpost_id_make_with_pointer(WTFSignpostLogHandle(), globalObject), "JSGlobalObject signpost", "%" PUBLIC_LOG_STRING, message.ascii().data());
 
     return JSValue::encode(jsUndefined());
 }
@@ -541,10 +543,24 @@ JSC_DEFINE_HOST_FUNCTION(signpostStop, (JSGlobalObject* globalObject, CallFrame*
     auto message = asSignpostString(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, EncodedJSValue());
 
-    WTFEndSignpostAlways(globalObject, "JSGlobalObject signpost", "%" PUBLIC_LOG_STRING, message.ascii().data());
+    os_signpost_interval_end(WTFSignpostLogHandle(), os_signpost_id_make_with_pointer(WTFSignpostLogHandle(), globalObject), "JSGlobalObject signpost", "%" PUBLIC_LOG_STRING, message.ascii().data());
 
     return JSValue::encode(jsUndefined());
 }
+
+#else
+
+JSC_DEFINE_HOST_FUNCTION(signpostStart, (JSGlobalObject*, CallFrame*))
+{
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(signpostStop, (JSGlobalObject*, CallFrame*))
+{
+    return JSValue::encode(jsUndefined());
+}
+
+#endif // HAVE(OS_SIGNPOST)
 
 JSC_DEFINE_HOST_FUNCTION(enableSuperSampler, (JSGlobalObject*, CallFrame*))
 {

--- a/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
@@ -26,9 +26,12 @@
 #import "config.h"
 #import "SystemTracing.h"
 
-#if HAVE(OS_SIGNPOST) && HAVE(KDEBUG_H)
+#if HAVE(OS_SIGNPOST)
 
 #import <dispatch/dispatch.h>
+#import <mach/mach_time.h>
+
+bool WTFSignpostIndirectLoggingEnabled;
 
 os_log_t WTFSignpostLogHandle()
 {
@@ -40,6 +43,113 @@ os_log_t WTFSignpostLogHandle()
     });
 
     return handle;
+}
+
+#define WTF_SIGNPOST_EVENT_EMIT_FUNC_CASE_LABEL(emitFunc, name, timeFormat) \
+    case WTFOSSignpostName ## name : \
+        emitFunc(log, signpostIdentifier, #name, "pid: %d | %{public}s" timeFormat, pid, logString, timestamp); \
+        break;
+
+static void beginSignpostInterval(os_log_t log, WTFOSSignpostName signpostName, uint64_t signpostIdentifier, uint64_t timestamp, pid_t pid, const char* logString)
+{
+#define WTF_SIGNPOST_EVENT_BEGIN_INTERVAL_CASE_LABEL(name) \
+    WTF_SIGNPOST_EVENT_EMIT_FUNC_CASE_LABEL(os_signpost_interval_begin, name, " %{signpost.description:begin_time}llu")
+
+    switch (signpostName) {
+        FOR_EACH_WTF_SIGNPOST_NAME(WTF_SIGNPOST_EVENT_BEGIN_INTERVAL_CASE_LABEL)
+        default: break;
+    }
+}
+
+static void endSignpostInterval(os_log_t log, WTFOSSignpostName signpostName, uint64_t signpostIdentifier, uint64_t timestamp, pid_t pid, const char* logString)
+{
+#define WTF_SIGNPOST_EVENT_END_INTERVAL_CASE_LABEL(name) \
+    WTF_SIGNPOST_EVENT_EMIT_FUNC_CASE_LABEL(os_signpost_interval_end, name, " %{signpost.description:end_time}llu")
+
+    switch (signpostName) {
+        FOR_EACH_WTF_SIGNPOST_NAME(WTF_SIGNPOST_EVENT_END_INTERVAL_CASE_LABEL)
+        default: break;
+    }
+}
+
+static void emitSignpostEvent(os_log_t log, WTFOSSignpostName signpostName, uint64_t signpostIdentifier, uint64_t timestamp, pid_t pid, const char* logString)
+{
+#define WTF_SIGNPOST_EVENT_EMIT_CASE_LABEL(name) \
+    WTF_SIGNPOST_EVENT_EMIT_FUNC_CASE_LABEL(os_signpost_event_emit, name, " %{signpost.description:event_time}llu")
+
+    switch (signpostName) {
+        FOR_EACH_WTF_SIGNPOST_NAME(WTF_SIGNPOST_EVENT_EMIT_CASE_LABEL)
+        default: break;
+    }
+}
+
+static void emitSignpost(os_log_t log, WTFOSSignpostType type, WTFOSSignpostName name, uint64_t signpostIdentifier, uint64_t timestamp, pid_t pid, const char* logString)
+{
+    switch (type) {
+    case WTFOSSignpostTypeBeginInterval:
+        beginSignpostInterval(log, name, signpostIdentifier, timestamp, pid, logString);
+        break;
+    case WTFOSSignpostTypeEndInterval:
+        endSignpostInterval(log, name, signpostIdentifier, timestamp, pid, logString);
+        break;
+    case WTFOSSignpostTypeEmitEvent:
+        emitSignpostEvent(log, name, signpostIdentifier, timestamp, pid, logString);
+        break;
+    default:
+        break;
+    }
+}
+
+bool WTFSignpostHandleIndirectLog(os_log_t log, pid_t pid, const char* logString)
+{
+    if (log != WTFSignpostLogHandle() || !logString)
+        return false;
+
+    int signpostType = 0;
+    int signpostName = 0;
+    uintptr_t signpostIdentifierPointer = 0;
+    uint64_t timestamp = 0;
+    int bytesConsumed = 0;
+
+    if (sscanf(logString, "type=%d name=%d p=%" SCNuPTR " ts=%llu %n", &signpostType, &signpostName, &signpostIdentifierPointer, &timestamp, &bytesConsumed) != 4)
+        return false;
+
+    if (signpostType < 0 || signpostType >= WTFOSSignpostTypeCount)
+        return false;
+
+    if (signpostName < 0 || signpostName >= WTFOSSignpostNameCount)
+        return false;
+
+    // Mix in bits from the pid, since pointers from different pids could be at the same address, causing signpost IDs to clash.
+    signpostIdentifierPointer ^= pid;
+    auto signpostIdentifier = os_signpost_id_make_with_pointer(log, reinterpret_cast<const void *>(signpostIdentifierPointer));
+
+    emitSignpost(log, static_cast<WTFOSSignpostType>(signpostType), static_cast<WTFOSSignpostName>(signpostName), signpostIdentifier, timestamp, pid, logString + bytesConsumed);
+    return true;
+}
+
+static const mach_timebase_info_data_t& machTimebaseInfo()
+{
+    static mach_timebase_info_data_t info;
+    static dispatch_once_t once;
+
+    dispatch_once(&once, ^{
+        mach_timebase_info(&info);
+    });
+
+    return info;
+}
+
+uint64_t WTFCurrentContinuousTime(Seconds deltaFromNow)
+{
+    if (!deltaFromNow)
+        return mach_continuous_time();
+
+    auto& info = machTimebaseInfo();
+    auto now = Seconds((mach_continuous_time() * info.numer) / (1.0e9 * info.denom));
+    auto timestamp = now + deltaFromNow;
+
+    return static_cast<uint64_t>((timestamp.seconds() * 1.0e9 * info.denom) / info.numer);
 }
 
 #endif

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -437,9 +437,9 @@ void ScriptElement::executeClassicScript(const ScriptSourceCode& sourceCode)
     IgnoreDestructiveWriteCountIncrementer ignoreDestructiveWriteCountIncrementer(m_isExternalScript ? document.ptr() : nullptr);
     CurrentScriptIncrementer currentScriptIncrementer(document, *this);
 
-    WTFBeginSignpost(this, "Execute Script Element", "executing classic script from URL: %" PRIVATE_LOG_STRING " async: %d defer: %d", m_isExternalScript ? sourceCode.url().string().utf8().data() : "inline", hasAsyncAttribute(), hasDeferAttribute());
+    WTFBeginSignpost(this, ExecuteScriptElement, "executing classic script from URL: %" PRIVATE_LOG_STRING " async: %d defer: %d", m_isExternalScript ? sourceCode.url().string().utf8().data() : "inline", hasAsyncAttribute(), hasDeferAttribute());
     frame->checkedScript()->evaluateIgnoringException(sourceCode);
-    WTFEndSignpost(this, "Execute Script Element");
+    WTFEndSignpost(this, ExecuteScriptElement);
 }
 
 void ScriptElement::registerImportMap(const ScriptSourceCode& sourceCode)
@@ -476,9 +476,9 @@ void ScriptElement::registerImportMap(const ScriptSourceCode& sourceCode)
     if (!frame)
         return;
 
-    WTFBeginSignpost(this, "Register ImportMap", "registering import-map from URL: %" PRIVATE_LOG_STRING " async: %d defer: %d", m_isExternalScript ? sourceCode.url().string().utf8().data() : "inline", hasAsyncAttribute(), hasDeferAttribute());
+    WTFBeginSignpost(this, RegisterImportMap, "registering import-map from URL: %" PRIVATE_LOG_STRING " async: %d defer: %d", m_isExternalScript ? sourceCode.url().string().utf8().data() : "inline", hasAsyncAttribute(), hasDeferAttribute());
     frame->checkedScript()->registerImportMap(sourceCode, document->baseURL());
-    WTFEndSignpost(this, "Register ImportMap");
+    WTFEndSignpost(this, RegisterImportMap);
 }
 
 void ScriptElement::executeModuleScript(LoadableModuleScript& loadableModuleScript)
@@ -495,9 +495,9 @@ void ScriptElement::executeModuleScript(LoadableModuleScript& loadableModuleScri
     IgnoreDestructiveWriteCountIncrementer ignoreDestructiveWriteCountIncrementer(document.ptr());
     CurrentScriptIncrementer currentScriptIncrementer(document, *this);
 
-    WTFBeginSignpost(this, "Execute Script Element", "executing module script");
+    WTFBeginSignpost(this, ExecuteScriptElement, "executing module script");
     frame->script().linkAndEvaluateModuleScript(loadableModuleScript);
-    WTFEndSignpost(this, "Execute Script Element", "executing module script");
+    WTFEndSignpost(this, ExecuteScriptElement, "executing module script");
 }
 
 void ScriptElement::dispatchLoadEventRespectingUserGestureIndicator()

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2336,22 +2336,18 @@ void LocalDOMWindow::dispatchLoadEvent()
         protectedLoader->timing().setLoadEventStart(now);
         if (RefPtr navigationTiming = performance().navigationTiming())
             navigationTiming->documentLoadTiming().setLoadEventStart(now);
+        WTFEmitSignpost(document(), NavigationAndPaintTiming, "loadEventBegin");
     }
 
-    bool isMainFrame = frame() && frame()->isMainFrame();
-    if (isMainFrame)
-        WTFBeginSignpost(document(), "Page Load: Load Event");
-
     dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No), protectedDocument().get());
-
-    if (isMainFrame)
-        WTFEndSignpost(document(), "Page Load: Load Event");
 
     if (shouldMarkLoadEventTimes) {
         auto now = MonotonicTime::now();
         protectedLoader->timing().setLoadEventEnd(now);
         if (RefPtr navigationTiming = performance().navigationTiming())
             navigationTiming->documentLoadTiming().setLoadEventEnd(now);
+        WTFEmitSignpost(document(), NavigationAndPaintTiming, "loadEventEnd");
+        WTFEndSignpost(document(), NavigationAndPaintTiming);
     }
 
     // Send a separate load event to the element that owns this frame.

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6002,8 +6002,6 @@ void LocalFrameView::firePaintRelatedMilestonesIfNeeded()
     if (m_milestonesPendingPaint & LayoutMilestone::DidFirstMeaningfulPaint) {
         if (page->requestedLayoutMilestones() & LayoutMilestone::DidFirstMeaningfulPaint)
             milestonesAchieved.add(LayoutMilestone::DidFirstMeaningfulPaint);
-        if (m_frame->isMainFrame())
-            WTFEmitSignpost(m_frame->document(), "Page Load: First Meaningful Paint");
     }
 
     m_milestonesPendingPaint = { };

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -187,10 +187,12 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
     }
 
     auto momentumPhase = wheelEvent.momentumPhase();
-    
+
+#if HAVE(OS_SIGNPOST)
     if (momentumPhase == PlatformWheelEventPhase::Began)
-        WTFBeginAnimationSignpostAlways(nullptr, "Momentum scroll", "");
-    
+        os_signpost_interval_begin(WTFSignpostLogHandle(), OS_SIGNPOST_ID_EXCLUSIVE, "Momentum scroll", "isAnimation=YES");
+#endif
+
     if (!m_momentumScrollInProgress && (momentumPhase == PlatformWheelEventPhase::Began || momentumPhase == PlatformWheelEventPhase::Changed))
         m_momentumScrollInProgress = true;
 
@@ -233,7 +235,9 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
     }
 
     if (m_momentumScrollInProgress && momentumPhase == PlatformWheelEventPhase::Ended) {
-        WTFEndSignpostAlways(nullptr, "Momentum scroll");
+#if HAVE(OS_SIGNPOST)
+        os_signpost_interval_end(WTFSignpostLogHandle(), OS_SIGNPOST_ID_EXCLUSIVE, "Momentum scroll");
+#endif
         m_momentumScrollInProgress = false;
         m_ignoreMomentumScrolls = false;
         m_lastMomentumScrollTimestamp = { };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -275,7 +275,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
         m_task.get()._hostOverride = adoptNS(nw_endpoint_create_host_with_numeric_port("localhost", url.port().value_or(0))).get();
 #endif
 
-    WTFBeginSignpost(m_task.get(), "DataTask", "%" PUBLIC_LOG_STRING " %" PRIVATE_LOG_STRING " pri: %.2f preconnect: %d", request.httpMethod().utf8().data(), url.string().utf8().data(), toNSURLSessionTaskPriority(request.priority()), parameters.shouldPreconnectOnly == PreconnectOnly::Yes);
+    WTFBeginSignpost(m_task.get(), DataTask, "%" PUBLIC_LOG_STRING " %" PRIVATE_LOG_STRING " pri: %.2f preconnect: %d", request.httpMethod().utf8().data(), url.string().utf8().data(), toNSURLSessionTaskPriority(request.priority()), parameters.shouldPreconnectOnly == PreconnectOnly::Yes);
 
     switch (parameters.storedCredentialsPolicy) {
     case WebCore::StoredCredentialsPolicy::Use:
@@ -331,7 +331,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 NetworkDataTaskCocoa::~NetworkDataTaskCocoa()
 {
     if (m_task)
-        WTFEndSignpost(m_task.get(), "DataTask");
+        WTFEndSignpost(m_task.get(), DataTask);
 
     if (m_task && m_sessionWrapper) {
         auto& map = m_sessionWrapper->dataTaskMap;
@@ -344,7 +344,7 @@ NetworkDataTaskCocoa::~NetworkDataTaskCocoa()
 
 void NetworkDataTaskCocoa::didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend)
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "sent %llu bytes (expected %llu bytes)", totalBytesSent, totalBytesExpectedToSend);
+    WTFEmitSignpost(m_task.get(), DataTask, "sent %llu bytes (expected %llu bytes)", totalBytesSent, totalBytesExpectedToSend);
 
     if (m_client)
         m_client->didSendData(totalBytesSent, totalBytesExpectedToSend);
@@ -352,7 +352,7 @@ void NetworkDataTaskCocoa::didSendData(uint64_t totalBytesSent, uint64_t totalBy
 
 void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler)
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "received challenge");
+    WTFEmitSignpost(m_task.get(), DataTask, "received challenge");
 
     if (tryPasswordBasedAuthentication(challenge, completionHandler))
         return;
@@ -373,7 +373,7 @@ void NetworkDataTaskCocoa::didNegotiateModernTLS(const URL& url)
 
 void NetworkDataTaskCocoa::didCompleteWithError(const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics& networkLoadMetrics)
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "completed with error: %d", !error.isNull());
+    WTFEmitSignpost(m_task.get(), DataTask, "completed with error: %d", !error.isNull());
 
     if (m_client)
         m_client->didCompleteWithError(error, networkLoadMetrics);
@@ -381,7 +381,7 @@ void NetworkDataTaskCocoa::didCompleteWithError(const WebCore::ResourceError& er
 
 void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "received %zd bytes", data.size());
+    WTFEmitSignpost(m_task.get(), DataTask, "received %zd bytes", data.size());
 
     if (m_client)
         m_client->didReceiveData(data);
@@ -389,7 +389,7 @@ void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
 
 void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS negotiatedLegacyTLS, PrivateRelayed privateRelayed, WebKit::ResponseCompletionHandler&& completionHandler)
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "received response headers");
+    WTFEmitSignpost(m_task.get(), DataTask, "received response headers");
     if (isTopLevelNavigation())
         updateFirstPartyInfoForSession(response.url());
 #if ENABLE(NETWORK_ISSUE_REPORTING)
@@ -403,7 +403,7 @@ void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& respon
 
 void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&& redirectResponse, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "redirect");
+    WTFEmitSignpost(m_task.get(), DataTask, "redirect");
 
     networkLoadMetrics().hasCrossOriginRedirect = networkLoadMetrics().hasCrossOriginRedirect || !WebCore::SecurityOrigin::create(request.url())->canRequest(redirectResponse.url(), WebCore::EmptyOriginAccessPatterns::singleton());
 
@@ -551,13 +551,13 @@ String NetworkDataTaskCocoa::suggestedFilename() const
 
 void NetworkDataTaskCocoa::cancel()
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "cancel");
+    WTFEmitSignpost(m_task.get(), DataTask, "cancel");
     [m_task cancel];
 }
 
 void NetworkDataTaskCocoa::resume()
 {
-    WTFEmitSignpost(m_task.get(), "DataTask", "resume");
+    WTFEmitSignpost(m_task.get(), DataTask, "resume");
 
     if (m_failureScheduled)
         return;

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -806,6 +806,8 @@ static void registerLogHook()
             free(messageString);
         }, qos);
     });
+
+    WTFSignpostIndirectLoggingEnabled = true;
 }
 #endif
 


### PR DESCRIPTION
#### 2242351e265d11469993410984fdda3ec21e6de2
<pre>
Add support for os_signpost for WebContent on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=264357">https://bugs.webkit.org/show_bug.cgi?id=264357</a>
<a href="https://rdar.apple.com/117593169">rdar://117593169</a>

Reviewed by Per Arne Vollan.

269026@main blocked WebContent from talking to logd. This also broke os_signpost in WebContent since
signposts are emitted to logd.

To work around this, in this patch we send WebContent os_signposts down the same IPC pipe as regular
os_logs. On the receiving side (in NetworkProcess), we deserialize the log line and emit an
os_signpost. This requires some unfortunate use of scanf on the receiving side, but I don&apos;t see a
better way of doing this without improved signpost hooks from libtrace (<a href="https://rdar.apple.com/111422207).">rdar://111422207).</a>

This also requires a bunch of C macros because signpost names *must* be C string literal tokens from
the point of view of the C preprocessor, due to the way os_signpost is implemented. So there are
several places here where we use a switch-case through every single possible signpost name in order
to emit the right os_signpost call. The various os_signpost APIs themselves are also macros, so
there are also places where we have to switch-case through every signpost API type (emit event,
begin interval, and end inverval) in order to call the appropriate os_signpost macro.

I also made some changes to few existing callers of os_signpost in the codebase:

- There were two places where we were calling the EmitSignpostAlways variant of the API. This
  probably doesn&apos;t make sense anymore considering a signpost is now heavier weight and requires an
  IPC. I converted those call sites to use `os_signpost` directly, which means they emit signposts
  when logd is enabled (on Mac), and don&apos;t emit signposts when logd is blocked.

- `handleWheelEvent` used the animation tagged variant of the signpost API. This is hard to continue
  using when sending signposts over IPC since it requires the format string to be encoded in a
  particular manner. I also converted this to use os_signpost directly, which should be okay since
  this code is only running on Mac.

- I consolidated all of the page loading and paint signposts under a single signpost name called
  NavigationAndPaintTiming. For each document loaded, we now emit an interval from [startTime,
  loadEventEnd) under this signpost name. Within this interval, key milestones from the
  NavigationTiming and PaintTiming APIs are annotated, e.g. domInteractive,
  domContentLoadedEventStart, loadEventStart, firstContentfulPaint, etc.

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp:
(beginSignpostInterval):
(endSignpostInterval):
(emitSignpostEvent):
(emitSignpost):
(WTFSignpostHandleIndirectLog):
(machTimebaseInfo):
(WTFCurrentContinuousTime):
* Source/WebCore/dom/Document.cpp:
(WebCore::m_frameIdentifier):
(WebCore::Document::~Document):
(WebCore::Document::setReadyState):
(WebCore::Document::enqueuePaintTimingEntryIfNeeded):
(WebCore::Document::finishedParsing):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::executeClassicScript):
(WebCore::ScriptElement::registerImportMap):
(WebCore::ScriptElement::executeModuleScript):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchLoadEvent):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::firePaintRelatedMilestonesIfNeeded):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::handleWheelEvent):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::logOnBehalfOfWebContent):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::~NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::didSendData):
(WebKit::NetworkDataTaskCocoa::didReceiveChallenge):
(WebKit::NetworkDataTaskCocoa::didCompleteWithError):
(WebKit::NetworkDataTaskCocoa::didReceiveData):
(WebKit::NetworkDataTaskCocoa::didReceiveResponse):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCocoa::cancel):
(WebKit::NetworkDataTaskCocoa::resume):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::registerLogHook):

Canonical link: <a href="https://commits.webkit.org/270471@main">https://commits.webkit.org/270471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/709906dc74c89f5adf781f24effcdfbca2884573

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25312 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23417 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28001 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28882 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22012 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26720 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24541 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/774 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31973 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3848 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6137 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->