### PR TITLE
Default binaryType value in RTCDataChannel should be 'Blob'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Default binaryType value assert_equals: dc.binaryType should be 'blob' expected "blob" but got "arraybuffer"
+PASS Default binaryType value
 PASS Setting binaryType to 'blob' should succeed
 PASS Setting binaryType to 'arraybuffer' should succeed
 PASS Setting binaryType to 'jellyfish' should be ignored

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -125,7 +125,10 @@ private:
     bool m_stopped { false };
     RTCDataChannelState m_readyState { RTCDataChannelState::Connecting };
 
-    BinaryType m_binaryType { BinaryType::Arraybuffer };
+    // https://w3c.github.io/webrtc-pc/#dom-datachannel-binarytype
+    // When an RTCDataChannel object is created, the binaryType attribute 
+    // MUST be initialized to the string "blob".
+    BinaryType m_binaryType { BinaryType::Blob };
 
     String m_label;
     RTCDataChannelInit m_options;


### PR DESCRIPTION
<pre>
Default binaryType value in RTCDataChannel should be 'Blob'
<a href="https://bugs.webkit.org/show_bug.cgi?id=264569">https://bugs.webkit.org/show_bug.cgi?id=264569</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Web-Specification [1]:

[1] <a href="https://w3c.github.io/webrtc-pc/#dom-datachannel-binarytype">https://w3c.github.io/webrtc-pc/#dom-datachannel-binarytype</a>

This patch modifies 'default' value set to 'Blob' as stated.

* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* LayoutTests/imported/w3c/web-platform-tests…/RTCDataChannel-binaryType.window-expected.txt: Rebaselined
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db51debab83b3333d3bafbc6efc802370ac464c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25726 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27827 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1767 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28407 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29202 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23481 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23498 "Found 2 new test failures: imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send.html, imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27065 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2889 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1123 "Found 2 new test failures: imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send.html, imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->