### PR TITLE
REGRESSION (268484@main): Dynamic Content Scaling is disabled

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
@@ -74,7 +74,7 @@
     }
 
     [self setValue:bridge_cast(data.get()) forKeyPath:WKDynamicContentScalingContentsKey];
-    [self setValue:ports.get() forKeyPath:WKDynamicContentScalingContentsKey];
+    [self setValue:ports.get() forKeyPath:WKDynamicContentScalingPortsKey];
     [self setNeedsDisplay];
 }
 


### PR DESCRIPTION
#### df2e0bf6a318dbefc436ede370832e8f83ca331f
<pre>
REGRESSION (268484@main): Dynamic Content Scaling is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=264463">https://bugs.webkit.org/show_bug.cgi?id=264463</a>
<a href="https://rdar.apple.com/117906435">rdar://117906435</a>

Reviewed by Brady Eidson.

* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm:
(-[WKCompositingLayer _setWKContents:withDisplayList:replayForTesting:]):
I accidentally copy-pasteo&apos;d WKDynamicContentScalingContentsKey into both
keys instead of WKDynamicContentScalingPortsKey in the second one.

Canonical link: <a href="https://commits.webkit.org/270420@main">https://commits.webkit.org/270420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7c152ad8e5a365686dc5f2f589e190a7bb7244a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23370 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25746 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28185 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/26860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3127 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3253 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->