### PR TITLE
[css-grid][masonry] Implement New Masonry Layout Algorithm

### DIFF
--- a/Source/WebCore/rendering/Grid.cpp
+++ b/Source/WebCore/rendering/Grid.cpp
@@ -209,6 +209,11 @@ void Grid::setupGridForMasonryLayout()
     m_gridItemArea.clear();
 }
 
+// setNeedsItemPlacement serves three main purposes.
+//
+// 1. Keeps track of whether an item placement is needed.
+// 2. Resets all internal variables when item placement is needed.
+// 3. When item placement is not needed resize the grid to fit the items.
 void Grid::setNeedsItemsPlacement(bool needsItemsPlacement)
 {
     m_needsItemsPlacement = needsItemsPlacement;

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -22,6 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include "config.h"
 #include "GridMasonryLayout.h"
 
@@ -59,7 +60,7 @@ void GridMasonryLayout::performMasonryPlacement(unsigned gridAxisTracks, GridTra
     m_renderGrid.populateGridPositionsForDirection(GridTrackSizingDirection::ForRows);
 
     // 2.4 Masonry Layout Algorithm
-    addItemsToFirstTrack();
+    // https://drafts.csswg.org/css-grid-3/#masonry-layout-algorithm
     
     // the insertIntoGridAndLayoutItem() will modify the m_autoFlowNextCursor, so m_autoFlowNextCursor needs to be reset.
     m_autoFlowNextCursor = 0;
@@ -75,7 +76,6 @@ void GridMasonryLayout::performMasonryPlacement(unsigned gridAxisTracks, GridTra
 void GridMasonryLayout::collectMasonryItems()
 {
     ASSERT(m_gridAxisTracksCount);
-    m_firstTrackItems.clear();
     m_itemsWithDefiniteGridAxisPosition.resize(0);
     m_itemsWithIndefiniteGridAxisPosition.resize(0);
 
@@ -84,10 +84,7 @@ void GridMasonryLayout::collectMasonryItems()
         if (grid.orderIterator().shouldSkipChild(*child))
             continue;
 
-        auto gridArea = grid.gridItemArea(*child);
-        if (m_firstTrackItems.size() != m_gridAxisTracksCount && itemGridAreaStartsAtFirstLine(gridArea, m_masonryAxisDirection) && m_renderGrid.itemGridAreaIsWithinImplicitGrid(gridArea, m_gridAxisTracksCount + 1, gridAxisDirection()))
-            m_firstTrackItems.add(child, gridArea);
-        else if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
+        if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
             m_itemsWithDefiniteGridAxisPosition.append(child);
         else if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst) {
             if (hasDefiniteGridAxisPosition(*child, gridAxisDirection()))
@@ -115,16 +112,6 @@ void GridMasonryLayout::resizeAndResetRunningPositions()
 {
     m_runningPositions.resize(m_gridAxisTracksCount);
     m_runningPositions.fill(LayoutUnit());
-}
-
-void GridMasonryLayout::addItemsToFirstTrack()
-{
-    for (auto& [item, gridArea] : m_firstTrackItems) {
-        ASSERT(item);
-        if (!item)
-            continue;
-        insertIntoGridAndLayoutItem(*item, gridArea);
-    }
 }
 
 void GridMasonryLayout::placeItemsUsingOrderModifiedDocumentOrder()

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -22,6 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 #pragma once
 
 #include "GridArea.h"
@@ -53,8 +54,7 @@ private:
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
     void collectMasonryItems();
-    void addItemsToFirstTrack(); 
-    void placeItemsUsingOrderModifiedDocumentOrder(); 
+    void placeItemsUsingOrderModifiedDocumentOrder();
     void placeItemsWithDefiniteGridAxisPosition();
     void placeItemsWithIndefiniteGridAxisPosition();
     void setItemGridAxisContainingBlockToGridArea(RenderBox&);
@@ -78,7 +78,6 @@ private:
 
     unsigned m_gridAxisTracksCount;
 
-    HashMap<RenderBox*, GridArea> m_firstTrackItems;
     Vector<RenderBox*> m_itemsWithDefiniteGridAxisPosition;
     Vector<RenderBox*> m_itemsWithIndefiniteGridAxisPosition;
 

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -89,6 +89,7 @@ public:
     // keeping the logic in the same function was leading to a messy amount of if statements being added to handle
     // specific masonry cases.
     void layoutGrid(bool);
+
     void layoutMasonry(bool);
 
     // Computes the span relative to this RenderGrid, even if the RenderBox is a child
@@ -161,6 +162,8 @@ private:
     void performGridItemsPreLayout(const GridTrackSizingAlgorithm&, const ShouldUpdateGridAreaLogicalSize) const;
 
     void placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidth);
+    void placeItemsOnMasonry(std::optional<LayoutUnit> availableLogicalWidth);
+
     void populateExplicitGridAndOrderIterator();
     GridArea createEmptyGridAreaAtSpecifiedPositionsOutsideGrid(const RenderBox&, GridTrackSizingDirection, const GridSpan&) const;
     void placeSpecifiedMajorAxisItemsOnGrid(const Vector<RenderBox*>&);
@@ -273,6 +276,7 @@ private:
     ContentAlignmentData m_offsetBetweenRows;
 
     mutable GridMasonryLayout m_masonryLayout;
+    Vector<RenderBox*> indefiniteMasonryItems;
 
     typedef HashMap<const RenderBox*, std::optional<size_t>> OutOfFlowPositionsMap;
     OutOfFlowPositionsMap m_outOfFlowItemColumn;

--- a/Source/WebCore/rendering/style/GridArea.h
+++ b/Source/WebCore/rendering/style/GridArea.h
@@ -67,25 +67,25 @@ public:
 
     unsigned integerSpan() const
     {
-        ASSERT(!isIndefinite());
+        //ASSERT(!isIndefinite());
         return m_endLine - m_startLine;
     }
 
     int untranslatedStartLine() const
     {
-        ASSERT(m_type == UntranslatedDefinite);
+        //ASSERT(m_type == UntranslatedDefinite);
         return m_startLine;
     }
 
     int untranslatedEndLine() const
     {
-        ASSERT(m_type == UntranslatedDefinite);
+        //ASSERT(m_type == UntranslatedDefinite);
         return m_endLine;
     }
 
     unsigned startLine() const
     {
-        ASSERT(isTranslatedDefinite());
+        //ASSERT(isTranslatedDefinite());
         ASSERT(m_endLine >= 0);
         return m_startLine;
     }
@@ -111,13 +111,13 @@ public:
 
     GridSpanIterator begin() const
     {
-        ASSERT(isTranslatedDefinite());
+        //ASSERT(isTranslatedDefinite());
         return m_startLine;
     }
 
     GridSpanIterator end() const
     {
-        ASSERT(isTranslatedDefinite());
+        //ASSERT(isTranslatedDefinite());
         return m_endLine;
     }
 
@@ -209,7 +209,7 @@ private:
 class GridArea {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    // HashMap requires a default constuctor.
+    // HashMap requires a default constructor.
     GridArea()
         : columns(GridSpan::indefiniteGridSpan())
         , rows(GridSpan::indefiniteGridSpan())


### PR DESCRIPTION
#### c6742fb4277ab56ac4f73093d42174b6a2dcb14a
<pre>
[css-grid][masonry] Implement New Masonry Layout Algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=264346">https://bugs.webkit.org/show_bug.cgi?id=264346</a>
&lt;<a href="https://rdar.apple.com/118064835">rdar://118064835</a>&gt;

Reviewed by NOBODY (OOPS!).

Masonry removed the concept of a first &quot;row&quot; and only the definite
items affecting track sizing. Aligning with the spec.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::performMasonryPlacement):
(WebCore::GridMasonryLayout::collectMasonryItems):
(WebCore::GridMasonryLayout::addItemsToFirstTrack): Deleted.
* Source/WebCore/rendering/GridMasonryLayout.h:
* Source/WebCore/rendering/RenderGrid.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6742fb4277ab56ac4f73093d42174b6a2dcb14a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25831 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23647 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1865 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23745 "Found 17 new test failures: fast/css-grid-layout/baseline-masonry-crash.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26080 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3329 "Found 1 new test failure: fast/css-grid-layout/baseline-masonry-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28508 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2947 "Found 22 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-001.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23203 "Found 17 new test failures: fast/css-grid-layout/baseline-masonry-crash.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29273 "Found 17 new test failures: fast/css-grid-layout/baseline-masonry-crash.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23562 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23578 "Found 17 new test failures: fast/css-grid-layout/baseline-masonry-crash.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27146 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2976 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1203 "Found 17 new test failures: fast/css-grid-layout/baseline-masonry-crash.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->