### PR TITLE
[UnifiedPDF] Use a tiled layer for rendering

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -39,12 +39,12 @@ static constexpr float minScale = 0.1; // Arbitrarily chosen min scale.
 
 FloatSize PDFDocumentLayout::documentMargin()
 {
-    return { 20, 20 };
+    return { 6, 8 };
 }
 
 FloatSize PDFDocumentLayout::pageMargin()
 {
-    return { 10, 10 };
+    return { 4, 6 };
 }
 
 PDFDocumentLayout::PDFDocumentLayout() = default;
@@ -175,7 +175,7 @@ void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWid
     currentYOffset += documentMargin.height();
 
     m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
-    m_documentBounds = FloatRect { 0, 0, availableWidth, currentYOffset };
+    m_documentBounds = FloatRect { 0, 0, maxRowWidth, currentYOffset };
 }
 
 void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidth)
@@ -233,7 +233,7 @@ void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidt
     currentYOffset += documentMargin.height();
 
     m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
-    m_documentBounds = FloatRect { 0, 0, availableWidth, currentYOffset };
+    m_documentBounds = FloatRect { 0, 0, maxRowWidth, currentYOffset };
 }
 
 size_t PDFDocumentLayout::pageCount() const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -92,12 +92,14 @@ private:
     id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
 
     // GraphicsLayerClient
+    void notifyFlushRequired(const GraphicsLayer*) override;
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
     float deviceScaleFactor() const override;
 
     void updateLayerHierarchy();
 
     void didChangeScrollOffset() override;
+    void didChangeIsInWindow();
 
     void invalidateScrollbarRect(WebCore::Scrollbar&, const WebCore::IntRect&) override;
     void invalidateScrollCornerRect(const WebCore::IntRect&) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -121,15 +121,29 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
     }
 
     if (!m_contentsLayer) {
-        auto contentsLayer = createGraphicsLayer("UnifiedPDFPlugin contents"_s, GraphicsLayer::Type::Normal);
+        auto contentsLayer = createGraphicsLayer("UnifiedPDFPlugin contents"_s, GraphicsLayer::Type::TiledBacking);
         m_contentsLayer = contentsLayer.copyRef();
         contentsLayer->setAnchorPoint({ });
         contentsLayer->setDrawsContent(true);
+        didChangeIsInWindow();
         m_rootLayer->addChild(*contentsLayer);
     }
 
-    m_contentsLayer->setSize(size());
+    m_contentsLayer->setSize(contentsSize());
     m_contentsLayer->setNeedsDisplay();
+}
+
+void UnifiedPDFPlugin::notifyFlushRequired(const GraphicsLayer*)
+{
+    scheduleRenderingUpdate();
+}
+
+void UnifiedPDFPlugin::didChangeIsInWindow()
+{
+    CheckedPtr page = this->page();
+    if (!page || !m_contentsLayer)
+        return;
+    m_contentsLayer->tiledBacking()->setIsInWindow(page->isInWindow());
 }
 
 void UnifiedPDFPlugin::paintContents(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>)
@@ -137,10 +151,10 @@ void UnifiedPDFPlugin::paintContents(const GraphicsLayer* layer, GraphicsContext
     if (layer != m_contentsLayer.get())
         return;
 
-    if (m_size.isEmpty())
+    if (m_size.isEmpty() || contentsSize().isEmpty())
         return;
 
-    auto drawingRect = IntRect { { }, m_size };
+    auto drawingRect = IntRect { { }, contentsSize() };
     drawingRect.intersect(enclosingIntRect(clipRect));
 
     auto imageBuffer = ImageBuffer::create(drawingRect.size(), RenderingPurpose::Unspecified, context.scaleFactor().width(), DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
@@ -183,9 +197,10 @@ void UnifiedPDFPlugin::paintContents(const GraphicsLayer* layer, GraphicsContext
         auto transform = CGPDFPageGetDrawingTransform(page.get(), kCGPDFCropBox, destinationRect, 0, preserveAspectRatio);
         bufferContext.concatCTM(transform);
 
-        CGContextDrawPDFPage(imageBuffer->context().platformContext(), page.get());
+        CGContextDrawPDFPage(bufferContext.platformContext(), page.get());
     }
 
+    context.fillRect(clipRect, WebCore::roundAndClampToSRGBALossy([WebCore::CocoaColor grayColor].CGColor));
     context.drawImageBuffer(*imageBuffer, drawingRect.location());
 }
 


### PR DESCRIPTION
#### f5f4745165e83c9db5289ecdf1705a6cc499057c
<pre>
[UnifiedPDF] Use a tiled layer for rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=264539">https://bugs.webkit.org/show_bug.cgi?id=264539</a>
<a href="https://rdar.apple.com/114831923">rdar://114831923</a>

Reviewed by Simon Fraser.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::documentMargin):
(WebKit::PDFDocumentLayout::pageMargin):
Adjust margins to match PDFExtensionViewController (the PDFLayerController
numbers are similar but confusingly nonintegral, and that seems nonideal).

(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::layoutTwoUpColumn):
m_documentBounds is in document space (below the scaling), so use the unscaled
width here.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
Make a tiled layer.

(WebKit::UnifiedPDFPlugin::notifyFlushRequired):
(WebKit::UnifiedPDFPlugin::didChangeIsInWindow):
Implement some tiled layer dependencies.

(WebKit::UnifiedPDFPlugin::paintContents):
Use the document size instead of view size in various places, fixing rendering once you scroll.
Also, paint the background color into the layer.

Canonical link: <a href="https://commits.webkit.org/270501@main">https://commits.webkit.org/270501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3343a15d151c92761b85662809cc30da5b7b7e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27760 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/23504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1700 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28340 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27002 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/2827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4205 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6154 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3274 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->