### PR TITLE
Support `<select>` in vertical writing mode

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1483,10 +1483,6 @@ webkit.org/b/133057 fast/table/border-collapsing/collapsed-borders-adjoining-sec
 
 webkit.org/b/169075 editing/selection/extend-by-character-007.html [ Failure ]
 
-# <select> element vertical writing mode support is not yet enabled
-fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html [ Failure ]
-fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar.html [ ImageOnlyFailure ]
-
 # CSS Font Loading is not yet enabled on all platforms
 webkit.org/b/135390 fast/css/fontloader-download-error.html [ Skip ]
 webkit.org/b/135390 fast/css/fontloader-events.html [ Skip ]
@@ -4401,14 +4397,6 @@ webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-013.html [ ImageOnlyFailure ]
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/individual-transform/animation/individual-transform-ordering.html [ ImageOnlyFailure ]
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform-fixed-bg-008.tentative.html [ ImageOnlyFailure ]
-
-# Vertical form controls support.
-webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-horizontal.optional.html [ ImageOnlyFailure ]
-webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-vlr.optional.html [ ImageOnlyFailure ]
-webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-vrl.optional.html [ ImageOnlyFailure ]
-webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-none-horizontal.optional.html [ ImageOnlyFailure ]
-webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-none-vlr.optional.html [ ImageOnlyFailure ]
-webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-none-vrl.optional.html [ ImageOnlyFailure ]
 
 webkit.org/b/208396 http/tests/misc/object-embedding-svg-delayed-size-negotiation-2.htm [ Pass Failure ]
 

--- a/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar-expected.txt
+++ b/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar-expected.txt
@@ -15,7 +15,7 @@ PASS select.scrollLeft is 0
 
 Drag horizontal scrollbar
 PASS select.scrollTop is 0
-PASS select.scrollLeft is 14
+PASS select.scrollLeft is > 0
 
 
 PASS successfullyParsed is true

--- a/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html
@@ -68,7 +68,7 @@ if (window.eventSender) {
     eventSender.mouseMoveTo(select.offsetLeft + 25, select.offsetTop + select.offsetHeight - 5);
     eventSender.mouseUp();
     shouldBeEqualToNumber("select.scrollTop", 0);
-    shouldBeEqualToNumber("select.scrollLeft", 14);
+    shouldBeGreaterThan("select.scrollLeft", "0");
     debug("\n");
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS select[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width
-FAIL select[style="writing-mode: vertical-lr"] block size should match width and inline size should match height assert_equals: expected "77px" but got "18px"
-FAIL select[style="writing-mode: vertical-rl"] block size should match width and inline size should match height assert_equals: expected "77px" but got "18px"
+PASS select[style="writing-mode: vertical-lr"] block size should match width and inline size should match height
+PASS select[style="writing-mode: vertical-rl"] block size should match width and inline size should match height
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional-expected.txt
@@ -1,8 +1,8 @@
 
 
 PASS select[multiple][style="writing-mode: horizontal-tb"] supports keyboard navigation
-FAIL select[multiple][style="writing-mode: vertical-lr"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
-FAIL select[multiple][style="writing-mode: vertical-rl"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
-FAIL select[multiple][style="writing-mode: sideways-lr"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
-FAIL select[multiple][style="writing-mode: sideways-rl"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
+PASS select[multiple][style="writing-mode: vertical-lr"] supports keyboard navigation
+PASS select[multiple][style="writing-mode: vertical-rl"] supports keyboard navigation
+PASS select[multiple][style="writing-mode: sideways-lr"] supports keyboard navigation
+PASS select[multiple][style="writing-mode: sideways-rl"] supports keyboard navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order-expected.txt
@@ -1,8 +1,8 @@
 
 
 PASS select[multiple][style="writing-mode: horizontal-tb"] has visually correct option order
-FAIL select[multiple][style="writing-mode: vertical-lr"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 1" but got "Option 3"
-FAIL select[multiple][style="writing-mode: vertical-rl"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 4" but got "Option 3"
-FAIL select[multiple][style="writing-mode: sideways-lr"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 1" but got "Option 3"
-FAIL select[multiple][style="writing-mode: sideways-rl"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 4" but got "Option 3"
+PASS select[multiple][style="writing-mode: vertical-lr"] has visually correct option order
+PASS select[multiple][style="writing-mode: vertical-rl"] has visually correct option order
+PASS select[multiple][style="writing-mode: sideways-lr"] has visually correct option order
+PASS select[multiple][style="writing-mode: sideways-rl"] has visually correct option order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
@@ -1,8 +1,8 @@
 
 
 PASS select[multiple][style="writing-mode: horizontal-tb"] scrolls correctly
-FAIL select[multiple][style="writing-mode: vertical-lr"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
-FAIL select[multiple][style="writing-mode: vertical-rl"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
-FAIL select[multiple][style="writing-mode: sideways-lr"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
-FAIL select[multiple][style="writing-mode: sideways-rl"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
+PASS select[multiple][style="writing-mode: vertical-lr"] scrolls correctly
+PASS select[multiple][style="writing-mode: vertical-rl"] scrolls correctly
+FAIL select[multiple][style="writing-mode: sideways-lr"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-lr expected 0 but got 98
+FAIL select[multiple][style="writing-mode: sideways-rl"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-rl expected 0 but got -98
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional-expected.txt
@@ -2,12 +2,12 @@
 
 PASS select[size][style="writing-mode: horizontal-tb"] scrolls correctly
 PASS select[size][style="writing-mode: horizontal-tb"] sizing works correctly
-FAIL select[size][style="writing-mode: vertical-lr"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
-FAIL select[size][style="writing-mode: vertical-lr"] sizing works correctly assert_true: clientWidth increased when increasing size expected true got false
-FAIL select[size][style="writing-mode: vertical-rl"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
-FAIL select[size][style="writing-mode: vertical-rl"] sizing works correctly assert_true: clientWidth increased when increasing size expected true got false
-FAIL select[size][style="writing-mode: sideways-lr"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
-FAIL select[size][style="writing-mode: sideways-lr"] sizing works correctly assert_true: clientWidth increased when increasing size expected true got false
-FAIL select[size][style="writing-mode: sideways-rl"] scrolls correctly assert_true: select should be scrollable in block axis expected true got false
-FAIL select[size][style="writing-mode: sideways-rl"] sizing works correctly assert_true: clientWidth increased when increasing size expected true got false
+PASS select[size][style="writing-mode: vertical-lr"] scrolls correctly
+PASS select[size][style="writing-mode: vertical-lr"] sizing works correctly
+PASS select[size][style="writing-mode: vertical-rl"] scrolls correctly
+PASS select[size][style="writing-mode: vertical-rl"] sizing works correctly
+PASS select[size][style="writing-mode: sideways-lr"] scrolls correctly
+PASS select[size][style="writing-mode: sideways-lr"] sizing works correctly
+PASS select[size][style="writing-mode: sideways-rl"] scrolls correctly
+PASS select[size][style="writing-mode: sideways-rl"] sizing works correctly
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -728,6 +728,7 @@ webkit.org/b/221308 [ Debug ] fast/selectors/is-backtracking.html [ Timeout ]
 
 fast/forms/vertical-writing-mode/meter.html [ ImageOnlyFailure ]
 fast/forms/vertical-writing-mode/progress.html [ ImageOnlyFailure ]
+webkit.org/b/264558 fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar.html [ ImageOnlyFailure ]
 
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/line-box-height-vlr-011.xht [ ImageOnlyFailure ]
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/line-box-height-vlr-013.xht [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
@@ -1,6 +1,0 @@
-
-
-PASS select[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width
-FAIL select[style="writing-mode: vertical-lr"] block size should match width and inline size should match height assert_equals: expected "88px" but got "30px"
-FAIL select[style="writing-mode: vertical-rl"] block size should match width and inline size should match height assert_equals: expected "88px" but got "30px"
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS select[multiple][style="writing-mode: horizontal-tb"] scrolls correctly
+PASS select[multiple][style="writing-mode: vertical-lr"] scrolls correctly
+PASS select[multiple][style="writing-mode: vertical-rl"] scrolls correctly
+FAIL select[multiple][style="writing-mode: sideways-lr"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-lr expected 0 but got 90
+FAIL select[multiple][style="writing-mode: sideways-rl"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-rl expected 0 but got -90
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt
@@ -1,6 +1,0 @@
-
-
-PASS select[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width
-FAIL select[style="writing-mode: vertical-lr"] block size should match width and inline size should match height assert_equals: expected "70px" but got "20px"
-FAIL select[style="writing-mode: vertical-rl"] block size should match width and inline size should match height assert_equals: expected "70px" but got "20px"
-

--- a/Source/WebCore/css/horizontalFormControls.css
+++ b/Source/WebCore/css/horizontalFormControls.css
@@ -25,6 +25,6 @@
 @namespace "http://www.w3.org/1999/xhtml";
 
 /* Every time a new control is supported in vertical writing mode, it should be added here and removed from the html.css rule */
-button, textarea, progress, meter, input {
+button, textarea, progress, meter, input, select {
     writing-mode: horizontal-tb !important;
 }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -399,11 +399,6 @@ button {
     appearance: auto;
 }
 
-/* Every time a new control is supported in vertical writing mode, it should be removed from here and added in the horizontalFormControls.css rule */
-select {
-    writing-mode: horizontal-tb !important;
-}
-
 input, textarea, select, button {
     margin: 0__qem;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)


### PR DESCRIPTION
#### acfe2805bf055c67d7594a694f535f074551bf90
<pre>
Support `&lt;select&gt;` in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=117233">https://bugs.webkit.org/show_bug.cgi?id=117233</a>
<a href="https://rdar.apple.com/102651643">rdar://102651643</a>

Reviewed by Tim Nguyen.

`&lt;select&gt;`, `&lt;select multiple&gt;`, and `&lt;select size=N&gt;` work in vertical writing
modes following fixes in `RenderMenuList`, `RenderListBox`, and related code.

Allow the use of vertical writing modes with `&lt;select&gt;` when the
`VerticalFormControlsEnabled` setting is turned on.

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar-expected.txt:
* LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html:

Adjust this test to avoid assuming a platform-specific option height. Simply
check that `scrollLeft` is greater than zero to verify that scrolling has occurred.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-appearance-native-computed-style-expected.txt: Removed.
* Source/WebCore/css/horizontalFormControls.css:
(button, textarea, progress, meter, input, select):
* Source/WebCore/css/html.css:
(select): Deleted.

Canonical link: <a href="https://commits.webkit.org/270545@main">https://commits.webkit.org/270545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/744f58f7ed61b1e86b8700e13e27d41e1806d1fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23542 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23666 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28384 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29178 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27039 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2866 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1101 "Found 1 new test failure: fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22853 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6184 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->