### PR TITLE
Add support for parsing Web Extension commands.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -490,6 +490,9 @@
 /* WKWebExtensionErrorInvalidManifestEntry description for default_icon in browser_action or page_action */
 "Empty or invalid `default_icon` for the `browser_action` or `page_action` manifest entry." = "Empty or invalid `default_icon` for the `browser_action` or `page_action` manifest entry.";
 
+/* WKWebExtensionErrorInvalidManifestEntry description for invalid command description */
+"Empty or invalid `description` in the `commands` manifest entry." = "Empty or invalid `description` in the `commands` manifest entry.";
+
 /* WKWebExtensionErrorInvalidManifestEntry description for externally_connectable */
 "Empty or invalid `externally_connectable` manifest entry." = "Empty or invalid `externally_connectable` manifest entry.";
 
@@ -501,6 +504,12 @@
 
 /* WKWebExtensionErrorInvalidManifestEntry description for options UI */
 "Empty or invalid `options_ui` manifest entry" = "Empty or invalid `options_ui` manifest entry";
+
+/* WKWebExtensionErrorInvalidManifestEntry description for invalid command */
+"Empty or invalid command in the `commands` manifest entry." = "Empty or invalid command in the `commands` manifest entry.";
+
+/* WKWebExtensionErrorInvalidManifestEntry description for invalid command identifier */
+"Empty or invalid identifier in the `commands` manifest entry." = "Empty or invalid identifier in the `commands` manifest entry.";
 
 /* Video Enter Full Screen context menu item */
 "Enter Full Screen" = "Enter Full Screen";
@@ -646,6 +655,9 @@
 /* Inspect Element context menu item */
 "Inspect Element" = "Inspect Element";
 
+/* WKWebExtensionErrorInvalidManifestEntry description for commands */
+"Invalid `commands` manifest entry." = "Invalid `commands` manifest entry.";
+
 /* WKWebExtensionErrorInvalidBackgroundPersistence description */
 "Invalid `persistent` manifest entry." = "Invalid `persistent` manifest entry.";
 
@@ -657,6 +669,9 @@
 
 /* WKWebExtensionErrorInvalidBackgroundPersistence description for iOS */
 "Invalid `persistent` manifest entry. A non-persistent background is required on iOS and iPadOS." = "Invalid `persistent` manifest entry. A non-persistent background is required on iOS and iPadOS.";
+
+/* WKWebExtensionErrorInvalidManifestEntry description for invalid command shortcut */
+"Invalid `suggested_key` in the `commands` manifest entry." = "Invalid `suggested_key` in the `commands` manifest entry.";
 
 /* WKWebExtensionErrorInvalidManifestEntry description for web_accessible_resources */
 "Invalid `web_accessible_resources` manifest entry." = "Invalid `web_accessible_resources` manifest entry.";
@@ -1278,6 +1293,9 @@
 
 /* prompt string in authentication panel */
 "To view this page, you must log in to this area on %@:" = "To view this page, you must log in to this area on %@:";
+
+/* WKWebExtensionErrorInvalidManifestEntry description for too many command shortcuts */
+"Too many shortcuts specified for `commands`, only 4 shortcuts are allowed." = "Too many shortcuts specified for `commands`, only 4 shortcuts are allowed.";
 
 /* Label for the top up with Apple Pay button. */
 "Top up with Apple Pay" = "Top up with Apple Pay";

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2119,6 +2119,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionCommand {
+    header "_WKWebExtensionCommand.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionCommandPrivate {
+    header "_WKWebExtensionCommandPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionContext {
     header "_WKWebExtensionContext.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3021,6 +3021,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionCommand {
+    header "_WKWebExtensionCommand.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionCommandPrivate {
+    header "_WKWebExtensionCommandPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionContext {
     header "_WKWebExtensionContext.h"
     export *

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -178,6 +178,7 @@ public:
 #if ENABLE(WK_WEB_EXTENSIONS)
         WebExtension,
         WebExtensionAction,
+        WebExtensionCommand,
         WebExtensionContext,
         WebExtensionController,
         WebExtensionControllerConfiguration,
@@ -441,6 +442,7 @@ template<> struct EnumTraits<API::Object::Type> {
 #if ENABLE(WK_WEB_EXTENSIONS)
         API::Object::Type::WebExtension,
         API::Object::Type::WebExtensionAction,
+        API::Object::Type::WebExtensionCommand,
         API::Object::Type::WebExtensionContext,
         API::Object::Type::WebExtensionController,
         API::Object::Type::WebExtensionControllerConfiguration,

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -105,6 +105,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 #import "_WKWebExtensionActionInternal.h"
+#import "_WKWebExtensionCommandInternal.h"
 #import "_WKWebExtensionContextInternal.h"
 #import "_WKWebExtensionControllerConfigurationInternal.h"
 #import "_WKWebExtensionControllerInternal.h"
@@ -407,6 +408,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::WebExtensionAction:
         wrapper = [_WKWebExtensionAction alloc];
+        break;
+
+    case Type::WebExtensionCommand:
+        wrapper = [_WKWebExtensionCommand alloc];
         break;
 
     case Type::WebExtensionController:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -232,6 +232,13 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  */
 @property (nonatomic, readonly) BOOL hasOverrideNewTabPage;
 
+/*!
+ @abstract A Boolean value indicating whether the extension includes commands that users can invoke.
+ @discussion If this property is `YES`, the extension contains one or more commands that can be performed by the user. These commands should be accessible via keyboard shortcuts,
+ menu items, or other user interface elements provided by the app. The list of commands can be accessed via `commands` on an extension context, and invoked via `performCommand:`.
+ */
+@property (nonatomic, readonly) BOOL hasCommands;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -265,6 +265,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return _webExtension->hasOverrideNewTabPage();
 }
 
+- (BOOL)hasCommands
+{
+    return _webExtension->hasCommands();
+}
+
 - (BOOL)_backgroundContentIsServiceWorker
 {
     return _webExtension->backgroundContentIsServiceWorker();
@@ -437,6 +442,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 }
 
 - (BOOL)hasOverrideNewTabPage
+{
+    return NO;
+}
+
+- (BOOL)hasCommands
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UICommand.h>
+#endif
+
+@class _WKWebExtensionContext;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ @abstract A `WKWebExtensionCommand` object encapsulates the properties for an individual web extension command.
+ @discussion Provides access to command properties such as a unique identifier, a descriptive title, and shortcut keys. Commands
+ can be used by a web extension to perform specific actions within a web extension context, such toggling features, or interacting with
+ web content. These commands enhance the functionality of the extension by allowing users to invoke actions quickly.
+ */
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+NS_SWIFT_NAME(WKWebExtension.Command)
+@interface _WKWebExtensionCommand : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+/*! @abstract The web extension context associated with the command. */
+@property (nonatomic, readonly, weak) _WKWebExtensionContext *webExtensionContext;
+
+/*! @abstract Unique identifier for the command. */
+@property (nonatomic, readonly, copy) NSString *identifier;
+
+/*!
+ @abstract Descriptive title for the command aiding discoverability.
+ @discussion This title can be displayed in user interface elements such as keyboard shortcuts lists or menu items to help users understand its purpose.
+ */
+@property (nonatomic, readonly, copy) NSString *discoverabilityTitle;
+
+/*!
+ @abstract The primary key used to trigger the command, distinct from any modifier flags.
+ @discussion This property can be customized within the app to avoid conflicts with existing shortcuts or to enable user personalization.
+ It should accurately represent the activation key as used by the app, which the extension can use to display the complete shortcut in its interface.
+ If no shortcut is desired for the command, the property should be set to `nil`.
+ */
+@property (nonatomic, nullable, copy) NSString *activationKey;
+
+/*!
+ @abstract The modifier flags used with the activation key to trigger the command.
+ @discussion This property can be customized within the app to avoid conflicts with existing shortcuts or to enable user personalization. It
+ should accurately represent the modifier keys as used by the app, which the extension can use to display the complete shortcut in its interface.
+ If no modifiers are desired for the command, the property should be set to `0`.
+ */
+#if TARGET_OS_IPHONE
+@property (nonatomic) UIKeyModifierFlags modifierFlags;
+#else
+@property (nonatomic) NSEventModifierFlags modifierFlags;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionCommandInternal.h"
+
+#import "WebExtensionCommand.h"
+#import "WebExtensionContext.h"
+#import <WebCore/WebCoreObjCExtras.h>
+
+#if USE(APPKIT)
+using CocoaModifierFlags = NSEventModifierFlags;
+#else
+using CocoaModifierFlags = UIKeyModifierFlags;
+#endif
+
+@implementation _WKWebExtensionCommand
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionCommand.class, self))
+        return;
+
+    _webExtensionCommand->~WebExtensionCommand();
+}
+
+- (NSUInteger)hash
+{
+    return self.identifier.hash;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+        return YES;
+
+    auto *other = dynamic_objc_cast<_WKWebExtensionCommand>(object);
+    if (!other)
+        return NO;
+
+    return *_webExtensionCommand == *other->_webExtensionCommand;
+}
+
+- (NSString *)description
+{
+    return self.discoverabilityTitle;
+}
+
+- (NSString *)debugDescription
+{
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@; shortcut = %@>", NSStringFromClass(self.class), self, self.identifier, self.activationKey.length ? (NSString *)self._webExtensionCommand.shortcutString() : @"(none)"];
+}
+
+- (_WKWebExtensionContext *)webExtensionContext
+{
+    if (auto *context = _webExtensionCommand->extensionContext())
+        return context->wrapper();
+    return nil;
+}
+
+- (NSString *)identifier
+{
+    return _webExtensionCommand->identifier();
+}
+
+- (NSString *)discoverabilityTitle
+{
+    return _webExtensionCommand->description();
+}
+
+- (NSString *)activationKey
+{
+    if (auto& activationKey = _webExtensionCommand->activationKey(); !activationKey.isEmpty())
+        return activationKey;
+    return nil;
+}
+
+- (void)setActivationKey:(NSString *)activationKey
+{
+    bool result = _webExtensionCommand->setActivationKey(activationKey);
+    NSAssert(result, @"Invalid parameter: an unsupported character was provided");
+}
+
+- (CocoaModifierFlags)modifierFlags
+{
+    return _webExtensionCommand->modifierFlags().toRaw();
+}
+
+- (void)setModifierFlags:(CocoaModifierFlags)modifierFlags
+{
+    auto optionSet = OptionSet<WebKit::WebExtension::ModifierFlags>::fromRaw(modifierFlags);
+    NSAssert(optionSet.toRaw() == modifierFlags, @"Invalid parameter: an unsupported modifier flag was provided");
+
+    _webExtensionCommand->setModifierFlags(optionSet);
+}
+
+#pragma mark WKObject protocol implementation
+
+- (API::Object&)_apiObject
+{
+    return *_webExtensionCommand;
+}
+
+- (WebKit::WebExtensionCommand&)_webExtensionCommand
+{
+    return *_webExtensionCommand;
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
+- (_WKWebExtensionContext *)webExtensionContext
+{
+    return nil;
+}
+
+- (NSString *)identifier
+{
+    return nil;
+}
+
+- (NSString *)discoverabilityTitle
+{
+    return nil;
+}
+
+- (NSString *)activationKey
+{
+    return nil;
+}
+
+- (void)setActivationKey:(NSString *)activationKey
+{
+}
+
+- (CocoaModifierFlags)modifierFlags
+{
+    return 0;
+}
+
+- (void)setModifierFlags:(CocoaModifierFlags)modifierFlags
+{
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandInternal.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "_WKWebExtensionCommandPrivate.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WKObject.h"
+#import "WebExtensionCommand.h"
+
+namespace WebKit {
+template<> struct WrapperTraits<WebExtensionCommand> {
+    using WrapperClass = _WKWebExtensionCommand;
+};
+}
+
+@interface _WKWebExtensionCommand () <WKObject> {
+@package
+    API::ObjectStorage<WebKit::WebExtensionCommand> _webExtensionCommand;
+}
+
+@property (nonatomic, readonly) WebKit::WebExtensionCommand& _webExtensionCommand;
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandPrivate.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/_WKWebExtensionCommand.h>
+
+@interface _WKWebExtensionCommand ()
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -34,6 +34,7 @@
 @class WKWebViewConfiguration;
 @class _WKWebExtension;
 @class _WKWebExtensionAction;
+@class _WKWebExtensionCommand;
 @class _WKWebExtensionController;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -488,6 +489,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @param tab The tab for which to retrieve the extension action, or `nil` to get the default action.
  @discussion The returned object represents the action specific to the tab when provided; otherwise, it returns the default action. The default
  action is useful when the context is unrelated to a specific tab. When possible, specify the tab to get the most context-relevant action.
+ @seealso performActionForTab:
  */
 - (nullable _WKWebExtensionAction *)actionForTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(action(for:));
 
@@ -500,6 +502,21 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  no action is performed for popup actions.
  */
 - (void)performActionForTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(performAction(for:));
+
+/*!
+ @abstract An array of commands associated with the extension context.
+ @discussion This property returns an array of all the commands currently available within the extension context. It allows for inspection of the
+ commands that have been registered and their current configuration.
+ @seealso performCommand:
+ */
+@property (nonatomic, readonly, copy) NSArray<_WKWebExtensionCommand *> *commands;
+
+/*!
+ @abstract Performs the specified command, triggering events specific to this extension.
+ @param command The command to be performed.
+ @discussion This method performs the given command as if it was triggered by a user gesture within the context of the focused window and active tab.
+ */
+- (void)performCommand:(_WKWebExtensionCommand *)command;
 
 /*!
  @abstract Should be called by the app when a user gesture is performed in a specific tab.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -34,13 +34,16 @@
 #import "WKWebView.h"
 #import "WebExtension.h"
 #import "WebExtensionAction.h"
+#import "WebExtensionCommand.h"
 #import "WebExtensionContext.h"
+#import "_WKWebExtensionCommandInternal.h"
 #import "_WKWebExtensionControllerInternal.h"
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
 #import "_WKWebExtensionTab.h"
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/URLParser.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 NSErrorDomain const _WKWebExtensionContextErrorDomain = @"_WKWebExtensionContextErrorDomain";
 
@@ -515,6 +518,20 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
         NSParameterAssert([tab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
 
     _webExtensionContext->performAction(toImplNullable(tab, *_webExtensionContext).get(), WebKit::WebExtensionContext::UserTriggered::Yes);
+}
+
+- (NSArray<_WKWebExtensionCommand *> *)commands
+{
+    return createNSArray(_webExtensionContext->commands(), [](auto& command) {
+        return command->wrapper();
+    }).get();
+}
+
+- (void)performCommand:(_WKWebExtensionCommand *)command
+{
+    NSParameterAssert([command isKindOfClass:_WKWebExtensionCommand.class]);
+
+    _webExtensionContext->performCommand(command._webExtensionCommand, WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
 - (void)userGesturePerformedInTab:(id<_WKWebExtensionTab>)tab
@@ -1001,6 +1018,15 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (void)performActionForTab:(id<_WKWebExtensionTab>)tab NS_SWIFT_NAME(performAction(for:))
+{
+}
+
+- (NSArray<_WKWebExtensionCommand *> *)commands
+{
+    return nil;
+}
+
+- (void)performCommand:(_WKWebExtensionCommand *)command
 {
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionCommand.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import <wtf/text/StringBuilder.h>
+
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIKit.h>
+#endif
+
+namespace WebKit {
+
+bool WebExtensionCommand::setActivationKey(String activationKey)
+{
+    if (activationKey.isEmpty()) {
+        m_activationKey = nullString();
+        return true;
+    }
+
+    if (activationKey.length() > 1)
+        return false;
+
+    static NSCharacterSet *notAllowedCharacterSet;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        auto *allowedCharacterSet = [NSMutableCharacterSet alphanumericCharacterSet];
+        [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF704, 12)];
+        [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF727, 3)];
+        [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF72B, 3)];
+        [allowedCharacterSet addCharactersInRange:NSMakeRange(0xF700, 4)];
+        [allowedCharacterSet addCharactersInString:@",. "];
+
+        notAllowedCharacterSet = allowedCharacterSet.invertedSet;
+    });
+
+    if ([(NSString *)activationKey rangeOfCharacterFromSet:notAllowedCharacterSet].location != NSNotFound)
+        return false;
+
+    m_activationKey = activationKey.convertToASCIILowercase();
+
+    return true;
+}
+
+String WebExtensionCommand::shortcutString() const
+{
+    auto flags = modifierFlags();
+    auto key = activationKey();
+
+    if (!flags || key.isEmpty())
+        return emptyString();
+
+    static NeverDestroyed<HashMap<String, String>> specialKeyMap = HashMap<String, String> {
+        { ","_s, "Comma"_s },
+        { "."_s, "Period"_s },
+        { " "_s, "Space"_s },
+        { @"\uF704", "F1"_s },
+        { @"\uF705", "F2"_s },
+        { @"\uF706", "F3"_s },
+        { @"\uF707", "F4"_s },
+        { @"\uF708", "F5"_s },
+        { @"\uF709", "F6"_s },
+        { @"\uF70A", "F7"_s },
+        { @"\uF70B", "F8"_s },
+        { @"\uF70C", "F9"_s },
+        { @"\uF70D", "F10"_s },
+        { @"\uF70E", "F11"_s },
+        { @"\uF70F", "F12"_s },
+        { @"\uF727", "Insert"_s },
+        { @"\uF728", "Delete"_s },
+        { @"\uF729", "Home"_s },
+        { @"\uF72B", "End"_s },
+        { @"\uF72C", "PageUp"_s },
+        { @"\uF72D", "PageDown"_s },
+        { @"\uF700", "Up"_s },
+        { @"\uF701", "Down"_s },
+        { @"\uF702", "Left"_s },
+        { @"\uF703", "Right"_s }
+    };
+
+    StringBuilder stringBuilder;
+
+    if (flags.contains(ModifierFlags::Control))
+        stringBuilder.append("MacCtrl"_s);
+
+    if (flags.contains(ModifierFlags::Option)) {
+        if (!stringBuilder.isEmpty())
+            stringBuilder.append('+');
+        stringBuilder.append("Alt"_s);
+    }
+
+    if (flags.contains(ModifierFlags::Shift)) {
+        if (!stringBuilder.isEmpty())
+            stringBuilder.append('+');
+        stringBuilder.append("Shift"_s);
+    }
+
+    if (flags.contains(ModifierFlags::Command)) {
+        if (!stringBuilder.isEmpty())
+            stringBuilder.append('+');
+        stringBuilder.append("Command"_s);
+    }
+
+    if (!stringBuilder.isEmpty())
+        stringBuilder.append('+');
+
+    if (auto specialKey = specialKeyMap.get().get(key); !specialKey.isEmpty())
+        stringBuilder.append(specialKey);
+    else
+        stringBuilder.append(key.convertToASCIIUppercase());
+
+    return stringBuilder.toString();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1701,6 +1701,30 @@ void WebExtensionContext::performAction(WebExtensionTab* tab, UserTriggered user
     fireActionClickedEventIfNeeded(tab);
 }
 
+const WebExtensionContext::CommandsVector& WebExtensionContext::commands()
+{
+    if (m_populatedCommands)
+        return m_commands;
+
+    for (auto& data : extension().commands())
+        m_commands.append(WebExtensionCommand::create(*this, data));
+
+    m_populatedCommands = true;
+
+    return m_commands;
+}
+
+void WebExtensionContext::performCommand(WebExtensionCommand& command, UserTriggered userTriggered)
+{
+    auto currentWindow = frontmostWindow();
+    auto activeTab = currentWindow ? currentWindow->activeTab() : nullptr;
+
+    if (activeTab && userTriggered == UserTriggered::Yes)
+        userGesturePerformed(*activeTab);
+
+    // FIXME: <https://webkit.org/b/260157> Dispatch the commands onCommand event.
+}
+
 void WebExtensionContext::userGesturePerformed(WebExtensionTab& tab)
 {
     // Nothing else to do if the extension does not have the activeTab permissions.

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WebExtensionCommand.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionContext.h"
+#import "WebExtensionContextProxyMessages.h"
+
+namespace WebKit {
+
+WebExtensionCommand::WebExtensionCommand(WebExtensionContext& extensionContext, const WebExtension::CommandData& data)
+    : m_extensionContext(extensionContext)
+    , m_identifier(data.identifier)
+    , m_description(data.description)
+    , m_activationKey(data.activationKey)
+    , m_modifierFlags(data.modifierFlags)
+{
+}
+
+bool WebExtensionCommand::operator==(const WebExtensionCommand& other) const
+{
+    return this == &other || (m_extensionContext == other.m_extensionContext && m_identifier == other.m_identifier);
+}
+
+WebExtensionContext* WebExtensionCommand::extensionContext() const
+{
+    return m_extensionContext.get();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "APIObject.h"
+#include "WebExtension.h"
+#include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+OBJC_CLASS _WKWebExtensionCommand;
+
+namespace WebKit {
+
+class WebExtensionContext;
+
+class WebExtensionCommand : public API::ObjectImpl<API::Object::Type::WebExtensionCommand>, public CanMakeWeakPtr<WebExtensionCommand> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionCommand);
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionCommand> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionCommand(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionCommand(WebExtensionContext&, const WebExtension::CommandData&);
+
+    using ModifierFlags = WebExtension::ModifierFlags;
+
+    bool operator==(const WebExtensionCommand&) const;
+
+    WebExtensionContext* extensionContext() const;
+
+    const String& identifier() const { return m_identifier; }
+    const String& description() const { return m_description; }
+
+    const String& activationKey() const { return m_modifierFlags ? m_activationKey : nullString(); }
+    bool setActivationKey(String);
+
+    OptionSet<ModifierFlags> modifierFlags() const { return !m_activationKey.isEmpty() ? m_modifierFlags : OptionSet<ModifierFlags> { }; }
+    void setModifierFlags(OptionSet<ModifierFlags> modifierFlags) { m_modifierFlags = modifierFlags; }
+
+    String shortcutString() const;
+
+#ifdef __OBJC__
+    _WKWebExtensionCommand *wrapper() const { return (_WKWebExtensionCommand *)API::ObjectImpl<API::Object::Type::WebExtensionCommand>::wrapper(); }
+#endif
+
+private:
+    WeakPtr<WebExtensionContext> m_extensionContext;
+    String m_identifier;
+    String m_description;
+    String m_activationKey;
+    OptionSet<ModifierFlags> m_modifierFlags;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -34,6 +34,7 @@
 #include "WebExtension.h"
 #include "WebExtensionAction.h"
 #include "WebExtensionAlarm.h"
+#include "WebExtensionCommand.h"
 #include "WebExtensionContextIdentifier.h"
 #include "WebExtensionController.h"
 #include "WebExtensionDynamicScripts.h"
@@ -136,6 +137,8 @@ public:
     using NativePortMap = HashMap<WebExtensionPortChannelIdentifier, Ref<WebExtensionMessagePort>>;
 
     using PageIdentifierTuple = std::tuple<WebCore::PageIdentifier, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>>;
+
+    using CommandsVector = Vector<Ref<WebExtensionCommand>>;
 
     enum class EqualityOnly : bool { No, Yes };
     enum class WindowIsClosing : bool { No, Yes };
@@ -299,6 +302,9 @@ public:
     Ref<WebExtensionAction> getOrCreateAction(WebExtensionWindow*);
     Ref<WebExtensionAction> getOrCreateAction(WebExtensionTab*);
     void performAction(WebExtensionTab*, UserTriggered = UserTriggered::No);
+
+    const CommandsVector& commands();
+    void performCommand(WebExtensionCommand&, UserTriggered = UserTriggered::No);
 
     void userGesturePerformed(WebExtensionTab&);
     bool hasActiveUserGesture(WebExtensionTab&) const;
@@ -583,6 +589,9 @@ private:
     std::optional<WebExtensionWindowIdentifier> m_focusedWindowIdentifier;
 
     TabIdentifierMap m_tabMap;
+
+    CommandsVector m_commands;
+    bool m_populatedCommands { false };
 };
 
 template<typename T>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -503,6 +503,13 @@
 		1C8E293912761E5B00BC7BD0 /* WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E293712761E5B00BC7BD0 /* WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C8E2A351277852400BC7BD0 /* WebInspectorMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C8E2A311277852400BC7BD0 /* WebInspectorMessageReceiver.cpp */; };
 		1C8E2A361277852400BC7BD0 /* WebInspectorMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E2A321277852400BC7BD0 /* WebInspectorMessages.h */; };
+		1C8ECFDA2AFC12CC007BAA62 /* WebExtensionCommandCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C8ECFD92AFC12CC007BAA62 /* WebExtensionCommandCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C974FDD2AFABCF0009DE8FC /* _WKWebExtensionCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C974FDC2AFABCF0009DE8FC /* _WKWebExtensionCommand.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C974FDF2AFABD03009DE8FC /* _WKWebExtensionCommand.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C974FDE2AFABD03009DE8FC /* _WKWebExtensionCommand.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C974FE12AFACB02009DE8FC /* _WKWebExtensionCommandInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C974FE02AFACB02009DE8FC /* _WKWebExtensionCommandInternal.h */; };
+		1C974FE32AFACB16009DE8FC /* _WKWebExtensionCommandPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C974FE22AFACB16009DE8FC /* _WKWebExtensionCommandPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C974FE52AFAD137009DE8FC /* WebExtensionCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C974FE42AFAD137009DE8FC /* WebExtensionCommand.h */; };
+		1C974FE72AFAD17D009DE8FC /* WebExtensionCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C974FE62AFAD17D009DE8FC /* WebExtensionCommand.cpp */; };
 		1C9A15C82ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C9A15C72ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h */; };
 		1C9A15CA2ABDEF13002CC12A /* WebExtensionAPIPort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C9A15C92ABDEF13002CC12A /* WebExtensionAPIPort.h */; };
 		1C9A15CE2ABDF1E2002CC12A /* JSWebExtensionAPIPort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C9A15CC2ABDF1E1002CC12A /* JSWebExtensionAPIPort.h */; };
@@ -3660,6 +3667,13 @@
 		1C8E2A321277852400BC7BD0 /* WebInspectorMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorMessages.h; sourceTree = "<group>"; };
 		1C8E2DAD1278C5B200BC7BC9 /* RemoteWebInspectorUIMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteWebInspectorUIMac.mm; sourceTree = "<group>"; };
 		1C8E2DAD1278C5B200BC7BD0 /* WebInspectorUIMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebInspectorUIMac.mm; sourceTree = "<group>"; };
+		1C8ECFD92AFC12CC007BAA62 /* WebExtensionCommandCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionCommandCocoa.mm; sourceTree = "<group>"; };
+		1C974FDC2AFABCF0009DE8FC /* _WKWebExtensionCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionCommand.h; sourceTree = "<group>"; };
+		1C974FDE2AFABD03009DE8FC /* _WKWebExtensionCommand.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionCommand.mm; sourceTree = "<group>"; };
+		1C974FE02AFACB02009DE8FC /* _WKWebExtensionCommandInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionCommandInternal.h; sourceTree = "<group>"; };
+		1C974FE22AFACB16009DE8FC /* _WKWebExtensionCommandPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionCommandPrivate.h; sourceTree = "<group>"; };
+		1C974FE42AFAD137009DE8FC /* WebExtensionCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionCommand.h; sourceTree = "<group>"; };
+		1C974FE62AFAD17D009DE8FC /* WebExtensionCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionCommand.cpp; sourceTree = "<group>"; };
 		1C98C01D27446A03002CCB78 /* RemoteGPU.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGPU.cpp; sourceTree = "<group>"; };
 		1C98C01F27446A03002CCB78 /* RemoteQuerySet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteQuerySet.h; sourceTree = "<group>"; };
 		1C98C02027446A04002CCB78 /* RemoteRenderBundle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRenderBundle.h; sourceTree = "<group>"; };
@@ -8952,6 +8966,7 @@
 				1C1549802926E7CC001B9E5B /* API */,
 				1CF0C94F2AC380E900EC82F2 /* WebExtensionActionCocoa.mm */,
 				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
+				1C8ECFD92AFC12CC007BAA62 /* WebExtensionCommandCocoa.mm */,
 				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
 				1C1549D129381B9F001B9E5B /* WebExtensionControllerConfigurationCocoa.mm */,
@@ -9375,6 +9390,8 @@
 				1CF0C94D2AC380C400EC82F2 /* WebExtensionAction.h */,
 				1C2B4D3C2A8091FF00C528A1 /* WebExtensionAlarm.cpp */,
 				1C2B4D3D2A8091FF00C528A1 /* WebExtensionAlarm.h */,
+				1C974FE62AFAD17D009DE8FC /* WebExtensionCommand.cpp */,
+				1C974FE42AFAD137009DE8FC /* WebExtensionCommand.h */,
 				1C0234C128A00E7D00AC1E5B /* WebExtensionContext.cpp */,
 				1C0234C228A00E7D00AC1E5B /* WebExtensionContext.h */,
 				1C0234C328A00E7E00AC1E5B /* WebExtensionContext.messages.in */,
@@ -10420,6 +10437,10 @@
 				1CF0C9472AC37FAD00EC82F2 /* _WKWebExtensionAction.mm */,
 				1CF0C94B2AC3801400EC82F2 /* _WKWebExtensionActionInternal.h */,
 				1CF0C9492AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h */,
+				1C974FDC2AFABCF0009DE8FC /* _WKWebExtensionCommand.h */,
+				1C974FDE2AFABD03009DE8FC /* _WKWebExtensionCommand.mm */,
+				1C974FE02AFACB02009DE8FC /* _WKWebExtensionCommandInternal.h */,
+				1C974FE22AFACB16009DE8FC /* _WKWebExtensionCommandPrivate.h */,
 				1C04983A289AFF9B0010308B /* _WKWebExtensionContext.h */,
 				1C0234D328A0135600AC1E5B /* _WKWebExtensionContext.mm */,
 				1C0234D628A013D900AC1E5B /* _WKWebExtensionContextInternal.h */,
@@ -14623,6 +14644,9 @@
 				1CF0C9462AC34BC600EC82F2 /* _WKWebExtensionAction.h in Headers */,
 				1CF0C94C2AC3801400EC82F2 /* _WKWebExtensionActionInternal.h in Headers */,
 				1CF0C94A2AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h in Headers */,
+				1C974FDD2AFABCF0009DE8FC /* _WKWebExtensionCommand.h in Headers */,
+				1C974FE12AFACB02009DE8FC /* _WKWebExtensionCommandInternal.h in Headers */,
+				1C974FE32AFACB16009DE8FC /* _WKWebExtensionCommandPrivate.h in Headers */,
 				1C04983E289AFF9B0010308B /* _WKWebExtensionContext.h in Headers */,
 				1C0234D828A013D900AC1E5B /* _WKWebExtensionContextInternal.h in Headers */,
 				1C0234D728A013D900AC1E5B /* _WKWebExtensionContextPrivate.h in Headers */,
@@ -15417,6 +15441,7 @@
 				33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */,
 				1C5ACFB02A96F9F200C041C0 /* WebExtensionAPIWindows.h in Headers */,
 				1C5ACFB22A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h in Headers */,
+				1C974FE52AFAD137009DE8FC /* WebExtensionCommand.h in Headers */,
 				1C4A14F12ABDDD6800A1018C /* WebExtensionContentWorldType.h in Headers */,
 				1C0234D928A01B1C00AC1E5B /* WebExtensionContextIdentifier.h in Headers */,
 				1C0234D228A00FF000AC1E5B /* WebExtensionContextMessages.h in Headers */,
@@ -17648,6 +17673,7 @@
 				99E7189A21F79D9E0055E975 /* _WKTouchEventGenerator.mm in Sources */,
 				1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */,
 				1CF0C9482AC37FAD00EC82F2 /* _WKWebExtensionAction.mm in Sources */,
+				1C974FDF2AFABD03009DE8FC /* _WKWebExtensionCommand.mm in Sources */,
 				1C0234D428A0135600AC1E5B /* _WKWebExtensionContext.mm in Sources */,
 				1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */,
 				1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */,
@@ -18042,6 +18068,8 @@
 				1C5ACFB82A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm in Sources */,
 				1C5ACFB42A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
+				1C974FE72AFAD17D009DE8FC /* WebExtensionCommand.cpp in Sources */,
+				1C8ECFDA2AFC12CC007BAA62 /* WebExtensionCommandCocoa.mm in Sources */,
 				1CC94E5A2AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm in Sources */,
 				1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -994,6 +994,54 @@ TEST(WKWebExtension, WebAccessibleResourcesV3)
     EXPECT_EQ(testExtension.errors.count, 1ul);
 }
 
+TEST(WKWebExtension, CommandsParsing)
+{
+    auto *testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"commands": @{
+            @"show-popup": @{
+                @"suggested_key": @{
+                    @"default": @"Ctrl+Shift+P",
+                    @"mac": @"Command+Shift+P"
+                },
+                @"description": @"Show the popup"
+            }
+        }
+    };
+
+    auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasCommands);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0"
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_FALSE(testExtension.hasCommands);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"commands": @{
+            @"show-popup": @"Invalid"
+        }
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_FALSE(testExtension.hasCommands);
+    EXPECT_EQ(testExtension.errors.count, 1ul);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 210a20b544ef3f77cea2f7dcb19ec21b9022d5cf
<pre>
Add support for parsing Web Extension commands.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260157">https://bugs.webkit.org/show_bug.cgi?id=260157</a>
<a href="https://rdar.apple.com/problem/114823250">rdar://problem/114823250</a>

Reviewed by Brian Weinstein.

Add support for parsing Web Extension commands and the new `_WKWebExtensionCommand`.
This does not expose the `browser.commands` API yet, that will be next.

The `_WKWebExtensionCommand` class supports customization by the app, which will
be reflected back to the extensions in `browser.commands.getAll()`.

* Source/WebCore/en.lproj/Localizable.strings: Updated.
* Source/WebKit/Modules/OSX_Private.modulemap: Added new _WKWebExtensionCommand.
* Source/WebKit/Modules/iOS_Private.modulemap: Ditto.
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension hasCommands]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm: Added.
(-[_WKWebExtensionCommand dealloc]):
(-[_WKWebExtensionCommand hash]):
(-[_WKWebExtensionCommand isEqual:]):
(-[_WKWebExtensionCommand description]):
(-[_WKWebExtensionCommand debugDescription]):
(-[_WKWebExtensionCommand webExtensionContext]):
(-[_WKWebExtensionCommand identifier]):
(-[_WKWebExtensionCommand discoverabilityTitle]):
(-[_WKWebExtensionCommand activationKey]):
(-[_WKWebExtensionCommand setActivationKey:]):
(-[_WKWebExtensionCommand modifierFlags]):
(-[_WKWebExtensionCommand setModifierFlags:]):
(-[_WKWebExtensionCommand _apiObject]):
(-[_WKWebExtensionCommand _webExtensionCommand]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandPrivate.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext commands]):
(-[_WKWebExtensionContext performCommand:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::toAPI):
(WebKit::WebExtension::createError):
(WebKit::WebExtension::errors):
(WebKit::WebExtension::commands):
(WebKit::WebExtension::hasCommands):
(WebKit::parseCommandShortcut):
(WebKit::WebExtension::populateCommandsIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm: Added.
(WebKit::WebExtensionCommand::setActivationKey):
(WebKit::WebExtensionCommand::setModifierFlags):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::commands):
(WebKit::WebExtensionContext::performCommand):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp: Added.
(WebKit::WebExtensionCommand::WebExtensionCommand):
(WebKit::WebExtensionCommand::operator== const):
(WebKit::WebExtensionCommand::extensionContext const):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h: Added.
(WebKit::WebExtensionCommand::create):
(WebKit::WebExtensionCommand::identifier const):
(WebKit::WebExtensionCommand::description const):
(WebKit::WebExtensionCommand::activationKey const):
(WebKit::WebExtensionCommand::modifierFlags const):
(WebKit::WebExtensionCommand::wrapper const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270494@main">https://commits.webkit.org/270494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b488c5e477e0892d9f4b2d2083a715f8bbcbeb95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25616 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1656 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28296 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23029 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26971 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1028 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4162 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3235 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3273 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->