### PR TITLE
[web-animations] move shared timing data between AnimationEffect and AcceleratedEffect to a dedicated struct

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -556,6 +556,7 @@ accessibility/isolatedtree/AXIsolatedObject.cpp
 accessibility/isolatedtree/AXIsolatedTree.cpp
 animation/AcceleratedTimeline.cpp
 animation/AnimationEffect.cpp
+animation/AnimationEffectTiming.cpp
 animation/AnimationEventBase.cpp
 animation/AnimationPlaybackEvent.cpp
 animation/AnimationTimeline.cpp

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -40,7 +40,6 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(AnimationEffect);
 
 AnimationEffect::AnimationEffect()
-    : m_timingFunction(LinearTimingFunction::create())
 {
 }
 
@@ -62,117 +61,43 @@ EffectTiming AnimationEffect::getBindingsTiming() const
 {
     if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation()))
         declarativeAnimation->flushPendingStyleChanges();
-    return getTiming();
-}
 
-EffectTiming AnimationEffect::getTiming() const
-{
     EffectTiming timing;
-    timing.delay = secondsToWebAnimationsAPITime(m_delay);
-    timing.endDelay = secondsToWebAnimationsAPITime(m_endDelay);
-    timing.fill = m_fill;
-    timing.iterationStart = m_iterationStart;
-    timing.iterations = m_iterations;
-    if (m_iterationDuration == 0_s)
+    timing.delay = secondsToWebAnimationsAPITime(m_timing.delay);
+    timing.endDelay = secondsToWebAnimationsAPITime(m_timing.endDelay);
+    timing.fill = m_timing.fill;
+    timing.iterationStart = m_timing.iterationStart;
+    timing.iterations = m_timing.iterations;
+    if (m_timing.iterationDuration == 0_s)
         timing.duration = autoAtom();
     else
-        timing.duration = secondsToWebAnimationsAPITime(m_iterationDuration);
-    timing.direction = m_direction;
-    timing.easing = m_timingFunction->cssText();
+        timing.duration = secondsToWebAnimationsAPITime(m_timing.iterationDuration);
+    timing.direction = m_timing.direction;
+    timing.easing = m_timing.timingFunction->cssText();
     return timing;
+}
+
+std::optional<Seconds> AnimationEffect::localTime(std::optional<Seconds> startTime) const
+{
+    // 4.5.4. Local time
+    // https://drafts.csswg.org/web-animations-1/#local-time-section
+
+    // The local time of an animation effect at a given moment is based on the first matching condition from the following:
+    // If the animation effect is associated with an animation, the local time is the current time of the animation.
+    // Otherwise, the local time is unresolved.
+    if (m_animation)
+        return m_animation->currentTime(startTime);
+    return std::nullopt;
+}
+
+double AnimationEffect::playbackRate() const
+{
+    return m_animation ? m_animation->playbackRate() : 1;
 }
 
 BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<Seconds> startTime) const
 {
-    // The Web Animations spec introduces a number of animation effect time-related definitions that refer
-    // to each other a fair bit, so rather than implementing them as individual methods, it's more efficient
-    // to return them all as a single BasicEffectTiming.
-
-    auto localTime = [this, startTime]() -> std::optional<Seconds> {
-        // 4.5.4. Local time
-        // https://drafts.csswg.org/web-animations-1/#local-time-section
-
-        // The local time of an animation effect at a given moment is based on the first matching condition from the following:
-        // If the animation effect is associated with an animation, the local time is the current time of the animation.
-        // Otherwise, the local time is unresolved.
-        if (m_animation)
-            return m_animation->currentTime(startTime);
-        return std::nullopt;
-    }();
-
-    auto phase = [this, localTime]() -> AnimationEffectPhase {
-        // 3.5.5. Animation effect phases and states
-        // https://drafts.csswg.org/web-animations-1/#animation-effect-phases-and-states
-
-        bool animationIsBackwards = m_animation && m_animation->playbackRate() < 0;
-        auto beforeActiveBoundaryTime = std::max(std::min(m_delay, m_endTime), 0_s);
-        auto activeAfterBoundaryTime = std::max(std::min(m_delay + m_activeDuration, m_endTime), 0_s);
-
-        // (This should be the last statement, but it's more efficient to cache the local time and return right away if it's not resolved.)
-        // Furthermore, it is often convenient to refer to the case when an animation effect is in none of the above phases
-        // as being in the idle phase.
-        if (!localTime)
-            return AnimationEffectPhase::Idle;
-
-        // An animation effect is in the before phase if the animation effect’s local time is not unresolved and
-        // either of the following conditions are met:
-        //     1. the local time is less than the before-active boundary time, or
-        //     2. the animation direction is ‘backwards’ and the local time is equal to the before-active boundary time.
-        if ((*localTime + timeEpsilon) < beforeActiveBoundaryTime || (animationIsBackwards && std::abs(localTime->microseconds() - beforeActiveBoundaryTime.microseconds()) < timeEpsilon.microseconds()))
-            return AnimationEffectPhase::Before;
-
-        // An animation effect is in the after phase if the animation effect’s local time is not unresolved and
-        // either of the following conditions are met:
-        //     1. the local time is greater than the active-after boundary time, or
-        //     2. the animation direction is ‘forwards’ and the local time is equal to the active-after boundary time.
-        if ((*localTime - timeEpsilon) > activeAfterBoundaryTime || (!animationIsBackwards && std::abs(localTime->microseconds() - activeAfterBoundaryTime.microseconds()) < timeEpsilon.microseconds()))
-            return AnimationEffectPhase::After;
-
-        // An animation effect is in the active phase if the animation effect’s local time is not unresolved and it is not
-        // in either the before phase nor the after phase.
-        // (No need to check, we've already established that local time was resolved).
-        return AnimationEffectPhase::Active;
-    }();
-
-    auto activeTime = [this, localTime, phase]() -> std::optional<Seconds> {
-        // 3.8.3.1. Calculating the active time
-        // https://drafts.csswg.org/web-animations-1/#calculating-the-active-time
-
-        // The active time is based on the local time and start delay. However, it is only defined
-        // when the animation effect should produce an output and hence depends on its fill mode
-        // and phase as follows,
-
-        // If the animation effect is in the before phase, the result depends on the first matching
-        // condition from the following,
-        if (phase == AnimationEffectPhase::Before) {
-            // If the fill mode is backwards or both, return the result of evaluating
-            // max(local time - start delay, 0).
-            if (m_fill == FillMode::Backwards || m_fill == FillMode::Both)
-                return std::max(*localTime - m_delay, 0_s);
-            // Otherwise, return an unresolved time value.
-            return std::nullopt;
-        }
-
-        // If the animation effect is in the active phase, return the result of evaluating local time - start delay.
-        if (phase == AnimationEffectPhase::Active)
-            return *localTime - m_delay;
-
-        // If the animation effect is in the after phase, the result depends on the first matching
-        // condition from the following,
-        if (phase == AnimationEffectPhase::After) {
-            // If the fill mode is forwards or both, return the result of evaluating
-            // max(min(local time - start delay, active duration), 0).
-            if (m_fill == FillMode::Forwards || m_fill == FillMode::Both)
-                return std::max(std::min(*localTime - m_delay, m_activeDuration), 0_s);
-            // Otherwise, return an unresolved time value.
-            return std::nullopt;
-        }
-
-        // Otherwise (the local time is unresolved), return an unresolved time value.
-        return std::nullopt;
-    }();
-
-    return { localTime, activeTime, m_endTime, m_activeDuration, phase };
+    return m_timing.getBasicTiming(localTime(startTime), playbackRate());
 }
 
 ComputedEffectTiming AnimationEffect::getBindingsComputedTiming() const
@@ -184,186 +109,26 @@ ComputedEffectTiming AnimationEffect::getBindingsComputedTiming() const
 
 ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<Seconds> startTime) const
 {
-    // The Web Animations spec introduces a number of animation effect time-related definitions that refer
-    // to each other a fair bit, so rather than implementing them as individual methods, it's more efficient
-    // to return them all as a single ComputedEffectTiming.
-
-    auto basicEffectTiming = getBasicTiming(startTime);
-    auto activeTime = basicEffectTiming.activeTime;
-    auto phase = basicEffectTiming.phase;
-
-    auto overallProgress = [this, phase, activeTime]() -> std::optional<double> {
-        // 3.8.3.2. Calculating the overall progress
-        // https://drafts.csswg.org/web-animations-1/#calculating-the-overall-progress
-
-        // The overall progress describes the number of iterations that have completed (including partial iterations) and is defined as follows:
-
-        // 1. If the active time is unresolved, return unresolved.
-        if (!activeTime)
-            return std::nullopt;
-
-        // 2. Calculate an initial value for overall progress based on the first matching condition from below,
-        double overallProgress;
-
-        if (!m_iterationDuration) {
-            // If the iteration duration is zero, if the animation effect is in the before phase, let overall progress be zero,
-            // otherwise, let it be equal to the iteration count.
-            overallProgress = phase == AnimationEffectPhase::Before ? 0 : m_iterations;
-        } else {
-            // Otherwise, let overall progress be the result of calculating active time / iteration duration.
-            overallProgress = secondsToWebAnimationsAPITime(*activeTime) / secondsToWebAnimationsAPITime(m_iterationDuration);
-        }
-
-        // 3. Return the result of calculating overall progress + iteration start.
-        overallProgress += m_iterationStart;
-        return std::abs(overallProgress);
-    }();
-
-    auto simpleIterationProgress = [this, overallProgress, phase, activeTime]() -> std::optional<double> {
-        // 3.8.3.3. Calculating the simple iteration progress
-        // https://drafts.csswg.org/web-animations-1/#calculating-the-simple-iteration-progress
-
-        // The simple iteration progress is a fraction of the progress through the current iteration that
-        // ignores transformations to the time introduced by the playback direction or timing functions
-        // applied to the effect, and is calculated as follows:
-
-        // 1. If the overall progress is unresolved, return unresolved.
-        if (!overallProgress)
-            return std::nullopt;
-
-        // 2. If overall progress is infinity, let the simple iteration progress be iteration start % 1.0,
-        // otherwise, let the simple iteration progress be overall progress % 1.0.
-        double simpleIterationProgress = std::isinf(*overallProgress) ? fmod(m_iterationStart, 1) : fmod(*overallProgress, 1);
-
-        // 3. If all of the following conditions are true,
-        //
-        // the simple iteration progress calculated above is zero, and
-        // the animation effect is in the active phase or the after phase, and
-        // the active time is equal to the active duration, and
-        // the iteration count is not equal to zero.
-        // let the simple iteration progress be 1.0.
-        if (!simpleIterationProgress && (phase == AnimationEffectPhase::Active || phase == AnimationEffectPhase::After) && std::abs(activeTime->microseconds() - m_activeDuration.microseconds()) < timeEpsilon.microseconds() && m_iterations)
-            return 1;
-
-        return simpleIterationProgress;
-    }();
-
-    auto currentIteration = [this, activeTime, phase, simpleIterationProgress, overallProgress]() -> std::optional<double> {
-        // 3.8.4. Calculating the current iteration
-        // https://drafts.csswg.org/web-animations-1/#calculating-the-current-iteration
-
-        // The current iteration can be calculated using the following steps:
-
-        // 1. If the active time is unresolved, return unresolved.
-        if (!activeTime)
-            return std::nullopt;
-
-        // 2. If the animation effect is in the after phase and the iteration count is infinity, return infinity.
-        if (phase == AnimationEffectPhase::After && std::isinf(m_iterations))
-            return std::numeric_limits<double>::infinity();
-
-        // 3. If the simple iteration progress is 1.0, return floor(overall progress) - 1.
-        if (*simpleIterationProgress == 1)
-            return floor(*overallProgress) - 1;
-
-        // 4. Otherwise, return floor(overall progress).
-        return floor(*overallProgress);
-    }();
-
-    auto currentDirection = [this, currentIteration]() -> AnimationEffect::ComputedDirection {
-        // 3.9.1. Calculating the directed progress
-        // https://drafts.csswg.org/web-animations-1/#calculating-the-directed-progress
-
-        // If playback direction is normal, let the current direction be forwards.
-        if (m_direction == PlaybackDirection::Normal)
-            return AnimationEffect::ComputedDirection::Forwards;
-    
-        // If playback direction is reverse, let the current direction be reverse.
-        if (m_direction == PlaybackDirection::Reverse)
-            return AnimationEffect::ComputedDirection::Reverse;
-
-        if (!currentIteration)
-            return AnimationEffect::ComputedDirection::Forwards;
-    
-        // Otherwise, let d be the current iteration.
-        auto d = *currentIteration;
-        // If playback direction is alternate-reverse increment d by 1.
-        if (m_direction == PlaybackDirection::AlternateReverse)
-            d++;
-        // If d % 2 == 0, let the current direction be forwards, otherwise let the current direction be reverse.
-        // If d is infinity, let the current direction be forwards.
-        if (std::isinf(d) || !fmod(d, 2))
-            return AnimationEffect::ComputedDirection::Forwards;
-        return AnimationEffect::ComputedDirection::Reverse;
-    }();
-
-    auto directedProgress = [simpleIterationProgress, currentDirection]() -> std::optional<double> {
-        // 3.9.1. Calculating the directed progress
-        // https://drafts.csswg.org/web-animations-1/#calculating-the-directed-progress
-
-        // The directed progress is calculated from the simple iteration progress using the following steps:
-
-        // 1. If the simple iteration progress is unresolved, return unresolved.
-        if (!simpleIterationProgress)
-            return std::nullopt;
-
-        // 2. Calculate the current direction (we implement this as a separate method).
-
-        // 3. If the current direction is forwards then return the simple iteration progress.
-        if (currentDirection == AnimationEffect::ComputedDirection::Forwards)
-            return *simpleIterationProgress;
-
-        // Otherwise, return 1.0 - simple iteration progress.
-        return 1 - *simpleIterationProgress;
-    }();
-
-    auto transformedProgress = [this, directedProgress, currentDirection, phase]() -> std::optional<double> {
-        // 3.10.1. Calculating the transformed progress
-        // https://drafts.csswg.org/web-animations-1/#calculating-the-transformed-progress
-
-        // The transformed progress is calculated from the directed progress using the following steps:
-        //
-        // 1. If the directed progress is unresolved, return unresolved.
-        if (!directedProgress)
-            return std::nullopt;
-
-        if (auto iterationDuration = m_iterationDuration.seconds()) {
-            bool before = false;
-            // 2. Calculate the value of the before flag as follows:
-            if (is<StepsTimingFunction>(m_timingFunction)) {
-                // 1. Determine the current direction using the procedure defined in §3.9.1 Calculating the directed progress.
-                // 2. If the current direction is forwards, let going forwards be true, otherwise it is false.
-                bool goingForwards = currentDirection == AnimationEffect::ComputedDirection::Forwards;
-                // 3. The before flag is set if the animation effect is in the before phase and going forwards is true;
-                //    or if the animation effect is in the after phase and going forwards is false.
-                before = (phase == AnimationEffectPhase::Before && goingForwards) || (phase == AnimationEffectPhase::After && !goingForwards);
-            }
-
-            // 3. Return the result of evaluating the animation effect’s timing function passing directed progress as the
-            //    input progress value and before flag as the before flag.
-            return m_timingFunction->transformProgress(*directedProgress, iterationDuration, before);
-        }
-
-        return *directedProgress;
-    }();
+    auto localTime = this->localTime(startTime);
+    auto resolvedTiming = m_timing.resolve(localTime, playbackRate());
 
     ComputedEffectTiming computedTiming;
-    computedTiming.delay = secondsToWebAnimationsAPITime(m_delay);
-    computedTiming.endDelay = secondsToWebAnimationsAPITime(m_endDelay);
-    computedTiming.fill = m_fill == FillMode::Auto ? FillMode::None : m_fill;
-    computedTiming.iterationStart = m_iterationStart;
-    computedTiming.iterations = m_iterations;
-    computedTiming.duration = secondsToWebAnimationsAPITime(m_iterationDuration);
-    computedTiming.direction = m_direction;
-    computedTiming.easing = m_timingFunction->cssText();
-    computedTiming.endTime = secondsToWebAnimationsAPITime(m_endTime);
-    computedTiming.activeDuration = secondsToWebAnimationsAPITime(m_activeDuration);
-    if (basicEffectTiming.localTime)
-        computedTiming.localTime = secondsToWebAnimationsAPITime(*basicEffectTiming.localTime);
-    computedTiming.simpleIterationProgress = simpleIterationProgress;
-    computedTiming.progress = transformedProgress;
-    computedTiming.currentIteration = currentIteration;
-    computedTiming.phase = phase;
+    computedTiming.delay = secondsToWebAnimationsAPITime(m_timing.delay);
+    computedTiming.endDelay = secondsToWebAnimationsAPITime(m_timing.endDelay);
+    computedTiming.fill = m_timing.fill == FillMode::Auto ? FillMode::None : m_timing.fill;
+    computedTiming.iterationStart = m_timing.iterationStart;
+    computedTiming.iterations = m_timing.iterations;
+    computedTiming.duration = secondsToWebAnimationsAPITime(m_timing.iterationDuration);
+    computedTiming.direction = m_timing.direction;
+    computedTiming.easing = m_timing.timingFunction->cssText();
+    computedTiming.endTime = secondsToWebAnimationsAPITime(m_timing.endTime);
+    computedTiming.activeDuration = secondsToWebAnimationsAPITime(m_timing.activeDuration);
+    if (localTime)
+        computedTiming.localTime = secondsToWebAnimationsAPITime(*localTime);
+    computedTiming.simpleIterationProgress = resolvedTiming.simpleIterationProgress;
+    computedTiming.progress = resolvedTiming.transformedProgress;
+    computedTiming.currentIteration = resolvedTiming.currentIteration;
+    computedTiming.phase = resolvedTiming.phase;
     return computedTiming;
 }
 
@@ -414,7 +179,7 @@ ExceptionOr<void> AnimationEffect::updateTiming(std::optional<OptionalEffectTimi
         auto timingFunctionResult = TimingFunction::createFromCSSText(timing->easing);
         if (timingFunctionResult.hasException())
             return timingFunctionResult.releaseException();
-        m_timingFunction = timingFunctionResult.returnValue();
+        m_timing.timingFunction = timingFunctionResult.returnValue();
     }
 
     // 5. Assign each member present in input to the corresponding timing property of effect as follows:
@@ -429,25 +194,25 @@ ExceptionOr<void> AnimationEffect::updateTiming(std::optional<OptionalEffectTimi
     //    easing → timing function
 
     if (timing->delay)
-        m_delay = Seconds::fromMilliseconds(timing->delay.value());
+        m_timing.delay = Seconds::fromMilliseconds(timing->delay.value());
 
     if (timing->endDelay)
-        m_endDelay = Seconds::fromMilliseconds(timing->endDelay.value());
+        m_timing.endDelay = Seconds::fromMilliseconds(timing->endDelay.value());
 
     if (timing->fill)
-        m_fill = timing->fill.value();
+        m_timing.fill = timing->fill.value();
 
     if (timing->iterationStart)
-        m_iterationStart = timing->iterationStart.value();
+        m_timing.iterationStart = timing->iterationStart.value();
 
     if (timing->iterations)
-        m_iterations = timing->iterations.value();
+        m_timing.iterations = timing->iterations.value();
 
     if (timing->duration)
-        m_iterationDuration = std::holds_alternative<double>(timing->duration.value()) ? Seconds::fromMilliseconds(std::get<double>(timing->duration.value())) : 0_s;
+        m_timing.iterationDuration = std::holds_alternative<double>(timing->duration.value()) ? Seconds::fromMilliseconds(std::get<double>(timing->duration.value())) : 0_s;
 
     if (timing->direction)
-        m_direction = timing->direction.value();
+        m_timing.direction = timing->direction.value();
 
     updateStaticTimingProperties();
 
@@ -459,24 +224,7 @@ ExceptionOr<void> AnimationEffect::updateTiming(std::optional<OptionalEffectTimi
 
 void AnimationEffect::updateStaticTimingProperties()
 {
-    // 3.8.2. Calculating the active duration
-    // https://drafts.csswg.org/web-animations-1/#calculating-the-active-duration
-
-    // The active duration is calculated as follows:
-    // active duration = iteration duration × iteration count
-    // If either the iteration duration or iteration count are zero, the active duration is zero.
-    if (!m_iterationDuration || !m_iterations)
-        m_activeDuration = 0_s;
-    else
-        m_activeDuration = m_iterationDuration * m_iterations;
-
-    // 3.5.3 The active interval
-    // https://drafts.csswg.org/web-animations-1/#end-time
-
-    // The end time of an animation effect is the result of evaluating max(start delay + active duration + end delay, 0).
-    m_endTime = m_delay + m_activeDuration + m_endDelay;
-    if (m_endTime < 0_s)
-        m_endTime = 0_s;
+    m_timing.updateComputedProperties();
 }
 
 ExceptionOr<void> AnimationEffect::setIterationStart(double iterationStart)
@@ -487,10 +235,10 @@ ExceptionOr<void> AnimationEffect::setIterationStart(double iterationStart)
     if (iterationStart < 0)
         return Exception { TypeError };
 
-    if (m_iterationStart == iterationStart)
+    if (m_timing.iterationStart == iterationStart)
         return { };
 
-    m_iterationStart = iterationStart;
+    m_timing.iterationStart = iterationStart;
 
     return { };
 }
@@ -503,65 +251,65 @@ ExceptionOr<void> AnimationEffect::setIterations(double iterations)
     if (iterations < 0 || std::isnan(iterations))
         return Exception { TypeError };
 
-    if (m_iterations == iterations)
+    if (m_timing.iterations == iterations)
         return { };
         
-    m_iterations = iterations;
+    m_timing.iterations = iterations;
 
     return { };
 }
 
 void AnimationEffect::setDelay(const Seconds& delay)
 {
-    if (m_delay == delay)
+    if (m_timing.delay == delay)
         return;
 
-    m_delay = delay;
+    m_timing.delay = delay;
 }
 
 void AnimationEffect::setEndDelay(const Seconds& endDelay)
 {
-    if (m_endDelay == endDelay)
+    if (m_timing.endDelay == endDelay)
         return;
 
-    m_endDelay = endDelay;
+    m_timing.endDelay = endDelay;
 }
 
 void AnimationEffect::setFill(FillMode fill)
 {
-    if (m_fill == fill)
+    if (m_timing.fill == fill)
         return;
 
-    m_fill = fill;
+    m_timing.fill = fill;
 }
 
 void AnimationEffect::setIterationDuration(const Seconds& duration)
 {
-    if (m_iterationDuration == duration)
+    if (m_timing.iterationDuration == duration)
         return;
 
-    m_iterationDuration = duration;
+    m_timing.iterationDuration = duration;
 }
 
 void AnimationEffect::setDirection(PlaybackDirection direction)
 {
-    if (m_direction == direction)
+    if (m_timing.direction == direction)
         return;
 
-    m_direction = direction;
+    m_timing.direction = direction;
 }
 
 void AnimationEffect::setTimingFunction(const RefPtr<TimingFunction>& timingFunction)
 {
-    m_timingFunction = timingFunction;
+    m_timing.timingFunction = timingFunction;
 }
 
 std::optional<double> AnimationEffect::progressUntilNextStep(double iterationProgress) const
 {
-    if (!is<StepsTimingFunction>(m_timingFunction))
+    if (!is<StepsTimingFunction>(m_timing.timingFunction))
         return std::nullopt;
 
-    auto numberOfSteps = downcast<StepsTimingFunction>(*m_timingFunction).numberOfSteps();
+    auto numberOfSteps = downcast<StepsTimingFunction>(*m_timing.timingFunction).numberOfSteps();
     auto nextStepProgress = ceil(iterationProgress * numberOfSteps) / numberOfSteps;
     return nextStepProgress - iterationProgress;
 }

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "AnimationEffect.h"
-#include "AnimationEffectPhase.h"
+#include "AnimationEffectTiming.h"
 #include "BasicEffectTiming.h"
 #include "ComputedEffectTiming.h"
 #include "ExceptionOr.h"
@@ -56,7 +56,6 @@ public:
     virtual bool isKeyframeEffect() const { return false; }
 
     EffectTiming getBindingsTiming() const;
-    EffectTiming getTiming() const;
     BasicEffectTiming getBasicTiming(std::optional<Seconds> = std::nullopt) const;
     ComputedEffectTiming getBindingsComputedTiming() const;
     ComputedEffectTiming getComputedTiming(std::optional<Seconds> = std::nullopt) const;
@@ -70,35 +69,37 @@ public:
     virtual void animationTimelineDidChange(AnimationTimeline*) { };
     virtual void animationDidFinish() { };
 
+    AnimationEffectTiming timing() const { return m_timing; }
+
     WebAnimation* animation() const { return m_animation.get(); }
     virtual void setAnimation(WebAnimation*);
 
-    Seconds delay() const { return m_delay; }
+    Seconds delay() const { return m_timing.delay; }
     void setDelay(const Seconds&);
 
-    Seconds endDelay() const { return m_endDelay; }
+    Seconds endDelay() const { return m_timing.endDelay; }
     void setEndDelay(const Seconds&);
 
-    FillMode fill() const { return m_fill; }
+    FillMode fill() const { return m_timing.fill; }
     void setFill(FillMode);
 
-    double iterationStart() const { return m_iterationStart; }
+    double iterationStart() const { return m_timing.iterationStart; }
     ExceptionOr<void> setIterationStart(double);
 
-    double iterations() const { return m_iterations; }
+    double iterations() const { return m_timing.iterations; }
     ExceptionOr<void> setIterations(double);
 
-    Seconds iterationDuration() const { return m_iterationDuration; }
+    Seconds iterationDuration() const { return m_timing.iterationDuration; }
     void setIterationDuration(const Seconds&);
 
-    PlaybackDirection direction() const { return m_direction; }
+    PlaybackDirection direction() const { return m_timing.direction; }
     void setDirection(PlaybackDirection);
 
-    TimingFunction* timingFunction() const { return m_timingFunction.get(); }
+    TimingFunction* timingFunction() const { return m_timing.timingFunction.get(); }
     void setTimingFunction(const RefPtr<TimingFunction>&);
 
-    Seconds activeDuration() const { return m_activeDuration; }
-    Seconds endTime() const { return m_endTime; }
+    Seconds activeDuration() const { return m_timing.activeDuration; }
+    Seconds endTime() const { return m_timing.endTime; }
 
     void updateStaticTimingProperties();
 
@@ -113,22 +114,11 @@ protected:
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:
-    enum class ComputedDirection : uint8_t { Forwards, Reverse };
+    std::optional<Seconds> localTime(std::optional<Seconds>) const;
+    double playbackRate() const;
 
-    FillMode m_fill { FillMode::Auto };
-    PlaybackDirection m_direction { PlaybackDirection::Normal };
-
+    AnimationEffectTiming m_timing;
     WeakPtr<WebAnimation, WeakPtrImplWithEventTargetData> m_animation;
-    RefPtr<TimingFunction> m_timingFunction;
-
-    double m_iterationStart { 0 };
-    double m_iterations { 1 };
-
-    Seconds m_delay { 0_s };
-    Seconds m_endDelay { 0_s };
-    Seconds m_iterationDuration { 0_s };
-    Seconds m_activeDuration { 0_s };
-    Seconds m_endTime { 0_s };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationEffectTiming.cpp
+++ b/Source/WebCore/animation/AnimationEffectTiming.cpp
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "config.h"
+#include "AnimationEffectTiming.h"
+
+namespace WebCore {
+
+void AnimationEffectTiming::updateComputedProperties()
+{
+    // 3.8.2. Calculating the active duration
+    // https://drafts.csswg.org/web-animations-1/#calculating-the-active-duration
+
+    // The active duration is calculated as follows:
+    // active duration = iteration duration × iteration count
+    // If either the iteration duration or iteration count are zero, the active duration is zero.
+    if (!iterationDuration || !iterations)
+        activeDuration = 0_s;
+    else
+        activeDuration = iterationDuration * iterations;
+
+    // 3.5.3 The active interval
+    // https://drafts.csswg.org/web-animations-1/#end-time
+
+    // The end time of an animation effect is the result of evaluating max(start delay + active duration + end delay, 0).
+    endTime = delay + activeDuration + endDelay;
+    if (endTime < 0_s)
+        endTime = 0_s;
+}
+
+BasicEffectTiming AnimationEffectTiming::getBasicTiming(std::optional<Seconds> localTime, double playbackRate) const
+{
+    // The Web Animations spec introduces a number of animation effect time-related definitions that refer
+    // to each other a fair bit, so rather than implementing them as individual methods, it's more efficient
+    // to return them all as a single BasicEffectTiming.
+
+    auto phase = [this, localTime, playbackRate]() -> AnimationEffectPhase {
+        // 3.5.5. Animation effect phases and states
+        // https://drafts.csswg.org/web-animations-1/#animation-effect-phases-and-states
+
+        bool animationIsBackwards = playbackRate < 0;
+        auto beforeActiveBoundaryTime = std::max(std::min(delay, endTime), 0_s);
+        auto activeAfterBoundaryTime = std::max(std::min(delay + activeDuration, endTime), 0_s);
+
+        // (This should be the last statement, but it's more efficient to cache the local time and return right away if it's not resolved.)
+        // Furthermore, it is often convenient to refer to the case when an animation effect is in none of the above phases
+        // as being in the idle phase.
+        if (!localTime)
+            return AnimationEffectPhase::Idle;
+
+        // An animation effect is in the before phase if the animation effect’s local time is not unresolved and
+        // either of the following conditions are met:
+        //     1. the local time is less than the before-active boundary time, or
+        //     2. the animation direction is ‘backwards’ and the local time is equal to the before-active boundary time.
+        if ((*localTime + timeEpsilon) < beforeActiveBoundaryTime || (animationIsBackwards && std::abs(localTime->microseconds() - beforeActiveBoundaryTime.microseconds()) < timeEpsilon.microseconds()))
+            return AnimationEffectPhase::Before;
+
+        // An animation effect is in the after phase if the animation effect’s local time is not unresolved and
+        // either of the following conditions are met:
+        //     1. the local time is greater than the active-after boundary time, or
+        //     2. the animation direction is ‘forwards’ and the local time is equal to the active-after boundary time.
+        if ((*localTime - timeEpsilon) > activeAfterBoundaryTime || (!animationIsBackwards && std::abs(localTime->microseconds() - activeAfterBoundaryTime.microseconds()) < timeEpsilon.microseconds()))
+            return AnimationEffectPhase::After;
+
+        // An animation effect is in the active phase if the animation effect’s local time is not unresolved and it is not
+        // in either the before phase nor the after phase.
+        // (No need to check, we've already established that local time was resolved).
+        return AnimationEffectPhase::Active;
+    }();
+
+    auto activeTime = [this, localTime, phase]() -> std::optional<Seconds> {
+        // 3.8.3.1. Calculating the active time
+        // https://drafts.csswg.org/web-animations-1/#calculating-the-active-time
+
+        // The active time is based on the local time and start delay. However, it is only defined
+        // when the animation effect should produce an output and hence depends on its fill mode
+        // and phase as follows,
+
+        // If the animation effect is in the before phase, the result depends on the first matching
+        // condition from the following,
+        if (phase == AnimationEffectPhase::Before) {
+            // If the fill mode is backwards or both, return the result of evaluating
+            // max(local time - start delay, 0).
+            if (fill == FillMode::Backwards || fill == FillMode::Both)
+                return std::max(*localTime - delay, 0_s);
+            // Otherwise, return an unresolved time value.
+            return std::nullopt;
+        }
+
+        // If the animation effect is in the active phase, return the result of evaluating local time - start delay.
+        if (phase == AnimationEffectPhase::Active)
+            return *localTime - delay;
+
+        // If the animation effect is in the after phase, the result depends on the first matching
+        // condition from the following,
+        if (phase == AnimationEffectPhase::After) {
+            // If the fill mode is forwards or both, return the result of evaluating
+            // max(min(local time - start delay, active duration), 0).
+            if (fill == FillMode::Forwards || fill == FillMode::Both)
+                return std::max(std::min(*localTime - delay, activeDuration), 0_s);
+            // Otherwise, return an unresolved time value.
+            return std::nullopt;
+        }
+
+        // Otherwise (the local time is unresolved), return an unresolved time value.
+        return std::nullopt;
+    }();
+
+    return { localTime, activeTime, endTime, activeDuration, phase };
+}
+
+enum ComputedDirection : uint8_t { Forwards, Reverse };
+
+ResolvedEffectTiming AnimationEffectTiming::resolve(std::optional<Seconds> localTime, double playbackRate) const
+{
+    // The Web Animations spec introduces a number of animation effect time-related definitions that refer
+    // to each other a fair bit, so rather than implementing them as individual methods, it's more efficient
+    // to return them all as a single ComputedEffectTiming.
+
+    auto basicEffectTiming = getBasicTiming(localTime, playbackRate);
+    auto activeTime = basicEffectTiming.activeTime;
+    auto phase = basicEffectTiming.phase;
+
+    auto overallProgress = [this, phase, activeTime]() -> std::optional<double> {
+        // 3.8.3.2. Calculating the overall progress
+        // https://drafts.csswg.org/web-animations-1/#calculating-the-overall-progress
+
+        // The overall progress describes the number of iterations that have completed (including partial iterations) and is defined as follows:
+
+        // 1. If the active time is unresolved, return unresolved.
+        if (!activeTime)
+            return std::nullopt;
+
+        // 2. Calculate an initial value for overall progress based on the first matching condition from below,
+        auto overallProgress = [&]() -> double {
+            // If the iteration duration is zero, if the animation effect is in the before phase, let overall progress be zero,
+            // otherwise, let it be equal to the iteration count.
+            if (!iterationDuration)
+                return phase == AnimationEffectPhase::Before ? 0 : iterations;
+            // Otherwise, let overall progress be the result of calculating active time / iteration duration.
+            return secondsToWebAnimationsAPITime(*activeTime) / secondsToWebAnimationsAPITime(iterationDuration);
+        }();
+
+        // 3. Return the result of calculating overall progress + iteration start.
+        overallProgress += iterationStart;
+        return std::abs(overallProgress);
+    }();
+
+    auto simpleIterationProgress = [this, overallProgress, phase, activeTime]() -> std::optional<double> {
+        // 3.8.3.3. Calculating the simple iteration progress
+        // https://drafts.csswg.org/web-animations-1/#calculating-the-simple-iteration-progress
+
+        // The simple iteration progress is a fraction of the progress through the current iteration that
+        // ignores transformations to the time introduced by the playback direction or timing functions
+        // applied to the effect, and is calculated as follows:
+
+        // 1. If the overall progress is unresolved, return unresolved.
+        if (!overallProgress)
+            return std::nullopt;
+
+        // 2. If overall progress is infinity, let the simple iteration progress be iteration start % 1.0,
+        // otherwise, let the simple iteration progress be overall progress % 1.0.
+        double simpleIterationProgress = std::isinf(*overallProgress) ? fmod(iterationStart, 1) : fmod(*overallProgress, 1);
+
+        // 3. If all of the following conditions are true,
+        //
+        // the simple iteration progress calculated above is zero, and
+        // the animation effect is in the active phase or the after phase, and
+        // the active time is equal to the active duration, and
+        // the iteration count is not equal to zero.
+        // let the simple iteration progress be 1.0.
+        if (!simpleIterationProgress && (phase == AnimationEffectPhase::Active || phase == AnimationEffectPhase::After) && std::abs(activeTime->microseconds() - activeDuration.microseconds()) < timeEpsilon.microseconds() && iterations)
+            return 1;
+
+        return simpleIterationProgress;
+    }();
+
+    auto currentIteration = [this, activeTime, phase, simpleIterationProgress, overallProgress]() -> std::optional<double> {
+        // 3.8.4. Calculating the current iteration
+        // https://drafts.csswg.org/web-animations-1/#calculating-the-current-iteration
+
+        // The current iteration can be calculated using the following steps:
+
+        // 1. If the active time is unresolved, return unresolved.
+        if (!activeTime)
+            return std::nullopt;
+
+        // 2. If the animation effect is in the after phase and the iteration count is infinity, return infinity.
+        if (phase == AnimationEffectPhase::After && std::isinf(iterations))
+            return std::numeric_limits<double>::infinity();
+
+        // 3. If the simple iteration progress is 1.0, return floor(overall progress) - 1.
+        if (*simpleIterationProgress == 1)
+            return floor(*overallProgress) - 1;
+
+        // 4. Otherwise, return floor(overall progress).
+        return floor(*overallProgress);
+    }();
+
+    auto currentDirection = [this, currentIteration]() -> ComputedDirection {
+        // 3.9.1. Calculating the directed progress
+        // https://drafts.csswg.org/web-animations-1/#calculating-the-directed-progress
+
+        // If playback direction is normal, let the current direction be forwards.
+        if (direction == PlaybackDirection::Normal)
+            return ComputedDirection::Forwards;
+
+        // If playback direction is reverse, let the current direction be reverse.
+        if (direction == PlaybackDirection::Reverse)
+            return ComputedDirection::Reverse;
+
+        if (!currentIteration)
+            return ComputedDirection::Forwards;
+
+        // Otherwise, let d be the current iteration.
+        auto d = *currentIteration;
+        // If playback direction is alternate-reverse increment d by 1.
+        if (direction == PlaybackDirection::AlternateReverse)
+            d++;
+        // If d % 2 == 0, let the current direction be forwards, otherwise let the current direction be reverse.
+        // If d is infinity, let the current direction be forwards.
+        if (std::isinf(d) || !fmod(d, 2))
+            return ComputedDirection::Forwards;
+        return ComputedDirection::Reverse;
+    }();
+
+    auto directedProgress = [simpleIterationProgress, currentDirection]() -> std::optional<double> {
+        // 3.9.1. Calculating the directed progress
+        // https://drafts.csswg.org/web-animations-1/#calculating-the-directed-progress
+
+        // The directed progress is calculated from the simple iteration progress using the following steps:
+
+        // 1. If the simple iteration progress is unresolved, return unresolved.
+        if (!simpleIterationProgress)
+            return std::nullopt;
+
+        // 2. Calculate the current direction (we implement this as a separate method).
+
+        // 3. If the current direction is forwards then return the simple iteration progress.
+        if (currentDirection == ComputedDirection::Forwards)
+            return *simpleIterationProgress;
+
+        // Otherwise, return 1.0 - simple iteration progress.
+        return 1 - *simpleIterationProgress;
+    }();
+
+    auto transformedProgress = [this, directedProgress, currentDirection, phase]() -> std::optional<double> {
+        // 3.10.1. Calculating the transformed progress
+        // https://drafts.csswg.org/web-animations-1/#calculating-the-transformed-progress
+
+        // The transformed progress is calculated from the directed progress using the following steps:
+        //
+        // 1. If the directed progress is unresolved, return unresolved.
+        if (!directedProgress)
+            return std::nullopt;
+
+        if (iterationDuration) {
+            bool before = false;
+            // 2. Calculate the value of the before flag as follows:
+            if (is<StepsTimingFunction>(timingFunction)) {
+                // 1. Determine the current direction using the procedure defined in §3.9.1 Calculating the directed progress.
+                // 2. If the current direction is forwards, let going forwards be true, otherwise it is false.
+                bool goingForwards = currentDirection == ComputedDirection::Forwards;
+                // 3. The before flag is set if the animation effect is in the before phase and going forwards is true;
+                //    or if the animation effect is in the after phase and going forwards is false.
+                before = (phase == AnimationEffectPhase::Before && goingForwards) || (phase == AnimationEffectPhase::After && !goingForwards);
+            }
+
+            // 3. Return the result of evaluating the animation effect’s timing function passing directed progress as the
+            //    input progress value and before flag as the before flag.
+            return timingFunction->transformProgress(*directedProgress, iterationDuration.seconds(), before);
+        }
+
+        return *directedProgress;
+    }();
+
+    return { currentIteration, phase, transformedProgress, simpleIterationProgress };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AnimationEffectPhase.h"
+#include "BasicEffectTiming.h"
+#include "FillMode.h"
+#include "PlaybackDirection.h"
+#include "TimingFunction.h"
+#include "WebAnimationTypes.h"
+#include <wtf/RefPtr.h>
+#include <wtf/Seconds.h>
+
+namespace WebCore {
+
+struct ResolvedEffectTiming {
+    MarkableDouble currentIteration;
+    AnimationEffectPhase phase { AnimationEffectPhase::Idle };
+    MarkableDouble transformedProgress;
+    MarkableDouble simpleIterationProgress;
+};
+
+struct AnimationEffectTiming {
+    RefPtr<TimingFunction> timingFunction { LinearTimingFunction::create() };
+    FillMode fill { FillMode::Auto };
+    PlaybackDirection direction { PlaybackDirection::Normal };
+    double iterationStart { 0 };
+    double iterations { 1 };
+    Seconds delay { 0_s };
+    Seconds endDelay { 0_s };
+    Seconds iterationDuration { 0_s };
+    Seconds activeDuration { 0_s };
+    Seconds endTime { 0_s };
+
+    void updateComputedProperties();
+    BasicEffectTiming getBasicTiming(std::optional<Seconds> localTime, double playbackRate) const;
+    ResolvedEffectTiming resolve(std::optional<Seconds> localTime, double playbackRate) const;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -28,9 +28,8 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include "AcceleratedEffectValues.h"
+#include "AnimationEffectTiming.h"
 #include "CompositeOperation.h"
-#include "FillMode.h"
-#include "PlaybackDirection.h"
 #include "TimingFunction.h"
 #include "WebAnimationTypes.h"
 #include <wtf/IsoMalloc.h>
@@ -75,7 +74,7 @@ class AcceleratedEffect : public RefCounted<AcceleratedEffect> {
     WTF_MAKE_ISO_ALLOCATED(AcceleratedEffect);
 public:
     static Ref<AcceleratedEffect> create(const KeyframeEffect&, const IntRect&);
-    WEBCORE_EXPORT static Ref<AcceleratedEffect> create(Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, FillMode, PlaybackDirection, CompositeOperation, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double iterationStart, double iterations, double playbackRate, Seconds delay, Seconds endDelay, Seconds iterationDuration, Seconds activeDuration, Seconds endTime, std::optional<Seconds> startTime, std::optional<Seconds> holdTime);
+    WEBCORE_EXPORT static Ref<AcceleratedEffect> create(AnimationEffectTiming, Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<Seconds> startTime, std::optional<Seconds> holdTime);
 
     virtual ~AcceleratedEffect() = default;
 
@@ -83,23 +82,14 @@ public:
     WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
     // Encoding and decoding support
+    AnimationEffectTiming timing() const { return m_timing; }
     const Vector<AcceleratedEffectKeyframe>& keyframes() const { return m_keyframes; }
     WebAnimationType animationType() const { return m_animationType; }
-    FillMode fill() const { return m_fill; }
-    PlaybackDirection direction() const { return m_direction; }
     CompositeOperation compositeOperation() const { return m_compositeOperation; }
-    const RefPtr<TimingFunction>& timingFunction() const { return m_timingFunction; }
     const RefPtr<TimingFunction>& defaultKeyframeTimingFunction() const { return m_defaultKeyframeTimingFunction; }
     const OptionSet<AcceleratedEffectProperty>& animatedProperties() const { return m_animatedProperties; }
     bool paused() const { return m_paused; }
-    double iterationStart() const { return m_iterationStart; }
-    double iterations() const { return m_iterations; }
     double playbackRate() const { return m_playbackRate; }
-    Seconds delay() const { return m_delay; }
-    Seconds endDelay() const { return m_endDelay; }
-    Seconds iterationDuration() const { return m_iterationDuration; }
-    Seconds activeDuration() const { return m_activeDuration; }
-    Seconds endTime() const { return m_endTime; }
     std::optional<Seconds> startTime() const { return m_startTime; }
     std::optional<Seconds> holdTime() const { return m_holdTime; }
 
@@ -107,26 +97,17 @@ public:
 
 private:
     AcceleratedEffect(const KeyframeEffect&, const IntRect&);
-    explicit AcceleratedEffect(Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, FillMode, PlaybackDirection, CompositeOperation, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double iterationStart, double iterations, double playbackRate, WTF::Seconds delay, WTF::Seconds endDelay, WTF::Seconds iterationDuration, WTF::Seconds activeDuration, WTF::Seconds endTime, std::optional<WTF::Seconds> startTime, std::optional<WTF::Seconds> holdTime);
+    explicit AcceleratedEffect(AnimationEffectTiming, Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WTF::Seconds> startTime, std::optional<WTF::Seconds> holdTime);
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 
+    AnimationEffectTiming m_timing;
     Vector<AcceleratedEffectKeyframe> m_keyframes;
     WebAnimationType m_animationType { WebAnimationType::WebAnimation };
-    FillMode m_fill { FillMode::Auto };
-    PlaybackDirection m_direction { PlaybackDirection::Normal };
     CompositeOperation m_compositeOperation { CompositeOperation::Replace };
-    RefPtr<TimingFunction> m_timingFunction;
     RefPtr<TimingFunction> m_defaultKeyframeTimingFunction;
     OptionSet<AcceleratedEffectProperty> m_animatedProperties;
     bool m_paused { false };
-    double m_iterationStart { 0 };
-    double m_iterations { 1 };
     double m_playbackRate { 1 };
-    Seconds m_delay { 0_s };
-    Seconds m_endDelay { 0_s };
-    Seconds m_iterationDuration { 0_s };
-    Seconds m_activeDuration { 0_s };
-    Seconds m_endTime { 0_s };
     std::optional<Seconds> m_startTime;
     std::optional<Seconds> m_holdTime;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5776,6 +5776,19 @@ struct WebCore::AcceleratedEffectValues {
 #endif
 }
 
+struct WebCore::AnimationEffectTiming {
+    RefPtr<WebCore::TimingFunction> timingFunction;
+    WebCore::FillMode fill;
+    WebCore::PlaybackDirection direction;
+    double iterationStart;
+    double iterations;
+    WTF::Seconds delay;
+    WTF::Seconds endDelay;
+    WTF::Seconds iterationDuration;
+    WTF::Seconds activeDuration;
+    WTF::Seconds endTime;
+};
+
 header: <WebCore/AcceleratedEffect.h>
 [CustomHeader] struct WebCore::AcceleratedEffectKeyframe {
     double offset;
@@ -5786,23 +5799,14 @@ header: <WebCore/AcceleratedEffect.h>
 };
 
 [RefCounted] class WebCore::AcceleratedEffect {
+    WebCore::AnimationEffectTiming timing();
     Vector<WebCore::AcceleratedEffectKeyframe> keyframes();
     WebCore::WebAnimationType animationType();
-    WebCore::FillMode fill();
-    WebCore::PlaybackDirection direction();
     WebCore::CompositeOperation compositeOperation();
-    RefPtr<WebCore::TimingFunction> timingFunction();
     RefPtr<WebCore::TimingFunction> defaultKeyframeTimingFunction();
     OptionSet<WebCore::AcceleratedEffectProperty> animatedProperties();
     bool paused();
-    double iterationStart();
-    double iterations();
     double playbackRate();
-    WTF::Seconds delay();
-    WTF::Seconds endDelay();
-    WTF::Seconds iterationDuration();
-    WTF::Seconds activeDuration();
-    WTF::Seconds endTime();
     std::optional<WTF::Seconds> startTime();
     std::optional<WTF::Seconds> holdTime();
 };


### PR DESCRIPTION
#### 8f40ab2aadbb297eab5010e432ae9e25812b71b9
<pre>
[web-animations] move shared timing data between AnimationEffect and AcceleratedEffect to a dedicated struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=264394">https://bugs.webkit.org/show_bug.cgi?id=264394</a>

Reviewed by Dean Jackson.

Refactor `AcceleratedEffect` and `AnimationEffect` to use a shared struct to store timing-related properties: `AnimationEffectTiming`.
This will allow `AcceleratedEffect` to resolve timing and compute the transformed progress of an animation with the same code used
for `KeyframeEffect` in the WebContent process.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::AnimationEffect):
(WebCore::AnimationEffect::getBindingsTiming const):
(WebCore::AnimationEffect::localTime const):
(WebCore::AnimationEffect::playbackRate const):
(WebCore::AnimationEffect::getBasicTiming const):
(WebCore::AnimationEffect::getComputedTiming const):
(WebCore::AnimationEffect::updateTiming):
(WebCore::AnimationEffect::updateStaticTimingProperties):
(WebCore::AnimationEffect::setIterationStart):
(WebCore::AnimationEffect::setIterations):
(WebCore::AnimationEffect::setDelay):
(WebCore::AnimationEffect::setEndDelay):
(WebCore::AnimationEffect::setFill):
(WebCore::AnimationEffect::setIterationDuration):
(WebCore::AnimationEffect::setDirection):
(WebCore::AnimationEffect::setTimingFunction):
(WebCore::AnimationEffect::progressUntilNextStep const):
(WebCore::AnimationEffect::getTiming const): Deleted.
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::timing const):
(WebCore::AnimationEffect::delay const):
(WebCore::AnimationEffect::endDelay const):
(WebCore::AnimationEffect::fill const):
(WebCore::AnimationEffect::iterationStart const):
(WebCore::AnimationEffect::iterations const):
(WebCore::AnimationEffect::iterationDuration const):
(WebCore::AnimationEffect::direction const):
(WebCore::AnimationEffect::timingFunction const):
(WebCore::AnimationEffect::activeDuration const):
(WebCore::AnimationEffect::endTime const):
* Source/WebCore/animation/AnimationEffectTiming.cpp: Added.
(WebCore::AnimationEffectTiming::updateComputedProperties):
(WebCore::AnimationEffectTiming::getBasicTiming const):
(WebCore::AnimationEffectTiming::resolve const):
* Source/WebCore/animation/AnimationEffectTiming.h: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::clone const):
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::timing const):
(WebCore::AcceleratedEffect::animationType const):
(WebCore::AcceleratedEffect::compositeOperation const):
(WebCore::AcceleratedEffect::paused const):
(WebCore::AcceleratedEffect::playbackRate const):
(WebCore::AcceleratedEffect::fill const): Deleted.
(WebCore::AcceleratedEffect::direction const): Deleted.
(WebCore::AcceleratedEffect::timingFunction const): Deleted.
(WebCore::AcceleratedEffect::iterationStart const): Deleted.
(WebCore::AcceleratedEffect::iterations const): Deleted.
(WebCore::AcceleratedEffect::delay const): Deleted.
(WebCore::AcceleratedEffect::endDelay const): Deleted.
(WebCore::AcceleratedEffect::iterationDuration const): Deleted.
(WebCore::AcceleratedEffect::activeDuration const): Deleted.
(WebCore::AcceleratedEffect::endTime const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270402@main">https://commits.webkit.org/270402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77ad6cf57f9d91c65b8d1c6585d9505228d9b448

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25342 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23245 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23434 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28032 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28904 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26754 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/804 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2963 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3244 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2855 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->