### PR TITLE
Convert ContentSecurityPolicyResponseHeaders to the new IPC serialization format

### DIFF
--- a/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
@@ -41,13 +41,15 @@ enum class ContentSecurityPolicyHeaderType : bool {
 class ContentSecurityPolicyResponseHeaders {
 public:
     ContentSecurityPolicyResponseHeaders() = default;
+    ContentSecurityPolicyResponseHeaders(Vector<std::pair<String, ContentSecurityPolicyHeaderType>>&& headers, int httpStatusCode)
+        : m_headers(WTFMove(headers))
+        , m_httpStatusCode(httpStatusCode)
+    { }
+
     WEBCORE_EXPORT explicit ContentSecurityPolicyResponseHeaders(const ResourceResponse&);
 
     ContentSecurityPolicyResponseHeaders isolatedCopy() const &;
     ContentSecurityPolicyResponseHeaders isolatedCopy() &&;
-
-    template <class Encoder> void encode(Encoder&) const;
-    template <class Decoder> static std::optional<ContentSecurityPolicyResponseHeaders> decode(Decoder&);
 
     enum EmptyTag { Empty };
     struct MarkableTraits {
@@ -64,6 +66,11 @@ public:
 
     void addPolicyHeadersTo(ResourceResponse&) const;
 
+    const Vector<std::pair<String, ContentSecurityPolicyHeaderType>>& headers() const { return m_headers; }
+    void setHeaders(Vector<std::pair<String, ContentSecurityPolicyHeaderType>>&& headers) { m_headers = WTFMove(headers); }
+    int httpStatusCode() const { return m_httpStatusCode; }
+    void setHTTPStatusCode(int httpStatusCode) { m_httpStatusCode = httpStatusCode; }
+
 private:
     friend bool operator==(const ContentSecurityPolicyResponseHeaders&, const ContentSecurityPolicyResponseHeaders&);
     friend class ContentSecurityPolicy;
@@ -79,48 +86,6 @@ private:
 inline bool operator==(const ContentSecurityPolicyResponseHeaders&a, const ContentSecurityPolicyResponseHeaders&b)
 {
     return a.m_headers == b.m_headers;
-}
-
-template <class Encoder>
-void ContentSecurityPolicyResponseHeaders::encode(Encoder& encoder) const
-{
-    encoder << static_cast<uint64_t>(m_headers.size());
-    for (auto& pair : m_headers) {
-        encoder << pair.first;
-        encoder << pair.second;
-    }
-    encoder << m_httpStatusCode;
-}
-
-template <class Decoder>
-std::optional<ContentSecurityPolicyResponseHeaders> ContentSecurityPolicyResponseHeaders::decode(Decoder& decoder)
-{
-    ContentSecurityPolicyResponseHeaders headers;
-
-    std::optional<uint64_t> headersSize;
-    decoder >> headersSize;
-    if (!headersSize)
-        return std::nullopt;
-    for (size_t i = 0; i < *headersSize; ++i) {
-        std::optional<String> header;
-        decoder >> header;
-        if (!header)
-            return std::nullopt;
-        std::optional<ContentSecurityPolicyHeaderType> headerType;
-        decoder >> headerType;
-        if (!headerType)
-            return std::nullopt;
-        headers.m_headers.append(std::make_pair(WTFMove(*header), WTFMove(*headerType)));
-    }
-    headers.m_headers.shrinkToFit();
-
-    std::optional<int> httpStatusCode;
-    decoder >> httpStatusCode;
-    if (!httpStatusCode)
-        return std::nullopt;
-    headers.m_httpStatusCode = *httpStatusCode;
-
-    return headers;
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6568,6 +6568,11 @@ header: <WebCore/GraphicsContextState.h>
     WebCore::AffineTransform spaceTransform;
 };
 
+class WebCore::ContentSecurityPolicyResponseHeaders {
+    Vector<std::pair<String, WebCore::ContentSecurityPolicyHeaderType>> headers();
+    int httpStatusCode();
+};
+
 #if PLATFORM(COCOA)
 struct WebCore::KeypressCommand {
     String commandName;


### PR DESCRIPTION
#### 0b83b4f40567e55e14e1f7920ffd21c3af6cea6d
<pre>
Convert ContentSecurityPolicyResponseHeaders to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264424">https://bugs.webkit.org/show_bug.cgi?id=264424</a>

Reviewed by Alex Christensen.

* Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h:
(WebCore::ContentSecurityPolicyResponseHeaders::ContentSecurityPolicyResponseHeaders):
(WebCore::ContentSecurityPolicyResponseHeaders::headers const):
(WebCore::ContentSecurityPolicyResponseHeaders::setHeaders):
(WebCore::ContentSecurityPolicyResponseHeaders::httpStatusCode const):
(WebCore::ContentSecurityPolicyResponseHeaders::setHTTPStatusCode):
(WebCore::ContentSecurityPolicyResponseHeaders::encode const): Deleted.
(WebCore::ContentSecurityPolicyResponseHeaders::decode): Deleted.
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::ContentSecurityPolicyResponseHeaders&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ContentSecurityPolicyResponseHeaders&gt;::decodeForPersistence):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270417@main">https://commits.webkit.org/270417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d9a3b97696b60860ebad0b1e71f6f13502e6c39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23479 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28097 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28989 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26814 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/859 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3056 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3251 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2948 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->