### PR TITLE
[UIAsyncTextInputClient] Adopt delegate methods to provide text context for the edit menu

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -486,7 +486,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isUnsuppressingSoftwareKeyboardUsingLastAutocorrectionContext;
     BOOL _waitingForKeyboardAppearanceAnimationToStart;
     BOOL _isHidingKeyboard;
-    BOOL _isPreparingEditMenu;
+    BOOL _isInterpretingKeyEvent;
     BOOL _isPresentingEditMenu;
 
     BOOL _focusRequiresStrongPasswordAssistance;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm
@@ -155,9 +155,9 @@ TEST(WebKit, CaptureTextFromCamera)
     [webView selectAll:nil];
     [webView waitForNextPresentationUpdate];
     EXPECT_TRUE([webView canPerformAction:@selector(captureTextFromCamera:) withSender:nil]);
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    EXPECT_FALSE([webView canPerformAction:@selector(captureTextFromCamera:) withSender:UIMenuController.sharedMenuController]);
-ALLOW_DEPRECATED_DECLARATIONS_END
+
+    RetainPtr command = [UIKeyCommand keyCommandWithInput:@"a" modifierFlags:UIKeyModifierCommand action:@selector(captureTextFromCamera:)];
+    EXPECT_FALSE([webView canPerformAction:@selector(captureTextFromCamera:) withSender:command.get()]);
 
     [webView collapseToEnd];
     [webView waitForNextPresentationUpdate];


### PR DESCRIPTION
#### bee60e18cb5824dc532e9aca13480c55c0e10ccd
<pre>
[UIAsyncTextInputClient] Adopt delegate methods to provide text context for the edit menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=264452">https://bugs.webkit.org/show_bug.cgi?id=264452</a>
<a href="https://rdar.apple.com/118145278">rdar://118145278</a>

Reviewed by Aditya Keerthi.

Implement `-selectTextForContextMenuWithLocationInView:completionHandler:`, refactoring the
underlying implementation to share code with `-prepareSelectionForContextMenuWithLocationInView:`.

Additionally, remove our reliance on `_isPreparingEditMenu`, which is currently used to prevent the
edit menu from containing certain actions (Select All, Insert) when the selection is ranged.
Instead, to know whether or not the action is for the edit menu, we check whether the sender is a
`UIKeyCommand` (which is the case, even when using the edit menu) and it&apos;s happening outside of the
context of interpreting key events.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _interpretKeyEvent:isCharEvent:]):
(-[WKContentView requestRVItemInSelectedRangeWithCompletionHandler:]):
(-[WKContentView prepareSelectionForContextMenuWithLocationInView:completionHandler:]):
(-[WKContentView _internalSelectTextForContextMenuWithLocationInView:completionHandler:]):
(-[WKContentView selectTextForContextMenuWithLocationInView:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm:

Update this test to properly exercise edit menu presentation, by passing in a `UIKeyCommand` as the
sender.

Canonical link: <a href="https://commits.webkit.org/270464@main">https://commits.webkit.org/270464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/078d3d9a5523e91927f82fc34b337d42ebefe44e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23505 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28158 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29017 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26839 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/900 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4023 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6133 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->