### PR TITLE
Security hardening for SincResampler

### DIFF
--- a/Source/WTF/wtf/Algorithms.h
+++ b/Source/WTF/wtf/Algorithms.h
@@ -66,7 +66,22 @@ std::span<T> spanReinterpretCast(std::span<U> span)
     return std::span<T> { reinterpret_cast<T*>(const_cast<std::remove_const_t<U>*>(span.data())), span.size_bytes() / sizeof(T) };
 }
 
+template<typename T, typename U>
+void memcpySpan(std::span<T> destination, std::span<U> source)
+{
+    RELEASE_ASSERT(destination.size() == source.size());
+    static_assert(sizeof(T) == sizeof(U));
+    memcpy(destination.data(), source.data(), destination.size() * sizeof(T));
+}
+
+template<typename T>
+void memsetSpan(std::span<T> destination, uint8_t byte)
+{
+    memset(destination.data(), byte, destination.size() * sizeof(T));
+}
+
 } // namespace WTF
 
 using WTF::spanReinterpretCast;
-
+using WTF::memcpySpan;
+using WTF::memsetSpan;

--- a/Source/WebCore/platform/audio/AudioArray.h
+++ b/Source/WebCore/platform/audio/AudioArray.h
@@ -29,6 +29,7 @@
 #ifndef AudioArray_h
 #define AudioArray_h
 
+#include <span>
 #include <string.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/FastMalloc.h>
@@ -72,6 +73,8 @@ public:
         zero();
     }
 
+    std::span<T> span() { return { data(), size() }; }
+    std::span<const T> span() const { return { data(), size() }; }
     T* data() { return m_allocation; }
     const T* data() const { return m_allocation; }
     size_t size() const { return m_size; }

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -541,8 +541,8 @@ RefPtr<AudioBus> AudioBus::createBySampleRateConverting(const AudioBus* sourceBu
     }
 
     // Calculate destination length based on the sample-rates.
-    int sourceLength = resamplerSourceBus->length();
-    int destinationLength = sourceLength / sampleRateRatio;
+    size_t sourceLength = resamplerSourceBus->length();
+    size_t destinationLength = sourceLength / sampleRateRatio;
 
     // Create destination bus with same number of channels.
     unsigned numberOfDestinationChannels = resamplerSourceBus->numberOfChannels();
@@ -550,10 +550,9 @@ RefPtr<AudioBus> AudioBus::createBySampleRateConverting(const AudioBus* sourceBu
 
     // Sample-rate convert each channel.
     for (unsigned i = 0; i < numberOfDestinationChannels; ++i) {
-        const float* source = resamplerSourceBus->channel(i)->data();
-        float* destination = destinationBus->channel(i)->mutableData();
-
-        SincResampler::processBuffer(source, destination, sourceLength, sampleRateRatio);
+        auto* sourceChannel = resamplerSourceBus->channel(i);
+        auto* destinationChannel = destinationBus->channel(i);
+        SincResampler::processBuffer(sourceChannel->span(), destinationChannel->mutableSpan(), sampleRateRatio);
     }
 
     destinationBus->clearSilentFlag();

--- a/Source/WebCore/platform/audio/AudioChannel.h
+++ b/Source/WebCore/platform/audio/AudioChannel.h
@@ -31,6 +31,7 @@
 
 #include "AudioArray.h"
 #include <memory>
+#include <span>
 #include <wtf/Noncopyable.h>
 
 namespace WebCore {
@@ -80,6 +81,9 @@ public:
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(newLength <= length());
         m_length = newLength;
     }
+
+    std::span<const float> span() const { return { data(), length() }; }
+    std::span<float> mutableSpan() { return { mutableData(), length() }; }
 
     // Direct access to PCM sample data. Non-const accessor clears silent flag.
     float* mutableData()

--- a/Source/WebCore/platform/audio/MultiChannelResampler.h
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.h
@@ -49,7 +49,7 @@ public:
     void process(AudioBus* destination, size_t framesToProcess);
 
 private:
-    void provideInputForChannel(float* buffer, size_t framesToProcess, unsigned channelIndex);
+    void provideInputForChannel(std::span<float> buffer, size_t framesToProcess, unsigned channelIndex);
 
     // FIXME: the mac port can have a more highly optimized implementation based on CoreAudio
     // instead of SincResampler. For now the default implementation will be used on all ports.

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -34,6 +34,7 @@
 
 #include "AudioBus.h"
 #include "AudioUtilities.h"
+#include <wtf/Algorithms.h>
 #include <wtf/MathExtras.h>
 
 #if USE(ACCELERATE)
@@ -125,14 +126,14 @@ static size_t calculateChunkSize(unsigned blockSize, double scaleFactor)
     return blockSize / scaleFactor;
 }
 
-SincResampler::SincResampler(double scaleFactor, unsigned requestFrames, Function<void(float* buffer, size_t framesToProcess)>&& provideInput)
+SincResampler::SincResampler(double scaleFactor, unsigned requestFrames, Function<void(std::span<float> buffer, size_t framesToProcess)>&& provideInput)
     : m_scaleFactor(scaleFactor)
     , m_kernelStorage(kernelStorageSize)
     , m_requestFrames(requestFrames)
     , m_provideInput(WTFMove(provideInput))
     , m_inputBuffer(m_requestFrames + kernelSize) // See input buffer layout above.
-    , m_r1(m_inputBuffer.data())
-    , m_r2(m_inputBuffer.data() + kernelSize / 2)
+    , m_r1(m_inputBuffer.data(), m_inputBuffer.size())
+    , m_r2(m_inputBuffer.span().subspan(kernelSize / 2))
 {
     ASSERT(m_provideInput);
     ASSERT(m_requestFrames > 0);
@@ -145,18 +146,18 @@ void SincResampler::updateRegions(bool isSecondLoad)
 {
     // Setup various region pointers in the buffer (see diagram above). If we're
     // on the second load we need to slide m_r0 to the right by kernelSize / 2.
-    m_r0 = m_inputBuffer.data() + (isSecondLoad ? kernelSize : kernelSize / 2);
-    m_r3 = m_r0 + m_requestFrames - kernelSize;
-    m_r4 = m_r0 + m_requestFrames - kernelSize / 2;
-    m_blockSize = m_r4 - m_r2;
+    m_r0 = m_inputBuffer.span().subspan(isSecondLoad ? kernelSize : kernelSize / 2);
+    m_r3 = m_r0.subspan(m_requestFrames - kernelSize);
+    m_r4 = m_r0.subspan(m_requestFrames - kernelSize / 2);
+    m_blockSize = std::distance(m_r2.begin(), m_r4.begin());
     m_chunkSize = calculateChunkSize(m_blockSize, m_scaleFactor);
 
     // m_r1 at the beginning of the buffer.
-    ASSERT(m_r1 == m_inputBuffer.data());
+    ASSERT(m_r1.data() == m_inputBuffer.data());
     // m_r1 left of m_r2, m_r4 left of m_r3 and size correct.
-    ASSERT((m_r2 - m_r1) == (m_r4 - m_r3));
+    ASSERT(std::distance(m_r1.begin(), m_r2.begin()) == std::distance(m_r3.begin(), m_r4.begin()));
     // m_r2 left of r3.
-    ASSERT(m_r2 <= m_r3);
+    ASSERT(m_r2.begin() <= m_r3.begin());
 }
 
 void SincResampler::initializeKernel()
@@ -200,34 +201,39 @@ void SincResampler::initializeKernel()
     }
 }
 
-void SincResampler::processBuffer(const float* source, float* destination, unsigned numberOfSourceFrames, double scaleFactor)
+void SincResampler::processBuffer(std::span<const float> source, std::span<float> destination, double scaleFactor)
 {
-    SincResampler resampler(scaleFactor, AudioUtilities::renderQuantumSize, [source, numberOfSourceFrames](float* buffer, size_t framesToProcess) mutable {
+    RELEASE_ASSERT(destination.size() == static_cast<size_t>(source.size() / scaleFactor));
+    SincResampler resampler(scaleFactor, AudioUtilities::renderQuantumSize, [&source](std::span<float> buffer, size_t framesToProcess) mutable {
         // Clamp to number of frames available and zero-pad.
-        size_t framesToCopy = std::min<size_t>(numberOfSourceFrames, framesToProcess);
-        memcpy(buffer, source, sizeof(float) * framesToCopy);
+        size_t framesToCopy = std::min(source.size(), framesToProcess);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
+
+        memcpySpan(buffer.subspan(0, framesToCopy), source.subspan(0, framesToCopy));
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
         // Zero-pad if necessary.
         if (framesToCopy < framesToProcess)
-            memset(buffer + framesToCopy, 0, sizeof(float) * (framesToProcess - framesToCopy));
+            memsetSpan(buffer.subspan(framesToCopy, framesToProcess - framesToCopy), 0);
 
-        numberOfSourceFrames -= framesToCopy;
-        source += framesToCopy;
+        source = source.subspan(framesToCopy);
     });
 
-    unsigned numberOfDestinationFrames = static_cast<unsigned>(numberOfSourceFrames / scaleFactor);
-    unsigned remaining = numberOfDestinationFrames;
-
-    while (remaining) {
-        unsigned framesThisTime = std::min<unsigned>(remaining, AudioUtilities::renderQuantumSize);
+    while (!destination.empty()) {
+        unsigned framesThisTime = std::min<size_t>(destination.size(), AudioUtilities::renderQuantumSize);
         resampler.process(destination, framesThisTime);
-        
-        destination += framesThisTime;
-        remaining -= framesThisTime;
+        destination = destination.subspan(framesThisTime);
     }
 }
 
-void SincResampler::process(float* destination, size_t framesToProcess)
+void SincResampler::process(std::span<float> destination, size_t framesToProcess)
 {
     unsigned numberOfDestinationFrames = framesToProcess;
 
@@ -240,6 +246,7 @@ void SincResampler::process(float* destination, size_t framesToProcess)
     
     // Step (2)
 
+    size_t destinationIndex = 0;
     while (numberOfDestinationFrames) {
         while (m_virtualSourceIndex < m_blockSize) {
             // m_virtualSourceIndex lies in between two kernel offsets so figure out what they are.
@@ -249,20 +256,20 @@ void SincResampler::process(float* destination, size_t framesToProcess)
             double virtualOffsetIndex = subsampleRemainder * numberOfKernelOffsets;
             int offsetIndex = static_cast<int>(virtualOffsetIndex);
             
-            float* k1 = m_kernelStorage.data() + offsetIndex * kernelSize;
-            float* k2 = k1 + kernelSize;
+            auto k1 = m_kernelStorage.span().subspan(offsetIndex * kernelSize);
+            auto k2 = k1.subspan(kernelSize);
 
             // Ensure |k1|, |k2| are 16-byte aligned for SIMD usage. Should always be true so long as kernelSize is a multiple of 16.
-            ASSERT(!(reinterpret_cast<uintptr_t>(k1) & 0x0F));
-            ASSERT(!(reinterpret_cast<uintptr_t>(k2) & 0x0F));
+            ASSERT(!(reinterpret_cast<uintptr_t>(k1.data()) & 0x0F));
+            ASSERT(!(reinterpret_cast<uintptr_t>(k2.data()) & 0x0F));
 
             // Initialize input pointer based on quantized m_virtualSourceIndex.
-            float* inputP = m_r1 + sourceIndexI;
+            auto inputP = m_r1.subspan(sourceIndexI);
 
             // Figure out how much to weight each kernel's "convolution".
             double kernelInterpolationFactor = virtualOffsetIndex - offsetIndex;
 
-            *destination++ = convolve(inputP, k1, k2, kernelInterpolationFactor);
+            destination[destinationIndex++] = convolve(inputP.data(), k1.data(), k2.data(), kernelInterpolationFactor);
 
             // Advance the virtual index.
             m_virtualSourceIndex += m_scaleFactor;
@@ -278,10 +285,10 @@ void SincResampler::process(float* destination, size_t framesToProcess)
 
         // Step (3) Copy r3 to r1.
         // This wraps the last input frames back to the start of the buffer.
-        memcpy(m_r1, m_r3, sizeof(float) * kernelSize);
+        memcpySpan(m_r1.subspan(0, kernelSize), m_r3.subspan(0, kernelSize));
 
         // Step (4) -- Reinitialize regions if necessary.
-        if (m_r0 == m_r2)
+        if (m_r0.data() == m_r2.data())
             updateRegions(true);
 
         // Step (5)


### PR DESCRIPTION
#### 4e588185b2305d1a7632ba08e25af52248716242
<pre>
Security hardening for SincResampler
<a href="https://bugs.webkit.org/show_bug.cgi?id=261317">https://bugs.webkit.org/show_bug.cgi?id=261317</a>
<a href="https://rdar.apple.com/105650262">rdar://105650262</a>

Reviewed by David Kilzer and Darin Adler.

Do security hardening for SincResampler as we have evidence that we&apos;re getting
the logic wrong in some cases and doing a heap-buffer overflow WRITE.

This patch updates SincResampler to use `std::span&lt;float&gt;` instead of `float*` and
to leverage new memcpySpans() / memsetSpan() functions
I added to WTF.

This had several benefits:
- Using std::span means we don&apos;t lose tracks of our buffer bounds so we can do
  extra bounds checks.
- We benefit from std::span&apos;s bounds checks too which are already enabled on trunk
  via `-D_LIBCPP_ENABLE_ASSERTIONS=1`. Those checks apply to subspan() and operator[]
  in particular, both of which are used by SincResampler.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Algorithms.h:.
(WTF::memcpySpans):
(WTF::memsetSpan):
* Source/WebCore/platform/audio/AudioArray.h:
(WebCore::AudioArray::toSpan):
(WebCore::AudioArray::toSpan const):
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::createBySampleRateConverting):
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::process):
(WebCore::MultiChannelResampler::provideInputForChannel):
* Source/WebCore/platform/audio/MultiChannelResampler.h:
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::SincResampler):
(WebCore::SincResampler::updateRegions):
(WebCore::SincResampler::processBuffer):
(WebCore::SincResampler::process):
* Source/WebCore/platform/audio/SincResampler.h:

Originally-landed-as: 265870.537@safari-7616-branch (9c1f377498c2). <a href="https://rdar.apple.com/118088415">rdar://118088415</a>
Canonical link: <a href="https://commits.webkit.org/270409@main">https://commits.webkit.org/270409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/745b9cfdc988fcbd27d2385090479c2af76c6a69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23462 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28072 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28934 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22080 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26780 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24612 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/835 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32043 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3954 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6996 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3033 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2925 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->