### PR TITLE
rdar://117803684 ([5d1fa25f3fa41fc3] ASAN_SEGV | WebCore::RenderBox::repaintLayerRectsForImage; WebCore::RenderBox::imageChanged; WebCore::CachedImage::notifyObservers)

### DIFF
--- a/LayoutTests/fast/svg/svg_should_not_crash-expected.txt
+++ b/LayoutTests/fast/svg/svg_should_not_crash-expected.txt
@@ -1,0 +1,3 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+    RenderSVGText {text}

--- a/LayoutTests/fast/svg/svg_should_not_crash.html
+++ b/LayoutTests/fast/svg/svg_should_not_crash.html
@@ -1,0 +1,13 @@
+<script>
+function freememory() {
+}
+function jsfuzzer() {
+  var00016 = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  var00046 = var00016.style;
+  var00046.setProperty("background", "url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7) 450%");
+  var00146 = svgvar00001.getRootNode();
+  var00146.replaceChild(var00016,var00146.childNodes[17%var00146.childNodes.length]);
+}
+</script>
+<body onload=jsfuzzer()>
+<svg id="svgvar00001" clip-rule="evenodd">

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2098,7 +2098,8 @@ bool RenderBox::repaintLayerRectsForImage(WrappedImagePtr image, const FillLayer
                     // (since root backgrounds cover the canvas, not just the element). If the root element
                     // is composited though, we need to issue the repaint to that root element.
                     auto documentElementRenderer = downcast<RenderBox>(document().documentElement()->renderer());
-                    if (documentElementRenderer->layer()->isComposited())
+                    auto rendererLayer = documentElementRenderer->layer();
+                    if (rendererLayer && rendererLayer->isComposited())
                         layerRenderer = documentElementRenderer;
                 } else {
                     layerRenderer = this;


### PR DESCRIPTION
#### 64eea79c096c633675ca43ab3d71227f0ddd4570
<pre>
<a href="https://rdar.apple.com/117803684">rdar://117803684</a> ([5d1fa25f3fa41fc3] ASAN_SEGV | WebCore::RenderBox::repaintLayerRectsForImage; WebCore::RenderBox::imageChanged; WebCore::CachedImage::notifyObservers)

Reviewed by Matt Woodrow.

This checks for a non-unexpected case where an Element has no direct layer to render to.

* LayoutTests/fast/svg/svg_should_not_crash-expected.txt: Added.
* LayoutTests/fast/svg/svg_should_not_crash.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::repaintLayerRectsForImage):

Canonical link: <a href="https://commits.webkit.org/270487@main">https://commits.webkit.org/270487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac664b0e7a80c9586cedc17306fbcee1f3ac5a48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23574 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28252 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29084 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26923 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/987 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22738 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6151 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->