### PR TITLE
Throw exception if querying SVGAnimationElement with unresolved interval

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/SVGAnimationElement-exceptions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/SVGAnimationElement-exceptions-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL SVGAnimationElement exceptions, getStartTime throws with unresolved interval. assert_throws_dom: function "function() { animationElement.getStartTime() }" did not throw
-FAIL SVGAnimationElement exceptions, getSimpleDuration throws with undefined simple duration. assert_throws_dom: function "function() { animationElement.getSimpleDuration() }" did not throw
+PASS SVGAnimationElement exceptions, getStartTime throws with unresolved interval.
+PASS SVGAnimationElement exceptions, getSimpleDuration throws with undefined simple duration.
 

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -228,9 +228,12 @@ void SVGAnimationElement::animationAttributeChanged()
     setInactive();
 }
 
-float SVGAnimationElement::getStartTime() const
+ExceptionOr<float> SVGAnimationElement::getStartTime() const
 {
-    return narrowPrecisionToFloat(intervalBegin().value());
+    auto intervalBegin = this->intervalBegin();
+    if (!intervalBegin.isFinite())
+        return Exception { InvalidStateError, "The animation element does not have a current interval."_s };
+    return narrowPrecisionToFloat(intervalBegin.value());
 }
 
 float SVGAnimationElement::getCurrentTime() const
@@ -238,9 +241,12 @@ float SVGAnimationElement::getCurrentTime() const
     return narrowPrecisionToFloat(elapsed().value());
 }
 
-float SVGAnimationElement::getSimpleDuration() const
+ExceptionOr<float> SVGAnimationElement::getSimpleDuration() const
 {
-    return narrowPrecisionToFloat(simpleDuration().value());
+    auto simpleDuration = this->simpleDuration();
+    if (!simpleDuration.isFinite())
+        return Exception { NotSupportedError, "The simple duration is not determined on the given element."_s };
+    return narrowPrecisionToFloat(simpleDuration.value());
 }    
     
 void SVGAnimationElement::beginElement()

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -40,9 +40,9 @@ enum AnimatedPropertyValueType { RegularPropertyValue, CurrentColorValue, Inheri
 class SVGAnimationElement : public SVGSMILElement, public SVGTests {
     WTF_MAKE_ISO_ALLOCATED(SVGAnimationElement);
 public:
-    float getStartTime() const;
+    ExceptionOr<float> getStartTime() const;
     float getCurrentTime() const;
-    float getSimpleDuration() const;
+    ExceptionOr<float> getSimpleDuration() const;
 
     void beginElement();
     void beginElementAt(float offset);


### PR DESCRIPTION
#### 73237f2bdac8b49a7a7e9ddaa1f55cdc7a76180d
<pre>
Throw exception if querying SVGAnimationElement with unresolved interval

<a href="https://bugs.webkit.org/show_bug.cgi?id=264543">https://bugs.webkit.org/show_bug.cgi?id=264543</a>

Reviewed by Said Abou-Hallawa.

This patch is to align WebKit with Blink / Chromium, Gecko / Firefox and Web Specification [1].

[1] <a href="https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement">https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement</a>

For &apos;getStartTime&apos;, it throws &apos;DOMException&apos; (NVALID_STATE_ERR) and for &apos;getSimpleDuration&apos;, it throws &apos;DOMException&apos; (NOT_SUPPORTED_ERR).

* Source/WebCore/svg/SVGAnimationElement.cpp:
(SVGAnimationElement::getStartTime):
(SVGAnimationElement::getSimpleDuration):
* Source/WebCore/svg/SVGAnimationElement.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/SVGAnimationElement-exceptions-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/270519@main">https://commits.webkit.org/270519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/513d0dcf334b5e2ea6ba7bf2c01b8ee4bb25b325

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23554 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1756 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3235 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28396 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23470 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2878 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/4259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3328 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3288 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->