### PR TITLE
Clean up trivial-case EnumTraits for enumerations under WebCore/{Modules,loader,page,workers}

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::ShapeDetection {
 
@@ -37,17 +36,3 @@ enum class LandmarkType : uint8_t {
 };
 
 } // namespace WebCore::ShapeDetection
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ShapeDetection::LandmarkType> {
-    using values = EnumValues<
-        WebCore::ShapeDetection::LandmarkType,
-        WebCore::ShapeDetection::LandmarkType::Mouth,
-        WebCore::ShapeDetection::LandmarkType::Eye,
-        WebCore::ShapeDetection::LandmarkType::Nose
-    >;
-};
-
-} // namespace WTF
-

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -47,19 +47,4 @@ struct CredentialRequestOptions {
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CredentialRequestOptions::MediationRequirement> {
-    using values = EnumValues<
-        WebCore::CredentialRequestOptions::MediationRequirement,
-        WebCore::CredentialRequestOptions::MediationRequirement::Silent,
-        WebCore::CredentialRequestOptions::MediationRequirement::Optional,
-        WebCore::CredentialRequestOptions::MediationRequirement::Required,
-        WebCore::CredentialRequestOptions::MediationRequirement::Conditional
-    >;
-};
-
-} // namespace WTF
-
-
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/mediastream/MediaAccessDenialReason.h
+++ b/Source/WebCore/Modules/mediastream/MediaAccessDenialReason.h
@@ -43,23 +43,4 @@ enum class MediaAccessDenialReason : uint8_t {
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::MediaAccessDenialReason> {
-    using values = EnumValues<
-    WebCore::MediaAccessDenialReason,
-    WebCore::MediaAccessDenialReason::NoReason,
-    WebCore::MediaAccessDenialReason::NoConstraints,
-    WebCore::MediaAccessDenialReason::UserMediaDisabled,
-    WebCore::MediaAccessDenialReason::NoCaptureDevices,
-    WebCore::MediaAccessDenialReason::InvalidConstraint,
-    WebCore::MediaAccessDenialReason::HardwareError,
-    WebCore::MediaAccessDenialReason::PermissionDenied,
-    WebCore::MediaAccessDenialReason::InvalidAccess,
-    WebCore::MediaAccessDenialReason::OtherFailure
-    >;
-};
-
-} // namespace WTF
-
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -96,19 +96,3 @@ std::optional<ResourceError> validateRangeRequestedFlag(const ResourceRequest&, 
 String validateCrossOriginRedirectionURL(const URL&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::HTTPHeadersToKeepFromCleaning> {
-    using values = EnumValues<
-        WebCore::HTTPHeadersToKeepFromCleaning,
-        WebCore::HTTPHeadersToKeepFromCleaning::ContentType,
-        WebCore::HTTPHeadersToKeepFromCleaning::Referer,
-        WebCore::HTTPHeadersToKeepFromCleaning::Origin,
-        WebCore::HTTPHeadersToKeepFromCleaning::UserAgent,
-        WebCore::HTTPHeadersToKeepFromCleaning::AcceptEncoding,
-        WebCore::HTTPHeadersToKeepFromCleaning::CacheControl
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.h
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.h
@@ -96,17 +96,3 @@ CrossOriginOpenerPolicy obtainCrossOriginOpenerPolicy(const ResourceResponse&);
 WEBCORE_EXPORT std::optional<CrossOriginOpenerPolicyEnforcementResult> doCrossOriginOpenerHandlingOfResponse(ReportingClient&, const ResourceResponse&, const std::optional<NavigationRequester>&, ContentSecurityPolicy* responseCSP, SandboxFlags effectiveSandboxFlags, const String& referrer, bool isDisplayingInitialEmptyDocument, const CrossOriginOpenerPolicyEnforcementResult& currentCoopEnforcementResult);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CrossOriginOpenerPolicyValue> {
-    using values = EnumValues<
-    WebCore::CrossOriginOpenerPolicyValue,
-    WebCore::CrossOriginOpenerPolicyValue::UnsafeNone,
-    WebCore::CrossOriginOpenerPolicyValue::SameOrigin,
-    WebCore::CrossOriginOpenerPolicyValue::SameOriginPlusCOEP,
-    WebCore::CrossOriginOpenerPolicyValue::SameOriginAllowPopups
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -249,17 +249,3 @@ struct ResourceLoaderOptions : public FetchOptions {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PreflightPolicy> {
-    using values = EnumValues<
-        WebCore::PreflightPolicy,
-        WebCore::PreflightPolicy::Consider,
-        WebCore::PreflightPolicy::Force,
-        WebCore::PreflightPolicy::Prevent
-    >;
-};
-
-
-} // namespace WTF

--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -35,17 +35,19 @@ namespace WebCore {
 
 class Event;
 
-class ContextMenuContext {
-public:
-    enum class Type : uint8_t {
-        ContextMenu,
+enum class ContextMenuContextType : uint8_t {
+    ContextMenu,
 #if ENABLE(SERVICE_CONTROLS)
-        ServicesMenu,
+    ServicesMenu,
 #endif // ENABLE(SERVICE_CONTROLS)
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-        MediaControls,
+    MediaControls,
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-    };
+};
+
+class ContextMenuContext {
+public:
+    using Type = ContextMenuContextType;
 
     ContextMenuContext();
     ContextMenuContext(Type, const HitTestResult&, Event*);
@@ -95,22 +97,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ContextMenuContext::Type> {
-    using values = EnumValues<
-        WebCore::ContextMenuContext::Type,
-        WebCore::ContextMenuContext::Type::ContextMenu
-#if ENABLE(SERVICE_CONTROLS)
-        , WebCore::ContextMenuContext::Type::ServicesMenu
-#endif // ENABLE(SERVICE_CONTROLS)
-#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-        , WebCore::ContextMenuContext::Type::MediaControls
-#endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebCore/page/CrossSiteNavigationDataTransfer.h
+++ b/Source/WebCore/page/CrossSiteNavigationDataTransfer.h
@@ -30,24 +30,15 @@
 
 namespace WebCore {
 
+enum class CrossSiteNavigationDataTransferFlag : uint8_t {
+    DestinationLinkDecoration = 1 << 1,
+    ReferrerLinkDecoration = 1 << 2,
+};
+
 struct CrossSiteNavigationDataTransfer {
-    enum class Flag : uint8_t {
-        DestinationLinkDecoration = 1 << 1,
-        ReferrerLinkDecoration = 1 << 2,
-    };
+    using Flag = CrossSiteNavigationDataTransferFlag;
 };
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CrossSiteNavigationDataTransfer::Flag> {
-    using values = EnumValues<
-        WebCore::CrossSiteNavigationDataTransfer::Flag,
-        WebCore::CrossSiteNavigationDataTransfer::Flag::DestinationLinkDecoration,
-        WebCore::CrossSiteNavigationDataTransfer::Flag::ReferrerLinkDecoration
-    >;
-};
-
-} // namespace WTF
 #endif // ENABLE(TRACKING_PREVENTION)

--- a/Source/WebCore/page/DebugOverlayRegions.h
+++ b/Source/WebCore/page/DebugOverlayRegions.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class DebugOverlayRegions : uint8_t {
@@ -38,18 +36,3 @@ enum class DebugOverlayRegions : uint8_t {
 };
 
 }
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::DebugOverlayRegions> {
-    using values = EnumValues<
-        WebCore::DebugOverlayRegions,
-        WebCore::DebugOverlayRegions::NonFastScrollableRegion,
-        WebCore::DebugOverlayRegions::WheelEventHandlerRegion,
-        WebCore::DebugOverlayRegions::TouchActionRegion,
-        WebCore::DebugOverlayRegions::EditableElementRegion,
-        WebCore::DebugOverlayRegions::InteractionRegion
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/LoggedInStatus.h
+++ b/Source/WebCore/page/LoggedInStatus.h
@@ -70,16 +70,3 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::LoggedInStatus::AuthenticationType> {
-    using values = EnumValues<
-        WebCore::LoggedInStatus::AuthenticationType,
-        WebCore::LoggedInStatus::AuthenticationType::WebAuthn,
-        WebCore::LoggedInStatus::AuthenticationType::PasswordManager,
-        WebCore::LoggedInStatus::AuthenticationType::Unmanaged
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/ModalContainerTypes.h
+++ b/Source/WebCore/page/ModalContainerTypes.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class ModalContainerControlType : uint8_t {
@@ -44,17 +42,3 @@ enum class ModalContainerDecision : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ModalContainerControlType> {
-    using values = EnumValues<
-        WebCore::ModalContainerControlType,
-        WebCore::ModalContainerControlType::Neutral,
-        WebCore::ModalContainerControlType::Positive,
-        WebCore::ModalContainerControlType::Negative,
-        WebCore::ModalContainerControlType::Other
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -28,7 +28,6 @@
 #include "FloatPoint.h"
 #include "KeyboardScroll.h"
 #include "ScrollTypes.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -217,51 +216,3 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollUpdateType);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const RequestedScrollData&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SynchronousScrollingReason> {
-    using values = EnumValues<
-        WebCore::SynchronousScrollingReason,
-        WebCore::SynchronousScrollingReason::ForcedOnMainThread,
-        WebCore::SynchronousScrollingReason::HasViewportConstrainedObjectsWithoutSupportingFixedLayers,
-        WebCore::SynchronousScrollingReason::HasNonLayerViewportConstrainedObjects,
-        WebCore::SynchronousScrollingReason::IsImageDocument,
-        WebCore::SynchronousScrollingReason::HasSlowRepaintObjects,
-        WebCore::SynchronousScrollingReason::DescendantScrollersHaveSynchronousScrolling
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ScrollRequestType> {
-    using values = EnumValues<
-        WebCore::ScrollRequestType,
-        WebCore::ScrollRequestType::PositionUpdate,
-        WebCore::ScrollRequestType::DeltaUpdate,
-        WebCore::ScrollRequestType::CancelAnimatedScroll
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ScrollingNodeType> {
-    using values = EnumValues<
-        WebCore::ScrollingNodeType,
-        WebCore::ScrollingNodeType::MainFrame,
-        WebCore::ScrollingNodeType::Subframe,
-        WebCore::ScrollingNodeType::FrameHosting,
-        WebCore::ScrollingNodeType::Overflow,
-        WebCore::ScrollingNodeType::OverflowProxy,
-        WebCore::ScrollingNodeType::Fixed,
-        WebCore::ScrollingNodeType::Sticky,
-        WebCore::ScrollingNodeType::Positioned
-    >;
-};
-
-template<> struct EnumTraits<WebCore::KeyboardScrollAction> {
-    using values = EnumValues<
-        WebCore::KeyboardScrollAction,
-        WebCore::KeyboardScrollAction::StartAnimation,
-        WebCore::KeyboardScrollAction::StopWithAnimation,
-        WebCore::KeyboardScrollAction::StopImmediately
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchFailureReason.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchFailureReason.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class BackgroundFetchFailureReason : uint8_t {
@@ -41,21 +39,5 @@ enum class BackgroundFetchFailureReason : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::BackgroundFetchFailureReason> {
-    using values = EnumValues<
-    WebCore::BackgroundFetchFailureReason,
-    WebCore::BackgroundFetchFailureReason::EmptyString,
-    WebCore::BackgroundFetchFailureReason::Aborted,
-    WebCore::BackgroundFetchFailureReason::BadStatus,
-    WebCore::BackgroundFetchFailureReason::FetchError,
-    WebCore::BackgroundFetchFailureReason::QuotaExceeded,
-    WebCore::BackgroundFetchFailureReason::DownloadTotalExceeded
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class BackgroundFetchResult : uint8_t {
@@ -38,18 +36,5 @@ enum class BackgroundFetchResult : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::BackgroundFetchResult> {
-    using values = EnumValues<
-    WebCore::BackgroundFetchResult,
-    WebCore::BackgroundFetchResult::EmptyString,
-    WebCore::BackgroundFetchResult::Success,
-    WebCore::BackgroundFetchResult::Failure
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6568,3 +6568,79 @@ struct WebCore::KeypressCommand {
     String text;
 }
 #endif
+
+header: <WebCore/CredentialRequestOptions.h>
+enum class WebCore::MediationRequirement : uint8_t {
+    Silent,
+    Optional,
+    Required,
+    Conditional,
+};
+
+header: <WebCore/CrossOriginAccessControl.h>
+[OptionSet] enum class WebCore::HTTPHeadersToKeepFromCleaning : uint8_t {
+    ContentType,
+    Referer,
+    Origin,
+    UserAgent,
+    AcceptEncoding,
+    CacheControl
+};
+
+header: <WebCore/ContextMenuContext.h>
+enum class WebCore::ContextMenuContextType : uint8_t {
+    ContextMenu,
+#if ENABLE(SERVICE_CONTROLS)
+    ServicesMenu,
+#endif
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    MediaControls,
+#endif
+};
+
+header: <WebCore/CrossSiteNavigationDataTransfer.h>
+[OptionSet] enum class WebCore::CrossSiteNavigationDataTransferFlag : uint8_t {
+    DestinationLinkDecoration,
+    ReferrerLinkDecoration
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[Nested, OptionSet] enum class WebCore::SynchronousScrollingReason : uint8_t {
+    ForcedOnMainThread,
+    HasViewportConstrainedObjectsWithoutSupportingFixedLayers,
+    HasNonLayerViewportConstrainedObjects,
+    IsImageDocument,
+    HasSlowRepaintObjects,
+    DescendantScrollersHaveSynchronousScrolling
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[Nested] enum class WebCore::ScrollRequestType : uint8_t {
+    PositionUpdate,
+    DeltaUpdate,
+    CancelAnimatedScroll
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[Nested] enum class WebCore::KeyboardScrollAction : uint8_t {
+    StartAnimation,
+    StopWithAnimation,
+    StopImmediately
+};
+
+header: <WebCore/BackgroundFetchFailureReason.h>
+enum class WebCore::BackgroundFetchFailureReason : uint8_t {
+    EmptyString,
+    Aborted,
+    BadStatus,
+    FetchError,
+    QuotaExceeded,
+    DownloadTotalExceeded
+};
+
+header: <WebCore/BackgroundFetchResult.h>
+enum class WebCore::BackgroundFetchResult : uint8_t {
+    EmptyString,
+    Success,
+    Failure
+};


### PR DESCRIPTION
#### 2d60f903af7186662ae4efd29756498d8eaf43f0
<pre>
Clean up trivial-case EnumTraits for enumerations under WebCore/{Modules,loader,page,workers}
<a href="https://bugs.webkit.org/show_bug.cgi?id=264418">https://bugs.webkit.org/show_bug.cgi?id=264418</a>

Reviewed by NOBODY (OOPS!).

Run through trivial-case EnumTraits specializations in WebCore, under the
Modules, loader, page and workers directories, removing unnecessary ones or
replacing them with IPC serialization specifications.

* Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h:
* Source/WebCore/Modules/mediastream/MediaAccessDenialReason.h:
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/CrossOriginOpenerPolicy.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/page/ContextMenuContext.h:
* Source/WebCore/page/CrossSiteNavigationDataTransfer.h:
* Source/WebCore/page/DebugOverlayRegions.h:
* Source/WebCore/page/LoggedInStatus.h:
* Source/WebCore/page/ModalContainerTypes.h:
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchFailureReason.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d60f903af7186662ae4efd29756498d8eaf43f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25379 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3982 "Hash 2d60f903 for PR 20172 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26663 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27492 "Hash 2d60f903 for PR 20172 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23280 "Hash 2d60f903 for PR 20172 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25654 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5703 "Hash 2d60f903 for PR 20172 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1421 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/27492 "Hash 2d60f903 for PR 20172 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25623 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/5703 "Hash 2d60f903 for PR 20172 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21897 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28071 "Hash 2d60f903 for PR 20172 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/5703 "Hash 2d60f903 for PR 20172 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22837 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/28071 "Hash 2d60f903 for PR 20172 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/5703 "Hash 2d60f903 for PR 20172 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23197 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/28071 "Hash 2d60f903 for PR 20172 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2585 "Hash 2d60f903 for PR 20172 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/833 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3953 "Hash 2d60f903 for PR 20172 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3032 "Hash 2d60f903 for PR 20172 does not build (failure)") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2924 "Hash 2d60f903 for PR 20172 does not build (failure)") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->