### PR TITLE
Move DragItem to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/DragImage.h
+++ b/Source/WebCore/platform/DragImage.h
@@ -103,15 +103,20 @@ public:
     WEBCORE_EXPORT DragImage(DragImage&&);
     WEBCORE_EXPORT ~DragImage();
 
+    DragImage(std::optional<TextIndicatorData>&& indicatorData, std::optional<Path>&& visiblePath)
+        : m_indicatorData(WTFMove(indicatorData))
+        , m_visiblePath(WTFMove(visiblePath))
+    { }
+
     WEBCORE_EXPORT DragImage& operator=(DragImage&&);
 
     void setIndicatorData(const TextIndicatorData& data) { m_indicatorData = data; }
     bool hasIndicatorData() const { return !!m_indicatorData; }
-    std::optional<TextIndicatorData> indicatorData() const { return m_indicatorData; }
+    const std::optional<TextIndicatorData>& indicatorData() const { return m_indicatorData; }
 
     void setVisiblePath(const Path& path) { m_visiblePath = path; }
     bool hasVisiblePath() const { return !!m_visiblePath; }
-    std::optional<Path> visiblePath() const { return m_visiblePath; }
+    const std::optional<Path>& visiblePath() const { return m_visiblePath; }
 
     explicit operator bool() const { return !!m_dragImageRef; }
     DragImageRef get() const { return m_dragImageRef; }

--- a/Source/WebCore/platform/DragItem.h
+++ b/Source/WebCore/platform/DragItem.h
@@ -50,75 +50,9 @@ struct DragItem final {
     IntRect dragPreviewFrameInRootViewCoordinates;
     bool containsSelection { false };
 
-    PasteboardWriterData data;
     PromisedAttachmentInfo promisedAttachmentInfo;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, DragItem&);
+    PasteboardWriterData data { };
 };
-
-template<class Encoder>
-void DragItem::encode(Encoder& encoder) const
-{
-    // FIXME(173815): We should encode and decode PasteboardWriterData and platform drag image data
-    // here too, as part of moving off of the legacy dragging codepath.
-    encoder << sourceAction;
-    encoder << imageAnchorPoint << eventPositionInContentCoordinates << dragLocationInContentCoordinates << dragLocationInWindowCoordinates << title << url << dragPreviewFrameInRootViewCoordinates << containsSelection;
-    bool hasIndicatorData = image.hasIndicatorData();
-    encoder << hasIndicatorData;
-    if (hasIndicatorData)
-        encoder << image.indicatorData().value();
-    bool hasVisiblePath = image.hasVisiblePath();
-    encoder << hasVisiblePath;
-    if (hasVisiblePath)
-        encoder << image.visiblePath().value();
-    encoder << promisedAttachmentInfo;
-}
-
-template<class Decoder>
-bool DragItem::decode(Decoder& decoder, DragItem& result)
-{
-    if (!decoder.decode(result.sourceAction))
-        return false;
-    if (!decoder.decode(result.imageAnchorPoint))
-        return false;
-    if (!decoder.decode(result.eventPositionInContentCoordinates))
-        return false;
-    if (!decoder.decode(result.dragLocationInContentCoordinates))
-        return false;
-    if (!decoder.decode(result.dragLocationInWindowCoordinates))
-        return false;
-    if (!decoder.decode(result.title))
-        return false;
-    if (!decoder.decode(result.url))
-        return false;
-    if (!decoder.decode(result.dragPreviewFrameInRootViewCoordinates))
-        return false;
-    if (!decoder.decode(result.containsSelection))
-        return false;
-    bool hasIndicatorData;
-    if (!decoder.decode(hasIndicatorData))
-        return false;
-    if (hasIndicatorData) {
-        std::optional<TextIndicatorData> indicatorData;
-        decoder >> indicatorData;
-        if (!indicatorData)
-            return false;
-        result.image.setIndicatorData(*indicatorData);
-    }
-    bool hasVisiblePath;
-    if (!decoder.decode(hasVisiblePath))
-        return false;
-    if (hasVisiblePath) {
-        std::optional<Path> visiblePath;
-        decoder >> visiblePath;
-        if (!visiblePath)
-            return false;
-        result.image.setVisiblePath(*visiblePath);
-    }
-    if (!decoder.decode(result.promisedAttachmentInfo))
-        return false;
-    return true;
-}
 
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6654,6 +6654,26 @@ class WebCore::ContentSecurityPolicyResponseHeaders {
     int httpStatusCode();
 };
 
+class WebCore::DragImage {
+    std::optional<WebCore::TextIndicatorData> indicatorData();
+    std::optional<WebCore::Path> visiblePath();
+};
+
+struct WebCore::DragItem {
+    WebCore::DragImage image;
+    WebCore::FloatPoint imageAnchorPoint;
+    std::optional<WebCore::DragSourceAction> sourceAction;
+    WebCore::IntPoint eventPositionInContentCoordinates;
+    WebCore::IntPoint dragLocationInContentCoordinates;
+    WebCore::IntPoint dragLocationInWindowCoordinates;
+    String title;
+    URL url;
+    WebCore::IntRect dragPreviewFrameInRootViewCoordinates;
+    bool containsSelection;
+    WebCore::PromisedAttachmentInfo promisedAttachmentInfo;
+    [NotSerialized] WebCore::PasteboardWriterData data;
+};
+
 #if PLATFORM(COCOA)
 struct WebCore::KeypressCommand {
     String commandName;


### PR DESCRIPTION
#### 86bb02460c0c42ba903b593672eaccf980918b88
<pre>
Move DragItem to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264501">https://bugs.webkit.org/show_bug.cgi?id=264501</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/DragImage.h:
* Source/WebCore/platform/DragItem.h:
(WebCore::DragItem::encode const): Deleted.
(WebCore::DragItem::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270472@main">https://commits.webkit.org/270472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27d7b8292cddb3f449837bdb5ac8df2405cd6f54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1628 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28269 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23004 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26940 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1006 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4139 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6139 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3212 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->