### PR TITLE
Use SIMD in HasConstantValue() in BiquadDSPKernel

### DIFF
--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
@@ -38,15 +38,51 @@
 
 namespace WebCore {
 
-static bool hasConstantValue(float* values, size_t framesToProcess)
+static bool hasConstantValue(float* values, int framesToProcess)
 {
-    if (framesToProcess <= 1)
-        return true;
+    // Load the initial value
+    const float value = values[0];
+    // This initialization ensures that we correctly handle the first frame and
+    // start the processing from the second frame onwards, effectively excluding
+    // the first frame from the subsequent comparisons in the non-SIMD paths
+    // it guarantees that we don't redundantly compare the first frame again
+    // during the loop execution.
+    int processedFrames = 1;
 
-    float constant = values[0];
-    for (size_t i = 1; i < framesToProcess; ++i) {
-        if (values[i] != constant)
+#if defined(__SSE2__)
+    // Process 4 floats at a time using SIMD.
+    __m128 valueVec = _mm_set1_ps(value);
+    // Start at 0 for byte alignment
+    for (processedFrames = 0; processedFrames < framesToProcess - 3; processedFrames += 4) {
+        // Load 4 floats from memory.
+        __m128 inputVec = _mm_loadu_ps(&values[processedFrames]);
+        // Compare the 4 floats with the value.
+        __m128 cmpVec = _mm_cmpneq_ps(inputVec, valueVec);
+        // Check if any of the floats are not equal to the value.
+        if (_mm_movemask_ps(cmpVec))
             return false;
+    }
+#elif defined(__ARM_NEON__)
+    // Process 4 floats at a time using SIMD.
+    float32x4_t valueVec = vdupq_n_f32(value);
+    // Start at 0 for byte alignment.
+    for (processedFrames = 0; processedFrames < framesToProcess - 3; processedFrames += 4) {
+        // Load 4 floats from memory.
+        float32x4_t inputVec = vld1q_f32(&values[processedFrames]);
+        // Compare the 4 floats with the value.
+        uint32x4_t cmpVec = vceqq_f32(inputVec, valueVec);
+        // Accumulate the elements of the cmpVec vector using bitwise AND.
+        uint32x2_t cmpReduced32 = vand_u32(vget_low_u32(cmpVec), vget_high_u32(cmpVec));
+        // Check if any of the floats are not equal to the value.
+        if (!vget_lane_u32(vpmin_u32(cmpReduced32, cmpReduced32), 0))
+            return false;
+    }
+#endif
+    // Fallback implementation without SIMD optimization.
+    while (processedFrames < framesToProcess) {
+        if (values[processedFrames] != value)
+            return false;
+        ++processedFrames;
     }
     return true;
 }


### PR DESCRIPTION
#### 0a313d9769badee3d73b11060a2a661102c71716
<pre>
Use SIMD in HasConstantValue() in BiquadDSPKernel
<a href="https://bugs.webkit.org/show_bug.cgi?id=264488">https://bugs.webkit.org/show_bug.cgi?id=264488</a>

Reviewed by Jean-Yves Avenard.

Cherry-pick the following optimization from Blink:
<a href="https://chromium-review.googlesource.com/c/chromium/src/+/4605295">https://chromium-review.googlesource.com/c/chromium/src/+/4605295</a>

Original patch by Ho Cheung.

* Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp:
(WebCore::hasConstantValue):

Canonical link: <a href="https://commits.webkit.org/270669@main">https://commits.webkit.org/270669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8826f18088d5bbb0b0e1a4216391838a605db959

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23569 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28244 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29078 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26915 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/984 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4113 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3189 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3349 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->