### PR TITLE
[JSC] Refine SyntaxError message for generator method parsing failure

### DIFF
--- a/JSTests/stress/generator-class-methods-syntax.js
+++ b/JSTests/stress/generator-class-methods-syntax.js
@@ -27,7 +27,7 @@ class Cocoa {
     {
     }
 }
-`, `SyntaxError: Cannot declare a generator function named 'constructor'.`);
+`, `SyntaxError: Cannot declare a generator method named 'constructor'.`);
 
 testSyntax(`
 class Cocoa {

--- a/JSTests/stress/regress-189292.js
+++ b/JSTests/stress/regress-189292.js
@@ -14,5 +14,5 @@ function test(script) {
 }
 
 assert(test("class C1 { async constructor() { } }"), "SyntaxError: Cannot declare an async method named 'constructor'.");
-assert(test("class C1 { *constructor() { } }"), "SyntaxError: Cannot declare a generator function named 'constructor'.");
+assert(test("class C1 { *constructor() { } }"), "SyntaxError: Cannot declare a generator method named 'constructor'.");
 assert(test("class C1 { async *constructor() { } }"), "SyntaxError: Cannot declare an async generator method named 'constructor'.");

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2265,11 +2265,11 @@ static const char* stringForFunctionMode(SourceParseMode mode)
         return "function";
     case SourceParseMode::MethodMode:
         return "method";
-    case SourceParseMode::GeneratorBodyMode:
-        return "generator";
     case SourceParseMode::GeneratorWrapperFunctionMode:
-    case SourceParseMode::GeneratorWrapperMethodMode:
+    case SourceParseMode::GeneratorBodyMode:
         return "generator function";
+    case SourceParseMode::GeneratorWrapperMethodMode:
+        return "generator method";
     case SourceParseMode::ArrowFunctionMode:
         return "arrow function";
     case SourceParseMode::AsyncFunctionMode:


### PR DESCRIPTION
#### 17d1d747ad3bb45ca5d2f0c735778816a3cd701f
<pre>
[JSC] Refine SyntaxError message for generator method parsing failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=264368">https://bugs.webkit.org/show_bug.cgi?id=264368</a>
&lt;<a href="https://rdar.apple.com/problem/118081884">rdar://problem/118081884</a>&gt;

Reviewed by Justin Michaud.

This change rewords SyntaxError message, thrown in case of generator method parsing failure,
to mention &quot;method&quot; rather than &quot;function&quot;, aligning error wording for sync generator functions
with async counterparts.

Also, tweaks the helper to return &quot;generator function&quot; instead of &quot;generator&quot; for GeneratorBodyMode,
which is unobservable yet matches the terminology of the spec [1].

[1]: <a href="https://tc39.es/ecma262/#sec-generator-objects">https://tc39.es/ecma262/#sec-generator-objects</a>

* JSTests/stress/generator-class-methods-syntax.js:
* JSTests/stress/regress-189292.js:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::stringForFunctionMode):

Canonical link: <a href="https://commits.webkit.org/270379@main">https://commits.webkit.org/270379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8b01376ef824f96d1b1e7395eddc08590796ed2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23197 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1262 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27976 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28865 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21993 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26700 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/756 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31949 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3827 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6987 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2914 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3232 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2807 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->