### PR TITLE
[WebGPU] Pipeline needs to pass zNear and zFar to fragment shader for clamping depth writes

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -256,14 +256,14 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
         }
 
         bindGroupLayoutEntries.add(entry.binding, BindGroupLayout::Entry {
-            entry.binding,
-            entry.visibility,
-            WTFMove(bindingLayout),
-            WTFMove(argumentBufferIndices),
-            WTFMove(bufferSizeArgumentBufferIndices),
-            WTFMove(dynamicOffsets[0]),
-            WTFMove(dynamicOffsets[1]),
-            WTFMove(dynamicOffsets[2])
+            .binding = entry.binding,
+            .visibility = entry.visibility,
+            .bindingLayout = WTFMove(bindingLayout),
+            .argumentBufferIndices = WTFMove(argumentBufferIndices),
+            .bufferSizeArgumentBufferIndices = WTFMove(bufferSizeArgumentBufferIndices),
+            .vertexDynamicOffset = WTFMove(dynamicOffsets[0]),
+            .fragmentDynamicOffset = WTFMove(dynamicOffsets[1]),
+            .computeDynamicOffset = WTFMove(dynamicOffsets[2])
         });
     }
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -61,6 +61,7 @@ public:
     void onSubmittedWorkDone(CompletionHandler<void(WGPUQueueWorkDoneStatus)>&& callback);
     void submit(Vector<std::reference_wrapper<CommandBuffer>>&& commands);
     void writeBuffer(const Buffer&, uint64_t bufferOffset, const void* data, size_t);
+    void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, const void* data, size_t);
     void writeTexture(const WGPUImageCopyTexture& destination, const void* data, size_t dataSize, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize);
     void setLabel(String&&);
 

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -271,6 +271,11 @@ void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, const void*
         }
     }
 
+    writeBuffer(buffer.buffer(), bufferOffset, data, size);
+}
+
+void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, const void* data, size_t size)
+{
     ensureBlitCommandEncoder();
     // FIXME(PERFORMANCE): Suballocate, so the common case doesn't need to hit the kernel.
     // FIXME(PERFORMANCE): Should this temporary buffer really be shared?
@@ -283,7 +288,7 @@ void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, const void*
     [m_blitCommandEncoder
         copyFromBuffer:temporaryBuffer
         sourceOffset:0
-        toBuffer:buffer.buffer()
+        toBuffer:buffer
         destinationOffset:static_cast<NSUInteger>(bufferOffset)
         size:static_cast<NSUInteger>(size)];
 }

--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -73,6 +73,7 @@ public:
     NSArray<RenderBundleICBWithResources*> *renderBundlesResources() const { return m_renderBundlesResources; }
 
     void replayCommands(id<MTLRenderCommandEncoder>) const;
+    void updateMinMaxDepths(float minDepth, float maxDepth);
 
 private:
     RenderBundle(NSArray<RenderBundleICBWithResources*> *, RefPtr<RenderBundleEncoder>, Device&);
@@ -81,6 +82,8 @@ private:
     const Ref<Device> m_device;
     RefPtr<RenderBundleEncoder> m_renderBundleEncoder;
     NSArray<RenderBundleICBWithResources*> *m_renderBundlesResources;
+    float m_minDepth { 0.f };
+    float m_maxDepth { 1.f };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -68,6 +68,18 @@ void RenderBundle::replayCommands(id<MTLRenderCommandEncoder> commandEncoder) co
         m_renderBundleEncoder->replayCommands(commandEncoder);
 }
 
+void RenderBundle::updateMinMaxDepths(float minDepth, float maxDepth)
+{
+    if (m_minDepth == minDepth && m_maxDepth == maxDepth)
+        return;
+
+    m_minDepth = minDepth;
+    m_maxDepth = maxDepth;
+    float twoFloats[2] = { m_minDepth, m_maxDepth };
+    for (RenderBundleICBWithResources* icb in m_renderBundlesResources)
+        m_device->getQueue().writeBuffer(icb.fragmentDynamicOffsetsBuffer, 0, twoFloats, sizeof(float) * 2);
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -39,7 +39,7 @@ struct WGPURenderBundleEncoderImpl {
 
 @interface RenderBundleICBWithResources : NSObject
 
-- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode depthBias:(float)depthBias depthBiasSlopeScale:(float)depthBiasSlopeScale depthBiasClamp:(float)depthBiasClamp NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithICB:(id<MTLIndirectCommandBuffer>)icb pipelineState:(id<MTLRenderPipelineState>)pipelineState depthStencilState:(id<MTLDepthStencilState>)depthStencilState cullMode:(MTLCullMode)cullMode frontFace:(MTLWinding)frontFace depthClipMode:(MTLDepthClipMode)depthClipMode depthBias:(float)depthBias depthBiasSlopeScale:(float)depthBiasSlopeScale depthBiasClamp:(float)depthBiasClamp fragmentDynamicOffsetsBuffer:(id<MTLBuffer>)fragmentDynamicOffsetsBuffer NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
 @property (readonly, nonatomic) id<MTLIndirectCommandBuffer> indirectCommandBuffer;
@@ -51,6 +51,7 @@ struct WGPURenderBundleEncoderImpl {
 @property (readonly, nonatomic) float depthBias;
 @property (readonly, nonatomic) float depthBiasSlopeScale;
 @property (readonly, nonatomic) float depthBiasClamp;
+@property (readonly, nonatomic) id<MTLBuffer> fragmentDynamicOffsetsBuffer;
 
 - (Vector<WebGPU::BindableResources>*)resources;
 @end

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -69,7 +69,7 @@ public:
     void endOcclusionQuery();
     void endPass();
     void endPipelineStatisticsQuery();
-    void executeBundles(Vector<std::reference_wrapper<const RenderBundle>>&& bundles);
+    void executeBundles(Vector<std::reference_wrapper<RenderBundle>>&& bundles);
     void insertDebugMarker(String&& markerLabel);
     void popDebugGroup();
     void pushDebugGroup(String&& groupLabel);
@@ -119,6 +119,8 @@ private:
     const RenderPipeline* m_pipeline { nullptr };
     RefPtr<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
+    float m_minDepth { 0.f };
+    float m_maxDepth { 1.f };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -33,8 +33,11 @@
 #import "QuerySet.h"
 #import "RenderBundle.h"
 #import "RenderPipeline.h"
+#import <wtf/StdLibExtras.h>
 
 namespace WebGPU {
+
+constexpr auto startIndexForFragmentDynamicOffsets = 2;
 
 RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, const WGPURenderPassDescriptor& descriptor, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, CommandEncoder& parentEncoder, Device& device)
     : m_renderCommandEncoder(renderCommandEncoder)
@@ -89,6 +92,18 @@ void RenderPassEncoder::beginPipelineStatisticsQuery(const QuerySet& querySet, u
     UNUSED_PARAM(queryIndex);
 }
 
+static void setViewportMinMaxDepthIntoBuffer(auto& fragmentDynamicOffsets, float minDepth, float maxDepth)
+{
+    static_assert(sizeof(fragmentDynamicOffsets[0]) == sizeof(minDepth), "expect dynamic offsets container to have matching size to depth values");
+    static_assert(startIndexForFragmentDynamicOffsets == 2, "code path assumes value is 2");
+    if (fragmentDynamicOffsets.size() < startIndexForFragmentDynamicOffsets)
+        fragmentDynamicOffsets.grow(startIndexForFragmentDynamicOffsets);
+
+    using destType = typename std::remove_reference<decltype(fragmentDynamicOffsets[0])>::type;
+    fragmentDynamicOffsets[0] = bitwise_cast<destType>(minDepth);
+    fragmentDynamicOffsets[1] = bitwise_cast<destType>(maxDepth);
+}
+
 void RenderPassEncoder::executePreDrawCommands()
 {
     if (!m_pipeline)
@@ -111,15 +126,16 @@ void RenderPassEncoder::executePreDrawCommands()
             auto& fragmentOffsets = *pfragmentOffsets;
             auto startIndex = pipelineLayout.fragmentOffsetForBindGroup(bindGroupIndex);
             RELEASE_ASSERT(fragmentOffsets.size() <= m_fragmentDynamicOffsets.size() + startIndex);
-            memcpy(&m_fragmentDynamicOffsets[startIndex], &fragmentOffsets[0], sizeof(fragmentOffsets[0]) * fragmentOffsets.size());
+            memcpy(&m_fragmentDynamicOffsets[startIndex + startIndexForFragmentDynamicOffsets], &fragmentOffsets[0], sizeof(fragmentOffsets[0]) * fragmentOffsets.size());
         }
     }
 
     if (m_vertexDynamicOffsets.size())
         [m_renderCommandEncoder setVertexBytes:&m_vertexDynamicOffsets[0] length:m_vertexDynamicOffsets.size() * sizeof(m_vertexDynamicOffsets[0]) atIndex:m_device->maxBuffersPlusVertexBuffersForVertexStage()];
 
-    if (m_fragmentDynamicOffsets.size())
-        [m_renderCommandEncoder setFragmentBytes:&m_fragmentDynamicOffsets[0] length:m_fragmentDynamicOffsets.size() * sizeof(m_fragmentDynamicOffsets[0]) atIndex:m_device->maxBuffersForFragmentStage()];
+    setViewportMinMaxDepthIntoBuffer(m_fragmentDynamicOffsets, m_minDepth, m_maxDepth);
+    ASSERT(m_fragmentDynamicOffsets.size());
+    [m_renderCommandEncoder setFragmentBytes:&m_fragmentDynamicOffsets[0] length:m_fragmentDynamicOffsets.size() * sizeof(m_fragmentDynamicOffsets[0]) atIndex:m_device->maxBuffersForFragmentStage()];
 
     m_bindGroupDynamicOffsets.clear();
 }
@@ -192,10 +208,11 @@ void RenderPassEncoder::endPipelineStatisticsQuery()
 
 }
 
-void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<const RenderBundle>>&& bundles)
+void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<RenderBundle>>&& bundles)
 {
     for (auto& bundle : bundles) {
-        const auto& renderBundle = bundle.get();
+        auto& renderBundle = bundle.get();
+        renderBundle.updateMinMaxDepths(m_minDepth, m_maxDepth);
 
         for (RenderBundleICBWithResources* icb in renderBundle.renderBundlesResources()) {
             if (id<MTLDepthStencilState> depthStencilState = icb.depthStencilState)
@@ -313,7 +330,7 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
     m_pipeline = &pipeline;
 
     m_vertexDynamicOffsets.resize(pipeline.pipelineLayout().sizeOfVertexDynamicOffsets());
-    m_fragmentDynamicOffsets.resize(pipeline.pipelineLayout().sizeOfFragmentDynamicOffsets());
+    m_fragmentDynamicOffsets.resize(pipeline.pipelineLayout().sizeOfFragmentDynamicOffsets() + startIndexForFragmentDynamicOffsets);
 
     if (pipeline.renderPipelineState())
         [m_renderCommandEncoder setRenderPipelineState:pipeline.renderPipelineState()];
@@ -344,6 +361,8 @@ void RenderPassEncoder::setVertexBuffer(uint32_t slot, const Buffer& buffer, uin
 
 void RenderPassEncoder::setViewport(float x, float y, float width, float height, float minDepth, float maxDepth)
 {
+    m_minDepth = minDepth;
+    m_maxDepth = maxDepth;
     [m_renderCommandEncoder setViewport: { x, y, width, height, minDepth, maxDepth } ];
 }
 
@@ -413,7 +432,7 @@ void wgpuRenderPassEncoderEndPipelineStatisticsQuery(WGPURenderPassEncoder rende
 
 void wgpuRenderPassEncoderExecuteBundles(WGPURenderPassEncoder renderPassEncoder, size_t bundlesCount, const WGPURenderBundle* bundles)
 {
-    Vector<std::reference_wrapper<const WebGPU::RenderBundle>> bundlesToForward;
+    Vector<std::reference_wrapper<WebGPU::RenderBundle>> bundlesToForward;
     for (uint32_t i = 0; i < bundlesCount; ++i)
         bundlesToForward.append(WebGPU::fromAPI(bundles[i]));
     WebGPU::fromAPI(renderPassEncoder).executeBundles(WTFMove(bundlesToForward));

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -368,7 +368,8 @@ WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& p
             wgslEntry.vertexBufferDynamicOffset = entry.value.vertexDynamicOffset;
             wgslEntry.fragmentArgumentBufferIndex = entry.value.argumentBufferIndices[WebGPU::ShaderStage::Fragment];
             wgslEntry.fragmentArgumentBufferSizeIndex = entry.value.bufferSizeArgumentBufferIndices[WebGPU::ShaderStage::Fragment];
-            wgslEntry.fragmentBufferDynamicOffset = entry.value.fragmentDynamicOffset;
+            if (entry.value.fragmentDynamicOffset)
+                wgslEntry.fragmentBufferDynamicOffset = *entry.value.fragmentDynamicOffset + 2;
             wgslEntry.computeArgumentBufferIndex = entry.value.argumentBufferIndices[WebGPU::ShaderStage::Compute];
             wgslEntry.computeArgumentBufferSizeIndex = entry.value.bufferSizeArgumentBufferIndices[WebGPU::ShaderStage::Compute];
             wgslEntry.computeBufferDynamicOffset = entry.value.computeDynamicOffset;


### PR DESCRIPTION
#### 48520e8acaa0a169267b7e63a4a7f02e6f2c68a3
<pre>
[WebGPU] Pipeline needs to pass zNear and zFar to fragment shader for clamping depth writes
<a href="https://bugs.webkit.org/show_bug.cgi?id=264436">https://bugs.webkit.org/show_bug.cgi?id=264436</a>
&lt;radar://118138930&gt;

Reviewed by Tadeu Zagallo.

WebGPU expects writes to frag_depth to be clipped to the viewport
bounds which is not something which natively exists in Metal, so
we need to pass the viewport bounds to the fragment shader so the
shader can clamp.

* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeBuffer):
* Source/WebGPU/WebGPU/RenderBundle.h:
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::updateMinMaxDepths):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(-[RenderBundleICBWithResources initWithICB:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:depthBias:depthBiasSlopeScale:depthBiasClamp:fragmentDynamicOffsetsBuffer:]):
(WebGPU::makeRenderBundleICBWithResources):
(WebGPU::Device::createRenderBundleEncoder):
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::setBindGroup):
(-[RenderBundleICBWithResources initWithICB:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:depthBias:depthBiasSlopeScale:depthBiasClamp:]): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::setViewportMinMaxDepthIntoBuffer):
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::setPipeline):
(WebGPU::RenderPassEncoder::setViewport):
(wgpuRenderPassEncoderExecuteBundles):

Canonical link: <a href="https://commits.webkit.org/270469@main">https://commits.webkit.org/270469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84738c859f72a5f61783cb3ea91263d07d55af76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23416 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23563 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28234 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29071 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26913 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/975 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4103 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6138 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->