### PR TITLE
Sync 'identifier' in Touch.idl with Web Specification

### DIFF
--- a/Source/WebCore/dom/Touch.cpp
+++ b/Source/WebCore/dom/Touch.cpp
@@ -63,7 +63,7 @@ static LayoutPoint scaledLocation(LocalFrame* frame, int pageX, int pageY)
     return { pageX * scaleFactor, pageY * scaleFactor };
 }
 
-Touch::Touch(LocalFrame* frame, EventTarget* target, unsigned identifier, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force)
+Touch::Touch(LocalFrame* frame, EventTarget* target, int identifier, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force)
     : m_target(target)
     , m_identifier(identifier)
     , m_clientX(pageX - contentsX(frame))
@@ -80,7 +80,7 @@ Touch::Touch(LocalFrame* frame, EventTarget* target, unsigned identifier, int sc
 {
 }
 
-Touch::Touch(EventTarget* target, unsigned identifier, int clientX, int clientY, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force, LayoutPoint absoluteLocation)
+Touch::Touch(EventTarget* target, int identifier, int clientX, int clientY, int screenX, int screenY, int pageX, int pageY, int radiusX, int radiusY, float rotationAngle, float force, LayoutPoint absoluteLocation)
     : m_target(target)
     , m_identifier(identifier)
     , m_clientX(clientX)

--- a/Source/WebCore/dom/Touch.h
+++ b/Source/WebCore/dom/Touch.h
@@ -41,7 +41,7 @@ class LocalFrame;
 class Touch : public RefCounted<Touch> {
 public:
     static Ref<Touch> create(LocalFrame* frame, EventTarget* target,
-            unsigned identifier, int screenX, int screenY, int pageX, int pageY,
+            int identifier, int screenX, int screenY, int pageX, int pageY,
             int radiusX, int radiusY, float rotationAngle, float force)
     {
         return adoptRef(*new Touch(frame, target, identifier, screenX, 
@@ -49,7 +49,7 @@ public:
     }
 
     EventTarget* target() const { return m_target.get(); }
-    unsigned identifier() const { return m_identifier; }
+    int identifier() const { return m_identifier; }
     int clientX() const { return m_clientX; }
     int clientY() const { return m_clientY; }
     int screenX() const { return m_screenX; }
@@ -64,16 +64,16 @@ public:
     Ref<Touch> cloneWithNewTarget(EventTarget*) const;
 
 private:
-    Touch(LocalFrame*, EventTarget*, unsigned identifier,
+    Touch(LocalFrame*, EventTarget*, int identifier,
             int screenX, int screenY, int pageX, int pageY,
             int radiusX, int radiusY, float rotationAngle, float force);
 
-    Touch(EventTarget*, unsigned identifier, int clientX, int clientY,
+    Touch(EventTarget*, int identifier, int clientX, int clientY,
         int screenX, int screenY, int pageX, int pageY,
         int radiusX, int radiusY, float rotationAngle, float force, LayoutPoint absoluteLocation);
 
     RefPtr<EventTarget> m_target;
-    unsigned m_identifier;
+    int m_identifier;
     int m_clientX;
     int m_clientY;
     int m_screenX;

--- a/Source/WebCore/dom/Touch.idl
+++ b/Source/WebCore/dom/Touch.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/touch-events/#touch-interface
+
 [
     Conditional=TOUCH_EVENTS,
     Exposed=Window
@@ -34,7 +36,7 @@
     readonly attribute long                pageX;
     readonly attribute long                pageY;
     readonly attribute EventTarget         target;
-    readonly attribute unsigned long       identifier;
+    readonly attribute long                identifier;
     readonly attribute long                webkitRadiusX;
     readonly attribute long               webkitRadiusY;
     readonly attribute unrestricted float webkitRotationAngle;


### PR DESCRIPTION
#### 514d977d7c92d059e9806cc84a32d413f376c594
<pre>
Sync &apos;identifier&apos; in Touch.idl with Web Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=264533">https://bugs.webkit.org/show_bug.cgi?id=264533</a>

Reviewed by Michael Catanzaro.

This patch is to align &apos;identifier&apos; with Web-Specification [1] by changing to &apos;long&apos; / &apos;int&apos;.

[1] <a href="https://w3c.github.io/touch-events/#touch-interface">https://w3c.github.io/touch-events/#touch-interface</a>

* Source/WebCore/dom/Touch.idl:
* Source/WebCore/dom/Touch.cpp:
(Touch::Touch):
(Touch::Touch):
* Source/WebCore/dom/Touch.h: All use cases in &apos;arguments&apos; as well
(create):

Canonical link: <a href="https://commits.webkit.org/270540@main">https://commits.webkit.org/270540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ecaadd16b383c61c4f2339ea6876c724ae98df3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25647 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28327 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29134 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26987 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1053 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4192 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6182 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->