### PR TITLE
Generate IPC serialization for enumerations under WebCore/workers

### DIFF
--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchFailureReason.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchFailureReason.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class BackgroundFetchFailureReason : uint8_t {
@@ -41,21 +39,5 @@ enum class BackgroundFetchFailureReason : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::BackgroundFetchFailureReason> {
-    using values = EnumValues<
-    WebCore::BackgroundFetchFailureReason,
-    WebCore::BackgroundFetchFailureReason::EmptyString,
-    WebCore::BackgroundFetchFailureReason::Aborted,
-    WebCore::BackgroundFetchFailureReason::BadStatus,
-    WebCore::BackgroundFetchFailureReason::FetchError,
-    WebCore::BackgroundFetchFailureReason::QuotaExceeded,
-    WebCore::BackgroundFetchFailureReason::DownloadTotalExceeded
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class BackgroundFetchResult : uint8_t {
@@ -38,18 +36,5 @@ enum class BackgroundFetchResult : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::BackgroundFetchResult> {
-    using values = EnumValues<
-    WebCore::BackgroundFetchResult,
-    WebCore::BackgroundFetchResult::EmptyString,
-    WebCore::BackgroundFetchResult::Success,
-    WebCore::BackgroundFetchResult::Failure
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6665,3 +6665,20 @@ enum class WebCore::ExceptionCode : uint8_t {
     OutOfMemoryError,
     ExistingExceptionError,
 }
+
+header: <WebCore/BackgroundFetchFailureReason.h>
+enum class WebCore::BackgroundFetchFailureReason : uint8_t {
+    EmptyString,
+    Aborted,
+    BadStatus,
+    FetchError,
+    QuotaExceeded,
+    DownloadTotalExceeded
+};
+
+header: <WebCore/BackgroundFetchResult.h>
+enum class WebCore::BackgroundFetchResult : uint8_t {
+    EmptyString,
+    Success,
+    Failure
+};


### PR DESCRIPTION
#### ecd3922c569d1ac9865d1d6040e3cc23ca5855c3
<pre>
Generate IPC serialization for enumerations under WebCore/workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=264563">https://bugs.webkit.org/show_bug.cgi?id=264563</a>

Reviewed by Chris Dumez.

Remove EnumTraits specializations for the BackgroundFetchFailureReason and
BackgroundFetchResult enumerations. Instead, provide IPC serialization
specification for the two enumerations in the WebCoreArgumentCoders
serialization input file.

* Source/WebCore/workers/service/background-fetch/BackgroundFetchFailureReason.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270595@main">https://commits.webkit.org/270595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a1f2bee1c5325e6d2b80c578b12583f89cd56e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1914 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28555 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29310 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27185 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1239 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4413 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6217 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->