### PR TITLE
MachSendRight calls to kernel redundantly when creating a send right and destroying moved-from instance

### DIFF
--- a/Source/WTF/wtf/MachSendRight.h
+++ b/Source/WTF/wtf/MachSendRight.h
@@ -38,6 +38,7 @@ class MachSendRight {
 public:
     WTF_EXPORT_PRIVATE static MachSendRight adopt(mach_port_t);
     WTF_EXPORT_PRIVATE static MachSendRight create(mach_port_t);
+    WTF_EXPORT_PRIVATE static MachSendRight createFromReceiveRight(mach_port_t);
 
     MachSendRight() = default;
     WTF_EXPORT_PRIVATE explicit MachSendRight(const MachSendRight&);

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -179,8 +179,7 @@ void Connection::platformOpen()
         m_isConnected = true;
 
         // Send the initialize message, which contains a send right for the server to use.
-        mach_port_insert_right(mach_task_self(), m_receivePort, m_receivePort, MACH_MSG_TYPE_MAKE_SEND);
-        auto serverSendRight = MachSendRight::adopt(m_receivePort);
+        auto serverSendRight = MachSendRight::createFromReceiveRight(m_receivePort);
 
         // Call Client::didClose() when the serverSendRight gets destroyed.
         requestNoSenderNotifications(m_receivePort);
@@ -595,8 +594,7 @@ std::optional<Connection::ConnectionIdentifierPair> Connection::createConnection
         RELEASE_LOG_ERROR(Process, "Connection::createConnectionIdentifierPair: Could not allocate mach port, returned port was invalid");
         return std::nullopt;
     }
-    mach_port_insert_right(mach_task_self(), listeningPort, listeningPort, MACH_MSG_TYPE_MAKE_SEND);
-    return ConnectionIdentifierPair { Identifier { listeningPort, nullptr }, MachSendRight::adopt(listeningPort) };
+    return ConnectionIdentifierPair { Identifier { listeningPort, nullptr }, MachSendRight::createFromReceiveRight(listeningPort) };
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
@@ -103,10 +103,10 @@ std::optional<EventSignalPair> createEventSignalPair()
     }
 
     setMachPortQueueLength(listeningPort, 1);
-    mach_port_insert_right(mach_task_self(), listeningPort, listeningPort, MACH_MSG_TYPE_MAKE_SEND);
+    auto sendRight = MachSendRight::createFromReceiveRight(listeningPort);
     requestNoSenderNotifications(listeningPort);
 
-    return EventSignalPair { Event { listeningPort }, Signal { MachSendRight::adopt(listeningPort) } };
+    return EventSignalPair { Event { listeningPort }, Signal { WTFMove(sendRight) } };
 }
 
 Event::~Event()


### PR DESCRIPTION
#### 749c5825ae30264ca8d772a5f7c48af273b53227
<pre>
MachSendRight calls to kernel redundantly when creating a send right and destroying moved-from instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=264486">https://bugs.webkit.org/show_bug.cgi?id=264486</a>
<a href="https://rdar.apple.com/118177694">rdar://118177694</a>

Reviewed by Matt Woodrow.

Avoid mach_port_get_refs in case the send right is created from a
receive right, as the succeeding MAKE_SEND guarantees the send right
existing.

Avoid mach_port_destroy in case the port is MACH_PORT_NULL, e.g.
mostly when the send right has been moved from.

* Source/WTF/wtf/MachSendRight.h:
* Source/WTF/wtf/cocoa/MachSendRight.cpp:
(WTF::deallocateSendRightSafely):
(WTF::MachSendRight::create):
(WTF::MachSendRight::createFromReceiveRight):
(WTF::MachSendRight::~MachSendRight):
(WTF::MachSendRight::operator=):
(WTF::releaseSendRight): Deleted.
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::platformOpen):
(IPC::Connection::createConnectionIdentifierPair):
* Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp:
(IPC::createEventSignalPair):

Canonical link: <a href="https://commits.webkit.org/270628@main">https://commits.webkit.org/270628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50326fcfd854284b9572501f762c4e0b4fb5a956

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23663 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28380 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29181 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22358 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27042 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24921 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1098 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32362 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4243 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7042 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6239 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->