### PR TITLE
Clearing Glyph Page cache when purging inactive font data

### DIFF
--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -289,7 +289,7 @@ void FontCache::purgeInactiveFontData(unsigned purgeCount)
     LOG(Fonts, "FontCache::purgeInactiveFontData(%u)", purgeCount);
 
     m_fontCascadeCache.pruneUnreferencedEntries();
-    m_fontCascadeCache.pruneSystemFallbackFonts();
+    m_fontCascadeCache.pruneGlyphPageCacheAndSystemFallbackFonts();
 
 #if PLATFORM(IOS_FAMILY)
     Locker locker { m_fontLock };

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -82,10 +82,10 @@ void FontCascadeCache::pruneUnreferencedEntries()
     });
 }
 
-void FontCascadeCache::pruneSystemFallbackFonts()
+void FontCascadeCache::pruneGlyphPageCacheAndSystemFallbackFonts()
 {
     for (auto& entry : m_entries.values())
-        entry->fonts->pruneSystemFallbacks();
+        entry->fonts->pruneGlyphPageCacheAndSystemFallbacks();
 }
 
 static FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription& description, FontSelector* fontSelector)

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -267,7 +267,7 @@ public:
     void invalidate();
     void clearWidthCaches();
     void pruneUnreferencedEntries();
-    void pruneSystemFallbackFonts();
+    void pruneGlyphPageCacheAndSystemFallbackFonts();
     Ref<FontCascadeFonts> retrieveOrAddCachedFonts(const FontCascadeDescription&, RefPtr<FontSelector>&&);
 
 private:

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -534,11 +534,9 @@ GlyphData FontCascadeFonts::glyphDataForCharacter(UChar32 c, const FontCascadeDe
     return glyphData;
 }
 
-void FontCascadeFonts::pruneSystemFallbacks()
+void FontCascadeFonts::pruneGlyphPageCacheAndSystemFallbacks()
 {
-    if (m_systemFallbackFontSet.isEmpty())
-        return;
-    // Mutable glyph pages may reference fallback fonts.
+    // Mutable glyph pages may reference cached fonts.
     for (auto& cachedPages : m_cachedPages) {
         cachedPages.removeIf([](auto& keyAndValue) {
             return keyAndValue.value.isMixedFont();

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -75,7 +75,7 @@ public:
     const Font& primaryFont(FontCascadeDescription&);
     WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, unsigned fallbackIndex);
 
-    void pruneSystemFallbacks();
+    void pruneGlyphPageCacheAndSystemFallbacks();
 
 private:
     FontCascadeFonts(RefPtr<FontSelector>&&);


### PR DESCRIPTION
#### e2fee49671622cd6780b22bdab85609979bd366f
<pre>
Clearing Glyph Page cache when purging inactive font data
<a href="https://bugs.webkit.org/show_bug.cgi?id=264445">https://bugs.webkit.org/show_bug.cgi?id=264445</a>
<a href="https://rdar.apple.com/118143806">rdar://118143806</a>

Reviewed by NOBODY (OOPS!).

Up to know, when we are purging inactive font data, we would just clear
the glyph page cache if we had to purge system fallback font.
This means that we consilder glyph page cache would only point to
fonts from system fonts fallback.

However, the glyph data stored in glyph page cache entry comes from FontCascadeFonts::glyphDataForVariant(...) which will not necessarily
return glyph data with a font pointer that is a system fallback font.

Since the glyph page has a non-owning reference to a font, this behavior
can generate a dangling pointer in the glyph page cache,
if the page is pointing to a custom font and this font is erased from
cache when we purge inactive font data during a memory pressure situation.

In the current, after patches [1][2][3] the fact that GlyphPage has a dangling reference is minimized because GlyphPage and GlyphData have now a WeakPtr
to a font, which allow us to check if the reference is still valid.

However, this patch tries to keep the glyph page cache free of
dangling pointers.

[1] <a href="https://commits.webkit.org/270013@main">https://commits.webkit.org/270013@main</a>
[2] <a href="https://commits.webkit.org/270190@main">https://commits.webkit.org/270190@main</a>
[3] https://commits.webkit.org/270320@main
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2fee49671622cd6780b22bdab85609979bd366f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23340 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28153 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29011 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23271 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26833 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/894 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->