### PR TITLE
Port GPUProcessPreferences to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -345,6 +345,7 @@ set(WebKit_MESSAGES_IN_FILES
 
 set(WebKit_SERIALIZATION_IN_FILES
     GPUProcess/GPUProcessCreationParameters.serialization.in
+    GPUProcess/GPUProcessPreferences.serialization.in
     GPUProcess/GPUProcessSessionParameters.serialization.in
 
     GPUProcess/graphics/PathSegment.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -34,6 +34,7 @@ $(PROJECT_DIR)/DerivedSources.make
 $(PROJECT_DIR)/GPUProcess/GPUConnectionToWebProcess.messages.in
 $(PROJECT_DIR)/GPUProcess/GPUProcess.messages.in
 $(PROJECT_DIR)/GPUProcess/GPUProcessCreationParameters.serialization.in
+$(PROJECT_DIR)/GPUProcess/GPUProcessPreferences.serialization.in
 $(PROJECT_DIR)/GPUProcess/GPUProcessSessionParameters.serialization.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -504,6 +504,7 @@ $(WEB_PREFERENCES_PATTERNS) : $(WTF_BUILD_SCRIPTS_DIR)/GeneratePreferences.rb $(
 
 SERIALIZATION_DESCRIPTION_FILES = \
 	GPUProcess/GPUProcessCreationParameters.serialization.in \
+	GPUProcess/GPUProcessPreferences.serialization.in \
 	GPUProcess/GPUProcessSessionParameters.serialization.in \
 	GPUProcess/graphics/PathSegment.serialization.in \
 	GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in \

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
@@ -28,21 +28,9 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "ArgumentCoders.h"
 #include "WebPreferences.h"
 
-#if PLATFORM(COCOA)
-#include "ArgumentCodersCF.h"
-#endif
-
 namespace WebKit {
-
-GPUProcessPreferences::GPUProcessPreferences() = default;
-
-GPUProcessPreferences::GPUProcessPreferences(const WebPreferences& webPreferences)
-{
-    copyEnabledWebPreferences(webPreferences);
-}
 
 void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webPreferences)
 {
@@ -80,86 +68,6 @@ void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webP
     if (webPreferences.alternateWebMPlayerEnabled())
         alternateWebMPlayerEnabled = true;
 #endif
-}
-
-void GPUProcessPreferences::encode(IPC::Encoder& encoder) const
-{
-#if ENABLE(OPUS)
-    encoder << opusDecoderEnabled;
-#endif
-    
-#if ENABLE(VORBIS)
-    encoder << vorbisDecoderEnabled;
-#endif
-    
-#if ENABLE(WEBM_FORMAT_READER)
-    encoder << webMFormatReaderEnabled;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && ENABLE(VP9)
-    encoder << webMParserEnabled;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)
-    encoder << mediaSourceInlinePaintingEnabled;
-#endif
-    
-#if HAVE(AVCONTENTKEYSPECIFIER)
-    encoder << sampleBufferContentKeySessionSupportEnabled;
-#endif
-    
-#if ENABLE(ALTERNATE_WEBM_PLAYER)
-    encoder << alternateWebMPlayerEnabled;
-#endif
-    
-#if ENABLE(SC_CONTENT_SHARING_PICKER)
-    encoder << useSCContentSharingPicker;
-#endif
-}
-
-bool GPUProcessPreferences::decode(IPC::Decoder& decoder, GPUProcessPreferences& result)
-{
-#if ENABLE(OPUS)
-    if (!decoder.decode(result.opusDecoderEnabled))
-        return false;
-#endif
-    
-#if ENABLE(VORBIS)
-    if (!decoder.decode(result.vorbisDecoderEnabled))
-        return false;
-#endif
-    
-#if ENABLE(WEBM_FORMAT_READER)
-    if (!decoder.decode(result.webMFormatReaderEnabled))
-        return false;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && ENABLE(VP9)
-    if (!decoder.decode(result.webMParserEnabled))
-        return false;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)
-    if (!decoder.decode(result.mediaSourceInlinePaintingEnabled))
-        return false;
-#endif
-    
-#if HAVE(AVCONTENTKEYSPECIFIER)
-    if (!decoder.decode(result.sampleBufferContentKeySessionSupportEnabled))
-        return false;
-#endif
-    
-#if ENABLE(ALTERNATE_WEBM_PLAYER)
-    if (!decoder.decode(result.alternateWebMPlayerEnabled))
-        return false;
-#endif
-    
-#if ENABLE(SC_CONTENT_SHARING_PICKER)
-    if (!decoder.decode(result.useSCContentSharingPicker))
-        return false;
-#endif
-
-    return true;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.h
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.h
@@ -29,18 +29,11 @@
 
 #include <optional>
 
-namespace IPC {
-class Decoder;
-class Encoder;
-}
-
 namespace WebKit {
 
 class WebPreferences;
 
 struct GPUProcessPreferences {
-    GPUProcessPreferences();
-    GPUProcessPreferences(const WebPreferences&);
     void copyEnabledWebPreferences(const WebPreferences&);
     
 #if ENABLE(OPUS)
@@ -74,9 +67,6 @@ struct GPUProcessPreferences {
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     std::optional<bool> useSCContentSharingPicker;
 #endif
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, GPUProcessPreferences&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+struct WebKit::GPUProcessPreferences {
+#if ENABLE(OPUS)
+    std::optional<bool> opusDecoderEnabled;
+#endif
+#if ENABLE(VORBIS)
+    std::optional<bool> vorbisDecoderEnabled;
+#endif
+#if ENABLE(WEBM_FORMAT_READER)
+    std::optional<bool> webMFormatReaderEnabled;
+#endif
+#if ENABLE(MEDIA_SOURCE) && ENABLE(VP9)
+    std::optional<bool> webMParserEnabled;
+#endif
+#if ENABLE(MEDIA_SOURCE) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)
+    std::optional<bool> mediaSourceInlinePaintingEnabled;
+#endif
+#if HAVE(AVCONTENTKEYSPECIFIER)
+    std::optional<bool> sampleBufferContentKeySessionSupportEnabled;
+#endif
+#if ENABLE(ALTERNATE_WEBM_PLAYER)
+    std::optional<bool> alternateWebMPlayerEnabled;
+#endif
+#if HAVE(SC_CONTENT_SHARING_PICKER)
+    std::optional<bool> useSCContentSharingPicker;
+#endif
+};
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4950,6 +4950,7 @@
 		46EE284C269E051700DD48AB /* NetworkBroadcastChannelRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkBroadcastChannelRegistry.h; sourceTree = "<group>"; };
 		46EE3E8A2763FD2A0060C70F /* WebSharedWorkerServerConnection.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebSharedWorkerServerConnection.messages.in; sourceTree = "<group>"; };
 		46F38E8B2416E66D0059375A /* RunningBoardServicesSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RunningBoardServicesSPI.h; sourceTree = "<group>"; };
+		46F5DD862AFD7DF100F3B26F /* GPUProcessPreferences.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUProcessPreferences.serialization.in; sourceTree = "<group>"; };
 		46F9B26223526ED0006FE5FA /* WebBackForwardCacheEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackForwardCacheEntry.h; sourceTree = "<group>"; };
 		46FA2E752A04240300912BFE /* RemoteWorkerType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWorkerType.serialization.in; sourceTree = "<group>"; };
 		493102BC2683F3A5002BB885 /* AppPrivacyReport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppPrivacyReport.h; sourceTree = "<group>"; };
@@ -9888,6 +9889,7 @@
 				FAC59A3D2AF9A6BB00FA7AB6 /* GPUProcessCreationParameters.serialization.in */,
 				5ABF2BEC2862353F000DCE74 /* GPUProcessPreferences.cpp */,
 				5ABF2BED2862353F000DCE74 /* GPUProcessPreferences.h */,
+				46F5DD862AFD7DF100F3B26F /* GPUProcessPreferences.serialization.in */,
 				4150A5A023E06C910051264A /* GPUProcessSessionParameters.h */,
 				5C046A17290B268500FF7820 /* GPUProcessSessionParameters.serialization.in */,
 			);


### PR DESCRIPTION
#### 2cda2e6a7d5c0c5c5db938cec00d63ec999726ab
<pre>
Port GPUProcessPreferences to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264514">https://bugs.webkit.org/show_bug.cgi?id=264514</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUProcessPreferences.cpp:
(WebKit::GPUProcessPreferences::encode const): Deleted.
(WebKit::GPUProcessPreferences::decode): Deleted.
* Source/WebKit/GPUProcess/GPUProcessPreferences.h:
* Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270491@main">https://commits.webkit.org/270491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2295e049632fa65bca97fe7fad3dbb58e2ca1ffe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23468 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1655 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28295 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2776 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26968 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1027 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3234 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3270 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->