### PR TITLE
[WGSL] Add constant support for primitive structs

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.cpp
+++ b/Source/WebGPU/WGSL/ConstantValue.cpp
@@ -86,6 +86,17 @@ void ConstantValue::dump(PrintStream& out) const
                 out.print(element);
             }
             out.print(")");
+        },
+        [&](const ConstantStruct& s) {
+            out.print("struct { ");
+            bool first = true;
+            for (const auto& entry : s.fields) {
+                if (!first)
+                    out.print(", ");
+                first = false;
+                out.print(entry.key, ": ", entry.value);
+            }
+            out.print(" }");
         });
 }
 

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -27,6 +27,9 @@
 #pragma once
 
 #include <wtf/FixedVector.h>
+#include <wtf/HashMap.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
 
 namespace WGSL {
 
@@ -87,7 +90,11 @@ struct ConstantMatrix {
     FixedVector<ConstantValue> elements;
 };
 
-using BaseValue = std::variant<float, double, int32_t, uint32_t, int64_t, bool, ConstantArray, ConstantVector, ConstantMatrix>;
+struct ConstantStruct {
+    HashMap<String, ConstantValue> fields;
+};
+
+using BaseValue = std::variant<float, double, int32_t, uint32_t, int64_t, bool, ConstantArray, ConstantVector, ConstantMatrix, ConstantStruct>;
 struct ConstantValue : BaseValue {
     ConstantValue() = default;
 

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1969,9 +1969,31 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
             // Not supported yet
             RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const PrimitiveStruct&) {
-            // Not supported yet
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const PrimitiveStruct& primitiveStruct) {
+            auto& constantStruct = std::get<ConstantStruct>(value);
+            const auto& keys = Types::PrimitiveStruct::keys[primitiveStruct.kind];
+
+            m_stringBuilder.append(primitiveStruct.name, "<");
+            bool first = true;
+            for (auto& value : primitiveStruct.values) {
+                if (!first)
+                    m_stringBuilder.append(", ");
+                first = false;
+                visit(value);
+            }
+            m_stringBuilder.append("> {");
+            first = true;
+            for (auto& entry : constantStruct.fields) {
+                if (!first)
+                    m_stringBuilder.append(", ");
+                first = false;
+                m_stringBuilder.append(".", entry.key, " = ");
+                auto* key = keys.tryGet(entry.key);
+                RELEASE_ASSERT(key);
+                auto* type = primitiveStruct.values[*key];
+                serializeConstant(type, entry.value);
+            }
+            m_stringBuilder.append("}");
         },
         [&](const Pointer&) {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1647,9 +1647,17 @@ bool TypeChecker::convertValue(const SourceSpan& span, const Type* type, Constan
             // FIXME: this should be supported
             RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const Types::PrimitiveStruct&) -> Conversion {
-            // FIXME: this should be supported
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Types::PrimitiveStruct& primitiveStruct) -> Conversion {
+            auto& constantStruct = std::get<ConstantStruct>(value);
+            const auto& keys = Types::PrimitiveStruct::keys[primitiveStruct.kind];
+            for (auto& entry : constantStruct.fields) {
+                auto* key = keys.tryGet(entry.key);
+                RELEASE_ASSERT(key);
+                auto* type = primitiveStruct.values[*key];
+                if (!convertValue(span, type, entry.value, explicitConversion))
+                    return FailedInner;
+            }
+            return Success;
         },
         [&](const Types::Function&) -> Conversion {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1423,25 +1423,32 @@ fn testFract()
 // 17.5.32
 fn testFrexp()
 {
-    // FIXME: we don't support constant evaluation yet, update tests when it's supported
     {
       let x: f32 = 1.5;
       let y = frexp(x);
+      let w = frexp(1.5);
+      let z = frexp(1.5f);
     }
 
     {
       let x: vec2<f32> = vec2(1.5);
       let y = frexp(x);
+      let w = frexp(vec2(1.5));
+      let z = frexp(vec2(1.5f));
     }
 
     {
       let x: vec3<f32> = vec3(1.5);
       let y = frexp(x);
+      let w = frexp(vec3(1.5));
+      let z = frexp(vec3(1.5f));
     }
 
     {
       let x: vec4<f32> = vec4(1.5);
       let y = frexp(x);
+      let w = frexp(vec4(1.5));
+      let z = frexp(vec4(1.5f));
     }
 }
 


### PR DESCRIPTION
#### 9cfe9c1080bc7b2b85e5197cdc1851d299b549dc
<pre>
[WGSL] Add constant support for primitive structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=264409">https://bugs.webkit.org/show_bug.cgi?id=264409</a>
<a href="https://rdar.apple.com/118118103">rdar://118118103</a>

Reviewed by Mike Wyrzykowski.

This is necessary to compute operations that return structs during constant
evaluation (e.g. frexp).

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/ConstantValue.cpp:
(WGSL::ConstantValue::dump const):
* Source/WebGPU/WGSL/ConstantValue.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::convertValue):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270435@main">https://commits.webkit.org/270435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe17e6141552560d29ebe94a28b676df567b9e54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23272 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23452 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28063 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2605 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28925 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23186 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26771 "Found 2 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/825 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3941 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6106 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->