### PR TITLE
[WGSL] Do not convert constant where there was a type error

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -429,7 +429,7 @@ CONSTANT_FUNCTION(Add)
         return { { result } };
     }
 
-    return constantBinaryOperation<Constraints::Number>(arguments, [&](auto left, auto right) {
+    return constantBinaryOperation<Constraints::Number>(arguments, [&]<typename T>(T left, T right) -> T {
         return left + right;
     });
 }
@@ -613,7 +613,7 @@ CONSTANT_FUNCTION(BitwiseShiftLeft)
     // i.e. we accept (u32, u32) as well as (i32, u32)
     UNUSED_PARAM(resultType);
     ASSERT(arguments.size() == 2);
-    const auto& shift = [&]<typename T>(T left, uint32_t right) {
+    const auto& shift = [&]<typename T>(T left, uint32_t right) -> T {
         return left << right;
     };
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -381,11 +381,13 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
             }
         } else if (unify(result, initializerType))
             variable.maybeInitializer()->m_inferredType = result;
-        else
+        else {
             typeError(InferBottom::No, variable.span(), "cannot initialize var of type '", *result, "' with value of type '", *initializerType, "'");
+            result = m_types.bottomType();
+        }
     }
 
-    if (value)
+    if (value && !isBottom(result))
         convertValue(variable.span(), result, *value);
 
     if (variable.flavor() == AST::VariableFlavor::Const && result != m_types.bottomType()) {

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -32,6 +32,9 @@ fn testConstraints() {
 
     // CHECK-L: no matching overload for operator -(vec2<u32>)
     let x8 = -vec2(1u, 1u);
+
+    // CHECK-L: cannot initialize var of type 'u32' with value of type 'i32'
+    const x: u32 = 1i << 1;
 }
 
 fn testBottomOverload() {


### PR DESCRIPTION
#### 291703d07512d596b4b2e781ecc4301cc768f421
<pre>
[WGSL] Do not convert constant where there was a type error
<a href="https://bugs.webkit.org/show_bug.cgi?id=264427">https://bugs.webkit.org/show_bug.cgi?id=264427</a>
<a href="https://rdar.apple.com/118129205">rdar://118129205</a>

Reviewed by Mike Wyrzykowski.

The constant version code has a strong assumption that typing is correct, i.e. it
assumes that the current type is compatible with the target type. That was causing
an assertion failure when initializing a variable with a constant of an incompatible
type, since we failed type checking but still tried to convert the constant.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
* Source/WebGPU/WGSL/tests/invalid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270437@main">https://commits.webkit.org/270437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b246ae03a0181b8dfc23b8d96a742fb66ff2fd32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23293 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23468 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28086 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2612 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28959 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23166 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26795 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/847 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3966 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6113 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->