### PR TITLE
Generate IPC serialization for enumerations under WebCore/applepay/

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePayLaterAvailability.h
+++ b/Source/WebCore/Modules/applepay/ApplePayLaterAvailability.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
 
-#include <wtf/Forward.h>
-
 namespace WebCore {
 
 enum class ApplePayLaterAvailability : uint8_t {
@@ -38,18 +36,5 @@ enum class ApplePayLaterAvailability : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ApplePayLaterAvailability> {
-    using values = EnumValues<
-        WebCore::ApplePayLaterAvailability,
-        WebCore::ApplePayLaterAvailability::Available,
-        WebCore::ApplePayLaterAvailability::UnavailableItemIneligible,
-        WebCore::ApplePayLaterAvailability::UnavailableRecurringTransaction
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(APPLE_PAY_LATER_AVAILABILITY)

--- a/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
@@ -38,12 +38,18 @@
 #include "ApplePayShippingMethod.h"
 #include "PaymentContact.h"
 #include "PaymentInstallmentConfigurationWebCore.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+enum class ApplePaySessionPaymentRequestShippingType : uint8_t {
+    Shipping,
+    Delivery,
+    StorePickup,
+    ServicePickup,
+};
 
 class ApplePaySessionPaymentRequest {
 public:
@@ -92,12 +98,7 @@ public:
     const MerchantCapabilities& merchantCapabilities() const { return m_merchantCapabilities; }
     void setMerchantCapabilities(const MerchantCapabilities& merchantCapabilities) { m_merchantCapabilities = merchantCapabilities; }
 
-    enum class ShippingType {
-        Shipping,
-        Delivery,
-        StorePickup,
-        ServicePickup,
-    };
+    using ShippingType = ApplePaySessionPaymentRequestShippingType;
     ShippingType shippingType() const { return m_shippingType; }
     void setShippingType(ShippingType shippingType) { m_shippingType = shippingType; }
 
@@ -228,19 +229,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ApplePaySessionPaymentRequest::ShippingType> {
-    using values = EnumValues<
-        WebCore::ApplePaySessionPaymentRequest::ShippingType,
-        WebCore::ApplePaySessionPaymentRequest::ShippingType::Shipping,
-        WebCore::ApplePaySessionPaymentRequest::ShippingType::Delivery,
-        WebCore::ApplePaySessionPaymentRequest::ShippingType::StorePickup,
-        WebCore::ApplePaySessionPaymentRequest::ShippingType::ServicePickup
-    >;
-};
-
-} // namespace WTF
 
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.h
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class ApplePayShippingContactEditingMode : uint8_t {
@@ -38,18 +36,5 @@ enum class ApplePayShippingContactEditingMode : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ApplePayShippingContactEditingMode> {
-    using values = EnumValues<
-        WebCore::ApplePayShippingContactEditingMode,
-        WebCore::ApplePayShippingContactEditingMode::Available,
-        WebCore::ApplePayShippingContactEditingMode::Enabled,
-        WebCore::ApplePayShippingContactEditingMode::StorePickup
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -89,3 +89,31 @@ struct WebCore::MediaRecorderPrivateOptions {
 [Nested] class WebCore::ProtectionSpace::PlatformData {
     RetainPtr<NSURLProtectionSpace> nsSpace;
 };
+
+#if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
+header: <WebCore/ApplePayLaterAvailability.h>
+enum class WebCore::ApplePayLaterAvailability : uint8_t {
+    Available,
+    UnavailableItemIneligible,
+    UnavailableRecurringTransaction,
+};
+#endif
+
+#if ENABLE(APPLE_PAY)
+header: <WebCore/ApplePaySessionPaymentRequest.h>
+enum class WebCore::ApplePaySessionPaymentRequestShippingType : uint8_t {
+    Shipping,
+    Delivery,
+    StorePickup,
+    ServicePickup,
+};
+#endif
+
+#if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)
+header: <WebCore/ApplePayShippingContactEditingMode.h>
+enum class WebCore::ApplePayShippingContactEditingMode : uint8_t {
+    Available,
+    Enabled,
+    StorePickup,
+};
+#endif


### PR DESCRIPTION
#### 6b051cebfd814c82ce3f264fb2b3d96c4d42f964
<pre>
Generate IPC serialization for enumerations under WebCore/applepay/
<a href="https://bugs.webkit.org/show_bug.cgi?id=264408">https://bugs.webkit.org/show_bug.cgi?id=264408</a>

Reviewed by Chris Dumez.

Move ApplePaySessionPaymentRequest::ShippingType enumeration outside the
ApplePaySessionPaymentRequest class scope and specify its underlying type alias
uint8_t, providing a type alias inside that class.

This allows specifying IPC serialization for this enumeration as well as the
ApplePayLaterAvailability and ApplePayShippingContactEditingMode enumerations,
enabling removal of the now-redundant EnumTraits specializations.

* Source/WebCore/Modules/applepay/ApplePayLaterAvailability.h:
* Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h:
* Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.h:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270596@main">https://commits.webkit.org/270596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eef899a08530cb3f37bcdd109261c3602b42a845

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23681 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28404 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29199 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27062 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1119 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4267 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6218 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->