### PR TITLE
[TextureMapper] Use OptionSet for BitmapTexture flags

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3267,7 +3267,10 @@ void MediaPlayerPrivateGStreamer::pushTextureToCompositor()
         } else {
             layerBuffer = proxy.getAvailableBuffer(frameHolder->size(), GL_DONT_CARE);
             if (UNLIKELY(!layerBuffer)) {
-                auto texture = BitmapTexture::create(frameHolder->size(), frameHolder->hasAlphaChannel() ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag);
+                OptionSet<BitmapTexture::Flags> flags;
+                if (frameHolder->hasAlphaChannel())
+                    flags.add(BitmapTexture::Flags::SupportsAlpha);
+                auto texture = BitmapTexture::create(frameHolder->size(), flags);
                 layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(texture));
             }
             frameHolder->updateTexture(layerBuffer->texture());

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
@@ -83,7 +83,10 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
                         return;
 
                     auto size = nativeImage->size();
-                    texture = BitmapTexture::create(size, nativeImage->hasAlpha() ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag);
+                    OptionSet<BitmapTexture::Flags> flags;
+                    if (nativeImage->hasAlpha())
+                        flags.add(BitmapTexture::Flags::SupportsAlpha);
+                    texture = BitmapTexture::create(size, flags);
 #if USE(CAIRO)
                     auto* surface = nativeImage->platformImage().get();
                     auto* imageData = cairo_image_surface_get_data(surface);

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -54,7 +54,7 @@ static const GLenum s_pixelDataType = GL_UNSIGNED_BYTE;
 
 namespace WebCore {
 
-BitmapTexture::BitmapTexture(const IntSize& size, const Flags flags, GLint internalFormat)
+BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags, GLint internalFormat)
     : m_flags(flags)
     , m_size(size)
     , m_internalFormat(internalFormat == GL_DONT_CARE ? GL_RGBA : internalFormat)
@@ -69,7 +69,7 @@ BitmapTexture::BitmapTexture(const IntSize& size, const Flags flags, GLint inter
     glTexImage2D(GL_TEXTURE_2D, 0, m_internalFormat, m_size.width(), m_size.height(), 0, m_format, s_pixelDataType, nullptr);
 }
 
-void BitmapTexture::reset(const IntSize& size, const Flags flags)
+void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
 {
     m_flags = flags;
     m_shouldClear = true;
@@ -256,7 +256,7 @@ void BitmapTexture::createFboIfNeeded()
     glGenFramebuffers(1, &m_fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, id(), 0);
-    if (flags() & DepthBuffer)
+    if (m_flags.contains(Flags::DepthBuffer))
         initializeDepthBuffer();
     m_shouldClear = true;
 }
@@ -267,7 +267,7 @@ void BitmapTexture::bindAsSurface()
     createFboIfNeeded();
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
     glViewport(0, 0, m_size.width(), m_size.height());
-    if (flags() & DepthBuffer)
+    if (m_flags.contains(Flags::DepthBuffer))
         glEnable(GL_DEPTH_TEST);
     else
         glDisable(GL_DEPTH_TEST);

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -52,15 +52,12 @@ enum class TextureMapperFlags : uint16_t;
 
 class BitmapTexture final : public RefCounted<BitmapTexture> {
 public:
-    enum Flag {
-        NoFlag = 0,
+    enum class Flags : uint8_t {
         SupportsAlpha = 1 << 0,
         DepthBuffer = 1 << 1,
     };
 
-    typedef unsigned Flags;
-
-    static Ref<BitmapTexture> create(const IntSize& size, const Flags flags = NoFlag, GLint internalFormat = GL_DONT_CARE)
+    static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { }, GLint internalFormat = GL_DONT_CARE)
     {
         return adoptRef(*new BitmapTexture(size, flags, internalFormat));
     }
@@ -68,9 +65,9 @@ public:
     WEBCORE_EXPORT ~BitmapTexture();
 
     const IntSize& size() const { return m_size; };
-    Flags flags() const { return m_flags; }
+    OptionSet<Flags> flags() const { return m_flags; }
     GLint internalFormat() const { return m_internalFormat; }
-    bool isOpaque() const { return !(m_flags & SupportsAlpha); }
+    bool isOpaque() const { return !m_flags.contains(Flags::SupportsAlpha); }
 
     void bindAsSurface();
     void initializeStencil();
@@ -81,7 +78,7 @@ public:
     void updateContents(GraphicsLayer*, const IntRect& target, const IntPoint& offset, float scale = 1);
     void updateContents(const void*, const IntRect& target, const IntPoint& offset, int bytesPerLine);
 
-    void reset(const IntSize&, Flags = NoFlag);
+    void reset(const IntSize&, OptionSet<Flags> = { });
 
     int numberOfBytes() const { return size().width() * size().height() * 32 >> 3; }
 
@@ -103,12 +100,12 @@ public:
     OptionSet<TextureMapperFlags> colorConvertFlags() const { return m_colorConvertFlags; }
 
 private:
-    BitmapTexture(const IntSize&, const Flags, GLint internalFormat);
+    BitmapTexture(const IntSize&, OptionSet<Flags>, GLint internalFormat);
 
     void clearIfNeeded();
     void createFboIfNeeded();
 
-    Flags m_flags { 0 };
+    OptionSet<Flags> m_flags;
     IntSize m_size;
     GLuint m_id { 0 };
     GLuint m_fbo { 0 };

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -40,13 +40,13 @@ BitmapTexturePool::BitmapTexturePool()
 {
 }
 
-RefPtr<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, const BitmapTexture::Flags flags)
+RefPtr<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
 {
     Entry* selectedEntry = std::find_if(m_textures.begin(), m_textures.end(),
         [&](Entry& entry) {
             return entry.m_texture->refCount() == 1
                 && entry.m_texture->size() == size
-                && (entry.m_texture->flags() & BitmapTexture::DepthBuffer) == (flags & BitmapTexture::DepthBuffer);
+                && entry.m_texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer);
         });
 
     if (selectedEntry == m_textures.end()) {

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -41,7 +41,7 @@ class BitmapTexturePool {
 public:
     BitmapTexturePool();
 
-    RefPtr<BitmapTexture> acquireTexture(const IntSize&, const BitmapTexture::Flags);
+    RefPtr<BitmapTexture> acquireTexture(const IntSize&, OptionSet<BitmapTexture::Flags>);
     void releaseUnusedTexturesTimerFired();
 
 private:

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -183,7 +183,7 @@ TextureMapper::TextureMapper()
 {
 }
 
-RefPtr<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size, const BitmapTexture::Flags flags)
+RefPtr<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size, OptionSet<BitmapTexture::Flags> flags)
 {
     return m_texturePool->acquireTexture(size, flags);
 }
@@ -287,7 +287,7 @@ void TextureMapper::drawNumber(int number, const Color& color, const FloatPoint&
     IntRect sourceRect(IntPoint::zero(), size);
     IntRect targetRect(roundedIntPoint(targetPoint), size);
 
-    RefPtr<BitmapTexture> texture = acquireTextureFromPool(size);
+    RefPtr<BitmapTexture> texture = m_texturePool->acquireTexture(size, { BitmapTexture::Flags::SupportsAlpha });
     const unsigned char* bits = cairo_image_surface_get_data(surface);
     int stride = cairo_image_surface_get_stride(surface);
     texture->updateContents(bits, sourceRect, IntPoint::zero(), stride);
@@ -913,7 +913,7 @@ RefPtr<BitmapTexture> TextureMapper::applyBlurFilter(RefPtr<BitmapTexture> sourc
     if (radiusX < MinBlurRadius && radiusY < MinBlurRadius)
         return sourceTexture;
 
-    RefPtr<BitmapTexture> resultTexture = acquireTextureFromPool(textureSize, BitmapTexture::SupportsAlpha);
+    RefPtr<BitmapTexture> resultTexture = m_texturePool->acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
     IntSize currentSize = textureSize;
     IntSize targetSize = currentSize;
     Vector<Direction> blurDirections;
@@ -989,8 +989,8 @@ RefPtr<BitmapTexture> TextureMapper::applyBlurFilter(RefPtr<BitmapTexture> sourc
 RefPtr<BitmapTexture> TextureMapper::applyDropShadowFilter(RefPtr<BitmapTexture> sourceTexture, const DropShadowFilterOperation& dropShadowFilter)
 {
     const auto& textureSize = sourceTexture->size();
-    RefPtr<BitmapTexture> resultTexture = acquireTextureFromPool(textureSize, BitmapTexture::SupportsAlpha);
-    RefPtr<BitmapTexture> contentTexture = acquireTextureFromPool(textureSize, BitmapTexture::SupportsAlpha);
+    RefPtr<BitmapTexture> resultTexture = m_texturePool->acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
+    RefPtr<BitmapTexture> contentTexture = m_texturePool->acquireTexture(textureSize, { BitmapTexture::Flags::SupportsAlpha });
     IntSize currentSize = textureSize;
     IntSize targetSize = currentSize;
     float radius = float(dropShadowFilter.stdDeviation());
@@ -1116,7 +1116,7 @@ RefPtr<BitmapTexture> TextureMapper::applySinglePassFilter(RefPtr<BitmapTexture>
         return sourceTexture;
     }
 
-    RefPtr<BitmapTexture> resultTexture = acquireTextureFromPool(sourceTexture->size(), BitmapTexture::SupportsAlpha);
+    RefPtr<BitmapTexture> resultTexture = m_texturePool->acquireTexture(sourceTexture->size(), { BitmapTexture::Flags::SupportsAlpha });
 
     bindSurface(resultTexture.get());
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -21,6 +21,7 @@
 
 #if USE(TEXTURE_MAPPER)
 
+#include "BitmapTexture.h"
 #include "ClipStack.h"
 #include "Color.h"
 #include "FilterOperation.h"
@@ -37,7 +38,6 @@
 
 namespace WebCore {
 
-class BitmapTexture;
 class BitmapTexturePool;
 class GraphicsLayer;
 class TextureMapperGLData;
@@ -90,7 +90,7 @@ public:
 
     RefPtr<BitmapTexture> applyFilter(RefPtr<BitmapTexture> sourceTexture, const RefPtr<const FilterOperation>&, bool defersLastPass);
 
-    WEBCORE_EXPORT RefPtr<BitmapTexture> acquireTextureFromPool(const IntSize&, const unsigned = 1);
+    WEBCORE_EXPORT RefPtr<BitmapTexture> acquireTextureFromPool(const IntSize&, OptionSet<BitmapTexture::Flags>);
 
 #if USE(GRAPHICS_LAYER_WC)
     WEBCORE_EXPORT void releaseUnusedTexturesNow();

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -697,7 +697,7 @@ static void commitSurface(TextureMapperPaintOptions& options, BitmapTexture& sur
 
 void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect)
 {
-    auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), BitmapTexture::SupportsAlpha);
+    auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
         SetForScope scopedSurface(options.surface, surface);
         SetForScope scopedOffset(options.offset, -toIntSize(rect.location()));
@@ -712,7 +712,7 @@ void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions&
 
 void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect)
 {
-    auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), BitmapTexture::SupportsAlpha);
+    auto surface = options.textureMapper.acquireTextureFromPool(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
         SetForScope scopedSurface(options.surface, surface);
         SetForScope scopedOffset(options.offset, -toIntSize(rect.location()));
@@ -796,7 +796,7 @@ void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& 
             for (int y = rect.y(); y < rect.maxY(); y += maxTextureSize.height()) {
                 IntRect tileRect(IntPoint(x, y), maxTextureSize);
                 tileRect.intersect(rect);
-                auto surface = options.textureMapper.acquireTextureFromPool(tileRect.size(), BitmapTexture::SupportsAlpha | BitmapTexture::DepthBuffer);
+                auto surface = options.textureMapper.acquireTextureFromPool(tileRect.size(), { BitmapTexture::Flags::SupportsAlpha, BitmapTexture::Flags::DepthBuffer });
                 {
                     SetForScope scopedSurface(options.surface, surface);
                     SetForScope scopedOffset(options.offset, -toIntSize(tileRect.location()));

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<TextureMapperPlatformLayerBuffer> TextureMapperPlatformLayerBuff
                 return nullptr;
             }
 
-            auto clonedTexture = BitmapTexture::create(m_size, BitmapTexture::NoFlag, m_internalFormat);
+            auto clonedTexture = BitmapTexture::create(m_size, { }, m_internalFormat);
             clonedTexture->copyFromExternalTexture(texture.id);
             return makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(clonedTexture), m_extraFlags);
         },

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp
@@ -57,8 +57,12 @@ void TextureMapperTile::updateContents(Image* image, const IntRect& dirtyRect)
 
     // Normalize targetRect to the texture's coordinates.
     targetRect.move(-m_rect.x(), -m_rect.y());
-    if (!m_texture)
-        m_texture = BitmapTexture::create(targetRect.size(), image->currentFrameKnownToBeOpaque() ? 0 : BitmapTexture::SupportsAlpha);
+    if (!m_texture) {
+        OptionSet<BitmapTexture::Flags> flags;
+        if (image->currentFrameKnownToBeOpaque())
+            flags.add(BitmapTexture::Flags::SupportsAlpha);
+        m_texture = BitmapTexture::create(targetRect.size(), flags);
+    }
 
     auto nativeImage = image->nativeImageForCurrentFrame();
     m_texture->updateContents(nativeImage.get(), targetRect, sourceOffset);
@@ -76,7 +80,7 @@ void TextureMapperTile::updateContents(GraphicsLayer* sourceLayer, const IntRect
     targetRect.move(-m_rect.x(), -m_rect.y());
 
     if (!m_texture)
-        m_texture = BitmapTexture::create(targetRect.size(), BitmapTexture::SupportsAlpha);
+        m_texture = BitmapTexture::create(targetRect.size(), { BitmapTexture::Flags::SupportsAlpha });
 
     m_texture->updateContents(sourceLayer, targetRect, sourceOffset, scale);
 }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperTiledBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperTiledBackingStore.cpp
@@ -133,8 +133,12 @@ void TextureMapperTiledBackingStore::createOrDestroyTilesIfNeeded(const FloatSiz
             tileIndicesToRemove.removeLast();
             tile.setRect(rect);
 
-            if (tile.texture())
-                tile.texture()->reset(enclosingIntRect(tile.rect()).size(), hasAlpha ? BitmapTexture::SupportsAlpha : 0);
+            if (tile.texture()) {
+                OptionSet<BitmapTexture::Flags> flags;
+                if (hasAlpha)
+                    flags.add(BitmapTexture::Flags::SupportsAlpha);
+                tile.texture()->reset(enclosingIntRect(tile.rect()).size(), flags);
+            }
             continue;
         }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -46,11 +46,15 @@ void CoordinatedBackingStoreTile::swapBuffers(TextureMapper& textureMapper)
         FloatRect unscaledTileRect(update.tileRect);
         unscaledTileRect.scale(1. / m_scale);
 
+        OptionSet<BitmapTexture::Flags> flags;
+        if (update.buffer->supportsAlpha())
+            flags.add(BitmapTexture::Flags::SupportsAlpha);
+
         if (!m_texture || unscaledTileRect != rect()) {
             setRect(unscaledTileRect);
-            m_texture = textureMapper.acquireTextureFromPool(update.tileRect.size(), update.buffer->supportsAlpha() ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag);
+            m_texture = textureMapper.acquireTextureFromPool(update.tileRect.size(), flags);
         } else if (update.buffer->supportsAlpha() == m_texture->isOpaque())
-            m_texture->reset(update.tileRect.size(), update.buffer->supportsAlpha());
+            m_texture->reset(update.tileRect.size(), flags);
 
         m_texture->updateContents(update.buffer->data(), update.sourceRect, update.bufferOffset, update.buffer->stride());
         update.buffer = nullptr;

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -247,11 +247,11 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
 
     if (update.remoteContextHostedIdentifier) {
         showFPS = false;
-        texture = m_textureMapper->acquireTextureFromPool(windowSize);
+        texture = m_textureMapper->acquireTextureFromPool(windowSize, { WebCore::BitmapTexture::Flags::SupportsAlpha });
         surface = texture.get();
     } else if (m_usesOffscreenRendering) {
         readPixel = true;
-        texture = m_textureMapper->acquireTextureFromPool(windowSize);
+        texture = m_textureMapper->acquireTextureFromPool(windowSize, { WebCore::BitmapTexture::Flags::SupportsAlpha });
         surface = texture.get();
     } else
         glViewport(0, 0, windowSize.width(), windowSize.height());


### PR DESCRIPTION
#### 47f3d4a12cef7fb553c7949e0ce97259ca86c17e
<pre>
[TextureMapper] Use OptionSet for BitmapTexture flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=264390">https://bugs.webkit.org/show_bug.cgi?id=264390</a>

Reviewed by Fujii Hironori.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushTextureToCompositor):
* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:
(Nicosia::NicosiaImageBufferPipeSource::handle):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::createFboIfNeeded):
(WebCore::BitmapTexture::bindAsSurface):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::acquireTexture):
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawNumber):
(WebCore::TextureMapper::applyBlurFilter):
(WebCore::TextureMapper::applyDropShadowFilter):
(WebCore::TextureMapper::applySinglePassFilter):
(WebCore::TextureMapper::acquireTextureFromPool): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
(WebCore::TextureMapper::texturePool):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintWithIntermediateSurface):
(WebCore::TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface):
(WebCore::TextureMapperLayer::paintWith3DRenderingContext):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp:
(WebCore::TextureMapperPlatformLayerBuffer::clone):
* Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp:
(WebCore::TextureMapperTile::updateContents):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStoreTile::swapBuffers):

Canonical link: <a href="https://commits.webkit.org/270633@main">https://commits.webkit.org/270633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40a30f85f99e43de2d6efa6a7211bd47ff3f05dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23864 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28654 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29393 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1327 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3575 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3332 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->