### PR TITLE
Add missing 'optional' in constructor of 'RTCIceCandidate.idl' as per WebIDL Specification

### DIFF
--- a/LayoutTests/fast/mediastream/RTCIceCandidate-expected.txt
+++ b/LayoutTests/fast/mediastream/RTCIceCandidate-expected.txt
@@ -32,7 +32,7 @@ candidate.sdpMLineIndex = 7
 PASS candidate.sdpMLineIndex is 6
 
 Dictionary argument is mandatory.
-PASS new RTCIceCandidate(); threw exception TypeError: Not enough arguments.
+PASS new RTCIceCandidate(); threw exception TypeError: Candidate must not have both null sdpMid and sdpMLineIndex.
 One of the 'sdpMid' or 'sdpMLineIndex' members must be present (and not null or undefined).
 PASS new RTCIceCandidate({candidate:"foo"}); threw exception TypeError: Candidate must not have both null sdpMid and sdpMLineIndex.
 PASS new RTCIceCandidate({candidate:"foo", sdpMid: null}); threw exception TypeError: Candidate must not have both null sdpMid and sdpMLineIndex.

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
@@ -145,7 +145,7 @@ PASS RTCSessionDescription interface: new RTCSessionDescription({ type: 'offer' 
 PASS RTCSessionDescription interface: new RTCSessionDescription({ type: 'offer' }) must inherit property "toJSON()" with the proper type
 PASS RTCSessionDescription interface: default toJSON operation on new RTCSessionDescription({ type: 'offer' })
 PASS RTCIceCandidate interface: existence and properties of interface object
-FAIL RTCIceCandidate interface object length assert_equals: wrong value for RTCIceCandidate.length expected 0 but got 1
+PASS RTCIceCandidate interface object length
 PASS RTCIceCandidate interface object name
 PASS RTCIceCandidate interface: existence and properties of interface prototype object
 PASS RTCIceCandidate interface: existence and properties of interface prototype object's "constructor" property

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.idl
@@ -30,12 +30,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#rtcicecandidate-interface
+
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCIceCandidate {
-    constructor(RTCIceCandidateInit candidateInitDict);
+    constructor(optional RTCIceCandidateInit candidateInitDict = {});
 
     readonly attribute DOMString candidate;
     readonly attribute DOMString? sdpMid;


### PR DESCRIPTION
#### ee948a9bf67068a398f12a067d5445f1187666c0
<pre>
Add missing &apos;optional&apos; in constructor of &apos;RTCIceCandidate.idl&apos; as per WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=264564">https://bugs.webkit.org/show_bug.cgi?id=264564</a>

Reviewed by Youenn Fablet.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification [1].

[1] <a href="https://w3c.github.io/webrtc-pc/#rtcicecandidate-interface">https://w3c.github.io/webrtc-pc/#rtcicecandidate-interface</a>

This PR is adding missing &apos;optional&apos; in constructor as required by web specification.

* Source/WebCore/Modules/mediastream/RTCIceCandidate.idl:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt: Rebaselined
* LayoutTests/fast/mediastream/RTCIceCandidate-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/270552@main">https://commits.webkit.org/270552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3090c29036d3114ae16a54d774fdbddaa0b078b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23691 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28408 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29203 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27066 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1124 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4271 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6192 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->