### PR TITLE
Add sandbox telemetry for Mach lookup extensions

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -930,13 +930,23 @@
         (global-name "com.apple.diagnosticd")
         (global-name "com.apple.osanalytics.osanalyticshelper")))
 
-(allow mach-lookup
+(define (mach-extension-list)
+    (global-name
+        "com.apple.frontboard.systemappservices"
+        "com.apple.iconservices"
+        "com.apple.mobileassetd.v2"
+        "com.apple.mobilegestalt.xpc"))
+
+(allow mach-lookup (with telemetry-backtrace)
     (require-all
         (extension "com.apple.webkit.extension.mach")
-        (global-name
-            "com.apple.frontboard.systemappservices"
-            "com.apple.mobileassetd.v2"
-            "com.apple.mobilegestalt.xpc")))
+        (mach-extension-list)))
+
+(with-filter (state-flag "EnableExperimentalSandbox")
+    (deny mach-lookup
+        (require-all
+            (extension "com.apple.webkit.extension.mach")
+            (mach-extension-list))))
 
 (allow mach-lookup
     (require-all
@@ -948,17 +958,7 @@
 (deny mach-lookup (with no-report)
     (require-all
         (require-not (extension "com.apple.webkit.extension.mach"))
-        (global-name
-            "com.apple.audio.AudioComponentRegistrar"
-        )
-    )
-)
-
-(allow mach-lookup
-    (require-all
-        (extension "com.apple.webkit.extension.mach")
-        (global-name
-            "com.apple.iconservices")))
+        (global-name "com.apple.audio.AudioComponentRegistrar")))
 
 #if HAVE(AGX_COMPILER_SERVICE)
 (allow iokit-open-user-client


### PR DESCRIPTION
#### eb8c417ba72934b54fef1e04365d142c790f8a2e
<pre>
Add sandbox telemetry for Mach lookup extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=264401">https://bugs.webkit.org/show_bug.cgi?id=264401</a>
<a href="https://rdar.apple.com/problem/118114355">rdar://problem/118114355</a>

Reviewed by Brent Fulgham.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/270638@main">https://commits.webkit.org/270638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feae040a24c8eee00e56c13b87b80ddd08dc8e86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27495 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23283 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23461 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28074 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2601 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28936 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26782 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/852 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3956 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3035 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3334 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->