### PR TITLE
[WGSL] countLeadingZeros, countOneBits, countTrailingZeros, reverseBits, extractBits, faceForward, insertBits are unimplemented

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1419,16 +1419,23 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
         }
 
         static constexpr std::pair<ComparableASCIILiteral, ASCIILiteral> directMappings[] {
+            { "countLeadingZeros", "clz"_s },
+            { "countOneBits", "popcount"_s },
+            { "countTrailingZeros", "ctz"_s },
             { "dpdx", "dfdx"_s },
             { "dpdxCoarse", "dfdx"_s },
             { "dpdxFine", "dfdx"_s },
             { "dpdy", "dfdy"_s },
             { "dpdyCoarse", "dfdy"_s },
             { "dpdyFine", "dfdy"_s },
+            { "extractBits", "extract_bits"_s },
+            { "faceForward", "faceforward"_s },
             { "frexp", "__wgslFrexp"_s },
             { "fwidthCoarse", "fwidth"_s },
             { "fwidthFine", "fwidth"_s },
+            { "insertBits", "insert_bits"_s },
             { "inverseSqrt", "rsqrt"_s },
+            { "reverseBits", "reverse_bits"_s },
         };
         static constexpr SortedArrayMap mappedNames { directMappings };
         if (call.isConstructor()) {

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -919,39 +919,65 @@ fn testClamp()
 // Tested in testTrigonometric and testTrigonometricHyperbolic
 
 // 17.5.13-15 (Bit counting)
+// RUN: %metal-compile testBitCounting
+@compute @workgroup_size(1)
 fn testBitCounting()
 {
     // [T < ConcreteInteger].(T) => T,
     {
+        let i = 1i;
+        let u = 1u;
         _ = countLeadingZeros(1);
         _ = countLeadingZeros(1i);
         _ = countLeadingZeros(1u);
+        let r1: i32 = countLeadingZeros(i);
+        let r2: u32 = countLeadingZeros(u);
     }
     {
+        let i = 1i;
+        let u = 1u;
         _ = countOneBits(1);
         _ = countOneBits(1i);
         _ = countOneBits(1u);
+        let r1: i32 = countOneBits(i);
+        let r2: u32 = countOneBits(u);
     }
     {
+        let i = 1i;
+        let u = 1u;
         _ = countTrailingZeros(1);
         _ = countTrailingZeros(1i);
         _ = countTrailingZeros(1u);
+        let r1: i32 = countTrailingZeros(i);
+        let r2: u32 = countTrailingZeros(u);
     }
     // [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
     {
+        let vi = vec2(1i);
+        let vu = vec2(1u);
         _ = countLeadingZeros(vec2(1, 1));
         _ = countLeadingZeros(vec2(1i, 1i));
         _ = countLeadingZeros(vec2(1u, 1u));
+        let r1: vec2i = countLeadingZeros(vi);
+        let r2: vec2u = countLeadingZeros(vu);
     }
     {
+        let vi = vec3(1i);
+        let vu = vec3(1u);
         _ = countOneBits(vec3(1, 1, 1));
         _ = countOneBits(vec3(1i, 1i, 1i));
         _ = countOneBits(vec3(1u, 1u, 1u));
+        let r1: vec3i = countOneBits(vi);
+        let r2: vec3u = countOneBits(vu);
     }
     {
+        let vi = vec4(1i);
+        let vu = vec4(1u);
         _ = countTrailingZeros(vec4(1, 1, 1, 1));
         _ = countTrailingZeros(vec4(1i, 1i, 1i, 1i));
         _ = countTrailingZeros(vec4(1u, 1u, 1u, 1u));
+        let r1: vec4i = countTrailingZeros(vi);
+        let r2: vec4u = countTrailingZeros(vu);
     }
 }
 
@@ -1138,76 +1164,102 @@ fn testExpAndExp2() {
 }
 
 // 17.5.23 & 17.5.24
+// RUN: %metal-compile testExtractBits
+@compute @workgroup_size(1)
 fn testExtractBits()
 {
     // signed
     // [].(I32, U32, U32) => I32,
     {
+        let i = 0i;
         _ = extractBits(0, 1, 1);
         _ = extractBits(0i, 1, 1);
         _ = extractBits(0i, 1u, 1u);
+        let r: i32 = extractBits(i, 1u, 1u);
     }
     // [N].(Vector[I32, N], U32, U32) => Vector[I32, N],
     {
+        let vi = vec2(0i);
         _ = extractBits(vec2(0), 1, 1);
         _ = extractBits(vec2(0i), 1, 1);
         _ = extractBits(vec2(0i), 1u, 1u);
+        let r: vec2i = extractBits(vi, 1u, 1u);
     }
     {
+        let vi = vec3(0i);
         _ = extractBits(vec3(0), 1, 1);
         _ = extractBits(vec3(0i), 1, 1);
         _ = extractBits(vec3(0i), 1u, 1u);
+        let r: vec3i = extractBits(vi, 1u, 1u);
     }
     {
+        let vi = vec4(0i);
         _ = extractBits(vec4(0), 1, 1);
         _ = extractBits(vec4(0i), 1, 1);
         _ = extractBits(vec4(0i), 1u, 1u);
+        let r: vec4i = extractBits(vi, 1u, 1u);
     }
 
     // unsigned
     // [].(U32, U32, U32) => U32,
     {
+        let u = 0u;
         _ = extractBits(0, 1, 1);
         _ = extractBits(0u, 1, 1);
         _ = extractBits(0u, 1u, 1u);
+        let r: u32 = extractBits(u, 1u, 1u);
     }
 
     // [N].(Vector[U32, N], U32, U32) => Vector[U32, N],
     {
+        let vu = vec2(0u);
         _ = extractBits(vec2(0), 1, 1);
         _ = extractBits(vec2(0u), 1, 1);
         _ = extractBits(vec2(0u), 1u, 1u);
+        let r: vec2u = extractBits(vu, 1u, 1u);
     }
     {
+        let vu = vec3(0u);
         _ = extractBits(vec3(0), 1, 1);
         _ = extractBits(vec3(0u), 1, 1);
         _ = extractBits(vec3(0u), 1u, 1u);
+        let r: vec3u = extractBits(vu, 1u, 1u);
     }
     {
+        let vu = vec4(0u);
         _ = extractBits(vec4(0), 1, 1);
         _ = extractBits(vec4(0u), 1, 1);
         _ = extractBits(vec4(0u), 1u, 1u);
+        let r: vec4u = extractBits(vu, 1u, 1u);
     }
 }
 
 // 17.5.25
+// RUN: %metal-compile testFaceForward
+@compute @workgroup_size(1)
 fn testFaceForward()
 {
     // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
     {
+        let vf = vec2(2f);
         _ = faceForward(vec2(0), vec2(1),   vec2(2));
         _ = faceForward(vec2(0), vec2(1),   vec2(2.0));
         _ = faceForward(vec2(0), vec2(1.0), vec2(2f));
+        let r: vec2f = faceForward(vf, vf, vf);
     }
     {
+        let vf = vec3(2f);
         _ = faceForward(vec3(0), vec3(1),   vec3(2));
         _ = faceForward(vec3(0), vec3(1),   vec3(2.0));
         _ = faceForward(vec3(0), vec3(1.0), vec3(2f));
+        let r: vec3f = faceForward(vf, vf, vf);
     }
     {
+        let vf = vec4(2f);
         _ = faceForward(vec4(0), vec4(1),   vec4(2));
         _ = faceForward(vec4(0), vec4(1),   vec4(2.0));
         _ = faceForward(vec4(0), vec4(1.0), vec4(2f));
+        let r: vec4f = faceForward(vf, vf, vf);
     }
 }
 
@@ -1393,10 +1445,16 @@ fn testFrexp()
 }
 
 // 17.5.33
+// RUN: %metal-compile testInsertBits
+@compute @workgroup_size(1)
 fn testInsertBits()
 {
     // [T < ConcreteInteger].(T, T, U32, U32) => T,
     {
+        let i = 0i;
+        let u = 0u;
+        let r1: i32 = insertBits(i, i, 0, 0);
+        let r2: u32 = insertBits(u, u, 0, 0);
         _ = insertBits(0, 0, 0, 0);
         _ = insertBits(0, 0i, 0, 0);
         _ = insertBits(0, 0u, 0, 0);
@@ -1404,19 +1462,31 @@ fn testInsertBits()
 
     // [T < ConcreteInteger, N].(Vector[T, N], Vector[T, N], U32, U32) => Vector[T, N],
     {
+        let vi = vec2(0i);
+        let vu = vec2(0u);
         _ = insertBits(vec2(0), vec2(0), 0, 0);
         _ = insertBits(vec2(0), vec2(0i), 0, 0);
         _ = insertBits(vec2(0), vec2(0u), 0, 0);
+        let r1: vec2i = insertBits(vi, vi, 0, 0);
+        let r2: vec2u = insertBits(vu, vu, 0, 0);
     }
     {
+        let vi = vec3(0i);
+        let vu = vec3(0u);
         _ = insertBits(vec3(0), vec3(0), 0, 0);
         _ = insertBits(vec3(0), vec3(0i), 0, 0);
         _ = insertBits(vec3(0), vec3(0u), 0, 0);
+        let r1: vec3i = insertBits(vi, vi, 0, 0);
+        let r2: vec3u = insertBits(vu, vu, 0, 0);
     }
     {
+        let vi = vec4(0i);
+        let vu = vec4(0u);
         _ = insertBits(vec4(0), vec4(0), 0, 0);
         _ = insertBits(vec4(0), vec4(0i), 0, 0);
         _ = insertBits(vec4(0), vec4(0u), 0, 0);
+        let r1: vec4i = insertBits(vi, vi, 0, 0);
+        let r2: vec4u = insertBits(vu, vu, 0, 0);
     }
 }
 
@@ -1865,29 +1935,47 @@ fn testRefract()
 }
 
 // 17.5.49
+// RUN: %metal-compile testReverseBits
+@compute @workgroup_size(1)
 fn testReverseBits()
 {
     // [T < ConcreteInteger].(T) => T,
     {
+        let i = 0i;
+        let u = 0u;
         _ = reverseBits(0);
         _ = reverseBits(0i);
         _ = reverseBits(0u);
+        let r1: i32 = reverseBits(i);
+        let r2: u32 = reverseBits(u);
     }
     // [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
     {
+        let vi = vec2(0i);
+        let vu = vec2(0u);
         _ = reverseBits(vec2(0));
         _ = reverseBits(vec2(0i));
         _ = reverseBits(vec2(0u));
+        let r1: vec2i = reverseBits(vi);
+        let r2: vec2u = reverseBits(vu);
     }
     {
+        let vi = vec3(0i);
+        let vu = vec3(0u);
         _ = reverseBits(vec3(0));
         _ = reverseBits(vec3(0i));
         _ = reverseBits(vec3(0u));
+        let r1: vec3i = reverseBits(vi);
+        let r2: vec3u = reverseBits(vu);
     }
     {
+        let vi = vec4(0i);
+        let vu = vec4(0u);
         _ = reverseBits(vec4(0));
         _ = reverseBits(vec4(0i));
         _ = reverseBits(vec4(0u));
+        let r1: vec4i = reverseBits(vi);
+        let r2: vec4u = reverseBits(vu);
     }
 }
 


### PR DESCRIPTION
#### e5c11b80e43b6b3e9cf189715ba00223aa1ab841
<pre>
[WGSL] countLeadingZeros, countOneBits, countTrailingZeros, reverseBits, extractBits, faceForward, insertBits are unimplemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=264384">https://bugs.webkit.org/show_bug.cgi?id=264384</a>
<a href="https://rdar.apple.com/118098831">rdar://118098831</a>

Reviewed by Mike Wyrzykowski.

Add code generation for all the missing bit functions

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270427@main">https://commits.webkit.org/270427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/173f7533dafc568d074c42631401149fbc9f36bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23449 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28057 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2584 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28923 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26769 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/821 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3929 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6101 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->