### PR TITLE
Create script to compile sandboxes

### DIFF
--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -406,34 +406,7 @@ all : $(SANDBOX_PROFILES_WITHOUT_WEBPUSHD) $(WEBPUSHD_SANDBOX_PROFILE) $(SANDBOX
 %.sb : %.sb.in
 	@echo Pre-processing $* sandbox profile...
 	grep -o '^[^;]*' $< | $(CC) $(SANITIZE_FLAGS) $(SDK_FLAGS) $(TARGET_TRIPLE_FLAGS) $(SANDBOX_DEFINES) $(TEXT_PREPROCESSOR_FLAGS) $(FRAMEWORK_FLAGS) $(HEADER_FLAGS) $(EXTERNAL_FLAGS) -include "wtf/Platform.h" - > $@
-	xcrun --sdk $(SDK_NAME) -f sbutil; \
-	if [[ $$? == 0 ]]; then \
-		if [[ $(SDK_NAME) =~ "iphone" || $(SDK_NAME) =~ "watch" || $(SDK_NAME) =~ "appletv" ]]; then \
-			if [[ $* == "com.apple.WebKit.adattributiond" || $* == "com.apple.WebKit.webpushd" ]]; then \
-				if [ ! -e $(SANDBOX_IMPORT_DIR) ]; then \
-					exit 0; \
-				fi; \
-				xcrun --sdk $(SDK_NAME) sbutil compile -D IMPORT_DIR=$(SANDBOX_IMPORT_DIR) $@ > /dev/null; \
-				if [[ $$? != 0 ]]; then \
-					exit 1; \
-				fi \
-			fi; \
-			if [[ $* == "com.apple.WebKit.GPU" || $* == "com.apple.WebKit.Networking" || $* == "com.apple.WebKit.WebContent" ]]; then \
-				xcrun --sdk $(SDK_NAME) sbutil compile $@ > /dev/null; \
-				if [[ $$? != 0 ]]; then \
-					exit 1; \
-				fi \
-			fi \
-		fi; \
-		if [[ $(SDK_NAME) =~ "mac" ]]; then \
-			if [[ $* == "com.apple.WebKit.GPUProcess" || $* == "com.apple.WebKit.NetworkProcess" || $* == "com.apple.WebProcess" ]]; then \
-				xcrun --sdk $(SDK_NAME) sbutil compile -D ENABLE_SANDBOX_MESSAGE_FILTER=YES -D WEBKIT2_FRAMEWORK_DIR=dir -D HOME_DIR=dir -D HOME_LIBRARY_PREFERENCES_DIR=dir -D DARWIN_USER_CACHE_DIR=dir -D DARWIN_USER_TEMP_DIR=dir $@ > /dev/null; \
-				if [[ $$? != 0 ]]; then \
-					exit 1; \
-				fi \
-			fi \
-		fi \
-	fi
+	$(WebKit2)/Scripts/compile-sandbox.sh $@ $* $(SDK_NAME) $(SANDBOX_IMPORT_DIR)
 
 AUTOMATION_PROTOCOL_GENERATOR_SCRIPTS = \
 	$(JavaScriptCore_SCRIPTS_DIR)/cpp_generator_templates.py \

--- a/Source/WebKit/Scripts/compile-sandbox.sh
+++ b/Source/WebKit/Scripts/compile-sandbox.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+SANDBOX_PATH=$1;
+SANDBOX_NAME=$2;
+SDK_NAME=$3
+SANDBOX_IMPORT_DIR=$4
+
+xcrun --sdk $SDK_NAME -f sbutil;
+if [[ $? == 0 ]]; then
+    if [[ $SDK_NAME =~ "iphone" || $SDK_NAME =~ "watch" || $SDK_NAME =~ "appletv" ]]; then
+        if [[ $SANDBOX_NAME == "com.apple.WebKit.adattributiond" || $SANDBOX_NAME == "com.apple.WebKit.webpushd" ]]; then
+            if [ ! -e $SANDBOX_IMPORT_DIR ]; then
+                exit 0;
+            fi;
+            xcrun --sdk $SDK_NAME sbutil compile -D IMPORT_DIR=$SANDBOX_IMPORT_DIR $SANDBOX_PATH > /dev/null;
+            if [[ $? != 0 ]]; then
+                exit 1;
+            fi
+        fi;
+        if [[ $SANDBOX_NAME == "com.apple.WebKit.GPU" || $SANDBOX_NAME == "com.apple.WebKit.Networking" || $SANDBOX_NAME == "com.apple.WebKit.WebContent" ]]; then
+            xcrun --sdk $SDK_NAME sbutil compile $SANDBOX_PATH > /dev/null;
+            if [[ $? != 0 ]]; then
+                exit 1;
+            fi
+        fi
+    fi;
+    if [[ $SDK_NAME =~ "mac" ]]; then
+        if [[ $SANDBOX_NAME == "com.apple.WebKit.GPUProcess" || $SANDBOX_NAME == "com.apple.WebKit.NetworkProcess" || $SANDBOX_NAME == "com.apple.WebProcess" ]]; then
+            xcrun --sdk $SDK_NAME sbutil compile -D ENABLE_SANDBOX_MESSAGE_FILTER=YES -D WEBKIT2_FRAMEWORK_DIR=dir -D HOME_DIR=dir -D HOME_LIBRARY_PREFERENCES_DIR=dir -D DARWIN_USER_CACHE_DIR=dir -D DARWIN_USER_TEMP_DIR=dir $SANDBOX_PATH > /dev/null;
+            if [[ $? != 0 ]]; then
+                exit 1;
+            fi
+        fi
+    fi
+fi;


### PR DESCRIPTION
#### 294e7cde17e6cc989c4bddcaea4d6738ee61d8e7
<pre>
Create script to compile sandboxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=264093">https://bugs.webkit.org/show_bug.cgi?id=264093</a>
<a href="https://rdar.apple.com/117854457">rdar://117854457</a>

Reviewed by Elliot Williams.

* Source/WebKit/DerivedSources.make:
* Source/WebKit/Scripts/compile-sandbox.sh: Added.

Canonical link: <a href="https://commits.webkit.org/270443@main">https://commits.webkit.org/270443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/796e790923a1c06659fa1ad7b5d819a57714c86e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23377 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28192 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/25670 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2678 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html (failure)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29038 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23303 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26867 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/appcache (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/933 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4059 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6117 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->