### PR TITLE
Add test function for WebCore::SincResampler

### DIFF
--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011, 2015 Google Inc. All rights reserved.
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,7 @@
 #include "ProcessWarming.h"
 #include "SWContextManager.h"
 #include "ServiceWorkerGlobalScope.h"
+#include "SincResampler.h"
 #include "WheelEventTestMonitor.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/CallFrame.h>
@@ -285,5 +286,12 @@ void populateDisassemblyLabels()
 #endif // ENABLE(JIT_OPERATION_DISASSEMBLY)
 
 #endif // ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
+
+#if ENABLE(WEB_AUDIO)
+void testSincResamplerProcessBuffer(std::span<const float> source, std::span<float> destination, double scaleFactor)
+{
+    SincResampler::processBuffer(source, destination, scaleFactor);
+}
+#endif // ENABLE(WEB_AUDIO)
 
 } // namespace WebCoreTestSupport

--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <span>
 #include <wtf/Forward.h>
 
 typedef const struct OpaqueJSContext* JSContextRef;
@@ -86,5 +87,9 @@ inline void populateJITOperations() { populateDisassemblyLabels(); }
 #else
 inline void populateJITOperations() { }
 #endif // ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
+
+#if ENABLE(WEB_AUDIO)
+void testSincResamplerProcessBuffer(std::span<const float> source, std::span<float> destination, double scaleFactor) TEST_SUPPORT_EXPORT;
+#endif
 
 } // namespace WebCoreTestSupport


### PR DESCRIPTION
#### 4a4d002cbb038d2909272619f38aa0705e6b2bcf
<pre>
Add test function for WebCore::SincResampler
<a href="https://bugs.webkit.org/show_bug.cgi?id=261702">https://bugs.webkit.org/show_bug.cgi?id=261702</a>
&lt;<a href="https://rdar.apple.com/115682448">rdar://115682448</a>&gt;

Reviewed by Chris Dumez and Alex Christensen.

Add test method that calls SincResampler::processBuffer().

* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::testSincResamplerProcessBuffer): Add.
* Source/WebCore/testing/js/WebCoreTestSupport.h:
(WebCoreTestSupport::testSincResamplerProcessBuffer): Add.

Originally-landed-as: 265870.567@safari-7616-branch (6380262a8580). <a href="https://rdar.apple.com/117819812">rdar://117819812</a>
Canonical link: <a href="https://commits.webkit.org/270470@main">https://commits.webkit.org/270470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10880be023ff7345aaf977f80e628e56691b3c5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23571 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28249 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22988 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29083 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html, imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26922 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/988 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4118 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6140 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->