### PR TITLE
Simplify PDFPlugin* access to Page

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1334,11 +1334,8 @@ void PDFPlugin::destroyScrollbar(ScrollbarOrientation orientation)
 
 bool PDFPlugin::hudEnabled() const
 {
-    if (auto* coreFrame = m_frame ? m_frame->coreLocalFrame() : nullptr) {
-        if (auto* page = coreFrame->page())
-            return page->settings().pdfPluginHUDEnabled();
-    }
-
+    if (CheckedPtr page = this->page())
+        return page->settings().pdfPluginHUDEnabled();
     return false;
 }
 
@@ -1390,7 +1387,7 @@ JSValueRef PDFPlugin::jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSOb
     if (!coreFrame)
         return JSValueMakeUndefined(ctx);
 
-    auto* page = coreFrame->page();
+    CheckedPtr page = coreFrame->page();
     if (!page)
         return JSValueMakeUndefined(ctx);
 
@@ -1653,7 +1650,7 @@ void PDFPlugin::createPDFDocument()
 void PDFPlugin::paintControlForLayerInContext(CALayer *layer, CGContextRef context)
 {
 #if PLATFORM(MAC)
-    auto* page = m_frame && m_frame->coreLocalFrame() ? m_frame->coreLocalFrame()->page() : nullptr;
+    CheckedPtr page = this->page();
     if (!page)
         return;
     LocalDefaultSystemAppearance localAppearance(page->useDarkAppearance());
@@ -1737,16 +1734,9 @@ IntPoint PDFPlugin::convertFromRootViewToPDFView(const IntPoint& point) const
 FloatRect PDFPlugin::convertFromPDFViewToScreen(const FloatRect& rect) const
 {
     return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::FloatRect>([&] () -> WebCore::FloatRect {
-        auto* coreFrame = m_frame ? m_frame->coreLocalFrame() : nullptr;
-        if (!coreFrame)
-            return { };
-        auto* frameView = coreFrame->view();
-        if (!frameView)
-            return { };
-
         FloatRect updatedRect = rect;
         updatedRect.setLocation(convertFromPDFViewToRootView(IntPoint(updatedRect.location())));
-        auto* page = coreFrame->page();
+        CheckedPtr page = this->page();
         if (!page)
             return { };
         return page->chrome().rootViewToScreen(enclosingIntRect(updatedRect));
@@ -1756,13 +1746,9 @@ FloatRect PDFPlugin::convertFromPDFViewToScreen(const FloatRect& rect) const
 IntRect PDFPlugin::boundsOnScreen() const
 {
     return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::IntRect>([&] () -> WebCore::IntRect {
-        auto* frameView = m_frame ? m_frame->coreLocalFrame()->view() : nullptr;
-        if (!frameView)
-            return { };
-
         FloatRect bounds = FloatRect(FloatPoint(), size());
         FloatRect rectInRootViewCoordinates = valueOrDefault(m_rootViewToPluginTransform.inverse()).mapRect(bounds);
-        auto* page = m_frame->coreLocalFrame()->page();
+        CheckedPtr page = this->page();
         if (!page)
             return { };
         return page->chrome().rootViewToScreen(enclosingIntRect(rectInRootViewCoordinates));

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -150,6 +150,8 @@ public:
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);
 
+    WebCore::Page* page() const;
+
     virtual void teardown() = 0;
 
     virtual void createPDFDocument() = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -93,8 +93,7 @@ void UnifiedPDFPlugin::installPDFDocument()
 
 RefPtr<GraphicsLayer> UnifiedPDFPlugin::createGraphicsLayer(const String& name, GraphicsLayer::Type layerType)
 {
-    RefPtr frame = m_view->frame();
-    CheckedPtr page = frame->page();
+    CheckedPtr page = this->page();
     if (!page)
         return nullptr;
 
@@ -106,8 +105,7 @@ RefPtr<GraphicsLayer> UnifiedPDFPlugin::createGraphicsLayer(const String& name, 
 
 void UnifiedPDFPlugin::scheduleRenderingUpdate()
 {
-    RefPtr frame = m_view->frame();
-    CheckedPtr page = frame->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
 


### PR DESCRIPTION
#### b2e2adf2a4fbb7526db06cb189e0941cf25ce701
<pre>
Simplify PDFPlugin* access to Page
<a href="https://bugs.webkit.org/show_bug.cgi?id=264423">https://bugs.webkit.org/show_bug.cgi?id=264423</a>
<a href="https://rdar.apple.com/118127511">rdar://118127511</a>

Reviewed by Chris Dumez.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::hudEnabled const):
(WebKit::PDFPlugin::jsPDFDocPrint):
(WebKit::PDFPlugin::paintControlForLayerInContext):
(WebKit::PDFPlugin::convertFromPDFViewToScreen const):
(WebKit::PDFPlugin::boundsOnScreen const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::page const):
(WebKit::PDFPluginBase::isActive const):
(WebKit::PDFPluginBase::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const):
(WebKit::PDFPluginBase::deviceScaleFactor const):
(WebKit::PDFPluginBase::createScrollbar):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createGraphicsLayer):
(WebKit::UnifiedPDFPlugin::scheduleRenderingUpdate):
Add page() helper and adopt it in a bunch of places where we do a humorous
amount of work just to get to Page.

Canonical link: <a href="https://commits.webkit.org/270401@main">https://commits.webkit.org/270401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7e70925c7445af18a8807a6880c36ff1767db53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27503 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1432 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28082 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23211 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/26787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/844 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3964 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6083 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3043 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->