### PR TITLE
[WGSL] Add support for matrix subtraction

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -442,6 +442,18 @@ CONSTANT_FUNCTION(Minus)
             return -arg;
         });
     }
+
+    if (auto* left = std::get_if<ConstantMatrix>(&arguments[0])) {
+        auto& right = std::get<ConstantMatrix>(arguments[1]);
+        auto* elementType = std::get<Types::Matrix>(*resultType).element;
+        ASSERT(left->columns == right.columns);
+        ASSERT(left->rows == right.rows);
+        ConstantMatrix result(left->columns, left->rows);
+        for (unsigned i = 0; i < result.elements.size(); ++i)
+            CALL_MOVE(result.elements[i], Minus, elementType, { left->elements[i], right.elements[i] });
+        return { { result } };
+    }
+
     return constantBinaryOperation<Constraints::Number>(arguments, [&](auto left, auto right) {
         return left - right;
     });

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -46,6 +46,7 @@ operator :-, {
     [T < Number, N].(vec[N][T], T) => vec[N][T],
     [T < Number, N].(T, vec[N][T]) => vec[N][T],
     [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
+    [T < Float, C, R].(mat[C,R][T], mat[C,R][T]) => mat[C,R][T],
 }
 
 operator :*, {

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -103,6 +103,7 @@ fn testBinaryMinus() {
   _ = vec2(1, 1) - 1;
   _ = 1 - vec2(1, 1);
   _ = vec2(1, 1) - vec2(1, 1);
+  _ = mat2x2(2, 2, 2, 2) - mat2x2(1, 1, 1, 1);
 }
 
 fn testComparison() {


### PR DESCRIPTION
#### 46bbee9398569bbb2fa1e4864fbc0f742d4a3f5c
<pre>
[WGSL] Add support for matrix subtraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=264406">https://bugs.webkit.org/show_bug.cgi?id=264406</a>
<a href="https://rdar.apple.com/118117794">rdar://118117794</a>

Reviewed by Mike Wyrzykowski.

The TypeDeclarations file was missing the subtraction overload for matrices. Add
the missing overload and implement constant matrix subtraction as well.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270428@main">https://commits.webkit.org/270428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f37a7a4e0d35c11a25fef50cd3ded3a831496bb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23268 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23475 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28059 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2586 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28922 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26767 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/823 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3932 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6103 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2912 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->