### PR TITLE
[WGSL] Bit shift operators are missing abstract overloads

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -623,6 +623,8 @@ CONSTANT_FUNCTION(BitwiseShiftLeft)
             return shift(*i32, right);
         if (auto* u32 = std::get_if<uint32_t>(&left))
             return shift(*u32, right);
+        if (auto* abstractInt = std::get_if<int64_t>(&left))
+            return shift(*abstractInt, right);
         RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0], arguments[1]);
 }
@@ -643,6 +645,8 @@ CONSTANT_FUNCTION(BitwiseShiftRight)
             return shift(*i32, right);
         if (auto* u32 = std::get_if<uint32_t>(&left))
             return shift(*u32, right);
+        if (auto* abstractInt = std::get_if<int64_t>(&left))
+            return shift(*abstractInt, right);
         RELEASE_ASSERT_NOT_REACHED();
     }, arguments[0], arguments[1]);
 }

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -206,8 +206,8 @@ end
         must_use: true,
         const: const_function,
 
-        [S < ConcreteInteger].(S, u32) => S,
-        [S < ConcreteInteger, N].(vec[N][S], vec[N][u32]) => vec[N][S],
+        [S < Integer].(S, u32) => S,
+        [S < Integer, N].(vec[N][S], vec[N][u32]) => vec[N][S],
     }
 end
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -317,7 +317,7 @@ fn testBitwise()
   }
 
   {
-    _ = 1  << 2;
+    const x: u32 = 1 << 2;
     _ = 1i << 2u;
     _ = 1u << 2u;
     _ = vec2(1) << vec2(2);
@@ -326,7 +326,7 @@ fn testBitwise()
   }
 
   {
-    _ = 1  >> 2;
+    const x: u32 = 1 >> 2;
     _ = 1i >> 2u;
     _ = 1u >> 2u;
     _ = vec2(1) >> vec2(2);


### PR DESCRIPTION
#### 1d013da1493025f798602e60734a2f44644dca82
<pre>
[WGSL] Bit shift operators are missing abstract overloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=264428">https://bugs.webkit.org/show_bug.cgi?id=264428</a>
<a href="https://rdar.apple.com/118129463">rdar://118129463</a>

Reviewed by Mike Wyrzykowski.

When writing the declaration for shift left and right, I missed that there is a
separate overload for abstract integers. Add the missing overload and constant
evaluation.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270434@main">https://commits.webkit.org/270434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbed2ed089c96cb1c56ab6602fac7c6018058098

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23294 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23469 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28087 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2617 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28944 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26790 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/850 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3967 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6109 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->