### PR TITLE
Correct <input type=checkbox switch> macOS RTL thumb placement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl-notref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl-notref.html
@@ -1,0 +1,1 @@
+<input type=checkbox switch>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative-expected-mismatch.html
@@ -1,0 +1,1 @@
+<input type=checkbox switch>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<link rel=mismatch href=input-checkbox-switch-rtl-notref.html>
+<input type=checkbox switch dir=rtl>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -221,6 +221,7 @@ imported/w3c/web-platform-tests/html/rendering/the-details-element/details-after
 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-before.html [ Pass ]
 imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-disabled-checked.html [ Pass ]
 imported/w3c/web-platform-tests/html/rendering/widgets/input-radio-disabled-checked.html [ Pass ]
+imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative.html [ Failure ]
 
 imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-ascii-case-insensitive.html [ Pass ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/placeholder-white-space.tentative.html [ Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3405,6 +3405,7 @@ http/wpt/webxr [ Skip ]
 http/tests/media/video-webm-stall.html [ Skip ]
 
 webkit.org/b/229291 imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/revoked-blob-print.html [ Pass ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative.html [ Failure ]
 
 #rdar://82146367 ([Mac, iOS Release] imported/w3c/web-platform-tests/worklets/layout-worklet-csp.https.html is a flaky failure) imported/w3c/web-platform-tests/worklets/layout-worklet-csp.https.html [ Pass Failure ] 
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -76,7 +76,8 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 
     auto inflatedTrackRect = inflatedRect(trackRect, size, outsets, style);
 
-    auto drawingThumbX = isOn ? inflatedTrackRect.width() - inflatedTrackRect.height() : 0;
+    auto drawingThumbIsLeft = (!isRTL && !isOn) || (isRTL && isOn);
+    auto drawingThumbX = drawingThumbIsLeft ? 0 : inflatedTrackRect.width() - inflatedTrackRect.height();
     auto drawingThumbRect = NSMakeRect(drawingThumbX, 0, inflatedTrackRect.height(), inflatedTrackRect.height());
 
     auto trackBuffer = context.createImageBuffer(inflatedTrackRect.size(), deviceScaleFactor);


### PR DESCRIPTION
#### b6413fe07ea1aa277f2e149c60a7b1584577a774
<pre>
Correct &lt;input type=checkbox switch&gt; macOS RTL thumb placement
<a href="https://bugs.webkit.org/show_bug.cgi?id=264477">https://bugs.webkit.org/show_bug.cgi?id=264477</a>
<a href="https://rdar.apple.com/118174107">rdar://118174107</a>

Reviewed by Mike Wyrzykowski.

While most RTL aspects are handled by bitmaps from AppKit, thumb
placement is on us and I forgot about it initially.

Test is exported via
<a href="https://github.com/web-platform-tests/wpt/pull/43074.">https://github.com/web-platform-tests/wpt/pull/43074.</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl-notref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/input-checkbox-switch-rtl.tentative.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
(WebCore::SwitchThumbMac::draw):

Canonical link: <a href="https://commits.webkit.org/270536@main">https://commits.webkit.org/270536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44deb94dc7de24c4ca850753e02302b4eb76a282

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1754 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28394 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29189 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23482 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27050 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1111 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22862 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6180 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3192 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->