### PR TITLE
Generate IPC serialization for WebCore::UserStyleLevel enumeration

### DIFF
--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -62,7 +62,7 @@ static Ref<CSSStyleSheet> createExtensionsStyleSheet(Document& document, URL url
     auto contents = StyleSheetContents::create(url.string(), CSSParserContext(document, url));
     auto styleSheet = CSSStyleSheet::create(contents.get(), document, true);
 
-    contents->setIsUserStyleSheet(level == UserStyleUserLevel);
+    contents->setIsUserStyleSheet(level == UserStyleLevel::User);
     contents->parseString(text);
 
     return styleSheet;
@@ -81,7 +81,7 @@ CSSStyleSheet* ExtensionStyleSheets::pageUserSheet()
     if (userSheetText.isEmpty())
         return 0;
     
-    m_pageUserSheet = createExtensionsStyleSheet(m_document, m_document.settings().userStyleSheetLocation(), userSheetText, UserStyleUserLevel);
+    m_pageUserSheet = createExtensionsStyleSheet(m_document, m_document.settings().userStyleSheetLocation(), userSheetText, UserStyleLevel::User);
 
     return m_pageUserSheet.get();
 }

--- a/Source/WebCore/page/UserStyleSheet.h
+++ b/Source/WebCore/page/UserStyleSheet.h
@@ -38,7 +38,7 @@ class UserStyleSheet {
 public:
     UserStyleSheet()
         : m_injectedFrames(UserContentInjectedFrames::InjectInAllFrames)
-        , m_level(UserStyleUserLevel)
+        , m_level(UserStyleLevel::User)
     {
     }
 

--- a/Source/WebCore/page/UserStyleSheetTypes.h
+++ b/Source/WebCore/page/UserStyleSheetTypes.h
@@ -25,14 +25,13 @@
  
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 enum UserStyleInjectionTime { InjectInExistingDocuments, InjectInSubsequentDocuments };
-enum UserStyleLevel { UserStyleUserLevel, UserStyleAuthorLevel };
+enum class UserStyleLevel : bool { User, Author };
 
 class DOMWrapperWorld;
 class UserStyleSheet;
@@ -41,15 +40,3 @@ typedef Vector<std::unique_ptr<UserStyleSheet>> UserStyleSheetVector;
 typedef HashMap<RefPtr<DOMWrapperWorld>, std::unique_ptr<UserStyleSheetVector>> UserStyleSheetMap;
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::UserStyleLevel> {
-    using values = EnumValues<
-        WebCore::UserStyleLevel,
-        WebCore::UserStyleLevel::UserStyleUserLevel,
-        WebCore::UserStyleLevel::UserStyleAuthorLevel
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6660,3 +6660,5 @@ struct WebCore::KeypressCommand {
     String text;
 }
 #endif
+
+[Nested] enum class WebCore::UserStyleLevel : bool;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
@@ -47,7 +47,7 @@
     // FIXME: In the API test, we can use generateUniqueURL below before the API::Object constructor has done this... where should this really be?
     WebKit::InitializeWebKit2();
 
-    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, API::UserStyleSheet::generateUniqueURL(), { }, { }, forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserStyleUserLevel }, API::ContentWorld::pageContentWorld());
+    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, API::UserStyleSheet::generateUniqueURL(), { }, { }, forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserStyleLevel::User }, API::ContentWorld::pageContentWorld());
 
     return self;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheetInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheetInternal.h
@@ -41,13 +41,13 @@ inline WebCore::UserStyleLevel toWebCoreUserStyleLevel(_WKUserStyleLevel level)
 {
     switch (level) {
     case _WKUserStyleUserLevel:
-        return WebCore::UserStyleUserLevel;
+        return WebCore::UserStyleLevel::User;
     case _WKUserStyleAuthorLevel:
-        return WebCore::UserStyleAuthorLevel;
+        return WebCore::UserStyleLevel::Author;
     }
 
     ASSERT_NOT_REACHED();
-    return WebCore::UserStyleUserLevel;
+    return WebCore::UserStyleLevel::User;
 }
 
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
@@ -52,12 +52,12 @@ static inline UserStyleLevel toUserStyleLevel(WebKitUserStyleLevel styleLevel)
 {
     switch (styleLevel) {
     case WEBKIT_USER_STYLE_LEVEL_USER:
-        return UserStyleUserLevel;
+        return UserStyleLevel::User;
     case WEBKIT_USER_STYLE_LEVEL_AUTHOR:
-        return UserStyleAuthorLevel;
+        return UserStyleLevel::Author;
     default:
         ASSERT_NOT_REACHED();
-        return UserStyleAuthorLevel;
+        return UserStyleLevel::Author;
     }
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2357,7 +2357,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
             if (!styleSheetString)
                 continue;
 
-            auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheetString, URL { m_baseURL, styleSheetPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectedFrames, WebCore::UserStyleUserLevel, std::nullopt }, executionWorld);
+            auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheetString, URL { m_baseURL, styleSheetPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectedFrames, WebCore::UserStyleLevel::User, std::nullopt }, executionWorld);
             originInjectedStyleSheets.append(userStyleSheet);
 
             for (auto& userContentController : userContentControllers)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -106,7 +106,7 @@ void injectStyleSheets(SourcePairs styleSheetPairs, WKWebView *webView, API::Con
         if (!styleSheet)
             continue;
 
-        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.value().first, styleSheet.value().second.value_or(URL { }), Vector<String> { }, Vector<String> { }, injectedFrames, WebCore::UserStyleUserLevel, pageID }, executionWorld);
+        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.value().first, styleSheet.value().second.value_or(URL { }), Vector<String> { }, Vector<String> { }, injectedFrames, WebCore::UserStyleLevel::User, pageID }, executionWorld);
 
         for (auto& controller : context.extensionController()->allUserContentControllers())
             controller.addUserStyleSheet(userStyleSheet);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7607,7 +7607,7 @@ void WebPage::addUserScript(String&& source, InjectedBundleScriptWorld& world, W
 
 void WebPage::addUserStyleSheet(const String& source, WebCore::UserContentInjectedFrames injectedFrames)
 {
-    WebCore::UserStyleSheet userStyleSheet {source, aboutBlankURL(), Vector<String>(), Vector<String>(), injectedFrames, UserStyleUserLevel };
+    WebCore::UserStyleSheet userStyleSheet { source, aboutBlankURL(), Vector<String>(), Vector<String>(), injectedFrames, UserStyleLevel::User };
 
     Ref { m_userContentController }->addUserStyleSheet(InjectedBundleScriptWorld::normalWorld(), WTFMove(userStyleSheet));
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -4274,7 +4274,7 @@ IGNORE_WARNINGS_END
     if (!world)
         return;
 
-    auto styleSheet = makeUnique<WebCore::UserStyleSheet>(source, url, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), injectedFrames == WebInjectInAllFrames ? WebCore::UserContentInjectedFrames::InjectInAllFrames : WebCore::UserContentInjectedFrames::InjectInTopFrameOnly, WebCore::UserStyleUserLevel);
+    auto styleSheet = makeUnique<WebCore::UserStyleSheet>(source, url, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), injectedFrames == WebInjectInAllFrames ? WebCore::UserContentInjectedFrames::InjectInAllFrames : WebCore::UserContentInjectedFrames::InjectInTopFrameOnly, WebCore::UserStyleLevel::User);
     viewGroup->userContentController().addUserStyleSheet(*core(world), WTFMove(styleSheet), WebCore::InjectInExistingDocuments);
 }
 


### PR DESCRIPTION
#### ead871fa35c6ac44d0eda9c5a5660eb62bb7e2d5
<pre>
Generate IPC serialization for WebCore::UserStyleLevel enumeration
<a href="https://bugs.webkit.org/show_bug.cgi?id=264403">https://bugs.webkit.org/show_bug.cgi?id=264403</a>

Reviewed by Chris Dumez and Michael Catanzaro.

Turn the WebCore::UserStyleLevel enumeration into a scoped one, adjusting uses
of values accordingly. This enables removing the EnumTraits specialization in
favor of better-handled IPC serialization specification.

* Source/WebCore/dom/ExtensionStyleSheets.cpp:
(WebCore::createExtensionsStyleSheet):
(WebCore::ExtensionStyleSheets::pageUserSheet):
* Source/WebCore/page/UserStyleSheet.h:
(WebCore::UserStyleSheet::UserStyleSheet):
* Source/WebCore/page/UserStyleSheetTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm:
(-[_WKUserStyleSheet initWithSource:forMainFrameOnly:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheetInternal.h:
(API::toWebCoreUserStyleLevel):
* Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp:
(toUserStyleLevel):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addInjectedContent):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::injectStyleSheets):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addUserStyleSheet):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView _addUserStyleSheetToGroup:world:source:url:includeMatchPatternStrings:excludeMatchPatternStrings:injectedFrames:]):

Canonical link: <a href="https://commits.webkit.org/270452@main">https://commits.webkit.org/270452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33c1b292e8f8bdfeb3f8c72c710d143dbd8d99bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1593 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28239 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22981 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23346 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/26912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2726 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4108 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6123 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->