### PR TITLE
When no clearance applies to an element with `clear` set, place the element below the float just as we would if it was `clear:none`

### DIFF
--- a/LayoutTests/fast/block/float/element-clears-float-without-clearance-expected.html
+++ b/LayoutTests/fast/block/float/element-clears-float-without-clearance-expected.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<style>
+.bfc {
+    overflow:hidden;
+    border:solid;
+    margin-top:1em;
+}
+
+.float {
+    background-color: aqua;
+    height: 30px;
+    display:inline-block;
+}
+
+.under {
+    height: 50px;
+    background-color: orange;
+}
+
+.clear {
+    margin-top:20px;
+    height: 50px;
+    background-color: orange;
+}
+section {
+    float: left;
+    width: 25%;
+    margin: 0 5px;
+    padding: 5px;
+    background: #ddd;
+}
+</style>
+<section>
+  crbug.com/434048 : The orange boxes should sit right under the float.
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="under">clear</div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="under">clear</div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="under">clear</div>
+  </div>
+</section>
+
+<section>
+  crbug.com/434048 : There should be 20px between the orange box and the float.
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="clear">clear</div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="clear">clear</div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="clear">clear</div>
+  </div>
+</section>
+
+<section>
+  crbug.com/434048 : There should be 20px between the orange box and the float.
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="clear">clear</div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="clear">clear</div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="clear">clear</div>
+  </div>
+</section>

--- a/LayoutTests/fast/block/float/element-clears-float-without-clearance.html
+++ b/LayoutTests/fast/block/float/element-clears-float-without-clearance.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<style>
+.bfc {
+    overflow:hidden;
+    border:solid;
+    margin-top:1em;
+}
+
+.float {
+    background-color: aqua;
+    float: left;
+    height: 30px;
+}
+
+.clear {
+    clear:left;
+    margin-top:50px;
+    height: 50px;
+    background-color: orange;
+}
+section {
+    float: left;
+    width: 25%;
+    margin: 0 5px;
+    padding: 5px;
+    background: #ddd;
+}
+
+</style>
+<section>
+  crbug.com/434048 : The orange boxes should sit right under the float.
+  <div class="bfc">
+    <div>
+      <div class="float">float</div>
+      <div>
+        <div class="clear">clear</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="bfc">
+    <div>
+      <div class="float">float</div>
+      <div class="clear">clear</div>
+    </div>
+  </div>
+
+  <div class="bfc">
+    <div>
+      <div>
+        <div class="float">float</div>
+      </div>
+      <div class="clear">clear</div>
+    </div>
+  </div>
+</section>
+
+<section>
+  crbug.com/434048 : There should be 20px between the orange box and the float.
+  <div class="bfc">
+    <div>
+      <div class="float">float</div>
+    </div>
+    <div class="clear">clear</div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div style="margin-top: 30px;">
+      <div>
+        <div class="clear">clear</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div style="margin-top: 10px;">
+      <div>
+        <div class="clear">clear</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  crbug.com/434048 : There should be 20px between the orange box and the float.
+  <div class="bfc">
+    <div class="float">float</div>
+    <div>
+      <div class="clear">clear</div>
+    </div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div style="margin-top: 40px;">
+      <div class="clear">clear</div>
+    </div>
+  </div>
+
+  <div class="bfc">
+    <div class="float">float</div>
+    <div class="clear">clear</div>
+  </div>
+</section>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1592,8 +1592,7 @@ void RenderBlockFlow::marginBeforeEstimateForChild(RenderBox& child, LayoutUnit&
             break;
     }
     
-    // Give up if there is clearance on the box, since it probably won't collapse into us.
-    if (!grandchildBox || RenderStyle::usedClear(*grandchildBox) != UsedClear::None)
+    if (!grandchildBox)
         return;
 
     // Make sure to update the block margins now for the grandchild box so that we're looking at current values.
@@ -1605,6 +1604,12 @@ void RenderBlockFlow::marginBeforeEstimateForChild(RenderBox& child, LayoutUnit&
             grandchildBlock.setHasMarginAfterQuirk(grandchildBox->style().marginAfter().hasQuirk());
         }
     }
+
+    // If we have a 'clear' value but also have a margin we may not actually require clearance to move past any floats.
+    // If that's the case we want to be sure we estimate the correct position including margins after any floats rather
+    // than use 'clearance' later which could give us the wrong position.
+    if (RenderStyle::usedClear(*grandchildBox) != UsedClear::None && !childBlock.marginBeforeForChild(*grandchildBox))
+        return;
 
     // Collapse the margin of the grandchild box with our own to produce an estimate.
     childBlock.marginBeforeEstimateForChild(*grandchildBox, positiveMarginBefore, negativeMarginBefore);


### PR DESCRIPTION
#### f5f625b225726f4253400640695c0aa7fc1e9f0f
<pre>
When no clearance applies to an element with `clear` set, place the element below the float just as we would if it was `clear:none`

<a href="https://bugs.webkit.org/show_bug.cgi?id=264397">https://bugs.webkit.org/show_bug.cgi?id=264397</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/502ffded2efe7d27b5e0ec085a47d4764b65c12c">https://chromium.googlesource.com/chromium/blink/+/502ffded2efe7d27b5e0ec085a47d4764b65c12c</a>

If an element has &apos;clear&apos; set but we don&apos;t actually calculate clearance
for it then it should be placed as though it had &apos;clear:none&apos;. This is
especially pertinent when the element has margin-top that puts it clear of any float.

The relevant web-specification [1] is:

&quot;Computing the clearance of an element on which clear is set is done by ...&quot;

[1] <a href="https://drafts.csswg.org/css2/#clearance">https://drafts.csswg.org/css2/#clearance</a>

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::marginBeforeEstimateForChild):
* LayoutTests/fast/block/float/element-clears-float-without-clearance.html: Add Test Case
* LayoutTests/fast/block/float/element-clears-float-without-clearance-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/270525@main">https://commits.webkit.org/270525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bccc10c478693f109ea0d8867c5b7f8536d69feb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23521 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28154 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29015 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/896 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6170 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->