### PR TITLE
REGRESSION (269641@main): [ Ventura+ arm64 ] inspector/unit-tests/iterableweakset.html is a flaky failure

### DIFF
--- a/LayoutTests/inspector/unit-tests/iterableweakset.html
+++ b/LayoutTests/inspector/unit-tests/iterableweakset.html
@@ -34,15 +34,32 @@ async function checkDoesNotKeepObjectsAlive()
         }
     }
 
+    async function waitUntilItemGoesAway(value)
+    {
+        let attempts = 50;
+        while (attempts--) {
+            let containsValue = false;
+            for (let item of iterableWeakSet) {
+               if (item.value === value) {
+                   containsValue = true;
+                   break;
+               }
+            }
+            if (!containsValue)
+                return;
+            await new Promise(setTimeout);
+            gc();
+            await new Promise(setTimeout);
+        }
+    }
+
     TestPage.dispatchEventToFrontend("TestPage-checkDoesNotKeepObjectsAlive-log", {message: JSON.stringify(iterableWeakSet)});
     check("construction", one[0], true);
     check("construction", two[0], true);
     check("construction", three[0], true);
 
     nukeArray(one);
-    await new Promise(setTimeout);
-    gc();
-    await new Promise(setTimeout);
+    await waitUntilItemGoesAway(1);
 
     TestPage.dispatchEventToFrontend("TestPage-checkDoesNotKeepObjectsAlive-log", {message: JSON.stringify(iterableWeakSet)});
     check("`one = null`", 1, false);
@@ -50,9 +67,7 @@ async function checkDoesNotKeepObjectsAlive()
     check("`one = null`", three[0], true);
 
     nukeArray(two);
-    await new Promise(setTimeout);
-    gc();
-    await new Promise(setTimeout);
+    await waitUntilItemGoesAway(2);
 
     TestPage.dispatchEventToFrontend("TestPage-checkDoesNotKeepObjectsAlive-log", {message: JSON.stringify(iterableWeakSet)});
     check("`two = null`", 1, false);
@@ -60,9 +75,7 @@ async function checkDoesNotKeepObjectsAlive()
     check("`two = null`", three[0], true);
 
     nukeArray(three);
-    await new Promise(setTimeout);
-    gc();
-    await new Promise(setTimeout);
+    await waitUntilItemGoesAway(3);
 
     TestPage.dispatchEventToFrontend("TestPage-checkDoesNotKeepObjectsAlive-log", {message: JSON.stringify(iterableWeakSet)});
     check("`three = null`", 1, false);

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2623,5 +2623,3 @@ webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallbac
 webkit.org/b/264177 requestidlecallback/requestidlecallback-deadline-shortened-by-rendering-update.html [ Pass Failure ]
 
 webkit.org/b/264349 http/tests/site-isolation/frame-access-after-window-open.html [ Timeout ]
-
-webkit.org/b/264426 [ Ventura+ arm64 ] inspector/unit-tests/iterableweakset.html [ Pass Failure ]


### PR DESCRIPTION
#### c6f849f610e052d63bb14ec603f505ebd2fe5469
<pre>
REGRESSION (269641@main): [ Ventura+ arm64 ] inspector/unit-tests/iterableweakset.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=264426">https://bugs.webkit.org/show_bug.cgi?id=264426</a>
<a href="https://rdar.apple.com/118129008">rdar://118129008</a>

Reviewed by Ryosuke Niwa.

Make the test a bit more robust and trigger gc() multiple times until the value
goes away.

* LayoutTests/inspector/unit-tests/iterableweakset.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270418@main">https://commits.webkit.org/270418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ced139907215c8f84b6367575b069ca972b171

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1492 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25706 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/2993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28151 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22897 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26829 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6092 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3093 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->