### PR TITLE
[git-webkit] `git revert` does not produce a meaningful commit message

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -39,27 +39,27 @@ sys.path.append(SCRIPTS)
 from webkitpy.common.checkout.diff_parser import DiffParser
 from webkitbugspy import radar
 
-
-BRANCH = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], **ENCODING_KWARGS).strip()
-for name, variable in dict(
-    title='COMMIT_MESSAGE_TITLE',
-    bug='COMMIT_MESSAGE_BUG',
-    cherry_picked='GIT_WEBKIT_CHERRY_PICKED',
-).items():
-    if variable in os.environ:
-        continue
-    try:
-        value = subprocess.check_output(
-            ['git', 'config', '--get-all', 'branch.{}.{}'.format(BRANCH, name)],
-            stderr=subprocess.PIPE,
-            **ENCODING_KWARGS
-        ).strip()
-        if value:
-            os.environ[variable] = value
-    except subprocess.CalledProcessError as error:
-        # `1` means that key did not exist, which is valid.
-        if error.returncode != 1:
-            sys.stderr.write(error.stderr)
+def set_env_variables_from_branch_config():
+    BRANCH = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], **ENCODING_KWARGS).strip()
+    for name, variable in dict(
+        title='COMMIT_MESSAGE_TITLE',
+        bug='COMMIT_MESSAGE_BUG',
+        cherry_picked='GIT_WEBKIT_CHERRY_PICKED',
+    ).items():
+        if variable in os.environ:
+            continue
+        try:
+            value = subprocess.check_output(
+                ['git', 'config', '--get-all', 'branch.{}.{}'.format(BRANCH, name)],
+                stderr=subprocess.PIPE,
+                **ENCODING_KWARGS
+            ).strip()
+            if value:
+                os.environ[variable] = value
+        except subprocess.CalledProcessError as error:
+            # `1` means that key did not exist, which is valid.
+            if error.returncode != 1:
+                sys.stderr.write(error.stderr)
 
 
 def get_bugs_string():
@@ -298,6 +298,13 @@ def main(file_name=None, source=None, sha=None):
     if source not in (None, 'commit', 'template', 'merge'):
         return 0
 
+    if os.environ.get('COMMIT_MESSAGE_TITLE', '').startswith('Unreviewed, reverting'):
+        pass  # TODO: Implement more useful revert commit message
+    elif source == 'merge' and content.startswith('Revert'):
+        return 0
+    else:
+        set_env_variables()
+
     for line in content.splitlines():
         if CHERRY_PICKING_RE.match(line):
             os.environ['GIT_REFLOG_ACTION'] = 'cherry-pick'
@@ -306,9 +313,6 @@ def main(file_name=None, source=None, sha=None):
     if source == 'merge' and os.environ.get('GIT_REFLOG_ACTION') == 'cherry-pick':
         with open(file_name, 'w') as commit_message_file:
             commit_message_file.write(cherry_pick(content))
-        return 0
-
-    if source == 'merge' and not content.startswith('Revert'):
         return 0
 
     if os.environ.get('GIT_EDITOR', '') == ':':

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -39,8 +39,8 @@ from ..commit import Commit
 class Revert(Command):
     name = 'revert'
     help = 'Revert provided list of commits and create a pull-request with this revert commit'
-    REVERT_TITLE_TEMPLATE = 'Revert [{}] {}'
-    REVERT_TITLE_RE = re.compile(r'^Revert \[{}\] [\s\S]*'.format(Commit.IDENTIFIER_RE.pattern))
+    REVERT_TITLE_TEMPLATE = 'Unreviewed, reverting {}'
+    REVERT_TITLE_RE = re.compile(r'^Unreviewed, reverting {}'.format(Commit.IDENTIFIER_RE.pattern))
 
     @classmethod
     def parser(cls, parser, loggers=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -51,13 +51,13 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Revert [5@main] Patch Series' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main' in repo.head.message)
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
 
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created the local development branch 'eng/pr-branch'\n"
-            "Created 'PR 1 | Revert [5@main] Patch Series'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -75,7 +75,6 @@ class TestRevert(testing.PathTestCase):
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
                 "Pushing 'eng/pr-branch' to 'fork'...",
                 "Creating pull-request for 'eng/pr-branch'...",
-                'Adding comment for reverted commits...'
             ],
         )
 
@@ -92,7 +91,7 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Revert [5@main] Patch Series' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main' in repo.head.message)
             result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
             self.assertEqual(0, result)
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
@@ -100,7 +99,7 @@ class TestRevert(testing.PathTestCase):
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created the local development branch 'eng/pr-branch'\n"
-            "Created 'PR 1 | Revert [5@main] Patch Series'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -119,7 +118,6 @@ class TestRevert(testing.PathTestCase):
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
                 "Pushing 'eng/pr-branch' to 'fork'...",
                 "Creating pull-request for 'eng/pr-branch'...",
-                'Adding comment for reverted commits...'
             ],
         )
 
@@ -168,9 +166,9 @@ index 05e8751..0bf3c85 100644
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created the local development branch 'eng/pr-branch'\n"
-            "Created 'PR 1 | Revert [5@main] Patch Series'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n"
-            "Updated 'PR 1 | Revert [5@main] Patch Series'!\n"
+            "Updated 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -189,7 +187,6 @@ index 05e8751..0bf3c85 100644
                 "Pushing 'eng/pr-branch' to 'fork'...",
                 "Creating 'eng/pr-branch-1' as a reference branch",
                 "Creating pull-request for 'eng/pr-branch'...",
-                'Adding comment for reverted commits...',
                 'Using committed changes...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",


### PR DESCRIPTION
#### a4e364130e7c85357bf8a04896e38fa7f89fe9b9
<pre>
[git-webkit] `git revert` does not produce a meaningful commit message
<a href="https://bugs.webkit.org/show_bug.cgi?id=243947">https://bugs.webkit.org/show_bug.cgi?id=243947</a>
<a href="https://rdar.apple.com/problem/98992367">rdar://problem/98992367</a>

Reviewed by Jonathan Bedard.

Changes to logic so git revert is no longer a blank template.
Also prevents git-webkit revert from affecting future commits on main.
A better commit message for git revert is in the works!

* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert.test_github):
(TestRevert.test_github_two_step):
(test_update):

Canonical link: <a href="https://commits.webkit.org/270375@main">https://commits.webkit.org/270375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37893995a7554aed2d805efb414e8de373fc5162

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27359 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23385 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27937 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/25408 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28843 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26676 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/731 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/25008 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3793 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6066 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2882 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2776 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->