### PR TITLE
Remove ResizeObserverEnabled preference

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/eventloop.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/eventloop.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!doctype html>
 <title>ResizeObserver notification event loop tests</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/idlharness.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/idlharness.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/resizeTestHelper.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!doctype html>
 <title>ResizeObserver tests</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/resizeTestHelper.js"></script>

--- a/LayoutTests/resize-observer/delete-observers-in-callbacks.html
+++ b/LayoutTests/resize-observer/delete-observers-in-callbacks.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
 <script src="../resources/testharness.js"></script>

--- a/LayoutTests/resize-observer/element-leak.html
+++ b/LayoutTests/resize-observer/element-leak.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <meta name="timeout" content="long">
 <head>

--- a/LayoutTests/resize-observer/modify-frametree-in-callback.html
+++ b/LayoutTests/resize-observer/modify-frametree-in-callback.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!doctype html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 

--- a/LayoutTests/resize-observer/multi-frames.html
+++ b/LayoutTests/resize-observer/multi-frames.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!doctype html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 <script src="./resources/resizeTestHelper.js"></script>

--- a/LayoutTests/resize-observer/observe-disconnected-target-crash.html
+++ b/LayoutTests/resize-observer/observe-disconnected-target-crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <p>This test passes if it doesn't crash.</p>
 <script>
   if (window.testRunner) {

--- a/LayoutTests/resize-observer/observe-element-from-other-frame.html
+++ b/LayoutTests/resize-observer/observe-element-from-other-frame.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!doctype html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 

--- a/LayoutTests/resize-observer/observe-then-disconnect-target.html
+++ b/LayoutTests/resize-observer/observe-then-disconnect-target.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <script src="../resources/js-test.js"></script>

--- a/LayoutTests/resize-observer/resize-observer-callback-leak.html
+++ b/LayoutTests/resize-observer/resize-observer-callback-leak.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
 <script src="../resources/testharness.js"></script>

--- a/LayoutTests/resize-observer/resize-observer-entry-keeps-js-wrapper-of-target-alive.html
+++ b/LayoutTests/resize-observer/resize-observer-entry-keeps-js-wrapper-of-target-alive.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <p>This tests that JS wrappers of targets in an ResizeObserverEntry do not get collected.</p>

--- a/LayoutTests/resize-observer/resize-observer-keeps-element-of-queued-entry-alive.html
+++ b/LayoutTests/resize-observer/resize-observer-keeps-element-of-queued-entry-alive.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <pre id="log">This tests observing an element with an ResizeObserver and removing the element from the document while it is queued for delivery.

--- a/LayoutTests/resize-observer/resize-observer-keeps-js-wrapper-of-target-alive.html
+++ b/LayoutTests/resize-observer/resize-observer-keeps-js-wrapper-of-target-alive.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <p>This tests that JS wrappers of targets removed from document to be delivered to an resize observer do not get collected.</p>

--- a/LayoutTests/resize-observer/resize-observer-should-not-leak-observed-nodes.html
+++ b/LayoutTests/resize-observer/resize-observer-should-not-leak-observed-nodes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <pre id="log">This tests observing an element with an ResizeObserver and removing the element from the document.

--- a/LayoutTests/resize-observer/resize-observer-with-zoom.html
+++ b/LayoutTests/resize-observer/resize-observer-with-zoom.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ResizeObserverEnabled=true ] -->
+<!DOCTYPE html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 <script src="./resources/resizeTestHelper.js"></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5437,19 +5437,6 @@ RequiresUserGestureToLoadVideo:
       "PLATFORM(IOS_FAMILY)": true
       default: false
 
-ResizeObserverEnabled:
-  type: bool
-  status: mature
-  humanReadableName: "Resize Observer"
-  humanReadableDescription: "Enable Resize Observer support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 ResourceLoadSchedulingEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/page/ResizeObserver.idl
+++ b/Source/WebCore/page/ResizeObserver.idl
@@ -26,7 +26,6 @@
 // https://wicg.github.io/ResizeObserver/
 
 [
-    EnabledBySetting=ResizeObserverEnabled,
     Exposed=Window,
     JSCustomMarkFunction,
     CustomIsReachable,

--- a/Source/WebCore/page/ResizeObserverEntry.idl
+++ b/Source/WebCore/page/ResizeObserverEntry.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.csswg.org/resize-observer/#resize-observer-entry-interface
 [
-    EnabledBySetting=ResizeObserverEnabled,
     JSCustomMarkFunction,
     Exposed=Window
 ] interface ResizeObserverEntry {

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -247,10 +247,8 @@
 #define WebKitMaskWebGLStringsEnabledPreferenceKey @"WebKitMaskWebGLStringsEnabled"
 #define WebKitServerTimingEnabledPreferenceKey @"WebKitServerTimingEnabled"
 #define WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey @"WebKitCSSCustomPropertiesAndValuesEnabled"
-#define WebKitResizeObserverEnabledPreferenceKey @"WebKitResizeObserverEnabled"
 #define WebKitPrivateClickMeasurementEnabledPreferenceKey @"WebKitPrivateClickMeasurementEnabled"
 #define WebKitGenericCueAPIEnabledKey @"WebKitGenericCueAPIEnabled"
-#define WebKitAspectRatioOfImgFromWidthAndHeightEnabledPreferenceKey @"WebKitAspectRatioOfImgFromWidthAndHeightEnabled"
 #define WebKitCoreMathMLEnabledPreferenceKey @"WebKitCoreMathMLEnabled"
 #define WebKitLinkPreloadResponsiveImagesEnabledPreferenceKey @"WebKitLinkPreloadResponsiveImagesEnabled"
 #define WebKitRemotePlaybackEnabledPreferenceKey @"WebKitRemotePlaybackEnabled"
@@ -263,6 +261,8 @@
 
 // The preference keys below this point are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
+#define WebKitAspectRatioOfImgFromWidthAndHeightEnabledPreferenceKey @"WebKitAspectRatioOfImgFromWidthAndHeightEnabled"
+#define WebKitResizeObserverEnabledPreferenceKey @"WebKitResizeObserverEnabled"
 #define WebKitShadowDOMEnabledPreferenceKey @"WebKitShadowDOMEnabled"
 #define WebKitHixie76WebSocketProtocolEnabledKey @"WebKitHixie76WebSocketProtocolEnabled"
 #define WebKitCustomElementsEnabledPreferenceKey @"WebKitCustomElementsEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -2996,16 +2996,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:flag forKey:WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey];
 }
 
-- (BOOL)resizeObserverEnabled
-{
-    return [self _boolValueForKey:WebKitResizeObserverEnabledPreferenceKey];
-}
-
-- (void)setResizeObserverEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitResizeObserverEnabledPreferenceKey];
-}
-
 - (BOOL)privateClickMeasurementEnabled
 {
     return [self _boolValueForKey:WebKitPrivateClickMeasurementEnabledPreferenceKey];
@@ -3129,6 +3119,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 }
 
 - (void)setAspectRatioOfImgFromWidthAndHeightEnabled:(BOOL)flag
+{
+}
+
+- (BOOL)resizeObserverEnabled
+{
+    return YES;
+}
+
+- (void)setResizeObserverEnabled:(BOOL)flag
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -312,7 +312,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL maskWebGLStringsEnabled;
 @property (nonatomic) BOOL serverTimingEnabled;
 @property (nonatomic) BOOL CSSCustomPropertiesAndValuesEnabled;
-@property (nonatomic) BOOL resizeObserverEnabled;
 @property (nonatomic) BOOL privateClickMeasurementEnabled;
 @property (nonatomic) BOOL genericCueAPIEnabled;
 @property (nonatomic) BOOL coreMathMLEnabled;
@@ -333,6 +332,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 // be removed when it is considered safe to do so.
 
 @property (nonatomic) BOOL aspectRatioOfImgFromWidthAndHeightEnabled;
+@property (nonatomic) BOOL resizeObserverEnabled;
 @property (nonatomic) BOOL subpixelCSSOMElementMetricsEnabled;
 @property (nonatomic) BOOL userTimingEnabled;
 @property (nonatomic) BOOL requestAnimationFrameEnabled;


### PR DESCRIPTION
#### 24772ebb16a56fa3ba366d906055707d4d0927b1
<pre>
Remove ResizeObserverEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=264561">https://bugs.webkit.org/show_bug.cgi?id=264561</a>

Reviewed by Simon Fraser.

This has been enabled for a long enough that we no longer need the
branching.

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/eventloop.html:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/idlharness.window.html:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify.html:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe.html:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg.html:
* LayoutTests/resize-observer/delete-observers-in-callbacks.html:
* LayoutTests/resize-observer/element-leak.html:
* LayoutTests/resize-observer/modify-frametree-in-callback.html:
* LayoutTests/resize-observer/multi-frames.html:
* LayoutTests/resize-observer/observe-disconnected-target-crash.html:
* LayoutTests/resize-observer/observe-element-from-other-frame.html:
* LayoutTests/resize-observer/observe-then-disconnect-target.html:
* LayoutTests/resize-observer/resize-observer-callback-leak.html:
* LayoutTests/resize-observer/resize-observer-entry-keeps-js-wrapper-of-target-alive.html:
* LayoutTests/resize-observer/resize-observer-keeps-element-of-queued-entry-alive.html:
* LayoutTests/resize-observer/resize-observer-keeps-js-wrapper-of-target-alive.html:
* LayoutTests/resize-observer/resize-observer-should-not-leak-observed-nodes.html:
* LayoutTests/resize-observer/resize-observer-with-zoom.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/ResizeObserver.idl:
* Source/WebCore/page/ResizeObserverEntry.idl:
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences resizeObserverEnabled]):
(-[WebPreferences setResizeObserverEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/270549@main">https://commits.webkit.org/270549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2b09bbf879ff5b7d3c28bd195061b8ba538ac66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23671 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28388 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29186 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22366 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27047 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24929 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1105 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32370 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22861 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6186 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->