### PR TITLE
[iOS] [UIAsyncTextInput] Support text context requests for autocorrection in UIKit

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -255,6 +255,8 @@ struct WKAutoCorrectionData {
     CGRect textLastRect;
 };
 
+enum class RequestAutocorrectionContextResult : bool { Empty, LastContext };
+
 struct RemoveBackgroundData {
     WebCore::ElementContext element;
     RetainPtr<CGImageRef> image;
@@ -498,7 +500,7 @@ struct ImageAnalysisContextMenuActionData {
     NSInteger _suppressNonEditableSingleTapTextInteractionCount;
     CompletionHandler<void(WebCore::DOMPasteAccessResponse)> _domPasteRequestHandler;
     std::optional<WebCore::DOMPasteAccessCategory> _domPasteRequestCategory;
-    BlockPtr<void(UIWKAutocorrectionContext *)> _pendingAutocorrectionContextHandler;
+    CompletionHandler<void(WebKit::RequestAutocorrectionContextResult)> _pendingAutocorrectionContextHandler;
     CompletionHandler<void()> _pendingRunModalJavaScriptDialogCallback;
 
     RetainPtr<NSDictionary> _additionalContextForStrongPasswordAssistance;

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -61,6 +61,16 @@ SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
     return self;
 }
 
+- (void)dealloc
+{
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    if (_asyncTextInteraction)
+        [_view removeInteraction:_asyncTextInteraction.get()];
+#endif
+
+    [super dealloc];
+}
+
 - (UIWKTextInteractionAssistant *)textInteractionAssistant
 {
     return _textInteractionAssistant.get();


### PR DESCRIPTION
#### 6f7cadfbdbe598673d2062be72141ead0a8b5aff
<pre>
[iOS] [UIAsyncTextInput] Support text context requests for autocorrection in UIKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=264412">https://bugs.webkit.org/show_bug.cgi?id=264412</a>

Reviewed by Tim Horton.

Adopt `-requestTextContextForAutocorrectionWithCompletionHandler:`, which is intended to replace
`-requestAutocorrectionContextWithCompletionHandler:`; the only functional difference here is that
the completion handler takes a `UIWKDocumentContext` (which will, itself, have a more generic name
in the near future) instead of a `UIWKAutocorrectionContext`.

To make this compatible with both the async text input codepath and legacy codepaths, we refactor
our logic for delivering this autocorrection context, such that the two codepaths both rely on a
common `-_internalRequestAutocorrectionContextWithCompletionHandler:` helper, which calls the
completion handler with an enum type indicating whether or not we should return the last cached
autocorrection context data on the content view. The logic to convert this cached WebKit struct into
either a `UIWKDocumentContext` or `UIWKAutocorrectionContext` exists in the delegate methods
themselves (`-requestAutocorrectionContextWithCompletionHandler:` and
`requestTextContextForAutocorrectionWithCompletionHandler:`).

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _cancelPendingAutocorrectionContextHandler]):
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):
(-[WKContentView _internalRequestAutocorrectionContextWithCompletionHandler:]):
(-[WKContentView requestTextContextForAutocorrectionWithCompletionHandler:]):
(-[WKContentView _invokePendingAutocorrectionContextHandler:]): Deleted.
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper dealloc]):

Drive-by fix: make sure we uninstall the async text interaction when tearing down the wrapper. This
is crucial to make sure that the interactions and related gestures are actually uninstalled from
the web view, upon calling `-[WKContentView cleanupInteraction]`

Canonical link: <a href="https://commits.webkit.org/270403@main">https://commits.webkit.org/270403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e18bc6aa59e9e16487b8afcb3a358c45cc23bf3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27513 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1442 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28092 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28949 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26793 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/855 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3972 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3051 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2943 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->