### PR TITLE
[macOS] Fix keyboard selection/editing of date/time inputs in vertical writing mode

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt
@@ -35,6 +35,22 @@ PASS input.value is "0002-03-03"
 PASS changeEventsFired is 3
 PASS inputEventsFired is 3
 
+Left/Right arrow keys (vertical-lr)
+PASS input.value is "2020-01-20"
+PASS input.value is "2020-02-20"
+PASS input.value is "2020-01-20"
+PASS input.value is "2020-12-20"
+PASS changeEventsFired is 4
+PASS inputEventsFired is 4
+
+Left/Right arrow keys (vertical-rl)
+PASS input.value is "2020-01-20"
+PASS input.value is "2020-02-20"
+PASS input.value is "2020-01-20"
+PASS input.value is "2020-12-20"
+PASS changeEventsFired is 4
+PASS inputEventsFired is 4
+
 Advance field keys
 PASS input.value is "2020-06-03"
 PASS input.value is "2020-06-04"
@@ -52,6 +68,18 @@ PASS input.value is "2020-01-20"
 PASS input.value is "2020-12-20"
 PASS changeEventsFired is 4
 PASS inputEventsFired is 4
+
+Up/Down arrow keys (vertical-lr)
+PASS input.value is "0002-02-02"
+PASS input.value is "0002-03-03"
+PASS changeEventsFired is 3
+PASS inputEventsFired is 3
+
+Up/Down arrow keys (vertical-rl)
+PASS input.value is "0002-02-02"
+PASS input.value is "0002-03-03"
+PASS changeEventsFired is 3
+PASS inputEventsFired is 3
 
 Tab key
 PASS input.value is "0002-02-02"

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html
@@ -24,9 +24,10 @@ function onInputEvent() {
     inputEventsFired++;
 }
 
-function beginTest(title, value) {
+function beginTest(title, value, style) {
     debug("\n" + title);
     input.value = value || "";
+    input.style = style || "";
     input.blur();
     input.focus();
 
@@ -130,6 +131,30 @@ addEventListener("load", async () => {
     shouldBe("changeEventsFired", "3");
     shouldBe("inputEventsFired", "3");
 
+    beginTest("Left/Right arrow keys (vertical-lr)", "2020-12-20", "writing-mode: vertical-lr");         // [12]/20/2020
+    UIHelper.keyDown("rightArrow");                                                                      // [01]/20/2020
+    shouldBeEqualToString("input.value", "2020-01-20");
+    UIHelper.keyDown("rightArrow");                                                                      // [02]/20/2020
+    shouldBeEqualToString("input.value", "2020-02-20");
+    UIHelper.keyDown("leftArrow");                                                                       // [01]/20/2020
+    shouldBeEqualToString("input.value", "2020-01-20");
+    UIHelper.keyDown("leftArrow");                                                                       // [12]/20/2020
+    shouldBeEqualToString("input.value", "2020-12-20");
+    shouldBe("changeEventsFired", "4");
+    shouldBe("inputEventsFired", "4");
+
+    beginTest("Left/Right arrow keys (vertical-rl)", "2020-12-20", "writing-mode: vertical-rl");         // [12]/20/2020
+    UIHelper.keyDown("rightArrow");                                                                      // [01]/20/2020
+    shouldBeEqualToString("input.value", "2020-01-20");
+    UIHelper.keyDown("rightArrow");                                                                      // [02]/20/2020
+    shouldBeEqualToString("input.value", "2020-02-20");
+    UIHelper.keyDown("leftArrow");                                                                       // [01]/20/2020
+    shouldBeEqualToString("input.value", "2020-01-20");
+    UIHelper.keyDown("leftArrow");                                                                       // [12]/20/2020
+    shouldBeEqualToString("input.value", "2020-12-20");
+    shouldBe("changeEventsFired", "4");
+    shouldBe("inputEventsFired", "4");
+
     beginTest("Advance field keys", "2020-06-05");         // [06]/05/2020
     UIHelper.keyDown("/");                                 // -> 06/[05]/2020
     UIHelper.keyDown("3");                                 // -> 06/[03]/2020
@@ -168,6 +193,36 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-12-20");
     shouldBe("changeEventsFired", "4");
     shouldBe("inputEventsFired", "4");
+
+    beginTest("Up/Down arrow keys (vertical-lr)", "", "writing-mode: vertical-lr");     // [mm]/dd/yyyy
+    UIHelper.keyDown("2");                                                              // -> [02]/dd/yyyy
+    UIHelper.keyDown("downArrow");                                                      // -> 02/[dd]/yyyy
+    UIHelper.keyDown("2");                                                              // -> 02/[02]/yyyy
+    UIHelper.keyDown("downArrow");                                                      // -> 02/02/[yyyy]
+    UIHelper.keyDown("2");                                                              // -> 02/02/[0002]
+    shouldBeEqualToString("input.value", "0002-02-02");
+    UIHelper.keyDown("upArrow");                                                        // -> 02/[02]/0002
+    UIHelper.keyDown("3");                                                              // -> 02/[03]/0002
+    UIHelper.keyDown("upArrow");                                                        // -> [02]/03/0002
+    UIHelper.keyDown("3");                                                              // -> [03]/03/0002
+    shouldBeEqualToString("input.value", "0002-03-03");
+    shouldBe("changeEventsFired", "3");
+    shouldBe("inputEventsFired", "3");
+
+    beginTest("Up/Down arrow keys (vertical-rl)", "", "writing-mode: vertical-rl");     // [mm]/dd/yyyy
+    UIHelper.keyDown("2");                                                              // -> [02]/dd/yyyy
+    UIHelper.keyDown("downArrow");                                                      // -> 02/[dd]/yyyy
+    UIHelper.keyDown("2");                                                              // -> 02/[02]/yyyy
+    UIHelper.keyDown("downArrow");                                                      // -> 02/02/[yyyy]
+    UIHelper.keyDown("2");                                                              // -> 02/02/[0002]
+    shouldBeEqualToString("input.value", "0002-02-02");
+    UIHelper.keyDown("upArrow");                                                        // -> 02/[02]/0002
+    UIHelper.keyDown("3");                                                              // -> 02/[03]/0002
+    UIHelper.keyDown("upArrow");                                                        // -> [02]/03/0002
+    UIHelper.keyDown("3");                                                              // -> [03]/03/0002
+    shouldBeEqualToString("input.value", "0002-03-03");
+    shouldBe("changeEventsFired", "3");
+    shouldBe("inputEventsFired", "3");
 
     beginTest("Tab key");
     UIHelper.keyDown("2");                                 // -> [02]/dd/yyyy

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events-expected.txt
@@ -37,6 +37,36 @@ PASS input.value is "0003-03-03T03:03"
 PASS changeEventsFired is 11
 PASS inputEventsFired is 11
 
+Left/Right arrow keys (vertical-lr)
+PASS input.value is "2020-01-20T23:59"
+PASS input.value is "2020-02-20T23:59"
+PASS input.value is "2020-01-20T23:59"
+PASS input.value is "2020-12-20T23:59"
+PASS input.value is "2020-12-20T12:59"
+PASS input.value is "2020-12-20T13:59"
+PASS input.value is "2020-12-20T12:59"
+PASS input.value is "2020-12-20T23:59"
+PASS input.value is "2020-12-20T11:59"
+PASS input.value is "2020-12-20T23:59"
+PASS input.value is "2020-12-20T11:59"
+PASS changeEventsFired is 11
+PASS inputEventsFired is 11
+
+Left/Right arrow keys (vertical-rl)
+PASS input.value is "2020-01-20T23:59"
+PASS input.value is "2020-02-20T23:59"
+PASS input.value is "2020-01-20T23:59"
+PASS input.value is "2020-12-20T23:59"
+PASS input.value is "2020-12-20T12:59"
+PASS input.value is "2020-12-20T13:59"
+PASS input.value is "2020-12-20T12:59"
+PASS input.value is "2020-12-20T23:59"
+PASS input.value is "2020-12-20T11:59"
+PASS input.value is "2020-12-20T23:59"
+PASS input.value is "2020-12-20T11:59"
+PASS changeEventsFired is 11
+PASS inputEventsFired is 11
+
 Advance field keys
 PASS input.value is "2020-06-03T16:27"
 PASS input.value is "2020-06-04T16:27"
@@ -59,6 +89,18 @@ PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
 PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
+PASS changeEventsFired is 11
+PASS inputEventsFired is 11
+
+Up/Down arrow keys (vertical-lr)
+PASS input.value is "0002-02-02T02:02"
+PASS input.value is "0003-03-03T03:03"
+PASS changeEventsFired is 11
+PASS inputEventsFired is 11
+
+Up/Down arrow keys (vertical-rl)
+PASS input.value is "0002-02-02T02:02"
+PASS input.value is "0003-03-03T03:03"
 PASS changeEventsFired is 11
 PASS inputEventsFired is 11
 

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events.html
@@ -24,9 +24,10 @@ function onInputEvent() {
     inputEventsFired++;
 }
 
-function beginTest(title, value) {
+function beginTest(title, value, style) {
     debug("\n" + title);
     input.value = value || "";
+    input.style = style || "";
     input.blur();
     input.focus();
 
@@ -141,6 +142,68 @@ addEventListener("load", async () => {
     shouldBe("changeEventsFired", "11");
     shouldBe("inputEventsFired", "11");
 
+    beginTest("Left/Right arrow keys (vertical-lr)", "2020-12-20T23:59", "writing-mode: vertical-lr");        // [12]/20/2020 11:59 PM
+    UIHelper.keyDown("rightArrow");                                                                           // -> [01]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-01-20T23:59");
+    UIHelper.keyDown("rightArrow");                                                                           // -> [02]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-02-20T23:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> [01]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-01-20T23:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> [12]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T23:59");
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/[20]/2020 11:59 PM
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/[2020] 11:59 PM
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/2020 [11]:59 PM
+    UIHelper.keyDown("rightArrow");                                                                           // -> 12/20/2020 [12]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T12:59");
+    UIHelper.keyDown("rightArrow");                                                                           // -> 12/20/2020 [01]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T13:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 [12]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T12:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 [11]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T23:59");
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/2020 11:[59] PM
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/2020 11:59 [PM]
+    UIHelper.keyDown("rightArrow");                                                                           // -> 12/20/2020 11:59 [AM]
+    shouldBeEqualToString("input.value", "2020-12-20T11:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 11:59 [PM]
+    shouldBeEqualToString("input.value", "2020-12-20T23:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 11:59 [AM]
+    shouldBeEqualToString("input.value", "2020-12-20T11:59");
+    shouldBe("changeEventsFired", "11");
+    shouldBe("inputEventsFired", "11");
+
+    beginTest("Left/Right arrow keys (vertical-rl)", "2020-12-20T23:59", "writing-mode: vertical-rl");        // [12]/20/2020 11:59 PM
+    UIHelper.keyDown("rightArrow");                                                                           // -> [01]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-01-20T23:59");
+    UIHelper.keyDown("rightArrow");                                                                           // -> [02]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-02-20T23:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> [01]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-01-20T23:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> [12]/20/2020 11:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T23:59");
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/[20]/2020 11:59 PM
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/[2020] 11:59 PM
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/2020 [11]:59 PM
+    UIHelper.keyDown("rightArrow");                                                                           // -> 12/20/2020 [12]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T12:59");
+    UIHelper.keyDown("rightArrow");                                                                           // -> 12/20/2020 [01]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T13:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 [12]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T12:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 [11]:59 PM
+    shouldBeEqualToString("input.value", "2020-12-20T23:59");
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/2020 11:[59] PM
+    UIHelper.keyDown("downArrow");                                                                            // -> 12/20/2020 11:59 [PM]
+    UIHelper.keyDown("rightArrow");                                                                           // -> 12/20/2020 11:59 [AM]
+    shouldBeEqualToString("input.value", "2020-12-20T11:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 11:59 [PM]
+    shouldBeEqualToString("input.value", "2020-12-20T23:59");
+    UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 11:59 [AM]
+    shouldBeEqualToString("input.value", "2020-12-20T11:59");
+    shouldBe("changeEventsFired", "11");
+    shouldBe("inputEventsFired", "11");
+
     beginTest("Advance field keys", "2020-06-05T16:27");        // [06]/05/2020 04:27 PM
     UIHelper.keyDown("/");                                      // -> 06/[05]/2020 04:27 PM
     UIHelper.keyDown("3");                                      // -> 06/[03]/2020 04:27 PM
@@ -196,6 +259,60 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-12-20T23:59");
     UIHelper.keyDown("downArrow");                              // -> 12/20/2020 11:59 [AM]
     shouldBeEqualToString("input.value", "2020-12-20T11:59");
+    shouldBe("changeEventsFired", "11");
+    shouldBe("inputEventsFired", "11");
+
+    beginTest("Up/Down arrow keys (vertical-lr)", "2007-04-30T15:27", "writing-mode: vertical-lr");     // [04]/30/2007 03:27 PM
+    UIHelper.keyDown("2");                                                                              // -> [02]/30/2007 03:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/[30]/2007 03:27 PM
+    UIHelper.keyDown("2");                                                                              // -> 02/[02]/2007 03:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/[2007] 03:27 PM
+    UIHelper.keyDown("2");                                                                              // -> 02/02/[0002] 03:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/0002 [03]:27 PM
+    UIHelper.keyDown("2");                                                                              // -> 02/02/0002 [02]:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/0002 02:[27] PM
+    UIHelper.keyDown("2");                                                                              // -> 02/02/0002 02:[02] PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/0002 02:02 [PM]
+    UIHelper.keyDown("A");                                                                              // -> 02/02/0002 02:02 [AM]
+    shouldBeEqualToString("input.value", "0002-02-02T02:02");
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/02/0002 02:[02] AM
+    UIHelper.keyDown("3");                                                                              // -> 02/02/0002 02:[03] AM
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/02/0002 [02]:03 AM
+    UIHelper.keyDown("3");                                                                              // -> 02/02/0002 [03]:03 AM
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/02/[0002] 03:03 AM
+    UIHelper.keyDown("3");                                                                              // -> 02/02/[0003] 03:03 AM
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/[02]/0003 03:03 AM
+    UIHelper.keyDown("3");                                                                              // -> 02/[03]/0003 03:03 AM
+    UIHelper.keyDown("upArrow");                                                                        // -> [02]/03/0003 03:03 AM
+    UIHelper.keyDown("3");                                                                              // -> [03]/03/0003 03:03 AM
+    shouldBeEqualToString("input.value", "0003-03-03T03:03");
+    shouldBe("changeEventsFired", "11");
+    shouldBe("inputEventsFired", "11");
+
+    beginTest("Up/Down arrow keys (vertical-rl)", "2007-04-30T15:27", "writing-mode: vertical-rl");     // [04]/30/2007 03:27 PM
+    UIHelper.keyDown("2");                                                                              // -> [02]/30/2007 03:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/[30]/2007 03:27 PM
+    UIHelper.keyDown("2");                                                                              // -> 02/[02]/2007 03:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/[2007] 03:27 PM
+    UIHelper.keyDown("2");                                                                              // -> 02/02/[0002] 03:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/0002 [03]:27 PM
+    UIHelper.keyDown("2");                                                                              // -> 02/02/0002 [02]:27 PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/0002 02:[27] PM
+    UIHelper.keyDown("2");                                                                              // -> 02/02/0002 02:[02] PM
+    UIHelper.keyDown("downArrow");                                                                      // -> 02/02/0002 02:02 [PM]
+    UIHelper.keyDown("A");                                                                              // -> 02/02/0002 02:02 [AM]
+    shouldBeEqualToString("input.value", "0002-02-02T02:02");
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/02/0002 02:[02] AM
+    UIHelper.keyDown("3");                                                                              // -> 02/02/0002 02:[03] AM
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/02/0002 [02]:03 AM
+    UIHelper.keyDown("3");                                                                              // -> 02/02/0002 [03]:03 AM
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/02/[0002] 03:03 AM
+    UIHelper.keyDown("3");                                                                              // -> 02/02/[0003] 03:03 AM
+    UIHelper.keyDown("upArrow");                                                                        // -> 02/[02]/0003 03:03 AM
+    UIHelper.keyDown("3");                                                                              // -> 02/[03]/0003 03:03 AM
+    UIHelper.keyDown("upArrow");                                                                        // -> [02]/03/0003 03:03 AM
+    UIHelper.keyDown("3");                                                                              // -> [03]/03/0003 03:03 AM
+    shouldBeEqualToString("input.value", "0003-03-03T03:03");
     shouldBe("changeEventsFired", "11");
     shouldBe("inputEventsFired", "11");
 

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events-expected.txt
@@ -35,6 +35,22 @@ PASS input.value is "0002-03"
 PASS changeEventsFired is 2
 PASS inputEventsFired is 2
 
+Left/Right arrow keys (vertical-lr)
+PASS input.value is "2020-01"
+PASS input.value is "2020-02"
+PASS input.value is "2020-01"
+PASS input.value is "2020-12"
+PASS changeEventsFired is 4
+PASS inputEventsFired is 4
+
+Left/Right arrow keys (vertical-rl)
+PASS input.value is "2020-01"
+PASS input.value is "2020-02"
+PASS input.value is "2020-01"
+PASS input.value is "2020-12"
+PASS changeEventsFired is 4
+PASS inputEventsFired is 4
+
 Advance field keys
 PASS input.value is "0003-06"
 PASS input.value is "0004-06"
@@ -52,6 +68,18 @@ PASS input.value is "2020-01"
 PASS input.value is "2020-12"
 PASS changeEventsFired is 4
 PASS inputEventsFired is 4
+
+Up/Down arrow keys (vertical-lr)
+PASS input.value is "0002-02"
+PASS input.value is "0002-03"
+PASS changeEventsFired is 2
+PASS inputEventsFired is 2
+
+Up/Down arrow keys (vertical-rl)
+PASS input.value is "0002-02"
+PASS input.value is "0002-03"
+PASS changeEventsFired is 2
+PASS inputEventsFired is 2
 
 Tab key
 PASS input.value is "0002-02"

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events.html
@@ -24,9 +24,10 @@ function onInputEvent() {
     inputEventsFired++;
 }
 
-function beginTest(title, value) {
+function beginTest(title, value, style) {
     debug("\n" + title);
     input.value = value || "";
+    input.style = style || "";
     input.blur();
     input.focus();
 
@@ -112,6 +113,30 @@ addEventListener("load", async () => {
     shouldBe("changeEventsFired", "2");
     shouldBe("inputEventsFired", "2");
 
+    beginTest("Left/Right arrow keys (vertical-lr)", "2020-12", "writing-mode: vertical-lr");            // [12]/2020
+    UIHelper.keyDown("rightArrow");                                                                      // [01]/2020
+    shouldBeEqualToString("input.value", "2020-01");
+    UIHelper.keyDown("rightArrow");                                                                      // [02]/2020
+    shouldBeEqualToString("input.value", "2020-02");
+    UIHelper.keyDown("leftArrow");                                                                       // [01]/2020
+    shouldBeEqualToString("input.value", "2020-01");
+    UIHelper.keyDown("leftArrow");                                                                       // [12]/2020
+    shouldBeEqualToString("input.value", "2020-12");
+    shouldBe("changeEventsFired", "4");
+    shouldBe("inputEventsFired", "4");
+
+    beginTest("Left/Right arrow keys (vertical-rl)", "2020-12", "writing-mode: vertical-rl");            // [12]/2020
+    UIHelper.keyDown("rightArrow");                                                                      // [01]/2020
+    shouldBeEqualToString("input.value", "2020-01");
+    UIHelper.keyDown("rightArrow");                                                                      // [02]/2020
+    shouldBeEqualToString("input.value", "2020-02");
+    UIHelper.keyDown("leftArrow");                                                                       // [01]/2020
+    shouldBeEqualToString("input.value", "2020-01");
+    UIHelper.keyDown("leftArrow");                                                                       // [12]/2020
+    shouldBeEqualToString("input.value", "2020-12");
+    shouldBe("changeEventsFired", "4");
+    shouldBe("inputEventsFired", "4");
+
     beginTest("Advance field keys", "2020-06");            // [06]/2020
     UIHelper.keyDown("/");                                 // -> 06/[2020]
     UIHelper.keyDown("3");                                 // -> 06/[0003]
@@ -150,6 +175,28 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-12");
     shouldBe("changeEventsFired", "4");
     shouldBe("inputEventsFired", "4");
+
+    beginTest("Up/Down arrow keys (vertical-lr)", "", "writing-mode: vertical-lr");     // [mm]/yyyy
+    UIHelper.keyDown("2");                                                              // -> [02]/yyyy
+    UIHelper.keyDown("downArrow");                                                      // -> 02/[yyyy]
+    UIHelper.keyDown("2");                                                              // -> 02/[0002]
+    shouldBeEqualToString("input.value", "0002-02");
+    UIHelper.keyDown("upArrow");                                                        // -> [02]/0002
+    UIHelper.keyDown("3");                                                              // -> [03]/0002
+    shouldBeEqualToString("input.value", "0002-03");
+    shouldBe("changeEventsFired", "2");
+    shouldBe("inputEventsFired", "2");
+
+    beginTest("Up/Down arrow keys (vertical-rl)", "", "writing-mode: vertical-rl");     // [mm]/yyyy
+    UIHelper.keyDown("2");                                                              // -> [02]/yyyy
+    UIHelper.keyDown("downArrow");                                                      // -> 02/[yyyy]
+    UIHelper.keyDown("2");                                                              // -> 02/[0002]
+    shouldBeEqualToString("input.value", "0002-02");
+    UIHelper.keyDown("upArrow");                                                        // -> [02]/0002
+    UIHelper.keyDown("3");                                                              // -> [03]/0002
+    shouldBeEqualToString("input.value", "0002-03");
+    shouldBe("changeEventsFired", "2");
+    shouldBe("inputEventsFired", "2");
 
     beginTest("Tab key");
     UIHelper.keyDown("2");                                 // -> [02]/yyyy

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events-expected.txt
@@ -29,6 +29,28 @@ PASS input.value is "03:03"
 PASS changeEventsFired is 5
 PASS inputEventsFired is 5
 
+Left/Right arrow keys (vertical-lr)
+PASS input.value is "12:59"
+PASS input.value is "13:59"
+PASS input.value is "12:59"
+PASS input.value is "23:59"
+PASS input.value is "11:59"
+PASS input.value is "23:59"
+PASS input.value is "11:59"
+PASS changeEventsFired is 7
+PASS inputEventsFired is 7
+
+Left/Right arrow keys (vertical-rl)
+PASS input.value is "12:59"
+PASS input.value is "13:59"
+PASS input.value is "12:59"
+PASS input.value is "23:59"
+PASS input.value is "11:59"
+PASS input.value is "23:59"
+PASS input.value is "11:59"
+PASS changeEventsFired is 7
+PASS inputEventsFired is 7
+
 Advance field keys
 PASS input.value is "01:03"
 PASS input.value is "01:04"
@@ -49,6 +71,18 @@ PASS input.value is "23:59"
 PASS input.value is "11:59"
 PASS changeEventsFired is 7
 PASS inputEventsFired is 7
+
+Up/Down arrow keys (vertical-lr)
+PASS input.value is "02:02"
+PASS input.value is "03:03"
+PASS changeEventsFired is 5
+PASS inputEventsFired is 5
+
+Up/Down arrow keys (vertical-rl)
+PASS input.value is "02:02"
+PASS input.value is "03:03"
+PASS changeEventsFired is 5
+PASS inputEventsFired is 5
 
 Tab key
 PASS input.value is "02:02"

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events.html
@@ -24,9 +24,10 @@ function onInputEvent() {
     inputEventsFired++;
 }
 
-function beginTest(title, value) {
+function beginTest(title, value, style) {
     debug("\n" + title);
     input.value = value || "";
+    input.style = style || "";
     input.blur();
     input.focus();
 
@@ -93,6 +94,46 @@ addEventListener("load", async () => {
     shouldBe("changeEventsFired", "5");
     shouldBe("inputEventsFired", "5");
 
+    beginTest("Left/Right arrow keys (vertical-lr)", "23:59", "writing-mode: vertical-lr");              // [11]:59 PM
+    UIHelper.keyDown("rightArrow");                                                                      // -> [12]:59 PM
+    shouldBeEqualToString("input.value", "12:59");
+    UIHelper.keyDown("rightArrow");                                                                      // -> [01]:59 PM
+    shouldBeEqualToString("input.value", "13:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> [12]:59 PM
+    shouldBeEqualToString("input.value", "12:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> [11]:59 PM
+    shouldBeEqualToString("input.value", "23:59");
+    UIHelper.keyDown("downArrow");                                                                       // -> 11:[59] PM
+    UIHelper.keyDown("downArrow");                                                                       // -> 11:59 [PM]
+    UIHelper.keyDown("rightArrow");                                                                      // -> 11:59 [AM]
+    shouldBeEqualToString("input.value", "11:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> 11:59 [PM]
+    shouldBeEqualToString("input.value", "23:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> 11:59 [AM]
+    shouldBeEqualToString("input.value", "11:59");
+    shouldBe("changeEventsFired", "7");
+    shouldBe("inputEventsFired", "7");
+
+    beginTest("Left/Right arrow keys (vertical-rl)", "23:59", "writing-mode: vertical-rl");              // [11]:59 PM
+    UIHelper.keyDown("rightArrow");                                                                      // -> [12]:59 PM
+    shouldBeEqualToString("input.value", "12:59");
+    UIHelper.keyDown("rightArrow");                                                                      // -> [01]:59 PM
+    shouldBeEqualToString("input.value", "13:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> [12]:59 PM
+    shouldBeEqualToString("input.value", "12:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> [11]:59 PM
+    shouldBeEqualToString("input.value", "23:59");
+    UIHelper.keyDown("downArrow");                                                                       // -> 11:[59] PM
+    UIHelper.keyDown("downArrow");                                                                       // -> 11:59 [PM]
+    UIHelper.keyDown("rightArrow");                                                                      // -> 11:59 [AM]
+    shouldBeEqualToString("input.value", "11:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> 11:59 [PM]
+    shouldBeEqualToString("input.value", "23:59");
+    UIHelper.keyDown("leftArrow");                                                                       // -> 11:59 [AM]
+    shouldBeEqualToString("input.value", "11:59");
+    shouldBe("changeEventsFired", "7");
+    shouldBe("inputEventsFired", "7");
+
     beginTest("Advance field keys", "01:28");              // [01]:28 AM
     UIHelper.keyDown("/");                                 // -> 01:[28] AM
     UIHelper.keyDown("3");                                 // -> 01:[03] AM
@@ -139,6 +180,36 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "11:59");
     shouldBe("changeEventsFired", "7");
     shouldBe("inputEventsFired", "7");
+
+    beginTest("Up/Down arrow keys (vertical-lr)", "15:27", "writing-mode: vertical-lr");           // [03]:27 PM
+    UIHelper.keyDown("2");                                                                         // -> [02]:27 PM
+    UIHelper.keyDown("downArrow");                                                                 // -> 02:[27] PM
+    UIHelper.keyDown("2");                                                                         // -> 02:[02] PM
+    UIHelper.keyDown("downArrow");                                                                 // -> 02:02 [PM]
+    UIHelper.keyDown("A");                                                                         // -> 02:02 [AM]
+    shouldBeEqualToString("input.value", "02:02");
+    UIHelper.keyDown("upArrow");                                                                   // -> 02:[02] AM
+    UIHelper.keyDown("3");                                                                         // -> 02:[03] AM
+    UIHelper.keyDown("upArrow");                                                                   // -> [02]:03 AM
+    UIHelper.keyDown("3");                                                                         // -> [03]:03 AM
+    shouldBeEqualToString("input.value", "03:03");
+    shouldBe("changeEventsFired", "5");
+    shouldBe("inputEventsFired", "5");
+
+    beginTest("Up/Down arrow keys (vertical-rl)", "15:27", "writing-mode: vertical-rl");           // [03]:27 PM
+    UIHelper.keyDown("2");                                                                         // -> [02]:27 PM
+    UIHelper.keyDown("downArrow");                                                                 // -> 02:[27] PM
+    UIHelper.keyDown("2");                                                                         // -> 02:[02] PM
+    UIHelper.keyDown("downArrow");                                                                 // -> 02:02 [PM]
+    UIHelper.keyDown("A");                                                                         // -> 02:02 [AM]
+    shouldBeEqualToString("input.value", "02:02");
+    UIHelper.keyDown("upArrow");                                                                   // -> 02:[02] AM
+    UIHelper.keyDown("3");                                                                         // -> 02:[03] AM
+    UIHelper.keyDown("upArrow");                                                                   // -> [02]:03 AM
+    UIHelper.keyDown("3");                                                                         // -> [03]:03 AM
+    shouldBeEqualToString("input.value", "03:03");
+    shouldBe("changeEventsFired", "5");
+    shouldBe("inputEventsFired", "5");
 
     beginTest("Tab key");                                  // [hh]:mm tt
     UIHelper.keyDown("2");                                 // -> [02]:mm tt

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -38,6 +38,7 @@
 #include "Event.h"
 #include "HTMLNames.h"
 #include "PlatformLocale.h"
+#include "RenderElement.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowPseudoIds.h"
 #include "Text.h"
@@ -360,6 +361,13 @@ bool DateTimeEditElement::isFieldOwnerDisabled() const
 bool DateTimeEditElement::isFieldOwnerReadOnly() const
 {
     return m_editControlOwner && m_editControlOwner->isEditControlOwnerReadOnly();
+}
+
+bool DateTimeEditElement::isFieldOwnerHorizontal() const
+{
+    if (CheckedPtr renderer = fieldsWrapperElement().renderer())
+        return renderer->isHorizontalWritingMode();
+    return true;
 }
 
 AtomString DateTimeEditElement::localeIdentifier() const

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -103,6 +103,7 @@ private:
     bool focusOnPreviousField(const DateTimeFieldElement&) final;
     bool isFieldOwnerDisabled() const final;
     bool isFieldOwnerReadOnly() const final;
+    bool isFieldOwnerHorizontal() const final;
     AtomString localeIdentifier() const final;
     const GregorianDateTime& placeholderDate() const final;
 

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -110,12 +110,18 @@ void DateTimeFieldElement::defaultKeyboardEventHandler(KeyboardEvent& keyboardEv
     auto key = keyboardEvent.keyIdentifier();
     auto code = keyboardEvent.code();
 
-    if (key == "Left"_s && m_fieldOwner && m_fieldOwner->focusOnPreviousField(*this)) {
+    bool isHorizontal = isFieldOwnerHorizontal();
+    auto nextKeyIdentifier = isHorizontal ? "Right"_s : "Down"_s;
+    auto previousKeyIdentifier = isHorizontal ? "Left"_s : "Up"_s;
+    auto stepUpKeyIdentifier = isHorizontal ? "Up"_s : "Right"_s;
+    auto stepDownKeyIdentifier = isHorizontal ? "Down"_s : "Left"_s;
+
+    if (key == previousKeyIdentifier && m_fieldOwner && m_fieldOwner->focusOnPreviousField(*this)) {
         keyboardEvent.setDefaultHandled();
         return;
     }
 
-    if ((key == "Right"_s || code == "Comma"_s || code == "Minus"_s || code == "Period"_s || code == "Slash"_s || code == "Semicolon"_s)
+    if ((key == nextKeyIdentifier || code == "Comma"_s || code == "Minus"_s || code == "Period"_s || code == "Slash"_s || code == "Semicolon"_s)
         && m_fieldOwner && m_fieldOwner->focusOnNextField(*this)) {
         keyboardEvent.setDefaultHandled();
         return;
@@ -124,13 +130,13 @@ void DateTimeFieldElement::defaultKeyboardEventHandler(KeyboardEvent& keyboardEv
     if (isFieldOwnerReadOnly())
         return;
 
-    if (key == "Up"_s) {
+    if (key == stepUpKeyIdentifier) {
         stepUp();
         keyboardEvent.setDefaultHandled();
         return;
     }
 
-    if (key == "Down"_s) {
+    if (key == stepDownKeyIdentifier) {
         stepDown();
         keyboardEvent.setDefaultHandled();
         return;
@@ -152,6 +158,13 @@ bool DateTimeFieldElement::isFieldOwnerDisabled() const
 bool DateTimeFieldElement::isFieldOwnerReadOnly() const
 {
     return m_fieldOwner && m_fieldOwner->isFieldOwnerReadOnly();
+}
+
+bool DateTimeFieldElement::isFieldOwnerHorizontal() const
+{
+    if (m_fieldOwner)
+        return m_fieldOwner->isFieldOwnerHorizontal();
+    return true;
 }
 
 bool DateTimeFieldElement::isFocusable() const

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -54,6 +54,7 @@ public:
         virtual bool focusOnPreviousField(const DateTimeFieldElement&) = 0;
         virtual bool isFieldOwnerDisabled() const = 0;
         virtual bool isFieldOwnerReadOnly() const = 0;
+        virtual bool isFieldOwnerHorizontal() const = 0;
         virtual AtomString localeIdentifier() const = 0;
         virtual const GregorianDateTime& placeholderDate() const = 0;
     };
@@ -93,6 +94,7 @@ private:
     void defaultKeyboardEventHandler(KeyboardEvent&);
     bool isFieldOwnerDisabled() const;
     bool isFieldOwnerReadOnly() const;
+    bool isFieldOwnerHorizontal() const;
 
     WeakPtr<FieldOwner> m_fieldOwner;
 };


### PR DESCRIPTION
#### 58847085b32f7aae4f8d6884547e063076834605
<pre>
[macOS] Fix keyboard selection/editing of date/time inputs in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=264466">https://bugs.webkit.org/show_bug.cgi?id=264466</a>
<a href="https://rdar.apple.com/118159670">rdar://118159670</a>

Reviewed by Wenson Hsieh.

In vertical writing mode, vertical arrow keys should select the next/previous
editable date/time component, and horizontal arrow keys should increment and
decrement the value of the currently selected component.

Update existing keyboard selection/editing tests to include vertical writing
modes.

* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events.html:
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events.html:
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events.html:
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditElement::isFieldOwnerHorizontal const):
* Source/WebCore/html/shadow/DateTimeEditElement.h:
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::defaultKeyboardEventHandler):
(WebCore::DateTimeFieldElement::isFieldOwnerHorizontal const):
* Source/WebCore/html/shadow/DateTimeFieldElement.h:

Canonical link: <a href="https://commits.webkit.org/270480@main">https://commits.webkit.org/270480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b908f5897f26f9ea1b831f931c4fda4115db3f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23386 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28201 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29043 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26876 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/941 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22695 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6144 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->