### PR TITLE
Reduce padding in MacroAssembler::Jump on ARM64

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -264,7 +264,7 @@ public:
 
     // (HS, LO, HI, LS) -> (AE, B, A, BE)
     // (VS, VC) -> (O, NO)
-    typedef enum {
+    typedef enum : uint8_t {
         ConditionEQ,
         ConditionNE,
         ConditionHS, ConditionCS = ConditionHS,
@@ -313,7 +313,7 @@ public:
 
 #define JUMP_ENUM_WITH_SIZE(index, value) (((value) << 4) | (index))
 #define JUMP_ENUM_SIZE(jump) ((jump) >> 4)
-    enum JumpType { JumpFixed = JUMP_ENUM_WITH_SIZE(0, 0),
+    enum JumpType : uint8_t { JumpFixed = JUMP_ENUM_WITH_SIZE(0, 0),
         JumpNoCondition = JUMP_ENUM_WITH_SIZE(1, 1 * sizeof(uint32_t)),
         JumpCondition = JUMP_ENUM_WITH_SIZE(2, 2 * sizeof(uint32_t)),
         JumpCompareAndBranch = JUMP_ENUM_WITH_SIZE(3, 2 * sizeof(uint32_t)),

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -632,9 +632,9 @@ public:
 
         Jump(AssemblerLabel jmp, ARM64Assembler::JumpType type, ARM64Assembler::Condition condition, unsigned bitNumber, ARM64Assembler::RegisterID compareRegister)
             : m_label(jmp)
+            , m_bitNumber(bitNumber)
             , m_type(type)
             , m_condition(condition)
-            , m_bitNumber(bitNumber)
             , m_compareRegister(compareRegister)
         {
             ASSERT((type == ARM64Assembler::JumpTestBit) || (type == ARM64Assembler::JumpTestBitFixedSize));
@@ -703,10 +703,10 @@ public:
         ARMv7Assembler::JumpType m_type { ARMv7Assembler::JumpNoCondition };
         ARMv7Assembler::Condition m_condition { ARMv7Assembler::ConditionInvalid };
 #elif CPU(ARM64)
+        unsigned m_bitNumber { 0 };
         ARM64Assembler::JumpType m_type { ARM64Assembler::JumpNoCondition };
         ARM64Assembler::Condition m_condition { ARM64Assembler::ConditionInvalid };
         bool m_is64Bit { false };
-        unsigned m_bitNumber { 0 };
         ARM64Assembler::RegisterID m_compareRegister { ARM64Registers::InvalidGPRReg };
 #endif
     };


### PR DESCRIPTION
#### c9f96b41388b940fad2d3d7e49140f4539cc8f17
<pre>
Reduce padding in MacroAssembler::Jump on ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=264513">https://bugs.webkit.org/show_bug.cgi?id=264513</a>
<a href="https://rdar.apple.com/118195458">rdar://118195458</a>

Reviewed by Mark Lam.

Rearranges the ARM64-specific fields of MacroAssembler::Jump, and
uses uint8_t as the storage type for ARM64Assembler::Condition and
ARM64Assembler::JumpType, overall bringing the size of Jump from
32 to 16 bytes.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::Jump::Jump):

Canonical link: <a href="https://commits.webkit.org/270716@main">https://commits.webkit.org/270716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89f1a2c365b7e316d7670024b664c71463205c34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23465 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28292 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29115 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22283 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26960 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24835 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1024 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32275 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4158 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6300 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->