### PR TITLE
Add clear cursor feature for search commit and regress point  in results.webkit.org

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/css/search.css
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/css/search.css
@@ -46,3 +46,20 @@
     background-color: var(--blue);
     color: white;
 }
+
+.next-regress-bar {
+    width:100%;
+    z-index:10
+}
+
+.next-regress-bar button {
+    background-color: var(--blurBackgroundColor);
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+}
+
+@media (prefers-color-scheme: dark) {
+    .next-regress-bar button{
+        background-color: var(--blurBackgroundColorDark);
+    }
+}

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js
@@ -145,16 +145,25 @@ function CommitSearchBar(onSearchAction = null) {
             onSearchAction(searchValue);
     });
 
+    const clearButtonRef = REF.createRef({});
+    clearButtonRef.fromEvent("click").action(e => {
+        if (onSearchAction)
+            onSearchAction(null);
+    });
+
     window.addEventListener("keypress", searchHotKeyFunction);
 
     return `<div class="input">
         <div class="row">
-            <div class="input col-9">
+            <div class="input col-7">
                 <input type="text" ref="${searchInputRef}" autocomplete="off" autocapitalize="none" required/>
                 <label>Search commit</label>
             </div>
             <button class="button col-3 primary" ref="${searchButtonRef}">
                 <img src="library/icons/search.svg" style="height: var(--largeSize); filter: invert(1);">
+            </button>
+            <button class="button col-2" ref="${clearButtonRef}">
+                X
             </button>
         </div>
     </div>`;

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/js/components/TimelineComponents.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/js/components/TimelineComponents.js
@@ -544,8 +544,8 @@ Timeline.CanvasSeriesComponent = (dots, scales, option = {}) => {
         const scrollLeft = typeof stateDiff.scrollLeft === 'number' ? stateDiff.scrollLeft : state.scrollLeft;
         const scales = stateDiff.scales ? stateDiff.scales : state.scales;
         const dots = stateDiff.dots ? stateDiff.dots : state.dots;
-        const highLightScale = stateDiff.highLightScale ? stateDiff.highLightScale : state.highLightScale;
-        const highLightDot = stateDiff.highLightDot ? stateDiff.highLightDot : state.highLightDot;
+        const highLightScale = "highLightScale" in stateDiff ? stateDiff.highLightScale : state.highLightScale;
+        const highLightDot = "highLightDot" in stateDiff ? stateDiff.highLightDot : state.highLightDot;
         if ('dots' in stateDiff)
             dots.forEach((dot, index) => dot._index = index);
         // This color maybe change when switch dark/light mode
@@ -673,12 +673,13 @@ Timeline.CanvasSeriesComponent = (dots, scales, option = {}) => {
         };
         const onSearchScaleAction = (scale) => {
             let clearHighLight = true;
-            canvasRef.state.scales.forEach((currentScale) => {
-                if (comp(currentScale, scale) === 0) {
-                    canvasRef.setState({highLightScale: scale});
-                    clearHighLight = false;
-                }
-            });
+            if (scale)
+                canvasRef.state.scales.forEach((currentScale) => {
+                    if (comp(currentScale, scale) === 0) {
+                        canvasRef.setState({highLightScale: scale});
+                        clearHighLight = false;
+                    }
+                });
             if (clearHighLight)
                 canvasRef.setState({highLightScale: false});
         };
@@ -819,7 +820,7 @@ Timeline.CanvasSeriesComponent = (dots, scales, option = {}) => {
             onStateUpdate: (element, stateDiff, state) => {
                 if (!state.onScreen && !stateDiff.onScreen)
                     return;
-                if (stateDiff.scales || stateDiff.dots || typeof stateDiff.scrollLeft === 'number' || typeof stateDiff.width === 'number' || stateDiff.onScreen || stateDiff.hasDotSelected || stateDiff.highLightScale || stateDiff.highLightDot) {
+                if (stateDiff.scales || stateDiff.dots || typeof stateDiff.scrollLeft === 'number' || typeof stateDiff.width === 'number' || stateDiff.onScreen || stateDiff.hasDotSelected || 'highLightDot' in stateDiff || 'highLightScale' in stateDiff) {
                     if (stateDiff.scales)
                         stateDiff.scales = stateDiff.scales.map(x => x);
                     if (stateDiff.dots)
@@ -1194,6 +1195,8 @@ Timeline.CanvasXAxisComponent = (scales, option = {}) => {
                 canvasRef.setState({width: width});
             };
             const onSearchScaleAction = (scale) => {
+                if (!scale)
+                    return;
                 canvasRef.state.scales.forEach((currentScale, index) => {
                     if (comp(currentScale, scale) === 0) {
                         const scaleLeft = index * scaleWidth;


### PR DESCRIPTION
#### 385868a78bb8e85b17252edae1296a4a3a09cc7d
<pre>
Add clear cursor feature for search commit and regress point  in results.webkit.org

<a href="https://bugs.webkit.org/show_bug.cgi?id=256809">https://bugs.webkit.org/show_bug.cgi?id=256809</a>
<a href="https://rdar.apple.com/108869264">rdar://108869264</a>

Reviewed by Jonathan Bedard.

This patch add a clear button for search commits and regress points, this can let user clear the highlight cursor

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/css/search.css:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/js/components/TimelineComponents.js:

Canonical link: <a href="https://commits.webkit.org/270482@main">https://commits.webkit.org/270482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dc0ef42765f33892835aa3618e2705d8737bca3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27725 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/23478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1667 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3149 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28307 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/25790 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23386 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26972 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/25390 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4172 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6145 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->