### PR TITLE
Remove IntersectionObserverEnabled preference

### DIFF
--- a/LayoutTests/intersection-observer/intersection-observer-callback-after-gc.html
+++ b/LayoutTests/intersection-observer/intersection-observer-callback-after-gc.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/LayoutTests/intersection-observer/intersection-observer-callback-leak.html
+++ b/LayoutTests/intersection-observer/intersection-observer-callback-leak.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/LayoutTests/intersection-observer/intersection-observer-entry-interface.html
+++ b/LayoutTests/intersection-observer/intersection-observer-entry-interface.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <head>
     <title>IntersectionObserverEntry interface tests.</title>
     <link rel="author" title="Simon Fraser" href="mailto:simon.fraser@apple.com" />

--- a/LayoutTests/intersection-observer/intersection-observer-interface.html
+++ b/LayoutTests/intersection-observer/intersection-observer-interface.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <head>
     <title>IntersectionObserver interface tests.</title>
     <link rel="author" title="Simon Fraser" href="mailto:simon.fraser@apple.com" />

--- a/LayoutTests/intersection-observer/intersection-observer-keeps-element-of-queued-entry-alive.html
+++ b/LayoutTests/intersection-observer/intersection-observer-keeps-element-of-queued-entry-alive.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <pre id="log">This tests observing an element with an IntersectionObserver and removing the element from the document while it is queued for delivery.

--- a/LayoutTests/intersection-observer/intersection-observer-should-not-leak-observed-nodes.html
+++ b/LayoutTests/intersection-observer/intersection-observer-should-not-leak-observed-nodes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <pre id="log">This tests observing an element with an IntersectionObserver and removing the element from the document.

--- a/LayoutTests/intersection-observer/root-element-deleted.html
+++ b/LayoutTests/intersection-observer/root-element-deleted.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <head>
 <script src="../resources/gc.js"></script>
 <body>

--- a/LayoutTests/intersection-observer/root-element-moved.html
+++ b/LayoutTests/intersection-observer/root-element-moved.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <head>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/intersection-observer/target-deleted.html
+++ b/LayoutTests/intersection-observer/target-deleted.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ IntersectionObserverEnabled=true ] -->
+<!DOCTYPE html>
 <head>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3462,19 +3462,6 @@ InterruptVideoOnPageVisibilityChangeEnabled:
     WebCore:
       default: false
 
-IntersectionObserverEnabled:
-  type: bool
-  status: mature
-  humanReadableName: "Intersection Observer"
-  humanReadableDescription: "Enable Intersection Observer support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 InvisibleAutoplayNotPermitted:
   type: bool
   status: embedder

--- a/Source/WebCore/page/IntersectionObserver.idl
+++ b/Source/WebCore/page/IntersectionObserver.idl
@@ -26,7 +26,6 @@
 // https://wicg.github.io/IntersectionObserver/
 
 [
-    EnabledBySetting=IntersectionObserverEnabled,
     Exposed=Window,
     JSCustomMarkFunction,
     CustomIsReachable,
@@ -43,9 +42,6 @@
     [ResultField=records] sequence<IntersectionObserverEntry> takeRecords();
 };
 
-[
-    EnabledBySetting=IntersectionObserverEnabled
-]
 dictionary IntersectionObserverInit {
     (Element or Document)? root = null;
     DOMString rootMargin = "0px";

--- a/Source/WebCore/page/IntersectionObserverEntry.idl
+++ b/Source/WebCore/page/IntersectionObserverEntry.idl
@@ -28,7 +28,6 @@
 typedef double DOMHighResTimeStamp;
 
 [
-    EnabledBySetting=IntersectionObserverEnabled,
     JSCustomMarkFunction,
     Exposed=Window
 ] interface IntersectionObserverEntry {

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -1539,12 +1539,11 @@ bool WKPreferencesGetDownloadAttributeEnabled(WKPreferencesRef preferencesRef)
 
 void WKPreferencesSetIntersectionObserverEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
-    toImpl(preferencesRef)->setIntersectionObserverEnabled(flag);
 }
 
 bool WKPreferencesGetIntersectionObserverEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->intersectionObserverEnabled();
+    return true;
 }
 
 void WKPreferencesSetMenuItemElementEnabled(WKPreferencesRef preferencesRef, bool flag)

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -413,10 +413,6 @@ WK_EXPORT void WKPreferencesSetAttachmentElementEnabled(WKPreferencesRef prefere
 WK_EXPORT bool WKPreferencesGetAttachmentElementEnabled(WKPreferencesRef preferencesRef);
 
 // Defaults to false
-WK_EXPORT void WKPreferencesSetIntersectionObserverEnabled(WKPreferencesRef, bool flag);
-WK_EXPORT bool WKPreferencesGetIntersectionObserverEnabled(WKPreferencesRef);
-
-// Defaults to false
 WK_EXPORT void WKPreferencesSetDataTransferItemsEnabled(WKPreferencesRef, bool flag);
 WK_EXPORT bool WKPreferencesGetDataTransferItemsEnabled(WKPreferencesRef);
 
@@ -531,6 +527,8 @@ WK_EXPORT void WKPreferencesSetFetchAPIEnabled(WKPreferencesRef, bool) WK_C_API_
 WK_EXPORT bool WKPreferencesGetFetchAPIEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetFetchAPIKeepAliveEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetFetchAPIKeepAliveEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
+WK_EXPORT void WKPreferencesSetIntersectionObserverEnabled(WKPreferencesRef, bool flag) WK_C_API_DEPRECATED;
+WK_EXPORT bool WKPreferencesGetIntersectionObserverEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetIsSecureContextAttributeEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetIsSecureContextAttributeEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetUserTimingEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -239,7 +239,6 @@
 #define WebKitRequestIdleCallbackEnabledPreferenceKey @"WebKitRequestIdleCallbackEnabled"
 #define WebKitHighlightAPIEnabledPreferenceKey @"WebKitHighlightAPIEnabled"
 #define WebKitAsyncClipboardAPIEnabledPreferenceKey @"WebKitAsyncClipboardAPIEnabled"
-#define WebKitIntersectionObserverEnabledPreferenceKey @"WebKitIntersectionObserverEnabled"
 #define WebKitVisualViewportAPIEnabledPreferenceKey @"WebKitVisualViewportAPIEnabled"
 #define WebKitSyntheticEditingCommandsEnabledPreferenceKey @"WebKitSyntheticEditingCommandsEnabled"
 #define WebKitCSSOMViewSmoothScrollingEnabledPreferenceKey @"WebKitCSSOMViewSmoothScrollingEnabled"
@@ -277,3 +276,4 @@
 #define WebKitAVFoundationNSURLSessionEnabledKey @"WebKitAVFoundationNSURLSessionEnabled"
 #define WebKitDisplayListDrawingEnabledPreferenceKey @"WebKitDisplayListDrawingEnabled"
 #define WebKitTransformStreamAPIEnabledPreferenceKey @"WebKitTransformStreamAPIEnabled"
+#define WebKitIntersectionObserverEnabledPreferenceKey @"WebKitIntersectionObserverEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -2916,16 +2916,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:flag forKey:WebKitContactPickerAPIEnabledPreferenceKey];
 }
 
-- (BOOL)intersectionObserverEnabled
-{
-    return [self _boolValueForKey:WebKitIntersectionObserverEnabledPreferenceKey];
-}
-
-- (void)setIntersectionObserverEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitIntersectionObserverEnabledPreferenceKey];
-}
-
 - (BOOL)visualViewportAPIEnabled
 {
     return [self _boolValueForKey:WebKitVisualViewportAPIEnabledPreferenceKey];
@@ -3213,6 +3203,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 - (BOOL)fetchAPIKeepAliveEnabled
 {
     return YES;
+}
+
+- (BOOL)intersectionObserverEnabled
+{
+    return YES;
+}
+
+- (void)setIntersectionObserverEnabled:(BOOL)flag
+{
 }
 
 - (void)setShadowDOMEnabled:(BOOL)flag

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -304,7 +304,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL requestIdleCallbackEnabled;
 @property (nonatomic) BOOL highlightAPIEnabled;
 @property (nonatomic) BOOL asyncClipboardAPIEnabled;
-@property (nonatomic) BOOL intersectionObserverEnabled;
 @property (nonatomic) BOOL visualViewportAPIEnabled;
 @property (nonatomic) BOOL syntheticEditingCommandsEnabled;
 @property (nonatomic) BOOL CSSOMViewSmoothScrollingEnabled;
@@ -342,6 +341,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL isSecureContextAttributeEnabled;
 @property (nonatomic) BOOL fetchAPIEnabled;
 @property (nonatomic) BOOL fetchAPIKeepAliveEnabled;
+@property (nonatomic) BOOL intersectionObserverEnabled;
 @property (nonatomic) BOOL shadowDOMEnabled;
 @property (nonatomic) BOOL customElementsEnabled;
 @property (nonatomic) BOOL keygenElementEnabled;


### PR DESCRIPTION
#### 9e3021af6e3806ee43e922d8cebc8eb28f2260d3
<pre>
Remove IntersectionObserverEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=264479">https://bugs.webkit.org/show_bug.cgi?id=264479</a>
<a href="https://rdar.apple.com/118175306">rdar://118175306</a>

Reviewed by Simon Fraser.

It&apos;s been enabled for a very long time now.

* LayoutTests/intersection-observer/intersection-observer-callback-after-gc.html:
* LayoutTests/intersection-observer/intersection-observer-callback-leak.html:
* LayoutTests/intersection-observer/intersection-observer-entry-interface.html:
* LayoutTests/intersection-observer/intersection-observer-interface.html:
* LayoutTests/intersection-observer/intersection-observer-keeps-element-of-queued-entry-alive.html:
* LayoutTests/intersection-observer/intersection-observer-should-not-leak-observed-nodes.html:
* LayoutTests/intersection-observer/root-element-deleted.html:
* LayoutTests/intersection-observer/root-element-moved.html:
* LayoutTests/intersection-observer/target-deleted.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/IntersectionObserver.idl:
* Source/WebCore/page/IntersectionObserverEntry.idl:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetIntersectionObserverEnabled):
(WKPreferencesGetIntersectionObserverEnabled):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences intersectionObserverEnabled]):
(-[WebPreferences setIntersectionObserverEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/270547@main">https://commits.webkit.org/270547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80f576a9c2a384a82cf89e2fc892e31f400efc0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23554 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28223 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29063 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22220 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26898 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24764 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/964 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32200 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22714 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6185 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->