### PR TITLE
Port RemoteScrollingUIState to the new IPC serialization format

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -249,6 +249,7 @@ $(PROJECT_DIR)/Shared/RTCNetwork.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/BufferAndBackendInfo.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+$(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteScrollingUIState.serialization.in
 $(PROJECT_DIR)/Shared/RemoteWorkerInitializationData.serialization.in
 $(PROJECT_DIR)/Shared/RemoteWorkerType.serialization.in
 $(PROJECT_DIR)/Shared/ResourceLoadInfo.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -626,6 +626,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/RemoteLayerTree/RemoteLayerTree.serialization.in \
 	Shared/RemoteLayerTree/BufferAndBackendInfo.serialization.in \
 	Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in \
+	Shared/RemoteLayerTree/RemoteScrollingUIState.serialization.in \
 	Shared/cf/CFTypes.serialization.in \
 	Shared/cf/CoreIPCBoolean.serialization.in \
 	Shared/cf/CoreIPCNumber.serialization.in \

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -84,13 +84,6 @@ enum class WebKit::SwapBuffersDisplayRequirement : uint8_t {
     NeedsNoDisplay
 };
 
-header: "RemoteScrollingUIState.h"
-[OptionSet] enum class WebKit::RemoteScrollingUIStateChanges : uint8_t {
-    ScrollSnapNodes
-    UserScrollNodes
-    RubberbandingNodes
-};
-
 [LegacyPopulateFromEmptyConstructor] class WebKit::RemoteLayerTreeTransaction {
 {
     WebCore::PlatformLayerIdentifier m_rootLayerID;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.cpp
@@ -32,43 +32,12 @@
 
 namespace WebKit {
 
-void RemoteScrollingUIState::encode(IPC::Encoder& encoder) const
+RemoteScrollingUIState::RemoteScrollingUIState(OptionSet<RemoteScrollingUIStateChanges> changes, HashSet<WebCore::ScrollingNodeID>&& nodesWithActiveScrollSnap, HashSet<WebCore::ScrollingNodeID>&& nodesWithActiveUserScrolls, HashSet<WebCore::ScrollingNodeID>&& nodesWithActiveRubberband)
+    : m_changes(changes)
+    , m_nodesWithActiveScrollSnap(WTFMove(nodesWithActiveScrollSnap))
+    , m_nodesWithActiveUserScrolls(WTFMove(nodesWithActiveUserScrolls))
+    , m_nodesWithActiveRubberband(WTFMove(nodesWithActiveRubberband))
 {
-    encoder << m_changes;
-
-    if (m_changes.contains(Changes::ScrollSnapNodes))
-        encoder << m_nodesWithActiveScrollSnap;
-
-    if (m_changes.contains(Changes::UserScrollNodes))
-        encoder << m_nodesWithActiveUserScrolls;
-
-    if (m_changes.contains(Changes::RubberbandingNodes))
-        encoder << m_nodesWithActiveRubberband;
-}
-
-std::optional<RemoteScrollingUIState> RemoteScrollingUIState::decode(IPC::Decoder& decoder)
-{
-    RemoteScrollingUIState uiState;
-
-    if (!decoder.decode(uiState.m_changes))
-        return std::nullopt;
-
-    if (uiState.m_changes.contains(Changes::ScrollSnapNodes)) {
-        if (!decoder.decode(uiState.m_nodesWithActiveScrollSnap))
-            return std::nullopt;
-    }
-
-    if (uiState.m_changes.contains(Changes::UserScrollNodes)) {
-        if (!decoder.decode(uiState.m_nodesWithActiveUserScrolls))
-            return std::nullopt;
-    }
-
-    if (uiState.m_changes.contains(Changes::RubberbandingNodes)) {
-        if (!decoder.decode(uiState.m_nodesWithActiveRubberband))
-            return std::nullopt;
-    }
-
-    return uiState;
 }
 
 void RemoteScrollingUIState::reset()

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
@@ -50,8 +50,8 @@ class RemoteScrollingUIState {
 public:
     using Changes = RemoteScrollingUIStateChanges;
 
-    void encode(IPC::Encoder&) const;
-    static std::optional<RemoteScrollingUIState> decode(IPC::Decoder&);
+    RemoteScrollingUIState() = default;
+    RemoteScrollingUIState(OptionSet<RemoteScrollingUIStateChanges>, HashSet<WebCore::ScrollingNodeID>&& nodesWithActiveScrollSnap, HashSet<WebCore::ScrollingNodeID>&& nodesWithActiveUserScrolls, HashSet<WebCore::ScrollingNodeID>&& nodesWithActiveRubberband);
 
     OptionSet<RemoteScrollingUIStateChanges> changes() const { return m_changes; }
     void clearChanges() { m_changes = { }; }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.serialization.in
@@ -1,0 +1,35 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class WebKit::RemoteScrollingUIState {
+    [OptionalTupleBits] OptionSet<WebKit::RemoteScrollingUIStateChanges> changes();
+    [OptionalTupleBit=WebKit::RemoteScrollingUIStateChanges::ScrollSnapNodes] HashSet<WebCore::ScrollingNodeID> nodesWithActiveScrollSnap();
+    [OptionalTupleBit=WebKit::RemoteScrollingUIStateChanges::UserScrollNodes] HashSet<WebCore::ScrollingNodeID> nodesWithActiveUserScrolls();
+    [OptionalTupleBit=WebKit::RemoteScrollingUIStateChanges::RubberbandingNodes] HashSet<WebCore::ScrollingNodeID> nodesWithActiveRubberband();
+};
+
+header: "RemoteScrollingUIState.h"
+[OptionSet] enum class WebKit::RemoteScrollingUIStateChanges : uint8_t {
+    ScrollSnapNodes
+    UserScrollNodes
+    RubberbandingNodes
+};

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4876,6 +4876,7 @@
 		460B87352AFD9F8200200D8C /* ScrollingAccelerationCurve.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScrollingAccelerationCurve.serialization.in; sourceTree = "<group>"; };
 		460F488D1F996F6C00CF4B87 /* WebSWContextManagerConnectionMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWContextManagerConnectionMessageReceiver.cpp; sourceTree = "<group>"; };
 		460F488E1F996F6C00CF4B87 /* WebSWContextManagerConnectionMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSWContextManagerConnectionMessages.h; sourceTree = "<group>"; };
+		4616C9A62AFD954100A37024 /* RemoteScrollingUIState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteScrollingUIState.serialization.in; sourceTree = "<group>"; };
 		461E1BEC279A010E006AF53B /* WebSharedWorkerContextManagerConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSharedWorkerContextManagerConnection.cpp; sourceTree = "<group>"; };
 		461E1BEF279A010F006AF53B /* WebSharedWorkerContextManagerConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSharedWorkerContextManagerConnection.h; sourceTree = "<group>"; };
 		461E1BF0279A010F006AF53B /* WebSharedWorkerContextManagerConnection.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebSharedWorkerContextManagerConnection.messages.in; sourceTree = "<group>"; };
@@ -9629,6 +9630,7 @@
 				FAC3C3BA2A93E561001E2EB8 /* RemoteScrollingCoordinatorTransaction.serialization.in */,
 				0FCD094E24C79F5B000C6D39 /* RemoteScrollingUIState.cpp */,
 				0FCD094F24C79F5B000C6D39 /* RemoteScrollingUIState.h */,
+				4616C9A62AFD954100A37024 /* RemoteScrollingUIState.serialization.in */,
 				0F65956727DB1D5800EE874B /* SwapBuffersDisplayRequirement.h */,
 				2D12DAB420662C73006F00FB /* WKAnimationDelegate.h */,
 			);


### PR DESCRIPTION
#### 94a4dd856588b80b2f7ca42d2d9facb62b67fa9d
<pre>
Port RemoteScrollingUIState to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264523">https://bugs.webkit.org/show_bug.cgi?id=264523</a>

Reviewed by Alex Christensen.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.cpp:
(WebKit::RemoteScrollingUIState::RemoteScrollingUIState):
(WebKit::emptyNodesHashSet):
(WebKit::RemoteScrollingUIState::nodesWithActiveScrollSnapIfChanged const):
(WebKit::RemoteScrollingUIState::nodesWithActiveUserScrollsIfChanged const):
(WebKit::RemoteScrollingUIState::nodesWithActiveRubberbandIfChanged const):
(WebKit::RemoteScrollingUIState::encode const): Deleted.
(WebKit::RemoteScrollingUIState::decode): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270506@main">https://commits.webkit.org/270506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61dbeecb91fe05d863271ed54e05f12281de1ec0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23518 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28358 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27018 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1077 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3291 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3281 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->