### PR TITLE
Port ScrollingAccelerationCurve to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -411,6 +411,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/ResourceLoadInfo.serialization.in
     Shared/ResourceLoadStatisticsParameters.serialization.in
     Shared/SameDocumentNavigationType.serialization.in
+    Shared/ScrollingAccelerationCurve.serialization.in
     Shared/SessionState.serialization.in
     Shared/ShareableBitmap.serialization.in
     Shared/ShareableResource.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -253,6 +253,7 @@ $(PROJECT_DIR)/Shared/RemoteWorkerType.serialization.in
 $(PROJECT_DIR)/Shared/ResourceLoadInfo.serialization.in
 $(PROJECT_DIR)/Shared/ResourceLoadStatisticsParameters.serialization.in
 $(PROJECT_DIR)/Shared/SameDocumentNavigationType.serialization.in
+$(PROJECT_DIR)/Shared/ScrollingAccelerationCurve.serialization.in
 $(PROJECT_DIR)/Shared/SessionState.serialization.in
 $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in
 $(PROJECT_DIR)/Shared/ShareableResource.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -593,6 +593,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/ResourceLoadInfo.serialization.in \
 	Shared/ResourceLoadStatisticsParameters.serialization.in \
 	Shared/SameDocumentNavigationType.serialization.in \
+	Shared/ScrollingAccelerationCurve.serialization.in \
 	Shared/SessionState.serialization.in \
 	Shared/ShareableBitmap.serialization.in \
 	Shared/ShareableResource.serialization.in \

--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.cpp
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.cpp
@@ -116,52 +116,6 @@ float ScrollingAccelerationCurve::accelerationFactor(float value)
     return multiplier * cursorScale;
 }
 
-void ScrollingAccelerationCurve::encode(IPC::Encoder& encoder) const
-{
-    encoder << m_parameters.gainLinear;
-    encoder << m_parameters.gainParabolic;
-    encoder << m_parameters.gainCubic;
-    encoder << m_parameters.gainQuartic;
-
-    encoder << m_parameters.tangentSpeedLinear;
-    encoder << m_parameters.tangentSpeedParabolicRoot;
-
-    encoder << m_parameters.resolution;
-    encoder << m_parameters.frameRate;
-}
-
-std::optional<ScrollingAccelerationCurve> ScrollingAccelerationCurve::decode(IPC::Decoder& decoder)
-{
-    float gainLinear;
-    if (!decoder.decode(gainLinear))
-        return std::nullopt;
-    float gainParabolic;
-    if (!decoder.decode(gainParabolic))
-        return std::nullopt;
-    float gainCubic;
-    if (!decoder.decode(gainCubic))
-        return std::nullopt;
-    float gainQuartic;
-    if (!decoder.decode(gainQuartic))
-        return std::nullopt;
-
-    float tangentSpeedLinear;
-    if (!decoder.decode(tangentSpeedLinear))
-        return std::nullopt;
-    float tangentSpeedParabolicRoot;
-    if (!decoder.decode(tangentSpeedParabolicRoot))
-        return std::nullopt;
-
-    float resolution;
-    if (!decoder.decode(resolution))
-        return std::nullopt;
-    float frameRate;
-    if (!decoder.decode(frameRate))
-        return std::nullopt;
-
-    return { { gainLinear, gainParabolic, gainCubic, gainQuartic, tangentSpeedLinear, tangentSpeedParabolicRoot, resolution, frameRate } };
-}
-
 TextStream& operator<<(TextStream& ts, const ScrollingAccelerationCurve& curve)
 {
     TextStream::GroupScope group(ts);

--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.h
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.h
@@ -47,11 +47,16 @@ public:
 
     static ScrollingAccelerationCurve interpolate(const ScrollingAccelerationCurve& from, const ScrollingAccelerationCurve& to, float amount);
 
-    float accelerationFactor(float);
+    float gainLinear() const { return m_parameters.gainLinear; }
+    float gainParabolic() const { return m_parameters.gainParabolic; }
+    float gainCubic() const { return m_parameters.gainCubic; }
+    float gainQuartic() const { return m_parameters.gainQuartic; }
+    float tangentSpeedLinear() const { return m_parameters.tangentSpeedLinear; };
+    float tangentSpeedParabolicRoot() const { return m_parameters.tangentSpeedParabolicRoot; };
+    float resolution() const { return m_parameters.resolution; }
     float frameRate() const { return m_parameters.frameRate; }
 
-    void encode(IPC::Encoder&) const;
-    static std::optional<ScrollingAccelerationCurve> decode(IPC::Decoder&);
+    float accelerationFactor(float);
 
     friend bool operator==(const ScrollingAccelerationCurve& a, const ScrollingAccelerationCurve& b)
     {

--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.serialization.in
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.serialization.in
@@ -1,0 +1,36 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+
+class WebKit::ScrollingAccelerationCurve {
+    float gainLinear();
+    float gainParabolic();
+    float gainCubic();
+    float gainQuartic();
+    float tangentSpeedLinear();
+    float tangentSpeedParabolicRoot();
+    float resolution();
+    float frameRate();
+};
+
+#endif // ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4872,6 +4872,7 @@
 		4603011A234BE31D009C8217 /* WebBackForwardCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebBackForwardCache.cpp; sourceTree = "<group>"; };
 		4603011B234BE31E009C8217 /* WebBackForwardCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackForwardCache.h; sourceTree = "<group>"; };
 		460889FF261FA8A900E2500D /* RemoteRenderingBackendCreationParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRenderingBackendCreationParameters.h; sourceTree = "<group>"; };
+		460B87352AFD9F8200200D8C /* ScrollingAccelerationCurve.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScrollingAccelerationCurve.serialization.in; sourceTree = "<group>"; };
 		460F488D1F996F6C00CF4B87 /* WebSWContextManagerConnectionMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWContextManagerConnectionMessageReceiver.cpp; sourceTree = "<group>"; };
 		460F488E1F996F6C00CF4B87 /* WebSWContextManagerConnectionMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSWContextManagerConnectionMessages.h; sourceTree = "<group>"; };
 		461E1BEC279A010E006AF53B /* WebSharedWorkerContextManagerConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSharedWorkerContextManagerConnection.cpp; sourceTree = "<group>"; };
@@ -8391,6 +8392,7 @@
 				E1E552C316AE065E004ED653 /* SandboxInitializationParameters.h */,
 				2D65D196274B8E84009C4101 /* ScrollingAccelerationCurve.cpp */,
 				2D65D195274B8E84009C4101 /* ScrollingAccelerationCurve.h */,
+				460B87352AFD9F8200200D8C /* ScrollingAccelerationCurve.serialization.in */,
 				5C96003F28C02EAF00F2693B /* SerializedTypeInfo.h */,
 				1AFDE6571954A42B00C48FFA /* SessionState.cpp */,
 				1AFDE6581954A42B00C48FFA /* SessionState.h */,


### PR DESCRIPTION
#### 976ca2f077d0aef11a2d9ee26563f93bd7be1514
<pre>
Port ScrollingAccelerationCurve to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264526">https://bugs.webkit.org/show_bug.cgi?id=264526</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/ScrollingAccelerationCurve.cpp:
(WebKit::ScrollingAccelerationCurve::encode const): Deleted.
(WebKit::ScrollingAccelerationCurve::decode): Deleted.
* Source/WebKit/Shared/ScrollingAccelerationCurve.h:
(WebKit::ScrollingAccelerationCurve::gainLinear const):
(WebKit::ScrollingAccelerationCurve::gainParabolic const):
(WebKit::ScrollingAccelerationCurve::gainCubic const):
(WebKit::ScrollingAccelerationCurve::gainQuartic const):
(WebKit::ScrollingAccelerationCurve::tangentSpeedLinear const):
(WebKit::ScrollingAccelerationCurve::tangentSpeedParabolicRoot const):
(WebKit::ScrollingAccelerationCurve::resolution const):
* Source/WebKit/Shared/ScrollingAccelerationCurve.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270499@main">https://commits.webkit.org/270499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6be18c88d66e8a32b7b914fcdae2d875eaeacd1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23485 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28319 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1047 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3253 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3277 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->