### PR TITLE
REGRESSION ( Sonoma?): [ Sonoma release ] TestWebKitAPI.WKInspectorExtension.EvaluateScriptOnPage is a consistent failure

### DIFF
--- a/LayoutTests/inspector/unit-tests/retryuntil-expected.txt
+++ b/LayoutTests/inspector/unit-tests/retryuntil-expected.txt
@@ -1,0 +1,21 @@
+
+== Running test suite: retryUntil
+-- Running test case: retryUntil.DefaultConfiguration.Success
+PASS: Waited at least the default 100ms delay between retries.
+PASS: Predicate is falsy on first try.
+PASS: Success within default number of retries.
+
+-- Running test case: retryUntil.CustomConfiguration.Success
+PASS: Retried 3 times.
+PASS: Success after 3 retries.
+
+-- Running test case: retryUntil.CustomConfiguration.Fail
+PASS: Retried 3 times.
+PASS: Failure after 3 retries for falsy value: false
+PASS: Retried 3 times.
+PASS: Failure after 3 retries for falsy value: null
+PASS: Retried 3 times.
+PASS: Failure after 3 retries for falsy value: undefined
+PASS: Retried 3 times.
+PASS: Failure after 3 retries for falsy value: 0
+

--- a/LayoutTests/inspector/unit-tests/retryuntil.html
+++ b/LayoutTests/inspector/unit-tests/retryuntil.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("retryUntil");
+
+    suite.addTestCase({
+        name: "retryUntil.DefaultConfiguration.Success",
+        description: "Retries within the default number of times and succeeds.",
+        async test() {
+            let count = 0;
+            let predicate = () => {
+                count++;
+                return count === 3;
+            }
+
+            let firstResult = predicate();
+            let startTime = performance.now();
+            let result = await retryUntil(predicate);
+
+            InspectorTest.expectGreaterThanOrEqual(performance.now() - startTime, 100, "Waited at least the default 100ms delay between retries.");
+            InspectorTest.expectFalse(firstResult, "Predicate is falsy on first try.");
+            InspectorTest.expectTrue(result, "Success within default number of retries.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "retryUntil.CustomConfiguration.Success",
+        description: "Retries a finite number of times and succeeds.",
+        async test() {
+            let retries = 3;
+            let count = 0;
+            let delay = 0; // Default 100ms. Avoid needlessly taking up test run time.
+            let predicate = () => {
+                count++;
+                return count === retries;
+            }
+
+            let result = await retryUntil(predicate, {retries, delay});
+
+            InspectorTest.expectEqual(count, retries, `Retried ${count} times.`);
+            InspectorTest.expectTrue(result, `Success after ${retries} retries.`);
+        }
+    });
+
+    suite.addTestCase({
+        name: "retryUntil.CustomConfiguration.Fail",
+        description: "Retries a finite number of times and fails.",
+        async test() {
+            async function testFalsy(value) {
+                let retries = 3;
+                let count = 0;
+                let delay = 0; // Default 100ms. Avoid needlessly taking up test run time.
+                let predicate = () => {
+                    count++;
+                    return value;
+                }
+                let result = await retryUntil(predicate, {retries, delay});
+
+                InspectorTest.expectEqual(count, retries, `Retried ${count} times.`);
+                InspectorTest.expectNull(result, `Failure after ${retries} retries for falsy value: ${value}`);
+            }
+
+            await testFalsy(false);
+            await testFalsy(null);
+            await testFalsy(undefined);
+            await testFalsy(0);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onLoad="runTest()">
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -1866,6 +1866,23 @@ function insertObjectIntoSortedArray(object, array, comparator)
     array.splice(insertionIndexForObjectInListSortedByFunction(object, array, comparator), 0, object);
 }
 
+async function retryUntil(predicate, {delay, retries} = {})
+{
+    retries ??= 100;
+    delay ??= 100;
+
+    for (let i = 0; i < retries; ++i) {
+        let result = predicate();
+        if (result)
+            return result;
+
+        await Promise.delay(delay);
+    }
+
+    console.assert(false, "retryUntil exceeded the maximum number of retries.", predicate, retries);
+    return null;
+}
+
 WI.setReentrantCheck = function(object, key)
 {
     key = "__checkReentrant_" + key;

--- a/Source/WebInspectorUI/UserInterface/Controllers/WebInspectorExtensionController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/WebInspectorExtensionController.js
@@ -125,7 +125,7 @@ WI.WebInspectorExtensionController = class WebInspectorExtensionController exten
         return {"result": extensionTabID};
     }
 
-    evaluateScriptForExtension(extensionID, scriptSource, {frameURL, contextSecurityOrigin, useContentScriptContext} = {})
+    async evaluateScriptForExtension(extensionID, scriptSource, {frameURL, contextSecurityOrigin, useContentScriptContext} = {})
     {
         let extension = this._extensionForExtensionIDMap.get(extensionID);
         if (!extension) {
@@ -133,7 +133,7 @@ WI.WebInspectorExtensionController = class WebInspectorExtensionController exten
             return WI.WebInspectorExtension.ErrorCode.InvalidRequest;
         }
 
-        let frame = this._frameForFrameURL(frameURL);
+        let frame = await retryUntil(() => this._frameForFrameURL(frameURL));
         if (!frame) {
             WI.reportInternalError("evaluateScriptForExtension: No frame matched provided frameURL: " + frameURL);
             return WI.WebInspectorExtension.ErrorCode.InvalidRequest;
@@ -149,7 +149,7 @@ WI.WebInspectorExtensionController = class WebInspectorExtensionController exten
             return WI.WebInspectorExtension.ErrorCode.NotImplemented;
         }
 
-        let evaluationContext = frame.pageExecutionContext;
+        let evaluationContext = await retryUntil(() => frame.pageExecutionContext);
         if (!evaluationContext) {
             WI.reportInternalError("evaluateScriptForExtension: No 'pageExecutionContext' was present for frame with URL: " + frame.url);
             return WI.WebInspectorExtension.ErrorCode.ContextDestroyed;


### PR DESCRIPTION
#### 3583b2ac96f10694075cac1324cf5b14a41d77cb
<pre>
REGRESSION ( Sonoma?): [ Sonoma release ] TestWebKitAPI.WKInspectorExtension.EvaluateScriptOnPage is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263447">https://bugs.webkit.org/show_bug.cgi?id=263447</a>
<a href="https://rdar.apple.com/117265270">rdar://117265270</a>

Reviewed by Timothy Hatcher.

The API test loads a page from an URL, opens Web Inspector for it, registers a Web Inspector Web Extension
and immediately sends a request to evaluate some JavaScript in the main frame and subframes for that URL.

The test fails because of a race condition: the objects that represent the frame and execution context
within Web Inspector frontend are not necessarily available when the evaluation request comes in.

The missing objects result in early returns with error codes:
`WI.WebInspectorExtension.ErrorCode.InvalidRequest` or `WI.WebInspectorExtension.ErrorCode.ContextDestroyed`.

Fixing the race means waiting for the corresponding `WI.Frame` and `WI.ExecutionContext` instances
to be available before attempting to use them. A simple retry approach with a timeout works fine.

---

A `WI.Frame` is created in response to initializing an `InspectorPageAgent`
and receiving a response to the `getResourceTree()` command.

A `WI.ExecutionContext` is created asynchronously in response to the &quot;executionContextCreated&quot; event
dispatched by `PageRuntimeAgent`.

The test failed consistently on Release builds but not on Debug builds. The slower Debug builds likely gave
enough time for the Web Inspector frontend to be created and populated with the necessary objects.

---

Why is Web Inspector frontend involved in an Web Extensions API test? Good question!

The call to evaluate a script from a Web Inspector web extension in the page context goes down this path:

`WebInspectorUIExtensionController::evaluateScriptForExtension` (C++)
    -&gt; `InspectorFrontendAPIDispatcher::dispatchCommandWithResultAsync()` (C++, Web Inspector backend)
        -&gt; `WI.WebInspectorExtensionController.evaluateScriptForExtension()` (JS, Web Inspector frontend)
            -&gt; `InspectorRuntimeAgent::evaluate()` (C++, Web Inspector backend)

The result of the evaluation gets ferried on the same route all the way back.

* LayoutTests/inspector/unit-tests/retryuntil.html: Added.
* LayoutTests/inspector/unit-tests/retryuntil-expected.txt: Added.
* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
* Source/WebInspectorUI/UserInterface/Controllers/WebInspectorExtensionController.js:
(WI.WebInspectorExtensionController.prototype.async evaluateScriptForExtension):
(WI.WebInspectorExtensionController.prototype.evaluateScriptForExtension): Deleted.

Canonical link: <a href="https://commits.webkit.org/271925@main">https://commits.webkit.org/271925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c97c89698f332a6e78881a2a543a5fb30639fd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27111 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27156 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6360 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26667 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33829 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32528 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30324 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7125 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->