### PR TITLE
Fix about:blank document.referrer initialization

### DIFF
--- a/LayoutTests/http/wpt/html/browsers/windows/browsing-context.html
+++ b/LayoutTests/http/wpt/html/browsers/windows/browsing-context.html
@@ -43,7 +43,7 @@
     }, "Check that new document nodes extant, empty");
 
     test(function () {
-      assert_equals(doc.referrer, document.location.origin + '/', "The document's referrer should be its creator document's origin.");
+      assert_equals(doc.referrer, document.URL, "The document's referrer should be its creator document's URL.");
       assert_equals(iframe.contentWindow.parent.document, document);
     }, "Check the document properties corresponding to the creator browsing context");
     </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Check that browsing context has new, ready HTML document
 PASS Check that new document nodes extant, empty
-FAIL Check the document properties corresponding to the creator browsing context assert_equals: The document's referrer should be its creator document's URL. expected "http://localhost:8800/html/browsers/windows/browsing-context.html" but got "http://localhost:8800/"
+PASS Check the document properties corresponding to the creator browsing context
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-expected.txt
@@ -1,5 +1,0 @@
-
-PASS Check that browsing context has new, ready HTML document
-PASS Check that new document nodes extant, empty
-FAIL Check the document properties corresponding to the creator browsing context assert_equals: The document's referrer should be its creator document's URL. expected "http://web-platform.test:8800/html/browsers/windows/browsing-context.html" but got "http://web-platform.test:8800/"
-


### PR DESCRIPTION
#### fd0640d8536fbfa6f4018be9ecc9eae72deec5bb
<pre>
Fix about:blank document.referrer initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=242965">https://bugs.webkit.org/show_bug.cgi?id=242965</a>

Reviewed by Darin Adler.

This change makes WebKit conform to the requirement in the HTML spec at
<a href="https://html.spec.whatwg.org/#creating-a-new-browsing-context">https://html.spec.whatwg.org/#creating-a-new-browsing-context</a> that a
new browsing context is created with its referrer set to &quot;the
serialization of [its] creator&apos;s URL&quot; — that is, the creator’s full URL,
without regard to Referrer Policy — which makes the WebKit behavior in
this case interoperable with existing behavior in Blink.

Otherwise, without this change, the referrer is set to an “origin string”
(origin + trailing slash) — which breaks conformance with the spec, and
breaks interop/compat with Blink.

* LayoutTests/http/wpt/html/browsers/windows/browsing-context.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-expected.txt: Removed.
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadSubframe):

Canonical link: <a href="https://commits.webkit.org/273830@main">https://commits.webkit.org/273830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fdf35388f67bcd8bcdf13f3348c359b2994befa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31505 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40667 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37511 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35632 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8342 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->