### PR TITLE
Save style sheet resources with same URL in different files

### DIFF
--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -53,7 +53,7 @@ String CSSFontFaceRule::cssText() const
     return cssTextInternal(m_fontFaceRule->properties().asText());
 }
 
-String CSSFontFaceRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings) const
+String CSSFontFaceRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>&) const
 {
     auto mutableStyleProperties = m_fontFaceRule->properties().mutableCopy();
     mutableStyleProperties->setReplacementURLForSubresources(replacementURLStrings);

--- a/Source/WebCore/css/CSSFontFaceRule.h
+++ b/Source/WebCore/css/CSSFontFaceRule.h
@@ -42,7 +42,7 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFace; }
     String cssText() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>&) const final;
+    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     String cssTextInternal(const String& declarations) const;
     void reattach(StyleRuleBase&) final;
 

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -147,7 +147,7 @@ void CSSGroupingRule::appendCSSTextForItems(StringBuilder& builder) const
 void CSSGroupingRule::cssTextForDeclsAndRules(StringBuilder&, StringBuilder& rules) const
 {
     auto& childRules = m_groupRule->childRules();
-    for (unsigned index = 0 ; index < childRules.size() ; index++) {
+    for (unsigned index = 0; index < childRules.size(); index++) {
         auto wrappedRule = item(index);
         rules.append("\n  ", wrappedRule->cssText());
     }

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -51,8 +51,11 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Import; }
     String cssText() const final;
+    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     void reattach(StyleRuleBase&) final;
+    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
 
+    String cssTextInternal(const String& urlString) const;
     const MQ::MediaQueryList& mediaQueries() const;
     void setMediaQueries(MQ::MediaQueryList&&);
 

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -43,7 +43,7 @@ public:
 
     virtual StyleRuleType styleRuleType() const = 0;
     virtual String cssText() const = 0;
-    virtual String cssTextWithReplacementURLs(const HashMap<String, String>&) const { return cssText(); }
+    virtual String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const { return cssText(); }
     virtual void reattach(StyleRuleBase&) = 0;
 
     void setParentStyleSheet(CSSStyleSheet*);
@@ -52,6 +52,7 @@ public:
     CSSRule* parentRule() const { return m_parentIsRule ? m_parentRule : nullptr; }
     bool hasStyleRuleAncestor() const;
     virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
+    virtual void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) { }
 
     WEBCORE_EXPORT ExceptionOr<void> setCssText(const String&);
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -158,11 +158,11 @@ String CSSStyleRule::cssText() const
 
 void CSSStyleRule::cssTextForRules(StringBuilder& rules) const
 {
-    for (unsigned index = 0 ; index < nestedRules().size() ; index++)
+    for (unsigned index = 0; index < length(); index++)
         rules.append("\n  ", item(index)->cssText());
 }
 
-String CSSStyleRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings) const
+String CSSStyleRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
 {
     StringBuilder declarations;
     StringBuilder rules;
@@ -173,15 +173,15 @@ String CSSStyleRule::cssTextWithReplacementURLs(const HashMap<String, String>& r
     mutableStyleProperties->clearReplacementURLForSubresources();
 
     declarations.append(declarationsString);
-    cssTextForRulesWithReplacementURLs(rules, replacementURLStrings);
+    cssTextForRulesWithReplacementURLs(rules, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
 
     return cssTextInternal(declarations, rules);
 }
 
-void CSSStyleRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>& replacementURLStrings) const
+void CSSStyleRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
 {
-    for (unsigned index = 0 ; index < nestedRules().size() ; index++)
-        rules.append("\n  ", item(index)->cssTextWithReplacementURLs(replacementURLStrings));
+    for (unsigned index = 0; index < length(); index++)
+        rules.append("\n  ", item(index)->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
 }
 
 String CSSStyleRule::cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const
@@ -311,6 +311,12 @@ CSSRuleList& CSSStyleRule::cssRules() const
         m_ruleListCSSOMWrapper = makeUniqueWithoutRefCountedCheck<LiveCSSRuleList<CSSStyleRule>>(const_cast<CSSStyleRule&>(*this));
 
     return *m_ruleListCSSOMWrapper;
+}
+
+void CSSStyleRule::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+{
+    for (unsigned index = 0; index < length(); ++index)
+        item(index)->getChildStyleSheets(childStyleSheets);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -63,14 +63,15 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Style; }
     String cssText() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>&) const final;
+    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
     void reattach(StyleRuleBase&) final;
+    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
 
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;
     void cssTextForRules(StringBuilder& rules) const;
-    void cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>& replacementURLStrings) const;
+    void cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
 
     Ref<StyleRule> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -479,7 +479,7 @@ String CSSStyleSheet::debugDescription() const
     return makeString("CSSStyleSheet "_s, "0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase), ' ', href());
 }
 
-String CSSStyleSheet::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings)
+String CSSStyleSheet::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet)
 {
     auto ruleList = cssRules();
     if (!ruleList)
@@ -491,7 +491,7 @@ String CSSStyleSheet::cssTextWithReplacementURLs(const HashMap<String, String>& 
         if (!rule)
             continue;
 
-        auto ruleText = rule->cssTextWithReplacementURLs(replacementURLStrings);
+        auto ruleText = rule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet);
         if (!result.isEmpty() && !ruleText.isEmpty())
             result.append(" ");
 
@@ -548,6 +548,18 @@ void CSSStyleSheet::removeAdoptingTreeScope(ContainerNode& treeScope)
 Ref<StyleSheetContents> CSSStyleSheet::protectedContents()
 {
     return m_contents;
+}
+
+void CSSStyleSheet::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+{
+    RefPtr ruleList = cssRules();
+    if (!ruleList)
+        return;
+
+    for (unsigned index = 0; index < ruleList->length(); ++index) {
+        if (RefPtr rule = ruleList->item(index))
+            rule->getChildStyleSheets(childStyleSheets);
+    }
 }
 
 CSSStyleSheet::RuleMutationScope::RuleMutationScope(CSSStyleSheet* sheet, RuleMutationType mutationType, StyleRuleKeyframes* insertedKeyframesRule)

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -160,7 +160,8 @@ public:
     bool canAccessRules() const;
 
     String debugDescription() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings);
+    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&);
+    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&);
 
 private:
     CSSStyleSheet(Ref<StyleSheetContents>&&, CSSImportRule* ownerRule);

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSStyleSheet.h"
 #include "Element.h"
 #include "markup.h"
 #include <wtf/HashMap.h>
@@ -65,7 +66,7 @@ constexpr auto EntityMaskInHTMLAttributeValue = { EntityMask::Amp, EntityMask::Q
 class MarkupAccumulator {
     WTF_MAKE_NONCOPYABLE(MarkupAccumulator);
 public:
-    MarkupAccumulator(Vector<Ref<Node>>*, ResolveURLs, SerializationSyntax, HashMap<String, String>&& replacementURLStrings = { }, ShouldIncludeShadowDOM = ShouldIncludeShadowDOM::No);
+    MarkupAccumulator(Vector<Ref<Node>>*, ResolveURLs, SerializationSyntax, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, ShouldIncludeShadowDOM = ShouldIncludeShadowDOM::No);
     virtual ~MarkupAccumulator();
 
     String serializeNodes(Node& targetNode, SerializedNodes, Vector<QualifiedName>* tagNamesToSkip = nullptr);
@@ -118,6 +119,7 @@ private:
     const SerializationSyntax m_serializationSyntax;
     unsigned m_prefixLevel { 0 };
     HashMap<String, String> m_replacementURLStrings;
+    HashMap<RefPtr<CSSStyleSheet>, String> m_replacementURLStringsForCSSStyleSheet;
     bool m_shouldIncludeShadowDOM { false };
 };
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1182,11 +1182,11 @@ Ref<DocumentFragment> createFragmentFromMarkup(Document& document, const String&
     return fragment;
 }
 
-String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, Vector<QualifiedName>* tagNamesToSkip, std::optional<SerializationSyntax> serializationSyntax, HashMap<String, String>&& replacementURLStrings, ShouldIncludeShadowDOM shouldIncludeShadowDOM)
+String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, Vector<QualifiedName>* tagNamesToSkip, std::optional<SerializationSyntax> serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, ShouldIncludeShadowDOM shouldIncludeShadowDOM)
 {
     if (!serializationSyntax)
         serializationSyntax = node.document().isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML;
-    MarkupAccumulator accumulator(nodes, resolveURLs, *serializationSyntax, WTFMove(replacementURLStrings), shouldIncludeShadowDOM);
+    MarkupAccumulator accumulator(nodes, resolveURLs, *serializationSyntax, WTFMove(replacementURLStrings), WTFMove(replacementURLStringsForCSSStyleSheet), shouldIncludeShadowDOM);
     return accumulator.serializeNodes(const_cast<Node&>(node), root, tagNamesToSkip);
 }
 

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSStyleSheet.h"
 #include "Element.h"
 #include "ExceptionOr.h"
 #include "FloatSize.h"
@@ -99,7 +100,7 @@ String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs 
 enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren };
 enum class SerializationSyntax : uint8_t { HTML, XML };
 enum class ShouldIncludeShadowDOM : bool { No, Yes };
-WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, Vector<QualifiedName>* tagNamesToSkip = nullptr, std::optional<SerializationSyntax> = std::nullopt, HashMap<String, String>&& replacementURLStrings = { }, ShouldIncludeShadowDOM = ShouldIncludeShadowDOM::No);
+WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, Vector<QualifiedName>* tagNamesToSkip = nullptr, std::optional<SerializationSyntax> = std::nullopt, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, ShouldIncludeShadowDOM = ShouldIncludeShadowDOM::No);
 
 String urlToMarkup(const URL&, const String& title);
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -704,12 +704,4 @@ RequestPriority HTMLLinkElement::fetchPriorityHint() const
     return RequestPriority::Auto;
 }
 
-String HTMLLinkElement::styleSheetContentWithReplacementURLs(const HashMap<String, String>& replacementURLStrings) const
-{
-    if (!m_sheet)
-        return { };
-
-    return m_sheet->cssTextWithReplacementURLs(replacementURLStrings);
-}
-
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -96,7 +96,6 @@ public:
     void setFetchPriorityForBindings(const AtomString&);
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriorityHint() const;
-    String styleSheetContentWithReplacementURLs(const HashMap<String, String>&) const;
 
 private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -177,14 +177,4 @@ void HTMLStyleElement::setDisabled(bool setDisabled)
         styleSheet->setDisabled(setDisabled);
 }
 
-String HTMLStyleElement::textContentWithReplacementURLs(const HashMap<String, String>& replacementURLStrings) const
-{
-    RefPtr styleSheet = sheet();
-    if (!styleSheet)
-        return TextNodeTraversal::contentsAsString(*this);
-
-    auto result = styleSheet->cssTextWithReplacementURLs(replacementURLStrings);
-    return result.isNull() ? TextNodeTraversal::contentsAsString(*this) : result;
-}
-
 }

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -43,7 +43,6 @@ public:
     virtual ~HTMLStyleElement();
 
     CSSStyleSheet* sheet() const { return m_styleSheetOwner.sheet(); }
-    String textContentWithReplacementURLs(const HashMap<String, String>&) const;
 
     WEBCORE_EXPORT bool disabled() const;
     WEBCORE_EXPORT void setDisabled(bool);

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "LegacyWebArchive.h"
 
+#include "CSSImportRule.h"
 #include "CachedResource.h"
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
@@ -42,7 +43,6 @@
 #include "HTMLFrameElement.h"
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLIFrameElement.h"
-#include "HTMLLinkElement.h"
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
 #include "Image.h"
@@ -54,6 +54,8 @@
 #include "SerializedAttachmentData.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
+#include "StyleSheet.h"
+#include "StyleSheetList.h"
 #include "markup.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/RetainPtr.h>
@@ -460,7 +462,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(Node& node, Function<bool(Loca
     }
 
     Vector<Ref<Node>> nodeList;
-    String markupString = serializeFragment(node, SerializedNodes::SubtreeIncludingNode, &nodeList, ResolveURLs::No, tagNamesToFilter.get(), std::nullopt, { }, ShouldIncludeShadowDOM::Yes);
+    String markupString = serializeFragment(node, SerializedNodes::SubtreeIncludingNode, &nodeList, ResolveURLs::No, tagNamesToFilter.get(), std::nullopt, { }, { }, ShouldIncludeShadowDOM::Yes);
     auto nodeType = node.nodeType();
     if (nodeType != Node::DOCUMENT_NODE && nodeType != Node::DOCUMENT_TYPE_NODE)
         markupString = documentTypeString(node.document()) + markupString;
@@ -538,6 +540,81 @@ static void addSubresourcesForAttachmentElementsIfNecessary(LocalFrame& frame, c
 }
 
 #endif
+
+static HashMap<RefPtr<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIfNecessary(LocalFrame& frame, const String& subresourcesDirectoryName, HashSet<String>& uniqueFileNames, HashMap<String, String>& uniqueSubresources, Vector<Ref<ArchiveResource>>& subresources)
+{
+    if (subresourcesDirectoryName.isEmpty())
+        return { };
+
+    RefPtr document = frame.protectedDocument();
+    if (!document)
+        return { };
+
+    HashMap<RefPtr<CSSStyleSheet>, String> uniqueCSSStyleSheets;
+    HashMap<RefPtr<CSSStyleSheet>, String> relativeUniqueCSSStyleSheets;
+    Ref documentStyleSheets = document->styleSheets();
+    for (unsigned index = 0; index < documentStyleSheets->length(); ++index) {
+        RefPtr styleSheet = documentStyleSheets->item(index);
+        if (!is<CSSStyleSheet>(styleSheet))
+            continue;
+
+        auto& cssStyleSheet = downcast<CSSStyleSheet>(*styleSheet);
+        if (uniqueCSSStyleSheets.contains(&cssStyleSheet))
+            continue;
+
+        HashSet<RefPtr<CSSStyleSheet>> cssStyleSheets;
+        cssStyleSheets.add(&cssStyleSheet);
+        cssStyleSheet.getChildStyleSheets(cssStyleSheets);
+        for (auto& currentCSSStyleSheet : cssStyleSheets) {
+            bool isExternalStyleSheet = !currentCSSStyleSheet->href().isEmpty() || currentCSSStyleSheet->ownerRule();
+            if (!isExternalStyleSheet)
+                continue;
+
+            auto url = currentCSSStyleSheet->baseURL();
+            if (url.isNull() || url.isEmpty())
+                continue;
+
+            auto addResult = uniqueCSSStyleSheets.add(currentCSSStyleSheet, emptyString());
+            if (!addResult.isNewEntry)
+                continue;
+
+            // Delete cached resource for this style sheet.
+            auto index = subresources.findIf([&](auto& subresource) {
+                return subresource->url() == url;
+            });
+            if (index != notFound) {
+                auto fileName = FileSystem::lastComponentOfPathIgnoringTrailingSlash(subresources[index]->relativeFilePath());
+                uniqueFileNames.remove(fileName);
+                uniqueSubresources.remove(url.string());
+                subresources.remove(index);
+            }
+
+            String subresourceFileName = generateValidFileName(url, uniqueFileNames);
+            uniqueFileNames.add(subresourceFileName);
+            String subresourceFilePath = FileSystem::pathByAppendingComponent(subresourcesDirectoryName, subresourceFileName);
+            addResult.iterator->value = frame.isMainFrame() ? subresourceFilePath : subresourceFileName;
+            relativeUniqueCSSStyleSheets.add(currentCSSStyleSheet, subresourceFileName);
+        }
+    }
+
+    auto frameName = frame.tree().uniqueName();
+    HashMap<String, String> relativeUniqueSubresources;
+    for (auto& [urlString, path] : uniqueSubresources) {
+        // The style sheet files are stored in the same directory as other subresources.
+        relativeUniqueSubresources.add(urlString, FileSystem::lastComponentOfPathIgnoringTrailingSlash(path));
+    }
+
+    for (auto& [cssStyleSheet, path]  : uniqueCSSStyleSheets) {
+        auto contentString = cssStyleSheet->cssTextWithReplacementURLs(relativeUniqueSubresources, relativeUniqueCSSStyleSheets);
+        if (contentString.isEmpty())
+            continue;
+
+        if (auto newResource = ArchiveResource::create(utf8Buffer(contentString), URL { cssStyleSheet->href() }, "text/css"_s, "UTF-8"_s, frameName, ResourceResponse(), path))
+            subresources.append(newResource.releaseNonNull());
+    }
+
+    return uniqueCSSStyleSheets;
+}
 
 RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, LocalFrame& frame, Vector<Ref<Node>>&& nodes, Function<bool(LocalFrame&)>&& frameFilter, const String& mainFrameFilePath)
 {
@@ -617,36 +694,10 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
 
                 subresources.append(resource.releaseNonNull());
             }
-
-            if (!subresourcesDirectoryName.isNull() && is<HTMLLinkElement>(node)) {
-                auto& element = downcast<HTMLLinkElement>(node.get());
-                if (!element.sheet())
-                    continue;
-                auto index = subresources.findIf([&](auto& resource) {
-                    return resource->url() == element.href();
-                });
-                if (index == notFound)
-                    continue;
-
-                HashMap<String, String> uniqueSubresourcesInElement;
-                for (auto [urlString, path] : uniqueSubresources) {
-                    if (subresourceURLs.contains(URL { urlString })) {
-                        // The linked file is placed in subresource directory as other subresource files.
-                        uniqueSubresourcesInElement.add(urlString, FileSystem::lastComponentOfPathIgnoringTrailingSlash(path));
-                    }
-                }
-
-                auto contentString = element.styleSheetContentWithReplacementURLs(uniqueSubresourcesInElement);
-                if (contentString.isEmpty())
-                    continue;
-
-                if (auto newResource = ArchiveResource::create(utf8Buffer(contentString), subresources[index]->url(), subresources[index]->mimeType(), subresources[index]->textEncoding(), subresources[index]->frameName(), ResourceResponse(), subresources[index]->relativeFilePath())) {
-                    subresources.remove(index);
-                    subresources.append(newResource.releaseNonNull());
-                }
-            }
         }
     }
+
+    auto uniqueCSSStyleSheets = addSubresourcesForCSSStyleSheetsIfNecessary(frame, subresourcesDirectoryName, uniqueFileNames, uniqueSubresources, subresources);
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     addSubresourcesForAttachmentElementsIfNecessary(frame, nodes, subresources);
@@ -675,7 +726,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
             extension = makeString(".", extension);
         auto mainFrameFilePathWithExtension = mainFrameFilePath.endsWith(extension) ? mainFrameFilePath : makeString(mainFrameFilePath, extension);
         auto filePathWithExtension = frame.isMainFrame() ? mainFrameFilePathWithExtension : makeString(subresourcesDirectoryName, "/frame_"_s, frame.frameID().toString(), extension);
-        String updatedMarkupString = serializeFragment(*document, SerializedNodes::SubtreeIncludingNode, nullptr, ResolveURLs::No, nullptr, std::nullopt, WTFMove(uniqueSubresources), ShouldIncludeShadowDOM::Yes);
+        String updatedMarkupString = serializeFragment(*document, SerializedNodes::SubtreeIncludingNode, nullptr, ResolveURLs::No, nullptr, std::nullopt, WTFMove(uniqueSubresources), WTFMove(uniqueCSSStyleSheets), ShouldIncludeShadowDOM::Yes);
         mainResource = ArchiveResource::create(utf8Buffer(updatedMarkupString), responseURL, response.mimeType(), "UTF-8"_s, frame.tree().uniqueName(), ResourceResponse(), filePathWithExtension);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
@@ -1249,14 +1249,16 @@ static const char* htmlDataBytesForLink = R"TESTRESOURCE(
 <head>
 <link href="style.css" rel="stylesheet">
 </head>
-<div id="div">Hello</div>
+<div><p id="console">Hello</p></div>
 <script>
 img = null;
 function onImageLoad() {
     img = null;
     window.webkit.messageHandlers.testHandler.postMessage("done");
 }
-div = document.getElementById("div");
+document.styleSheets[0].insertRule("p { color: fuchsia; }");
+console = document.getElementById("console");
+computedStyle = getComputedStyle(console);
 var img = document.createElement("img");
 img.src = "files/image.png";
 img.onload = onImageLoad;
@@ -1329,6 +1331,182 @@ TEST(WebArchive, SaveResourcesLink)
         NSString *styleResourceFilePath = [resourceDirectoryPath stringByAppendingPathComponent:@"style.css"];
         NSString *savedStyleResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:styleResourceFilePath] encoding:NSUTF8StringEncoding];
         EXPECT_TRUE([savedStyleResource containsString:@"url(\"image.png\")"]);
+        EXPECT_TRUE([savedStyleResource containsString:@"color: fuchsia"]);
+
+        saved = true;
+    }];
+    Util::run(&saved);
+}
+
+static const char* htmlDataBytesForLinksWithSameURL = R"TESTRESOURCE(
+<head>
+<link href="style.css" rel="stylesheet">
+<link href="style.css" rel="stylesheet">
+</head>
+<div>Hello</div>
+<p id="console">World</p>
+<script>
+document.styleSheets[0].deleteRule(0);
+document.styleSheets[0].insertRule("p { color: gray; }");
+console = document.getElementById("console");
+computedStyle = getComputedStyle(console);
+window.webkit.messageHandlers.testHandler.postMessage("done");
+</script>
+)TESTRESOURCE";
+static const char* cssDataBytesForLinksWithSameURL = R"TESTRESOURCE(
+div {
+    color: blue;
+}
+)TESTRESOURCE";
+
+TEST(WebArchive, SaveResourcesLinksWithSameURL)
+{
+    RetainPtr<NSURL> directoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"SaveResourcesTest"] isDirectory:YES];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtURL:directoryURL.get() error:nil];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
+    NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForLinksWithSameURL length:strlen(htmlDataBytesForLinksWithSameURL)];
+    NSData *cssData = [NSData dataWithBytes:cssDataBytesForLinksWithSameURL length:strlen(cssDataBytesForLinksWithSameURL)];
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSData *data = nil;
+        NSString *mimeType = nil;
+        if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
+            mimeType = @"text/html";
+            data = htmlData;
+        } else if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/style.css"]) {
+            mimeType = @"text/css";
+            data = cssData;
+        }
+
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:data];
+        [task didFinish];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    static bool messageReceived = false;
+    [webView performAfterReceivingMessage:@"done" action:[&] {
+        messageReceived = true;
+    }];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"webarchivetest://host/main.html"]]];
+    Util::run(&messageReceived);
+
+    static bool saved = false;
+    [webView _saveResources:directoryURL.get() suggestedFileName:@"host" completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
+        NSString *mainResourcePath = [directoryURL URLByAppendingPathComponent:@"host.html"].path;
+        EXPECT_TRUE([fileManager fileExistsAtPath:mainResourcePath]);
+        NSString *savedMainResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
+
+        NSString *resourceDirectoryName = @"host_files";
+        NSString *resourceDirectoryPath =[directoryURL URLByAppendingPathComponent:resourceDirectoryName].path;
+        NSArray *resourceFileNames = [fileManager contentsOfDirectoryAtPath:resourceDirectoryPath error:nil];
+        EXPECT_EQ(2llu, resourceFileNames.count);
+
+        NSMutableSet *styleResourceContentsToFind = [NSMutableSet set];
+        [styleResourceContentsToFind addObjectsFromArray:[NSArray arrayWithObjects:@"color: blue", @"color: fuchsia", nil]];
+        for (NSString *fileName in resourceFileNames) {
+            NSString *replacementPath = [resourceDirectoryName stringByAppendingPathComponent:fileName];
+            EXPECT_TRUE([savedMainResource containsString:replacementPath]);
+            NSString *resourceFilePath = [resourceDirectoryPath stringByAppendingPathComponent:fileName];
+            NSString* savedStyleResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
+            NSRange range = [savedStyleResource rangeOfString:@"color: "];
+            EXPECT_NE(NSNotFound, (long)range.location);
+            NSString *styleResourceContent = [savedStyleResource substringWithRange:NSMakeRange(range.location, range.length + 4)];
+            [styleResourceContentsToFind removeObject:styleResourceContent];
+        }
+
+        saved = true;
+    }];
+    Util::run(&saved);
+}
+
+static const char* htmlDataBytesForCSSImportRule = R"TESTRESOURCE(
+<head>
+<style>
+@import url("style.css");
+</style>
+</head>
+<div><p id="console">Hello</p></div>
+<script>
+img = null;
+function onImageLoad() {
+    img = null;
+    window.webkit.messageHandlers.testHandler.postMessage("done");
+}
+document.styleSheets[0].cssRules[0].styleSheet.insertRule("p { color: fuchsia; }");
+console = document.getElementById("console");
+computedStyle = getComputedStyle(console);
+var img = document.createElement("img");
+img.src = "files/image.png";
+img.onload = onImageLoad;
+</script>
+)TESTRESOURCE";
+
+TEST(WebArchive, SaveResourcesCSSImportRule)
+{
+    RetainPtr<NSURL> directoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"SaveResourcesTest"] isDirectory:YES];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtURL:directoryURL.get() error:nil];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
+    NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCSSImportRule length:strlen(htmlDataBytesForCSSImportRule)];
+    NSData *cssData = [NSData dataWithBytes:cssDataBytesForLink length:strlen(cssDataBytesForLink)];
+    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSData *data = nil;
+        NSString *mimeType = nil;
+        if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
+            mimeType = @"text/html";
+            data = htmlData;
+        } else if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/files/image.png"]) {
+            mimeType = @"image/png";
+            data = imageData;
+        } else if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/style.css"]) {
+            mimeType = @"text/css";
+            data = cssData;
+        }
+
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:data];
+        [task didFinish];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    static bool messageReceived = false;
+    [webView performAfterReceivingMessage:@"done" action:[&] {
+        messageReceived = true;
+    }];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"webarchivetest://host/main.html"]]];
+    Util::run(&messageReceived);
+
+    static bool saved = false;
+    [webView _saveResources:directoryURL.get() suggestedFileName:@"host" completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
+        NSString *mainResourcePath = [directoryURL URLByAppendingPathComponent:@"host.html"].path;
+        EXPECT_TRUE([fileManager fileExistsAtPath:mainResourcePath]);
+        NSString *savedMainResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
+
+        NSString *resourceDirectoryName = @"host_files";
+        NSString *resourceDirectoryPath =[directoryURL URLByAppendingPathComponent:resourceDirectoryName].path;
+        NSArray *resourceFileNames = [fileManager contentsOfDirectoryAtPath:resourceDirectoryPath error:nil];
+        NSSet *savedFileNames = [NSSet setWithArray:resourceFileNames];
+        NSSet *expectedFileNames = [NSSet setWithArray:[NSArray arrayWithObjects:@"image.png", @"style.css", nil]];
+        EXPECT_TRUE([savedFileNames isEqualToSet:expectedFileNames]);
+
+        NSString *styleResourceFileName = [resourceDirectoryName stringByAppendingPathComponent:@"style.css"];
+        EXPECT_TRUE([savedMainResource containsString:styleResourceFileName]);
+        NSString *styleResourceFilePath = [resourceDirectoryPath stringByAppendingPathComponent:@"style.css"];
+        NSString *savedStyleResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:styleResourceFilePath] encoding:NSUTF8StringEncoding];
+        EXPECT_TRUE([savedStyleResource containsString:@"url(\"image.png\")"]);
+        EXPECT_TRUE([savedStyleResource containsString:@"color: fuchsia"]);
 
         saved = true;
     }];


### PR DESCRIPTION
#### 04a136a53bf6b2e2dc118536618fd00b41fc65f3
<pre>
Save style sheet resources with same URL in different files
<a href="https://bugs.webkit.org/show_bug.cgi?id=264520">https://bugs.webkit.org/show_bug.cgi?id=264520</a>
<a href="https://rdar.apple.com/118199671">rdar://118199671</a>

Reviewed by Ryosuke Niwa.

In current implementation, if two link elements have the same url, we only create one file for storing the resource.
However, two link elements corresponds to two CSSStyleSheet objects, which can be modified independently by script. To
ensure the changes from script are captured, now we store content of CSSStyleSheet object in its own file.

API tests: WebArchive.SaveResourcesLink
           WebArchive.SaveResourcesLinksWithSameURL
           WebArchive.SaveResourcesCSSImportRule

* Source/WebCore/css/CSSFontFaceRule.cpp:
(WebCore::CSSFontFaceRule::cssTextWithReplacementURLs const):
* Source/WebCore/css/CSSFontFaceRule.h:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::cssTextInternal const):
(WebCore::CSSImportRule::cssText const):
(WebCore::CSSImportRule::cssTextWithReplacementURLs const):
(WebCore::CSSImportRule::getChildStyleSheets):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::cssTextWithReplacementURLs const):
(WebCore::CSSRule::getChildStyleSheets):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::cssTextForRules const):
(WebCore::CSSStyleRule::cssTextWithReplacementURLs const):
(WebCore::CSSStyleRule::cssTextForRulesWithReplacementURLs const):
(WebCore::CSSStyleRule::getChildStyleSheets):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::cssTextWithReplacementURLs):
(WebCore::CSSStyleSheet::getChildStyleSheets):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::MarkupAccumulator):
(WebCore::MarkupAccumulator::appendContentsForNode):
(WebCore::MarkupAccumulator::resolveURLIfNeeded const):
* Source/WebCore/editing/MarkupAccumulator.h:
(WebCore::MarkupAccumulator::MarkupAccumulator):
* Source/WebCore/editing/markup.cpp:
(WebCore::serializeFragment):
* Source/WebCore/editing/markup.h:
(WebCore::serializeFragment):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::styleSheetContentWithReplacementURLs const): Deleted.
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::textContentWithReplacementURLs const): Deleted.
* Source/WebCore/html/HTMLStyleElement.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
(WebCore::addSubresourcesForCSSStyleSheetsIfNecessary):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/270562@main">https://commits.webkit.org/270562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ee91beb6f9a04bc9f0a1c6bc4e9faf00432d590

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25757 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1800 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28437 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23154 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4301 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6199 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->