### PR TITLE
[iOS] `svh`/`dvh` units are unexpectedly equal when Safari tab bar is not visible

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -559,6 +559,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 // DERECATED: The setters of the three following function are deprecated, please use overrideLayoutParameters.
 // Define the smallest size a page take with a regular viewport.
 @property (nonatomic, readonly) CGSize _minimumLayoutSizeOverride;
+// Define the smallest size the unobscured area can get for the current view bounds. This value is used to define viewport units.
+@property (nonatomic, readonly) CGSize _minimumUnobscuredSizeOverride WK_API_AVAILABLE(ios(WK_IOS_TBA));
 // Define the largest size the unobscured area can get for the current view bounds. This value is used to define viewport units.
 @property (nonatomic, readonly) CGSize _maximumUnobscuredSizeOverride;
 
@@ -622,7 +624,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 - (void)_snapshotRectAfterScreenUpdates:(BOOL)afterScreenUpdates rectInViewCoordinates:(CGRect)rectInViewCoordinates intoImageOfWidth:(CGFloat)imageWidth completionHandler:(void(^)(CGImageRef))completionHandler WK_API_AVAILABLE(ios(16.0));
 - (void)_snapshotRect:(CGRect)rectInViewCoordinates intoImageOfWidth:(CGFloat)imageWidth completionHandler:(void(^)(CGImageRef))completionHandler;
 
-- (void)_overrideLayoutParametersWithMinimumLayoutSize:(CGSize)minimumLayoutSize maximumUnobscuredSizeOverride:(CGSize)maximumUnobscuredSizeOverride WK_API_AVAILABLE(ios(9_0));
+- (void)_overrideLayoutParametersWithMinimumLayoutSize:(CGSize)minimumLayoutSize maximumUnobscuredSizeOverride:(CGSize)maximumUnobscuredSizeOverride WK_API_DEPRECATED_WITH_REPLACEMENT("-_overrideLayoutParametersWithMinimumLayoutSize:minimumUnobscuredSizeOverride:maximumUnobscuredSizeOverride:", ios(9.0, WK_IOS_TBA));
+- (void)_overrideLayoutParametersWithMinimumLayoutSize:(CGSize)minimumLayoutSize minimumUnobscuredSizeOverride:(CGSize)minimumUnobscuredSizeOverride maximumUnobscuredSizeOverride:(CGSize)maximumUnobscuredSizeOverride WK_API_AVAILABLE(ios(WK_IOS_TBA));
 - (void)_clearOverrideLayoutParameters WK_API_AVAILABLE(ios(11.0));
 - (void)_overrideViewportWithArguments:(NSDictionary<NSString *, NSString *> *)arguments WK_API_AVAILABLE(ios(13.0));
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4132,13 +4132,18 @@ static bool isLockdownModeWarningNeeded()
 
 - (void)_overrideLayoutParametersWithMinimumLayoutSize:(CGSize)minimumLayoutSize maximumUnobscuredSizeOverride:(CGSize)maximumUnobscuredSizeOverride
 {
-    LOG_WITH_STREAM(VisibleRects, stream << "-[WKWebView " << _page->identifier() << " _overrideLayoutParametersWithMinimumLayoutSize:" << WebCore::FloatSize(minimumLayoutSize) << " maximumUnobscuredSizeOverride:" << WebCore::FloatSize(maximumUnobscuredSizeOverride) << "]");
+    [self _overrideLayoutParametersWithMinimumLayoutSize:minimumLayoutSize minimumUnobscuredSizeOverride:minimumLayoutSize maximumUnobscuredSizeOverride:maximumUnobscuredSizeOverride];
+}
+
+- (void)_overrideLayoutParametersWithMinimumLayoutSize:(CGSize)minimumLayoutSize minimumUnobscuredSizeOverride:(CGSize)minimumUnobscuredSizeOverride maximumUnobscuredSizeOverride:(CGSize)maximumUnobscuredSizeOverride
+{
+    LOG_WITH_STREAM(VisibleRects, stream << "-[WKWebView " << _page->identifier() << " _overrideLayoutParametersWithMinimumLayoutSize:" << WebCore::FloatSize(minimumLayoutSize) << " minimumUnobscuredSizeOverride:" << WebCore::FloatSize(minimumUnobscuredSizeOverride) << " maximumUnobscuredSizeOverride:" << WebCore::FloatSize(maximumUnobscuredSizeOverride) << "]");
 
     if (minimumLayoutSize.width < 0 || minimumLayoutSize.height < 0)
         RELEASE_LOG_FAULT(VisibleRects, "%s: Error: attempting to override layout parameters with negative width or height: %@", __PRETTY_FUNCTION__, NSStringFromCGSize(minimumLayoutSize));
 
     [self _setViewLayoutSizeOverride:CGSizeMake(std::max<CGFloat>(0, minimumLayoutSize.width), std::max<CGFloat>(0, minimumLayoutSize.height))];
-    [self _setMinimumUnobscuredSizeOverride:minimumLayoutSize];
+    [self _setMinimumUnobscuredSizeOverride:minimumUnobscuredSizeOverride];
     [self _setMaximumUnobscuredSizeOverride:maximumUnobscuredSizeOverride];
 }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -194,7 +194,7 @@ struct WKWebViewState {
             [webView _resetUnobscuredSafeAreaInsets];
 
         if (_savedHasOverriddenLayoutParameters && _savedMinimumUnobscuredSizeOverride && _savedMaximumUnobscuredSizeOverride)
-            [webView _overrideLayoutParametersWithMinimumLayoutSize:*_savedMinimumUnobscuredSizeOverride maximumUnobscuredSizeOverride:*_savedMaximumUnobscuredSizeOverride];
+            [webView _overrideLayoutParametersWithMinimumLayoutSize:*_savedMinimumUnobscuredSizeOverride minimumUnobscuredSizeOverride:*_savedMinimumUnobscuredSizeOverride maximumUnobscuredSizeOverride:*_savedMaximumUnobscuredSizeOverride];
         else
             [webView _clearOverrideLayoutParameters];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
@@ -199,7 +199,8 @@ TEST(AnimatedResize, OverrideLayoutSizeChangesDuringAnimatedResizeSucceed)
     auto webView = createAnimatedResizeWebView();
     [webView setUIDelegate:webView.get()];
 
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(200, 50) maximumUnobscuredSizeOverride:CGSizeMake(200, 50)];
+    auto layoutSize = CGSizeMake(200, 50);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
 
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
@@ -214,7 +215,8 @@ TEST(AnimatedResize, OverrideLayoutSizeChangesDuringAnimatedResizeSucceed)
         [webView setFrame:CGRectMake(0, 0, [webView frame].size.width + 100, 400)];
     }];
 
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(100, 200) maximumUnobscuredSizeOverride:CGSizeMake(100, 200)];
+    layoutSize = CGSizeMake(100, 200);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
     [webView _endAnimatedResize];
 
     __block bool didReadLayoutSize = false;
@@ -239,7 +241,8 @@ TEST(AnimatedResize, OverrideLayoutSizeIsRestoredAfterProcessRelaunch)
     auto webView = createAnimatedResizeWebView();
     [webView setUIDelegate:webView.get()];
 
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(200, 50) maximumUnobscuredSizeOverride:CGSizeMake(200, 50)];
+    auto layoutSize = CGSizeMake(200, 50);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
 
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -270,7 +273,8 @@ TEST(AnimatedResize, OverrideLayoutSizeIsRestoredAfterChangingDuringProcessRelau
     auto webView = createAnimatedResizeWebView();
     [webView setUIDelegate:webView.get()];
 
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(100, 100) maximumUnobscuredSizeOverride:CGSizeMake(100, 100)];
+    auto layoutSize = CGSizeMake(100, 100);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
 
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -280,7 +284,8 @@ TEST(AnimatedResize, OverrideLayoutSizeIsRestoredAfterChangingDuringProcessRelau
     [window setHidden:NO];
 
     [webView _killWebContentProcessAndResetState];
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(200, 50) maximumUnobscuredSizeOverride:CGSizeMake(200, 50)];
+    layoutSize = CGSizeMake(200, 50);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
 
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
@@ -1128,8 +1128,7 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMinimumViewportInset)
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5)
-                              maximumUnobscuredSizeOverride:CGSizeMake(30.5, 40.5)];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5) minimumUnobscuredSizeOverride:CGSizeMake(10.5, 30.5) maximumUnobscuredSizeOverride:CGSizeMake(30.5, 40.5)];
 
     [webView waitForNextPresentationUpdate];
 
@@ -1141,10 +1140,10 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMinimumViewportInset)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"vi"));
 
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svw"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svh"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svmin"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svmax"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svb"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svi"));
 
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvw"));
@@ -1172,8 +1171,7 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMaximumViewportInset)
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5)
-                              maximumUnobscuredSizeOverride:CGSizeMake(30.5, 40.5)];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5) minimumUnobscuredSizeOverride:CGSizeMake(10.5, 30.5) maximumUnobscuredSizeOverride:CGSizeMake(30.5, 40.5)];
 
     [webView waitForNextPresentationUpdate];
 
@@ -1185,10 +1183,10 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMaximumViewportInset)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"vi"));
 
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svw"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svh"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svmin"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svmax"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svb"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svi"));
 
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvw"));
@@ -1213,8 +1211,7 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMaximumViewportInset)
 TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5)
-                              maximumUnobscuredSizeOverride:CGSizeZero];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5) minimumUnobscuredSizeOverride:CGSizeZero maximumUnobscuredSizeOverride:CGSizeZero];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
     [webView waitForNextPresentationUpdate];
 
@@ -1359,8 +1356,8 @@ TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
 TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5)
-                              maximumUnobscuredSizeOverride:CGSizeMake(10.5, 20.5)];
+    auto unobscuredSizeOverride = CGSizeMake(10.5, 20.5);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:unobscuredSizeOverride minimumUnobscuredSizeOverride:unobscuredSizeOverride maximumUnobscuredSizeOverride:unobscuredSizeOverride];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
     [webView waitForNextPresentationUpdate];
 
@@ -1505,8 +1502,7 @@ TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
 TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5)
-                              maximumUnobscuredSizeOverride:CGSizeMake(30.5, 40.5)];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5) minimumUnobscuredSizeOverride:CGSizeMake(10.5, 30.5) maximumUnobscuredSizeOverride:CGSizeMake(30.5, 40.5)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
     [webView waitForNextPresentationUpdate];
 
@@ -1518,10 +1514,10 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"vi"));
 
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svw"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svh"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svmin"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svmax"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svb"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svi"));
 
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvw"));
@@ -1553,10 +1549,10 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"vi"));
 
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svw"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svh"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svmin"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svmax"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svb"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svi"));
 
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvw"));
@@ -1588,11 +1584,11 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(40.5, viewportUnitLength(webView, @"vi"));
 
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svw"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svh"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svmin"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svmax"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svb"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svi"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svi"));
 
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvw"));
     EXPECT_FLOAT_EQ(40.5, viewportUnitLength(webView, @"lvh"));
@@ -1623,10 +1619,10 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"vi"));
 
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svw"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svh"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svmin"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svmax"));
-    EXPECT_FLOAT_EQ(20.5, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"svb"));
     EXPECT_FLOAT_EQ(10.5, viewportUnitLength(webView, @"svi"));
 
     EXPECT_FLOAT_EQ(30.5, viewportUnitLength(webView, @"lvw"));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FixedLayoutSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FixedLayoutSize.mm
@@ -37,7 +37,7 @@
 TEST(WebKit, OverrideMinimumLayoutSizeWithNegativeHeight)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(320, -1000) maximumUnobscuredSizeOverride:CGSizeMake(0, 0)];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(320, -1000) minimumUnobscuredSizeOverride:CGSizeZero maximumUnobscuredSizeOverride:CGSizeZero];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><body>Hello</body>"];
     EXPECT_GE([webView _fixedLayoutSize].height, 0);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
@@ -51,7 +51,8 @@ TEST(RestoreScrollPositionTests, RestoreScrollPositionWithLargeContentInset)
     [webView scrollView].contentOffset = CGPointMake(0, -topInset);
     
     [webView waitForNextPresentationUpdate];
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(375, 727) maximumUnobscuredSizeOverride:CGSizeMake(375, 727)];
+    auto layoutSize = CGSizeMake(375, 727);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
 
     [webView scrollView].contentInset = UIEdgeInsetsMake(1024, 0, 0, 0);
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
@@ -348,7 +348,7 @@ TEST(ScrollViewInsetTests, ScrollabilityWithObscuredInsetsAndOverrideSizes)
 
     auto minimumLayoutSize = CGSizeMake(390, 664);
     auto maxUnobscuredLayoutSize = CGSizeMake(390, 745);
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:minimumLayoutSize maximumUnobscuredSizeOverride:maxUnobscuredLayoutSize];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:minimumLayoutSize minimumUnobscuredSizeOverride:minimumLayoutSize maximumUnobscuredSizeOverride:maxUnobscuredLayoutSize];
 
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><style> body { overflow: hidden; height: 2000px; } </style>"];
     [webView waitForNextPresentationUpdate];
@@ -368,7 +368,7 @@ TEST(ScrollViewInsetTests, ScrollabilityWithMaxOverrideSize)
     [webView _setObscuredInsets:insets];
 
     auto unobscuredLayoutSize = CGSizeMake(390, 797);
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:unobscuredLayoutSize maximumUnobscuredSizeOverride:unobscuredLayoutSize];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:unobscuredLayoutSize minimumUnobscuredSizeOverride:unobscuredLayoutSize maximumUnobscuredSizeOverride:unobscuredLayoutSize];
 
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><style> body { overflow: hidden; height: 2000px; } </style>"];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm
@@ -115,7 +115,8 @@ TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndVisibleUI)
     obscuredInsets.right = 0;
 
     [webView _setObscuredInsets:obscuredInsets];
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(320, 406) maximumUnobscuredSizeOverride:CGSizeMake(320, 490)];
+    auto unobscuredLayoutSize = CGSizeMake(320, 406);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:unobscuredLayoutSize minimumUnobscuredSizeOverride:unobscuredLayoutSize maximumUnobscuredSizeOverride:CGSizeMake(320, 490)];
 
     [webView synchronouslyLoadHTMLString:nonScrollableDocumentMarkup];
     [webView waitForNextPresentationUpdate];
@@ -134,7 +135,8 @@ TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndShrunkUI)
     obscuredInsets.right = 0;
 
     [webView _setObscuredInsets:obscuredInsets];
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(viewHeight, 325) maximumUnobscuredSizeOverride:CGSizeMake(viewHeight, 375)];
+    auto unobscuredLayoutSize = CGSizeMake(viewHeight, 325);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:unobscuredLayoutSize minimumUnobscuredSizeOverride:unobscuredLayoutSize maximumUnobscuredSizeOverride:CGSizeMake(viewHeight, 375)];
 
     [webView synchronouslyLoadHTMLString:nonScrollableDocumentMarkup];
     [webView waitForNextPresentationUpdate];

--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -176,7 +176,7 @@ static CGRect viewRectForWindowRect(CGRect, PlatformWebView::WebViewSizingMode);
         if (webView.usesSafariLikeRotation) {
             [webView _beginAnimatedResizeWithUpdates:^{
                 webView.frame = viewRectForWindowRect(self.view.bounds, WTR::PlatformWebView::WebViewSizingMode::HeightRespectsStatusBar);
-                [webView _overrideLayoutParametersWithMinimumLayoutSize:webView.frame.size maximumUnobscuredSizeOverride:webView.frame.size];
+                [webView _overrideLayoutParametersWithMinimumLayoutSize:webView.frame.size minimumUnobscuredSizeOverride:webView.frame.size maximumUnobscuredSizeOverride:webView.frame.size];
                 [webView _setInterfaceOrientationOverride:[[UIApplication sharedApplication] statusBarOrientation]];
             }];
         } else


### PR DESCRIPTION
#### cc2d17a95691b8c0632e2739542ad65f82153695
<pre>
[iOS] `svh`/`dvh` units are unexpectedly equal when Safari tab bar is not visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=261185">https://bugs.webkit.org/show_bug.cgi?id=261185</a>
<a href="https://rdar.apple.com/115085360">rdar://115085360</a>

Reviewed by Wenson Hsieh.

The SPI `-[WKWebView _overrideLayoutParametersWithMinimumLayoutSize:maximumUnobscuredSizeOverride:]`
is underspecified, and clients calling into this method conflate
`minimumLayoutSize` as _the_ current layout size. This is not appropriate
for us to use as the `minimumUnobscuredSizeOverride` because the current
layout size may not be computed in light of the fact that some dynamic
UI of a client is not visible.

To address this issue, we update the SPI signature to include a new
`minimumUnobscuredSizeOverride` argument, following the precedence set
by the `maximumUnobscuredSizeOverride` parameter, which callers should
populate with the minimum unobscured layout size assuming all dynamic UI
is expanded.

We also update some API tests that call this SPI and reflect the
semantics of the new argument in the updated test expectations.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _overrideLayoutParametersWithMinimumLayoutSize:maximumUnobscuredSizeOverride:]):
(-[WKWebView _overrideLayoutParametersWithMinimumLayoutSize:minimumUnobscuredSizeOverride:maximumUnobscuredSizeOverride:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FixedLayoutSize.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/ios/ScrollViewScrollabilityTests.mm:
(TestWebKitAPI::TEST):
* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(-[PlatformWebViewController viewWillTransitionToSize:withTransitionCoordinator:]):

Canonical link: <a href="https://commits.webkit.org/270516@main">https://commits.webkit.org/270516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e626f5a7b66b5e73ff025688869e4eff60b3758a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23638 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28345 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29151 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27006 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1069 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4210 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6164 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->