### PR TITLE
Unify the naming of the RenderObject type checking functions

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -698,7 +698,7 @@ Ref<AccessibilityObject> AXObjectCache::createObjectFromRenderer(RenderObject* r
         return AccessibilityMediaObject::create(renderer);
 #endif
 
-    if (renderer->isSVGRootOrLegacySVGRoot())
+    if (renderer->isRenderOrLegacyRenderSVGRoot())
         return AccessibilitySVGRoot::create(renderer, this);
 
     if (is<SVGElement>(node))

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -162,7 +162,7 @@ AccessibilityRole AccessibilityList::determineAccessibilityRole()
             listItemCount++;
         else if (child->roleValue() == AccessibilityRole::ListItem) {
             // Rendered list items always count.
-            if (auto* childRenderer = child->renderer(); childRenderer && childRenderer->isListItem()) {
+            if (auto* childRenderer = child->renderer(); childRenderer && childRenderer->isRenderListItem()) {
                 if (!hasVisibleMarkers && (childRenderer->style().listStyleType().type != ListStyleType::Type::None || childRenderer->style().listStyleImage() || childHasPseudoVisibleListItemMarkers(childRenderer->node())))
                     hasVisibleMarkers = true;
                 listItemCount++;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1141,7 +1141,7 @@ bool AccessibilityObject::isMeter() const
         return true;
 
     RenderObject* renderer = this->renderer();
-    return renderer && renderer->isMeter();
+    return renderer && renderer->isRenderMeter();
 }
 
 static IntRect boundsForRects(const LayoutRect& rect1, const LayoutRect& rect2, const SimpleRange& dataRange)

--- a/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
@@ -156,7 +156,7 @@ String AccessibilitySVGElement::description() const
     // FIXME: This is here to not break the svg-image.html test. But 'alt' is not
     // listed as a supported attribute of the 'image' element in the SVG spec:
     // https://www.w3.org/TR/SVG/struct.html#ImageElement
-    if (m_renderer->isSVGImageOrLegacySVGImage()) {
+    if (m_renderer->isRenderOrLegacyRenderSVGImage()) {
         const AtomString& alt = getAttribute(HTMLNames::altAttr);
         if (!alt.isNull())
             return alt;
@@ -210,7 +210,7 @@ bool AccessibilitySVGElement::computeAccessibilityIsIgnored() const
     if (decision == AccessibilityObjectInclusion::IgnoreObject)
         return true;
 
-    if (!m_renderer || m_renderer->isLegacySVGHiddenContainer() || m_renderer->isSVGHiddenContainer())
+    if (!m_renderer || m_renderer->isLegacyRenderSVGHiddenContainer() || m_renderer->isRenderSVGHiddenContainer())
         return true;
 
     // The SVG AAM states objects with at least one 'title' or 'desc' element MUST be included.
@@ -227,7 +227,7 @@ bool AccessibilitySVGElement::computeAccessibilityIsIgnored() const
         return false;
 
     // The SVG AAM states text elements should also be included, if they have content.
-    if (m_renderer->isSVGText() || m_renderer->isSVGTextPath()) {
+    if (m_renderer->isRenderSVGText() || m_renderer->isRenderSVGTextPath()) {
         for (auto& child : childrenOfType<RenderText>(downcast<RenderElement>(*m_renderer))) {
             if (!child.containsOnlyCollapsibleWhitespace())
                 return false;
@@ -236,7 +236,7 @@ bool AccessibilitySVGElement::computeAccessibilityIsIgnored() const
 
     // SVG shapes should not be included unless there's a concrete reason for inclusion.
     // https://rawgit.com/w3c/aria/master/svg-aam/svg-aam.html#exclude_elements
-    if (m_renderer->isSVGShapeOrLegacySVGShape()) {
+    if (m_renderer->isRenderOrLegacyRenderSVGShape()) {
         if (canSetFocusAttribute() || element()->hasEventListeners())
             return false;
         if (auto* svgParent = Accessibility::findAncestor<AccessibilityObject>(*this, true, [] (const AccessibilityObject& object) {
@@ -293,15 +293,15 @@ AccessibilityRole AccessibilitySVGElement::determineAccessibilityRole()
 
     Element* svgElement = element();
 
-    if (m_renderer->isSVGShapeOrLegacySVGShape() || m_renderer->isSVGPathOrLegacySVGPath() || m_renderer->isSVGImageOrLegacySVGImage() || is<SVGUseElement>(svgElement))
+    if (m_renderer->isRenderOrLegacyRenderSVGShape() || m_renderer->isRenderOrLegacyRenderSVGPath() || m_renderer->isRenderOrLegacyRenderSVGImage() || is<SVGUseElement>(svgElement))
         return AccessibilityRole::Image;
-    if (m_renderer->isSVGForeignObjectOrLegacySVGForeignObject() || is<SVGGElement>(svgElement))
+    if (m_renderer->isRenderOrLegacyRenderSVGForeignObject() || is<SVGGElement>(svgElement))
         return AccessibilityRole::Group;
-    if (m_renderer->isSVGText())
+    if (m_renderer->isRenderSVGText())
         return AccessibilityRole::SVGText;
-    if (m_renderer->isSVGTextPath())
+    if (m_renderer->isRenderSVGTextPath())
         return AccessibilityRole::SVGTextPath;
-    if (m_renderer->isSVGTSpan())
+    if (m_renderer->isRenderSVGTSpan())
         return AccessibilityRole::SVGTSpan;
     if (is<SVGAElement>(svgElement))
         return AccessibilityRole::WebCoreLink;

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -176,7 +176,7 @@ LayoutRect AccessibilitySliderThumb::elementRect() const
         return LayoutRect();
     
     RenderObject* sliderRenderer = m_parent->renderer();
-    if (!sliderRenderer || !sliderRenderer->isSlider())
+    if (!sliderRenderer || !sliderRenderer->isRenderSlider())
         return LayoutRect();
     if (auto* thumbRenderer = downcast<RenderSlider>(*sliderRenderer).element().sliderThumbElement()->renderer())
         return thumbRenderer->absoluteBoundingBoxRect();

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -527,7 +527,7 @@ static RefPtr<CSSValue> positionOffsetValue(const RenderStyle& style, CSSPropert
     auto offset = getOffsetComputedLength(style, propertyID);
 
     // If the element is not displayed; return the "computed value".
-    if (!renderer || !renderer->isBox())
+    if (!renderer || !renderer->isRenderBox())
         return zoomAdjustedPixelValueForLength(offset, style);
 
     auto& box = downcast<RenderBox>(*renderer);
@@ -2279,12 +2279,12 @@ static RefPtr<CSSValue> zoomAdjustedPaddingOrMarginPixelValue(const RenderStyle&
 template<RenderStyleLengthGetter lengthGetter>
 static bool paddingOrMarginIsRendererDependent(const RenderStyle* style, RenderObject* renderer)
 {
-    return renderer && style && renderer->isBox() && !(style->*lengthGetter)().isFixed();
+    return renderer && style && renderer->isRenderBox() && !(style->*lengthGetter)().isFixed();
 }
 
 static bool positionOffsetValueIsRendererDependent(const RenderStyle* style, RenderObject* renderer)
 {
-    return renderer && style && renderer->isBox();
+    return renderer && style && renderer->isRenderBox();
 }
 
 static CSSValueID convertToPageBreak(BreakBetween value)
@@ -2814,7 +2814,7 @@ static Ref<CSSValue> paintOrder(PaintOrder paintOrder)
 
 static inline bool isFlexOrGridItem(RenderObject* renderer)
 {
-    if (!renderer || !renderer->isBox())
+    if (!renderer || !renderer->isRenderBox())
         return false;
     auto& box = downcast<RenderBox>(*renderer);
     return box.isFlexItem() || box.isGridItem();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7956,7 +7956,7 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
             // will need to reference this chain.
             for (CheckedPtr curr = newActiveElement->renderer(); curr; curr = curr->parent()) {
                 RefPtr element = curr->element();
-                if (!element || curr->isTextOrLineBreak())
+                if (!element || curr->isRenderTextOrLineBreak())
                     continue;
                 m_userActionElements.setInActiveChain(*element, true);
             }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1484,7 +1484,7 @@ int Element::clientWidth()
         // Currently, WebKit doesn't have table wrapper box, and we are supposed to
         // retrieve clientWidth/Height from table wrapper box, not table grid box. So
         // when we retrieve clientWidth/Height, it includes table's border size.
-        if (renderer->isTable())
+        if (renderer->isRenderTable())
             clientWidth += renderer->borderLeft() + renderer->borderRight();
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(clientWidth, *renderer).toDouble());
     }
@@ -1518,7 +1518,7 @@ int Element::clientHeight()
         // Currently, WebKit doesn't have table wrapper box, and we are supposed to
         // retrieve clientWidth/Height from table wrapper box, not table grid box. So
         // when we retrieve clientWidth/Height, it includes table's border size.
-        if (renderer->isTable())
+        if (renderer->isRenderTable())
             clientHeight += renderer->borderTop() + renderer->borderBottom();
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(clientHeight, *renderer).toDouble());
     }

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1026,7 +1026,7 @@ void ApplyStyleCommand::applyInlineStyleToPushDown(Node& node, EditingStyle* sty
     {
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
-        if (node.renderer()->isText() && static_cast<RenderText*>(node.renderer())->containsOnlyCollapsibleWhitespace())
+        if (is<RenderText>(*node.renderer()) && downcast<RenderText>(*node.renderer()).containsOnlyCollapsibleWhitespace())
             return;
         if (node.renderer()->isBR() && !node.renderer()->style().preserveNewline())
             return;

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1165,7 +1165,7 @@ RefPtr<Node> CompositeEditCommand::addBlockPlaceholderIfNeeded(Element* containe
             return nullptr;
 
         // Append the placeholder to make sure it follows any unrendered blocks.
-        if (blockFlow->height() && (!blockFlow->isListItem() || blockFlow->firstChild()))
+        if (blockFlow->height() && (!blockFlow->isRenderListItem() || blockFlow->firstChild()))
             return nullptr;
     }
 

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -314,7 +314,7 @@ Position lastEditablePositionBeforePositionInRoot(const Position& position, Cont
 // Whether or not content before and after this node will collapse onto the same line as it.
 bool isBlock(const Node& node)
 {
-    return node.renderer() && !node.renderer()->isInline() && !node.renderer()->isRubyText();
+    return node.renderer() && !node.renderer()->isInline() && !node.renderer()->isRenderRubyText();
 }
 
 bool isInline(const Node& node)
@@ -402,7 +402,7 @@ String stringWithRebalancedWhitespace(const String& string, bool startIsStartOfP
 bool isTableStructureNode(const Node& node)
 {
     auto* renderer = node.renderer();
-    return renderer && (renderer->isTableCell() || renderer->isTableRow() || renderer->isTableSection() || renderer->isRenderTableCol());
+    return renderer && (renderer->isRenderTableCell() || renderer->isRenderTableRow() || renderer->isRenderTableSection() || renderer->isRenderTableCol());
 }
 
 const String& nonBreakingSpaceString()
@@ -418,7 +418,7 @@ RefPtr<Element> isFirstPositionAfterTable(const VisiblePosition& position)
     if (!node)
         return nullptr;
     auto* renderer = node->renderer();
-    if (!renderer || !renderer->isTable() || !upstream.atLastEditingPositionForNode())
+    if (!renderer || !renderer->isRenderTable() || !upstream.atLastEditingPositionForNode())
         return nullptr;
     return downcast<Element>(node.releaseNonNull());
 }
@@ -430,7 +430,7 @@ RefPtr<Element> isLastPositionBeforeTable(const VisiblePosition& position)
     if (!node)
         return nullptr;
     auto* renderer = node->renderer();
-    if (!renderer || !renderer->isTable() || !downstream.atFirstEditingPositionForNode())
+    if (!renderer || !renderer->isRenderTable() || !downstream.atFirstEditingPositionForNode())
         return nullptr;
     return downcast<Element>(node.releaseNonNull());
 }
@@ -488,7 +488,7 @@ bool isListHTMLElement(Node* node)
 
 bool isListItem(const Node& node)
 {
-    return isListHTMLElement(node.parentNode()) || (node.renderer() && node.renderer()->isListItem());
+    return isListHTMLElement(node.parentNode()) || (node.renderer() && node.renderer()->isRenderListItem());
 }
 
 Element* enclosingElementWithTag(const Position& position, const QualifiedName& tagName)
@@ -716,7 +716,7 @@ bool isRenderedTable(const Node* node)
     if (!is<HTMLElement>(node))
         return false;
     auto* renderer = downcast<HTMLElement>(*node).renderer();
-    return renderer && renderer->isTable();
+    return renderer && renderer->isRenderTable();
 }
 
 bool isTableCell(const Node& node)
@@ -724,7 +724,7 @@ bool isTableCell(const Node& node)
     auto* renderer = node.renderer();
     if (!renderer)
         return node.hasTagName(tdTag) || node.hasTagName(thTag);
-    return renderer->isTableCell();
+    return renderer->isRenderTableCell();
 }
 
 bool isEmptyTableCell(const Node* node)
@@ -874,7 +874,7 @@ bool isMailBlockquote(const Node& node)
 int caretMinOffset(const Node& node)
 {
     auto* renderer = node.renderer();
-    ASSERT(!node.isCharacterDataNode() || !renderer || renderer->isText());
+    ASSERT(!node.isCharacterDataNode() || !renderer || renderer->isRenderText());
     return renderer ? renderer->caretMinOffset() : 0;
 }
 
@@ -1052,7 +1052,7 @@ bool isRenderedAsNonInlineTableImageOrHR(const Node* node)
     if (!node)
         return false;
     RenderObject* renderer = node->renderer();
-    return renderer && ((renderer->isTable() && !renderer->isInline()) || (renderer->isImage() && !renderer->isInline()) || renderer->isHR());
+    return renderer && ((renderer->isRenderTable() && !renderer->isInline()) || (renderer->isImage() && !renderer->isInline()) || renderer->isHR());
 }
 
 bool areIdenticalElements(const Node& first, const Node& second)

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4068,7 +4068,7 @@ static RefPtr<Node> findFirstMarkable(Node* startingNode)
             ScriptDisallowedScope::InMainThread scriptDisallowedScope;
             if (!node->renderer())
                 return nullptr;
-            if (node->renderer()->isTextOrLineBreak())
+            if (node->renderer()->isRenderTextOrLineBreak())
                 return node;
         }
         if (is<HTMLTextFormControlElement>(*node) && downcast<Element>(*node).isTextField())

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -252,7 +252,7 @@ void InsertParagraphSeparatorCommand::doApply()
         || isTableCell(*startBlock)
         || is<HTMLFormElement>(*startBlock)
         // FIXME: If the node is hidden, we don't have a canonical position so we will do the wrong thing for tables and <hr>. https://bugs.webkit.org/show_bug.cgi?id=40342
-        || (!canonicalPos.isNull() && canonicalPos.deprecatedNode()->renderer() && canonicalPos.deprecatedNode()->renderer()->isTable())
+        || (!canonicalPos.isNull() && canonicalPos.deprecatedNode()->renderer() && canonicalPos.deprecatedNode()->renderer()->isRenderTable())
         || (!canonicalPos.isNull() && canonicalPos.deprecatedNode()->hasTagName(hrTag))) {
         applyCommandToComposite(InsertLineBreakCommand::create(WTFMove(document)));
         return;

--- a/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -79,7 +79,7 @@ static bool getStartEndListChildren(const VisibleSelection& selection, RefPtr<No
     }
     
     // if the selection ends on a list item with a sublist, include the entire sublist
-    if (endListChild->renderer()->isListItem()) {
+    if (endListChild->renderer()->isRenderListItem()) {
         RenderObject* r = endListChild->renderer()->nextSibling();
         if (r && isListHTMLElement(r->node()) && r->node()->parentNode() == startListChild->parentNode())
             endListChild = r->node();

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1315,7 +1315,7 @@ void ReplaceSelectionCommand::doApply()
 
     RefPtr blockStart { enclosingBlock(insertionPos.protectedDeprecatedNode()) };
     bool isInsertingIntoList = (isListHTMLElement(refNode.get()) || (isLegacyAppleStyleSpan(refNode.get()) && isListHTMLElement(refNode->firstChild())))
-    && blockStart && blockStart->renderer()->isListItem() && blockStart->parentNode()->hasEditableStyle();
+    && blockStart && blockStart->renderer()->isRenderListItem() && blockStart->parentNode()->hasEditableStyle();
     if (isInsertingIntoList)
         refNode = insertAsListItems(downcast<HTMLElement>(*refNode), blockStart.get(), insertionPos, insertedNodes);
     else if (isEditablePosition(insertionPos)) {

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -219,7 +219,7 @@ static inline bool fullyClipsContents(Node& node)
 static inline bool ignoresContainerClip(Node& node)
 {
     CheckedPtr renderer = node.renderer();
-    if (!renderer || renderer->isTextOrLineBreak())
+    if (!renderer || renderer->isRenderTextOrLineBreak())
         return false;
     return renderer->style().hasOutOfFlowPosition();
 }
@@ -269,9 +269,9 @@ bool isRendererReplacedElement(RenderObject* renderer, TextIteratorBehaviors beh
     
     bool isAttachment = false;
 #if ENABLE(ATTACHMENT_ELEMENT)
-    isAttachment = renderer->isAttachment();
+    isAttachment = renderer->isRenderAttachment();
 #endif
-    if (renderer->isImage() || renderer->isWidget() || renderer->isMedia() || isAttachment)
+    if (renderer->isImage() || renderer->isRenderWidget() || renderer->isRenderMedia() || isAttachment)
         return true;
 
     if (is<Element>(renderer->node())) {
@@ -485,7 +485,7 @@ void TextIterator::advance()
                 m_handledChildren = true;
             } else {
                 // handle current node according to its type
-                if (renderer->isText() && m_currentNode->isTextNode())
+                if (renderer->isRenderText() && m_currentNode->isTextNode())
                     m_handledNode = handleTextNode();
                 else if (isRendererReplacedElement(renderer.get(), m_behaviors))
                     m_handledNode = handleReplacedElement();
@@ -898,7 +898,7 @@ static bool shouldEmitNewlinesBeforeAndAfterNode(Node& node)
         && is<RenderBlock>(*renderer)
         && !renderer->isFloatingOrOutOfFlowPositioned()
         && !renderer->isBody()
-        && !renderer->isRubyText();
+        && !renderer->isRenderRubyText();
 }
 
 static bool shouldEmitNewlineAfterNode(Node& node, bool emitsCharactersBetweenAllVisiblePositions = false)
@@ -976,7 +976,7 @@ static int maxOffsetIncludingCollapsedSpaces(Node& node)
 bool TextIterator::shouldRepresentNodeOffsetZero()
 {
     if (m_behaviors.contains(TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions)) {
-        if (CheckedPtr renderer = m_currentNode->renderer(); renderer && renderer->isTable())
+        if (CheckedPtr renderer = m_currentNode->renderer(); renderer && renderer->isRenderTable())
             return true;
     }
 
@@ -1034,7 +1034,7 @@ bool TextIterator::shouldRepresentNodeOffsetZero()
 
 bool TextIterator::shouldEmitSpaceBeforeAndAfterNode(Node& node)
 {
-    return node.renderer() && node.renderer()->isTable() && (node.renderer()->isInline() || m_behaviors.contains(TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions));
+    return node.renderer() && node.renderer()->isRenderTable() && (node.renderer()->isInline() || m_behaviors.contains(TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions));
 }
 
 void TextIterator::representNodeOffsetZero()
@@ -1251,7 +1251,7 @@ void SimplifiedBackwardsTextIterator::advance()
         // Don't handle node if we start iterating at [node, 0].
         if (!m_handledNode && !(m_node == m_endContainer && !m_endOffset)) {
             CheckedPtr renderer = m_node->renderer();
-            if (renderer && renderer->isText() && m_node->isTextNode()) {
+            if (renderer && renderer->isRenderText() && m_node->isTextNode()) {
                 if (renderer->style().visibility() == Visibility::Visible && m_offset > 0)
                     m_handledNode = handleTextNode();
             } else if (isRendererReplacedElement(renderer.get(), m_behaviors)) {

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -807,7 +807,7 @@ void TypingCommand::forwardDeleteKeyPressed(TextGranularity granularity, bool sh
         if (visibleEnd == endOfParagraph(visibleEnd))
             downstreamEnd = visibleEnd.next(CannotCrossEditingBoundary).deepEquivalent().downstream();
         // When deleting tables: Select the table first, then perform the deletion
-        if (downstreamEnd.containerNode() && downstreamEnd.containerNode()->renderer() && downstreamEnd.containerNode()->renderer()->isTable()
+        if (downstreamEnd.containerNode() && downstreamEnd.containerNode()->renderer() && downstreamEnd.containerNode()->renderer()->isRenderTable()
             && downstreamEnd.computeOffsetInContainerNode() <= caretMinOffset(*downstreamEnd.containerNode())) {
             setEndingSelection(VisibleSelection(endingSelection().end(), positionAfterNode(downstreamEnd.containerNode()), Affinity::Downstream, endingSelection().isDirectional()));
             typingAddedToOpenCommand(Type::ForwardDeleteKey);

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -195,7 +195,7 @@ bool HTMLEmbedElement::rendererIsNeeded(const RenderStyle& style)
         if (!parent->renderer())
             return false;
         if (!downcast<HTMLObjectElement>(*parent).useFallbackContent()) {
-            ASSERT(!parent->renderer()->isEmbeddedObject());
+            ASSERT(!parent->renderer()->isRenderEmbeddedObject());
             return false;
         }
     }

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -79,7 +79,7 @@ bool HTMLPlugInElement::willRespondToMouseClickEventsWithEditability(Editability
     if (isDisabledFormControl())
         return false;
     auto renderer = this->renderer();
-    return renderer && renderer->isWidget();
+    return renderer && renderer->isRenderWidget();
 }
 
 void HTMLPlugInElement::willDetachRenderers()

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -674,9 +674,9 @@ void HTMLSelectElement::updateListBoxSelection(bool deselectOtherOptions)
     ASSERT(renderer());
 
 #if !PLATFORM(IOS_FAMILY)
-    ASSERT(renderer()->isListBox() || m_multiple);
+    ASSERT(renderer()->isRenderListBox() || m_multiple);
 #else
-    ASSERT(renderer()->isMenuList() || m_multiple);
+    ASSERT(renderer()->isRenderMenuList() || m_multiple);
 #endif
 
     ASSERT(!listItems().size() || m_activeSelectionAnchorIndex >= 0);
@@ -1165,7 +1165,7 @@ bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
 void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
 {
     ASSERT(renderer());
-    ASSERT(renderer()->isMenuList());
+    ASSERT(renderer()->isRenderMenuList());
 
     auto& eventNames = WebCore::eventNames();
     if (event.type() == eventNames.keydownEvent) {
@@ -1568,7 +1568,7 @@ void HTMLSelectElement::defaultEventHandler(Event& event)
         return;
     }
 
-    if (renderer->isMenuList())
+    if (renderer->isRenderMenuList())
         menuListDefaultEventHandler(event);
     else 
         listBoxDefaultEventHandler(event);

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -109,7 +109,7 @@ RenderBox::LogicalExtentComputedValues RenderSliderContainer::computeLogicalHeig
     bool isVertical = hasVerticalAppearance(input);
 
 #if ENABLE(DATALIST_ELEMENT)
-    if (input.renderer()->isSlider() && !isVertical && input.list()) {
+    if (input.renderer()->isRenderSlider() && !isVertical && input.list()) {
         int offsetFromCenter = theme().sliderTickOffsetFromTrackCenter();
         LayoutUnit trackHeight;
         if (offsetFromCenter < 0)

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -149,7 +149,7 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
     auto* mainView = localMainFrame ? localMainFrame->view() : nullptr;
 
     // (Legacy)RenderSVGRoot should be highlighted through the isBox() code path, all other SVG elements should just dump their absoluteQuads().
-    bool isSVGRenderer = renderer->node() && renderer->node()->isSVGElement() && !renderer->isSVGRootOrLegacySVGRoot();
+    bool isSVGRenderer = renderer->node() && renderer->node()->isSVGElement() && !renderer->isRenderOrLegacyRenderSVGRoot();
 
     if (isSVGRenderer) {
         highlight.type = InspectorOverlay::Highlight::Type::Rects;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -34,7 +34,7 @@ namespace Layout {
 inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const RenderStyle& style, InlineLayoutUnit logicalLeft, InlineLayoutSize logicalSize, Type type, OptionSet<PositionWithinLayoutBox> positionWithinLayoutBox)
     : m_layoutBox(layoutBox)
     , m_logicalRect({ }, logicalLeft, logicalSize.width(), logicalSize.height())
-    , m_hasContent(layoutBox.isRubyBase() && layoutBox.associatedRubyAnnotationBox()) // Normally we set inline box's has-content state as we come across child content, but ruby annotations are not visible to inline layout.
+    , m_hasContent(layoutBox.isRenderRubyBase() && layoutBox.associatedRubyAnnotationBox()) // Normally we set inline box's has-content state as we come across child content, but ruby annotations are not visible to inline layout.
     , m_isFirstWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::First))
     , m_isLastWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::Last))
     , m_type(type)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -270,7 +270,7 @@ void LineBoxBuilder::setVerticalPropertiesForInlineLevelBox(const LineBox& lineB
         // With text-box-trim, the inline box top is not always where the content starts.
         auto fontMetricBasedAscent = primaryFontMetricsForInlineBox(inlineLevelBox, lineBox.baselineType()).ascent;
         inlineLevelBox.setInlineBoxContentOffsetForTextBoxTrim(fontMetricBasedAscent - ascentAndDescent.ascent);
-        if (inlineLevelBox.layoutBox().isRubyBase())
+        if (inlineLevelBox.layoutBox().isRenderRubyBase())
             RubyFormattingContext { formattingContext() }.applyAnnotationContributionToLayoutBounds(inlineLevelBox);
         return;
     }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -627,7 +627,7 @@ void LineBuilder::candidateContentForLine(LineCandidate& lineCandidate, size_t c
     }
 
     auto appendRubyContainerIfApplicable = [&] {
-        auto isRubyContent = currentInlineItemIndex < layoutRange.endIndex() && (m_inlineItemList[currentInlineItemIndex].layoutBox().isRuby() || m_inlineItemList[currentInlineItemIndex].layoutBox().isRubyBase());
+        auto isRubyContent = currentInlineItemIndex < layoutRange.endIndex() && (m_inlineItemList[currentInlineItemIndex].layoutBox().isRuby() || m_inlineItemList[currentInlineItemIndex].layoutBox().isRenderRubyBase());
         if (!isRubyContent)
             return false;
         // We must be at a ruby container/base and we should let the ruby formatting context handle the rest of the ruby content.

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -394,7 +394,7 @@ void InlineDisplayContentBuilder::appendInlineBoxDisplayBox(const Line::Run& lin
     });
 
     if (auto* annotationBox = layoutBox.associatedRubyAnnotationBox()) {
-        ASSERT(layoutBox.isRubyBase());
+        ASSERT(layoutBox.isRenderRubyBase());
         if (isInterlinearAnnotationBox(annotationBox))
             m_interlinearRubyColumnRangeList.append({ boxes.size() - 1, boxes.size() });
         appendRubyAnnotationBox(layoutBox, boxes);
@@ -407,7 +407,7 @@ void InlineDisplayContentBuilder::appendSpanningInlineBoxDisplayBox(const Line::
     ASSERT(inlineBox.isInlineBox());
     ASSERT(!inlineBox.isFirstBox());
     // We don't break inside bases yet.
-    ASSERT(!lineRun.layoutBox().isRubyBase());
+    ASSERT(!lineRun.layoutBox().isRenderRubyBase());
 
     if (!linehasContent) {
         // When a spanning inline box (e.g. <div>text<span><br></span></div>) lands on an empty line
@@ -442,7 +442,7 @@ void InlineDisplayContentBuilder::appendSpanningInlineBoxDisplayBox(const Line::
 
 void InlineDisplayContentBuilder::handleInlineBoxEnd(const Line::Run& lineRun, const InlineDisplay::Boxes& boxes)
 {
-    if (!lineRun.layoutBox().isRubyBase())
+    if (!lineRun.layoutBox().isRenderRubyBase())
         return;
     auto* annotationBox = lineRun.layoutBox().associatedRubyAnnotationBox();
     if (!annotationBox)
@@ -476,7 +476,7 @@ void InlineDisplayContentBuilder::appendInlineDisplayBoxAtBidiBoundary(const Box
 
 void InlineDisplayContentBuilder::appendRubyAnnotationBox(const Box& rubyBaseLayoutBox, InlineDisplay::Boxes& boxes)
 {
-    ASSERT(rubyBaseLayoutBox.isRubyBase());
+    ASSERT(rubyBaseLayoutBox.isRenderRubyBase());
 
     auto& annotationBox = *rubyBaseLayoutBox.associatedRubyAnnotationBox();
     auto rubyFormattingContext = RubyFormattingContext { formattingContext() };
@@ -1103,7 +1103,7 @@ void InlineDisplayContentBuilder::applyRubyOverhang(InlineDisplay::Boxes& boxes)
     for (auto startEndPair : m_interlinearRubyColumnRangeList) {
         auto rubyBaseIndex = startEndPair.begin();
         auto& rubyBaseLayoutBox = boxes[rubyBaseIndex].layoutBox();
-        ASSERT(rubyBaseLayoutBox.isRubyBase());
+        ASSERT(rubyBaseLayoutBox.isRenderRubyBase());
         ASSERT(isInterlinearAnnotationBox(rubyBaseLayoutBox.associatedRubyAnnotationBox()));
 
         auto beforeOverhang = rubyFormattingContext.overhangForAnnotationBefore(rubyBaseLayoutBox, rubyBaseIndex, boxes);
@@ -1116,7 +1116,7 @@ void InlineDisplayContentBuilder::applyRubyOverhang(InlineDisplay::Boxes& boxes)
                 isHorizontalWritingMode ? boxes[index].moveHorizontally(LayoutUnit { -shiftValue }) : boxes[index].moveVertically(LayoutUnit { -shiftValue });
                 auto updateAnnotationGeometryIfNeeded = [&] {
                     auto& layoutBox = boxes[index].layoutBox();
-                    if (!layoutBox.isRubyBase() || !layoutBox.associatedRubyAnnotationBox())
+                    if (!layoutBox.isRenderRubyBase() || !layoutBox.associatedRubyAnnotationBox())
                         return;
                     auto& annotationBoxGeometry = formattingContext().geometryForBox(*layoutBox.associatedRubyAnnotationBox());
                     isHorizontalWritingMode ? annotationBoxGeometry.moveHorizontally(LayoutUnit { -shiftValue }) : annotationBoxGeometry.moveVertically(LayoutUnit { -shiftValue });

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
@@ -38,7 +38,7 @@ static inline size_t nextWrapOpportunityWithinRubyContainer(size_t startIndex, c
     // We only allow wrap opportunity between ruby bases.
     for (size_t index = startIndex; index < rubyRange.endIndex(); ++index) {
         auto& rubyItem = inlineItemList[index];
-        if (rubyItem.isInlineBoxEnd() && rubyItem.layoutBox().isRubyBase()) {
+        if (rubyItem.isInlineBoxEnd() && rubyItem.layoutBox().isRenderRubyBase()) {
             // We are at the end of a ruby base, need to check if we are between bases.
             if (index + 1 == rubyRange.endIndex()) {
                 ASSERT_NOT_REACHED();
@@ -46,7 +46,7 @@ static inline size_t nextWrapOpportunityWithinRubyContainer(size_t startIndex, c
             }
             auto& nextRubyItem = inlineItemList[index + 1];
             if (nextRubyItem.isInlineBoxStart()) {
-                ASSERT(nextRubyItem.layoutBox().isRubyBase());
+                ASSERT(nextRubyItem.layoutBox().isRenderRubyBase());
                 return index + 1;
             }
         }
@@ -86,14 +86,14 @@ RubyFormattingContext::InlineLayoutResult RubyFormattingContext::layoutInlineAxi
 void RubyFormattingContext::placeRubyContent(WTF::Range<size_t> candidateRange, const InlineItemList& inlineItemList, Line& line)
 {
     ASSERT(candidateRange.end() <= inlineItemList.size());
-    ASSERT(inlineItemList[candidateRange.begin()].layoutBox().isRuby() || inlineItemList[candidateRange.begin()].layoutBox().isRubyBase());
+    ASSERT(inlineItemList[candidateRange.begin()].layoutBox().isRuby() || inlineItemList[candidateRange.begin()].layoutBox().isRenderRubyBase());
     auto& formattingUtils = parentFormattingContext().formattingUtils();
 
     auto index = candidateRange.begin();
     auto logicalRightSpacingForBase = InlineLayoutUnit { };
     while (index < candidateRange.end()) {
         auto appendInlineLevelItem = [&](auto& inlineBoxItem, InlineLayoutUnit extraSpacingEnd = { }) {
-            ASSERT(inlineBoxItem.layoutBox().isRuby() || inlineBoxItem.layoutBox().isRubyBase() || inlineBoxItem.layoutBox().isRubyAnnotationBox());
+            ASSERT(inlineBoxItem.layoutBox().isRuby() || inlineBoxItem.layoutBox().isRenderRubyBase() || inlineBoxItem.layoutBox().isRubyAnnotationBox());
 
             auto logicalWidth = formattingUtils.inlineItemWidth(inlineBoxItem, line.contentLogicalRight(), { });
             line.append(inlineBoxItem, inlineBoxItem.style(), logicalWidth + extraSpacingEnd);
@@ -109,7 +109,7 @@ void RubyFormattingContext::placeRubyContent(WTF::Range<size_t> candidateRange, 
             ASSERT(rubyItem.isInlineBoxStart() || (rubyItem.isInlineBoxEnd() && index == candidateRange.end()));
             continue;
         }
-        if (rubyLayoutBox.isRubyBase()) {
+        if (rubyLayoutBox.isRenderRubyBase()) {
             // ruby column: represented by a single ruby base and one ruby annotation
             // from each interlinear annotation level in its ruby segment.
             if (rubyItem.isInlineBoxStart()) {
@@ -152,7 +152,7 @@ RubyFormattingContext::BaseLayoutResult RubyFormattingContext::layoutRubyBaseInl
 
 InlineLayoutPoint RubyFormattingContext::placeAnnotationBox(const Box& rubyBaseLayoutBox)
 {
-    ASSERT(rubyBaseLayoutBox.isRubyBase());
+    ASSERT(rubyBaseLayoutBox.isRenderRubyBase());
     auto* annotationBox = rubyBaseLayoutBox.associatedRubyAnnotationBox();
     if (!annotationBox) {
         ASSERT_NOT_REACHED();
@@ -200,7 +200,7 @@ InlineLayoutPoint RubyFormattingContext::placeAnnotationBox(const Box& rubyBaseL
 InlineLayoutSize RubyFormattingContext::sizeAnnotationBox(const Box& rubyBaseLayoutBox)
 {
     // FIXME: This is where we should take advantage of the ruby-column setup.
-    ASSERT(rubyBaseLayoutBox.isRubyBase());
+    ASSERT(rubyBaseLayoutBox.isRenderRubyBase());
     auto* annotationBox = rubyBaseLayoutBox.associatedRubyAnnotationBox();
     if (!annotationBox) {
         ASSERT_NOT_REACHED();
@@ -233,7 +233,7 @@ void RubyFormattingContext::applyAnnotationContributionToLayoutBounds(InlineLeve
     // container and the bottom of the bottom ruby annotation container, then additional leading is added on the appropriate side(s).
 
     auto& rubyBaseLayoutBox = rubyBaseInlineBox.layoutBox();
-    ASSERT(rubyBaseLayoutBox.isRubyBase());
+    ASSERT(rubyBaseLayoutBox.isRenderRubyBase());
     auto* annotationBox = rubyBaseLayoutBox.associatedRubyAnnotationBox();
     if (!isInterlinearAnnotation(annotationBox))
         return;
@@ -374,7 +374,7 @@ std::optional<size_t> RubyFormattingContext::nextWrapOpportunity(size_t inlineIt
     ASSERT(inlineItem.isInlineBoxStart() || inlineItem.isInlineBoxEnd());
 
     auto& layoutBox = inlineItem.layoutBox();
-    auto startsWithRubyInlineBox = layoutBox.isRuby() || layoutBox.isRubyBase();
+    auto startsWithRubyInlineBox = layoutBox.isRuby() || layoutBox.isRenderRubyBase();
     if (!startsWithRubyInlineBox) {
         // This is not ruby content.
         return { };
@@ -446,7 +446,7 @@ std::optional<bool> RubyFormattingContext::annotationOverlapCheck(const InlineDi
     // Check if there might be some inline box (end decoration) overlapping as previous content.
     if (&adjacentLayoutBox.parent() == &parentFormattingContext().root())
         return false;
-    if (adjacentLayoutBox.isRubyBase() && adjacentLayoutBox.associatedRubyAnnotationBox()) {
+    if (adjacentLayoutBox.isRenderRubyBase() && adjacentLayoutBox.associatedRubyAnnotationBox()) {
         auto annotationMarginBoxRect = InlineLayoutRect { BoxGeometry::marginBoxRect(parentFormattingContext().geometryForBox(*adjacentLayoutBox.associatedRubyAnnotationBox())) };
         if (visualRectIncludingBlockDirection(annotationMarginBoxRect).intersects(visualRectIncludingBlockDirection(overhangingRect)))
             return true;
@@ -457,7 +457,7 @@ std::optional<bool> RubyFormattingContext::annotationOverlapCheck(const InlineDi
 InlineLayoutUnit RubyFormattingContext::logicaWidthForRubyRange(WTF::Range<size_t> candidateRange, const InlineItemList& inlineItemList, InlineLayoutUnit lineContentLogicalRight) const
 {
     ASSERT(candidateRange.end() <= inlineItemList.size());
-    ASSERT(inlineItemList[candidateRange.begin()].layoutBox().isRuby() || inlineItemList[candidateRange.begin()].layoutBox().isRubyBase());
+    ASSERT(inlineItemList[candidateRange.begin()].layoutBox().isRuby() || inlineItemList[candidateRange.begin()].layoutBox().isRenderRubyBase());
 
     auto& formattingUtils = parentFormattingContext().formattingUtils();
     auto candidateContentLogicalWidth = InlineLayoutUnit { };
@@ -474,7 +474,7 @@ InlineLayoutUnit RubyFormattingContext::logicaWidthForRubyRange(WTF::Range<size_
             continue;
         }
 
-        if (rubyLayoutBox.isRubyBase()) {
+        if (rubyLayoutBox.isRenderRubyBase()) {
             ASSERT(rubyItem.isInlineBoxStart());
 
             auto baseLogicalWidth = [&] {

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -161,7 +161,7 @@ void BoxTree::adjustStyleIfNeeded(const RenderElement& renderer, RenderStyle& st
             }
             return;
         }
-        if (renderer.isLineBreak()) {
+        if (renderer.isRenderLineBreak()) {
             if (!styleToAdjust.hasOutOfFlowPosition()) {
                 // Force in-flow display value to inline (see webkit.org/b/223151).
                 styleToAdjust.setDisplay(DisplayType::Inline);

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -57,7 +57,7 @@ namespace LayoutIntegration {
 static std::optional<AvoidanceReason> canUseForChild(const RenderObject& child)
 {
     if (is<RenderText>(child)) {
-        if (child.isSVGInlineText())
+        if (child.isRenderSVGInlineText())
             return AvoidanceReason::ContentIsSVG;
         return { };
     }
@@ -66,7 +66,7 @@ static std::optional<AvoidanceReason> canUseForChild(const RenderObject& child)
         return { };
 
     auto& renderer = downcast<RenderElement>(child);
-    if (renderer.isRubyRun())
+    if (renderer.isRenderRubyRun())
         return AvoidanceReason::ContentIsRuby;
 
     if (is<RenderBlockFlow>(renderer)
@@ -84,9 +84,9 @@ static std::optional<AvoidanceReason> canUseForChild(const RenderObject& child)
         return { };
 
     if (is<RenderInline>(renderer)) {
-        if (renderer.isSVGInline())
+        if (renderer.isRenderSVGInline())
             return AvoidanceReason::ContentIsSVG;
-        if (renderer.isRubyInline())
+        if (renderer.isRenderRubyAsInline())
             return AvoidanceReason::ContentIsRuby;
         return { };
     }
@@ -104,7 +104,7 @@ static std::optional<AvoidanceReason> canUseForLineLayoutWithReason(const Render
         ASSERT(is<RenderSVGBlock>(flow));
         return AvoidanceReason::ContentIsSVG;
     }
-    if (flow.isRubyText() || flow.isRubyBase())
+    if (flow.isRenderRubyText() || flow.isRenderRubyBase())
         return AvoidanceReason::ContentIsRuby;
     for (auto walker = InlineWalker(flow); !walker.atEnd(); walker.advance()) {
         auto& child = *walker.current();
@@ -123,7 +123,7 @@ bool canUseForPreferredWidthComputation(const RenderBlockFlow& blockContainer)
 {
     for (auto walker = InlineWalker(blockContainer); !walker.atEnd(); walker.advance()) {
         auto& renderer = *walker.current();
-        if (renderer.isText())
+        if (renderer.isRenderText())
             continue;
         if (is<RenderLineBreak>(renderer))
             continue;
@@ -262,14 +262,14 @@ bool canUseForFlexLayout(const RenderFlexibleBox& flexBox)
             return false;
         if (flexItem.isFloating() || flexItem.isOutOfFlowPositioned())
             return false;
-        if (flexItem.isSVGRootOrLegacySVGRoot())
+        if (flexItem.isRenderOrLegacyRenderSVGRoot())
             return false;
         // FIXME: No nested flexbox support.
         if (flexItem.isFlexibleBoxIncludingDeprecated())
             return false;
         if (flexItem.isFieldset() || flexItem.isRenderTextControl())
             return false;
-        if (flexItem.isTable())
+        if (flexItem.isRenderTable())
             return false;
         auto& flexItemStyle = flexItem.style();
         if (!flexItemStyle.isHorizontalWritingMode() || !flexItemStyle.isLeftToRightDirection())

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -143,15 +143,15 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
     if (firstBox == lastBox && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (firstBox && horizontalPosition <= firstBox->logicalLeftIgnoringInlineDirection() && !firstBox->renderer().isListMarker() && (!editableOnly || isEditable(firstBox)))
+    if (firstBox && horizontalPosition <= firstBox->logicalLeftIgnoringInlineDirection() && !firstBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (lastBox && horizontalPosition >= lastBox->logicalRightIgnoringInlineDirection() && !lastBox->renderer().isListMarker() && (!editableOnly || isEditable(lastBox)))
+    if (lastBox && horizontalPosition >= lastBox->logicalRightIgnoringInlineDirection() && !lastBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(lastBox)))
         return lastBox;
 
     auto closestBox = lastBox;
     for (auto box = firstBox; box; box = box.traverseNextOnLineIgnoringLineBreak()) {
-        if (!box->renderer().isListMarker() && (!editableOnly || isEditable(box))) {
+        if (!box->renderer().isRenderListMarker() && (!editableOnly || isEditable(box))) {
             if (horizontalPosition < box->logicalRightIgnoringInlineDirection())
                 return box;
             closestBox = box;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -99,7 +99,7 @@ LineLayout::~LineLayout()
 static inline bool isContentRenderer(const RenderObject& renderer)
 {
     // FIXME: These fake renderers have their parent set but are not actually in the tree.
-    return !renderer.isReplica() && !renderer.isRenderScrollbarPart();
+    return !renderer.isRenderReplica() && !renderer.isRenderScrollbarPart();
 }
 
 RenderBlockFlow* LineLayout::blockContainer(const RenderObject& renderer)
@@ -128,7 +128,7 @@ LineLayout* LineLayout::containing(RenderObject& renderer)
             // SVG content inside svg root shows up as block (see RenderSVGBlock). We only support inline root svg as "atomic content".
             return nullptr;
         }
-        if (renderer.isFrameSet()) {
+        if (renderer.isRenderFrameSet()) {
             // Since RenderFrameSet is not a RenderBlock, finding container for nested framesets can't use containingBlock ancestor walk.
             if (auto* parent = renderer.parent(); is<RenderBlockFlow>(parent))
                 return downcast<RenderBlockFlow>(*parent).modernLineLayout();

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -124,7 +124,7 @@ public:
     bool isDocumentBox() const { return m_nodeType == NodeType::DocumentElement; }
     bool isBodyBox() const { return m_nodeType == NodeType::Body; }
     bool isRuby() const { return style().display() == DisplayType::Ruby; }
-    bool isRubyBase() const { return style().display() == DisplayType::RubyBase; }
+    bool isRenderRubyBase() const { return style().display() == DisplayType::RubyBase; }
     bool isTableWrapperBox() const { return m_nodeType == NodeType::TableWrapperBox; }
     bool isTableBox() const { return m_nodeType == NodeType::TableBox; }
     bool isTableCaption() const { return style().display() == DisplayType::TableCaption; }

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -78,7 +78,7 @@ void AutoscrollController::startAutoscrollForSelection(RenderObject* renderer)
         return;
     auto* scrollable = RenderBox::findAutoscrollable(renderer);
     if (!scrollable)
-        scrollable = renderer->isListBox() ? downcast<RenderListBox>(renderer) : nullptr;
+        scrollable = renderer->isRenderListBox() ? downcast<RenderListBox>(renderer) : nullptr;
     if (!scrollable)
         return;
     m_autoscrollType = AutoscrollForSelection;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -937,7 +937,7 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
             return false;
 
         renderer = parent->renderer();
-        if (!renderer || !renderer->isListBox())
+        if (!renderer || !renderer->isRenderListBox())
             return false;
     }
 
@@ -1040,7 +1040,7 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
     // FIXME: Isn't there a better non-SVG-specific way to do this?
     if (RefPtr selectionBaseNode = newSelection.base().deprecatedNode()) {
         if (RenderObject* selectionBaseRenderer = selectionBaseNode->renderer()) {
-            if (selectionBaseRenderer->isSVGText()) {
+            if (selectionBaseRenderer->isRenderSVGText()) {
                 if (target->renderer()->containingBlock() != selectionBaseRenderer->containingBlock())
                     return;
             }
@@ -1294,7 +1294,7 @@ bool EventHandler::scrollOverflow(ScrollDirection direction, ScrollGranularity g
     
     if (node) {
         auto r = node->renderer();
-        if (r && !r->isListBox() && r->enclosingBox().scroll(direction, granularity)) {
+        if (r && !r->isRenderListBox() && r->enclosingBox().scroll(direction, granularity)) {
             setFrameWasScrolledByUser();
             return true;
         }
@@ -1315,7 +1315,7 @@ bool EventHandler::logicalScrollOverflow(ScrollLogicalDirection direction, Scrol
     
     if (node) {
         auto r = node->renderer();
-        if (r && !r->isListBox() && r->enclosingBox().logicalScroll(direction, granularity)) {
+        if (r && !r->isRenderListBox() && r->enclosingBox().logicalScroll(direction, granularity)) {
             setFrameWasScrolledByUser();
             return true;
         }
@@ -1619,7 +1619,7 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
             && !m_capturingMouseEventsElement)
                 return iBeam;
 
-        if ((editable || (renderer && renderer->isText() && node->canStartSelection())) && !inResizer && !result.scrollbar())
+        if ((editable || (renderer && renderer->isRenderText() && node->canStartSelection())) && !inResizer && !result.scrollbar())
             return iBeam;
         return pointerCursor();
     }
@@ -4613,7 +4613,7 @@ bool EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer(Sc
             return false;
 
         RenderBox& renderBox = renderer->enclosingBox();
-        if (!renderer->isListBox() && startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(direction, granularity, &renderBox, isKeyRepeat))
+        if (!renderer->isRenderListBox() && startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(direction, granularity, &renderBox, isKeyRepeat))
             return true;
     }
     return false;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2559,7 +2559,7 @@ void LocalFrameView::scrollToFocusedElementInternal()
         updateTarget = updateTarget->shadowHost();
 
     auto* renderer = updateTarget->renderer();
-    if (!renderer || renderer->isWidget())
+    if (!renderer || renderer->isRenderWidget())
         return;
 
     bool insideFixed;

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -554,7 +554,7 @@ Node* LocalFrame::nodeRespondingToScrollWheelEvents(const FloatPoint& viewportLo
             if (!renderer)
                 continue;
 
-            if ((renderer->isTextField() || renderer->isTextArea()) && downcast<RenderTextControl>(*renderer).canScroll()) {
+            if ((renderer->isRenderTextControlSingleLine() || renderer->isRenderTextControlMultiLine()) && downcast<RenderTextControl>(*renderer).canScroll()) {
                 scrollingAncestor = node;
                 continue;
             }

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -276,7 +276,7 @@ static LayoutRect computeCaretRectForBox(const RenderBox& renderer, const Inline
     //
     // FIXME: ignoring :first-line, missing good reason to take care of
     LayoutUnit fontHeight = renderer.style().metricsOfPrimaryFont().height();
-    if (fontHeight > rect.height() || (!renderer.isReplacedOrInlineBlock() && !renderer.isTable()))
+    if (fontHeight > rect.height() || (!renderer.isReplacedOrInlineBlock() && !renderer.isRenderTable()))
         rect.setHeight(fontHeight);
 
     // Move to local coords

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -468,7 +468,7 @@ HTMLMediaElement* HitTestResult::mediaElement() const
     if (!m_innerNonSharedNode)
         return nullptr;
 
-    if (!(m_innerNonSharedNode->renderer() && m_innerNonSharedNode->renderer()->isMedia()))
+    if (!(m_innerNonSharedNode->renderer() && m_innerNonSharedNode->renderer()->isRenderMedia()))
         return nullptr;
 
     if (is<HTMLMediaElement>(*m_innerNonSharedNode))

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -138,7 +138,7 @@ float LegacyInlineBox::logicalHeight() const
         return 0;
 
     const RenderStyle& lineStyle = this->lineStyle();
-    if (renderer().isTextOrLineBreak())
+    if (renderer().isRenderTextOrLineBreak())
         return lineStyle.metricsOfPrimaryFont().height();
     if (is<RenderBox>(renderer()) && parent())
         return isHorizontal() ? downcast<RenderBox>(renderer()).height() : downcast<RenderBox>(renderer()).width();

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -47,7 +47,7 @@ public:
     virtual void extractLine() = 0;
     virtual void attachLine() = 0;
 
-    virtual bool isLineBreak() const { return renderer().isLineBreak(); }
+    virtual bool isLineBreak() const { return renderer().isRenderLineBreak(); }
 
     WEBCORE_EXPORT virtual void adjustPosition(float dx, float dy);
     void adjustLogicalPosition(float deltaLogicalLeft, float deltaLogicalTop)

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -132,7 +132,7 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
         if (child->renderer().isReplacedOrInlineBlock())
             shouldClearDescendantsHaveSameLineHeightAndBaseline = true;
         else if (child->behavesLikeText()) {
-            if (child->renderer().isLineBreak() || child->renderer().parent() != &renderer()) {
+            if (child->renderer().isRenderLineBreak() || child->renderer().parent() != &renderer()) {
                 if (!parentStyle.fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(childStyle.fontCascade().metricsOfPrimaryFont())
                     || parentStyle.lineHeight() != childStyle.lineHeight()
                     || (parentStyle.verticalAlign() != VerticalAlign::Baseline && !isRootInlineBox()) || childStyle.verticalAlign() != VerticalAlign::Baseline)
@@ -141,7 +141,7 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
             if (childStyle.hasTextCombine() || childStyle.textEmphasisMark() != TextEmphasisMark::None)
                 shouldClearDescendantsHaveSameLineHeightAndBaseline = true;
         } else {
-            if (child->renderer().isLineBreak()) {
+            if (child->renderer().isRenderLineBreak()) {
                 // FIXME: This isn't ideal. We only turn off because current layout test results expect the <br> to be 0-height on the baseline.
                 // Other than making a zillion tests have to regenerate results, there's no reason to ditch the optimization here.
                 auto childIsHardLinebreak = child->renderer().isBR();
@@ -178,7 +178,7 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
             const RenderBox& box = downcast<RenderBox>(child->renderer());
             if (box.hasRenderOverflow() || box.hasSelfPaintingLayer())
                 child->clearKnownToHaveNoOverflow();
-        } else if (!child->renderer().isLineBreak() && (childStyle.boxShadow() || child->boxModelObject()->hasSelfPaintingLayer()
+        } else if (!child->renderer().isRenderLineBreak() && (childStyle.boxShadow() || child->boxModelObject()->hasSelfPaintingLayer()
             || (is<RenderListMarker>(child->renderer()) && !downcast<RenderListMarker>(child->renderer()).isInside())
             || childStyle.hasBorderImageOutsets()))
             child->clearKnownToHaveNoOverflow();
@@ -502,10 +502,10 @@ static bool verticalAlignApplies(const RenderObject& renderer)
 {
     // http://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align - vertical-align only applies to inline level and table-cell elements.
     // FIXME: Ideally we would only align inline level boxes which means that text inside an inline box would just sit on the box itself.
-    if (!renderer.isText())
+    if (!renderer.isRenderText())
         return true;
     auto& parentRenderer = *renderer.parent();
-    return (parentRenderer.isInline() && parentRenderer.style().display() != DisplayType::InlineBlock) || parentRenderer.isTableCell();
+    return (parentRenderer.isInline() && parentRenderer.style().display() != DisplayType::InlineBlock) || parentRenderer.isRenderTableCell();
 }
 
 void LegacyInlineFlowBox::adjustMaxAscentAndDescent(LayoutUnit& maxAscent, LayoutUnit& maxDescent, LayoutUnit maxPositionTop, LayoutUnit maxPositionBottom)
@@ -1135,7 +1135,7 @@ void LegacyInlineFlowBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOf
     // Paint our children.
     if (paintPhase != PaintPhase::SelfOutline) {
         for (auto* curr = firstChild(); curr; curr = curr->nextOnLine()) {
-            if (curr->renderer().isText() || !curr->boxModelObject()->hasSelfPaintingLayer())
+            if (curr->renderer().isRenderText() || !curr->boxModelObject()->hasSelfPaintingLayer())
                 curr->paint(childInfo, paintOffset, lineTop, lineBottom);
         }
     }

--- a/Source/WebCore/rendering/LegacyInlineIterator.h
+++ b/Source/WebCore/rendering/LegacyInlineIterator.h
@@ -185,7 +185,7 @@ static inline void notifyObserverWillExitObject(Observer* observer, RenderObject
 static inline bool isIteratorTarget(RenderObject* object)
 {
     ASSERT(object); // The iterator will of course return 0, but its not an expected argument to this function.
-    return object->isTextOrLineBreak() || object->isFloating() || object->isOutOfFlowPositioned() || object->isReplacedOrInlineBlock();
+    return object->isRenderTextOrLineBreak() || object->isFloating() || object->isOutOfFlowPositioned() || object->isReplacedOrInlineBlock();
 }
 
 template <class Observer>
@@ -354,7 +354,7 @@ ALWAYS_INLINE UCharDirection LegacyInlineIterator::direction() const
         return surrogateTextDirection(codeUnit);
     }
 
-    if (m_renderer->isListMarker())
+    if (m_renderer->isRenderListMarker())
         return m_renderer->style().isLeftToRightDirection() ? U_LEFT_TO_RIGHT : U_RIGHT_TO_LEFT;
 
     return U_OTHER_NEUTRAL;

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -303,8 +303,8 @@ LegacyRootInlineBox* LegacyLineLayout::constructLine(BidiRunList<BidiRun>& bidiR
     for (BidiRun* r = bidiRuns.firstRun(); r; r = r->next()) {
         // Create a box for our object.
         bool isOnlyRun = (runCount == 1);
-        if (runCount == 2 && !r->renderer().isListMarker())
-            isOnlyRun = (!style().isLeftToRightDirection() ? bidiRuns.lastRun() : bidiRuns.firstRun())->renderer().isListMarker();
+        if (runCount == 2 && !r->renderer().isRenderListMarker())
+            isOnlyRun = (!style().isLeftToRightDirection() ? bidiRuns.lastRun() : bidiRuns.firstRun())->renderer().isRenderListMarker();
 
         if (lineInfo.isEmpty())
             continue;
@@ -344,7 +344,7 @@ LegacyRootInlineBox* LegacyLineLayout::constructLine(BidiRunList<BidiRun>& bidiR
     // paint borders/margins/padding. This knowledge will ultimately be used when
     // we determine the horizontal positions and widths of all the inline boxes on
     // the line.
-    bool isLogicallyLastRunWrapped = bidiRuns.logicallyLastRun()->renderer().isText() ? !reachedEndOfTextRenderer(bidiRuns) : !is<RenderInline>(bidiRuns.logicallyLastRun()->renderer());
+    bool isLogicallyLastRunWrapped = bidiRuns.logicallyLastRun()->renderer().isRenderText() ? !reachedEndOfTextRenderer(bidiRuns) : !is<RenderInline>(bidiRuns.logicallyLastRun()->renderer());
     lastRootBox()->determineSpacingForFlowBoxes(lineInfo.isLastLine(), isLogicallyLastRunWrapped, &bidiRuns.logicallyLastRun()->renderer());
 
     // Now mark the line boxes as being constructed.
@@ -1265,7 +1265,7 @@ LegacyRootInlineBox* LegacyLineLayout::createLineBoxesFromBidiRuns(unsigned bidi
     // contains reversed text or not. If we wouldn't do that editing and thus
     // text selection in RTL boxes would not work as expected.
     if (isSVGRootInlineBox) {
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_flow.isSVGText());
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_flow.isRenderSVGText());
         downcast<SVGRootInlineBox>(*lineBox).computePerCharacterLayoutInformation();
     }
     
@@ -1776,7 +1776,7 @@ void LegacyLineLayout::layoutLineBoxes(bool relayoutChildren, LayoutUnit& repain
                     else
                         box.layoutIfNeeded();
                 }
-            } else if (o.isTextOrLineBreak() || is<RenderInline>(o)) {
+            } else if (o.isRenderTextOrLineBreak() || is<RenderInline>(o)) {
                 if (layoutState.isFullLayout() || o.selfNeedsLayout()) {
                     dirtyLineBoxesForRenderer(o, layoutState.isFullLayout());
                     hasDirtyRenderCounterWithInlineBoxParent = hasDirtyRenderCounterWithInlineBoxParent || (is<RenderCounter>(o) && is<RenderInline>(o.parent()));

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -483,7 +483,7 @@ LayoutUnit LegacyRootInlineBox::selectionTop() const
 
 #if !PLATFORM(IOS_FAMILY)
     // See rdar://problem/19692206 ... don't want to do this adjustment for iOS where overlap is ok and handled.
-    if (renderer().isRubyBase()) {
+    if (renderer().isRenderRubyBase()) {
         // The ruby base selection should avoid intruding into the ruby text. This is only the case if there is an actual ruby text above us.
         RenderRubyBase* base = &downcast<RenderRubyBase>(renderer());
         RenderRubyRun* run = base->rubyRun();
@@ -494,7 +494,7 @@ LayoutUnit LegacyRootInlineBox::selectionTop() const
                 return selectionTop;
             }
         }
-    } else if (renderer().isRubyText()) {
+    } else if (renderer().isRenderRubyText()) {
         // The ruby text selection should go all the way to the selection top of the containing line.
         RenderRubyText* text = &downcast<RenderRubyText>(renderer());
         RenderRubyRun* run = text->rubyRun();
@@ -550,7 +550,7 @@ LayoutUnit LegacyRootInlineBox::selectionBottom() const
     
 #if !PLATFORM(IOS_FAMILY)
     // See rdar://problem/19692206 ... don't want to do this adjustment for iOS where overlap is ok and handled.
-    if (renderer().isRubyBase()) {
+    if (renderer().isRenderRubyBase()) {
         // The ruby base selection should avoid intruding into the ruby text. This is only the case if there is an actual ruby text below us.
         RenderRubyBase* base = &downcast<RenderRubyBase>(renderer());
         RenderRubyRun* run = base->rubyRun();
@@ -561,7 +561,7 @@ LayoutUnit LegacyRootInlineBox::selectionBottom() const
                 return selectionBottom;
             }
         }
-    } else if (renderer().isRubyText()) {
+    } else if (renderer().isRenderRubyText()) {
         // The ruby text selection should go all the way to the selection bottom of the containing line.
         RenderRubyText* text = &downcast<RenderRubyText>(renderer());
         RenderRubyRun* run = text->rubyRun();
@@ -776,7 +776,7 @@ void LegacyRootInlineBox::ascentAndDescentForBox(LegacyInlineBox& box, GlyphOver
     if (includeMarginForBox(box)) {
         LayoutUnit ascentWithMargin = boxLineStyle.metricsOfPrimaryFont().ascent(baselineType());
         LayoutUnit descentWithMargin = boxLineStyle.metricsOfPrimaryFont().descent(baselineType());
-        if (box.parent() && !box.renderer().isTextOrLineBreak()) {
+        if (box.parent() && !box.renderer().isRenderTextOrLineBreak()) {
             ascentWithMargin += box.boxModelObject()->borderAndPaddingBefore() + box.boxModelObject()->marginBefore();
             descentWithMargin += box.boxModelObject()->borderAndPaddingAfter() + box.boxModelObject()->marginAfter();
         }
@@ -790,7 +790,7 @@ void LegacyRootInlineBox::ascentAndDescentForBox(LegacyInlineBox& box, GlyphOver
 
 LayoutUnit LegacyRootInlineBox::verticalPositionForBox(LegacyInlineBox* box, VerticalPositionCache& verticalPositionCache)
 {
-    if (box->renderer().isTextOrLineBreak())
+    if (box->renderer().isRenderTextOrLineBreak())
         return LayoutUnit(box->parent()->logicalTop());
     
     RenderBoxModelObject* renderer = box->boxModelObject();
@@ -861,7 +861,7 @@ LayoutUnit LegacyRootInlineBox::verticalPositionForBox(LegacyInlineBox* box, Ver
 
 bool LegacyRootInlineBox::includeLeadingForBox(LegacyInlineBox& box) const
 {
-    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isTextOrLineBreak() && !box.behavesLikeText()))
+    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
 
     auto lineBoxContain = renderer().style().lineBoxContain();
@@ -870,7 +870,7 @@ bool LegacyRootInlineBox::includeLeadingForBox(LegacyInlineBox& box) const
 
 bool LegacyRootInlineBox::includeFontForBox(LegacyInlineBox& box) const
 {
-    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isTextOrLineBreak() && !box.behavesLikeText()))
+    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
     
     if (!box.behavesLikeText() && is<LegacyInlineFlowBox>(box) && !downcast<LegacyInlineFlowBox>(box).hasTextChildren())
@@ -881,7 +881,7 @@ bool LegacyRootInlineBox::includeFontForBox(LegacyInlineBox& box) const
 
 bool LegacyRootInlineBox::includeGlyphsForBox(LegacyInlineBox& box) const
 {
-    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isTextOrLineBreak() && !box.behavesLikeText()))
+    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
     
     if (!box.behavesLikeText() && is<LegacyInlineFlowBox>(box) && !downcast<LegacyInlineFlowBox>(box).hasTextChildren())
@@ -892,7 +892,7 @@ bool LegacyRootInlineBox::includeGlyphsForBox(LegacyInlineBox& box) const
 
 bool LegacyRootInlineBox::includeInitialLetterForBox(LegacyInlineBox& box) const
 {
-    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isTextOrLineBreak() && !box.behavesLikeText()))
+    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
     
     if (!box.behavesLikeText() && is<LegacyInlineFlowBox>(box) && !downcast<LegacyInlineFlowBox>(box).hasTextChildren())
@@ -903,7 +903,7 @@ bool LegacyRootInlineBox::includeInitialLetterForBox(LegacyInlineBox& box) const
 
 bool LegacyRootInlineBox::includeMarginForBox(LegacyInlineBox& box) const
 {
-    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isTextOrLineBreak() && !box.behavesLikeText()))
+    if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
 
     return renderer().style().lineBoxContain().contains(LineBoxContain::InlineBox);

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -49,7 +49,7 @@ RenderAttachment::RenderAttachment(HTMLAttachmentElement& element, RenderStyle&&
     : RenderReplaced(Type::Attachment, element, WTFMove(style), LayoutSize())
     , m_isWideLayout(element.isWideLayout())
 {
-    ASSERT(isAttachment());
+    ASSERT(isRenderAttachment());
 #if ENABLE(SERVICE_CONTROLS)
     m_hasShadowControls = element.isImageMenuEnabled();
 #endif

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -72,6 +72,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderAttachment, isAttachment())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderAttachment, isRenderAttachment())
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -109,7 +109,7 @@ RenderBlockFlow::MarginInfo::MarginInfo(const RenderBlockFlow& block, LayoutUnit
     m_canCollapseMarginAfterWithChildren = m_canCollapseWithChildren && !afterBorderPadding
         && blockStyle.logicalHeight().isAuto() && !blockStyle.logicalHeight().value();
     
-    m_quirkContainer = block.isTableCell() || block.isBody();
+    m_quirkContainer = block.isRenderTableCell() || block.isBody();
 
     m_positiveMargin = m_canCollapseMarginBeforeWithChildren ? block.maxPositiveMarginBefore() : 0_lu;
     m_negativeMargin = m_canCollapseMarginBeforeWithChildren ? block.maxNegativeMarginBefore() : 0_lu;
@@ -213,7 +213,7 @@ void RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats()
     }
 
     // Inline blocks are covered by the isReplacedOrInlineBlock() check in the avoidFloats method.
-    if (avoidsFloats() || isDocumentElementRenderer() || isRenderView() || isFloatingOrOutOfFlowPositioned() || isTableCell()) {
+    if (avoidsFloats() || isDocumentElementRenderer() || isRenderView() || isFloatingOrOutOfFlowPositioned() || isRenderTableCell()) {
         if (m_floatingObjects)
             m_floatingObjects->clear();
         if (!oldIntrudingFloatSet.isEmpty())
@@ -435,9 +435,9 @@ void RenderBlockFlow::computeColumnCountAndWidth()
 bool RenderBlockFlow::willCreateColumns(std::optional<unsigned> desiredColumnCount) const
 {
     // The following types are not supposed to create multicol context.
-    if (isFileUploadControl() || isRenderTextControl() || isListBox())
+    if (isRenderFileUploadControl() || isRenderTextControl() || isRenderListBox())
         return false;
-    if (isRenderSVGBlock() || isRubyRun() || isRubyBlock() || isRubyInline() || isRubyBase())
+    if (isRenderSVGBlock() || isRenderRubyRun() || isRenderRubyAsBlock() || isRenderRubyAsInline() || isRenderRubyBase())
         return false;
 #if ENABLE(MATHML)
     if (isRenderMathMLBlock())
@@ -527,7 +527,7 @@ void RenderBlockFlow::layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalH
         //
         // Start out by setting our margin values to our current margins. Table cells have
         // no margins, so we don't fill in the values for table cells.
-        bool isCell = isTableCell();
+        bool isCell = isRenderTableCell();
         if (!isCell) {
             initMaxMarginValues();
 
@@ -1568,7 +1568,7 @@ void RenderBlockFlow::marginBeforeEstimateForChild(RenderBox& child, LayoutUnit&
 {
     // Give up if in quirks mode and we're a body/table cell and the top margin of the child box is quirky.
     // Give up if the child specified -webkit-margin-collapse: separate that prevents collapsing.
-    if (document().inQuirksMode() && hasMarginBeforeQuirk(child) && (isTableCell() || isBody()))
+    if (document().inQuirksMode() && hasMarginBeforeQuirk(child) && (isRenderTableCell() || isBody()))
         return;
 
     LayoutUnit beforeChildMargin = marginBeforeForChild(child);
@@ -1847,7 +1847,7 @@ LayoutUnit RenderBlockFlow::adjustBlockChildForPagination(LayoutUnit logicalTopA
     if (paginationStrut) {
         // We are willing to propagate out to our parent block as long as we were at the top of the block prior
         // to collapsing our margins, and as long as we didn't clear or move as a result of other pagination.
-        if (atBeforeSideOfBlock && oldTop == result && !isOutOfFlowPositioned() && !isTableCell()) {
+        if (atBeforeSideOfBlock && oldTop == result && !isOutOfFlowPositioned() && !isRenderTableCell()) {
             // FIXME: Should really check if we're exceeding the page height before propagating the strut, but we don't
             // have all the information to do so (the strut only has the remaining amount to push). Gecko gets this wrong too
             // and pushes to the next page anyway, so not too concerned about it.
@@ -2028,7 +2028,7 @@ RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustment
         bool avoidFirstLinePageBreak = lineBox->isFirst() && totalLogicalHeight < pageLogicalHeightAtNewOffset && !floatMinimumBottom;
         bool affectedByOrphans = !style().hasAutoOrphans() && style().orphans() >= lineNumber;
 
-        if ((avoidFirstLinePageBreak || affectedByOrphans) && !isOutOfFlowPositioned() && !isTableCell()) {
+        if ((avoidFirstLinePageBreak || affectedByOrphans) && !isOutOfFlowPositioned() && !isRenderTableCell()) {
             if (needsAppleMailPaginationQuirk(*this))
                 return { };
 
@@ -3281,7 +3281,7 @@ void RenderBlockFlow::markLinesDirtyInBlockRange(LayoutUnit logicalTop, LayoutUn
 
 std::optional<LayoutUnit> RenderBlockFlow::firstLineBaseline() const
 {
-    if (isWritingModeRoot() && !isRubyRun() && !isGridItem() && !isFlexItem())
+    if (isWritingModeRoot() && !isRenderRubyRun() && !isGridItem() && !isFlexItem())
         return std::nullopt;
 
     if (shouldApplyLayoutContainment())
@@ -3304,7 +3304,7 @@ std::optional<LayoutUnit> RenderBlockFlow::firstLineBaseline() const
 
 std::optional<LayoutUnit> RenderBlockFlow::lastLineBaseline() const
 {
-    if (isWritingModeRoot() && !isRubyRun() && !isGridItem() && !isFlexItem())
+    if (isWritingModeRoot() && !isRenderRubyRun() && !isGridItem() && !isFlexItem())
         return std::nullopt;
 
     if (shouldApplyLayoutContainment())
@@ -3329,7 +3329,7 @@ std::optional<LayoutUnit> RenderBlockFlow::lastLineBaseline() const
 
 std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode lineDirection) const
 {
-    if (isWritingModeRoot() && !isRubyRun())
+    if (isWritingModeRoot() && !isRenderRubyRun())
         return std::nullopt;
 
     if (shouldApplyLayoutContainment())
@@ -3338,7 +3338,7 @@ std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode
     if (style().display() == DisplayType::InlineBlock) {
         // The baseline of an 'inline-block' is the baseline of its last line box in the normal flow, unless it has either no in-flow line boxes or if its 'overflow'
         // property has a computed value other than 'visible'. see https://www.w3.org/TR/CSS22/visudet.html
-        auto shouldSynthesizeBaseline = !style().isOverflowVisible() && !is<HTMLFormControlElement>(element()) && !isTextControlInnerBlock();
+        auto shouldSynthesizeBaseline = !style().isOverflowVisible() && !is<HTMLFormControlElement>(element()) && !isRenderTextControlInnerBlock();
         if (shouldSynthesizeBaseline)
             return std::nullopt;
     }
@@ -3531,7 +3531,7 @@ GapRects RenderBlockFlow::inlineSelectionGaps(RenderBlock& rootBlock, const Layo
 
         if (!containsStart && !lastSelectedLineBox
             && selectionState() != HighlightState::Start
-            && selectionState() != HighlightState::Both && !isRubyBase())
+            && selectionState() != HighlightState::Both && !isRenderRubyBase())
             result.uniteCenter(blockSelectionGap(rootBlock, rootBlockPhysicalPosition, offsetFromRootBlock, lastLogicalTop, lastLogicalLeft, lastLogicalRight, selectionTop, cache, paintInfo));
 
         LayoutRect logicalRect { LayoutUnit(lineBox->contentLogicalLeft()), selectionTop, LayoutUnit(lineBox->contentLogicalWidth()), selectionTop + selectionHeight };
@@ -4116,7 +4116,7 @@ static bool isNonBlocksOrNonFixedHeightListItems(const RenderObject& renderer)
 {
     if (!renderer.isRenderBlock())
         return true;
-    if (renderer.isListItem())
+    if (renderer.isRenderListItem())
         return renderer.style().height().type() != LengthType::Fixed;
     return false;
 }
@@ -4417,7 +4417,7 @@ RenderObject* InlineMinMaxIterator::next()
         if (!result)
             break;
 
-        if (!result->isOutOfFlowPositioned() && (result->isTextOrLineBreak() || result->isFloating() || result->isReplacedOrInlineBlock() || result->isRenderInline()))
+        if (!result->isOutOfFlowPositioned() && (result->isRenderTextOrLineBreak() || result->isFloating() || result->isReplacedOrInlineBlock() || result->isRenderInline()))
             break;
 
         current = result;
@@ -4486,7 +4486,7 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
     // Firefox and Opera will allow a table cell to grow to fit an image inside it under
     // very specific cirucumstances (in order to match common WinIE renderings). 
     // Not supporting the quirk has caused us to mis-render some real sites. (See Bugzilla 10517.) 
-    bool allowImagesToBreak = !document().inQuirksMode() || !isTableCell() || !styleToUse.logicalWidth().isIntrinsicOrAuto();
+    bool allowImagesToBreak = !document().inQuirksMode() || !isRenderTableCell() || !styleToUse.logicalWidth().isIntrinsicOrAuto();
 
     bool oldAutoWrap = styleToUse.autoWrap();
 
@@ -4555,7 +4555,7 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
             float childMin = 0;
             float childMax = 0;
 
-            if (!child->isText()) {
+            if (!child->isRenderText()) {
                 if (child->isLineBreakOpportunity()) {
                     minLogicalWidth = preferredWidth(minLogicalWidth, inlineMin);
                     inlineMin = 0;
@@ -4674,7 +4674,7 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                 // Case (3). Text.
                 RenderText& renderText = downcast<RenderText>(*child);
 
-                if (renderText.style().hasTextCombine() && renderText.isCombineText())
+                if (renderText.style().hasTextCombine() && renderText.isRenderCombineText())
                     downcast<RenderCombineText>(renderText).combineTextIfNeeded();
 
                 // Determine if we have a breakable character. Pass in
@@ -4783,7 +4783,7 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
             }
 
             // Ignore spaces after a list marker.
-            if (child->isListMarker())
+            if (child->isRenderListMarker())
                 stripFrontSpaces = true;
         } else {
             if (styleToUse.collapseWhiteSpace())
@@ -4797,7 +4797,7 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
             addedStartPunctuationHang = true;
         }
 
-        if (!child->isText() && child->isRenderInline())
+        if (!child->isRenderText() && child->isRenderInline())
             isPrevChildInlineFlow = true;
         else
             isPrevChildInlineFlow = false;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -155,15 +155,15 @@ bool RenderBox::s_hadNonVisibleOverflow = false;
 RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderBoxModelObject(type, element, WTFMove(style), baseTypeFlags)
 {
-    setIsBox();
-    ASSERT(isBox());
+    setIsRenderBox();
+    ASSERT(isRenderBox());
 }
 
 RenderBox::RenderBox(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderBoxModelObject(type, document, WTFMove(style), baseTypeFlags)
 {
-    setIsBox();
-    ASSERT(isBox());
+    setIsRenderBox();
+    ASSERT(isRenderBox());
 }
 
 RenderBox::~RenderBox()
@@ -1901,7 +1901,7 @@ bool RenderBox::computeBackgroundIsKnownToBeObscured(const LayoutPoint& paintOff
     if (!hasBackground())
         return false;
     // Table and root background painting is special.
-    if (isTable() || isDocumentElementRenderer())
+    if (isRenderTable() || isDocumentElementRenderer())
         return false;
 
     LayoutRect backgroundRect;
@@ -2597,7 +2597,7 @@ std::optional<LayoutRect> RenderBox::computeVisibleRectInContainer(const LayoutR
 
     LayoutSize locationOffset = this->locationOffset();
     // FIXME: This is needed as long as RenderWidget snaps to integral size/position.
-    if (isRenderReplaced() && isWidget()) {
+    if (isRenderReplaced() && isRenderWidget()) {
         LayoutSize flooredLocationOffset = toIntSize(flooredIntPoint(locationOffset));
         adjustedRect.expand(locationOffset - flooredLocationOffset);
         locationOffset = flooredLocationOffset;
@@ -2719,14 +2719,14 @@ void RenderBox::computeLogicalWidthInFragment(LogicalExtentComputedValues& compu
     // width.  Use the width from the style context.
     // FIXME: Account for block-flow in flexible boxes.
     // https://bugs.webkit.org/show_bug.cgi?id=46418
-    if (hasOverridingLogicalWidth() && (isRubyRun() || (parent()->isFlexibleBoxIncludingDeprecated()))) {
+    if (hasOverridingLogicalWidth() && (isRenderRubyRun() || (parent()->isFlexibleBoxIncludingDeprecated()))) {
         computedValues.m_extent = overridingLogicalWidth();
         return;
     }
 
     // FIXME: Account for block-flow in flexible boxes.
     // https://bugs.webkit.org/show_bug.cgi?id=46418
-    bool inVerticalBox = parent()->isDeprecatedFlexibleBox() && (parent()->style().boxOrient() == BoxOrient::Vertical);
+    bool inVerticalBox = parent()->isRenderDeprecatedFlexibleBox() && (parent()->style().boxOrient() == BoxOrient::Vertical);
     bool stretching = (parent()->style().boxAlign() == BoxAlignment::Stretch);
     // FIXME: Stretching is the only reason why we don't want the box to be treated as a replaced element, so we could perhaps
     // refactor all this logic, not only for flex and grid since alignment is intended to be applied to any block.
@@ -2904,7 +2904,7 @@ bool RenderBox::columnFlexItemHasStretchAlignment() const
 
 bool RenderBox::isStretchingColumnFlexItem() const
 {
-    if (parent()->isDeprecatedFlexibleBox() && parent()->style().boxOrient() == BoxOrient::Vertical && parent()->style().boxAlign() == BoxAlignment::Stretch)
+    if (parent()->isRenderDeprecatedFlexibleBox() && parent()->style().boxOrient() == BoxOrient::Vertical && parent()->style().boxAlign() == BoxAlignment::Stretch)
         return true;
 
     // We don't stretch multiline flexboxes because they need to apply line spacing (align-content) first.
@@ -3006,7 +3006,7 @@ bool RenderBox::sizesLogicalWidthToFitContent(SizeType widthType) const
     // that don't stretch their kids lay out their children at their intrinsic widths.
     // FIXME: Think about block-flow here.
     // https://bugs.webkit.org/show_bug.cgi?id=46473
-    if (parent()->isDeprecatedFlexibleBox() && (parent()->style().boxOrient() == BoxOrient::Horizontal || parent()->style().boxAlign() != BoxAlignment::Stretch))
+    if (parent()->isRenderDeprecatedFlexibleBox() && (parent()->style().boxOrient() == BoxOrient::Horizontal || parent()->style().boxAlign() != BoxAlignment::Stretch))
         return true;
 
     // Button, input, select, textarea, and legend treat width value of 'auto' as 'intrinsic' unless it's in a
@@ -3175,7 +3175,7 @@ void RenderBox::overrideLogicalHeightForSizeContainment()
     LayoutUnit intrinsicHeight;
     if (auto height = explicitIntrinsicInnerLogicalHeight())
         intrinsicHeight = height.value();
-    else if (isMenuList()) {
+    else if (isRenderMenuList()) {
         // RenderMenuList has its own theme, if there isn't explicitIntrinsicInnerLogicalHeight,
         // as a size containment, it should be treated as if there is no content, and the height
         // should the original logical height for theme.
@@ -3209,7 +3209,7 @@ RenderBox::LogicalExtentComputedValues RenderBox::computeLogicalHeight(LayoutUni
     computedValues.m_position = logicalTop;
 
     // Cell height is managed by the table and inline non-replaced elements do not support a height property.
-    if (isTableCell() || (isInline() && !isReplacedOrInlineBlock()))
+    if (isRenderTableCell() || (isInline() && !isReplacedOrInlineBlock()))
         return computedValues;
 
     Length h;
@@ -3227,7 +3227,7 @@ RenderBox::LogicalExtentComputedValues RenderBox::computeLogicalHeight(LayoutUni
         }
 
         // For tables, calculate margins only.
-        if (isTable()) {
+        if (isRenderTable()) {
             if (shouldComputeLogicalHeightFromAspectRatio())
                 computedValues.m_extent = blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), style().logicalAspectRatio(), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatioType(), isRenderReplaced());
             if (hasPerpendicularContainingBlock) {
@@ -3241,7 +3241,7 @@ RenderBox::LogicalExtentComputedValues RenderBox::computeLogicalHeight(LayoutUni
 
         // FIXME: Account for block-flow in flexible boxes.
         // https://bugs.webkit.org/show_bug.cgi?id=46418
-        bool inHorizontalBox = parent()->isDeprecatedFlexibleBox() && parent()->style().boxOrient() == BoxOrient::Horizontal;
+        bool inHorizontalBox = parent()->isRenderDeprecatedFlexibleBox() && parent()->style().boxOrient() == BoxOrient::Horizontal;
         bool stretching = parent()->style().boxAlign() == BoxAlignment::Stretch;
         bool treatAsReplaced = shouldComputeSizeAsReplaced() && (!inHorizontalBox || !stretching);
         bool checkMinMaxHeight = false;
@@ -3429,7 +3429,7 @@ bool RenderBox::skipContainingBlockForPercentHeightCalculation(const RenderBox& 
     
     // For quirks mode, we skip most auto-height containing blocks when computing
     // percentages.
-    return document().inQuirksMode() && !containingBlock.isTableCell() && !containingBlock.isOutOfFlowPositioned() && !containingBlock.isRenderGrid() && !containingBlock.isFlexibleBoxIncludingDeprecated() && containingBlock.style().logicalHeight().isAuto();
+    return document().inQuirksMode() && !containingBlock.isRenderTableCell() && !containingBlock.isOutOfFlowPositioned() && !containingBlock.isRenderGrid() && !containingBlock.isFlexibleBoxIncludingDeprecated() && containingBlock.style().logicalHeight().isAuto();
 }
 
 bool RenderBox::shouldTreatChildAsReplacedInTableCells() const
@@ -3494,7 +3494,7 @@ std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Length
     if (!availableHeight)
         return availableHeight;
 
-    LayoutUnit result = valueForLength(height, availableHeight.value() - rootMarginBorderPaddingHeight + (isTable() && isOutOfFlowPositioned() ? cb->paddingBefore() + cb->paddingAfter() : 0_lu));
+    LayoutUnit result = valueForLength(height, availableHeight.value() - rootMarginBorderPaddingHeight + (isRenderTable() && isOutOfFlowPositioned() ? cb->paddingBefore() + cb->paddingAfter() : 0_lu));
     
     // |overridingLogicalHeight| is the maximum height made available by the
     // cell to its percent height children when we decide they can determine the
@@ -3502,7 +3502,7 @@ std::optional<LayoutUnit> RenderBox::computePercentageLogicalHeight(const Length
     // then we must subtract the border and padding from the cell's
     // |availableHeight| (given by |overridingLogicalHeight|) to arrive
     // at the child's computed height.
-    bool subtractBorderAndPadding = isTable() || (is<RenderTableCell>(*cb) && !skippedAutoHeightContainingBlock && cb->hasOverridingLogicalHeight() && style().boxSizing() == BoxSizing::ContentBox);
+    bool subtractBorderAndPadding = isRenderTable() || (is<RenderTableCell>(*cb) && !skippedAutoHeightContainingBlock && cb->hasOverridingLogicalHeight() && style().boxSizing() == BoxSizing::ContentBox);
     if (subtractBorderAndPadding) {
         result -= borderAndPaddingLogicalHeight();
         return std::max(0_lu, result);
@@ -3722,7 +3722,7 @@ LayoutUnit RenderBox::computeReplacedLogicalHeightUsing(SizeType heightType, Len
             // https://bugs.webkit.org/show_bug.cgi?id=46997
             while (container && !is<RenderView>(*container)
                 && (container->style().logicalHeight().isAuto() || container->style().logicalHeight().isPercentOrCalculated())) {
-                if (container->isTableCell()) {
+                if (container->isRenderTableCell()) {
                     // Don't let table cells squeeze percent-height replaced elements
                     // <http://bugs.webkit.org/show_bug.cgi?id=15359>
                     availableHeight = std::max(availableHeight, intrinsicLogicalHeight());
@@ -3754,7 +3754,7 @@ LayoutUnit RenderBox::availableLogicalHeightUsing(const Length& h, AvailableLogi
     // We need to stop here, since we don't want to increase the height of the table
     // artificially.  We're going to rely on this cell getting expanded to some new
     // height, and then when we lay out again we'll use the calculation below.
-    if (isTableCell() && (h.isAuto() || h.isPercentOrCalculated())) {
+    if (isRenderTableCell() && (h.isAuto() || h.isPercentOrCalculated())) {
         if (hasOverridingLogicalHeight())
             return overridingLogicalHeight() - computedCSSPaddingBefore() - computedCSSPaddingAfter() - borderBefore() - borderAfter() - scrollbarLogicalHeight();
         return logicalHeight() - borderAndPaddingLogicalHeight();
@@ -3799,9 +3799,9 @@ LayoutUnit RenderBox::availableLogicalHeightUsing(const Length& h, AvailableLogi
 void RenderBox::computeBlockDirectionMargins(const RenderBlock& containingBlock, LayoutUnit& marginBefore, LayoutUnit& marginAfter) const
 {
     // First assert that we're not calling this method on box types that don't support margins.
-    ASSERT(!isTableCell());
-    ASSERT(!isTableRow());
-    ASSERT(!isTableSection());
+    ASSERT(!isRenderTableCell());
+    ASSERT(!isRenderTableRow());
+    ASSERT(!isRenderTableSection());
     ASSERT(!isRenderTableCol());
 
     // Margins are calculated with respect to the logical width of
@@ -3895,7 +3895,7 @@ LayoutUnit RenderBox::containingBlockLogicalHeightForPositioned(const RenderBoxM
             return height.value();
     }
 
-    if (containingBlock.isBox()) {
+    if (containingBlock.isRenderBox()) {
         bool isFixedPosition = isFixedPositioned();
 
         if (isFixedPosition && is<RenderView>(containingBlock))
@@ -4573,7 +4573,7 @@ void RenderBox::computePositionedLogicalHeightUsing(SizeType heightType, Length 
 
     // Height is never unsolved for tables.
     LayoutUnit resolvedLogicalHeight;
-    if (isTable()) {
+    if (isRenderTable()) {
         resolvedLogicalHeight = contentLogicalHeight;
         logicalHeightIsAuto = false;
     } else {
@@ -4995,7 +4995,7 @@ VisiblePosition RenderBox::positionForPoint(const LayoutPoint& point, const Rend
     if (!firstChild())
         return createVisiblePosition(nonPseudoElement() ? firstPositionInOrBeforeNode(nonPseudoElement()) : Position());
 
-    if (isTable() && nonPseudoElement()) {
+    if (isRenderTable() && nonPseudoElement()) {
         LayoutUnit right = contentWidth() + horizontalBorderAndPaddingExtent();
         LayoutUnit bottom = contentHeight() + verticalBorderAndPaddingExtent();
         
@@ -5010,7 +5010,7 @@ VisiblePosition RenderBox::positionForPoint(const LayoutPoint& point, const Rend
     LayoutUnit minDist = LayoutUnit::max();
     RenderBox* closestRenderer = nullptr;
     LayoutPoint adjustedPoint = point;
-    if (isTableRow())
+    if (isRenderTableRow())
         adjustedPoint.moveBy(location());
 
     for (auto& renderer : childrenOfType<RenderBox>(*this)) {

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -894,4 +894,4 @@ LayoutUnit synthesizedBaseline(const RenderBox&, const RenderStyle& parentStyle,
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderBox, isBox())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderBox, isRenderBox())

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -170,13 +170,13 @@ bool RenderBoxModelObject::hasAcceleratedCompositing() const
 RenderBoxModelObject::RenderBoxModelObject(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderLayerModelObject(type, element, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
 {
-    ASSERT(isBoxModelObject());
+    ASSERT(isRenderBoxModelObject());
 }
 
 RenderBoxModelObject::RenderBoxModelObject(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderLayerModelObject(type, document, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
 {
-    ASSERT(isBoxModelObject());
+    ASSERT(isRenderBoxModelObject());
 }
 
 RenderBoxModelObject::~RenderBoxModelObject()
@@ -259,7 +259,7 @@ RenderBlock* RenderBoxModelObject::containingBlockForAutoHeightDetection(Length 
     // ignoring table cell's attribute value, where it says that table cells
     // violate what the CSS spec says to do with heights. Basically we don't care
     // if the cell specified a height or not.
-    if (cb->isTableCell())
+    if (cb->isRenderTableCell())
         return nullptr;
     
     // Match RenderBox::availableLogicalHeightUsing by special casing the layout
@@ -275,11 +275,11 @@ RenderBlock* RenderBoxModelObject::containingBlockForAutoHeightDetection(Length 
     
 bool RenderBoxModelObject::hasAutoHeightOrContainingBlockWithAutoHeight() const
 {
-    const auto* thisBox = isBox() ? downcast<RenderBox>(this) : nullptr;
+    const auto* thisBox = isRenderBox() ? downcast<RenderBox>(this) : nullptr;
     Length logicalHeightLength = style().logicalHeight();
     auto* cb = containingBlockForAutoHeightDetection(logicalHeightLength);
     
-    if (logicalHeightLength.isPercentOrCalculated() && cb && isBox())
+    if (logicalHeightLength.isPercentOrCalculated() && cb && isRenderBox())
         cb->addPercentHeightDescendant(*const_cast<RenderBox*>(downcast<RenderBox>(this)));
 
     if (thisBox && thisBox->isFlexItem() && downcast<RenderFlexibleBox>(*parent()).useChildOverridingLogicalHeightForPercentageResolution(*thisBox))
@@ -551,7 +551,7 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     // have already done a similar call to move from the containing block to the scrolling
     // ancestor above, but localToContainerQuad takes care of a lot of complex situations
     // involving inlines, tables, and transformations.
-    if (parent()->isBox())
+    if (parent()->isRenderBox())
         downcast<RenderBox>(parent())->flipForWritingMode(stickyBoxRect);
     auto stickyBoxRelativeToScrollingAncestor = parent()->localToContainerQuad(FloatRect(stickyBoxRect), &enclosingClippingBox, { } /* ignore transforms */).boundingBox();
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -188,7 +188,7 @@ public:
 
     void setSelectionState(HighlightState) override;
 
-    bool canHaveBoxInfoInFragment() const { return !isFloating() && !isReplacedOrInlineBlock() && !isInline() && !isTableCell() && isRenderBlock() && !isRenderSVGBlock(); }
+    bool canHaveBoxInfoInFragment() const { return !isFloating() && !isReplacedOrInlineBlock() && !isInline() && !isRenderTableCell() && isRenderBlock() && !isRenderSVGBlock(); }
 
     void contentChanged(ContentChangeType);
     bool hasAcceleratedCompositing() const;
@@ -269,4 +269,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderBoxModelObject, isBoxModelObject())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderBoxModelObject, isRenderBoxModelObject())

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -38,7 +38,7 @@ RenderCombineText::RenderCombineText(Text& textNode, const String& string)
     , m_isCombined(false)
     , m_needsFontUpdate(false)
 {
-    ASSERT(isCombineText());
+    ASSERT(isRenderCombineText());
 }
 
 void RenderCombineText::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderCombineText.h
+++ b/Source/WebCore/rendering/RenderCombineText.h
@@ -58,4 +58,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderCombineText, isCombineText())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderCombineText, isRenderCombineText())

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -435,7 +435,7 @@ RenderCounter::RenderCounter(Document& document, const CounterContent& counter)
     : RenderText(Type::Counter, document, emptyString())
     , m_counter(counter)
 {
-    ASSERT(isCounter());
+    ASSERT(isRenderCounter());
     view().addCounterNeedingUpdate(*this);
 }
 

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -60,7 +60,7 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderCounter, isCounter())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderCounter, isRenderCounter())
 
 #if ENABLE(TREE_DEBUGGING)
 // Outside the WebCore namespace for ease of invocation from the debugger.

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -320,7 +320,7 @@ void RenderDeprecatedFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
         updateLogicalHeight();
 
         if (previousSize != size()
-            || (parent()->isDeprecatedFlexibleBox() && parent()->style().boxOrient() == BoxOrient::Horizontal
+            || (parent()->isRenderDeprecatedFlexibleBox() && parent()->style().boxOrient() == BoxOrient::Horizontal
                 && parent()->style().boxAlign() == BoxAlignment::Stretch))
             relayoutChildren = true;
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -52,7 +52,7 @@ public:
     void placeChild(RenderBox* child, const LayoutPoint& location, LayoutSize* childLayoutDelta = nullptr);
 
 private:
-    bool isDeprecatedFlexibleBox() const override { return true; }
+    bool isRenderDeprecatedFlexibleBox() const override { return true; }
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
     void computePreferredLogicalWidths() override;
 
@@ -75,4 +75,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderDeprecatedFlexibleBox, isDeprecatedFlexibleBox())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderDeprecatedFlexibleBox, isRenderDeprecatedFlexibleBox())

--- a/Source/WebCore/rendering/RenderDetailsMarker.cpp
+++ b/Source/WebCore/rendering/RenderDetailsMarker.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderDetailsMarker);
 RenderDetailsMarker::RenderDetailsMarker(DetailsMarkerControl& element, RenderStyle&& style)
     : RenderBlockFlow(Type::DetailsMarker, element, WTFMove(style))
 {
-    ASSERT(isDetailsMarker());
+    ASSERT(isRenderDetailsMarker());
 }
 
 static Path createPath(const FloatPoint* path)

--- a/Source/WebCore/rendering/RenderDetailsMarker.h
+++ b/Source/WebCore/rendering/RenderDetailsMarker.h
@@ -45,4 +45,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderDetailsMarker, isDetailsMarker())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderDetailsMarker, isRenderDetailsMarker())

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -758,7 +758,7 @@ bool RenderElement::layerCreationAllowedForSubtree() const
 
     RenderElement* parentRenderer = parent();
     while (parentRenderer) {
-        if (parentRenderer->isLegacySVGHiddenContainer())
+        if (parentRenderer->isLegacyRenderSVGHiddenContainer())
             return false;
         parentRenderer = parentRenderer->parent();
     }
@@ -2123,7 +2123,7 @@ void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWid
             depthStack.append(newFixedDepth);
 
         int stackSize = depthStack.size();
-        if (is<RenderBlockFlow>(*descendant) && !descendant->isListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
+        if (is<RenderBlockFlow>(*descendant) && !descendant->isRenderListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
             downcast<RenderBlockFlow>(*descendant).adjustComputedFontSizes(size, visibleWidth);
         newFixedDepth = 0;
     }
@@ -2153,7 +2153,7 @@ void RenderElement::resetTextAutosizing()
             depthStack.append(newFixedDepth);
 
         int stackSize = depthStack.size();
-        if (is<RenderBlockFlow>(*descendant) && !descendant->isListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
+        if (is<RenderBlockFlow>(*descendant) && !descendant->isRenderListItem() && (!stackSize || currentDepth - depthStack[stackSize - 1] > TextAutoSizingFixedHeightDepth))
             downcast<RenderBlockFlow>(*descendant).resetComputedFontSize();
         newFixedDepth = 0;
     }
@@ -2207,7 +2207,7 @@ bool RenderElement::createsNewFormattingContext() const
     if (isWritingModeRoot() && isBlockContainer())
         return true;
     return isInlineBlockOrInlineTable() || isFlexItemIncludingDeprecated()
-        || isTableCell() || isTableCaption() || isFieldset() || isDocumentElementRenderer() || isRenderFragmentedFlow() || isSVGForeignObject()
+        || isRenderTableCell() || isRenderTableCaption() || isFieldset() || isDocumentElementRenderer() || isRenderFragmentedFlow() || isRenderSVGForeignObject()
         || style().specifiesColumns() || style().columnSpan() == ColumnSpan::All || style().display() == DisplayType::FlowRoot || establishesIndependentFormattingContext();
 }
 
@@ -2245,7 +2245,7 @@ FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const
         // including a translation to the enclosing transformed ancestor ('offsetFromAncestor').
         // Avoid that, and move by -nominalSVGLayoutLocation().
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-        if (isSVGLayerAwareRenderer() && !isSVGRoot() && document().settings().layerBasedSVGEngineEnabled())
+        if (isSVGLayerAwareRenderer() && !isRenderSVGRoot() && document().settings().layerBasedSVGEngineEnabled())
             referenceBox.moveBy(-downcast<RenderLayerModelObject>(*this).nominalSVGLayoutLocation());
 #endif
         return referenceBox;

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -122,7 +122,7 @@ public:
 
     // FIXME: Make these standalone and move to relevant files.
     bool isRenderLayerModelObject() const;
-    bool isBoxModelObject() const;
+    bool isRenderBoxModelObject() const;
     bool isRenderBlock() const;
     bool isRenderBlockFlow() const;
     bool isRenderReplaced() const;
@@ -284,7 +284,7 @@ public:
 
     bool isWritingModeRoot() const { return !parent() || parent()->style().writingMode() != style().writingMode(); }
 
-    bool isDeprecatedFlexItem() const { return !isInline() && !isFloatingOrOutOfFlowPositioned() && parent() && parent()->isDeprecatedFlexibleBox(); }
+    bool isDeprecatedFlexItem() const { return !isInline() && !isFloatingOrOutOfFlowPositioned() && parent() && parent()->isRenderDeprecatedFlexibleBox(); }
     bool isFlexItemIncludingDeprecated() const { return !isInline() && !isFloatingOrOutOfFlowPositioned() && parent() && parent()->isFlexibleBoxIncludingDeprecated(); }
 
     virtual LayoutRect paintRectToClipOutFromBorder(const LayoutRect&) { return { }; }
@@ -360,7 +360,7 @@ private:
     void node() const = delete;
     void nonPseudoNode() const = delete;
     void generatingNode() const = delete;
-    void isText() const = delete;
+    void isRenderText() const = delete;
     void isRenderElement() const = delete;
 
     RenderObject* firstChildSlow() const final { return firstChild(); }
@@ -451,7 +451,7 @@ inline bool RenderElement::isRenderLayerModelObject() const
     return m_baseTypeFlags & RenderLayerModelObjectFlag;
 }
 
-inline bool RenderElement::isBoxModelObject() const
+inline bool RenderElement::isRenderBoxModelObject() const
 {
     return m_baseTypeFlags & RenderBoxModelObjectFlag;
 }
@@ -501,9 +501,9 @@ inline bool RenderObject::isRenderLayerModelObject() const
     return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderLayerModelObject();
 }
 
-inline bool RenderObject::isBoxModelObject() const
+inline bool RenderObject::isRenderBoxModelObject() const
 {
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isBoxModelObject();
+    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderBoxModelObject();
 }
 
 inline bool RenderObject::isRenderBlock() const
@@ -538,19 +538,19 @@ inline bool RenderObject::isRenderTextControl() const
 
 inline bool RenderObject::isFlexibleBoxIncludingDeprecated() const
 {
-    return isRenderFlexibleBox() || isDeprecatedFlexibleBox();
+    return isRenderFlexibleBox() || isRenderDeprecatedFlexibleBox();
 }
 
 inline const RenderStyle& RenderObject::style() const
 {
-    if (isText())
+    if (isRenderText())
         return m_parent->style();
     return downcast<RenderElement>(*this).style();
 }
 
 inline const RenderStyle& RenderObject::firstLineStyle() const
 {
-    if (isText())
+    if (isRenderText())
         return m_parent->firstLineStyle();
     return downcast<RenderElement>(*this).firstLineStyle();
 }
@@ -587,7 +587,7 @@ inline RenderObject* RenderElement::lastInFlowChild() const
 
 inline bool RenderObject::isSkippedContentRoot() const
 {
-    if (isText())
+    if (isRenderText())
         return false;
     return downcast<RenderElement>(*this).isSkippedContentRoot();
 }

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -49,7 +49,7 @@ inline bool RenderElement::canContainAbsolutelyPositionedObjects() const
         || (canEstablishContainingBlockWithTransform() && hasTransformRelatedProperty())
         || (hasBackdropFilter() && !isDocumentElementRenderer())
         || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForAbsolutelyPositioned(isDocumentElementRenderer()))
-        || isSVGForeignObjectOrLegacySVGForeignObject()
+        || isRenderOrLegacyRenderSVGForeignObject()
         || shouldApplyLayoutOrPaintContainment();
 }
 
@@ -59,7 +59,7 @@ inline bool RenderElement::canContainFixedPositionObjects() const
         || (canEstablishContainingBlockWithTransform() && hasTransformRelatedProperty())
         || (hasBackdropFilter() && !isDocumentElementRenderer())
         || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForOutOfFlowPositioned(isDocumentElementRenderer()))
-        || isSVGForeignObjectOrLegacySVGForeignObject()
+        || isRenderOrLegacyRenderSVGForeignObject()
         || shouldApplyLayoutOrPaintContainment();
 }
 
@@ -85,7 +85,7 @@ inline bool RenderElement::shouldApplyLayoutContainment() const
 
 inline bool RenderElement::shouldApplyLayoutOrPaintContainment(bool containsAccordingToStyle) const
 {
-    return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRubyText() && (!isTablePart() || isRenderBlockFlow());
+    return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRenderRubyText() && (!isTablePart() || isRenderBlockFlow());
 }
 
 inline bool RenderElement::shouldApplyLayoutOrPaintContainment() const
@@ -110,7 +110,7 @@ inline bool RenderElement::shouldApplySizeOrInlineSizeContainment() const
 
 inline bool RenderElement::shouldApplySizeOrStyleContainment(bool containsAccordingToStyle) const
 {
-    return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRubyText() && (!isTablePart() || isTableCaption()) && !isTable();
+    return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRenderRubyText() && (!isTablePart() || isRenderTableCaption()) && !isRenderTable();
 }
 
 inline bool RenderElement::shouldApplyStyleContainment() const

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -86,7 +86,7 @@ RenderEmbeddedObject::RenderEmbeddedObject(HTMLFrameOwnerElement& element, Rende
     , m_unavailablePluginIndicatorIsPressed(false)
     , m_mouseDownWasInUnavailablePluginIndicator(false)
 {
-    ASSERT(isEmbeddedObject());
+    ASSERT(isRenderEmbeddedObject());
 }
 
 RenderEmbeddedObject::~RenderEmbeddedObject()

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -97,4 +97,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderEmbeddedObject, isEmbeddedObject())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderEmbeddedObject, isRenderEmbeddedObject())

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -72,7 +72,7 @@ RenderFileUploadControl::RenderFileUploadControl(HTMLInputElement& input, Render
     : RenderBlockFlow(Type::FileUploadControl, input, WTFMove(style))
     , m_canReceiveDroppedFiles(input.canReceiveDroppedFiles())
 {
-    ASSERT(isFileUploadControl());
+    ASSERT(isRenderFileUploadControl());
 }
 
 RenderFileUploadControl::~RenderFileUploadControl() = default;

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -63,4 +63,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderFileUploadControl, isFileUploadControl())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderFileUploadControl, isRenderFileUploadControl())

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -237,7 +237,7 @@ private:
 
 void RenderFlexibleBox::computeChildIntrinsicLogicalWidths(RenderObject& childObject, LayoutUnit& minPreferredLogicalWidth, LayoutUnit& maxPreferredLogicalWidth) const
 {
-    ASSERT(childObject.isBox());
+    ASSERT(childObject.isRenderBox());
     RenderBox& child = downcast<RenderBox>(childObject);
 
     // If the item cross size should use the definite container cross size then set the overriding size now so
@@ -692,7 +692,7 @@ LayoutUnit RenderFlexibleBox::mainAxisContentExtent(LayoutUnit contentLogicalHei
 // plus this extra check. See wkb.ug/231955.
 static bool isSVGRootWithIntrinsicAspectRatio(const RenderBox& child)
 {
-    if (!child.isSVGRootOrLegacySVGRoot())
+    if (!child.isRenderOrLegacyRenderSVGRoot())
         return false;
     // It's common for some replaced elements, such as SVGs, to have intrinsic aspect ratios but no intrinsic sizes.
     // That's why it isn't enough just to check for intrinsic sizes in those cases.
@@ -1086,7 +1086,7 @@ LayoutUnit RenderFlexibleBox::computeMainSizeFromAspectRatioUsing(const RenderBo
 
     double ratio;
     LayoutUnit borderAndPadding;
-    if (child.isSVGRootOrLegacySVGRoot())
+    if (child.isRenderOrLegacyRenderSVGRoot())
         ratio = downcast<RenderReplaced>(child).computeIntrinsicAspectRatio();
     else {
         auto childIntrinsicSize = child.intrinsicSize();
@@ -1560,7 +1560,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
     if (min.isSpecified() || (min.isIntrinsic() && mainAxisIsChildInlineAxis(child))) {
         auto minExtent = computeMainAxisExtentForChild(child, MinSize, min).value_or(0_lu);
         // We must never return a min size smaller than the min preferred size for tables.
-        if (child.isTable() && mainAxisIsChildInlineAxis(child))
+        if (child.isRenderTable() && mainAxisIsChildInlineAxis(child))
             minExtent = std::max(minExtent, child.minPreferredLogicalWidth());
         return { minExtent, maxExtent.value_or(LayoutUnit::max()) };
     }

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -744,7 +744,7 @@ bool RenderFragmentedFlow::objectShouldFragmentInFlowFragment(const RenderObject
         && !fragmentInRange(fragment, enclosingBoxStartFragment, enclosingBoxEndFragment))
         return false;
     
-    return object->isBox() || object->isRenderInline();
+    return object->isRenderBox() || object->isRenderInline();
 }
 
 bool RenderFragmentedFlow::objectInFlowFragment(const RenderObject* object, const RenderFragmentContainer* fragment) const
@@ -767,7 +767,7 @@ bool RenderFragmentedFlow::objectInFlowFragment(const RenderObject* object, cons
     if (!fragmentInRange(fragment, enclosingBoxStartFragment, enclosingBoxEndFragment))
         return false;
 
-    if (object->isBox())
+    if (object->isRenderBox())
         return true;
 
     LayoutRect objectABBRect = object->absoluteBoundingBoxRect(true);

--- a/Source/WebCore/rendering/RenderFrame.cpp
+++ b/Source/WebCore/rendering/RenderFrame.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFrame);
 RenderFrame::RenderFrame(HTMLFrameElement& frame, RenderStyle&& style)
     : RenderFrameBase(Type::Frame, frame, WTFMove(style))
 {
-    ASSERT(isFrame());
+    ASSERT(isRenderFrame());
 }
 
 HTMLFrameElement& RenderFrame::frameElement() const

--- a/Source/WebCore/rendering/RenderFrame.h
+++ b/Source/WebCore/rendering/RenderFrame.h
@@ -52,4 +52,4 @@ inline RenderFrame* HTMLFrameElement::renderer() const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderFrame, isFrame())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderFrame, isRenderFrame())

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -58,7 +58,7 @@ RenderFrameSet::RenderFrameSet(HTMLFrameSetElement& frameSet, RenderStyle&& styl
     : RenderBox(Type::FrameSet, frameSet, WTFMove(style), 0)
     , m_isResizing(false)
 {
-    ASSERT(isFrameSet());
+    ASSERT(isRenderFrameSet());
     setInline(false);
 }
 
@@ -444,7 +444,7 @@ void RenderFrameSet::layout()
         oldBounds = clippedOverflowRectForRepaint(repaintContainer.get());
     }
 
-    if (!parent()->isFrameSet() && !document().printing()) {
+    if (!parent()->isRenderFrameSet() && !document().printing()) {
         setWidth(view().viewWidth());
         setHeight(view().viewHeight());
     }
@@ -646,7 +646,7 @@ int RenderFrameSet::hitTestSplit(const GridAxis& axis, int position) const
 
 bool RenderFrameSet::isChildAllowed(const RenderObject& child, const RenderStyle&) const
 {
-    return child.isFrame() || child.isFrameSet();
+    return child.isRenderFrame() || child.isRenderFrameSet();
 }
 
 CursorDirective RenderFrameSet::getCursor(const LayoutPoint& point, Cursor& cursor) const

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -118,4 +118,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderFrameSet, isFrameSet())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderFrameSet, isRenderFrameSet())

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -159,7 +159,7 @@ static bool canMapBetweenRenderersViaLayers(const RenderLayerModelObject& render
         if (current->isRenderFragmentedFlow())
             return false;
 
-        if (current->isLegacySVGRoot())
+        if (current->isLegacyRenderSVGRoot())
             return false;
 
         if (current == &ancestor)

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -52,7 +52,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderHTMLCanvas);
 RenderHTMLCanvas::RenderHTMLCanvas(HTMLCanvasElement& element, RenderStyle&& style)
     : RenderReplaced(Type::HTMLCanvas, element, WTFMove(style), element.size())
 {
-    ASSERT(isCanvas());
+    ASSERT(isRenderHTMLCanvas());
 }
 
 HTMLCanvasElement& RenderHTMLCanvas::canvasElement() const

--- a/Source/WebCore/rendering/RenderHTMLCanvas.h
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.h
@@ -50,4 +50,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderHTMLCanvas, isCanvas())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderHTMLCanvas, isRenderHTMLCanvas())

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -447,7 +447,7 @@ public:
     inline bool isTransparent() const; // FIXME: This function is incorrectly named. It's isNotOpaque, sometimes called hasOpacity, not isEntirelyTransparent.
 
     bool hasReflection() const { return renderer().hasReflection(); }
-    bool isReflection() const { return renderer().isReplica(); }
+    bool isReflection() const { return renderer().isRenderReplica(); }
     RenderLayer* reflectionLayer() const;
     bool isReflectionLayer(const RenderLayer&) const;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -110,7 +110,7 @@ using namespace HTMLNames;
 
 CanvasCompositingStrategy canvasCompositingStrategy(const RenderObject& renderer)
 {
-    ASSERT(renderer.isCanvas());
+    ASSERT(renderer.isRenderHTMLCanvas());
     
     const HTMLCanvasElement* canvas = downcast<HTMLCanvasElement>(renderer.node());
     auto* context = canvas->renderingContext();
@@ -543,7 +543,7 @@ void RenderLayerBacking::createPrimaryGraphicsLayer()
 #endif
 
 #if PLATFORM(COCOA) && USE(CA)
-    if (!compositor().acceleratedDrawingEnabled() && renderer().isCanvas()) {
+    if (!compositor().acceleratedDrawingEnabled() && renderer().isRenderHTMLCanvas()) {
         const HTMLCanvasElement* canvas = downcast<HTMLCanvasElement>(renderer().element());
         if (canvas->shouldAccelerate(canvas->size()))
             m_graphicsLayer->setAcceleratesDrawing(true);
@@ -568,7 +568,7 @@ void RenderLayerBacking::createPrimaryGraphicsLayer()
 
 bool RenderLayerBacking::shouldSetContentsDisplayDelegate() const
 {
-    if (!renderer().isCanvas())
+    if (!renderer().isRenderHTMLCanvas())
         return false;
 
     if (canvasCompositingStrategy(renderer()) != CanvasAsLayerContents)
@@ -818,7 +818,7 @@ void RenderLayerBacking::updateBlendMode(const RenderStyle& style)
 #if ENABLE(VIDEO)
 void RenderLayerBacking::updateVideoGravity(const RenderStyle& style)
 {
-    if (!renderer().isVideo())
+    if (!renderer().isRenderVideo())
         return;
 
     MediaPlayerVideoGravity videoGravity;
@@ -843,7 +843,7 @@ void RenderLayerBacking::updateVideoGravity(const RenderStyle& style)
 
 void RenderLayerBacking::updateContentsScalingFilters(const RenderStyle& style)
 {
-    if (!renderer().isCanvas() || canvasCompositingStrategy(renderer()) != CanvasAsLayerContents)
+    if (!renderer().isRenderHTMLCanvas() || canvasCompositingStrategy(renderer()) != CanvasAsLayerContents)
         return;
     auto minificationFilter = GraphicsLayer::ScalingFilter::Linear;
     auto magnificationFilter = GraphicsLayer::ScalingFilter::Linear;
@@ -3201,7 +3201,7 @@ void RenderLayerBacking::contentChanged(ContentChangeType changeType)
         m_owningLayer.setNeedsCompositingConfigurationUpdate();
 
 #if ENABLE(WEBGL) || ENABLE(OFFSCREEN_CANVAS)
-    if ((changeType == CanvasChanged || changeType == CanvasPixelsChanged) && renderer().isCanvas() && canvasCompositingStrategy(renderer()) == CanvasAsLayerContents) {
+    if ((changeType == CanvasChanged || changeType == CanvasPixelsChanged) && renderer().isRenderHTMLCanvas() && canvasCompositingStrategy(renderer()) == CanvasAsLayerContents) {
         if (changeType == CanvasChanged)
             compositor().scheduleCompositingLayerUpdate();
 
@@ -3958,7 +3958,7 @@ void RenderLayerBacking::verifyNotPainting()
 
 bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& animation, const KeyframeList& keyframes)
 {
-    bool shouldApplyAnimationsToTargetRenderer = renderer().isBox() || renderer().isSVGLayerAwareRenderer();
+    bool shouldApplyAnimationsToTargetRenderer = renderer().isRenderBox() || renderer().isSVGLayerAwareRenderer();
 
     bool hasOpacity = keyframes.containsProperty(CSSPropertyOpacity);
     bool hasRotate = shouldApplyAnimationsToTargetRenderer && keyframes.containsProperty(CSSPropertyRotate);

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1092,7 +1092,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
     // RenderLayer children and whose children can't use its backing to render
     // into. These children (the controls) always need to be promoted into their
     // own layers to draw on top of the accelerated video.
-    if (compositingState.compositingAncestor && compositingState.compositingAncestor->renderer().isVideo())
+    if (compositingState.compositingAncestor && compositingState.compositingAncestor->renderer().isRenderVideo())
         compositingReason = IndirectCompositingReason::Overlap;
 #endif
 
@@ -3423,7 +3423,7 @@ bool RenderLayerCompositor::requiresCompositingForCanvas(RenderLayerModelObject&
     if (!(m_compositingTriggers & ChromeClient::CanvasTrigger))
         return false;
 
-    if (!renderer.isCanvas())
+    if (!renderer.isRenderHTMLCanvas())
         return false;
 
     bool isCanvasLargeEnoughToForceCompositing = true;

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -42,7 +42,7 @@ inline bool RenderLayer::hasBlendMode() const { return renderer().hasBlendMode()
 inline bool RenderLayer::canUseOffsetFromAncestor() const
 {
     // FIXME: This really needs to know if there are transforms on this layer and any of the layers between it and the ancestor in question.
-    return !isTransformed() && !renderer().isSVGRootOrLegacySVGRoot();
+    return !isTransformed() && !renderer().isRenderOrLegacyRenderSVGRoot();
 }
 
 inline bool RenderLayer::paintsWithTransparency(OptionSet<PaintBehavior> paintBehavior) const

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -536,7 +536,7 @@ void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()
 bool rendererNeedsPixelSnapping(const RenderLayerModelObject& renderer)
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (renderer.document().settings().layerBasedSVGEngineEnabled() && renderer.isSVGLayerAwareRenderer() && !renderer.isSVGRoot())
+    if (renderer.document().settings().layerBasedSVGEngineEnabled() && renderer.isSVGLayerAwareRenderer() && !renderer.isRenderSVGRoot())
         return false;
 #else
     UNUSED_PARAM(renderer);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -481,7 +481,7 @@ void RenderLayerScrollableArea::updateMarqueePosition()
 void RenderLayerScrollableArea::createOrDestroyMarquee()
 {
     auto& renderer = m_layer.renderer();
-    if (renderer.isHTMLMarquee() && renderer.style().marqueeBehavior() != MarqueeBehavior::None && renderer.isBox()) {
+    if (renderer.isHTMLMarquee() && renderer.style().marqueeBehavior() != MarqueeBehavior::None && renderer.isRenderBox()) {
         if (!m_marquee)
             m_marquee = makeUnique<RenderMarquee>(&m_layer);
         m_marquee->updateMarqueeStyle();
@@ -588,7 +588,7 @@ IntRect RenderLayerScrollableArea::scrollCornerRect() const
 
 bool RenderLayerScrollableArea::isScrollCornerVisible() const
 {
-    ASSERT(m_layer.renderer().isBox());
+    ASSERT(m_layer.renderer().isRenderBox());
     return !scrollCornerRect().isEmpty();
 }
 
@@ -1307,7 +1307,7 @@ void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
 
         // FIXME: This does not belong here.
         auto* parent = renderer.parent();
-        if (is<RenderFlexibleBox>(parent) && renderer.isBox())
+        if (is<RenderFlexibleBox>(parent) && renderer.isRenderBox())
             downcast<RenderFlexibleBox>(parent)->clearCachedMainSizeForChild(*m_layer.renderBox());
     }
 

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -55,7 +55,7 @@ RenderLineBreak::RenderLineBreak(HTMLElement& element, RenderStyle&& style)
     , m_cachedLineHeight(invalidLineHeight)
     , m_isWBR(is<HTMLWBRElement>(element))
 {
-    ASSERT(isLineBreak());
+    ASSERT(isRenderLineBreak());
 }
 
 RenderLineBreak::~RenderLineBreak()
@@ -219,7 +219,7 @@ void RenderLineBreak::collectSelectionGeometries(Vector<SelectionGeometry>& rect
         extentsRect = extentsRect.transposedRect();
     bool isFirstOnLine = !run->previousOnLine();
     bool isLastOnLine = !run->nextOnLine();
-    if (containingBlock->isRubyBase() || containingBlock->isRubyText())
+    if (containingBlock->isRenderRubyBase() || containingBlock->isRenderRubyText())
         isLastOnLine = !containingBlock->containingBlock()->inlineBoxWrapper()->nextOnLineExists();
 
     bool isFixed = false;
@@ -235,7 +235,7 @@ void RenderLineBreak::collectSelectionGeometries(Vector<SelectionGeometry>& rect
         }
     }
 
-    rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(element()), run->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, run->isLineBreak(), isFirstOnLine, isLastOnLine, false, false, boxIsHorizontal, isFixed, containingBlock->isRubyText(), view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
+    rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(element()), run->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, run->isLineBreak(), isFirstOnLine, isLastOnLine, false, false, boxIsHorizontal, isFixed, containingBlock->isRenderRubyText(), view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderLineBreak.h
+++ b/Source/WebCore/rendering/RenderLineBreak.h
@@ -93,4 +93,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderLineBreak, isLineBreak())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderLineBreak, isRenderLineBreak())

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -222,6 +222,6 @@ private:
 } // namepace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RenderListBox)
-    static bool isType(const WebCore::RenderObject& widget) { return widget.isListBox(); }
+    static bool isType(const WebCore::RenderObject& renderer) { return renderer.isRenderListBox(); }
     static bool isType(const WebCore::ScrollableArea& area) { return area.isListBox(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -52,7 +52,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderListItem);
 RenderListItem::RenderListItem(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::ListItem, element, WTFMove(style))
 {
-    ASSERT(isListItem());
+    ASSERT(isRenderListItem());
     setInline(false);
 }
 

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -91,4 +91,4 @@ inline int RenderListItem::value() const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderListItem, isListItem())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderListItem, isRenderListItem())

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -55,7 +55,7 @@ RenderListMarker::RenderListMarker(RenderListItem& listItem, RenderStyle&& style
 {
     setInline(true);
     setReplacedOrInlineBlock(true); // pretend to be replaced
-    ASSERT(isListMarker());
+    ASSERT(isRenderListMarker());
 }
 
 RenderListMarker::~RenderListMarker()
@@ -260,7 +260,7 @@ RenderBox* RenderListMarker::parentBox(RenderBox& box)
 void RenderListMarker::addOverflowFromListMarker()
 {
     ASSERT(m_listItem);
-    if (!parent() || !parent()->isBox())
+    if (!parent() || !parent()->isRenderBox())
         return;
 
     if (isInside() || !inlineBoxWrapper())

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -91,4 +91,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderListMarker, isListMarker())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderListMarker, isRenderListMarker())

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -55,7 +55,7 @@ private:
     bool canHaveChildren() const final { return true; }
 
     ASCIILiteral renderName() const override { return "RenderMedia"_s; }
-    bool isMedia() const final { return true; }
+    bool isRenderMedia() const final { return true; }
     bool isImage() const final { return false; }
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
 };
@@ -67,6 +67,6 @@ inline RenderMedia* HTMLMediaElement::renderer() const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderMedia, isMedia())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderMedia, isRenderMedia())
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -89,7 +89,7 @@ RenderMenuList::RenderMenuList(HTMLSelectElement& element, RenderStyle&& style)
     , m_popupIsVisible(false)
 #endif
 {
-    ASSERT(isMenuList());
+    ASSERT(isRenderMenuList());
 }
 
 RenderMenuList::~RenderMenuList()

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -159,4 +159,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderMenuList, isMenuList())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderMenuList, isRenderMenuList())

--- a/Source/WebCore/rendering/RenderMeter.cpp
+++ b/Source/WebCore/rendering/RenderMeter.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMeter);
 RenderMeter::RenderMeter(HTMLElement& element, RenderStyle&& style)
     : RenderBlockFlow(Type::Meter, element, WTFMove(style))
 {
-    ASSERT(isMeter());
+    ASSERT(isRenderMeter());
 }
 
 RenderMeter::~RenderMeter() = default;

--- a/Source/WebCore/rendering/RenderMeter.h
+++ b/Source/WebCore/rendering/RenderMeter.h
@@ -44,4 +44,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderMeter, isMeter())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderMeter, isRenderMeter())

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -517,7 +517,7 @@ static inline bool objectIsRelayoutBoundary(const RenderElement* object)
     if (object->shouldApplyLayoutContainment() && object->shouldApplySizeContainment())
         return true;
 
-    if (object->isSVGRootOrLegacySVGRoot())
+    if (object->isRenderOrLegacyRenderSVGRoot())
         return true;
 
     if (!object->hasNonVisibleOverflow())
@@ -633,7 +633,7 @@ void RenderObject::setPreferredLogicalWidthsDirty(bool shouldBeDirty, MarkingBeh
 {
     bool alreadyDirty = preferredLogicalWidthsDirty();
     m_bitfields.setPreferredLogicalWidthsDirty(shouldBeDirty);
-    if (shouldBeDirty && !alreadyDirty && markParents == MarkContainingBlockChain && (isText() || !style().hasOutOfFlowPosition()))
+    if (shouldBeDirty && !alreadyDirty && markParents == MarkContainingBlockChain && (isRenderText() || !style().hasOutOfFlowPosition()))
         invalidateContainerPreferredLogicalWidths();
 }
 
@@ -641,11 +641,11 @@ void RenderObject::invalidateContainerPreferredLogicalWidths()
 {
     // In order to avoid pathological behavior when inlines are deeply nested, we do include them
     // in the chain that we mark dirty (even though they're kind of irrelevant).
-    CheckedPtr o = isTableCell() ? containingBlock() : container();
+    CheckedPtr o = isRenderTableCell() ? containingBlock() : container();
     while (o && !o->preferredLogicalWidthsDirty()) {
         // Don't invalidate the outermost object of an unrooted subtree. That object will be 
         // invalidated when the subtree is added to the document.
-        CheckedPtr container = o->isTableCell() ? o->containingBlock() : o->container();
+        CheckedPtr container = o->isRenderTableCell() ? o->containingBlock() : o->container();
         if (!container && !o->isRenderView())
             break;
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -315,9 +315,9 @@ public:
 
     bool isPseudoElement() const { return node() && node()->isPseudoElement(); }
 
-    bool isRenderElement() const { return !isText(); }
+    bool isRenderElement() const { return !isRenderText(); }
     bool isRenderReplaced() const;
-    bool isBoxModelObject() const;
+    bool isRenderBoxModelObject() const;
     bool isRenderBlock() const;
     bool isRenderBlockFlow() const;
     bool isRenderInline() const;
@@ -325,56 +325,56 @@ public:
 
     inline bool isAtomicInlineLevelBox() const;
 
-    bool isCounter() const { return type() == Type::Counter; }
-    bool isQuote() const { return type() == Type::Quote; }
+    bool isRenderCounter() const { return type() == Type::Counter; }
+    bool isRenderQuote() const { return type() == Type::Quote; }
 
-    bool isDetailsMarker() const { return type() == Type::DetailsMarker; }
-    bool isEmbeddedObject() const { return type() == Type::EmbeddedObject; }
+    bool isRenderDetailsMarker() const { return type() == Type::DetailsMarker; }
+    bool isRenderEmbeddedObject() const { return type() == Type::EmbeddedObject; }
     bool isFieldset() const;
-    bool isFileUploadControl() const { return type() == Type::FileUploadControl; }
-    bool isFrame() const { return type() == Type::Frame; }
-    bool isFrameSet() const { return type() == Type::FrameSet; }
+    bool isRenderFileUploadControl() const { return type() == Type::FileUploadControl; }
+    bool isRenderFrame() const { return type() == Type::Frame; }
+    bool isRenderFrameSet() const { return type() == Type::FrameSet; }
     virtual bool isImage() const { return false; }
     virtual bool isInlineBlockOrInlineTable() const { return false; }
-    bool isListBox() const { return type() == Type::ListBox; }
-    bool isListItem() const { return type() == Type::ListItem; }
-    bool isListMarker() const { return type() == Type::ListMarker; }
-    virtual bool isMedia() const { return false; }
-    bool isMenuList() const { return type() == Type::MenuList; }
-    bool isMeter() const { return type() == Type::Meter; }
-    bool isProgress() const { return type() == Type::Progress; }
+    bool isRenderListBox() const { return type() == Type::ListBox; }
+    bool isRenderListItem() const { return type() == Type::ListItem; }
+    bool isRenderListMarker() const { return type() == Type::ListMarker; }
+    virtual bool isRenderMedia() const { return false; }
+    bool isRenderMenuList() const { return type() == Type::MenuList; }
+    bool isRenderMeter() const { return type() == Type::Meter; }
+    bool isRenderProgress() const { return type() == Type::Progress; }
     bool isRenderButton() const { return type() == Type::Button; }
     bool isRenderIFrame() const { return type() == Type::IFrame; }
     virtual bool isRenderImage() const { return false; }
-    bool isTextFragment() const { return type() == Type::TextFragment; }
+    bool isRenderTextFragment() const { return type() == Type::TextFragment; }
 #if ENABLE(MODEL_ELEMENT)
     bool isRenderModel() const { return type() == Type::Model; }
 #endif
     virtual bool isRenderFragmentContainer() const { return false; }
-    bool isReplica() const { return type() == Type::Replica; }
+    bool isRenderReplica() const { return type() == Type::Replica; }
 
-    bool isRubyInline() const { return type() == Type::RubyAsInline; }
-    bool isRubyBlock() const { return type() == Type::RubyAsBlock; }
-    bool isRubyBase() const { return type() == Type::RubyBase; }
-    bool isRubyRun() const { return type() == Type::RubyRun; }
-    bool isRubyText() const { return type() == Type::RubyText; }
+    bool isRenderRubyAsInline() const { return type() == Type::RubyAsInline; }
+    bool isRenderRubyAsBlock() const { return type() == Type::RubyAsBlock; }
+    bool isRenderRubyBase() const { return type() == Type::RubyBase; }
+    bool isRenderRubyRun() const { return type() == Type::RubyRun; }
+    bool isRenderRubyText() const { return type() == Type::RubyText; }
 
-    bool isSlider() const { return type() == Type::Slider; }
-    bool isTable() const;
-    bool isTableCell() const { return type() == Type::TableCell; }
+    bool isRenderSlider() const { return type() == Type::Slider; }
+    bool isRenderTable() const;
+    bool isRenderTableCell() const { return type() == Type::TableCell; }
     bool isRenderTableCol() const { return type() == Type::TableCol; }
-    bool isTableCaption() const { return type() == Type::TableCaption; }
-    bool isTableSection() const { return type() == Type::TableSection; }
+    bool isRenderTableCaption() const { return type() == Type::TableCaption; }
+    bool isRenderTableSection() const { return type() == Type::TableSection; }
     inline bool isRenderTextControl() const; // Defined in RenderElement.h.
-    bool isTextArea() const { return type() == Type::TextControlMultiLine; }
-    virtual bool isTextField() const { return false; }
-    bool isSearchField() const { return type() == Type::SearchField; }
-    bool isTextControlInnerBlock() const { return type() == Type::TextControlInnerBlock; }
-    bool isVideo() const { return type() == Type::Video; }
-    virtual bool isWidget() const { return false; }
-    bool isCanvas() const { return type() == Type::HTMLCanvas; }
+    bool isRenderTextControlMultiLine() const { return type() == Type::TextControlMultiLine; }
+    virtual bool isRenderTextControlSingleLine() const { return false; }
+    bool isRenderSearchField() const { return type() == Type::SearchField; }
+    bool isRenderTextControlInnerBlock() const { return type() == Type::TextControlInnerBlock; }
+    bool isRenderVideo() const { return type() == Type::Video; }
+    virtual bool isRenderWidget() const { return false; }
+    bool isRenderHTMLCanvas() const { return type() == Type::HTMLCanvas; }
 #if ENABLE(ATTACHMENT_ELEMENT)
-    bool isAttachment() const { return type() == Type::Attachment; }
+    bool isRenderAttachment() const { return type() == Type::Attachment; }
 #endif
     bool isRenderGrid() const { return type() == Type::Grid; }
 
@@ -393,7 +393,7 @@ public:
 
     bool isHTMLMarquee() const;
 
-    bool isTablePart() const { return isTableCell() || isRenderTableCol() || isTableCaption() || isTableRow() || isTableSection(); }
+    bool isTablePart() const { return isRenderTableCell() || isRenderTableCol() || isRenderTableCaption() || isRenderTableRow() || isRenderTableSection(); }
 
     inline bool isBeforeContent() const;
     inline bool isAfterContent() const;
@@ -442,43 +442,43 @@ public:
     virtual bool isLegacyRenderSVGModelObject() const { return false; }
     virtual bool isRenderSVGModelObject() const { return false; }
     virtual bool isRenderSVGBlock() const { return false; }
-    bool isLegacySVGRoot() const { return type() == Type::LegacySVGRoot; }
-    bool isSVGRoot() const { return type() == Type::SVGRoot; }
-    virtual bool isSVGContainer() const { return false; }
-    virtual bool isLegacySVGContainer() const { return false; }
-    bool isSVGTransformableContainer() const { return type() == Type::SVGTransformableContainer; }
-    bool isLegacySVGTransformableContainer() const { return type() == Type::LegacySVGTransformableContainer; }
-    bool isSVGViewportContainer() const { return type() == Type::SVGViewportContainer; }
-    bool isLegacySVGViewportContainer() const { return type() == Type::LegacySVGViewportContainer; }
-    bool isSVGGradientStop() const { return type() == Type::SVGGradientStop; }
-    virtual bool isLegacySVGHiddenContainer() const { return false; }
-    bool isSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer || isSVGResourceContainer(); }
-    bool isLegacySVGPath() const { return type() == Type::LegacySVGPath; }
-    bool isSVGPath() const { return type() == Type::SVGPath; }
-    virtual bool isSVGShape() const { return false; }
-    virtual bool isLegacySVGShape() const { return false; }
-    bool isSVGText() const { return type() == Type::SVGText; }
-    bool isSVGTextPath() const { return type() == Type::SVGTextPath; }
-    bool isSVGTSpan() const { return type() == Type::SVGTSpan; }
-    bool isSVGInline() const { return type() == Type::SVGInline || type() == Type::SVGTSpan || type() == Type::SVGTextPath; }
-    bool isSVGInlineText() const { return type() == Type::SVGInlineText; }
-    bool isLegacySVGImage() const { return type() == Type::LegacySVGImage; }
-    bool isSVGImage() const { return type() == Type::SVGImage; }
-    bool isLegacySVGForeignObject() const { return type() == Type::LegacySVGForeignObject; }
-    bool isSVGForeignObject() const { return type() == Type::SVGForeignObject; }
-    virtual bool isLegacySVGResourceContainer() const { return false; }
-    bool isSVGResourceContainer() const { return type() == Type::SVGResourceClipper; }
-    bool isSVGResourceFilter() const { return type() == Type::SVGResourceFilter; }
-    bool isLegacySVGResourceClipper() const { return type() == Type::LegacySVGResourceClipper; }
-    bool isSVGResourceClipper() const { return type() == Type::SVGResourceClipper; }
-    bool isSVGResourceFilterPrimitive() const { return type() == Type::SVGResourceFilterPrimitive; }
-    bool isSVGRootOrLegacySVGRoot() const { return isSVGRoot() || isLegacySVGRoot(); }
-    bool isSVGShapeOrLegacySVGShape() const { return isSVGShape() || isLegacySVGShape(); }
-    bool isSVGPathOrLegacySVGPath() const { return isSVGPath() || isLegacySVGPath(); }
-    bool isSVGImageOrLegacySVGImage() const { return isSVGImage() || isLegacySVGImage(); }
-    bool isSVGForeignObjectOrLegacySVGForeignObject() const { return isSVGForeignObject() || isLegacySVGForeignObject(); }
+    bool isLegacyRenderSVGRoot() const { return type() == Type::LegacySVGRoot; }
+    bool isRenderSVGRoot() const { return type() == Type::SVGRoot; }
+    virtual bool isRenderSVGContainer() const { return false; }
+    virtual bool isLegacyRenderSVGContainer() const { return false; }
+    bool isRenderSVGTransformableContainer() const { return type() == Type::SVGTransformableContainer; }
+    bool isLegacyRenderSVGTransformableContainer() const { return type() == Type::LegacySVGTransformableContainer; }
+    bool isRenderSVGViewportContainer() const { return type() == Type::SVGViewportContainer; }
+    bool isLegacyRenderSVGViewportContainer() const { return type() == Type::LegacySVGViewportContainer; }
+    bool isRenderSVGGradientStop() const { return type() == Type::SVGGradientStop; }
+    virtual bool isLegacyRenderSVGHiddenContainer() const { return false; }
+    bool isRenderSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer || isRenderSVGResourceContainer(); }
+    bool isLegacyRenderSVGPath() const { return type() == Type::LegacySVGPath; }
+    bool isRenderSVGPath() const { return type() == Type::SVGPath; }
+    virtual bool isRenderSVGShape() const { return false; }
+    virtual bool isLegacyRenderSVGShape() const { return false; }
+    bool isRenderSVGText() const { return type() == Type::SVGText; }
+    bool isRenderSVGTextPath() const { return type() == Type::SVGTextPath; }
+    bool isRenderSVGTSpan() const { return type() == Type::SVGTSpan; }
+    bool isRenderSVGInline() const { return type() == Type::SVGInline || type() == Type::SVGTSpan || type() == Type::SVGTextPath; }
+    bool isRenderSVGInlineText() const { return type() == Type::SVGInlineText; }
+    bool isLegacyRenderSVGImage() const { return type() == Type::LegacySVGImage; }
+    bool isRenderSVGImage() const { return type() == Type::SVGImage; }
+    bool isLegacyRenderSVGForeignObject() const { return type() == Type::LegacySVGForeignObject; }
+    bool isRenderSVGForeignObject() const { return type() == Type::SVGForeignObject; }
+    virtual bool isLegacyRenderSVGResourceContainer() const { return false; }
+    bool isRenderSVGResourceContainer() const { return type() == Type::SVGResourceClipper; }
+    bool isRenderSVGResourceFilter() const { return type() == Type::SVGResourceFilter; }
+    bool isLegacyRenderSVGResourceClipper() const { return type() == Type::LegacySVGResourceClipper; }
+    bool isRenderSVGResourceClipper() const { return type() == Type::SVGResourceClipper; }
+    bool isRenderSVGResourceFilterPrimitive() const { return type() == Type::SVGResourceFilterPrimitive; }
+    bool isRenderOrLegacyRenderSVGRoot() const { return isRenderSVGRoot() || isLegacyRenderSVGRoot(); }
+    bool isRenderOrLegacyRenderSVGShape() const { return isRenderSVGShape() || isLegacyRenderSVGShape(); }
+    bool isRenderOrLegacyRenderSVGPath() const { return isRenderSVGPath() || isLegacyRenderSVGPath(); }
+    bool isRenderOrLegacyRenderSVGImage() const { return isRenderSVGImage() || isLegacyRenderSVGImage(); }
+    bool isRenderOrLegacyRenderSVGForeignObject() const { return isRenderSVGForeignObject() || isLegacyRenderSVGForeignObject(); }
     bool isRenderOrLegacyRenderSVGModelObject() const { return isRenderSVGModelObject() || isLegacyRenderSVGModelObject(); }
-    bool isSVGLayerAwareRenderer() const { return isSVGRoot() || isRenderSVGModelObject() || isSVGText() || isSVGInline() || isSVGForeignObject(); }
+    bool isSVGLayerAwareRenderer() const { return isRenderSVGRoot() || isRenderSVGModelObject() || isRenderSVGText() || isRenderSVGInline() || isRenderSVGForeignObject(); }
 
     // FIXME: Those belong into a SVG specific base-class for all renderers (see above)
     // Unfortunately we don't have such a class yet, because it's not possible for all renderers
@@ -527,7 +527,7 @@ public:
     // rest of the rendering tree will move to a similar model.
     virtual bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction);
 
-    virtual bool hasIntrinsicAspectRatio() const { return isReplacedOrInlineBlock() && (isImage() || isVideo() || isCanvas()); }
+    virtual bool hasIntrinsicAspectRatio() const { return isReplacedOrInlineBlock() && (isImage() || isRenderVideo() || isRenderHTMLCanvas()); }
     bool isAnonymous() const { return m_bitfields.isAnonymous(); }
     bool isAnonymousBlock() const;
     bool isBlockContainer() const;
@@ -541,15 +541,15 @@ public:
     bool isAbsolutelyPositioned() const { return isOutOfFlowPositioned() && style().position() == PositionType::Absolute; }
     bool isRelativelyPositioned() const { return m_bitfields.isRelativelyPositioned(); }
     bool isStickilyPositioned() const { return m_bitfields.isStickilyPositioned(); }
-    bool shouldUsePositionedClipping() const { return isAbsolutelyPositioned() || isSVGForeignObject(); }
+    bool shouldUsePositionedClipping() const { return isAbsolutelyPositioned() || isRenderSVGForeignObject(); }
 
-    bool isText() const { return m_bitfields.isText(); }
-    bool isLineBreak() const { return type() == Type::LineBreak; }
-    bool isBR() const { return isLineBreak() && !isWBR(); }
-    bool isLineBreakOpportunity() const { return isLineBreak() && isWBR(); }
-    bool isTextOrLineBreak() const { return isText() || isLineBreak(); }
-    bool isBox() const { return m_bitfields.isBox(); }
-    bool isTableRow() const { return type() == Type::TableRow; }
+    bool isRenderText() const { return m_bitfields.isRenderText(); }
+    bool isRenderLineBreak() const { return type() == Type::LineBreak; }
+    bool isBR() const { return isRenderLineBreak() && !isWBR(); }
+    bool isLineBreakOpportunity() const { return isRenderLineBreak() && isWBR(); }
+    bool isRenderTextOrLineBreak() const { return isRenderText() || isRenderLineBreak(); }
+    bool isRenderBox() const { return m_bitfields.isRenderBox(); }
+    bool isRenderTableRow() const { return type() == Type::TableRow; }
     bool isRenderView() const  { return type() == Type::View; }
     bool isInline() const { return m_bitfields.isInline(); } // inline object
     bool isReplacedOrInlineBlock() const { return m_bitfields.isReplacedOrInlineBlock(); }
@@ -662,8 +662,8 @@ public:
     void invalidateBackgroundObscurationStatus();
     virtual bool computeBackgroundIsKnownToBeObscured(const LayoutPoint&) { return false; }
 
-    void setIsText() { ASSERT(!isBox()); m_bitfields.setIsText(true); }
-    void setIsBox() { m_bitfields.setIsBox(true); }
+    void setIsRenderText() { ASSERT(!isRenderBox()); m_bitfields.setIsRenderText(true); }
+    void setIsRenderBox() { m_bitfields.setIsRenderBox(true); }
     void setReplacedOrInlineBlock(bool b = true) { m_bitfields.setIsReplacedOrInlineBlock(b); }
     void setHorizontalWritingMode(bool b = true) { m_bitfields.setHorizontalWritingMode(b); }
     void setHasNonVisibleOverflow(bool b = true) { m_bitfields.setHasNonVisibleOverflow(b); }
@@ -881,12 +881,12 @@ public:
     void destroy();
 
     // Virtual function helpers for the deprecated Flexible Box Layout (display: -webkit-box).
-    virtual bool isDeprecatedFlexibleBox() const { return false; }
+    virtual bool isRenderDeprecatedFlexibleBox() const { return false; }
     // Virtual function helper for the new FlexibleBox Layout (display: -webkit-flex).
     inline bool isRenderFlexibleBox() const; // Defined in RenderElement.h.
     inline bool isFlexibleBoxIncludingDeprecated() const; // Defined in RenderElement.h.
 
-    bool isCombineText() const { return type() == Type::CombineText; }
+    bool isRenderCombineText() const { return type() == Type::CombineText; }
 
     virtual int caretMinOffset() const;
     virtual int caretMaxOffset() const;
@@ -1035,8 +1035,8 @@ private:
             , m_preferredLogicalWidthsDirty(false)
             , m_floating(false)
             , m_isAnonymous(node.isDocumentNode())
-            , m_isText(false)
-            , m_isBox(false)
+            , m_isRenderText(false)
+            , m_isRenderBox(false)
             , m_isInline(true)
             , m_isReplacedOrInlineBlock(false)
             , m_horizontalWritingMode(true)
@@ -1065,8 +1065,8 @@ private:
         ADD_BOOLEAN_BITFIELD(floating, Floating);
 
         ADD_BOOLEAN_BITFIELD(isAnonymous, IsAnonymous);
-        ADD_BOOLEAN_BITFIELD(isText, IsText);
-        ADD_BOOLEAN_BITFIELD(isBox, IsBox);
+        ADD_BOOLEAN_BITFIELD(isRenderText, IsRenderText);
+        ADD_BOOLEAN_BITFIELD(isRenderBox, IsRenderBox);
         ADD_BOOLEAN_BITFIELD(isInline, IsInline);
         ADD_BOOLEAN_BITFIELD(isReplacedOrInlineBlock, IsReplacedOrInlineBlock);
         ADD_BOOLEAN_BITFIELD(horizontalWritingMode, HorizontalWritingMode);
@@ -1191,7 +1191,7 @@ inline bool RenderObject::renderTreeBeingDestroyed() const
 inline bool RenderObject::isBeforeContent() const
 {
     // Text nodes don't have their own styles, so ignore the style on a text node.
-    if (isText())
+    if (isRenderText())
         return false;
     if (style().styleType() != PseudoId::Before)
         return false;
@@ -1201,7 +1201,7 @@ inline bool RenderObject::isBeforeContent() const
 inline bool RenderObject::isAfterContent() const
 {
     // Text nodes don't have their own styles, so ignore the style on a text node.
-    if (isText())
+    if (isRenderText())
         return false;
     if (style().styleType() != PseudoId::After)
         return false;
@@ -1286,7 +1286,7 @@ inline bool RenderObject::isAnonymousBlock() const
 #if ENABLE(MATHML)
         && !isRenderMathMLBlock()
 #endif
-        && !isListMarker()
+        && !isRenderListMarker()
         && !isRenderFragmentedFlow()
         && !isRenderMultiColumnSet()
         && !isRenderView();
@@ -1318,7 +1318,7 @@ inline void RenderObject::setNeedsLayoutAndPrefWidthsRecalc()
 
 inline void RenderObject::setPositionState(PositionType position)
 {
-    ASSERT((position != PositionType::Absolute && position != PositionType::Fixed) || isBox());
+    ASSERT((position != PositionType::Absolute && position != PositionType::Fixed) || isRenderBox());
     m_bitfields.setPositionedState(static_cast<int>(position));
 }
 
@@ -1408,7 +1408,7 @@ inline bool RenderObject::isRenderMathMLRow() const
 }
 #endif
 
-inline bool RenderObject::isTable() const
+inline bool RenderObject::isRenderTable() const
 {
     switch (type()) {
     case Type::Table:

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -28,7 +28,7 @@ namespace WebCore {
 inline bool RenderObject::hasTransformOrPerspective() const { return hasTransformRelatedProperty() && (isTransformed() || style().hasPerspective()); }
 inline bool RenderObject::isAtomicInlineLevelBox() const { return style().isDisplayInlineType() && !(style().display() == DisplayType::Inline && !isReplacedOrInlineBlock()); }
 inline bool RenderObject::isTransformed() const { return hasTransformRelatedProperty() && (style().affectsTransform() || hasSVGTransform()); }
-inline bool RenderObject::preservesNewline() const { return !isSVGInlineText() && style().preserveNewline(); }
+inline bool RenderObject::preservesNewline() const { return !isRenderSVGInlineText() && style().preserveNewline(); }
 inline Ref<Document> RenderObject::protectedDocument() const { return document(); }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -37,7 +37,7 @@ RenderProgress::RenderProgress(HTMLElement& element, RenderStyle&& style)
     , m_position(HTMLProgressElement::InvalidPosition)
     , m_animationTimer(*this, &RenderProgress::animationTimerFired)
 {
-    ASSERT(isProgress());
+    ASSERT(isRenderProgress());
 }
 
 RenderProgress::~RenderProgress() = default;

--- a/Source/WebCore/rendering/RenderProgress.h
+++ b/Source/WebCore/rendering/RenderProgress.h
@@ -58,4 +58,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderProgress, isProgress())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderProgress, isRenderProgress())

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -41,7 +41,7 @@ RenderQuote::RenderQuote(Document& document, RenderStyle&& style, QuoteType quot
     , m_type(quote)
     , m_text(emptyString())
 {
-    ASSERT(isQuote());
+    ASSERT(isRenderQuote());
 }
 
 RenderQuote::~RenderQuote()

--- a/Source/WebCore/rendering/RenderQuote.h
+++ b/Source/WebCore/rendering/RenderQuote.h
@@ -53,4 +53,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderQuote, isQuote())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderQuote, isRenderQuote())

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -533,7 +533,7 @@ void RenderReplaced::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, 
             return;
     }
     // Figure out if we need to compute an intrinsic ratio.
-    if (!RenderObject::hasIntrinsicAspectRatio() && !isSVGRootOrLegacySVGRoot())
+    if (!RenderObject::hasIntrinsicAspectRatio() && !isRenderOrLegacyRenderSVGRoot())
         return;
 
     // After supporting contain-intrinsic-size, the intrinsicSize of size containment is not always empty.
@@ -576,7 +576,7 @@ static inline bool hasIntrinsicSize(RenderBox*contentRenderer, bool hasIntrinsic
     if (hasIntrinsicWidth && hasIntrinsicHeight)
         return true;
     if (hasIntrinsicWidth || hasIntrinsicHeight)
-        return contentRenderer && contentRenderer->isSVGRootOrLegacySVGRoot();
+        return contentRenderer && contentRenderer->isRenderOrLegacyRenderSVGRoot();
     return false;
 }
 

--- a/Source/WebCore/rendering/RenderReplica.h
+++ b/Source/WebCore/rendering/RenderReplica.h
@@ -52,3 +52,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderReplica, isRenderReplica())

--- a/Source/WebCore/rendering/RenderRuby.cpp
+++ b/Source/WebCore/rendering/RenderRuby.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyAsBlock);
 RenderRubyAsInline::RenderRubyAsInline(Element& element, RenderStyle&& style)
     : RenderInline(Type::RubyAsInline, element, WTFMove(style))
 {
-    ASSERT(isRubyInline());
+    ASSERT(isRenderRubyAsInline());
 }
 
 RenderRubyAsInline::~RenderRubyAsInline() = default;
@@ -67,7 +67,7 @@ void RenderRubyAsInline::styleDidChange(StyleDifference diff, const RenderStyle*
 RenderRubyAsBlock::RenderRubyAsBlock(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::RubyAsBlock, element, WTFMove(style))
 {
-    ASSERT(isRubyBlock());
+    ASSERT(isRenderRubyAsBlock());
 }
 
 RenderRubyAsBlock::~RenderRubyAsBlock() = default;

--- a/Source/WebCore/rendering/RenderRuby.h
+++ b/Source/WebCore/rendering/RenderRuby.h
@@ -85,5 +85,5 @@ inline bool isRuby(const RenderObject* renderer) { return (renderer && isRuby(*r
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyAsInline, isRubyInline())
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyAsBlock, isRubyBlock())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyAsInline, isRenderRubyAsInline())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyAsBlock, isRenderRubyAsBlock())

--- a/Source/WebCore/rendering/RenderRubyBase.cpp
+++ b/Source/WebCore/rendering/RenderRubyBase.cpp
@@ -49,7 +49,7 @@ RenderRubyBase::RenderRubyBase(Document& document, RenderStyle&& style)
     , m_isAfterExpansion(true)
 {
     setInline(false);
-    ASSERT(isRubyBase());
+    ASSERT(isRenderRubyBase());
 }
 
 RenderRubyBase::~RenderRubyBase() = default;

--- a/Source/WebCore/rendering/RenderRubyBase.h
+++ b/Source/WebCore/rendering/RenderRubyBase.h
@@ -73,4 +73,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyBase, isRubyBase())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyBase, isRenderRubyBase())

--- a/Source/WebCore/rendering/RenderRubyRun.cpp
+++ b/Source/WebCore/rendering/RenderRubyRun.cpp
@@ -56,7 +56,7 @@ RenderRubyRun::RenderRubyRun(Document& document, RenderStyle&& style)
 {
     setReplacedOrInlineBlock(true);
     setInline(true);
-    ASSERT(isRubyRun());
+    ASSERT(isRenderRubyRun());
 }
 
 RenderRubyRun::~RenderRubyRun() = default;
@@ -65,14 +65,14 @@ bool RenderRubyRun::hasRubyText() const
 {
     // The only place where a ruby text can be is in the first position
     // Note: As anonymous blocks, ruby runs do not have ':before' or ':after' content themselves.
-    return firstChild() && firstChild()->isRubyText();
+    return firstChild() && firstChild()->isRenderRubyText();
 }
 
 bool RenderRubyRun::hasRubyBase() const
 {
     // The only place where a ruby base can be is in the last position
     // Note: As anonymous blocks, ruby runs do not have ':before' or ':after' content themselves.
-    return lastChild() && lastChild()->isRubyBase();
+    return lastChild() && lastChild()->isRenderRubyBase();
 }
 
 RenderRubyText* RenderRubyRun::rubyText() const
@@ -80,19 +80,19 @@ RenderRubyText* RenderRubyRun::rubyText() const
     RenderObject* child = firstChild();
     // If in future it becomes necessary to support floating or positioned ruby text,
     // layout will have to be changed to handle them properly.
-    ASSERT(!child || !child->isRubyText() || !child->isFloatingOrOutOfFlowPositioned());
-    return child && child->isRubyText() ? static_cast<RenderRubyText*>(child) : nullptr;
+    ASSERT(!child || !child->isRenderRubyText() || !child->isFloatingOrOutOfFlowPositioned());
+    return child && child->isRenderRubyText() ? static_cast<RenderRubyText*>(child) : nullptr;
 }
 
 RenderRubyBase* RenderRubyRun::rubyBase() const
 {
     RenderObject* child = lastChild();
-    return child && child->isRubyBase() ? static_cast<RenderRubyBase*>(child) : nullptr;
+    return child && child->isRenderRubyBase() ? static_cast<RenderRubyBase*>(child) : nullptr;
 }
 
 bool RenderRubyRun::isChildAllowed(const RenderObject& child, const RenderStyle&) const
 {
-    return child.isInline() || child.isRubyText();
+    return child.isInline() || child.isRenderRubyText();
 }
 
 RenderPtr<RenderRubyBase> RenderRubyRun::createRubyBase() const
@@ -217,7 +217,7 @@ LayoutUnit RenderRubyRun::baselinePosition(FontBaseline baselineType, bool first
 
 static bool shouldOverhang(bool firstLine, const RenderObject* renderer, const RenderRubyBase& rubyBase)
 {
-    if (!renderer || !renderer->isText())
+    if (!renderer || !renderer->isRenderText())
         return false;
     const RenderStyle& rubyBaseStyle = firstLine ? rubyBase.firstLineStyle() : rubyBase.style();
     const RenderStyle& style = firstLine ? renderer->firstLineStyle() : renderer->style();

--- a/Source/WebCore/rendering/RenderRubyRun.h
+++ b/Source/WebCore/rendering/RenderRubyRun.h
@@ -88,4 +88,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyRun, isRubyRun())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyRun, isRenderRubyRun())

--- a/Source/WebCore/rendering/RenderRubyText.cpp
+++ b/Source/WebCore/rendering/RenderRubyText.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyText);
 RenderRubyText::RenderRubyText(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::RubyText, element, WTFMove(style))
 {
-    ASSERT(isRubyText());
+    ASSERT(isRenderRubyText());
 }
 
 RenderRubyText::~RenderRubyText() = default;

--- a/Source/WebCore/rendering/RenderRubyText.h
+++ b/Source/WebCore/rendering/RenderRubyText.h
@@ -60,4 +60,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyText, isRubyText())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderRubyText, isRenderRubyText())

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -61,7 +61,7 @@ RenderSearchField::RenderSearchField(HTMLInputElement& element, RenderStyle&& st
     , m_searchPopup(nullptr)
 {
     ASSERT(element.isSearchField());
-    ASSERT(isSearchField());
+    ASSERT(isRenderSearchField());
 }
 
 RenderSearchField::~RenderSearchField()

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -92,4 +92,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSearchField, isSearchField())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSearchField, isRenderSearchField())

--- a/Source/WebCore/rendering/RenderSelection.cpp
+++ b/Source/WebCore/rendering/RenderSelection.cpp
@@ -260,7 +260,7 @@ void RenderSelection::apply(const RenderRange& newSelection, RepaintMode blockRe
 #if ENABLE(SERVICE_CONTROLS)
             for (auto& quad : selectionGeometry->collectedSelectionQuads())
                 m_selectionGeometryGatherer.addQuad(selectionGeometry->repaintContainer(), quad);
-            if (!currentRenderer->isTextOrLineBreak())
+            if (!currentRenderer->isRenderTextOrLineBreak())
                 m_selectionGeometryGatherer.setTextOnly(false);
 #endif
             newSelectedRenderers.set(currentRenderer, WTFMove(selectionGeometry));

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -55,7 +55,7 @@ RenderSlider::RenderSlider(HTMLInputElement& element, RenderStyle&& style)
 {
     // We assume RenderSlider works only with <input type=range>.
     ASSERT(element.isRangeControl());
-    ASSERT(isSlider());
+    ASSERT(isRenderSlider());
 }
 
 RenderSlider::~RenderSlider() = default;

--- a/Source/WebCore/rendering/RenderSlider.h
+++ b/Source/WebCore/rendering/RenderSlider.h
@@ -53,4 +53,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSlider, isSlider())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSlider, isRenderSlider())

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -84,7 +84,7 @@ RenderTable::RenderTable(Type type, Element& element, RenderStyle&& style)
     , m_columnOffsetHeight(-1)
 {
     setChildrenInline(false);
-    ASSERT(isTable());
+    ASSERT(isRenderTable());
 }
 
 RenderTable::RenderTable(Type type, Document& document, RenderStyle&& style)
@@ -102,7 +102,7 @@ RenderTable::RenderTable(Type type, Document& document, RenderStyle&& style)
     , m_borderEnd(0)
 {
     setChildrenInline(false);
-    ASSERT(isTable());
+    ASSERT(isRenderTable());
 }
 
 RenderTable::~RenderTable() = default;
@@ -753,7 +753,7 @@ void RenderTable::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
     info.updateSubtreePaintRootForChildren(this);
 
     for (auto& box : childrenOfType<RenderBox>(*this)) {
-        if (!box.hasSelfPaintingLayer() && (box.isTableSection() || box.isTableCaption())) {
+        if (!box.hasSelfPaintingLayer() && (box.isRenderTableSection() || box.isRenderTableCaption())) {
             LayoutPoint childPoint = flipForWritingModeForChild(box, paintOffset);
             box.paint(info, childPoint);
         }
@@ -1614,7 +1614,7 @@ bool RenderTable::nodeAtPoint(const HitTestRequest& request, HitTestResult& resu
     // Check kids first.
     if (!hasNonVisibleOverflow() || locationInContainer.intersects(overflowClipRect(adjustedLocation, nullptr))) {
         for (RenderObject* child = lastChild(); child; child = child->previousSibling()) {
-            if (is<RenderBox>(*child) && !downcast<RenderBox>(*child).hasSelfPaintingLayer() && (child->isTableSection() || child->isTableCaption())) {
+            if (is<RenderBox>(*child) && !downcast<RenderBox>(*child).hasSelfPaintingLayer() && (child->isRenderTableSection() || child->isRenderTableCaption())) {
                 LayoutPoint childPoint = flipForWritingModeForChild(*downcast<RenderBox>(child), adjustedLocation);
                 if (child->nodeAtPoint(request, result, locationInContainer, childPoint, action)) {
                     updateHitTestResult(result, toLayoutPoint(locationInContainer.point() - childPoint));

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -328,4 +328,4 @@ inline RenderPtr<RenderBox> RenderTable::createAnonymousBoxWithSameTypeAs(const 
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTable, isTable())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTable, isRenderTable())

--- a/Source/WebCore/rendering/RenderTableCaption.cpp
+++ b/Source/WebCore/rendering/RenderTableCaption.cpp
@@ -32,7 +32,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableCaption);
 RenderTableCaption::RenderTableCaption(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::TableCaption, element, WTFMove(style))
 {
-    ASSERT(isTableCaption());
+    ASSERT(isRenderTableCaption());
 }
 
 RenderTableCaption::~RenderTableCaption() = default;

--- a/Source/WebCore/rendering/RenderTableCaption.h
+++ b/Source/WebCore/rendering/RenderTableCaption.h
@@ -43,4 +43,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableCaption, isTableCaption())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableCaption, isRenderTableCaption())

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -81,7 +81,7 @@ RenderTableCell::RenderTableCell(Element& element, RenderStyle&& style)
     // We only update the flags when notified of DOM changes in colSpanOrRowSpanChanged()
     // so we need to set their initial values here in case something asks for colSpan()/rowSpan() before then.
     updateColAndRowSpanFlags();
-    ASSERT(isTableCell());
+    ASSERT(isRenderTableCell());
 }
 
 RenderTableCell::RenderTableCell(Document& document, RenderStyle&& style)
@@ -95,7 +95,7 @@ RenderTableCell::RenderTableCell(Document& document, RenderStyle&& style)
     , m_hasEmptyCollapsedStartBorder(false)
     , m_hasEmptyCollapsedEndBorder(false)
 {
-    ASSERT(isTableCell());
+    ASSERT(isRenderTableCell());
 }
 
 void RenderTableCell::willBeRemovedFromTree(IsInternalMove isInternalMove)

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -326,4 +326,4 @@ inline RenderPtr<RenderBox> RenderTableCell::createAnonymousBoxWithSameTypeAs(co
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableCell, isTableCell())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableCell, isRenderTableCell())

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -52,7 +52,7 @@ RenderTableRow::RenderTableRow(Element& element, RenderStyle&& style)
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
-    ASSERT(isTableRow());
+    ASSERT(isRenderTableRow());
 }
 
 RenderTableRow::RenderTableRow(Document& document, RenderStyle&& style)
@@ -60,7 +60,7 @@ RenderTableRow::RenderTableRow(Document& document, RenderStyle&& style)
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
-    ASSERT(isTableRow());
+    ASSERT(isRenderTableRow());
 }
 
 void RenderTableRow::willBeRemovedFromTree(IsInternalMove isInternalMove)

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -129,4 +129,4 @@ inline RenderTableRow* RenderTableSection::lastRow() const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableRow, isTableRow())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableRow, isRenderTableRow())

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -94,14 +94,14 @@ RenderTableSection::RenderTableSection(Element& element, RenderStyle&& style)
     : RenderBox(Type::TableSection, element, WTFMove(style), 0)
 {
     setInline(false);
-    ASSERT(isTableSection());
+    ASSERT(isRenderTableSection());
 }
 
 RenderTableSection::RenderTableSection(Document& document, RenderStyle&& style)
     : RenderBox(Type::TableSection, document, WTFMove(style), 0)
 {
     setInline(false);
-    ASSERT(isTableSection());
+    ASSERT(isRenderTableSection());
 }
 
 RenderTableSection::~RenderTableSection() = default;

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -299,4 +299,4 @@ inline RenderPtr<RenderBox> RenderTableSection::createAnonymousBoxWithSameTypeAs
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableSection, isTableSection())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTableSection, isRenderTableSection())

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -249,9 +249,9 @@ inline RenderText::RenderText(Type type, Node& node, const String& text)
     , m_containsOnlyASCII(text.impl()->containsOnlyASCII())
 {
     ASSERT(!m_text.isNull());
-    setIsText();
+    setIsRenderText();
     m_canUseSimpleFontCodePath = computeCanUseSimpleFontCodePath();
-    ASSERT(isText());
+    ASSERT(isRenderText());
 }
 
 RenderText::RenderText(Type type, Text& textNode, const String& text)
@@ -432,7 +432,7 @@ void RenderText::collectSelectionGeometries(Vector<SelectionGeometry>& rects, un
             extentsRect = extentsRect.transposedRect();
         bool isFirstOnLine = !textBox->previousOnLine();
         bool isLastOnLine = !textBox->nextOnLine();
-        if (containingBlock->isRubyBase() || containingBlock->isRubyText())
+        if (containingBlock->isRenderRubyBase() || containingBlock->isRenderRubyText())
             isLastOnLine = !containingBlock->containingBlock()->inlineBoxWrapper()->nextOnLineExists();
 
         bool containsStart = textBox->start() <= start && textBox->end() >= start;
@@ -451,7 +451,7 @@ void RenderText::collectSelectionGeometries(Vector<SelectionGeometry>& rects, un
             }
         }
 
-        rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(textNode()), textBox->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, textBox->isLineBreak(), isFirstOnLine, isLastOnLine, containsStart, containsEnd, boxIsHorizontal, isFixed, containingBlock->isRubyText(), view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
+        rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(textNode()), textBox->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, textBox->isLineBreak(), isFirstOnLine, isLastOnLine, containsStart, containsEnd, boxIsHorizontal, isFixed, containingBlock->isRenderRubyText(), view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
     }
 }
 #endif
@@ -2053,7 +2053,7 @@ std::optional<bool> RenderText::emphasisMarkExistsAndIsAbove(const RenderText& r
         return isAbove; // Ruby text is always over, so it cannot suppress emphasis marks under.
 
     RenderBlock* containingBlock = renderer.containingBlock();
-    if (!containingBlock || !containingBlock->isRubyBase())
+    if (!containingBlock || !containingBlock->isRenderRubyBase())
         return isAbove; // This text is not inside a ruby base, so it does not have ruby text over it.
 
     if (!is<RenderRubyRun>(*containingBlock->parent()))

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -329,4 +329,4 @@ inline void RenderText::resetMinMaxWidth()
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderText, isText())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderText, isRenderText())

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlMultiLine);
 RenderTextControlMultiLine::RenderTextControlMultiLine(HTMLTextAreaElement& element, RenderStyle&& style)
     : RenderTextControl(Type::TextControlMultiLine, element, WTFMove(style))
 {
-    ASSERT(isTextArea());
+    ASSERT(isRenderTextControlMultiLine());
 }
 
 RenderTextControlMultiLine::~RenderTextControlMultiLine()

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.h
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.h
@@ -54,4 +54,4 @@ inline RenderTextControlMultiLine* HTMLTextAreaElement::renderer() const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTextControlMultiLine, isTextArea())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTextControlMultiLine, isRenderTextControlMultiLine())

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -489,7 +489,7 @@ HTMLInputElement& RenderTextControlSingleLine::inputElement() const
 RenderTextControlInnerBlock::RenderTextControlInnerBlock(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::TextControlInnerBlock, element, WTFMove(style))
 {
-    ASSERT(isTextControlInnerBlock());
+    ASSERT(isRenderTextControlInnerBlock());
 }
 
 }

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -43,7 +43,7 @@ private:
 
     bool hasControlClip() const override;
     LayoutRect controlClipRect(const LayoutPoint&) const override;
-    bool isTextField() const final { return true; }
+    bool isRenderTextControlSingleLine() const final { return true; }
 
     void layout() override;
 
@@ -101,5 +101,5 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTextControlSingleLine, isTextField())
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTextControlInnerBlock, isTextControlInnerBlock())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTextControlSingleLine, isRenderTextControlSingleLine())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderTextControlInnerBlock, isRenderTextControlInnerBlock())

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -72,6 +72,6 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RenderTextFragment)
-    static bool isType(const WebCore::RenderText& renderer) { return renderer.isTextFragment(); }
+    static bool isType(const WebCore::RenderText& renderer) { return renderer.isRenderTextFragment(); }
     static bool isType(const WebCore::RenderObject& renderer) { return is<WebCore::RenderText>(renderer) && isType(downcast<WebCore::RenderText>(renderer)); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -457,7 +457,7 @@ IntRect RenderThemeAdwaita::progressBarRectForBounds(const RenderProgress&, cons
 
 bool RenderThemeAdwaita::paintProgressBar(const RenderObject& renderObject, const PaintInfo& paintInfo, const IntRect& rect)
 {
-    if (!renderObject.isProgress())
+    if (!renderObject.isRenderProgress())
         return true;
 
     auto& graphicsContext = paintInfo.context();

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -930,7 +930,7 @@ void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const 
 
     // Paint Indicators.
 
-    if (box.isMenuList() && downcast<HTMLSelectElement>(box.element())->multiple()) {
+    if (box.isRenderMenuList() && downcast<HTMLSelectElement>(box.element())->multiple()) {
         int size = 2;
         int count = 3;
         int padding = 3;
@@ -2464,7 +2464,7 @@ void RenderThemeIOS::paintMenuListButtonDecorationsWithFormControlRefresh(const 
     Path glyphPath;
     FloatSize glyphSize;
 
-    if (box.isMenuList() && downcast<HTMLSelectElement>(box.element())->multiple()) {
+    if (box.isRenderMenuList() && downcast<HTMLSelectElement>(box.element())->multiple()) {
         constexpr int length = 18;
         constexpr int count = 3;
         constexpr int padding = 12;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -254,7 +254,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
     }
     
     RenderBlock* cb = o.containingBlock();
-    bool adjustForTableCells = cb ? cb->isTableCell() : false;
+    bool adjustForTableCells = cb ? cb->isRenderTableCell() : false;
 
     bool enableSubpixelPrecisionForTextDump = shouldEnableSubpixelPrecisionForTextDump(o.document());
     LayoutRect r;

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -55,7 +55,7 @@ RenderVideo::RenderVideo(HTMLVideoElement& element, RenderStyle&& style)
     : RenderMedia(Type::Video, element, WTFMove(style))
 {
     setIntrinsicSize(calculateIntrinsicSize());
-    ASSERT(isVideo());
+    ASSERT(isRenderVideo());
 }
 
 RenderVideo::~RenderVideo()

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -97,6 +97,6 @@ inline RenderVideo* HTMLVideoElement::renderer() const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderVideo, isVideo())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderVideo, isRenderVideo())
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -184,7 +184,7 @@ LayoutUnit RenderView::availableLogicalHeight(AvailableLogicalHeightType) const
 
 bool RenderView::isChildAllowed(const RenderObject& child, const RenderStyle&) const
 {
-    return child.isBox();
+    return child.isRenderBox();
 }
 
 void RenderView::layout()
@@ -210,7 +210,7 @@ void RenderView::layout()
                 || box.style().logicalHeight().isPercentOrCalculated()
                 || box.style().logicalMinHeight().isPercentOrCalculated()
                 || box.style().logicalMaxHeight().isPercentOrCalculated()
-                || box.isSVGRootOrLegacySVGRoot()
+                || box.isRenderOrLegacyRenderSVGRoot()
                 )
                 box.setChildNeedsLayout(MarkOnlyThis);
         }

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -95,7 +95,7 @@ protected:
 private:
     void element() const = delete;
 
-    bool isWidget() const final { return true; }
+    bool isRenderWidget() const final { return true; }
 
     bool needsPreferredWidthsRecalculation() const final;
     RenderBox* embeddedContentBox() const final;
@@ -114,4 +114,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderWidget, isWidget())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderWidget, isRenderWidget())

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -362,7 +362,7 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
         const auto& style = styleForRenderer(*current);
         extractDecorations(style, style.textDecorationLine());
 
-        if (current->isRubyText())
+        if (current->isRenderRubyText())
             return;
 
         current = current->parent();

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -106,7 +106,7 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
             context.handleEmptyInline();
         } else if (context.currentObject()->isReplacedOrInlineBlock()) {
             context.handleReplaced();
-        } else if (context.currentObject()->isText()) {
+        } else if (context.currentObject()->isRenderText()) {
             if (context.handleText(wordMeasurements, m_hyphenated, consecutiveHyphenatedLines)) {
                 // We've hit a hard text line break. Our line break iterator is updated, so early return.
                 return context.lineBreak();

--- a/Source/WebCore/rendering/line/TrailingObjects.cpp
+++ b/Source/WebCore/rendering/line/TrailingObjects.cpp
@@ -59,7 +59,7 @@ void TrailingObjects::updateWhitespaceCollapsingTransitionsForTrailingBoxes(Line
             currentTransition += 2;
         }
     } else if (!lBreak.renderer()) {
-        ASSERT(m_whitespace->isText());
+        ASSERT(m_whitespace->isRenderText());
         ASSERT(collapseFirstSpace == CollapseFirstSpace::Yes);
         // Add a new end transition that stops right at the very end.
         unsigned length = m_whitespace->text().length();

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -70,11 +70,11 @@ protected:
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
 
 private:
-    bool isSVGContainer() const final { return true; }
+    bool isRenderSVGContainer() const final { return true; }
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGContainer, isSVGContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGContainer, isRenderSVGContainer())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -49,7 +49,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGForeignObject);
 RenderSVGForeignObject::RenderSVGForeignObject(SVGForeignObjectElement& element, RenderStyle&& style)
     : RenderSVGBlock(Type::SVGForeignObject, element, WTFMove(style))
 {
-    ASSERT(isSVGForeignObject());
+    ASSERT(isRenderSVGForeignObject());
 }
 
 RenderSVGForeignObject::~RenderSVGForeignObject() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -71,6 +71,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGForeignObject, isSVGForeignObject())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGForeignObject, isRenderSVGForeignObject())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGGradientStop);
 RenderSVGGradientStop::RenderSVGGradientStop(SVGStopElement& element, RenderStyle&& style)
     : RenderElement(Type::SVGGradientStop, element, WTFMove(style), 0)
 {
-    ASSERT(isSVGGradientStop());
+    ASSERT(isRenderSVGGradientStop());
 }
 
 RenderSVGGradientStop::~RenderSVGGradientStop() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
@@ -61,4 +61,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGGradientStop, isSVGGradientStop())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGGradientStop, isRenderSVGGradientStop())

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
@@ -33,7 +33,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGHiddenContainer);
 RenderSVGHiddenContainer::RenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style)
     : RenderSVGContainer(type, element, WTFMove(style))
 {
-    ASSERT(isSVGHiddenContainer());
+    ASSERT(isRenderSVGHiddenContainer());
 }
 
 void RenderSVGHiddenContainer::layout()

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -59,6 +59,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGHiddenContainer, isSVGHiddenContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGHiddenContainer, isRenderSVGHiddenContainer())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -59,7 +59,7 @@ RenderSVGImage::RenderSVGImage(SVGImageElement& element, RenderStyle&& style)
     : RenderSVGModelObject(Type::SVGImage, element, WTFMove(style))
     , m_imageResource(makeUnique<RenderImageResource>())
 {
-    ASSERT(isSVGImage());
+    ASSERT(isRenderSVGImage());
     imageResource().initialize(*this);
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -86,6 +86,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGImage, isSVGImage())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGImage, isRenderSVGImage())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGInline);
 RenderSVGInline::RenderSVGInline(Type type, SVGGraphicsElement& element, RenderStyle&& style)
     : RenderInline(type, element, WTFMove(style))
 {
-    ASSERT(isSVGInline());
+    ASSERT(isRenderSVGInline());
 }
 
 std::unique_ptr<LegacyInlineFlowBox> RenderSVGInline::createInlineFlowBox()

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -71,4 +71,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGInline, isSVGInline())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGInline, isRenderSVGInline())

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -76,7 +76,7 @@ RenderSVGInlineText::RenderSVGInlineText(Text& textNode, const String& string)
     , m_scalingFactor(1)
     , m_layoutAttributes(*this)
 {
-    ASSERT(isSVGInlineText());
+    ASSERT(isRenderSVGInlineText());
 }
 
 String RenderSVGInlineText::originalText() const
@@ -143,7 +143,7 @@ bool RenderSVGInlineText::characterStartsNewTextChunk(int position) const
     ASSERT(position < static_cast<int>(text().length()));
 
     // Each <textPath> element starts a new text chunk, regardless of any x/y values.
-    if (!position && parent()->isSVGTextPath() && !previousSibling())
+    if (!position && parent()->isRenderSVGTextPath() && !previousSibling())
         return true;
 
     const SVGCharacterDataMap::const_iterator it = m_layoutAttributes.characterDataMap().find(static_cast<unsigned>(position + 1));

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -75,4 +75,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGInlineText, isSVGInlineText())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGInlineText, isRenderSVGInlineText())

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -212,7 +212,7 @@ static bool intersectsAllowingEmpty(const FloatRect& r, const FloatRect& other)
 // image, line, path, polygon, polyline, rect, text and use.
 static bool isGraphicsElement(const RenderElement& renderer)
 {
-    return renderer.isSVGShape() || renderer.isSVGText() || renderer.isSVGImage() || renderer.element()->hasTagName(SVGNames::useTag);
+    return renderer.isRenderSVGShape() || renderer.isRenderSVGText() || renderer.isRenderSVGImage() || renderer.element()->hasTagName(SVGNames::useTag);
 }
 
 bool RenderSVGModelObject::checkIntersection(RenderElement* renderer, const FloatRect& rect)

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -47,7 +47,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGPath);
 RenderSVGPath::RenderSVGPath(SVGGraphicsElement& element, RenderStyle&& style)
     : RenderSVGShape(Type::SVGPath, element, WTFMove(style))
 {
-    ASSERT(isSVGPath());
+    ASSERT(isRenderSVGPath());
 }
 
 RenderSVGPath::~RenderSVGPath() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -66,6 +66,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGPath, isSVGPath())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGPath, isRenderSVGPath())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -61,7 +61,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceClipper);
 RenderSVGResourceClipper::RenderSVGResourceClipper(SVGClipPathElement& element, RenderStyle&& style)
     : RenderSVGResourceContainer(Type::SVGResourceClipper, element, WTFMove(style))
 {
-    ASSERT(isSVGResourceClipper());
+    ASSERT(isRenderSVGResourceClipper());
 }
 
 RenderSVGResourceClipper::~RenderSVGResourceClipper() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -65,6 +65,6 @@ private:
 
 }
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceClipper, isSVGResourceClipper())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceClipper, isRenderSVGResourceClipper())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -39,7 +39,7 @@ RenderSVGResourceContainer::RenderSVGResourceContainer(Type type, SVGElement& el
     : RenderSVGHiddenContainer(type, element, WTFMove(style))
     , m_id(element.getIdAttribute())
 {
-    ASSERT(isSVGResourceContainer());
+    ASSERT(isRenderSVGResourceContainer());
 }
 
 RenderSVGResourceContainer::~RenderSVGResourceContainer() = default;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -56,6 +56,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceContainer, isSVGResourceContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceContainer, isRenderSVGResourceContainer())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -92,6 +92,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, FilterData::FilterDataState);
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RenderSVGResourceFilter)
-    static bool isType(const WebCore::RenderObject& renderer) { return renderer.isSVGResourceFilter(); }
+    static bool isType(const WebCore::RenderObject& renderer) { return renderer.isRenderSVGResourceFilter(); }
     static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::FilterResourceType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
@@ -51,3 +51,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceFilterPrimitive, isRenderSVGResourceFilterPrimitive())

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -69,7 +69,7 @@ const int defaultHeight = 150;
 RenderSVGRoot::RenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
     : RenderReplaced(Type::SVGRoot, element, WTFMove(style))
 {
-    ASSERT(isSVGRoot());
+    ASSERT(isRenderSVGRoot());
     LayoutSize intrinsicSize(calculateIntrinsicSize());
     if (!intrinsicSize.width())
         intrinsicSize.setWidth(defaultWidth);
@@ -141,7 +141,7 @@ bool RenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument() const
 {
     // If our frame has an owner renderer, we're embedded through eg. object/embed/iframe,
     // but we only negotiate if we're in an SVG document inside object/embed, not iframe.
-    if (!frame().ownerRenderer() || !frame().ownerRenderer()->isEmbeddedObject() || !isDocumentElementRenderer())
+    if (!frame().ownerRenderer() || !frame().ownerRenderer()->isRenderEmbeddedObject() || !isDocumentElementRenderer())
         return false;
     return frame().document()->isSVGDocument();
 }
@@ -342,7 +342,7 @@ void RenderSVGRoot::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOf
     GraphicsContext& context = paintInfo.context();
     if (context.detectingContentfulPaint()) {
         for (auto& current : childrenOfType<RenderObject>(*this)) {
-            if (!current.isSVGHiddenContainer()) {
+            if (!current.isRenderSVGHiddenContainer()) {
                 context.setContentfulPaintDetected();
                 return;
             }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -130,6 +130,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGRoot, isSVGRoot())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGRoot, isRenderSVGRoot())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -120,7 +120,7 @@ private:
     bool fillContains(const FloatPoint&, bool requiresFill = true, const WindRule fillRule = WindRule::NonZero);
     bool strokeContains(const FloatPoint&, bool requiresStroke = true);
 
-    bool isSVGShape() const final { return true; }
+    bool isRenderSVGShape() const final { return true; }
     bool canHaveChildren() const final { return false; }
     ASCIILiteral renderName() const override { return "RenderSVGShape"_s; }
 
@@ -160,6 +160,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGShape, isSVGShape())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGShape, isRenderSVGShape())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGTSpan.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTSpan.h
@@ -33,7 +33,7 @@ public:
     explicit RenderSVGTSpan(SVGTextPositioningElement& element, RenderStyle&& style)
         : RenderSVGInline(Type::SVGTSpan, element, WTFMove(style))
     {
-        ASSERT(isSVGTSpan());
+        ASSERT(isRenderSVGTSpan());
     }
 
 private:
@@ -43,4 +43,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGTSpan, isSVGTSpan())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGTSpan, isRenderSVGTSpan())

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -62,7 +62,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGText);
 RenderSVGText::RenderSVGText(SVGTextElement& element, RenderStyle&& style)
     : RenderSVGBlock(Type::SVGText, element, WTFMove(style))
 {
-    ASSERT(isSVGText());
+    ASSERT(isRenderSVGText());
 }
 
 RenderSVGText::~RenderSVGText()
@@ -149,7 +149,7 @@ void RenderSVGText::subtreeChildWasAdded(RenderObject* child)
     // cache, as the next buildLayoutAttributesForTextRenderer() call rebuilds it.
     m_layoutAttributesBuilder.clearTextPositioningElements();
 
-    if (!child->isSVGInlineText() && !child->isSVGInline())
+    if (!child->isRenderSVGInlineText() && !child->isRenderSVGInline())
         return;
 
     // Detect changes in layout attributes and only measure those text parts that have changed!
@@ -222,7 +222,7 @@ void RenderSVGText::subtreeChildWillBeRemoved(RenderObject* child, Vector<SVGTex
     // The positioning elements cache depends on the size of each text renderer in the
     // subtree. If this changes, clear the cache. It's going to be rebuilt below.
     m_layoutAttributesBuilder.clearTextPositioningElements();
-    if (m_layoutAttributes.isEmpty() || !child->isSVGInlineText())
+    if (m_layoutAttributes.isEmpty() || !child->isRenderSVGInlineText())
         return;
 
     // This logic requires that the 'text' child is still inserted in the tree.

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -117,4 +117,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGText, isSVGText())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGText, isRenderSVGText())

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGTextPath);
 RenderSVGTextPath::RenderSVGTextPath(SVGTextPathElement& element, RenderStyle&& style)
     : RenderSVGInline(Type::SVGTextPath, element, WTFMove(style))
 {
-    ASSERT(isSVGTextPath());
+    ASSERT(isRenderSVGTextPath());
 }
 
 SVGTextPathElement& RenderSVGTextPath::textPathElement() const

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.h
@@ -49,4 +49,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGTextPath, isSVGTextPath())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGTextPath, isRenderSVGTextPath())

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGTransformableContainer);
 RenderSVGTransformableContainer::RenderSVGTransformableContainer(SVGGraphicsElement& element, RenderStyle&& style)
     : RenderSVGContainer(Type::SVGTransformableContainer, element, WTFMove(style))
 {
-    ASSERT(isSVGTransformableContainer());
+    ASSERT(isRenderSVGTransformableContainer());
 }
 
 SVGGraphicsElement& RenderSVGTransformableContainer::graphicsElement() const

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
@@ -49,6 +49,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGTransformableContainer, isSVGTransformableContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGTransformableContainer, isRenderSVGTransformableContainer())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -41,13 +41,13 @@ RenderSVGViewportContainer::RenderSVGViewportContainer(RenderSVGRoot& parent, Re
     : RenderSVGContainer(Type::SVGViewportContainer, parent.document(), WTFMove(style))
     , m_owningSVGRoot(parent)
 {
-    ASSERT(isSVGViewportContainer());
+    ASSERT(isRenderSVGViewportContainer());
 }
 
 RenderSVGViewportContainer::RenderSVGViewportContainer(SVGSVGElement& element, RenderStyle&& style)
     : RenderSVGContainer(Type::SVGViewportContainer, element, WTFMove(style))
 {
-    ASSERT(isSVGViewportContainer());
+    ASSERT(isRenderSVGViewportContainer());
 }
 
 SVGSVGElement& RenderSVGViewportContainer::svgSVGElement() const

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
@@ -67,6 +67,6 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGViewportContainer, isSVGViewportContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGViewportContainer, isRenderSVGViewportContainer())
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -138,7 +138,7 @@ FloatRect SVGBoundingBoxComputation::handleRootOrContainer(const SVGBoundingBoxC
             return std::nullopt;
 
         ASSERT(child.isSVGLayerAwareRenderer());
-        ASSERT(!child.isSVGRoot());
+        ASSERT(!child.isRenderSVGRoot());
 
         auto transform = SVGLayerTransformComputation(child).computeAccumulatedTransform(&m_renderer, TransformState::TrackSVGCTMMatrix);
         return transform.isIdentity() ? std::nullopt : std::make_optional(WTFMove(transform));

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -128,8 +128,8 @@ void SVGContainerLayout::positionChildrenRelativeToContainer()
     auto verifyPositionedChildRendererExpectation = [](RenderObject& renderer) {
 #if !defined(NDEBUG)
         ASSERT(renderer.isSVGLayerAwareRenderer()); // Pre-condition to enter m_positionedChildren
-        ASSERT(!renderer.isSVGRoot()); // There is only one outermost RenderSVGRoot object
-        ASSERT(!renderer.isSVGInline()); // Inlines are only allowed within a RenderSVGText tree
+        ASSERT(!renderer.isRenderSVGRoot()); // There is only one outermost RenderSVGRoot object
+        ASSERT(!renderer.isRenderSVGInline()); // Inlines are only allowed within a RenderSVGText tree
 
         if (is<RenderSVGModelObject>(renderer) || is<RenderSVGBlock>(renderer))
             return;
@@ -172,13 +172,13 @@ void SVGContainerLayout::positionChildrenRelativeToContainer()
 
 void SVGContainerLayout::verifyLayoutLocationConsistency(const RenderLayerModelObject& renderer)
 {
-    if (renderer.isSVGLayerAwareRenderer() && !renderer.isSVGRoot()) {
+    if (renderer.isSVGLayerAwareRenderer() && !renderer.isRenderSVGRoot()) {
         auto currentLayoutLocation = renderer.currentSVGLayoutLocation();
 
         auto expectedLayoutLocation = currentLayoutLocation;
         for (auto& ancestor : ancestorsOfType<RenderLayerModelObject>(renderer)) {
             ASSERT(ancestor.isSVGLayerAwareRenderer());
-            if (ancestor.isSVGRoot())
+            if (ancestor.isRenderSVGRoot())
                 break;
             expectedLayoutLocation.moveBy(ancestor.currentSVGLayoutLocation());
         }
@@ -209,7 +209,7 @@ void SVGContainerLayout::verifyLayoutLocationConsistency(const RenderLayerModelO
     }
 
 #if !defined(NDEBUG)
-    if (renderer.isSVGRoot()) {
+    if (renderer.isRenderSVGRoot()) {
         LOG_WITH_STREAM(SVG, stream << "--> SVGContainerLayout renderer " << &renderer << " (" << renderer.renderName().characters() << ")"
             << " - verifyLayoutLocationConsistency() end");
     }

--- a/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
@@ -97,7 +97,7 @@ public:
 
         // When we've climbed the ancestor tree up to and including RenderSVGRoot, the CTM is aligned with the top-left of the renderers bounding box (= nominal SVG layout location).
         // However, for getCTM/getScreenCTM we're supposed to align by the top-left corner of the enclosing "viewport element" -- correct for that.
-        if (m_renderer.isSVGRoot())
+        if (m_renderer.isRenderSVGRoot())
             return ctm;
 
         ctm.translate(-toFloatSize(m_renderer.nominalSVGLayoutLocation()));

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -153,7 +153,7 @@ void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
     objectBoundingBoxValid = false;
     repaintBoundingBox = FloatRect();
     for (auto& current : childrenOfType<RenderObject>(container)) {
-        if (current.isLegacySVGHiddenContainer())
+        if (current.isLegacyRenderSVGHiddenContainer())
             continue;
 
         // Don't include elements in the union that do not render.
@@ -173,10 +173,10 @@ void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
 
 FloatRect SVGRenderSupport::computeContainerStrokeBoundingBox(const RenderElement& container)
 {
-    ASSERT(container.isLegacySVGRoot() || container.isLegacySVGContainer());
+    ASSERT(container.isLegacyRenderSVGRoot() || container.isLegacyRenderSVGContainer());
     FloatRect strokeBoundingBox = FloatRect();
     for (auto& current : childrenOfType<RenderObject>(container)) {
-        if (current.isLegacySVGHiddenContainer())
+        if (current.isLegacyRenderSVGHiddenContainer())
             continue;
 
         // Don't include elements in the union that do not render.
@@ -238,7 +238,7 @@ static inline bool layoutSizeOfNearestViewportChanged(const RenderElement& rende
 
 bool SVGRenderSupport::transformToRootChanged(RenderElement* ancestor)
 {
-    while (ancestor && !ancestor->isSVGRootOrLegacySVGRoot()) {
+    while (ancestor && !ancestor->isRenderOrLegacyRenderSVGRoot()) {
         if (is<LegacyRenderSVGTransformableContainer>(*ancestor))
             return downcast<LegacyRenderSVGTransformableContainer>(*ancestor).didTransformToRootUpdate();
         if (is<LegacyRenderSVGViewportContainer>(*ancestor))
@@ -474,7 +474,7 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
         float scaleFactor = 1;
 
         if (is<SVGGeometryElement>(element)) {
-            ASSERT(renderer.isSVGShapeOrLegacySVGShape());
+            ASSERT(renderer.isRenderOrLegacyRenderSVGShape());
             // FIXME: A value of zero is valid. Need to differentiate this case from being unspecified.
             if (float pathLength = downcast<SVGGeometryElement>(element)->pathLength()) {
                 if (is<LegacyRenderSVGShape>(renderer))

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -541,7 +541,7 @@ void writeSVGResourceContainer(TextStream& ts, const LegacyRenderSVGResourceCont
 void writeSVGContainer(TextStream& ts, const LegacyRenderSVGContainer& container, OptionSet<RenderAsTextFlag> behavior)
 {
     // Currently RenderSVGResourceFilterPrimitive has no meaningful output.
-    if (container.isSVGResourceFilterPrimitive())
+    if (container.isRenderSVGResourceFilterPrimitive())
         return;
     writeStandardPrefix(ts, container, behavior);
     writePositionAndStyle(ts, container, behavior);

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -96,7 +96,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
     // Setup transparency layers before setting up SVG resources!
     bool isRenderingMask = isRenderingMaskImage(*m_renderer);
     // RenderLayer takes care of root opacity.
-    float opacity = (renderer.isLegacySVGRoot() || isRenderingMask) ? 1 : style.opacity();
+    float opacity = (renderer.isLegacyRenderSVGRoot() || isRenderingMask) ? 1 : style.opacity();
     bool hasBlendMode = style.hasBlendMode();
     bool hasIsolation = style.hasIsolation();
     bool isolateMaskForBlending = false;
@@ -161,7 +161,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
 
     // SVG roots with filters specified (using CSS or SVG presentation attributes) are applied
     // as CSSFilter by RenderLayer, so don't reapply the filter here.
-    if (!isRenderingMask && !renderer.isSVGRootOrLegacySVGRoot()) {
+    if (!isRenderingMask && !renderer.isRenderOrLegacyRenderSVGRoot()) {
         m_filter = resources->filter();
         if (m_filter && !m_filter->isIdentity()) {
             m_savedContext = &m_paintInfo->context();
@@ -207,7 +207,7 @@ AffineTransform SVGRenderingContext::calculateTransformationToOutermostCoordinat
     const RenderObject* ancestor = &renderer;
     while (ancestor) {
         absoluteTransform = ancestor->localToParentTransform() * absoluteTransform;
-        if (ancestor->isSVGRootOrLegacySVGRoot())
+        if (ancestor->isRenderOrLegacyRenderSVGRoot())
             break;
         ancestor = ancestor->parent();
     }

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -103,7 +103,7 @@ void SVGResourcesCache::clientLayoutChanged(RenderElement& renderer)
 
 static inline bool rendererCanHaveResources(RenderObject& renderer)
 {
-    return renderer.node() && renderer.node()->isSVGElement() && !renderer.isSVGInlineText();
+    return renderer.node() && renderer.node()->isSVGElement() && !renderer.isRenderSVGInlineText();
 }
 
 void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDifference diff, const RenderStyle* oldStyle, const RenderStyle& newStyle)
@@ -123,7 +123,7 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDiffere
     // so we don't return early just when diff == StyleDifference::Equal. But
     // this isn't necessary for filter primitives, to which the filter property
     // doesn't apply, so we check for it here too.
-    if (renderer.isSVGResourceFilterPrimitive() && (diff == StyleDifference::Equal || diff == StyleDifference::Repaint || diff == StyleDifference::RepaintIfText))
+    if (renderer.isRenderSVGResourceFilterPrimitive() && (diff == StyleDifference::Equal || diff == StyleDifference::Repaint || diff == StyleDifference::RepaintIfText))
         return;
 
     auto& cache = resourcesCacheFromRenderer(renderer);

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
@@ -46,7 +46,7 @@ bool SVGResourcesCycleSolver::resourceContainsCycles(LegacyRenderSVGResourceCont
 
     RenderObject* node = &resource;
     while (node) {
-        if (node != &resource && node->isLegacySVGResourceContainer()) {
+        if (node != &resource && node->isLegacyRenderSVGResourceContainer()) {
             node = node->nextInPreOrderAfterChildren(&resource);
             continue;
         }

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
@@ -90,7 +90,7 @@ void SVGRootInlineBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (renderer().document().settings().layerBasedSVGEngineEnabled()) {
         for (auto* child = firstChild(); child; child = child->nextOnLine()) {
-            if (child->renderer().isText() || !child->boxModelObject()->hasSelfPaintingLayer())
+            if (child->renderer().isRenderText() || !child->boxModelObject()->hasSelfPaintingLayer())
                 child->paint(childPaintInfo, paintOffset, lineTop, lineBottom);
         }
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -141,7 +141,7 @@ bool SVGTextLayoutEngine::parentDefinesTextLength(RenderObject* parent) const
                 return true;
         }
 
-        if (currentParent->isSVGText())
+        if (currentParent->isRenderSVGText())
             return false;
 
         currentParent = currentParent->parent();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -70,7 +70,7 @@ protected:
     void updateCachedBoundaries();
 
 private:
-    bool isLegacySVGContainer() const final { return true; }
+    bool isLegacyRenderSVGContainer() const final { return true; }
 
     FloatRect m_objectBoundingBox;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
@@ -83,4 +83,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGContainer, isLegacySVGContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGContainer, isLegacyRenderSVGContainer())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -46,7 +46,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGForeignObject);
 LegacyRenderSVGForeignObject::LegacyRenderSVGForeignObject(SVGForeignObjectElement& element, RenderStyle&& style)
     : RenderSVGBlock(Type::LegacySVGForeignObject, element, WTFMove(style))
 {
-    ASSERT(isLegacySVGForeignObject());
+    ASSERT(isLegacyRenderSVGForeignObject());
 }
 
 LegacyRenderSVGForeignObject::~LegacyRenderSVGForeignObject() = default;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -72,4 +72,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGForeignObject, isLegacySVGForeignObject())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGForeignObject, isLegacyRenderSVGForeignObject())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
@@ -36,7 +36,7 @@ protected:
     void layout() override;
 
 private:
-    bool isLegacySVGHiddenContainer() const final { return true; }
+    bool isLegacyRenderSVGHiddenContainer() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGHiddenContainer"_s; }
 
     void paint(PaintInfo&, const LayoutPoint&) final;
@@ -48,3 +48,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGHiddenContainer, isLegacyRenderSVGHiddenContainer())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -55,7 +55,7 @@ LegacyRenderSVGImage::LegacyRenderSVGImage(SVGImageElement& element, RenderStyle
     , m_imageResource(makeUnique<RenderImageResource>())
 {
     imageResource().initialize(*this);
-    ASSERT(isLegacySVGImage());
+    ASSERT(isLegacyRenderSVGImage());
 }
 
 LegacyRenderSVGImage::~LegacyRenderSVGImage() = default;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -90,4 +90,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGImage, isLegacySVGImage())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGImage, isLegacyRenderSVGImage())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -157,7 +157,7 @@ static bool intersectsAllowingEmpty(const FloatRect& r, const FloatRect& other)
 // image, line, path, polygon, polyline, rect, text and use.
 static bool isGraphicsElement(const RenderElement& renderer)
 {
-    return renderer.isLegacySVGShape() || renderer.isSVGText() || renderer.isLegacySVGImage() || renderer.element()->hasTagName(SVGNames::useTag);
+    return renderer.isLegacyRenderSVGShape() || renderer.isRenderSVGText() || renderer.isLegacyRenderSVGImage() || renderer.element()->hasTagName(SVGNames::useTag);
 }
 
 // The SVG addFocusRingRects() method adds rects in local coordinates so the default absoluteFocusRingQuads

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGPath);
 LegacyRenderSVGPath::LegacyRenderSVGPath(SVGGraphicsElement& element, RenderStyle&& style)
     : LegacyRenderSVGShape(Type::LegacySVGPath, element, WTFMove(style))
 {
-    ASSERT(isLegacySVGPath());
+    ASSERT(isLegacyRenderSVGPath());
 }
 
 LegacyRenderSVGPath::~LegacyRenderSVGPath() = default;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -64,4 +64,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGPath, isLegacySVGPath())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGPath, isLegacyRenderSVGPath())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -265,7 +265,7 @@ void LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded
 void LegacyRenderSVGResource::fillAndStrokePathOrShape(GraphicsContext& context, OptionSet<RenderSVGResourceMode> resourceMode, const Path* path, const RenderElement* shape) const
 {
     if (shape) {
-        ASSERT(shape->isSVGShapeOrLegacySVGShape());
+        ASSERT(shape->isRenderOrLegacyRenderSVGShape());
 
         if (resourceMode.contains(RenderSVGResourceMode::ApplyToFill)) {
             if (is<LegacyRenderSVGShape>(shape))

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -270,7 +270,7 @@ bool LegacyRenderSVGResourceClipper::drawContentIntoMaskImage(ImageBuffer& maskI
         }
 
         // Only shapes, paths and texts are allowed for clipping.
-        if (!renderer->isSVGShapeOrLegacySVGShape() && !renderer->isSVGText())
+        if (!renderer->isRenderOrLegacyRenderSVGShape() && !renderer->isRenderSVGText())
             continue;
 
         maskContext.setFillRule(newClipRule);
@@ -292,7 +292,7 @@ void LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect(RepaintRect
         RenderObject* renderer = childNode->renderer();
         if (!childNode->isSVGElement() || !renderer)
             continue;
-        if (!renderer->isSVGShapeOrLegacySVGShape() && !renderer->isSVGText() && !childNode->hasTagName(SVGNames::useTag))
+        if (!renderer->isRenderOrLegacyRenderSVGShape() && !renderer->isRenderSVGText() && !childNode->hasTagName(SVGNames::useTag))
             continue;
         const RenderStyle& style = renderer->style();
         if (style.display() == DisplayType::None || style.visibility() != Visibility::Visible)
@@ -323,7 +323,7 @@ bool LegacyRenderSVGResourceClipper::hitTestClipContent(const FloatRect& objectB
         RenderObject* renderer = childNode->renderer();
         if (!childNode->isSVGElement() || !renderer)
             continue;
-        if (!renderer->isSVGShapeOrLegacySVGShape() && !renderer->isSVGText() && !childNode->hasTagName(SVGNames::useTag))
+        if (!renderer->isRenderOrLegacyRenderSVGShape() && !renderer->isRenderSVGText() && !childNode->hasTagName(SVGNames::useTag))
             continue;
 
         IntPoint hitPoint;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -102,6 +102,6 @@ private:
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceClipper)
-static bool isType(const WebCore::RenderObject& renderer) { return renderer.isLegacySVGResourceClipper(); }
+static bool isType(const WebCore::RenderObject& renderer) { return renderer.isLegacyRenderSVGResourceClipper(); }
 static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::ClipperResourceType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -223,7 +223,7 @@ float LegacyRenderSVGResourceContainer::computeTextPaintingScale(const RenderEle
     return 1;
 #else
     // This method should only be called for RenderObjects that deal with text rendering. Cmp. RenderObject.h's is*() methods.
-    ASSERT(renderer.isSVGText() || renderer.isSVGTextPath() || renderer.isSVGInline());
+    ASSERT(renderer.isRenderSVGText() || renderer.isRenderSVGTextPath() || renderer.isRenderSVGInline());
 
     // In text drawing, the scaling part of the graphics context CTM is removed, compare SVGInlineTextBox::paintTextWithShadows.
     // So, we use that scaling factor here, too, and then push it down to pattern or gradient space
@@ -235,7 +235,7 @@ float LegacyRenderSVGResourceContainer::computeTextPaintingScale(const RenderEle
 // FIXME: This does not belong here.
 AffineTransform LegacyRenderSVGResourceContainer::transformOnNonScalingStroke(RenderObject* object, const AffineTransform& resourceTransform)
 {
-    if (!object->isSVGShapeOrLegacySVGShape())
+    if (!object->isRenderOrLegacyRenderSVGShape())
         return resourceTransform;
 
     SVGGraphicsElement* element = downcast<SVGGraphicsElement>(object->node());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -36,7 +36,7 @@ public:
     void layout() override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 
-    bool isLegacySVGResourceContainer() const final { return true; }
+    bool isLegacyRenderSVGResourceContainer() const final { return true; }
 
     static float computeTextPaintingScale(const RenderElement&);
     static AffineTransform transformOnNonScalingStroke(RenderObject*, const AffineTransform& resourceTransform);
@@ -104,4 +104,4 @@ Renderer* getRenderSVGResourceById(TreeScope& treeScope, const AtomString& id)
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceContainer, isLegacySVGResourceContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceContainer, isLegacyRenderSVGResourceContainer())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -65,7 +65,7 @@ LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& s
     , m_needsBoundariesOrTransformUpdate(true)
     , m_hasBoxDecorations(false)
 {
-    ASSERT(isLegacySVGRoot());
+    ASSERT(isLegacyRenderSVGRoot());
     LayoutSize intrinsicSize(calculateIntrinsicSize());
     if (!intrinsicSize.width())
         intrinsicSize.setWidth(defaultWidth);
@@ -247,7 +247,7 @@ void LegacyRenderSVGRoot::paintReplaced(PaintInfo& paintInfo, const LayoutPoint&
     GraphicsContext& context = paintInfo.context();
     if (context.detectingContentfulPaint()) {
         for (auto& current : childrenOfType<RenderObject>(*this)) {
-            if (!current.isLegacySVGHiddenContainer()) {
+            if (!current.isLegacyRenderSVGHiddenContainer()) {
                 context.setContentfulPaintDetected();
                 return;
             }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -123,4 +123,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGRoot, isLegacySVGRoot())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGRoot, isLegacyRenderSVGRoot())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -115,7 +115,7 @@ private:
     const AffineTransform& localToParentTransform() const final { return m_localTransform; }
     AffineTransform localTransform() const final { return m_localTransform; }
 
-    bool isLegacySVGShape() const final { return true; }
+    bool isLegacyRenderSVGShape() const final { return true; }
     bool canHaveChildren() const final { return false; }
     ASCIILiteral renderName() const override { return "RenderSVGShape"_s; }
 
@@ -161,4 +161,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGShape, isLegacySVGShape())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGShape, isLegacyRenderSVGShape())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -39,7 +39,7 @@ LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer(SVG
     , m_needsTransformUpdate(true)
     , m_didTransformToRootUpdate(false)
 {
-    ASSERT(isLegacySVGTransformableContainer());
+    ASSERT(isLegacyRenderSVGTransformableContainer());
 }
 
 bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -51,4 +51,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGTransformableContainer, isLegacySVGTransformableContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGTransformableContainer, isLegacyRenderSVGTransformableContainer())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
@@ -39,7 +39,7 @@ LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer(SVGSVGElement
     , m_isLayoutSizeChanged(false)
     , m_needsTransformUpdate(true)
 {
-    ASSERT(isLegacySVGViewportContainer());
+    ASSERT(isLegacyRenderSVGViewportContainer());
 }
 
 SVGSVGElement& LegacyRenderSVGViewportContainer::svgSVGElement() const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
@@ -69,4 +69,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGViewportContainer, isLegacySVGViewportContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGViewportContainer, isLegacyRenderSVGViewportContainer())

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -432,7 +432,7 @@ void RenderTreeBuilder::attachToRenderElementInternal(RenderElement& parent, Ren
     RELEASE_ASSERT_WITH_MESSAGE(!parent.view().frameView().layoutContext().layoutState(), "Layout must not mutate render tree");
     ASSERT(parent.canHaveChildren() || parent.canHaveGeneratedChildren());
     ASSERT(!child->parent());
-    ASSERT(!parent.isRenderBlockFlow() || (!child->isTableSection() && !child->isTableRow() && !child->isTableCell()));
+    ASSERT(!parent.isRenderBlockFlow() || (!child->isRenderTableSection() && !child->isRenderTableRow() && !child->isRenderTableCell()));
 
     while (beforeChild && beforeChild->parent() && beforeChild->parent() != &parent)
         beforeChild = beforeChild->parent();
@@ -835,7 +835,7 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
     }
 
     auto isAnonymousAndSafeToDelete = [] (const auto& renderer) {
-        return renderer.isAnonymous() && !is<RenderRubyBase>(renderer) && !renderer.isRenderView() && !renderer.isRenderFragmentedFlow() && !renderer.isSVGViewportContainer();
+        return renderer.isAnonymous() && !is<RenderRubyBase>(renderer) && !renderer.isRenderView() && !renderer.isRenderFragmentedFlow() && !renderer.isRenderSVGViewportContainer();
     };
 
     auto destroyRootIncludingAnonymous = [&] () -> RenderObject& {
@@ -962,7 +962,7 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
     else if (is<RenderText>(child))
         downcast<RenderText>(child).removeAndDestroyTextBoxes();
 
-    if (!parent.renderTreeBeingDestroyed() && is<RenderFlexibleBox>(parent) && !child.isFloatingOrOutOfFlowPositioned() && child.isBox())
+    if (!parent.renderTreeBeingDestroyed() && is<RenderFlexibleBox>(parent) && !child.isFloatingOrOutOfFlowPositioned() && child.isRenderBox())
         downcast<RenderFlexibleBox>(parent).clearCachedChildIntrinsicContentLogicalHeight(downcast<RenderBox>(child));
 
     // If child is the start or end of the selection, then clear the selection to
@@ -1020,7 +1020,7 @@ void RenderTreeBuilder::reportVisuallyNonEmptyContent(const RenderElement& paren
         m_view.frameView().incrementVisuallyNonEmptyPixelCount(roundedIntSize(replacedRenderer.intrinsicSize()));
         return;
     }
-    if (child.isSVGRootOrLegacySVGRoot()) {
+    if (child.isRenderOrLegacyRenderSVGRoot()) {
         auto fixedSize = [] (const auto& renderer) -> std::optional<IntSize> {
             auto& style = renderer.style();
             if (!style.width().isFixed() || !style.height().isFixed())

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -47,7 +47,7 @@ static bool canDropAnonymousBlock(const RenderBlock& anonymousBlock)
 {
     if (anonymousBlock.beingDestroyed() || anonymousBlock.continuation())
         return false;
-    if (anonymousBlock.isRubyRun() || anonymousBlock.isRubyBase())
+    if (anonymousBlock.isRenderRubyRun() || anonymousBlock.isRenderRubyBase())
         return false;
     return true;
 }
@@ -173,7 +173,7 @@ void RenderTreeBuilder::Block::attachIgnoringContinuation(RenderBlock& parent, R
                 m_builder.attach(parent, WTFMove(child), beforeChildContainer);
                 return;
             }
-            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!beforeChildContainer->isInline() || beforeChildContainer->isTable());
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!beforeChildContainer->isInline() || beforeChildContainer->isRenderTable());
 
             // If the requested beforeChild is not one of our children, then this is because
             // there is an anonymous container within this object that contains the beforeChild.
@@ -197,7 +197,7 @@ void RenderTreeBuilder::Block::attachIgnoringContinuation(RenderBlock& parent, R
                 return;
             }
 
-            ASSERT(beforeChildAnonymousContainer->isTable());
+            ASSERT(beforeChildAnonymousContainer->isRenderTable());
 
             if (child->isTablePart()) {
                 // Insert into the anonymous table.

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -77,7 +77,7 @@ static inline bool isRubyAfterBlock(const RenderObject* object)
 #if ASSERT_ENABLED
 static inline bool isRubyChildForNormalRemoval(const RenderObject& object)
 {
-    return object.isRubyRun()
+    return object.isRenderRubyRun()
     || object.isBeforeContent()
     || object.isAfterContent()
     || object.isRenderMultiColumnFlow()
@@ -187,7 +187,7 @@ void RenderTreeBuilder::Ruby::moveChildrenInternal(RenderRubyBase& from, RenderR
 
 void RenderTreeBuilder::Ruby::attach(RenderRubyRun& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
 {
-    if (child->isRubyText()) {
+    if (child->isRenderRubyText()) {
         if (!beforeChild) {
             // RenderRuby has already ascertained that we can add the child here.
             ASSERT(!parent.hasRubyText());
@@ -195,7 +195,7 @@ void RenderTreeBuilder::Ruby::attach(RenderRubyRun& parent, RenderPtr<RenderObje
             m_builder.blockFlowBuilder().attach(parent, WTFMove(child), parent.firstChild());
             return;
         }
-        if (beforeChild->isRubyText()) {
+        if (beforeChild->isRenderRubyText()) {
             // New text is inserted just before another.
             // In this case the new text takes the place of the old one, and
             // the old text goes into a new run that is inserted as next sibling.
@@ -228,7 +228,7 @@ void RenderTreeBuilder::Ruby::attach(RenderRubyRun& parent, RenderPtr<RenderObje
         return;
     }
     // child is not a text -> insert it into the base
-    if (beforeChild && beforeChild->isRubyText()) {
+    if (beforeChild && beforeChild->isRenderRubyText()) {
         // Append it instead if beforeChild is the ruby text.
         beforeChild = nullptr;
     }
@@ -273,14 +273,14 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForChild(RenderRubyAsB
     }
 
     // If the child is a ruby run, just add it normally.
-    if (child.isRubyRun())
+    if (child.isRenderRubyRun())
         return parent;
 
     if (beforeChild && !parent.isBeforeOrAfterContent(beforeChild)) {
         // insert child into run
-        ASSERT(!beforeChild->isRubyRun());
+        ASSERT(!beforeChild->isRenderRubyRun());
         auto* run = beforeChild->parent();
-        while (run && !run->isRubyRun())
+        while (run && !run->isRenderRubyRun())
             run = run->parent();
         if (run)
             return *run;
@@ -335,14 +335,14 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForChild(RenderRubyAsI
     }
 
     // If the child is a ruby run, just add it normally.
-    if (child.isRubyRun())
+    if (child.isRenderRubyRun())
         return parent;
 
     if (beforeChild && !parent.isBeforeOrAfterContent(beforeChild)) {
         // insert child into run
-        ASSERT(!beforeChild->isRubyRun());
+        ASSERT(!beforeChild->isRenderRubyRun());
         auto* run = beforeChild->parent();
-        while (run && !run->isRubyRun())
+        while (run && !run->isRenderRubyRun())
             run = run->parent();
         if (run)
             return *run;
@@ -365,7 +365,7 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForChild(RenderRubyAsI
 
 RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild(RenderElement& parent, const RenderObject& child, RenderObject*& beforeChild)
 {
-    if (!child.isText() && child.style().display() == DisplayType::Ruby && parent.style().display() == DisplayType::RubyBlock)
+    if (!child.isRenderText() && child.style().display() == DisplayType::Ruby && parent.style().display() == DisplayType::RubyBlock)
         return parent;
 
     if (parent.style().display() != DisplayType::Ruby) {
@@ -377,7 +377,7 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
         return *newParent;
     }
 
-    if (!child.isText() && (child.style().display() == DisplayType::RubyBase || child.style().display() == DisplayType::RubyAnnotation))
+    if (!child.isRenderText() && (child.style().display() == DisplayType::RubyBase || child.style().display() == DisplayType::RubyAnnotation))
         return parent;
 
     if (beforeChild && beforeChild->parent()->style().display() == DisplayType::RubyBase)
@@ -456,7 +456,7 @@ RenderPtr<RenderObject> RenderTreeBuilder::Ruby::detach(RenderRubyRun& parent, R
 {
     // If the child is a ruby text, then merge the ruby base with the base of
     // the right sibling run, if possible.
-    if (!parent.beingDestroyed() && !parent.renderTreeBeingDestroyed() && child.isRubyText()) {
+    if (!parent.beingDestroyed() && !parent.renderTreeBeingDestroyed() && child.isRenderRubyText()) {
         RenderRubyBase* base = parent.rubyBase();
         RenderObject* rightNeighbour = parent.nextSibling();
         if (base && is<RenderRubyRun>(rightNeighbour)) {

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -446,7 +446,7 @@ bool RenderTreeUpdater::textRendererIsNeeded(const Text& textNode)
     if (is<RenderText>(renderingParent.previousChildRenderer))
         return true;
     // This text node has nothing but white space. We may still need a renderer in some cases.
-    if (parentRenderer.isTable() || parentRenderer.isTableRow() || parentRenderer.isTableSection() || parentRenderer.isRenderTableCol() || parentRenderer.isFrameSet() || parentRenderer.isRenderGrid() || (parentRenderer.isRenderFlexibleBox() && !parentRenderer.isRenderButton()))
+    if (parentRenderer.isRenderTable() || parentRenderer.isRenderTableRow() || parentRenderer.isRenderTableSection() || parentRenderer.isRenderTableCol() || parentRenderer.isRenderFrameSet() || parentRenderer.isRenderGrid() || (parentRenderer.isRenderFlexibleBox() && !parentRenderer.isRenderButton()))
         return false;
     if (parentRenderer.style().preserveNewline()) // pre/pre-wrap/pre-line always make renderers.
         return true;

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1162,7 +1162,7 @@ bool SVGElement::hasAssociatedSVGLayoutBox() const
         return false;
 
     // Legacy SVG engine specific condition.
-    if (renderer()->isLegacySVGRoot())
+    if (renderer()->isLegacyRenderSVGRoot())
         return false;
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -120,7 +120,7 @@ void SVGFELightElement::svgAttributeChanged(const QualifiedName& attrName)
             return;
 
         auto* renderer = parent->renderer();
-        if (!renderer || !renderer->isSVGResourceFilterPrimitive())
+        if (!renderer || !renderer->isRenderSVGResourceFilterPrimitive())
             return;
 
         if (is<SVGFEDiffuseLightingElement>(*parent)) {

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -169,7 +169,7 @@ void SVGFilterPrimitiveStandardAttributes::invalidateFilterPrimitiveParent(SVGEl
         return;
 
     RenderElement* renderer = parent->renderer();
-    if (!renderer || !renderer->isSVGResourceFilterPrimitive())
+    if (!renderer || !renderer->isRenderSVGResourceFilterPrimitive())
         return;
 
     downcast<SVGElement>(*parent).updateSVGRendererForElementChange();

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -130,7 +130,7 @@ bool SVGForeignObjectElement::rendererIsNeeded(const RenderStyle& style)
         return false;
 
     while (ancestor && ancestor->isSVGElement()) {
-        if (ancestor->renderer() && (ancestor->renderer()->isSVGHiddenContainer() || ancestor->renderer()->isLegacySVGHiddenContainer()))
+        if (ancestor->renderer() && (ancestor->renderer()->isRenderSVGHiddenContainer() || ancestor->renderer()->isLegacyRenderSVGHiddenContainer()))
             return false;
 
         ancestor = ancestor->parentElement();

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -214,7 +214,7 @@ SVGTextContentElement* SVGTextContentElement::elementFromRenderer(RenderObject* 
     if (!renderer)
         return nullptr;
 
-    if (!renderer->isSVGText() && !renderer->isSVGInline())
+    if (!renderer->isRenderSVGText() && !renderer->isRenderSVGInline())
         return nullptr;
 
     SVGElement* element = downcast<SVGElement>(renderer->node());

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -127,7 +127,7 @@ void SVGImage::setContainerSize(const FloatSize& size)
         return;
 
     auto rootElement = this->rootElement();
-    if (!rootElement || !rootElement->renderer() || !rootElement->renderer()->isSVGRootOrLegacySVGRoot())
+    if (!rootElement || !rootElement->renderer() || !rootElement->renderer()->isRenderOrLegacyRenderSVGRoot())
         return;
 
     RefPtr view = frameView();
@@ -149,7 +149,7 @@ void SVGImage::setContainerSize(const FloatSize& size)
 IntSize SVGImage::containerSize() const
 {
     auto rootElement = this->rootElement();
-    if (!rootElement || !rootElement->renderer() || !rootElement->renderer()->isSVGRootOrLegacySVGRoot())
+    if (!rootElement || !rootElement->renderer() || !rootElement->renderer()->isRenderOrLegacyRenderSVGRoot())
         return { };
 
     // If a container size is available it has precedence.

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -50,7 +50,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
         return { };
 
     auto colorSpaceForBitmap = screenColorSpace(localMainFrame->view());
-    if (!renderImage.isMedia() && !renderImage.opacity() && options.useSnapshotForTransparentImages == UseSnapshotForTransparentImages::Yes) {
+    if (!renderImage.isRenderMedia() && !renderImage.opacity() && options.useSnapshotForTransparentImages == UseSnapshotForTransparentImages::Yes) {
         auto snapshotRect = renderImage.absoluteBoundingBoxRect();
         if (snapshotRect.isEmpty())
             return { };

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3216,7 +3216,7 @@ static bool canForceCaretForPosition(const VisiblePosition& position)
     if (!renderer)
         return false;
 
-    return renderer->isText() && node->canStartSelection();
+    return renderer->isRenderText() && node->canStartSelection();
 }
 
 static void populateCaretContext(const HitTestResult& hitTestResult, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)

--- a/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
@@ -208,7 +208,7 @@ static WebCore::Node* firstNodeAfter(const WebCore::BoundaryPoint& point)
     return renderer
         && renderer->childrenInline()
         && (is<RenderBlock>(*renderer) && !downcast<RenderBlock>(*renderer).inlineContinuation())
-        && !renderer->isTable();
+        && !renderer->isRenderTable();
 }
 
 - (BOOL)isSelectableBlock
@@ -261,7 +261,7 @@ static WebCore::Node* firstNodeAfter(const WebCore::BoundaryPoint& point)
     RenderObject * renderer = core(self)->renderer();
     if (renderer) {
         if (renderer->isFloatingOrOutOfFlowPositioned() ||
-            renderer->isWidget()) {
+            renderer->isRenderWidget()) {
             result = INT_MAX;
         } else if (!renderer->firstChildSlow()) {
             result = 0;


### PR DESCRIPTION
#### 56ee1935e46b77c6ea9eff813922be2dcae4f876
<pre>
Unify the naming of the RenderObject type checking functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=264378">https://bugs.webkit.org/show_bug.cgi?id=264378</a>

Reviewed by Simon Fraser.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isMeter const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::boundingBoxRect const):
(WebCore::AccessibilityRenderObject::supportsPath const):
(WebCore::AccessibilityRenderObject::computeAccessibilityIsIgnored const):
(WebCore::AccessibilityRenderObject::setValue):
(WebCore::AccessibilityRenderObject::renderObjectIsObservable const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilitySVGElement.cpp:
(WebCore::AccessibilitySVGElement::description const):
(WebCore::AccessibilitySVGElement::computeAccessibilityIsIgnored const):
(WebCore::AccessibilitySVGElement::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySliderThumb::elementRect const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::positionOffsetValue):
(WebCore::paddingOrMarginIsRendererDependent):
(WebCore::positionOffsetValueIsRendererDependent):
(WebCore::isFlexOrGridItem):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateHoverActiveState):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::clientWidth):
(WebCore::Element::clientHeight):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::addBlockPlaceholderIfNeeded):
* Source/WebCore/editing/Editing.cpp:
(WebCore::isBlock):
(WebCore::isTableStructureNode):
(WebCore::isFirstPositionAfterTable):
(WebCore::isLastPositionBeforeTable):
(WebCore::isListItem):
(WebCore::isRenderedTable):
(WebCore::isTableCell):
(WebCore::isRenderedAsNonInlineTableImageOrHR):
* Source/WebCore/editing/Editor.cpp:
(WebCore::findFirstMarkable):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::InsertParagraphSeparatorCommand::doApply):
* Source/WebCore/editing/ModifySelectionListLevel.cpp:
(WebCore::getStartEndListChildren):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::doApply):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::ignoresContainerClip):
(WebCore::isRendererReplacedElement):
(WebCore::shouldEmitNewlinesBeforeAndAfterNode):
(WebCore::TextIterator::shouldRepresentNodeOffsetZero):
(WebCore::TextIterator::shouldEmitSpaceBeforeAndAfterNode):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::forwardDeleteKeyPressed):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::rendererIsNeeded):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::willRespondToMouseClickEventsWithEditability const):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::updateListBoxSelection):
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::defaultEventHandler):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::RenderSliderContainer::computeLogicalHeight const):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::buildRendererHighlight):
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::setVerticalPropertiesForInlineLevelBox const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::candidateContentForLine):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::appendInlineBoxDisplayBox):
(WebCore::Layout::InlineDisplayContentBuilder::appendSpanningInlineBoxDisplayBox):
(WebCore::Layout::InlineDisplayContentBuilder::handleInlineBoxEnd):
(WebCore::Layout::InlineDisplayContentBuilder::appendRubyAnnotationBox):
(WebCore::Layout::InlineDisplayContentBuilder::applyRubyOverhang):
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
(WebCore::Layout::nextWrapOpportunityWithinRubyContainer):
(WebCore::Layout::RubyFormattingContext::placeRubyContent):
(WebCore::Layout::RubyFormattingContext::placeAnnotationBox):
(WebCore::Layout::RubyFormattingContext::sizeAnnotationBox):
(WebCore::Layout::RubyFormattingContext::applyAnnotationContributionToLayoutBounds const):
(WebCore::Layout::RubyFormattingContext::nextWrapOpportunity):
(WebCore::Layout::RubyFormattingContext::annotationOverlapCheck const):
(WebCore::Layout::RubyFormattingContext::logicaWidthForRubyRange const):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForChild):
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
(WebCore::LayoutIntegration::canUseForFlexLayout):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp:
(WebCore::InlineIterator::closestBoxForHorizontalPosition):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::isContentRenderer):
(WebCore::LayoutIntegration::LineLayout::containing):
* Source/WebCore/layout/layouttree/LayoutBox.h:
(WebCore::Layout::Box::isRenderRubyBase const):
(WebCore::Layout::Box::isRubyBase const): Deleted.
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::startAutoscrollForSelection):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMouseDraggedEvent):
(WebCore::EventHandler::updateSelectionForMouseDrag):
(WebCore::EventHandler::scrollOverflow):
(WebCore::EventHandler::logicalScrollOverflow):
(WebCore::EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFocusedElementInternal):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::nodeRespondingToScrollWheelEvents):
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForText):
(WebCore::computeCaretRectForBox):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::mediaElement const):
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::logicalHeight const):
* Source/WebCore/rendering/LegacyInlineBox.h:
(WebCore::LegacyInlineBox::isLineBreak const):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addToLine):
(WebCore::verticalAlignApplies):
* Source/WebCore/rendering/LegacyInlineIterator.h:
(WebCore::isIteratorTarget):
(WebCore::LegacyInlineIterator::direction const):
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::isRenderLineBreak const):
(WebCore::LegacyInlineTextBox::nodeAtPoint):
(WebCore::LegacyInlineTextBox::paint):
(WebCore::LegacyInlineTextBox::selectableRange const):
(WebCore::LegacyInlineTextBox::expansionBehavior const):
(WebCore::LegacyInlineTextBox::isLineBreak const): Deleted.
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::constructLine):
(WebCore::LegacyLineLayout::setMarginsForRubyRun):
(WebCore::LegacyLineLayout::computeExpansionForJustifiedText):
(WebCore::isLastInFlowRun):
(WebCore::LegacyLineLayout::computeInlineDirectionPositionsForSegment):
(WebCore::LegacyLineLayout::createLineBoxesFromBidiRuns):
(WebCore::LegacyLineLayout::layoutLineBoxes):
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::selectionTop const):
(WebCore::LegacyRootInlineBox::selectionBottom const):
(WebCore::LegacyRootInlineBox::ascentAndDescentForBox const):
(WebCore::LegacyRootInlineBox::verticalPositionForBox):
(WebCore::LegacyRootInlineBox::includeLeadingForBox const):
(WebCore::LegacyRootInlineBox::includeFontForBox const):
(WebCore::LegacyRootInlineBox::includeGlyphsForBox const):
(WebCore::LegacyRootInlineBox::includeInitialLetterForBox const):
(WebCore::LegacyRootInlineBox::includeMarginForBox const):
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::RenderAttachment):
* Source/WebCore/rendering/RenderAttachment.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::isSelfCollapsingBlock const):
(WebCore::RenderBlock::isSelectionRoot const):
(WebCore::RenderBlock::paintSelection):
(WebCore::RenderBlock::selectionGaps):
(WebCore::RenderBlock::blockSelectionGaps):
(WebCore::RenderBlock::hitTestContents):
(WebCore::RenderBlock::positionForPoint):
(WebCore::RenderBlock::computePreferredLogicalWidths):
(WebCore::RenderBlock::computeBlockPreferredLogicalWidths const):
(WebCore::RenderBlock::computeChildPreferredLogicalWidths const):
(WebCore::RenderBlock::baselinePosition const):
(WebCore::RenderBlock::firstLineBaseline const):
(WebCore::RenderBlock::lastLineBaseline const):
(WebCore::RenderBlock::inlineBlockBaseline const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::MarginInfo::MarginInfo):
(WebCore::RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats):
(WebCore::RenderBlockFlow::willCreateColumns const):
(WebCore::RenderBlockFlow::layoutBlock):
(WebCore::RenderBlockFlow::marginBeforeEstimateForChild const):
(WebCore::RenderBlockFlow::adjustBlockChildForPagination):
(WebCore::RenderBlockFlow::computeLineAdjustmentForPagination):
(WebCore::RenderBlockFlow::firstLineBaseline const):
(WebCore::RenderBlockFlow::lastLineBaseline const):
(WebCore::RenderBlockFlow::inlineBlockBaseline const):
(WebCore::RenderBlockFlow::inlineSelectionGaps):
(WebCore::RenderBlockFlow::positionForPointWithInlineChildren):
(WebCore::isNonBlocksOrNonFixedHeightListItems):
(WebCore::InlineMinMaxIterator::next):
(WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::RenderBox):
(WebCore::RenderBox::computeBackgroundIsKnownToBeObscured):
(WebCore::RenderBox::computeVisibleRectInContainer const):
(WebCore::RenderBox::computeLogicalWidthInFragment const):
(WebCore::RenderBox::isStretchingColumnFlexItem const):
(WebCore::RenderBox::sizesLogicalWidthToFitContent const):
(WebCore::RenderBox::overrideLogicalHeightForSizeContainment):
(WebCore::RenderBox::computeLogicalHeight const):
(WebCore::RenderBox::skipContainingBlockForPercentHeightCalculation const):
(WebCore::RenderBox::computePercentageLogicalHeight const):
(WebCore::RenderBox::computeReplacedLogicalHeightUsing const):
(WebCore::RenderBox::availableLogicalHeightUsing const):
(WebCore::RenderBox::computeBlockDirectionMargins const):
(WebCore::RenderBox::containingBlockLogicalHeightForPositioned const):
(WebCore::RenderBox::computePositionedLogicalHeightUsing const):
(WebCore::RenderBox::positionForPoint):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::RenderBoxModelObject):
(WebCore::RenderBoxModelObject::containingBlockForAutoHeightDetection const):
(WebCore::RenderBoxModelObject::hasAutoHeightOrContainingBlockWithAutoHeight const):
(WebCore::RenderBoxModelObject::computeStickyPositionConstraints const):
* Source/WebCore/rendering/RenderBoxModelObject.h:
(WebCore::RenderBoxModelObject::canHaveBoxInfoInFragment const):
* Source/WebCore/rendering/RenderCombineText.cpp:
(WebCore::RenderCombineText::RenderCombineText):
* Source/WebCore/rendering/RenderCombineText.h:
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::RenderCounter::RenderCounter):
* Source/WebCore/rendering/RenderCounter.h:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::layoutBlock):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h:
* Source/WebCore/rendering/RenderDetailsMarker.cpp:
(WebCore::RenderDetailsMarker::RenderDetailsMarker):
* Source/WebCore/rendering/RenderDetailsMarker.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::layerCreationAllowedForSubtree const):
(WebCore::RenderElement::adjustComputedFontSizesOnBlocks):
(WebCore::RenderElement::resetTextAutosizing):
(WebCore::RenderElement::createsNewFormattingContext const):
(WebCore::RenderElement::referenceBoxRect const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::isDeprecatedFlexItem const):
(WebCore::RenderElement::isRenderBoxModelObject const):
(WebCore::RenderObject::isRenderBoxModelObject const):
(WebCore::RenderObject::isFlexibleBoxIncludingDeprecated const):
(WebCore::RenderObject::style const):
(WebCore::RenderObject::firstLineStyle const):
(WebCore::RenderObject::isSkippedContentRoot const):
(WebCore::RenderElement::isBoxModelObject const): Deleted.
(WebCore::RenderObject::isBoxModelObject const): Deleted.
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::canContainAbsolutelyPositionedObjects const):
(WebCore::RenderElement::canContainFixedPositionObjects const):
(WebCore::RenderElement::shouldApplyLayoutOrPaintContainment const):
(WebCore::RenderElement::shouldApplySizeOrStyleContainment const):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::RenderEmbeddedObject):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::RenderFileUploadControl):
* Source/WebCore/rendering/RenderFileUploadControl.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeChildIntrinsicLogicalWidths const):
(WebCore::isSVGRootWithIntrinsicAspectRatio):
(WebCore::RenderFlexibleBox::computeMainSizeFromAspectRatioUsing const):
(WebCore::RenderFlexibleBox::computeFlexItemMinMaxSizes):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::objectShouldFragmentInFlowFragment const):
(WebCore::RenderFragmentedFlow::objectInFlowFragment const):
* Source/WebCore/rendering/RenderFrame.cpp:
(WebCore::RenderFrame::RenderFrame):
* Source/WebCore/rendering/RenderFrame.h:
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::RenderFrameSet):
(WebCore::RenderFrameSet::layout):
(WebCore::RenderFrameSet::isChildAllowed const):
* Source/WebCore/rendering/RenderFrameSet.h:
* Source/WebCore/rendering/RenderGeometryMap.cpp:
(WebCore::canMapBetweenRenderersViaLayers):
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::RenderHTMLCanvas):
* Source/WebCore/rendering/RenderHTMLCanvas.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::RenderLayer):
(WebCore::RenderLayer::shouldBeNormalFlowOnly const):
(WebCore::RenderLayer::referenceBoxRectForClipPath const):
(WebCore::expandClipRectForDescendantsAndReflection):
(WebCore::RenderLayer::beginTransparencyLayers):
(WebCore::RenderLayer::convertToLayerCoords const):
(WebCore::RenderLayer::shouldTryToScrollForScrollIntoView const):
(WebCore::RenderLayer::paintLayerByApplyingTransform):
(WebCore::RenderLayer::enclosingSVGRootLayer const):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
(WebCore::RenderLayer::isReflection const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::canvasCompositingStrategy):
(WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):
(WebCore::RenderLayerBacking::shouldSetContentsDisplayDelegate const):
(WebCore::RenderLayerBacking::updateVideoGravity):
(WebCore::RenderLayerBacking::updateContentsScalingFilters):
(WebCore::RenderLayerBacking::contentChanged):
(WebCore::RenderLayerBacking::startAnimation):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::requiresCompositingForCanvas const):
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::canUseOffsetFromAncestor const):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::rendererNeedsPixelSnapping):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::createOrDestroyMarquee):
(WebCore::RenderLayerScrollableArea::isScrollCornerVisible const):
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::RenderLineBreak):
(WebCore::RenderLineBreak::collectSelectionGeometries):
* Source/WebCore/rendering/RenderLineBreak.h:
* Source/WebCore/rendering/RenderListBox.h:
(isType):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::RenderListItem):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::RenderListMarker):
(WebCore::RenderListMarker::addOverflowFromListMarker):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/RenderMedia.h:
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::RenderMenuList):
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderMeter.cpp:
(WebCore::RenderMeter::RenderMeter):
* Source/WebCore/rendering/RenderMeter.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::objectIsRelayoutBoundary):
(WebCore::RenderObject::invalidateContainerPreferredLogicalWidths):
(WebCore::RenderObject::collectSelectionGeometriesInternal):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderElement const):
(WebCore::RenderObject::isRenderCounter const):
(WebCore::RenderObject::isRenderQuote const):
(WebCore::RenderObject::isRenderDetailsMarker const):
(WebCore::RenderObject::isRenderEmbeddedObject const):
(WebCore::RenderObject::isRenderFileUploadControl const):
(WebCore::RenderObject::isRenderFrame const):
(WebCore::RenderObject::isRenderFrameSet const):
(WebCore::RenderObject::isRenderListBox const):
(WebCore::RenderObject::isRenderListItem const):
(WebCore::RenderObject::isRenderListMarker const):
(WebCore::RenderObject::isRenderMedia const):
(WebCore::RenderObject::isRenderMenuList const):
(WebCore::RenderObject::isRenderMeter const):
(WebCore::RenderObject::isRenderProgress const):
(WebCore::RenderObject::isRenderTextFragment const):
(WebCore::RenderObject::isRenderReplica const):
(WebCore::RenderObject::isRenderRubyAsInline const):
(WebCore::RenderObject::isRenderRubyAsBlock const):
(WebCore::RenderObject::isRenderRubyBase const):
(WebCore::RenderObject::isRenderRubyRun const):
(WebCore::RenderObject::isRenderRubyText const):
(WebCore::RenderObject::isRenderSlider const):
(WebCore::RenderObject::isRenderTableCell const):
(WebCore::RenderObject::isRenderTableCaption const):
(WebCore::RenderObject::isRenderTableSection const):
(WebCore::RenderObject::isRenderTextControlMultiLine const):
(WebCore::RenderObject::isRenderTextControlSingleLine const):
(WebCore::RenderObject::isRenderSearchField const):
(WebCore::RenderObject::isRenderTextControlInnerBlock const):
(WebCore::RenderObject::isRenderVideo const):
(WebCore::RenderObject::isRenderWidget const):
(WebCore::RenderObject::isRenderHTMLCanvas const):
(WebCore::RenderObject::isRenderAttachment const):
(WebCore::RenderObject::isTablePart const):
(WebCore::RenderObject::isLegacyRenderSVGRoot const):
(WebCore::RenderObject::isRenderSVGRoot const):
(WebCore::RenderObject::isRenderSVGContainer const):
(WebCore::RenderObject::isLegacyRenderSVGContainer const):
(WebCore::RenderObject::isRenderSVGTransformableContainer const):
(WebCore::RenderObject::isLegacyRenderSVGTransformableContainer const):
(WebCore::RenderObject::isRenderSVGViewportContainer const):
(WebCore::RenderObject::isLegacyRenderSVGViewportContainer const):
(WebCore::RenderObject::isRenderSVGGradientStop const):
(WebCore::RenderObject::isLegacyRenderSVGHiddenContainer const):
(WebCore::RenderObject::isRenderSVGHiddenContainer const):
(WebCore::RenderObject::isLegacyRenderSVGPath const):
(WebCore::RenderObject::isRenderSVGPath const):
(WebCore::RenderObject::isRenderSVGShape const):
(WebCore::RenderObject::isLegacyRenderSVGShape const):
(WebCore::RenderObject::isRenderSVGText const):
(WebCore::RenderObject::isRenderSVGTextPath const):
(WebCore::RenderObject::isRenderSVGTSpan const):
(WebCore::RenderObject::isRenderSVGInline const):
(WebCore::RenderObject::isRenderSVGInlineText const):
(WebCore::RenderObject::isLegacyRenderSVGImage const):
(WebCore::RenderObject::isRenderSVGImage const):
(WebCore::RenderObject::isLegacyRenderSVGForeignObject const):
(WebCore::RenderObject::isRenderSVGForeignObject const):
(WebCore::RenderObject::isLegacyRenderSVGResourceContainer const):
(WebCore::RenderObject::isRenderSVGResourceContainer const):
(WebCore::RenderObject::isRenderSVGResourceFilter const):
(WebCore::RenderObject::isLegacyRenderSVGResourceClipper const):
(WebCore::RenderObject::isRenderSVGResourceClipper const):
(WebCore::RenderObject::isRenderSVGResourceFilterPrimitive const):
(WebCore::RenderObject::isRenderOrLegacyRenderSVGRoot const):
(WebCore::RenderObject::isRenderOrLegacyRenderSVGShape const):
(WebCore::RenderObject::isRenderOrLegacyRenderSVGPath const):
(WebCore::RenderObject::isRenderOrLegacyRenderSVGImage const):
(WebCore::RenderObject::isRenderOrLegacyRenderSVGForeignObject const):
(WebCore::RenderObject::isSVGLayerAwareRenderer const):
(WebCore::RenderObject::hasIntrinsicAspectRatio const):
(WebCore::RenderObject::shouldUsePositionedClipping const):
(WebCore::RenderObject::isRenderText const):
(WebCore::RenderObject::isRenderLineBreak const):
(WebCore::RenderObject::isBR const):
(WebCore::RenderObject::isLineBreakOpportunity const):
(WebCore::RenderObject::isRenderTextOrLineBreak const):
(WebCore::RenderObject::isRenderBox const):
(WebCore::RenderObject::isRenderTableRow const):
(WebCore::RenderObject::setIsRenderText):
(WebCore::RenderObject::setIsRenderBox):
(WebCore::RenderObject::isRenderDeprecatedFlexibleBox const):
(WebCore::RenderObject::isRenderCombineText const):
(WebCore::RenderObject::RenderObjectBitfields::RenderObjectBitfields):
(WebCore::RenderObject::isBeforeContent const):
(WebCore::RenderObject::isAfterContent const):
(WebCore::RenderObject::isAnonymousBlock const):
(WebCore::RenderObject::setPositionState):
(WebCore::RenderObject::isRenderTable const):
(WebCore::RenderObject::isCounter const): Deleted.
(WebCore::RenderObject::isQuote const): Deleted.
(WebCore::RenderObject::isDetailsMarker const): Deleted.
(WebCore::RenderObject::isEmbeddedObject const): Deleted.
(WebCore::RenderObject::isFileUploadControl const): Deleted.
(WebCore::RenderObject::isFrame const): Deleted.
(WebCore::RenderObject::isFrameSet const): Deleted.
(WebCore::RenderObject::isListBox const): Deleted.
(WebCore::RenderObject::isListItem const): Deleted.
(WebCore::RenderObject::isListMarker const): Deleted.
(WebCore::RenderObject::isMedia const): Deleted.
(WebCore::RenderObject::isMenuList const): Deleted.
(WebCore::RenderObject::isMeter const): Deleted.
(WebCore::RenderObject::isProgress const): Deleted.
(WebCore::RenderObject::isTextFragment const): Deleted.
(WebCore::RenderObject::isReplica const): Deleted.
(WebCore::RenderObject::isRubyInline const): Deleted.
(WebCore::RenderObject::isRubyBlock const): Deleted.
(WebCore::RenderObject::isRubyBase const): Deleted.
(WebCore::RenderObject::isRubyRun const): Deleted.
(WebCore::RenderObject::isRubyText const): Deleted.
(WebCore::RenderObject::isSlider const): Deleted.
(WebCore::RenderObject::isTableCell const): Deleted.
(WebCore::RenderObject::isTableCaption const): Deleted.
(WebCore::RenderObject::isTableSection const): Deleted.
(WebCore::RenderObject::isTextArea const): Deleted.
(WebCore::RenderObject::isTextField const): Deleted.
(WebCore::RenderObject::isSearchField const): Deleted.
(WebCore::RenderObject::isTextControlInnerBlock const): Deleted.
(WebCore::RenderObject::isVideo const): Deleted.
(WebCore::RenderObject::isWidget const): Deleted.
(WebCore::RenderObject::isCanvas const): Deleted.
(WebCore::RenderObject::isAttachment const): Deleted.
(WebCore::RenderObject::isLegacySVGRoot const): Deleted.
(WebCore::RenderObject::isSVGRoot const): Deleted.
(WebCore::RenderObject::isSVGContainer const): Deleted.
(WebCore::RenderObject::isLegacySVGContainer const): Deleted.
(WebCore::RenderObject::isSVGTransformableContainer const): Deleted.
(WebCore::RenderObject::isLegacySVGTransformableContainer const): Deleted.
(WebCore::RenderObject::isSVGViewportContainer const): Deleted.
(WebCore::RenderObject::isLegacySVGViewportContainer const): Deleted.
(WebCore::RenderObject::isSVGGradientStop const): Deleted.
(WebCore::RenderObject::isLegacySVGHiddenContainer const): Deleted.
(WebCore::RenderObject::isSVGHiddenContainer const): Deleted.
(WebCore::RenderObject::isLegacySVGPath const): Deleted.
(WebCore::RenderObject::isSVGPath const): Deleted.
(WebCore::RenderObject::isSVGShape const): Deleted.
(WebCore::RenderObject::isLegacySVGShape const): Deleted.
(WebCore::RenderObject::isSVGText const): Deleted.
(WebCore::RenderObject::isSVGTextPath const): Deleted.
(WebCore::RenderObject::isSVGTSpan const): Deleted.
(WebCore::RenderObject::isSVGInline const): Deleted.
(WebCore::RenderObject::isSVGInlineText const): Deleted.
(WebCore::RenderObject::isLegacySVGImage const): Deleted.
(WebCore::RenderObject::isSVGImage const): Deleted.
(WebCore::RenderObject::isLegacySVGForeignObject const): Deleted.
(WebCore::RenderObject::isSVGForeignObject const): Deleted.
(WebCore::RenderObject::isLegacySVGResourceContainer const): Deleted.
(WebCore::RenderObject::isSVGResourceContainer const): Deleted.
(WebCore::RenderObject::isSVGResourceFilter const): Deleted.
(WebCore::RenderObject::isLegacySVGResourceClipper const): Deleted.
(WebCore::RenderObject::isSVGResourceClipper const): Deleted.
(WebCore::RenderObject::isSVGResourceFilterPrimitive const): Deleted.
(WebCore::RenderObject::isSVGRootOrLegacySVGRoot const): Deleted.
(WebCore::RenderObject::isSVGShapeOrLegacySVGShape const): Deleted.
(WebCore::RenderObject::isSVGPathOrLegacySVGPath const): Deleted.
(WebCore::RenderObject::isSVGImageOrLegacySVGImage const): Deleted.
(WebCore::RenderObject::isSVGForeignObjectOrLegacySVGForeignObject const): Deleted.
(WebCore::RenderObject::isText const): Deleted.
(WebCore::RenderObject::isLineBreak const): Deleted.
(WebCore::RenderObject::isTextOrLineBreak const): Deleted.
(WebCore::RenderObject::isBox const): Deleted.
(WebCore::RenderObject::isTableRow const): Deleted.
(WebCore::RenderObject::setIsText): Deleted.
(WebCore::RenderObject::setIsBox): Deleted.
(WebCore::RenderObject::isDeprecatedFlexibleBox const): Deleted.
(WebCore::RenderObject::isCombineText const): Deleted.
(WebCore::RenderObject::isTable const): Deleted.
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::preservesNewline const):
* Source/WebCore/rendering/RenderProgress.cpp:
(WebCore::RenderProgress::RenderProgress):
* Source/WebCore/rendering/RenderProgress.h:
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::RenderQuote::RenderQuote):
* Source/WebCore/rendering/RenderQuote.h:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeIntrinsicRatioInformation const):
(WebCore::hasIntrinsicSize):
* Source/WebCore/rendering/RenderReplica.h:
* Source/WebCore/rendering/RenderRuby.cpp:
(WebCore::RenderRubyAsInline::RenderRubyAsInline):
(WebCore::RenderRubyAsBlock::RenderRubyAsBlock):
* Source/WebCore/rendering/RenderRuby.h:
* Source/WebCore/rendering/RenderRubyBase.cpp:
(WebCore::RenderRubyBase::RenderRubyBase):
* Source/WebCore/rendering/RenderRubyBase.h:
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::RenderRubyRun):
(WebCore::RenderRubyRun::hasRubyText const):
(WebCore::RenderRubyRun::hasRubyBase const):
(WebCore::RenderRubyRun::rubyText const):
(WebCore::RenderRubyRun::rubyBase const):
(WebCore::RenderRubyRun::isChildAllowed const):
* Source/WebCore/rendering/RenderRubyRun.h:
* Source/WebCore/rendering/RenderRubyText.cpp:
(WebCore::RenderRubyText::RenderRubyText):
* Source/WebCore/rendering/RenderRubyText.h:
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::RenderSearchField):
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/rendering/RenderSelection.cpp:
(WebCore::RenderSelection::apply):
* Source/WebCore/rendering/RenderSlider.cpp:
(WebCore::RenderSlider::RenderSlider):
* Source/WebCore/rendering/RenderSlider.h:
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::RenderTable):
(WebCore::RenderTable::paintObject):
(WebCore::RenderTable::nodeAtPoint):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableCaption.cpp:
(WebCore::RenderTableCaption::RenderTableCaption):
* Source/WebCore/rendering/RenderTableCaption.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::RenderTableCell):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::RenderTableRow):
* Source/WebCore/rendering/RenderTableRow.h:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::RenderTableSection):
* Source/WebCore/rendering/RenderTableSection.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::offsetForPositionInRun):
(WebCore::RenderText::RenderText):
(WebCore::RenderText::collectSelectionGeometries):
(WebCore::RenderText::positionForPoint):
(WebCore::containsOffset):
(WebCore::RenderText::emphasisMarkExistsAndIsAbove):
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/RenderTextControlMultiLine.cpp:
(WebCore::RenderTextControlMultiLine::RenderTextControlMultiLine):
* Source/WebCore/rendering/RenderTextControlMultiLine.h:
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlInnerBlock::RenderTextControlInnerBlock):
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
* Source/WebCore/rendering/RenderTextFragment.h:
(isType):
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::paintProgressBar):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintMenuListButtonDecorations):
(WebCore::RenderThemeIOS::paintMenuListButtonDecorationsWithFormControlRefresh):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::RenderVideo):
* Source/WebCore/rendering/RenderVideo.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::isChildAllowed const):
(WebCore::RenderView::layout):
* Source/WebCore/rendering/RenderWidget.h:
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::collectStylesForRenderer):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::BreakingContext):
(WebCore::BreakingContext::initializeForCurrentObject):
(WebCore::BreakingContext::handleText):
(WebCore::BreakingContext::canBreakAtThisPosition):
(WebCore::BreakingContext::commitAndUpdateLineBreakIfNeeded):
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(WebCore::RenderSVGForeignObject::RenderSVGForeignObject):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::RenderSVGGradientStop):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.h:
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp:
(WebCore::RenderSVGHiddenContainer::RenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::RenderSVGImage):
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::RenderSVGInline):
* Source/WebCore/rendering/svg/RenderSVGInline.h:
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::RenderSVGInlineText):
(WebCore::RenderSVGInlineText::characterStartsNewTextChunk const):
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::isGraphicsElement):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::RenderSVGPath):
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::RenderSVGResourceClipper):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::RenderSVGResourceContainer):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
(isType):
* Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::RenderSVGRoot):
(WebCore::RenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument const):
(WebCore::RenderSVGRoot::paintObject):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGTSpan.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::RenderSVGText):
(WebCore::RenderSVGText::subtreeChildWasAdded):
(WebCore::RenderSVGText::subtreeChildWillBeRemoved):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
(WebCore::RenderSVGTextPath::RenderSVGTextPath):
* Source/WebCore/rendering/svg/RenderSVGTextPath.h:
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::RenderSVGTransformableContainer::RenderSVGTransformableContainer):
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::RenderSVGViewportContainer):
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.h:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::positionChildrenRelativeToContainer):
(WebCore::SVGContainerLayout::verifyLayoutLocationConsistency):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::nodeAtPoint):
* Source/WebCore/rendering/svg/SVGLayerTransformComputation.h:
(WebCore::SVGLayerTransformComputation::computeAccumulatedTransform const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
(WebCore::SVGRenderSupport::computeContainerStrokeBoundingBox):
(WebCore::SVGRenderSupport::transformToRootChanged):
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGContainer):
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):
(WebCore::SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::rendererCanHaveResources):
(WebCore::SVGResourcesCache::clientStyleChanged):
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp:
(WebCore::SVGResourcesCycleSolver::resourceContainsCycles):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::parentDefinesTextLength const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::LegacyRenderSVGForeignObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::LegacyRenderSVGImage):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::isGraphicsElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::LegacyRenderSVGPath):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::LegacyRenderSVGResource::fillAndStrokePathOrShape const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::drawContentIntoMaskImage):
(WebCore::LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect):
(WebCore::LegacyRenderSVGResourceClipper::hitTestClipContent):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::computeTextPaintingScale):
(WebCore::LegacyRenderSVGResourceContainer::transformOnNonScalingStroke):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::LegacyRenderSVGRoot):
(WebCore::LegacyRenderSVGRoot::paintReplaced):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp:
(WebCore::LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::attachToRenderElementInternal):
(WebCore::RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers):
(WebCore::RenderTreeBuilder::detachFromRenderElement):
(WebCore::RenderTreeBuilder::reportVisuallyNonEmptyContent):
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::canDropAnonymousBlock):
(WebCore::RenderTreeBuilder::Block::attachIgnoringContinuation):
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::isRubyChildForNormalRemoval):
(WebCore::RenderTreeBuilder::Ruby::attach):
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForChild):
(WebCore::RenderTreeBuilder::Ruby::detach):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::textRendererIsNeeded):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::hasAssociatedSVGLayoutBox const):
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::invalidateFilterPrimitiveParent):
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::rendererIsNeeded):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::elementFromRenderer):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::setContainerSize):
(WebCore::SVGImage::containerSize const):
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm:
(-[DOMNode containsOnlyInlineObjects]):
(-[DOMHTMLElement structuralComplexityContribution]):

Canonical link: <a href="https://commits.webkit.org/270396@main">https://commits.webkit.org/270396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d867f485da85b0074e8cedb5cba4cee13f6863d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23269 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1393 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28060 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22830 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26773 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/824 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3935 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3016 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3240 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2913 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->