### PR TITLE
[WGSL] Add missing tests for 270436@main

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/constants.wgsl
@@ -1,0 +1,44 @@
+// RUN: %not %wgslc | %check
+
+
+fn testOutOfBounds()
+{
+    {
+        const x = array(0);
+        // CHECK-L: index -1 is out of bounds [0..0]
+        _ = x[-1];
+        // CHECK-NOT-L: index 0 is out of bounds [0..0]
+        _ = x[0];
+        // CHECK-L: index 1 is out of bounds [0..0]
+        _ = x[1];
+    }
+
+    {
+        const x = mat2x2(0, 0, 0, 0);
+        // CHECK-L: index -1 is out of bounds [0..1]
+        _ = x[-1];
+        // CHECK-NOT-L: index 0 is out of bounds [0..1]
+        _ = x[0];
+        // CHECK-NOT-L: index 1 is out of bounds [0..1]
+        _ = x[1];
+        // CHECK-L: index 2 is out of bounds [0..1]
+        _ = x[2];
+    }
+
+    {
+        const x = vec2(0);
+        // CHECK-L: index -1 is out of bounds [0..1]
+        _ = x[-1];
+        // CHECK-NOT-L: index 0 is out of bounds [0..1]
+        _ = x[0];
+        // CHECK-NOT-L: index 1 is out of bounds [0..1]
+        _ = x[1];
+        // CHECK-L: index 2 is out of bounds [0..1]
+        _ = x[2];
+    }
+}
+
+fn main()
+{
+    testOutOfBounds();
+}


### PR DESCRIPTION
#### 43c8caa4265ce99fcc405b617b7338cf00522a9a
<pre>
[WGSL] Add missing tests for 270436@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=264497">https://bugs.webkit.org/show_bug.cgi?id=264497</a>
<a href="https://rdar.apple.com/118180741">rdar://118180741</a>

Reviewed by Mike Wyrzykowski.

For some reason the test wasn&apos;t included in the original commit.

* Source/WebGPU/WGSL/tests/invalid/constants.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/270521@main">https://commits.webkit.org/270521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ac0363a17172778d174bff386fe2c6630ff76e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23432 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23576 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28254 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2762 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29086 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26925 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/990 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4123 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6167 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3076 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->