### PR TITLE
Regression(264919@main) Use-after-free of MediaRecorderPrivate in GPUProcessConnection::didClose()

### DIFF
--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
@@ -78,7 +78,7 @@ void MediaRecorder::setCustomPrivateRecorderCreator(CreatorFunction creator)
     m_customCreator = creator;
 }
 
-ExceptionOr<std::unique_ptr<MediaRecorderPrivate>> MediaRecorder::createMediaRecorderPrivate(Document& document, MediaStreamPrivate& stream, const Options& options)
+ExceptionOr<Ref<MediaRecorderPrivate>> MediaRecorder::createMediaRecorderPrivate(Document& document, MediaStreamPrivate& stream, const Options& options)
 {
     auto* page = document.page();
     if (!page)
@@ -87,14 +87,13 @@ ExceptionOr<std::unique_ptr<MediaRecorderPrivate>> MediaRecorder::createMediaRec
     if (m_customCreator)
         return m_customCreator(stream, options);
 
+    RefPtr<MediaRecorderPrivate> result;
 #if PLATFORM(COCOA) || USE(GSTREAMER_TRANSCODER)
-    auto result = page->mediaRecorderProvider().createMediaRecorderPrivate(stream, options);
-#else
-    std::unique_ptr<MediaRecorderPrivate> result;
+    result = page->mediaRecorderProvider().createMediaRecorderPrivate(stream, options);
 #endif
     if (!result)
         return Exception { NotSupportedError, "The MediaRecorder is unsupported on this platform"_s };
-    return result;
+    return result.releaseNonNull();
 }
 
 MediaRecorder::MediaRecorder(Document& document, Ref<MediaStream>&& stream, Options&& options)
@@ -318,11 +317,11 @@ ExceptionOr<void> MediaRecorder::resumeRecording()
 
 void MediaRecorder::fetchData(FetchDataCallback&& callback, TakePrivateRecorder takeRecorder)
 {
-    auto& privateRecorder = *m_private;
+    Ref privateRecorder = *m_private;
 
-    std::unique_ptr<MediaRecorderPrivate> takenPrivateRecorder;
+    RefPtr<MediaRecorderPrivate> takenPrivateRecorder;
     if (takeRecorder == TakePrivateRecorder::Yes)
-        takenPrivateRecorder = WTFMove(m_private);
+        takenPrivateRecorder = std::exchange(m_private, nullptr);
 
     auto fetchDataCallback = [this, privateRecorder = WTFMove(takenPrivateRecorder), callback = WTFMove(callback)](RefPtr<FragmentedSharedBuffer>&& buffer, auto& mimeType, auto timeCode) mutable {
         queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [buffer = WTFMove(buffer), mimeType, timeCode, callback = WTFMove(callback)]() mutable {
@@ -336,7 +335,7 @@ void MediaRecorder::fetchData(FetchDataCallback&& callback, TakePrivateRecorder 
     }
 
     m_isFetchingData = true;
-    privateRecorder.fetchData([this, pendingActivity = makePendingActivity(*this), callback = WTFMove(fetchDataCallback)](RefPtr<FragmentedSharedBuffer>&& buffer, auto& mimeType, auto timeCode) mutable {
+    privateRecorder->fetchData([this, pendingActivity = makePendingActivity(*this), callback = WTFMove(fetchDataCallback)](RefPtr<FragmentedSharedBuffer>&& buffer, auto& mimeType, auto timeCode) mutable {
         m_isFetchingData = false;
         callback(WTFMove(buffer), mimeType, timeCode);
         for (auto& task : std::exchange(m_pendingFetchDataTasks, { }))

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -59,7 +59,7 @@ public:
     using Options = MediaRecorderPrivateOptions;
     static ExceptionOr<Ref<MediaRecorder>> create(Document&, Ref<MediaStream>&&, Options&& = { });
 
-    using CreatorFunction = ExceptionOr<std::unique_ptr<MediaRecorderPrivate>> (*)(MediaStreamPrivate&, const Options&);
+    using CreatorFunction = ExceptionOr<Ref<MediaRecorderPrivate>> (*)(MediaStreamPrivate&, const Options&);
 
     WEBCORE_EXPORT static void setCustomPrivateRecorderCreator(CreatorFunction);
 
@@ -87,7 +87,7 @@ public:
 private:
     MediaRecorder(Document&, Ref<MediaStream>&&, Options&&);
 
-    static ExceptionOr<std::unique_ptr<MediaRecorderPrivate>> createMediaRecorderPrivate(Document&, MediaStreamPrivate&, const Options&);
+    static ExceptionOr<Ref<MediaRecorderPrivate>> createMediaRecorderPrivate(Document&, MediaStreamPrivate&, const Options&);
     
     Document* document() const;
 
@@ -130,7 +130,7 @@ private:
 
     Options m_options;
     Ref<MediaStream> m_stream;
-    std::unique_ptr<MediaRecorderPrivate> m_private;
+    RefPtr<MediaRecorderPrivate> m_private;
     RecordingState m_state { RecordingState::Inactive };
     Vector<Ref<MediaStreamTrackPrivate>> m_tracks;
     std::optional<unsigned> m_timeSlice;

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-std::unique_ptr<MediaRecorderPrivate> MediaRecorderProvider::createMediaRecorderPrivate(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
+RefPtr<MediaRecorderPrivate> MediaRecorderProvider::createMediaRecorderPrivate(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
 {
 #if PLATFORM(COCOA) && USE(AVFOUNDATION)
     return MediaRecorderPrivateAVFImpl::create(stream, options);

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.h
@@ -41,7 +41,7 @@ public:
     virtual ~MediaRecorderProvider() = default;
 
 #if ENABLE(MEDIA_RECORDER)
-    virtual std::unique_ptr<MediaRecorderPrivate> createMediaRecorderPrivate(MediaStreamPrivate&, const MediaRecorderPrivateOptions&);
+    virtual RefPtr<MediaRecorderPrivate> createMediaRecorderPrivate(MediaStreamPrivate&, const MediaRecorderPrivateOptions&);
     virtual bool isSupported(const String&);
 #endif
 };

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1173,7 +1173,7 @@ public:
     EmptyMediaRecorderProvider() = default;
 private:
 #if ENABLE(MEDIA_RECORDER)
-    std::unique_ptr<MediaRecorderPrivate> createMediaRecorderPrivate(MediaStreamPrivate&, const MediaRecorderPrivateOptions&) final { return nullptr; }
+    RefPtr<MediaRecorderPrivate> createMediaRecorderPrivate(MediaStreamPrivate&, const MediaRecorderPrivateOptions&) final { return nullptr; }
 #endif
 };
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
@@ -29,6 +29,7 @@
 #include "RealtimeMediaSource.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 #if ENABLE(MEDIA_RECORDER)
 
@@ -48,10 +49,11 @@ class FragmentedSharedBuffer;
 struct MediaRecorderPrivateOptions;
 
 class MediaRecorderPrivate
-    : public RealtimeMediaSource::AudioSampleObserver
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate>
+    , public RealtimeMediaSource::AudioSampleObserver
     , public RealtimeMediaSource::VideoFrameObserver {
 public:
-    ~MediaRecorderPrivate();
+    virtual ~MediaRecorderPrivate();
 
     struct AudioVideoSelectedTracks {
         MediaStreamTrackPrivate* audioTrack { nullptr };
@@ -80,6 +82,7 @@ public:
     static BitRates computeBitRates(const MediaRecorderPrivateOptions&, const MediaStreamPrivate* = nullptr);
 
 protected:
+    MediaRecorderPrivate() = default;
     void setAudioSource(RefPtr<RealtimeMediaSource>&&);
     void setVideoSource(RefPtr<RealtimeMediaSource>&&);
 
@@ -93,7 +96,6 @@ private:
     virtual void pauseRecording(CompletionHandler<void()>&&) = 0;
     virtual void resumeRecording(CompletionHandler<void()>&&) = 0;
 
-private:
     bool m_shouldMuteAudio { false };
     bool m_shouldMuteVideo { false };
     RefPtr<RealtimeMediaSource> m_audioSource;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -44,7 +44,7 @@
 
 namespace WebCore {
 
-std::unique_ptr<MediaRecorderPrivateAVFImpl> MediaRecorderPrivateAVFImpl::create(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
+RefPtr<MediaRecorderPrivateAVFImpl> MediaRecorderPrivateAVFImpl::create(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
 {
     // FIXME: we will need to implement support for multiple audio/video tracks
     // Currently we only choose the first track as the recorded track.
@@ -56,7 +56,7 @@ std::unique_ptr<MediaRecorderPrivateAVFImpl> MediaRecorderPrivateAVFImpl::create
     if (!writer)
         return nullptr;
 
-    auto recorder = std::unique_ptr<MediaRecorderPrivateAVFImpl>(new MediaRecorderPrivateAVFImpl(writer.releaseNonNull()));
+    auto recorder = adoptRef(*new MediaRecorderPrivateAVFImpl(writer.releaseNonNull()));
     if (selectedTracks.audioTrack) {
         recorder->setAudioSource(&selectedTracks.audioTrack->source());
         recorder->checkTrackState(*selectedTracks.audioTrack);

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
@@ -42,7 +42,7 @@ class MediaRecorderPrivateAVFImpl final
     : public MediaRecorderPrivate {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<MediaRecorderPrivateAVFImpl> create(MediaStreamPrivate&, const MediaRecorderPrivateOptions&);
+    static RefPtr<MediaRecorderPrivateAVFImpl> create(MediaStreamPrivate&, const MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivateAVFImpl();
 
 private:

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_media_recorder_debug);
 #define GST_CAT_DEFAULT webkit_media_recorder_debug
 
-std::unique_ptr<MediaRecorderPrivateGStreamer> MediaRecorderPrivateGStreamer::create(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
+RefPtr<MediaRecorderPrivateGStreamer> MediaRecorderPrivateGStreamer::create(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
 {
     ensureGStreamerInitialized();
     registerWebKitGStreamerElements();

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
@@ -44,7 +44,6 @@ public:
     {
         return adoptRef(*new MediaRecorderPrivateBackend(stream, options));
     }
-
     ~MediaRecorderPrivateBackend();
 
     bool preparePipeline();
@@ -94,13 +93,14 @@ private:
 class MediaRecorderPrivateGStreamer final : public MediaRecorderPrivate {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<MediaRecorderPrivateGStreamer> create(MediaStreamPrivate&, const MediaRecorderPrivateOptions&);
-    explicit MediaRecorderPrivateGStreamer(Ref<MediaRecorderPrivateBackend>&&);
+    static RefPtr<MediaRecorderPrivateGStreamer> create(Ref<MediaRecorderPrivateBackend>&&, const MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivateGStreamer() = default;
 
     static bool isTypeSupported(const ContentType&);
 
 private:
+    MediaRecorderPrivateGStreamer(Ref<MediaRecorderPrivateBackend>&&);
+
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final { };
     void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final { };
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
@@ -36,6 +36,11 @@
 
 namespace WebCore {
 
+Ref<MediaRecorderPrivateMock> MediaRecorderPrivateMock::create(MediaStreamPrivate& stream)
+{
+    return adoptRef(*new MediaRecorderPrivateMock(stream));
+}
+
 MediaRecorderPrivateMock::MediaRecorderPrivateMock(MediaStreamPrivate& stream)
 {
     auto selectedTracks = MediaRecorderPrivate::selectTracks(stream);

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
@@ -38,10 +38,11 @@ class MediaStreamTrackPrivate;
 class WEBCORE_EXPORT MediaRecorderPrivateMock final
     : public MediaRecorderPrivate {
 public:
-    explicit MediaRecorderPrivateMock(MediaStreamPrivate&);
+    static Ref<MediaRecorderPrivateMock> create(MediaStreamPrivate&);
     ~MediaRecorderPrivateMock();
 
 private:
+    explicit MediaRecorderPrivateMock(MediaStreamPrivate&);
     // MediaRecorderPrivate
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final;
     void fetchData(FetchDataCallback&&) final;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1803,9 +1803,9 @@ void Internals::setShouldInterruptAudioOnPageVisibilityChange(bool shouldInterru
 #endif // ENABLE(MEDIA_STREAM)
 
 #if ENABLE(MEDIA_RECORDER)
-static ExceptionOr<std::unique_ptr<MediaRecorderPrivate>> createRecorderMockSource(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions&)
+static ExceptionOr<Ref<MediaRecorderPrivate>> createRecorderMockSource(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions&)
 {
-    return std::unique_ptr<MediaRecorderPrivate>(new MediaRecorderPrivateMock(stream));
+    return { MediaRecorderPrivateMock::create(stream) };
 }
 
 void Internals::setCustomPrivateRecorderCreator()

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -76,6 +76,11 @@ private:
     WeakPtr<MediaRecorderPrivate> m_recorder;
 };
 
+Ref<MediaRecorderPrivate> MediaRecorderPrivate::create(WebCore::MediaStreamPrivate& stream, const WebCore::MediaRecorderPrivateOptions& options)
+{
+    return adoptRef(*new MediaRecorderPrivate(stream, options));
+}
+
 MediaRecorderPrivate::MediaRecorderPrivate(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
     : m_identifier(MediaRecorderIdentifier::generate())
     , m_stream(stream)

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -50,13 +50,20 @@ class MediaRecorderPrivateGPUProcessDidCloseObserver;
 
 class MediaRecorderPrivate final
     : public WebCore::MediaRecorderPrivate
-    , public CanMakeWeakPtr<MediaRecorderPrivate> {
+    , public CanMakeWeakPtr<MediaRecorderPrivate>
+    , public GPUProcessConnection::Client {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
+    static Ref<MediaRecorderPrivate> create(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivate();
 
+    void ref() const final { return WebCore::MediaRecorderPrivate::ref(); }
+    void deref() const final { return WebCore::MediaRecorderPrivate::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return WebCore::MediaRecorderPrivate::controlBlock(); }
+
 private:
+    MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
+
     // WebCore::MediaRecorderPrivate
     void videoFrameAvailable(WebCore::VideoFrame&, WebCore::VideoFrameTimeMetadata) final;
     void fetchData(CompletionHandler<void(RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& mimeType, double)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
@@ -37,12 +37,12 @@
 namespace WebKit {
 using namespace WebCore;
 
-std::unique_ptr<WebCore::MediaRecorderPrivate> MediaRecorderProvider::createMediaRecorderPrivate(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
+RefPtr<WebCore::MediaRecorderPrivate> MediaRecorderProvider::createMediaRecorderPrivate(MediaStreamPrivate& stream, const MediaRecorderPrivateOptions& options)
 {
 #if ENABLE(GPU_PROCESS)
     auto* page = m_webPage.corePage();
     if (page && page->settings().webRTCPlatformCodecsInGPUProcessEnabled())
-        return makeUnique<MediaRecorderPrivate>(stream, options);
+        return MediaRecorderPrivate::create(stream, options);
 #endif
     return WebCore::MediaRecorderProvider::createMediaRecorderPrivate(stream, options);
 }

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.h
@@ -37,7 +37,7 @@ public:
 
 private:
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
-    std::unique_ptr<WebCore::MediaRecorderPrivate> createMediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&) final;
+    RefPtr<WebCore::MediaRecorderPrivate> createMediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&) final;
 #endif
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### e9ef0e6885886803fa3bcdec45c12b456c9699a7
<pre>
Regression(264919@main) Use-after-free of MediaRecorderPrivate in GPUProcessConnection::didClose()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261224">https://bugs.webkit.org/show_bug.cgi?id=261224</a>
<a href="https://rdar.apple.com/114807341">rdar://114807341</a>

Reviewed by Alex Christensen.

264919@main made WebKit::MediaRecorderPrivate subclass ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr.
However, MediaRecorderPrivate is stored in std::unique_ptr&lt;&gt; throughout our code base, thus not obeying
the refcount when managing its lifetime. This was the source of use-after-frees in
GPUProcessConnection::didClose(), which held a strong Ref&lt;&gt; to the MediaRecorderPrivate but it wouldn&apos;t
prevent the object from dying.

To address the issue, we now use Ref&lt;&gt; / RefPtr&lt;&gt; everywhere for MediaRecorderPrivate. I also moved
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr to the base class (WebCore::MediaRecorderPrivate) since
WebCore needs to know it can hold a Ref&lt;&gt; / RefPtr&lt;&gt; to such objects.

* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::createMediaRecorderPrivate):
(WebCore::MediaRecorder::fetchData):
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp:
(WebCore::MediaRecorderProvider::createMediaRecorderPrivate):
* Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::create):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateGStreamer::create):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp:
(WebCore::MediaRecorderPrivateMock::create):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::createRecorderMockSource):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::create):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.cpp:
(WebKit::MediaRecorderProvider::createMediaRecorderPrivate):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderProvider.h:

Originally-landed-as: 265870.524@safari-7616-branch (5a87cf9c496f). rdar://118127983
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9ef0e6885886803fa3bcdec45c12b456c9699a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25391 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3994 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26675 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27504 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23292 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25666 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5717 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1433 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/27504 "Hash e9ef0e68 for PR 20178 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25635 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/5717 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/26675 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28083 "Hash e9ef0e68 for PR 20178 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/5717 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/26675 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/28083 "Hash e9ef0e68 for PR 20178 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/5717 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/26675 "Hash e9ef0e68 for PR 20178 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/28083 "Hash e9ef0e68 for PR 20178 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2597 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/1433 "Hash e9ef0e68 for PR 20178 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3965 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/26675 "Hash e9ef0e68 for PR 20178 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3044 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2936 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->