### PR TITLE
Fixing bad angle computation in 2D canvas arc rendering

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -144,7 +144,13 @@ static void normalizeAngles(float& startAngle, float& endAngle, bool anticlockwi
 {
     constexpr auto twoPiFloat = 2 * piFloat;
     float newStartAngle = fmodf(startAngle, twoPiFloat);
-    if (newStartAngle < 0)
+    if (newStartAngle < 0) {
+        newStartAngle += twoPiFloat;
+        // Check for possible catastrophic cancellation in cases where
+        // newStartAngle was a tiny negative number.
+        if (newStartAngle >= twoPiFloat)
+            newStartAngle -= twoPiFloat;
+    }
         newStartAngle += twoPiFloat;
 
     float delta = newStartAngle - startAngle;


### PR DESCRIPTION
<pre>
Fixing bad angle computation in 2D canvas arc rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=264367">https://bugs.webkit.org/show_bug.cgi?id=264367</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/06056d49d9a569e51ffedb99b5b737d785a269ac">https://chromium.googlesource.com/chromium/blink/+/06056d49d9a569e51ffedb99b5b737d785a269ac</a>

This PR is on top of previous commit 269925@main, where the commit had potential to cause crashes while
computing angle in 2D canvas arch rendering. In WebKit, previous merge didn't caused any crash but this commit
is to potentially fix any crash issue.

This crash test from Blink commit was later changed to 'WPT' test suite named
'element/path-objects/2d.path.ellipse.basics.html', which we area have in tree.

* Source/WebCore/html/canvas/CanvasPath.cpp:
(normalizeAngles):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d6abee6161c7da933a7d9c0925024229b9d8cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27373 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1236 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23393 "Found 3 new test failures: imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.worker.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27951 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2503 "Found 10 new test failures: imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html, imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.isPointInStroke.scaleddashes.html, imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.isPointInStroke.scaleddashes.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.isPointInStroke.scaleddashes.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.worker.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22736 "Found 6 new test failures: imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.isPointInStroke.scaleddashes.html, imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.isPointInStroke.scaleddashes.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.isPointInStroke.scaleddashes.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28854 "Found 3 new test failures: imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.worker.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23052 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23086 "Found 6 new test failures: imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.isPointInStroke.scaleddashes.html, imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.isPointInStroke.scaleddashes.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.isPointInStroke.scaleddashes.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.html, imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.prune.arc.worker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2455 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/742 "Found 60 new test failures: compositing/layer-creation/scale-rotation-animation-overlap.html, css1/box_properties/acid_test.html, fast/canvas/arc360.html, fast/canvas/canvas-arc-connecting-line.html, fast/canvas/canvas-arc-zero-lineto.html, fast/canvas/canvas-ellipse-circumference-fill.html, fast/canvas/canvas-ellipse-circumference.html, fast/canvas/canvas-ellipse-connecting-line.html, fast/canvas/canvas-ellipse.html, fast/canvas/canvas_arc_largeangles.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2896 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2790 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->