### PR TITLE
Deploy smart pointers in TreeScope.cpp, TreeScopeOrderedMap.cpp, and UserGestureIndicator.cpp

### DIFF
--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -362,8 +362,8 @@ const Vector<CheckedRef<Element>>* TreeScope::labelElementsForId(const AtomStrin
         // Populate the map on first access.
         m_labelsByForAttribute = makeUnique<TreeScopeOrderedMap>();
 
-        for (auto& label : descendantsOfType<HTMLLabelElement>(m_rootNode)) {
-            const AtomString& forValue = label.attributeWithoutSynchronization(forAttr);
+        for (Ref label : descendantsOfType<HTMLLabelElement>(m_rootNode)) {
+            const AtomString& forValue = label->attributeWithoutSynchronization(forAttr);
             if (!forValue.isEmpty())
                 addLabel(forValue, label);
         }
@@ -425,8 +425,7 @@ RefPtr<Node> TreeScope::nodeFromPoint(const LayoutPoint& clientPoint, LayoutPoin
 
 RefPtr<Element> TreeScope::elementFromPoint(double clientX, double clientY)
 {
-    Document& document = documentScope();
-    if (!document.hasLivingRenderTree())
+    if (!protectedDocumentScope()->hasLivingRenderTree())
         return nullptr;
 
     auto node = nodeFromPoint(LayoutPoint { clientX, clientY }, nullptr);
@@ -510,8 +509,9 @@ RefPtr<Element> TreeScope::findAnchor(StringView name)
         return nullptr;
     if (RefPtr element = getElementById(name))
         return element;
-    for (Ref anchor : descendantsOfType<HTMLAnchorElement>(m_rootNode)) {
-        if (m_rootNode.document().inQuirksMode()) {
+    auto inQuirksMode = documentScope().inQuirksMode();
+    for (Ref anchor : descendantsOfType<HTMLAnchorElement>(protectedRootNode())) {
+        if (inQuirksMode) {
             // Quirks mode, ASCII case-insensitive comparison of names.
             // FIXME: This behavior is not mentioned in the HTML specification.
             // We should either remove this or get this into the specification.

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -132,6 +132,7 @@ public:
     RefPtr<Element> findAnchor(StringView name);
 
     ContainerNode& rootNode() const { return m_rootNode; }
+    Ref<ContainerNode> protectedRootNode() const;
 
     IdTargetObserverRegistry& idTargetObserverRegistry() { return m_idTargetObserverRegistry.get(); }
     const IdTargetObserverRegistry& idTargetObserverRegistry() const { return m_idTargetObserverRegistry.get(); }

--- a/Source/WebCore/dom/TreeScopeInlines.h
+++ b/Source/WebCore/dom/TreeScopeInlines.h
@@ -25,9 +25,15 @@
 
 #pragma once
 
+#include "ContainerNode.h"
 #include "TreeScopeOrderedMap.h"
 
 namespace WebCore {
+
+inline Ref<ContainerNode> TreeScope::protectedRootNode() const
+{
+    return rootNode();
+}
 
 inline bool TreeScope::hasElementWithId(const AtomString& id) const
 {

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -37,6 +37,7 @@
 #include "HTMLLabelElement.h"
 #include "HTMLMapElement.h"
 #include "HTMLNameCollection.h"
+#include "TreeScopeInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
 
 namespace WebCore {
@@ -117,7 +118,7 @@ inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomString& key, const Tre
     }
 
     // We know there's at least one node that matches; iterate to find the first one.
-    for (Ref element : descendantsOfType<Element>(scope.rootNode())) {
+    for (Ref element : descendantsOfType<Element>(scope.protectedRootNode().get())) {
         if (!element->isInTreeScope())
             continue;
         if (!keyMatches(key, element))
@@ -163,7 +164,7 @@ inline Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAll(const AtomString
 
     if (entry.orderedList.isEmpty()) {
         entry.orderedList.reserveCapacity(entry.count);
-        auto elementDescendants = descendantsOfType<Element>(scope.rootNode());
+        auto elementDescendants = descendantsOfType<Element>(scope.protectedRootNode().get());
         for (auto it = entry.element ? elementDescendants.beginAt(*entry.element) : elementDescendants.begin(); it; ++it) {
             if (keyMatches(key, *it))
                 entry.orderedList.append(*it);

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -69,13 +69,14 @@ UserGestureToken::UserGestureToken(IsProcessingUserGesture isProcessingUserGestu
             m_documentsImpactedByUserGesture.add(*ancestorDocument);
     }
 
-    auto& documentOrigin = document->securityOrigin();
+    Ref documentOrigin = document->securityOrigin();
     for (RefPtr frame = &documentFrame->tree().top(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
         RefPtr frameDocument = localFrame->document();
-        if (frameDocument && documentOrigin.isSameOriginDomain(frameDocument->securityOrigin()))
+        Ref frameOrigin = frameDocument->securityOrigin();
+        if (frameDocument && documentOrigin->isSameOriginDomain(frameOrigin.get()))
             m_documentsImpactedByUserGesture.add(*frameDocument);
     }
 }


### PR DESCRIPTION
#### 0def6ce9c00084dc3c6c2e973423645daca875cc
<pre>
Deploy smart pointers in TreeScope.cpp, TreeScopeOrderedMap.cpp, and UserGestureIndicator.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264393">https://bugs.webkit.org/show_bug.cgi?id=264393</a>

Reviewed by Chris Dumez.

Deploy smart pointers as warned by the clang static analyzer.

* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::labelElementsForId):
(WebCore::TreeScope::elementFromPoint):
(WebCore::TreeScope::findAnchor):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/dom/TreeScopeInlines.h:
(WebCore::TreeScope::protectedRootNode const):
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::get const):
(WebCore::TreeScopeOrderedMap::getAll const):
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureToken::UserGestureToken):

Canonical link: <a href="https://commits.webkit.org/270392@main">https://commits.webkit.org/270392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41943cee1e0d197b4f1bd64be708596660c5e54a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23431 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28021 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28895 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26738 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3867 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6081 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2952 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2844 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->