### PR TITLE
[WGSL] Add support for constant indexing of vectors, arrays and matrices

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.cpp
+++ b/Source/WebGPU/WGSL/ConstantValue.cpp
@@ -31,6 +31,24 @@
 
 namespace WGSL {
 
+ConstantValue ConstantArray::operator[](unsigned index)
+{
+    return elements[index];
+}
+
+ConstantValue ConstantVector::operator[](unsigned index)
+{
+    return elements[index];
+}
+
+ConstantVector ConstantMatrix::operator[](unsigned index)
+{
+    ConstantVector result(rows);
+    for (unsigned i = 0; i < rows; ++i)
+        result.elements[i] = elements[index * rows + i];
+    return result;
+}
+
 void ConstantValue::dump(PrintStream& out) const
 {
     WTF::switchOn(*this,

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -52,6 +52,9 @@ struct ConstantArray {
     {
     }
 
+    size_t upperBound() { return elements.size(); }
+    ConstantValue operator[](unsigned);
+
     FixedVector<ConstantValue> elements;
 };
 
@@ -65,6 +68,9 @@ struct ConstantVector {
         : elements(WTFMove(elements))
     {
     }
+
+    size_t upperBound() { return elements.size(); }
+    ConstantValue operator[](unsigned);
 
     FixedVector<ConstantValue> elements;
 };
@@ -84,6 +90,9 @@ struct ConstantMatrix {
     {
         RELEASE_ASSERT(elements.size() == columns * rows);
     }
+
+    size_t upperBound() { return columns; }
+    ConstantVector operator[](unsigned);
 
     uint32_t columns;
     uint32_t rows;


### PR DESCRIPTION
#### 015a6cdeb6aa6c9b161c15649ddeaa507dcecf03
<pre>
[WGSL] Add support for constant indexing of vectors, arrays and matrices
<a href="https://bugs.webkit.org/show_bug.cgi?id=264430">https://bugs.webkit.org/show_bug.cgi?id=264430</a>
<a href="https://rdar.apple.com/118130183">rdar://118130183</a>

Reviewed by Mike Wyrzykowski.

Perform bounds checking and set the constant result of the access if both the
base and the index are constants.

* Source/WebGPU/WGSL/ConstantValue.cpp:
(WGSL::ConstantArray::operator[]):
(WGSL::ConstantVector::operator[]):
(WGSL::ConstantMatrix::operator[]):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantArray::upperBound):
(WGSL::ConstantVector::upperBound):
(WGSL::ConstantMatrix::upperBound):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):

Canonical link: <a href="https://commits.webkit.org/270436@main">https://commits.webkit.org/270436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b98f9a925f308fd5795ae0af71cef8c9bb9fb992

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25399 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23298 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23473 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28091 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2643 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28977 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26792 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/854 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3971 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6112 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->