### PR TITLE
Move approved WebGL extensions out of draft

### DIFF
--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,31 +2,17 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 38 PASS, 0 FAIL
+TEST COMPLETE: 22 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
 PASS webgl:EXT_blend_func_extended: Has object.
-PASS webgl:EXT_clip_control: Supported
-PASS webgl:EXT_clip_control: Has object.
-PASS webgl:EXT_depth_clamp: Supported
-PASS webgl:EXT_depth_clamp: Has object.
-PASS webgl:EXT_polygon_offset_clamp: Supported
-PASS webgl:EXT_polygon_offset_clamp: Has object.
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl:WEBGL_polygon_mode: Supported
-PASS webgl:WEBGL_polygon_mode: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_clip_control: Supported
-PASS webgl2:EXT_clip_control: Has object.
 PASS webgl2:EXT_conservative_depth: Supported
 PASS webgl2:EXT_conservative_depth: Has object.
-PASS webgl2:EXT_depth_clamp: Supported
-PASS webgl2:EXT_depth_clamp: Has object.
-PASS webgl2:EXT_polygon_offset_clamp: Supported
-PASS webgl2:EXT_polygon_offset_clamp: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
@@ -38,8 +24,6 @@ PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
-PASS webgl2:WEBGL_polygon_mode: Supported
-PASS webgl2:WEBGL_polygon_mode: Has object.
 PASS webgl2:WEBGL_stencil_texturing: Supported
 PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,31 +2,17 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 38 PASS, 0 FAIL
+TEST COMPLETE: 22 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
 PASS webgl:EXT_blend_func_extended: Has object.
-PASS webgl:EXT_clip_control: Supported
-PASS webgl:EXT_clip_control: Has object.
-PASS webgl:EXT_depth_clamp: Supported
-PASS webgl:EXT_depth_clamp: Has object.
-PASS webgl:EXT_polygon_offset_clamp: Supported
-PASS webgl:EXT_polygon_offset_clamp: Has object.
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl:WEBGL_polygon_mode: Supported
-PASS webgl:WEBGL_polygon_mode: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_clip_control: Supported
-PASS webgl2:EXT_clip_control: Has object.
 PASS webgl2:EXT_conservative_depth: Supported
 PASS webgl2:EXT_conservative_depth: Has object.
-PASS webgl2:EXT_depth_clamp: Supported
-PASS webgl2:EXT_depth_clamp: Has object.
-PASS webgl2:EXT_polygon_offset_clamp: Supported
-PASS webgl2:EXT_polygon_offset_clamp: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
@@ -38,8 +24,6 @@ PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
-PASS webgl2:WEBGL_polygon_mode: Supported
-PASS webgl2:WEBGL_polygon_mode: Has object.
 PASS webgl2:WEBGL_stencil_texturing: Supported
 PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true

--- a/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
+++ b/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
@@ -5,18 +5,11 @@
 let currentDraftExtensions = {
     "webgl": [
         "EXT_blend_func_extended",
-        "EXT_clip_control",
-        "EXT_depth_clamp",
-        "EXT_polygon_offset_clamp",
         "EXT_texture_mirror_clamp_to_edge",
-        "WEBGL_polygon_mode",
     ],
     "webgl2" : [
         "EXT_blend_func_extended",
-        "EXT_clip_control",
         "EXT_conservative_depth",
-        "EXT_depth_clamp",
-        "EXT_polygon_offset_clamp",
         "EXT_render_snorm",
         "EXT_texture_mirror_clamp_to_edge",
         "NV_shader_noperspective_interpolation",
@@ -24,7 +17,6 @@ let currentDraftExtensions = {
         "OES_shader_multisample_interpolation",
         "WEBGL_draw_instanced_base_vertex_base_instance",
         "WEBGL_multi_draw_instanced_base_vertex_base_instance",
-        "WEBGL_polygon_mode",
         // Not checked here because availability would be
         // different for Intel and Apple silicon Macs
         // "WEBGL_render_shared_exponent",

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,31 +2,17 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 41 PASS, 0 FAIL
+TEST COMPLETE: 25 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
 PASS webgl:EXT_blend_func_extended: Has object.
-PASS webgl:EXT_clip_control: Supported
-PASS webgl:EXT_clip_control: Has object.
-PASS webgl:EXT_depth_clamp: Supported
-PASS webgl:EXT_depth_clamp: Has object.
-PASS webgl:EXT_polygon_offset_clamp: Supported
-PASS webgl:EXT_polygon_offset_clamp: Has object.
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl:WEBGL_polygon_mode: Supported
-PASS webgl:WEBGL_polygon_mode: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_clip_control: Supported
-PASS webgl2:EXT_clip_control: Has object.
 PASS webgl2:EXT_conservative_depth: Supported
 PASS webgl2:EXT_conservative_depth: Has object.
-PASS webgl2:EXT_depth_clamp: Supported
-PASS webgl2:EXT_depth_clamp: Has object.
-PASS webgl2:EXT_polygon_offset_clamp: Supported
-PASS webgl2:EXT_polygon_offset_clamp: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
@@ -41,8 +27,6 @@ PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Has object.
-PASS webgl2:WEBGL_polygon_mode: Supported
-PASS webgl2:WEBGL_polygon_mode: Has object.
 PASS webgl2:WEBGL_stencil_texturing: Supported
 PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
@@ -2,20 +2,13 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 21 PASS, 0 FAIL
+TEST COMPLETE: 13 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Not supported
-PASS webgl:EXT_clip_control: Not supported
-PASS webgl:EXT_depth_clamp: Not supported
-PASS webgl:EXT_polygon_offset_clamp: Not supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Not supported
-PASS webgl:WEBGL_polygon_mode: Not supported
 PASS webgl2:EXT_blend_func_extended: Not supported
-PASS webgl2:EXT_clip_control: Not supported
 PASS webgl2:EXT_conservative_depth: Not supported
-PASS webgl2:EXT_depth_clamp: Not supported
-PASS webgl2:EXT_polygon_offset_clamp: Not supported
 PASS webgl2:EXT_render_snorm: Not supported
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Not supported
 PASS webgl2:NV_shader_noperspective_interpolation: Not supported
@@ -23,7 +16,6 @@ PASS webgl2:OES_sample_variables: Not supported
 PASS webgl2:OES_shader_multisample_interpolation: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
-PASS webgl2:WEBGL_polygon_mode: Not supported
 PASS webgl2:WEBGL_stencil_texturing: Not supported
 PASS successfullyParsed is true
 

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,31 +2,17 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 41 PASS, 0 FAIL
+TEST COMPLETE: 25 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
 PASS webgl:EXT_blend_func_extended: Has object.
-PASS webgl:EXT_clip_control: Supported
-PASS webgl:EXT_clip_control: Has object.
-PASS webgl:EXT_depth_clamp: Supported
-PASS webgl:EXT_depth_clamp: Has object.
-PASS webgl:EXT_polygon_offset_clamp: Supported
-PASS webgl:EXT_polygon_offset_clamp: Has object.
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl:WEBGL_polygon_mode: Supported
-PASS webgl:WEBGL_polygon_mode: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_clip_control: Supported
-PASS webgl2:EXT_clip_control: Has object.
 PASS webgl2:EXT_conservative_depth: Supported
 PASS webgl2:EXT_conservative_depth: Has object.
-PASS webgl2:EXT_depth_clamp: Supported
-PASS webgl2:EXT_depth_clamp: Has object.
-PASS webgl2:EXT_polygon_offset_clamp: Supported
-PASS webgl2:EXT_polygon_offset_clamp: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
@@ -41,8 +27,6 @@ PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Has object.
-PASS webgl2:WEBGL_polygon_mode: Supported
-PASS webgl2:WEBGL_polygon_mode: Has object.
 PASS webgl2:WEBGL_stencil_texturing: Supported
 PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2557,14 +2557,14 @@ std::optional<WebGLExtensionAny> WebGL2RenderingContext::getExtension(const Stri
     }
 
     ENABLE_IF_REQUESTED(EXTBlendFuncExtended, m_extBlendFuncExtended, "EXT_blend_func_extended"_s, EXTBlendFuncExtended::supported(*m_context) && enableDraftExtensions);
-    ENABLE_IF_REQUESTED(EXTClipControl, m_extClipControl, "EXT_clip_control"_s, EXTClipControl::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTClipControl, m_extClipControl, "EXT_clip_control"_s, EXTClipControl::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTColorBufferFloat, m_extColorBufferFloat, "EXT_color_buffer_float"_s, EXTColorBufferFloat::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTColorBufferHalfFloat, m_extColorBufferHalfFloat, "EXT_color_buffer_half_float"_s, EXTColorBufferHalfFloat::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTConservativeDepth, m_extConservativeDepth, "EXT_conservative_depth"_s, EXTConservativeDepth::supported(*m_context) && enableDraftExtensions);
-    ENABLE_IF_REQUESTED(EXTDepthClamp, m_extDepthClamp, "EXT_depth_clamp"_s, EXTDepthClamp::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTDepthClamp, m_extDepthClamp, "EXT_depth_clamp"_s, EXTDepthClamp::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTDisjointTimerQueryWebGL2, m_extDisjointTimerQueryWebGL2, "EXT_disjoint_timer_query_webgl2"_s, EXTDisjointTimerQueryWebGL2::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled);
     ENABLE_IF_REQUESTED(EXTFloatBlend, m_extFloatBlend, "EXT_float_blend"_s, EXTFloatBlend::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTPolygonOffsetClamp, m_extPolygonOffsetClamp, "EXT_polygon_offset_clamp"_s, EXTPolygonOffsetClamp::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTPolygonOffsetClamp, m_extPolygonOffsetClamp, "EXT_polygon_offset_clamp"_s, EXTPolygonOffsetClamp::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTRenderSnorm, m_extRenderSnorm, "EXT_render_snorm"_s, EXTRenderSnorm::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(EXTTextureCompressionBPTC, m_extTextureCompressionBPTC, "EXT_texture_compression_bptc"_s, EXTTextureCompressionBPTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureCompressionRGTC, m_extTextureCompressionRGTC, "EXT_texture_compression_rgtc"_s, EXTTextureCompressionRGTC::supported(*m_context));
@@ -2591,7 +2591,7 @@ std::optional<WebGLExtensionAny> WebGL2RenderingContext::getExtension(const Stri
     ENABLE_IF_REQUESTED(WebGLLoseContext, m_webglLoseContext, "WEBGL_lose_context"_s, true);
     ENABLE_IF_REQUESTED(WebGLMultiDraw, m_webglMultiDraw, "WEBGL_multi_draw"_s, WebGLMultiDraw::supported(*m_context));
     ENABLE_IF_REQUESTED(WebGLMultiDrawInstancedBaseVertexBaseInstance, m_webglMultiDrawInstancedBaseVertexBaseInstance, "WEBGL_multi_draw_instanced_base_vertex_base_instance"_s, WebGLMultiDrawInstancedBaseVertexBaseInstance::supported(*m_context) && enableDraftExtensions);
-    ENABLE_IF_REQUESTED(WebGLPolygonMode, m_webglPolygonMode, "WEBGL_polygon_mode"_s, WebGLPolygonMode::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(WebGLPolygonMode, m_webglPolygonMode, "WEBGL_polygon_mode"_s, WebGLPolygonMode::supported(*m_context));
     ENABLE_IF_REQUESTED(WebGLProvokingVertex, m_webglProvokingVertex, "WEBGL_provoking_vertex"_s, WebGLProvokingVertex::supported(*m_context));
     ENABLE_IF_REQUESTED(WebGLRenderSharedExponent, m_webglRenderSharedExponent, "WEBGL_render_shared_exponent"_s, WebGLRenderSharedExponent::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(WebGLStencilTexturing, m_webglStencilTexturing, "WEBGL_stencil_texturing"_s, WebGLStencilTexturing::supported(*m_context) && enableDraftExtensions);
@@ -2612,14 +2612,14 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
         result.append(nameLiteral ## _s);
 
     APPEND_IF_SUPPORTED("EXT_blend_func_extended", EXTBlendFuncExtended::supported(*m_context) && enableDraftExtensions)
-    APPEND_IF_SUPPORTED("EXT_clip_control", EXTClipControl::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_clip_control", EXTClipControl::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_color_buffer_float", EXTColorBufferFloat::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_color_buffer_half_float", EXTColorBufferHalfFloat::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_conservative_depth", EXTConservativeDepth::supported(*m_context) && enableDraftExtensions)
-    APPEND_IF_SUPPORTED("EXT_depth_clamp", EXTDepthClamp::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_depth_clamp", EXTDepthClamp::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_disjoint_timer_query_webgl2", EXTDisjointTimerQueryWebGL2::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled)
     APPEND_IF_SUPPORTED("EXT_float_blend", EXTFloatBlend::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_polygon_offset_clamp", EXTPolygonOffsetClamp::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_polygon_offset_clamp", EXTPolygonOffsetClamp::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_render_snorm", EXTRenderSnorm::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("EXT_texture_compression_bptc", EXTTextureCompressionBPTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_compression_rgtc", EXTTextureCompressionRGTC::supported(*m_context))
@@ -2646,7 +2646,7 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("WEBGL_lose_context", true)
     APPEND_IF_SUPPORTED("WEBGL_multi_draw", WebGLMultiDraw::supported(*m_context))
     APPEND_IF_SUPPORTED("WEBGL_multi_draw_instanced_base_vertex_base_instance", WebGLMultiDrawInstancedBaseVertexBaseInstance::supported(*m_context) && enableDraftExtensions)
-    APPEND_IF_SUPPORTED("WEBGL_polygon_mode", WebGLPolygonMode::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("WEBGL_polygon_mode", WebGLPolygonMode::supported(*m_context))
     APPEND_IF_SUPPORTED("WEBGL_provoking_vertex", WebGLProvokingVertex::supported(*m_context))
     APPEND_IF_SUPPORTED("WEBGL_render_shared_exponent", WebGLRenderSharedExponent::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("WEBGL_stencil_texturing", WebGLStencilTexturing::supported(*m_context) && enableDraftExtensions)

--- a/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
+++ b/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
@@ -38,6 +38,7 @@ WebGLPolygonMode::WebGLPolygonMode(WebGLRenderingContextBase& context)
     : WebGLExtension(context)
 {
     context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_polygon_mode"_s);
+    context.printToConsole(MessageLevel::Warning, "WebGL: non-portable extension enabled: WEBGL_polygon_mode"_s);
 }
 
 WebGLPolygonMode::~WebGLPolygonMode() = default;

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -150,13 +150,13 @@ std::optional<WebGLExtensionAny> WebGLRenderingContext::getExtension(const Strin
     ENABLE_IF_REQUESTED(ANGLEInstancedArrays, m_angleInstancedArrays, "ANGLE_instanced_arrays", ANGLEInstancedArrays::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTBlendFuncExtended, m_extBlendFuncExtended, "EXT_blend_func_extended", EXTBlendFuncExtended::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(EXTBlendMinMax, m_extBlendMinMax, "EXT_blend_minmax", EXTBlendMinMax::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTClipControl, m_extClipControl, "EXT_clip_control", EXTClipControl::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTClipControl, m_extClipControl, "EXT_clip_control", EXTClipControl::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTColorBufferHalfFloat, m_extColorBufferHalfFloat, "EXT_color_buffer_half_float", EXTColorBufferHalfFloat::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTDepthClamp, m_extDepthClamp, "EXT_depth_clamp", EXTDepthClamp::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTDepthClamp, m_extDepthClamp, "EXT_depth_clamp", EXTDepthClamp::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTDisjointTimerQuery, m_extDisjointTimerQuery, "EXT_disjoint_timer_query", EXTDisjointTimerQuery::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled);
     ENABLE_IF_REQUESTED(EXTFloatBlend, m_extFloatBlend, "EXT_float_blend", EXTFloatBlend::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTFragDepth, m_extFragDepth, "EXT_frag_depth", EXTFragDepth::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTPolygonOffsetClamp, m_extPolygonOffsetClamp, "EXT_polygon_offset_clamp", EXTPolygonOffsetClamp::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTPolygonOffsetClamp, m_extPolygonOffsetClamp, "EXT_polygon_offset_clamp", EXTPolygonOffsetClamp::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTShaderTextureLOD, m_extShaderTextureLOD, "EXT_shader_texture_lod", EXTShaderTextureLOD::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureCompressionBPTC, m_extTextureCompressionBPTC, "EXT_texture_compression_bptc", EXTTextureCompressionBPTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureCompressionRGTC, m_extTextureCompressionRGTC, "EXT_texture_compression_rgtc", EXTTextureCompressionRGTC::supported(*m_context));
@@ -186,7 +186,7 @@ std::optional<WebGLExtensionAny> WebGLRenderingContext::getExtension(const Strin
     ENABLE_IF_REQUESTED(WebGLDrawBuffers, m_webglDrawBuffers, "WEBGL_draw_buffers", supportsDrawBuffers());
     ENABLE_IF_REQUESTED(WebGLLoseContext, m_webglLoseContext, "WEBGL_lose_context", true);
     ENABLE_IF_REQUESTED(WebGLMultiDraw, m_webglMultiDraw, "WEBGL_multi_draw", WebGLMultiDraw::supported(*m_context));
-    ENABLE_IF_REQUESTED(WebGLPolygonMode, m_webglPolygonMode, "WEBGL_polygon_mode", WebGLPolygonMode::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(WebGLPolygonMode, m_webglPolygonMode, "WEBGL_polygon_mode", WebGLPolygonMode::supported(*m_context));
     return std::nullopt;
 }
 
@@ -206,13 +206,13 @@ std::optional<Vector<String>> WebGLRenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("ANGLE_instanced_arrays", ANGLEInstancedArrays::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_blend_func_extended", EXTBlendFuncExtended::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("EXT_blend_minmax", EXTBlendMinMax::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_clip_control", EXTClipControl::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_clip_control", EXTClipControl::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_color_buffer_half_float", EXTColorBufferHalfFloat::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_depth_clamp", EXTDepthClamp::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_depth_clamp", EXTDepthClamp::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_disjoint_timer_query", EXTDisjointTimerQuery::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled)
     APPEND_IF_SUPPORTED("EXT_float_blend", EXTFloatBlend::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_frag_depth", EXTFragDepth::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_polygon_offset_clamp", EXTPolygonOffsetClamp::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_polygon_offset_clamp", EXTPolygonOffsetClamp::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_shader_texture_lod", EXTShaderTextureLOD::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_compression_bptc", EXTTextureCompressionBPTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_compression_rgtc", EXTTextureCompressionRGTC::supported(*m_context))
@@ -242,7 +242,7 @@ std::optional<Vector<String>> WebGLRenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("WEBGL_draw_buffers", supportsDrawBuffers())
     APPEND_IF_SUPPORTED("WEBGL_lose_context", true)
     APPEND_IF_SUPPORTED("WEBGL_multi_draw", WebGLMultiDraw::supported(*m_context))
-    APPEND_IF_SUPPORTED("WEBGL_polygon_mode", WebGLPolygonMode::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("WEBGL_polygon_mode", WebGLPolygonMode::supported(*m_context))
 
     return result;
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -468,6 +468,7 @@ protected:
     friend class WebGLDrawInstancedBaseVertexBaseInstance;
     friend class WebGLMultiDraw;
     friend class WebGLMultiDrawInstancedBaseVertexBaseInstance;
+    friend class WebGLPolygonMode;
 
     friend class WebGLFramebuffer;
     friend class WebGLObject;


### PR DESCRIPTION
#### dbf64f1b24966bbad23ee57abf64c1c5ff1d07dd
<pre>
Move approved WebGL extensions out of draft
<a href="https://bugs.webkit.org/show_bug.cgi?id=264365">https://bugs.webkit.org/show_bug.cgi?id=264365</a>

Reviewed by Kimmo Kinnunen.

Enabled support for the following approved extensions:
* EXT_clip_control
* EXT_depth_clamp
* EXT_polygon_offset_clamp
* WEBGL_polygon_mode

* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt:
* LayoutTests/webgl/resources/webgl-draft-extensions-flag.js:
* LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getExtension):
(WebCore::WebGL2RenderingContext::getSupportedExtensions):
* Source/WebCore/html/canvas/WebGLPolygonMode.cpp:
(WebCore::WebGLPolygonMode::WebGLPolygonMode):
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::getExtension):
(WebCore::WebGLRenderingContext::getSupportedExtensions):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/270382@main">https://commits.webkit.org/270382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4cd386c82bd0e0fb1a3f418c27ea12c33e9a3ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23228 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1300 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28015 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28888 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26729 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3861 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6070 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2946 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2838 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->