### PR TITLE
Clean up EnumTraits specializations under WebCore/loader

### DIFF
--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -96,19 +96,3 @@ std::optional<ResourceError> validateRangeRequestedFlag(const ResourceRequest&, 
 String validateCrossOriginRedirectionURL(const URL&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::HTTPHeadersToKeepFromCleaning> {
-    using values = EnumValues<
-        WebCore::HTTPHeadersToKeepFromCleaning,
-        WebCore::HTTPHeadersToKeepFromCleaning::ContentType,
-        WebCore::HTTPHeadersToKeepFromCleaning::Referer,
-        WebCore::HTTPHeadersToKeepFromCleaning::Origin,
-        WebCore::HTTPHeadersToKeepFromCleaning::UserAgent,
-        WebCore::HTTPHeadersToKeepFromCleaning::AcceptEncoding,
-        WebCore::HTTPHeadersToKeepFromCleaning::CacheControl
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.h
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.h
@@ -96,17 +96,3 @@ CrossOriginOpenerPolicy obtainCrossOriginOpenerPolicy(const ResourceResponse&);
 WEBCORE_EXPORT std::optional<CrossOriginOpenerPolicyEnforcementResult> doCrossOriginOpenerHandlingOfResponse(ReportingClient&, const ResourceResponse&, const std::optional<NavigationRequester>&, ContentSecurityPolicy* responseCSP, SandboxFlags effectiveSandboxFlags, const String& referrer, bool isDisplayingInitialEmptyDocument, const CrossOriginOpenerPolicyEnforcementResult& currentCoopEnforcementResult);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CrossOriginOpenerPolicyValue> {
-    using values = EnumValues<
-    WebCore::CrossOriginOpenerPolicyValue,
-    WebCore::CrossOriginOpenerPolicyValue::UnsafeNone,
-    WebCore::CrossOriginOpenerPolicyValue::SameOrigin,
-    WebCore::CrossOriginOpenerPolicyValue::SameOriginPlusCOEP,
-    WebCore::CrossOriginOpenerPolicyValue::SameOriginAllowPopups
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -249,17 +249,3 @@ struct ResourceLoaderOptions : public FetchOptions {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PreflightPolicy> {
-    using values = EnumValues<
-        WebCore::PreflightPolicy,
-        WebCore::PreflightPolicy::Consider,
-        WebCore::PreflightPolicy::Force,
-        WebCore::PreflightPolicy::Prevent
-    >;
-};
-
-
-} // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6614,3 +6614,13 @@ header: <WebCore/WheelEventTestMonitor.h>
     ContentScrollInProgress,
     RequestedScrollPosition,
 };
+
+header: <WebCore/CrossOriginAccessControl.h>
+[OptionSet] enum class WebCore::HTTPHeadersToKeepFromCleaning : uint8_t {
+    ContentType,
+    Referer,
+    Origin,
+    UserAgent,
+    AcceptEncoding,
+    CacheControl,
+};


### PR DESCRIPTION
#### c59bab5f663d352d0937cae0dbe0922dbf230dab
<pre>
Clean up EnumTraits specializations under WebCore/loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=264560">https://bugs.webkit.org/show_bug.cgi?id=264560</a>

Reviewed by Chris Dumez.

Remove EnumTraits specializations for the HTTPHeadersToKeepFromCleaning,
CrossOriginOpenerPolicyValue and PreflightPolicy enumerations. IPC serialization
specification is added for the first one, the latter two are already covered.

* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/CrossOriginOpenerPolicy.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270538@main">https://commits.webkit.org/270538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/549ed4666bcc55c4dc1c5354a8d5e574b52c3a9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1762 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28402 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29196 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27059 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1118 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4265 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6179 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->