### PR TITLE
jsc shell and testapi process should also have CaptivePortal entitlement

### DIFF
--- a/Source/JavaScriptCore/Scripts/process-entitlements.sh
+++ b/Source/JavaScriptCore/Scripts/process-entitlements.sh
@@ -17,6 +17,7 @@ function mac_process_jsc_entitlements()
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
+            plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
         fi
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
@@ -37,6 +38,7 @@ function mac_process_testapi_entitlements()
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
+            plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
         fi
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
@@ -60,6 +62,7 @@ function maccatalyst_process_jsc_entitlements()
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
+            plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
         fi
     fi
 
@@ -78,6 +81,7 @@ function maccatalyst_process_testapi_entitlements()
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
     then
         plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
+        plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
     fi
 
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
@@ -95,6 +99,7 @@ function ios_family_process_jsc_entitlements()
 {
     plistbuddy Add :com.apple.private.verified-jit bool YES
     plistbuddy Add :dynamic-codesigning bool YES
+    plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
 }
 
 function ios_family_process_testapi_entitlements()


### PR DESCRIPTION
#### 0dcfb0a78a1d7433cd19b6cd7baec50719036eac
<pre>
jsc shell and testapi process should also have CaptivePortal entitlement
<a href="https://bugs.webkit.org/show_bug.cgi?id=264432">https://bugs.webkit.org/show_bug.cgi?id=264432</a>
<a href="https://rdar.apple.com/118131530">rdar://118131530</a>

Reviewed by Mark Lam.

When JIT is disabled, the jsc shell and testapi process also needs
to be able to allocate the Gigacage.

* Source/JavaScriptCore/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/270484@main">https://commits.webkit.org/270484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25dedb5c64acbf64778c12469f68467c95a5ae91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1645 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28285 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23018 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22278 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26955 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24828 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1017 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32268 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4152 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7023 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3225 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3268 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->