### PR TITLE
Remove 'dumpSVGCharacterDataMapValue' and 'dump' functions from 'SVGTextLayoutAttributes.cpp|h'

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
@@ -42,33 +42,4 @@ float SVGTextLayoutAttributes::emptyValue()
     return s_emptyValue;
 }
 
-static inline void dumpSVGCharacterDataMapValue(const char* identifier, float value, bool appendSpace = true)
-{
-    if (value == SVGTextLayoutAttributes::emptyValue()) {
-        fprintf(stderr, "%s=x", identifier);
-        if (appendSpace)
-            fprintf(stderr, " ");
-        return;
-    }
-    fprintf(stderr, "%s=%lf", identifier, value);
-    if (appendSpace)
-        fprintf(stderr, " ");
-}
-
-void SVGTextLayoutAttributes::dump() const
-{
-    fprintf(stderr, "context: %p\n", &m_context);
-    const SVGCharacterDataMap::const_iterator end = m_characterDataMap.end();
-    for (SVGCharacterDataMap::const_iterator it = m_characterDataMap.begin(); it != end; ++it) {
-        const SVGCharacterData& data = it->value;
-        fprintf(stderr, " ---> pos=%i, data={", it->key);
-        dumpSVGCharacterDataMapValue("x", data.x);
-        dumpSVGCharacterDataMapValue("y", data.y);
-        dumpSVGCharacterDataMapValue("dx", data.dx);
-        dumpSVGCharacterDataMapValue("dy", data.dy);
-        dumpSVGCharacterDataMapValue("rotate", data.rotate, false);
-        fprintf(stderr, "}\n");
-    }
-}
-
 }

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
@@ -46,7 +46,6 @@ public:
     explicit SVGTextLayoutAttributes(RenderSVGInlineText&);
 
     void clear();
-    void dump() const;
     static float emptyValue();
 
     RenderSVGInlineText& context() { return m_context; }


### PR DESCRIPTION
#### d42df0c67eeab27085ab2da5c826d3d5de33adbc
<pre>
Remove &apos;dumpSVGCharacterDataMapValue&apos; and &apos;dump&apos; functions from &apos;SVGTextLayoutAttributes.cpp|h&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=264476">https://bugs.webkit.org/show_bug.cgi?id=264476</a>

Reviewed by Nikolas Zimmermann.

This PR removes unused code in &apos;SVGTextLayoutAttributes.cpp&apos; and related header file.

* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp:
(dumpSVGCharacterDataMapValue):
(SVGTextLayoutAttributes::dump):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h:

Canonical link: <a href="https://commits.webkit.org/270937@main">https://commits.webkit.org/270937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0950f581e3f8d800efce53c255781cf6010cecd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27653 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23562 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22024 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/2737 "Found 1 new API test failure: /TestWTF:ThreadMessage.MultipleSenders (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28235 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29073 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26907 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4104 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6454 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->