### PR TITLE
[iOS] Non-fullscreen content peeks into top safe area in element fullscreen mode

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -207,6 +207,7 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly) std::optional<CGSize> _viewLayoutSizeOverride;
 @property (nonatomic, readonly) std::optional<CGSize> _minimumUnobscuredSizeOverride;
 @property (nonatomic, readonly) std::optional<CGSize> _maximumUnobscuredSizeOverride;
+- (void)_resetContentOffset;
 - (void)_resetUnobscuredSafeAreaInsets;
 - (void)_resetObscuredInsets;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3422,6 +3422,11 @@ static bool isLockdownModeWarningNeeded()
     return _haveSetUnobscuredSafeAreaInsets;
 }
 
+- (void)_resetContentOffset
+{
+    [_scrollView setContentOffset:[self _initialContentOffsetForScrollView]];
+}
+
 - (void)_resetUnobscuredSafeAreaInsets
 {
     _haveSetUnobscuredSafeAreaInsets = NO;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -952,6 +952,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         [webView _setMinimumEffectiveDeviceWidth:0];
         [webView _setViewScale:1.f];
         WebKit::WKWebViewState().applyTo(webView.get());
+        [webView _resetContentOffset];
         [_window insertSubview:webView.get() atIndex:0];
         [webView setNeedsLayout];
         [webView layoutIfNeeded];


### PR DESCRIPTION
#### e5bf2b80f8e57e5186df3c301de3259c6e1e812c
<pre>
[iOS] Non-fullscreen content peeks into top safe area in element fullscreen mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=264455">https://bugs.webkit.org/show_bug.cgi?id=264455</a>
<a href="https://rdar.apple.com/118147164">rdar://118147164</a>

Reviewed by Simon Fraser.

When entering fullscreen, certain properties of the WKWebView and scrollView are reset to
default values, as clients like Safari may have overridden them. One of these properties,
contentInset, is reset to zero by that machinery. However, this causes overflow content to
be visible above the safe area; instead, it should be reset to a correct initial value that
accounts for the page&apos;s adoption of safe areas, via -_initialContentOffsetForScrollView.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _resetContentOffset]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):

Canonical link: <a href="https://commits.webkit.org/270424@main">https://commits.webkit.org/270424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f046e9023235daab0b23c985f63c9b19de19364

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23346 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23507 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28161 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2653 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29028 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26852 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/902 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4026 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6095 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->