### PR TITLE
Port WebCompiledContentRuleListData to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -423,6 +423,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/WTFArgumentCoders.serialization.in
     Shared/WebBackForwardListCounts.serialization.in
     Shared/WebCoreArgumentCoders.serialization.in
+    Shared/WebCompiledContentRuleListData.serialization.in
     Shared/WebEvent.serialization.in
     Shared/WebFoundTextRange.serialization.in
     Shared/WebHitTestResultData.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -268,6 +268,7 @@ $(PROJECT_DIR)/Shared/ViewWindowCoordinates.serialization.in
 $(PROJECT_DIR)/Shared/VisibleContentRectUpdateInfo.serialization.in
 $(PROJECT_DIR)/Shared/WTFArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebBackForwardListCounts.serialization.in
+$(PROJECT_DIR)/Shared/WebCompiledContentRuleListData.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebEvent.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -601,6 +601,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/TextRecognitionResult.serialization.in \
 	Shared/UserContentControllerParameters.serialization.in \
 	Shared/UserInterfaceIdiom.serialization.in \
+	Shared/WebCompiledContentRuleListData.serialization.in \
 	Shared/ViewWindowCoordinates.serialization.in \
 	Shared/VisibleContentRectUpdateInfo.serialization.in \
 	Shared/WTFArgumentCoders.serialization.in \

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
@@ -75,8 +75,8 @@ void NetworkContentRuleListManager::addContentRuleLists(UserContentControllerIde
     for (auto&& pair : contentRuleLists) {
         auto&& contentRuleList = WTFMove(pair.first);
         String identifier = contentRuleList.identifier;
-        auto compiledContentRuleList = WebCompiledContentRuleList::create(WTFMove(contentRuleList));
-        backend.addContentExtension(identifier, WTFMove(compiledContentRuleList), WTFMove(pair.second), ContentExtensions::ContentExtension::ShouldCompileCSS::No);
+        if (RefPtr compiledContentRuleList = WebCompiledContentRuleList::create(WTFMove(contentRuleList)))
+            backend.addContentExtension(identifier, compiledContentRuleList.releaseNonNull(), WTFMove(pair.second), ContentExtensions::ContentExtension::ShouldCompileCSS::No);
     }
 
     auto pendingCallbacks = m_pendingCallbacks.take(identifier);

--- a/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
+++ b/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
@@ -30,8 +30,10 @@
 
 namespace WebKit {
 
-Ref<WebCompiledContentRuleList> WebCompiledContentRuleList::create(WebCompiledContentRuleListData&& data)
+RefPtr<WebCompiledContentRuleList> WebCompiledContentRuleList::create(WebCompiledContentRuleListData&& data)
 {
+    if (!data.data)
+        return nullptr;
     return adoptRef(*new WebCompiledContentRuleList(WTFMove(data)));
 }
 

--- a/Source/WebKit/Shared/WebCompiledContentRuleList.h
+++ b/Source/WebKit/Shared/WebCompiledContentRuleList.h
@@ -35,7 +35,7 @@ namespace WebKit {
 
 class WebCompiledContentRuleList final : public WebCore::ContentExtensions::CompiledContentExtension {
 public:
-    static Ref<WebCompiledContentRuleList> create(WebCompiledContentRuleListData&&);
+    static RefPtr<WebCompiledContentRuleList> create(WebCompiledContentRuleListData&&);
     virtual ~WebCompiledContentRuleList();
 
     const WebCompiledContentRuleListData& data() const { return m_data; }

--- a/Source/WebKit/Shared/WebCompiledContentRuleListData.h
+++ b/Source/WebKit/Shared/WebCompiledContentRuleListData.h
@@ -32,11 +32,6 @@
 #include <variant>
 #include <wtf/RefPtr.h>
 
-namespace IPC {
-class Decoder;
-class Encoder;
-}
-
 namespace WebKit {
 
 class WebCompiledContentRuleListData {
@@ -55,11 +50,12 @@ public:
     {
     }
 
-    void encode(IPC::Encoder&) const;
-    static std::optional<WebCompiledContentRuleListData> decode(IPC::Decoder&);
+    WebCompiledContentRuleListData(String&& identifier, std::optional<WebKit::SharedMemoryHandle>&& data, size_t actionsOffset, size_t actionsSize, size_t urlFiltersBytecodeOffset, size_t urlFiltersBytecodeSize, size_t topURLFiltersBytecodeOffset, size_t topURLFiltersBytecodeSize, size_t frameURLFiltersBytecodeOffset, size_t frameURLFiltersBytecodeSize);
+
+    std::optional<SharedMemoryHandle> createDataHandle(SharedMemory::Protection = SharedMemory::Protection::ReadOnly) const;
 
     String identifier;
-    Ref<SharedMemory> data;
+    RefPtr<SharedMemory> data;
     size_t actionsOffset { 0 };
     size_t actionsSize { 0 };
     size_t urlFiltersBytecodeOffset { 0 };

--- a/Source/WebKit/Shared/WebCompiledContentRuleListData.serialization.in
+++ b/Source/WebKit/Shared/WebCompiledContentRuleListData.serialization.in
@@ -1,0 +1,38 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+class WebKit::WebCompiledContentRuleListData {
+    String identifier;
+    std::optional<WebKit::SharedMemoryHandle> createDataHandle();
+    size_t actionsOffset;
+    size_t actionsSize;
+    size_t urlFiltersBytecodeOffset;
+    size_t urlFiltersBytecodeSize;
+    size_t topURLFiltersBytecodeOffset;
+    size_t topURLFiltersBytecodeSize;
+    size_t frameURLFiltersBytecodeOffset;
+    size_t frameURLFiltersBytecodeSize;
+};
+
+#endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -441,8 +441,9 @@ static Ref<API::ContentRuleList> createExtension(WTF::String&& identifier, Mappe
         frameURLFiltersOffset,
         data.metaData.frameURLFiltersBytecodeSize
     );
-    auto compiledContentRuleList = WebKit::WebCompiledContentRuleList::create(WTFMove(compiledContentRuleListData));
-    return API::ContentRuleList::create(WTFMove(compiledContentRuleList), WTFMove(data.data));
+    RefPtr compiledContentRuleList = WebKit::WebCompiledContentRuleList::create(WTFMove(compiledContentRuleListData));
+    ASSERT(compiledContentRuleList);
+    return API::ContentRuleList::create(compiledContentRuleList.releaseNonNull(), WTFMove(data.data));
 }
 
 static WTF::String getContentRuleListSourceFromMappedFile(const MappedData& mappedData)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4892,6 +4892,7 @@
 		463A074A2AFD8C6600CA8DBE /* BufferAndBackendInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BufferAndBackendInfo.h; sourceTree = "<group>"; };
 		463FD47F1EB9458400A2982C /* WKProcessTerminationReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKProcessTerminationReason.h; sourceTree = "<group>"; };
 		463FD4811EB94EAD00A2982C /* ProcessTerminationReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessTerminationReason.h; sourceTree = "<group>"; };
+		46411E3D2AFDA94400CC00E4 /* WebCompiledContentRuleListData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCompiledContentRuleListData.serialization.in; sourceTree = "<group>"; };
 		4651ECE622178A850067EB95 /* WebProcessCacheCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebProcessCacheCocoa.mm; sourceTree = "<group>"; };
 		465250E51ECF52CD002025CB /* WebKit2InitializeCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKit2InitializeCocoa.mm; sourceTree = "<group>"; };
 		4656F7BA27ACAA8000CB3D7C /* WebSharedWorkerServerToContextConnection.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebSharedWorkerServerToContextConnection.messages.in; sourceTree = "<group>"; };
@@ -8444,6 +8445,7 @@
 				7C4ABECF1AA8E9F00088AA37 /* WebCompiledContentRuleList.h */,
 				7C4ABED21AA8FCB80088AA37 /* WebCompiledContentRuleListData.cpp */,
 				7C4ABED31AA8FCB80088AA37 /* WebCompiledContentRuleListData.h */,
+				46411E3D2AFDA94400CC00E4 /* WebCompiledContentRuleListData.serialization.in */,
 				BC4A628B147312BE006C681A /* WebConnection.cpp */,
 				BC4A628C147312BE006C681A /* WebConnection.h */,
 				1A1FEC191627B3EF00700F6D /* WebConnection.messages.in */,

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -417,9 +417,8 @@ void WebUserContentController::addContentRuleLists(Vector<std::pair<WebCompiledC
     for (auto&& pair : contentRuleLists) {
         auto&& contentRuleList = WTFMove(pair.first);
         String identifier = contentRuleList.identifier;
-        auto compiledContentRuleList = WebCompiledContentRuleList::create(WTFMove(contentRuleList));
-
-        m_contentExtensionBackend.addContentExtension(identifier, WTFMove(compiledContentRuleList), WTFMove(pair.second));
+        if (RefPtr compiledContentRuleList = WebCompiledContentRuleList::create(WTFMove(contentRuleList)))
+            m_contentExtensionBackend.addContentExtension(identifier, compiledContentRuleList.releaseNonNull(), WTFMove(pair.second));
     }
 }
 


### PR DESCRIPTION
#### 5783584ba3aa701f6248ca97a68f5c4788af7288
<pre>
Port WebCompiledContentRuleListData to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264538">https://bugs.webkit.org/show_bug.cgi?id=264538</a>

Reviewed by Alex Christensen.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp:
(WebKit::NetworkContentRuleListManager::addContentRuleLists):
* Source/WebKit/Shared/WebCompiledContentRuleList.cpp:
(WebKit::WebCompiledContentRuleList::create):
* Source/WebKit/Shared/WebCompiledContentRuleList.h:
* Source/WebKit/Shared/WebCompiledContentRuleListData.cpp:
(WebKit::WebCompiledContentRuleListData::createDataHandle const):
(WebKit::WebCompiledContentRuleListData::WebCompiledContentRuleListData):
(WebKit::WebCompiledContentRuleListData::encode const): Deleted.
(WebKit::WebCompiledContentRuleListData::decode): Deleted.
* Source/WebKit/Shared/WebCompiledContentRuleListData.h:
* Source/WebKit/Shared/WebCompiledContentRuleListData.serialization.in: Added.
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::createExtension):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentRuleLists):

Canonical link: <a href="https://commits.webkit.org/270505@main">https://commits.webkit.org/270505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ab3a1d1ac7cdc3a322c3f058f352a302a284a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25677 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27777 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23517 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28357 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23447 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1076 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4222 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3290 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->