### PR TITLE
[ macOS wk2 debug ] fast/mediastream/device-change-event-2.html is a flaky failure.

### DIFF
--- a/LayoutTests/fast/mediastream/device-change-event-2-expected.txt
+++ b/LayoutTests/fast/mediastream/device-change-event-2-expected.txt
@@ -3,6 +3,5 @@ CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
 
 PASS 'devicechange' event fired when device list changes
 PASS 'devicechange' events fired quickly are coalesced
-PASS 'devicechange' event is not fired when the document doesn't has focus or permission to capture
-PASS 'devicechange' event is fired when the document doesn't has focus but has permission to capture
+PASS 'devicechange' event is not fired when the document is not visible
 

--- a/LayoutTests/fast/mediastream/device-change-event-2.html
+++ b/LayoutTests/fast/mediastream/device-change-event-2.html
@@ -113,71 +113,31 @@
 
     promise_test(async (test) => {
         await setup(test);
+        assert_equals(document.visibilityState, "visible", "visible1");
 
-        await new Promise((resolve, reject) => {
-            let timeout = setTimeout(() => {
-                console.log("window.onblur took too long");
-                resolve();
-            }, 5000);
+        let promise = new Promise(resolve => document.onvisibilitychange = resolve);
+        testRunner.setPageVisibility("hidden");
+        await promise;
+        assert_equals(document.visibilityState, "hidden", "hidden");
 
-            window.onblur = () => {
-                clearTimeout(timeout);
-                resolve();
-            }
-        
-            internals.setPageIsFocusedAndActive(false);
-        });
+        testRunner.addMockMicrophoneDevice("id3", "microphone 2");
 
-        await new Promise((resolve, reject) => {
-            assert_false(document.hasFocus(), "document.hasFocus()");
+        let testPromise = new Promise(resolve => navigator.mediaDevices.ondevicechange = resolve);
+        testPromise = testPromise.then(test.step_func(() => {
+            assert_equals(document.visibilityState, "visible", "devicechange should only fire when the document is focused and active");
+        }));
 
-            navigator.mediaDevices.ondevicechange = () => {
-                assert_true(document.hasFocus(), "devicechange should only fire when the document is focused and active");
-                resolve();
-            };
+        promise = new Promise(resolve => document.onvisibilitychange = resolve);
+        // Let's delay to give enough time for navigator.mediaDevices.ondevicechange to fire
+        setTimeout(() => {
+            testRunner.setPageVisibility("visible");
+        }, 500);
 
-            setTimeout(() => {
-                internals.setPageIsFocusedAndActive(true);
-            }, 200);
+        await promise;
+        assert_equals(document.visibilityState, "visible", "visible2");
 
-            testRunner.addMockMicrophoneDevice("id3", "microphone 2");
-        });
-
-    }, "'devicechange' event is not fired when the document doesn't has focus or permission to capture");
-
-    promise_test(async (test) => {
-        await setup(test);
-
-        await navigator.mediaDevices.getUserMedia({ audio:true, video:true })
-            .then(s => stream = s);
-
-        await new Promise((resolve, reject) => {
-            let timeout = setTimeout(() => {
-                console.log("window.onblur took too long");
-                resolve();
-            }, 5000);
-
-            window.onblur = () => {
-                clearTimeout(timeout);
-                resolve();
-            }
-        
-            internals.setPageIsFocusedAndActive(false);
-        });
-
-        await new Promise((resolve, reject) => {
-            assert_false(document.hasFocus(), "document.hasFocus()");
-
-            navigator.mediaDevices.ondevicechange = () => {
-                assert_false(document.hasFocus(), "devicechange should fire when the document is not focused but can capture");
-                resolve();
-            };
-
-            testRunner.addMockMicrophoneDevice("id3", "microphone 2");
-        });
-
-    }, "'devicechange' event is fired when the document doesn't has focus but has permission to capture");
-
+        return testPromise;
+    }, "'devicechange' event is not fired when the document is not visible");
     </script>
 </head>
 <body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -396,6 +396,7 @@ webkit.org/b/165799 svg/animations/animations-paused-in-background-page-iframe.h
 webkit.org/b/165799 svg/animations/animations-paused-in-background-page.html [ Skip ]
 webkit.org/b/165799 webaudio/silent-audio-interrupted-in-background.html [ Skip ]
 webkit.org/b/165799 imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
+webkit.org/b/165799 fast/mediastream/device-change-event-2.html [ Skip ]
 
 # AutoFill button is not supported
 fast/forms/auto-fill-button/mouse-down-input-mouse-release-auto-fill-button.html

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -384,8 +384,13 @@ MediaTrackSupportedConstraints MediaDevices::getSupportedConstraints()
 
 void MediaDevices::scheduledEventTimerFired()
 {
-    ASSERT(!isContextStopped());
-    dispatchEvent(Event::create(eventNames().devicechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    RefPtr document = this->document();
+    if (!document)
+        return;
+
+    document->whenVisible([protectedThis = makePendingActivity(*this), this] {
+        queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().devicechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    });
 }
 
 bool MediaDevices::virtualHasPendingActivity() const


### PR DESCRIPTION
#### 2d5fd917570a4fb655d21f2828d466fd22d8aa2b
<pre>
[ macOS wk2 debug ] fast/mediastream/device-change-event-2.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261356">https://bugs.webkit.org/show_bug.cgi?id=261356</a>
<a href="https://rdar.apple.com/115192271">rdar://115192271</a>

Reviewed by Jean-Yves Avenard.

We never implemented focus restrictions. The spec has been updated to use inview/visibility restrictions.
We align the implementation and the test with the spec.

* LayoutTests/fast/mediastream/device-change-event-2-expected.txt:
* LayoutTests/fast/mediastream/device-change-event-2.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::scheduledEventTimerFired):

Canonical link: <a href="https://commits.webkit.org/270702@main">https://commits.webkit.org/270702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79a6d40b60097446513c36134ea81e61066376ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25733 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23572 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23686 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28414 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29205 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27068 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1127 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22883 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6291 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->