### PR TITLE
[WGSL] MSL compilation error opening https://webllm.mlc.ai/ - 'global2' is not declared

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -401,6 +401,7 @@ auto RewriteGlobalVariables::getPacking(AST::FieldAccessExpression& expression) 
 auto RewriteGlobalVariables::getPacking(AST::IndexAccessExpression& expression) -> Packing
 {
     auto basePacking = pack(Packing::Either, expression.base());
+    pack(Packing::Unpacked, expression.index());
     if (basePacking & Packing::Unpacked)
         return Packing::Unpacked;
     auto* baseType = expression.base().inferredType();

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -159,16 +159,19 @@ fn testFieldAccess() -> i32
     return 0;
 }
 
+@group(0) @binding(9) var<storage, read_write> index: u32;
 fn testIndexAccess() -> i32
 {
     // CHECK: local\d+ = __unpack\(global\d+\);
     // CHECK-NEXT: local\d+\[0\] = __unpack\(global\d+\[0\]\);
     // CHECK-NEXT: global\d+\[0\] = global\d+\[0\];
     // CHECK-NEXT: global\d+\[0\] = __pack\(local\d+\[0\]\);
+    // CHECK-NEXT: global\d+\[global\d+\] = __pack\(local\d+\[global\d+\]\);
     var at = at1;
     at[0] = at1[0];
     at1[0] = at2[0];
     at2[0] = at[0];
+    at2[index] = at[index];
     return 0;
 }
 


### PR DESCRIPTION
#### 05939152b8cdf82e762d92acf17feeeb252caa1a
<pre>
[WGSL] MSL compilation error opening <a href="https://webllm.mlc.ai/">https://webllm.mlc.ai/</a> - &apos;global2&apos; is not declared
<a href="https://bugs.webkit.org/show_bug.cgi?id=264373">https://bugs.webkit.org/show_bug.cgi?id=264373</a>
<a href="https://rdar.apple.com/118086159">rdar://118086159</a>

Reviewed by Mike Wyrzykowski.

The GlobalVariableRewriter wasn&apos;t visiting the MemberAccessExpression&apos;s index, so
globals that were only used as indices were never marked as used.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/270431@main">https://commits.webkit.org/270431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a168e2849c035f6caf673f174abec822fe895464

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23450 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28058 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2585 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28921 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26766 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/822 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3931 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->