### PR TITLE
[Cocoa] Baseline alignment of checkboxes and radio buttons is incorrect in vertical writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of checkboxes in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of checkboxes in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#checkbox-state-(type=checkbox)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of checkboxes in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="checkbox-appearance-native-vertical-lr-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of checkboxes in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of checkboxes in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#checkbox-state-(type=checkbox)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of checkboxes in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="checkbox-appearance-native-vertical-rl-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The checkbox should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="checkbox" id="checkbox" checked>
+    <label for="checkbox">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of radio buttons in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of radio buttons in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#radio-button-state-(type=radio)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of radio buttons in vertical-lr writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="radio-appearance-native-vertical-lr-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-lr">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of radio buttons in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Test baseline alignment of radio buttons in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+input {
+    visibility: hidden;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#radio-button-state-(type=radio)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test baseline alignment of radio buttons in vertical-rl writing mode.</title>
+<meta charset="utf-8">
+<link rel="match" href="radio-appearance-native-vertical-rl-baseline.optional-ref.html">
+<style>
+
+label {
+    color: red;
+    background-color: red;
+    margin-top: -30px;
+}
+
+</style>
+<p>The radio button should be center-aligned with the label text.</p>
+<div style="writing-mode: vertical-rl">
+    <input type="radio" id="radio" checked>
+    <label for="radio">こんにちわ</label>
+</div>

--- a/Source/WebCore/platform/Theme.cpp
+++ b/Source/WebCore/platform/Theme.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-int Theme::baselinePositionAdjustment(StyleAppearance) const
+int Theme::baselinePositionAdjustment(StyleAppearance, bool) const
 {
     return 0;
 }

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -51,7 +51,7 @@ public:
     // position cannot be determined by examining child content. Checkboxes and radio buttons are examples of
     // controls that need to do this. The adjustment is an offset that adds to the baseline, e.g., marginTop() + height() + |offset|.
     // The offset is not zoomed.
-    virtual int baselinePositionAdjustment(StyleAppearance) const;
+    virtual int baselinePositionAdjustment(StyleAppearance, bool isHorizontalWritingMode) const;
 
     // The font description result should have a zoomed font size.
     virtual std::optional<FontCascadeDescription> controlFont(StyleAppearance, const FontCascade&, float zoomFactor) const;

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -44,7 +44,7 @@ private:
     friend NeverDestroyed<ThemeMac>;
     ThemeMac() = default;
 
-    int baselinePositionAdjustment(StyleAppearance) const final;
+    int baselinePositionAdjustment(StyleAppearance, bool isHorizontalWritingMode) const final;
 
     std::optional<FontCascadeDescription> controlFont(StyleAppearance, const FontCascade&, float zoomFactor) const final;
 

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -548,11 +548,11 @@ static LengthSize switchSize(const LengthSize& zoomedSize, float zoomFactor)
 
 // Theme overrides
 
-int ThemeMac::baselinePositionAdjustment(StyleAppearance appearance) const
+int ThemeMac::baselinePositionAdjustment(StyleAppearance appearance, bool isHorizontalWritingMode) const
 {
-    if (appearance == StyleAppearance::Checkbox || appearance == StyleAppearance::Radio)
+    if ((appearance == StyleAppearance::Checkbox || appearance == StyleAppearance::Radio) && isHorizontalWritingMode)
         return -2;
-    return Theme::baselinePositionAdjustment(appearance);
+    return Theme::baselinePositionAdjustment(appearance, isHorizontalWritingMode);
 }
 
 std::optional<FontCascadeDescription> ThemeMac::controlFont(StyleAppearance appearance, const FontCascade& font, float zoomFactor) const

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1189,10 +1189,17 @@ Color RenderTheme::platformInactiveListBoxSelectionForegroundColor(OptionSet<Sty
 
 int RenderTheme::baselinePosition(const RenderBox& box) const
 {
+    auto baseline = [&]() -> int {
+        if (box.isHorizontalWritingMode())
+            return box.height() + box.marginTop();
+
+        return (box.width() / 2.0f) + box.marginBefore();
+    }();
+
 #if USE(NEW_THEME)
-    return box.height() + box.marginTop() + Theme::singleton().baselinePositionAdjustment(box.style().effectiveAppearance()) * box.style().effectiveZoom();
+    return baseline + Theme::singleton().baselinePositionAdjustment(box.style().effectiveAppearance(), box.isHorizontalWritingMode()) * box.style().effectiveZoom();
 #else
-    return box.height() + box.marginTop();
+    return baseline;
 #endif
 }
 

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -474,11 +474,15 @@ LayoutRect RenderThemeIOS::adjustedPaintRect(const RenderBox& box, const LayoutR
 
 int RenderThemeIOS::baselinePosition(const RenderBox& box) const
 {
+    auto baseline = RenderTheme::baselinePosition(box);
+    if (!box.isHorizontalWritingMode())
+        return baseline;
+
     if (box.style().effectiveAppearance() == StyleAppearance::Checkbox || box.style().effectiveAppearance() == StyleAppearance::Radio)
-        return box.marginTop() + box.height() - 2; // The baseline is 2px up from the bottom of the checkbox/radio in AppKit.
+        return baseline - 2; // The baseline is 2px up from the bottom of the checkbox/radio in AppKit.
     if (box.style().effectiveAppearance() == StyleAppearance::Menulist)
-        return box.marginTop() + box.height() - 5; // This is to match AppKit. There might be a better way to calculate this though.
-    return RenderTheme::baselinePosition(box);
+        return baseline - 5; // This is to match AppKit. There might be a better way to calculate this though.
+    return baseline;
 }
 
 bool RenderThemeIOS::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const


### PR DESCRIPTION
#### 8a732f35575e95679ac399f167939dd2760ed70f
<pre>
[Cocoa] Baseline alignment of checkboxes and radio buttons is incorrect in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=264532">https://bugs.webkit.org/show_bug.cgi?id=264532</a>
<a href="https://rdar.apple.com/118203958">rdar://118203958</a>

Reviewed by Alan Baradlay.

Checkboxes and radio buttons should be horizontally centered relative to
associated text in vertical writing mode.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-lr-baseline.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-appearance-native-vertical-rl-baseline.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-lr-baseline.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/radio-appearance-native-vertical-rl-baseline.optional.html: Added.
* Source/WebCore/platform/Theme.cpp:
(WebCore::Theme::baselinePositionAdjustment const):
* Source/WebCore/platform/Theme.h:
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::baselinePositionAdjustment const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::baselinePosition const):

Compute the center baseline in vertical writing mode.

* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::baselinePosition const):

Canonical link: <a href="https://commits.webkit.org/270565@main">https://commits.webkit.org/270565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6212f2460c526c724a1ec0d4488c3c142a5cd837

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27867 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/23600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1810 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3283 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28447 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23163 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27102 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1157 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6200 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->