### PR TITLE
Refactor some fundamentals in ArgumentCodersCocoa.h

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -632,7 +632,7 @@ def decode_type(type):
         if len(decodable_classes) == 1:
             match = re.search("RetainPtr<(.*)>", member.type)
             assert match
-            result.append('    auto ' + sanitized_variable_name + ' = IPC::decode<' + match.groups()[0] + '>(decoder, @[ ' + decodable_classes[0] + ' ]);')
+            result.append('    auto ' + sanitized_variable_name + ' = decoder.decodeWithAllowedClasses<' + match.groups()[0] + '>(@[ ' + decodable_classes[0] + ' ]);')
         elif member.is_subclass:
             result.append('    if (type == ' + type.subclass_enum_name() + "::" + member.name + ') {')
             typename = member.namespace + "::" + member.name

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -204,7 +204,7 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
 {
     auto a = decoder.decode<int>();
     auto b = decoder.decode<bool>();
-    auto dataDetectorResults = IPC::decode<NSArray>(decoder, @[ NSArray.class, PAL::getDDScannerResultClass() ]);
+    auto dataDetectorResults = decoder.decodeWithAllowedClasses<NSArray>(@[ NSArray.class, PAL::getDDScannerResultClass() ]);
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {
@@ -563,8 +563,8 @@ void ArgumentCoder<SoftLinkedMember>::encode(Encoder& encoder, const SoftLinkedM
 
 std::optional<SoftLinkedMember> ArgumentCoder<SoftLinkedMember>::decode(Decoder& decoder)
 {
-    auto firstMember = IPC::decode<DDActionContext>(decoder, @[ PAL::getDDActionContextClass() ]);
-    auto secondMember = IPC::decode<DDActionContext>(decoder, @[ PAL::getDDActionContextClass() ]);
+    auto firstMember = decoder.decodeWithAllowedClasses<DDActionContext>(@[ PAL::getDDActionContextClass() ]);
+    auto secondMember = decoder.decodeWithAllowedClasses<DDActionContext>(@[ PAL::getDDActionContextClass() ]);
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -492,13 +492,13 @@ static inline void encodeFontInternal(Encoder& encoder, CocoaFont *font)
 
 static std::optional<RetainPtr<id>> decodeFontInternal(Decoder& decoder)
 {
-    RetainPtr<NSDictionary> fontAttributes;
-    if (!decode(decoder, fontAttributes))
+    std::optional<RetainPtr<NSDictionary>> fontAttributes = decoder.decode<RetainPtr<NSDictionary>>();
+    if (!fontAttributes)
         return std::nullopt;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    return { WebKit::fontWithAttributes(fontAttributes.get(), 0) };
+    return { WebKit::fontWithAttributes(fontAttributes->get(), 0) };
 
     END_BLOCK_OBJC_EXCEPTIONS
 

--- a/Source/WebKit/Shared/mac/ObjCObjectGraph.mm
+++ b/Source/WebKit/Shared/mac/ObjCObjectGraph.mm
@@ -245,20 +245,20 @@ bool ObjCObjectGraph::decode(IPC::Decoder& decoder, RetainPtr<id>& result)
     }
 
     case ObjCType::NSData: {
-        RetainPtr<NSData> data;
-        if (!IPC::decode(decoder, data))
+        std::optional<RetainPtr<NSData>> data = decoder.decode<RetainPtr<NSData>>();
+        if (!data)
             return false;
 
-        result = WTFMove(data);
+        result = WTFMove(*data);
         return true;
     }
 
     case ObjCType::NSDate: {
-        RetainPtr<NSDate> date;
-        if (!IPC::decode(decoder, date))
+        std::optional<RetainPtr<NSDate>> date = decoder.decode<RetainPtr<NSDate>>();
+        if (!date)
             return false;
 
-        result = WTFMove(date);
+        result = WTFMove(*date);
         return true;
     }
 
@@ -289,20 +289,20 @@ bool ObjCObjectGraph::decode(IPC::Decoder& decoder, RetainPtr<id>& result)
     }
 
     case ObjCType::NSNumber: {
-        RetainPtr<NSNumber> number;
-        if (!IPC::decode(decoder, number))
+        std::optional<RetainPtr<NSNumber>> number = decoder.decode<RetainPtr<NSNumber>>();
+        if (!number)
             return false;
 
-        result = WTFMove(number);
+        result = WTFMove(*number);
         return true;
     }
 
     case ObjCType::NSString: {
-        RetainPtr<NSString> string;
-        if (!IPC::decode(decoder, string))
+        std::optional<RetainPtr<NSString>> string = decoder.decode<RetainPtr<NSString>>();
+        if (!string)
             return false;
 
-        result = WTFMove(string);
+        result = WTFMove(*string);
         return true;
     }
 

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -197,7 +197,7 @@ void ArgumentCoder<WebCore::Credential>::encodePlatformData(Encoder& encoder, co
 
 bool ArgumentCoder<WebCore::Credential>::decodePlatformData(Decoder& decoder, WebCore::Credential& credential)
 {
-    auto nsCredential = IPC::decode<NSURLCredential>(decoder);
+    std::optional<RetainPtr<NSURLCredential>> nsCredential = decoder.decode<RetainPtr<NSURLCredential>>();
     if (!nsCredential)
         return false;
     credential = WebCore::Credential { nsCredential->get() };


### PR DESCRIPTION
#### 90ecb2cd9622645eadbe43708accc91290196bdf
<pre>
Refactor some fundamentals in ArgumentCodersCocoa.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=264385">https://bugs.webkit.org/show_bug.cgi?id=264385</a>
<a href="https://rdar.apple.com/118099847">rdar://118099847</a>

Reviewed by Alex Christensen.

- Make all encode() methods work in terms of a single master encode() method
- Get rid of many extra decode() methods
- Make all decode() methods work in terms of a single master decode() method
- Rename the final decode() method that takes &quot;allowed classes&quot; to &quot;decodeWithAllowedClasses&quot; for compile
  safety and clarity
- Move the main &quot;decodeWithAllowedClasses&quot; entry point to Decoder itself to avoid re-entrancy in some situations.
- Make the way that &quot;decodeWithAllowedClasses&quot; gets the default array-of-allowed-classes a template so
  our softlinked classes can work with the default parameter
- Update callers that used to explicitly pass an allowed class to rely on the default, when possible.

Why do all this?

It makes Obj-C decode use nicer to write and to look at.

But also upcoming work for NSArray and NSDictionary will completely upend how we encode/decode for our Obj-C types
and this patch is a standalone prerequisite to enabling that work.

* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::getClass):
(IPC::Decoder::decodeWithAllowedClasses):
* Source/WebKit/Scripts/generate-serializers.py:
(decode_type):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;SoftLinkedMember&gt;::decode):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
(IPC::decodeWithAllowedClasses):
(IPC::ArgumentCoder&lt;RetainPtr&lt;T&gt;&gt;::decode):
(IPC::encode):
(IPC::decode): Deleted.
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::decodeFontInternal):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::getClass&lt;PKPayment&gt;):
(IPC::getClass&lt;PKContact&gt;):
(IPC::getClass&lt;PKPaymentMerchantSession&gt;):
(IPC::getClass&lt;PKPaymentMethod&gt;):
(IPC::ArgumentCoder&lt;WebCore::Payment&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::PaymentContact&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::PaymentMerchantSession&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::PaymentMethod&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::PaymentSessionError&gt;::decode):
(IPC::getClass&lt;DDScannerResult&gt;):
(IPC::ArgumentCoder&lt;WebCore::DataDetectorElementInfo&gt;::decode):
(IPC::getClass&lt;AVOutputContext&gt;):
(IPC::ArgumentCoder&lt;WebCore::MediaPlaybackTargetContext&gt;::decodePlatformData):
(IPC::ArgumentCoder&lt;WebCore::TextRecognitionDataDetector&gt;::decodePlatformData):
(IPC::getClass&lt;VKCImageAnalysis&gt;):
(IPC::ArgumentCoder&lt;RetainPtr&lt;VKCImageAnalysis&gt;&gt;::decode):
* Source/WebKit/Shared/mac/ObjCObjectGraph.mm:
(WebKit::ObjCObjectGraph::decode):
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;WebCore::Credential&gt;::decodePlatformData):

Canonical link: <a href="https://commits.webkit.org/270461@main">https://commits.webkit.org/270461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d847459df1330503b36a21620ac336ebc40a886f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23414 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23561 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28232 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/25709 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29069 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26916 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/973 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4101 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6131 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->