### PR TITLE
Deploy smart pointers in UserTypingGestureIndicator.cpp, VisitedLinkState.cpp, and ImageControlsMac.cpp

### DIFF
--- a/Source/WebCore/dom/UserTypingGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserTypingGestureIndicator.cpp
@@ -54,7 +54,8 @@ UserTypingGestureIndicator::UserTypingGestureIndicator(LocalFrame& frame)
     , m_previousFocusedNode(focusedNode())
 {
     s_processingUserTypingGesture = true;
-    focusedNode() = frame.document() ? frame.document()->focusedElement() : nullptr;
+    RefPtr document = frame.document();
+    focusedNode() = document ? document->focusedElement() : nullptr;
 }
 
 UserTypingGestureIndicator::~UserTypingGestureIndicator()

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -49,7 +49,7 @@ public:
 private:
     InsideLink determineLinkStateSlowCase(const Element&);
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
     HashSet<SharedStringHash, SharedStringHashHash> m_linksCheckedForVisitedState;
 };
 

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -127,7 +127,7 @@ void createImageControls(HTMLElement& element)
     controlLayer->appendChild(button);
     controlLayer->setPseudo(ShadowPseudoIds::appleAttachmentControlsContainer());
     
-    if (auto* renderObject = element.renderer(); is<RenderImage>(renderObject))
+    if (CheckedPtr renderObject = element.renderer(); is<RenderImage>(renderObject))
         downcast<RenderImage>(*renderObject).setHasShadowControls(true);
 }
 
@@ -151,7 +151,7 @@ bool handleEvent(HTMLElement& element, Event& event)
     if (!frame)
         return false;
 
-    Page* page = element.document().page();
+    CheckedPtr page = element.document().page();
     if (!page)
         return false;
     
@@ -176,7 +176,7 @@ bool handleEvent(HTMLElement& element, Event& event)
         auto point = view->contentsToWindow(renderer->absoluteBoundingBoxRect()).minXMaxYCorner();
 
         if (RefPtr shadowHost = dynamicDowncast<HTMLImageElement>(node.shadowHost())) {
-            auto* image = imageFromImageElementNode(*shadowHost);
+            RefPtr image = imageFromImageElementNode(*shadowHost);
             if (!image)
                 return false;
             page->chrome().client().handleImageServiceClick(point, *image, *shadowHost);


### PR DESCRIPTION
#### 4a439beec114c45217f5cf7f2d8b7ef486f96dfe
<pre>
Deploy smart pointers in UserTypingGestureIndicator.cpp, VisitedLinkState.cpp, and ImageControlsMac.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264389">https://bugs.webkit.org/show_bug.cgi?id=264389</a>

Reviewed by Chris Dumez.

Deploy smart pointers as warned by the clang static analyzer.

* Source/WebCore/dom/UserTypingGestureIndicator.cpp:
(WebCore::UserTypingGestureIndicator::UserTypingGestureIndicator):
* Source/WebCore/dom/VisitedLinkState.cpp:
(WebCore::linkAttribute):
(WebCore::VisitedLinkState::invalidateStyleForAllLinks):
(WebCore::VisitedLinkState::invalidateStyleForLink):
(WebCore::VisitedLinkState::determineLinkStateSlowCase):
* Source/WebCore/dom/VisitedLinkState.h:
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::createImageControls):
(WebCore::ImageControlsMac::handleEvent):

Canonical link: <a href="https://commits.webkit.org/270391@main">https://commits.webkit.org/270391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fd2b27e54a05537b24ee6b35b78563ecc69c703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27439 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23429 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28018 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28892 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/791 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3864 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2949 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2841 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->