### PR TITLE
REGRESSION (270237@main): ASSERTION FAILED: !m_deletionHasBegun in RefCountedBase::hasOneRef() when running media/media-source/mock-managedmse-bufferedchange.html

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -231,7 +231,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
             ensureOnMainThread([self, protectedSelf = RetainPtr { self }, layer = WTFMove(layer), error = WTFMove(error)] {
                 ASSERT(_layers.contains(layer.get()));
-                if (RefPtr parent = _parent.get())
+                if (auto parent = _parent.get())
                     parent->layerDidReceiveError(layer.get(), error.get());
             });
             return;
@@ -244,7 +244,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
             ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), error = WTFMove(error)] {
                 ASSERT(_renderers.contains(renderer.get()));
-                if (RefPtr parent = _parent.get())
+                if (auto parent = _parent.get())
                     parent->rendererDidReceiveError(renderer.get(), error.get());
             });
             return;
@@ -260,7 +260,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
         ensureOnMainThread([self, protectedSelf = RetainPtr { self }, layer = WTFMove(layer), isObscured] {
             ASSERT(_layers.contains(layer.get()));
-            if (RefPtr parent = _parent.get())
+            if (auto parent = _parent.get())
                 parent->outputObscuredDueToInsufficientExternalProtectionChanged(isObscured);
         });
         return;
@@ -277,7 +277,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, layer = WTFMove(layer), error = WTFMove(error)] {
         if (!_layers.contains(layer.get()))
             return;
-        if (RefPtr parent = _parent.get())
+        if (auto parent = _parent.get())
             parent->layerDidReceiveError(layer.get(), error.get());
     });
 }
@@ -290,7 +290,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, layer = WTFMove(layer), requiresFlush] {
         if (!_layers.contains(layer.get()))
             return;
-        if (RefPtr parent = _parent.get())
+        if (auto parent = _parent.get())
             parent->layerRequiresFlushToResumeDecodingChanged(layer.get(), requiresFlush);
     });
 }
@@ -304,7 +304,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, layer = WTFMove(layer), isReadyForDisplay] {
         if (!_layers.contains(layer.get()))
             return;
-        if (RefPtr parent = _parent.get())
+        if (auto parent = _parent.get())
             parent->layerReadyForDisplayChanged(layer.get(), isReadyForDisplay);
     });
 }
@@ -318,7 +318,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), flushTime] {
         if (!_renderers.contains(renderer.get()))
             return;
-        if (RefPtr parent = _parent.get())
+        if (auto parent = _parent.get())
             parent->rendererWasAutomaticallyFlushed(renderer.get(), flushTime);
     });
 }


### PR DESCRIPTION
#### 7fcc1635bd52135380e4d5aa62fdf936facf1c03
<pre>
REGRESSION (270237@main): ASSERTION FAILED: !m_deletionHasBegun in RefCountedBase::hasOneRef() when running media/media-source/mock-managedmse-bufferedchange.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=264535">https://bugs.webkit.org/show_bug.cgi?id=264535</a>
<a href="https://rdar.apple.com/problem/118206047">rdar://problem/118206047</a>

Reviewed by Jer Noble.

media/media-source/mock-managedmse-bufferedchange.html (and others) crash in Debug builds when
HAVE(AVSAMPLEBUFFERDISPLAYLAYER_READYFORDISPLAY) is enabled due to an attempt to ref() an instance
of SourceBufferPrivateAVFObjC in its destructor.

Addressed this by partially reverting 270237@main to not create RefPtrs when getting
WebAVSampleBufferListener&apos;s _parent WeakPtr.

No new tests; covered by existing tests.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(-[WebAVSampleBufferListener observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVSampleBufferListener layerFailedToDecode:]):
(-[WebAVSampleBufferListener layerRequiresFlushToResumeDecodingChanged:]):
(-[WebAVSampleBufferListener layerReadyForDisplayChanged:]):
(-[WebAVSampleBufferListener audioRendererWasAutomaticallyFlushed:]):

Canonical link: <a href="https://commits.webkit.org/270510@main">https://commits.webkit.org/270510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f46918344bc4441bd9f9a9736c0cc165da069b08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23629 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28334 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29141 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26996 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4199 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6159 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->