### PR TITLE
Share the export-compile-commands options with build-webkit and make builds.

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -21,8 +21,11 @@ BUILD_WEBKIT_OPTIONS += --no-use-workspace
 BUILD_GOAL = $(notdir $(CURDIR))
 endif
 
+ifneq (,$(EXPORT_COMPILE_COMMANDS))
+	BUILD_WEBKIT_OPTIONS += --export-compile-commands
+endif
 
-XCODE_OPTIONS = `perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_OPTIONS)` $(ARGS)
+XCODE_OPTIONS = $(shell perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_OPTIONS)) $(ARGS)
 XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_ADDITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
 ifeq (ON,$(ENABLE_LLVM_PROFILE_GENERATION))
 	XCODE_OPTIONS += ENABLE_LLVM_PROFILE_GENERATION=ENABLE_LLVM_PROFILE_GENERATION
@@ -60,13 +63,6 @@ ifeq (, $(findstring WK_USE_CCACHE, $(ARGS)))
 	ifneq (, $(shell which ccache))
 		XCODE_OPTIONS += WK_USE_CCACHE=YES
 	endif
-endif
-
-ifneq (,$(EXPORT_COMPILE_COMMANDS))
-		XCODE_OPTIONS += OTHER_CFLAGS='$$(inherited) -gen-cdb-fragment-path $$(BUILT_PRODUCTS_DIR)/compile_commands'
-		XCODE_OPTIONS += GCC_PRECOMPILE_PREFIX_HEADER=NO
-		XCODE_OPTIONS += CLANG_ENABLE_MODULE_DEBUGGING=NO
-		XCODE_OPTIONS += COMPILER_INDEX_STORE_ENABLE=NO
 endif
 
 endif # ifneq ($(MAKECMDGOALS),installsrc)

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -83,7 +83,6 @@ my $startTime = time();
 my $archs32bit = 0;
 my $skipLibraryUpdate = 0;
 my $useCCache = -1;
-my $exportCompileCommands = 0;
 
 my @features = getFeatureOptionList();
 
@@ -149,8 +148,6 @@ Usage: $programName [options] [options to pass to build system]
 
   --[no-]use-ccache                 Enable (or disable) CCache, if available
 
-  --export-compile-commands         Generate compile_commands.json (Apple platforms only)
-
 EOF
 
 my %options = (
@@ -171,7 +168,6 @@ my %options = (
     'use-workspace!' => \$useWorkspace,
     'skip-library-update' => \$skipLibraryUpdate,
     'use-ccache!' => \$useCCache,
-    'export-compile-commands' => \$exportCompileCommands
 );
 
 # Build usage text and options list from features
@@ -195,8 +191,6 @@ if ($useCCache == 1) {
 } elsif ($useCCache == 0) {
     $ENV{'WK_USE_CCACHE'} = "NO";
 }
-
-$ENV{'EXPORT_COMPILE_COMMANDS'} = "YES" if $exportCompileCommands;
 
 my $productDir = productDir();
 
@@ -251,7 +245,7 @@ if (isAppleCocoaWebKit()) {
     }
 
     foreach (@features) {
-        my $option = option($_->{define}, ${$_->{value}});
+        my $option = option($_->{define}, ${$_->{value}}) unless $_->{option} eq "export-compile-commands";
         push @options, $option unless $option eq "";
     }
 
@@ -351,7 +345,6 @@ if (isWinCairo() || isPlayStation()) {
     push @local_options, XcodeCoverageSupportOptions() if $coverageSupport;
     push @local_options, XcodeStaticAnalyzerOption() if $shouldRunStaticAnalyzer;
     push @local_options, "WK_LTO_MODE=$ltoMode" if ($ltoMode ne "default");
-    push @local_options, XcodeExportCompileCommandsOptions() if $exportCompileCommands;
     # FIXME: Move this setting to xcconfigs once all local Xcode builds of WebKit
     # happen in the workspace. When this is only passed on the command line, it
     # invalidates build results made in the IDE (rdar://88135402).

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1261,12 +1261,17 @@ sub XcodeOptions
 
     my @features = webkitperl::FeatureList::getFeatureOptionList();
     foreach (@features) {
+        if ("$_->{option}" eq "export-compile-commands"
+            and (defined(${$_->{value}}) or checkForArgumentAndRemoveFromARGV("--$_->{option}"))) {
+            push @options, XcodeExportCompileCommandsOptions();
+            next
+        }
         if (checkForArgumentAndRemoveFromARGV("--no-$_->{option}")) {
             push @options, "$_->{define}=";
-        } 
+        }
         if (checkForArgumentAndRemoveFromARGV("--$_->{option}")) {
             push @options, "$_->{define}=$_->{define}";
-        }   
+        }
     }
 
     # When this environment variable is set Tools/Scripts/check-for-weak-vtables-and-externals
@@ -1282,7 +1287,7 @@ sub XcodeOptions
 
 sub XcodeOptionString
 {
-    return join " ", XcodeOptions();
+    return join " ", map { /\s/ ? "\'$_\'" : $_ } XcodeOptions()
 }
 
 sub XcodeOptionStringNoConfig

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -198,7 +198,6 @@ if (isAppleCocoaWebKit()) {
     my @additionalSupportOptions = ();
     push @additionalSupportOptions, XcodeCoverageSupportOptions() if $coverageSupport;
     push @additionalSupportOptions, XcodeStaticAnalyzerOption() if $shouldRunStaticAnalyzer;
-    push @additionalSupportOptions, XcodeExportCompileCommandsOptions() if $exportCompileCommands;
 
     push @options, ($forceCLoop ? "ENABLE_JIT=ENABLE_JIT=0" : "ENABLE_JIT=ENABLE_JIT");
     push @options, ($forceCLoop ? "ENABLE_C_LOOP=ENABLE_C_LOOP" : "ENABLE_C_LOOP=ENABLE_C_LOOP=0");

--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -88,6 +88,7 @@ my (
     $downloadAttributeSupport,
     $dragSupportSupport,
     $encryptedMediaSupport,
+    $exportCompileCommands,
     $fatalWarnings,
     $filtersLevel2Support,
     $ftlJITSupport,
@@ -288,6 +289,9 @@ my @features = (
 
     { option => "encrypted-media", desc => "Toggle EME V3 support",
       define => "ENABLE_ENCRYPTED_MEDIA", value => \$encryptedMediaSupport },
+
+    { option => "export-compile-commands", desc => "Toggle compile_commands.json generation (Apple platforms only)",
+      define => "ENABLE_EXPORT_COMPILE_COMMANDS", value => \$exportCompileCommands},
 
     { option => "filters-level-2", desc => "Toggle Filters Module Level 2",
       define => "ENABLE_FILTERS_LEVEL_2", value => \$filtersLevel2Support },


### PR DESCRIPTION
#### ab2ef65030cb779b86e7f5873f72f14a3dc7e8bb
<pre>
Share the export-compile-commands options with build-webkit and make builds.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264391">https://bugs.webkit.org/show_bug.cgi?id=264391</a>

Reviewed by NOBODY (OOPS!).

This is a follow-up of 270348@main [1]. To export compile-commands.json, we
appended the same Xcode options to Makefile.shared and webkitdirs.pm. This patch
makes the two build systems get the Xcode options from the same single function,
XcodeOptions().

* Makefile.shared:
* Tools/Scripts/build-webkit:
* Tools/Scripts/webkitdirs.pm:
(XcodeOptions):
(XcodeOptionString):
* Tools/Scripts/webkitperl/BuildSubproject.pm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab2ef65030cb779b86e7f5873f72f14a3dc7e8bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23827 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28610 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29359 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22582 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27235 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1286 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32595 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4466 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7080 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->