### PR TITLE
[git-webkit] Handle multiple bugs associated with a single branch

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -41,19 +41,34 @@ from webkitbugspy import radar
 
 def set_env_variables_from_branch_config():
     BRANCH = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], **ENCODING_KWARGS).strip()
-    for name, variable in dict(
-        title='COMMIT_MESSAGE_TITLE',
-        bug='COMMIT_MESSAGE_BUG',
-        cherry_picked='GIT_WEBKIT_CHERRY_PICKED',
+    for name, data in dict(
+        title=('COMMIT_MESSAGE_TITLE', 1),
+        bug=('COMMIT_MESSAGE_BUG', re.compile(r'^(\D+)\d+$')),
+        cherry_picked=('GIT_WEBKIT_CHERRY_PICKED', 1),
     ).items():
+        variable, mode = data
         if variable in os.environ:
             continue
         try:
-            value = subprocess.check_output(
+            value = ''
+            count = 0
+            for line in reversed(subprocess.check_output(
                 ['git', 'config', '--get-all', 'branch.{}.{}'.format(BRANCH, name)],
                 stderr=subprocess.PIPE,
                 **ENCODING_KWARGS
-            ).strip()
+            ).strip().splitlines()):
+                if isinstance(mode, int) and count >= mode:
+                    break
+                elif isinstance(mode, re.Pattern):
+                    match = mode.match(line)
+                    if match and match.group(1) in value:
+                        continue
+
+                if line:
+                    value += line + '\n'
+                    count += 1
+
+            value = value.strip()
             if value:
                 os.environ[variable] = value
         except subprocess.CalledProcessError as error:


### PR DESCRIPTION
#### 88a259f2f225e68684db60360a653993ae1e8628
<pre>
[git-webkit] Handle multiple bugs associated with a single branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=264450">https://bugs.webkit.org/show_bug.cgi?id=264450</a>
<a href="https://rdar.apple.com/118144919">rdar://118144919</a>

Reviewed by Elliott Williams.

Parse `git config` output backwards to prefer newer config values.
Except for bugs, only allow a single line to be passed to the template
via &apos;git config&apos;. For bugs, we should only allow a single bug from each
tracker to be associated with the issue.

* Tools/Scripts/hooks/prepare-commit-msg:

Canonical link: <a href="https://commits.webkit.org/270921@main">https://commits.webkit.org/270921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f48b900e1eb3f6e4713640bee6ef436a6cbcf3c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27575 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23504 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/2669 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26835 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4021 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3097 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3473 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->