### PR TITLE
[scroll-animations] add the ViewTimeline interface

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6836,7 +6836,31 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animation
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/update-playback-rate.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative.html [ Skip ] 
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-1.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-2.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-3.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-4.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-5.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-6.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-large-subject.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-root-source.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes.html [ Skip ]
+
+
+
 
 # webkit.org/b/229520 CSS @scope unimplemented
 imported/w3c/web-platform-tests/css/css-cascade/import-conditional-002.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-events-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timelime generates animationstart and animationend events promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+FAIL View timelime generates animationstart and animationend events assert_equals: scrollstart event received after scrolling into view. expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt
@@ -1,5 +1,3 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: ViewTimeline
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: ViewTimeline
-
+FAIL View timeline generates and resolves finish promises and events promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: waitForCompositorReady"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL View timeline with container having vertical-rl layout promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with container having vertical-rl layout Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt
@@ -1,5 +1,7 @@
 
-FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline does not clamp starting scroll offset at 0 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline  does not clamp end scroll offset at max scroll promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with start and end scroll offsets that do not align with the scroll boundaries Test timed out
+NOTRUN View timeline does not clamp starting scroll offset at 0
+NOTRUN View timeline  does not clamp end scroll offset at max scroll
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL View timeline with subject that is not a direct descendant of the scroll container promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with subject that is not a direct descendant of the scroll container Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Report specified timeline offsets promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL Computed offsets can be outside [0,1] for keyframes with timeline offsets promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL Retain specified ordering of keyframes with timeline offsets promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+FAIL Report specified timeline offsets promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
+FAIL Computed offsets can be outside [0,1] for keyframes with timeline offsets promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
+FAIL Retain specified ordering of keyframes with timeline offsets promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
 FAIL Include unreachable keyframes promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Mix of computed and timeline offsets. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+FAIL Mix of computed and timeline offsets. promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
@@ -1,6 +1,8 @@
 
-FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline does not clamp starting scroll offset at 0 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline does not clamp end scroll offset at max scroll promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline with container having RTL layout promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with start and end scroll offsets that do not align with the scroll boundaries Test timed out
+NOTRUN View timeline does not clamp starting scroll offset at 0
+NOTRUN View timeline does not clamp end scroll offset at max scroll
+NOTRUN View timeline with container having RTL layout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-1-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline top-sticky during entry. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline top-sticky during entry. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-2-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline bottom-sticky during entry and top-sticky during exit. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline bottom-sticky during entry and top-sticky during exit. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-3-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline top-sticky and bottom-sticky during entry. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline top-sticky and bottom-sticky during entry. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-4-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline top-sticky before entry. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline top-sticky before entry. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-5-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline bottom-sticky before entry and top-sticky after exit. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline bottom-sticky before entry and top-sticky after exit. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-6-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline target > viewport, bottom-sticky during entry and top-sticky during exit. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline target > viewport, bottom-sticky during entry and top-sticky during exit. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline target > viewport, bottom-sticky and top-sticky during contain. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline target > viewport, bottom-sticky and top-sticky during contain. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt
@@ -1,13 +1,9 @@
 
-FAIL Timeline offsets in programmatic keyframes promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL String offsets in programmatic keyframes promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL Invalid timeline offset in programmatic keyframe throws assert_throws_js: Invalid keyframes test case "[{"offset":{"rangeName":"somewhere","offset":{}}}]" function "() => {
-        target.animate(keyframes, {
-          timeline: new ViewTimeline( { subject: target }),
-        });
-      }" threw object "ReferenceError: Can't find variable: ViewTimeline" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Timeline offsets in programmatic keyframes adjust for change in timeline promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Timeline offsets in programmatic keyframes resolved when updating the animation effect promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+FAIL Timeline offsets in programmatic keyframes promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
+TIMEOUT String offsets in programmatic keyframes Test timed out
+NOTRUN Invalid timeline offset in programmatic keyframe throws
+NOTRUN Timeline offsets in programmatic keyframes adjust for change in timeline
+NOTRUN Timeline offsets in programmatic keyframes resolved when updating the animation effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Creating a view timeline with a subject that is not attached to the document works as expected promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+FAIL Creating a view timeline with a subject that is not attached to the document works as expected assert_equals: Null source while detached expected (object) null but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-current-time-range-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-current-time-range-name-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline current time for named range promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+FAIL View timeline current time for named range promise_test: Unhandled rejection with value: object "TypeError: timeline.getCurrentTime is not a function. (In 'timeline.getCurrentTime('cover')', 'timeline.getCurrentTime' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Getting and setting the animation range promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Getting and setting the animation range Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
@@ -1,16 +1,11 @@
 
-FAIL View timeline with px based inset. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline with percent based inset. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL view timeline with inset auto. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL view timeline with font relative inset. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL view timeline with viewport relative insets. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL view timeline inset as string promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL view timeline with invalid inset assert_throws_js: function "() => {
-    new ViewTimeline({
-      subject: target,
-      inset: [ CSS.rad(1) ]
-    });
-  }" threw object "ReferenceError: Can't find variable: ViewTimeline" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with px based inset. Test timed out
+NOTRUN View timeline with percent based inset.
+NOTRUN view timeline with inset auto.
+NOTRUN view timeline with font relative inset.
+NOTRUN view timeline with viewport relative insets.
+NOTRUN view timeline inset as string
+NOTRUN view timeline with invalid inset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline with missing subject promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+PASS ViewTimeline with missing subject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-on-display-none-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-on-display-none-element-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL element with display: none should have inactive viewtimeline promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+PASS element with display: none should have inactive viewtimeline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
@@ -1,7 +1,9 @@
 
-FAIL View timeline with range as <name> <percent> pair. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline with range and inferred name or offset. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline with range as <name> <px> pair. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline with range as <name> <percent+px> pair. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline with range as strings. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with range as <name> <percent> pair. Test timed out
+NOTRUN View timeline with range and inferred name or offset.
+NOTRUN View timeline with range as <name> <px> pair.
+NOTRUN View timeline with range as <name> <percent+px> pair.
+NOTRUN View timeline with range as strings.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-large-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-large-subject-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL View timeline with range set via delays. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with range set via delays. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-root-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-root-source-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Test view-timeline with document scrolling element. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Test view-timeline with document scrolling element. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Default ViewTimeline is not affected by scroll-padding promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Default ViewTimeline is not affected by scroll-padding Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Default source for a View timeline is the nearest scroll ancestor to the subject promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline ignores explicitly set source promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
-FAIL View timeline source is null when display:none promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+FAIL Default source for a View timeline is the nearest scroll ancestor to the subject assert_true: No source expected true got false
+FAIL View timeline ignores explicitly set source assert_true: No source expected true got false
+FAIL View timeline source is null when display:none assert_true: No source expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block-expected.txt
@@ -1,4 +1,6 @@
 Subject
 
-FAIL View timeline with sticky target, block axis. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with sticky target, block axis. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL View timeline with sticky target, block axis. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with sticky target, block axis. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL View timeline with subject size change after the creation of the animation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ViewTimeline"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline with subject size change after the creation of the animation Test timed out
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -868,6 +868,8 @@ set(WebCore_NON_SVG_IDL_FILES
     animation/ScrollAxis.idl
     animation/ScrollTimeline.idl
     animation/ScrollTimelineOptions.idl
+    animation/ViewTimeline.idl
+    animation/ViewTimelineOptions.idl
     animation/WebAnimation.idl
 
     crypto/CryptoAlgorithmParameters.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1145,6 +1145,8 @@ $(PROJECT_DIR)/animation/ScrollAxis.idl
 $(PROJECT_DIR)/animation/ScrollTimeline.idl
 $(PROJECT_DIR)/animation/ScrollTimelineOptions.idl
 $(PROJECT_DIR)/animation/TransitionEvent.idl
+$(PROJECT_DIR)/animation/ViewTimeline.idl
+$(PROJECT_DIR)/animation/ViewTimelineOptions.idl
 $(PROJECT_DIR)/animation/WebAnimation.idl
 $(PROJECT_DIR)/bindings/js/JSDOMBindingInternals.js
 $(PROJECT_DIR)/bindings/scripts/CodeGenerator.pm

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2984,6 +2984,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackMediaSource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackMediaSource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTransferCharacteristics.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTransferCharacteristics.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimeline.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimeline.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimelineOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSViewTimelineOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisibilityState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisibilityState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisualViewport.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -884,6 +884,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/animation/ScrollAxis.idl \
     $(WebCore)/animation/ScrollTimeline.idl \
     $(WebCore)/animation/ScrollTimelineOptions.idl \
+    $(WebCore)/animation/ViewTimeline.idl \
+    $(WebCore)/animation/ViewTimelineOptions.idl \
     $(WebCore)/animation/WebAnimation.idl \
     $(WebCore)/crypto/CryptoAlgorithmParameters.idl \
     $(WebCore)/crypto/CryptoKey.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -576,6 +576,7 @@ animation/FrameRateAligner.cpp
 animation/KeyframeEffect.cpp
 animation/KeyframeEffectStack.cpp
 animation/ScrollTimeline.cpp
+animation/ViewTimeline.cpp
 animation/WebAnimation.cpp
 animation/WebAnimationUtilities.cpp
 bindings/js/CachedModuleScriptLoader.cpp
@@ -4406,6 +4407,8 @@ JSVideoTrack.cpp
 JSVideoTrackConfiguration.cpp
 JSVideoTrackList.cpp
 JSVideoTransferCharacteristics.cpp
+JSViewTimeline.cpp
+JSViewTimelineOptions.cpp
 JSVisibilityState.cpp
 JSVisualViewport.cpp
 JSVoidCallback.cpp

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -42,6 +42,7 @@ public:
 
     virtual bool isDocumentTimeline() const { return false; }
     virtual bool isScrollTimeline() const { return false; }
+    virtual bool isViewTimeline() const { return false; }
 
     const AnimationCollection& relevantAnimations() const { return m_animations; }
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ViewTimeline.h"
+
+#include "CSSNumericFactory.h"
+#include "Element.h"
+
+namespace WebCore {
+
+Ref<ViewTimeline> ViewTimeline::create(ViewTimelineOptions&& options)
+{
+    return adoptRef(*new ViewTimeline(WTFMove(options)));
+}
+
+// FIXME: compute offset values from options.
+ViewTimeline::ViewTimeline(ViewTimelineOptions&& options)
+    : m_subject(WTFMove(options.subject))
+    , m_axis(options.axis)
+    , m_startOffset(CSSNumericFactory::px(0))
+    , m_endOffset(CSSNumericFactory::px(0))
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AnimationTimeline.h"
+#include "CSSNumericValue.h"
+#include "ViewTimelineOptions.h"
+#include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Element;
+
+class ViewTimeline final : public AnimationTimeline {
+public:
+    static Ref<ViewTimeline> create(ViewTimelineOptions&& = { });
+
+    Element* subject() const { return m_subject.get(); }
+    ScrollAxis axis() const { return m_axis; }
+    const CSSNumericValue& startOffset() const { return m_startOffset.get(); }
+    const CSSNumericValue& endOffset() const { return m_endOffset.get(); }
+
+private:
+    explicit ViewTimeline(ViewTimelineOptions&& = { });
+
+    bool isViewTimeline() const final { return true; }
+
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;
+    ScrollAxis m_axis;
+    Ref<CSSNumericValue> m_startOffset;
+    Ref<CSSNumericValue> m_endOffset;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_ANIMATION_TIMELINE(ViewTimeline, isViewTimeline())

--- a/Source/WebCore/animation/ViewTimeline.idl
+++ b/Source/WebCore/animation/ViewTimeline.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=ScrollDrivenAnimationsEnabled,
+    Exposed=Window,
+    JSGenerateToJSObject
+] interface ViewTimeline : AnimationTimeline {
+    constructor(optional ViewTimelineOptions options = {});
+    readonly attribute Element subject;
+    readonly attribute CSSNumericValue startOffset;
+    readonly attribute CSSNumericValue endOffset;
+};

--- a/Source/WebCore/animation/ViewTimelineOptions.h
+++ b/Source/WebCore/animation/ViewTimelineOptions.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSKeywordValue.h"
+#include "CSSNumericValue.h"
+#include "Element.h"
+#include "ScrollAxis.h"
+
+namespace WebCore {
+
+struct ViewTimelineOptions {
+    RefPtr<Element> subject;
+    ScrollAxis axis;
+    std::variant<String, Vector<std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>>> inset;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/animation/ViewTimelineOptions.idl
+++ b/Source/WebCore/animation/ViewTimelineOptions.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary ViewTimelineOptions {
+    Element subject;
+    ScrollAxis axis = "block";
+    (DOMString or sequence<(CSSNumericValue or CSSKeywordValue)>) inset = "auto";
+};

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -438,6 +438,7 @@ namespace WebCore {
     macro(VideoDecoder) \
     macro(VideoEncoder) \
     macro(VideoFrame) \
+    macro(ViewTimeline) \
     macro(VisualViewport) \
     macro(WakeLock) \
     macro(WakeLockSentinel) \


### PR DESCRIPTION
#### b848c9c402a36379b0281443afd2388b01c28a5a
<pre>
[scroll-animations] add the ViewTimeline interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=264411">https://bugs.webkit.org/show_bug.cgi?id=264411</a>

Reviewed by Chris Dumez.

The Scroll-driven Animations spec introduces a new ViewTimeline subclass of AnimationTimeline.
We add the IDL and supporting code for this interface as well as the supporting ViewTimelineOptions
dictionary, both behind the appropriate runtime flag.

We&apos;re skipping some additional tests because merely exposing the ViewTimeline interface makes some
tests progress further and turn early failures into timeouts for unfulfilled promises.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-3-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-4-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-5-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-6-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-current-time-range-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-missing-subject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-on-display-none-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-large-subject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-root-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::isViewTimeline const):
* Source/WebCore/animation/ViewTimeline.cpp: Copied from Source/WebCore/animation/AnimationTimeline.h.
(WebCore::ViewTimeline::create):
(WebCore::ViewTimeline::ViewTimeline):
* Source/WebCore/animation/ViewTimeline.h: Copied from Source/WebCore/animation/AnimationTimeline.h.
* Source/WebCore/animation/ViewTimeline.idl: Added.
* Source/WebCore/animation/ViewTimelineOptions.h: Copied from Source/WebCore/animation/AnimationTimeline.h.
* Source/WebCore/animation/ViewTimelineOptions.idl: Added.
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/270508@main">https://commits.webkit.org/270508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd513fb6898f3fc96d6df640e1c4e17442c5da91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27685 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23444 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23585 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28267 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29096 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26958 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1002 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3210 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3283 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->