### PR TITLE
Add the ability for the IPCTestingAPI to report when a sync message fails to be received correctly

### DIFF
--- a/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception-expected.txt
+++ b/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Sending sync message with incorrect parameters must throw error
+

--- a/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception.html
+++ b/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception.html
@@ -1,0 +1,19 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that sending invalid sync messages via the IPC testing API throws the correct errors</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+const defaultTimeout = 1000;
+
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+    
+    assert_throws_js(TypeError,
+        () => { IPC.sendSyncMessage("UI", 0, IPC.messages.IPCTester_SyncPingEmptyReply.name, defaultTimeout, []); },
+        `failed sync message must throw error`);
+}, "Sending sync message with incorrect parameters must throw error");
+
+</script>
+</body>

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1109,6 +1109,8 @@ void Connection::dispatchSyncMessage(Decoder& decoder)
 
 #if ENABLE(IPC_TESTING_API)
     ASSERT(decoder.isValid() || m_ignoreInvalidMessageForTesting);
+    if (!decoder.isValid())
+        replyEncoder->setSyncMessageDeserializationFailure();
 #else
     ASSERT(decoder.isValid());
 #endif

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -123,6 +123,13 @@ bool Decoder::shouldMaintainOrderingWithAsyncMessages() const
     return m_messageFlags.contains(MessageFlags::MaintainOrderingWithAsyncMessages);
 }
 
+#if ENABLE(IPC_TESTING_API)
+bool Decoder::hasSyncMessageDeserializationFailure() const
+{
+    return m_messageFlags.contains(MessageFlags::SyncMessageDeserializationFailure);
+}
+#endif
+
 #if PLATFORM(MAC)
 void Decoder::setImportanceAssertion(ImportanceAssertion&& assertion)
 {

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -92,6 +92,9 @@ public:
     ShouldDispatchWhenWaitingForSyncReply shouldDispatchMessageWhenWaitingForSyncReply() const;
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || m_isAllowedWhenWaitingForSyncReplyOverride; }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
+#if ENABLE(IPC_TESTING_API)
+    bool hasSyncMessageDeserializationFailure() const;
+#endif
     bool shouldUseFullySynchronousModeForTesting() const;
     bool shouldMaintainOrderingWithAsyncMessages() const;
     void setIsAllowedWhenWaitingForSyncReplyOverride(bool value) { m_isAllowedWhenWaitingForSyncReplyOverride = value; }

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -114,6 +114,13 @@ void Encoder::setFullySynchronousModeForTesting()
     messageFlags().add(MessageFlags::UseFullySynchronousModeForTesting);
 }
 
+#if ENABLE(IPC_TESTING_API)
+void Encoder::setSyncMessageDeserializationFailure()
+{
+    messageFlags().add(MessageFlags::SyncMessageDeserializationFailure);
+}
+#endif
+
 void Encoder::setShouldMaintainOrderingWithAsyncMessages()
 {
     messageFlags().add(MessageFlags::MaintainOrderingWithAsyncMessages);

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -65,6 +65,9 @@ public:
     void setShouldMaintainOrderingWithAsyncMessages();
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || isFullySynchronousModeForTesting(); }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
+#if ENABLE(IPC_TESTING_API)
+    void setSyncMessageDeserializationFailure();
+#endif
 
     void wrapForTesting(UniqueRef<Encoder>&&);
 

--- a/Source/WebKit/Platform/IPC/MessageFlags.h
+++ b/Source/WebKit/Platform/IPC/MessageFlags.h
@@ -32,6 +32,9 @@ enum class MessageFlags : uint8_t {
     DispatchMessageWhenWaitingForUnboundedSyncReply = 1 << 1,
     UseFullySynchronousModeForTesting = 1 << 2,
     MaintainOrderingWithAsyncMessages = 1 << 3,
+#if ENABLE(IPC_TESTING_API)
+    SyncMessageDeserializationFailure = 1 << 4,
+#endif
 };
 
 enum class ShouldDispatchWhenWaitingForSyncReply : uint8_t {
@@ -46,11 +49,14 @@ namespace WTF {
 
 template<> struct EnumTraits<IPC::MessageFlags> {
     using values = EnumValues<
-        IPC::MessageFlags,
-        IPC::MessageFlags::DispatchMessageWhenWaitingForSyncReply,
-        IPC::MessageFlags::DispatchMessageWhenWaitingForUnboundedSyncReply,
-        IPC::MessageFlags::UseFullySynchronousModeForTesting,
-        IPC::MessageFlags::MaintainOrderingWithAsyncMessages
+        IPC::MessageFlags
+        , IPC::MessageFlags::DispatchMessageWhenWaitingForSyncReply
+        , IPC::MessageFlags::DispatchMessageWhenWaitingForUnboundedSyncReply
+        , IPC::MessageFlags::UseFullySynchronousModeForTesting
+        , IPC::MessageFlags::MaintainOrderingWithAsyncMessages
+#if ENABLE(IPC_TESTING_API)
+        , IPC::MessageFlags::SyncMessageDeserializationFailure
+#endif
     >;
 };
 

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -213,6 +213,12 @@ void IPCTester::syncPing(IPC::Connection&, uint32_t value, CompletionHandler<voi
     completionHandler(value + 1);
 }
 
+void IPCTester::syncPingEmptyReply(IPC::Connection&, uint32_t value, CompletionHandler<void()>&& completionHandler)
+{
+    UNUSED_PARAM(value);
+    completionHandler();
+}
+
 void IPCTester::stopIfNeeded()
 {
     if (m_testQueue) {

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -73,6 +73,7 @@ private:
     void sendAsyncMessageToReceiver(IPC::Connection&, uint32_t);
     void asyncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
+    void syncPingEmptyReply(IPC::Connection&, uint32_t value, CompletionHandler<void()>&&);
 
     void stopIfNeeded();
 

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -37,6 +37,8 @@ messages -> IPCTester NotRefCounted {
     AsyncPing(uint32_t value) -> (uint32_t nextValue)
     SyncPing(uint32_t value) -> (uint32_t nextValue) Synchronous
 
+    SyncPingEmptyReply(uint32_t value) -> () Synchronous
+
     SendAsyncMessageToReceiver(uint32_t arg0)
 }
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2344,6 +2344,11 @@ static JSC::JSObject* jsResultFromReplyDecoder(JSC::JSGlobalObject* globalObject
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    if (decoder.hasSyncMessageDeserializationFailure()) {
+        throwException(globalObject, scope, JSC::createTypeError(globalObject, "Failed to successfully deserialize the message"_s));
+        return nullptr;
+    }
+
     auto arrayBuffer = JSC::ArrayBuffer::create(decoder.buffer());
     JSC::JSArrayBuffer* jsArrayBuffer = nullptr;
     if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))


### PR DESCRIPTION
#### e36c14395c0e952c75c21a9347377024e071a1b8
<pre>
Add the ability for the IPCTestingAPI to report when a sync message fails to be received correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=264506">https://bugs.webkit.org/show_bug.cgi?id=264506</a>
<a href="https://rdar.apple.com/118188347">rdar://118188347</a>

Reviewed by Alex Christensen.

Add the ability for the IPCTestingAPI to report when a sync message
fails to be received correctly. The existing behaviour is that both
failed messages and empty replies return an empty IPC object. This change
records the decoder validity on failure into the MessageSyncReply so the
IPCTestingAPI can raise an exception instead.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchSyncMessage):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::hasMessageTestingError const):
* Source/WebKit/Platform/IPC/Decoder.h:
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::setMessageTestingError):
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/MessageFlags.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::jsResultFromReplyDecoder):

Canonical link: <a href="https://commits.webkit.org/270705@main">https://commits.webkit.org/270705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a072f83886181b6f5160e9f230b24ca2c69a977

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28272 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23964 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2207 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28847 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23489 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27429 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23237 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6293 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->