### PR TITLE
[iOS] Fix rendering of <select> in vertical writing mode

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1098,6 +1098,8 @@ public:
 
     inline void setLogicalMinWidth(Length&&);
     inline void setLogicalMaxWidth(Length&&);
+    inline void setLogicalMinHeight(Length&&);
+    inline void setLogicalMaxHeight(Length&&);
 
     inline void resetBorder();
     inline void resetBorderExceptRadius();

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -506,6 +506,22 @@ inline void RenderStyle::setLogicalMaxWidth(Length&& width)
         setMaxHeight(WTFMove(width));
 }
 
+inline void RenderStyle::setLogicalMinHeight(Length&& height)
+{
+    if (isHorizontalWritingMode())
+        setMinHeight(WTFMove(height));
+    else
+        setMinWidth(WTFMove(height));
+}
+
+inline void RenderStyle::setLogicalMaxHeight(Length&& height)
+{
+    if (isHorizontalWritingMode())
+        setMaxHeight(WTFMove(height));
+    else
+        setMaxWidth(WTFMove(height));
+}
+
 inline void RenderStyle::setOpacity(float opacity)
 {
     float clampedOpacity = clampTo(opacity, 0.f, 1.f);


### PR DESCRIPTION
#### b6917b9c28b68740ab75cdf5b592623cc9ecf6ed
<pre>
[iOS] Fix rendering of &lt;select&gt; in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=264441">https://bugs.webkit.org/show_bug.cgi?id=264441</a>
<a href="https://rdar.apple.com/118141664">rdar://118141664</a>

Reviewed by Tim Nguyen.

Fix the position of the arrows in vertical writing mode, and ensure logical
properties are used instead of physical properties.

* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustRoundBorderRadius):
(WebCore::applyCommonButtonPaddingToStyle):
(WebCore::RenderThemeIOS::adjustMenuListButtonStyle const):
(WebCore::RenderThemeIOS::adjustButtonStyle const):
(WebCore::RenderThemeIOS::paintMenuListButtonDecorationsWithFormControlRefresh):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setLogicalMinHeight):
(WebCore::RenderStyle::setLogicalMaxHeight):

Canonical link: <a href="https://commits.webkit.org/270453@main">https://commits.webkit.org/270453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b57d5e50e3eb61b584478c1ae0e4e88037dd7c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23391 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23541 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28207 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29048 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26882 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/948 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4073 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3148 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3260 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->