### PR TITLE
Stop using Vector::unsafeAppendWithoutCapacityCheck() in TinyLRUCache

### DIFF
--- a/Source/WTF/wtf/TinyLRUCache.h
+++ b/Source/WTF/wtf/TinyLRUCache.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include <algorithm>
+#include <span>
+#include <type_traits>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/Vector.h>
 
 namespace WTF {
 
@@ -49,29 +51,38 @@ public:
             return valueForNull;
         }
 
-        auto index = m_cache.reverseFindIf([&key](auto& entry) { return entry.first == key; });
-        if (index != notFound) {
-            // Move entry to the end of the cache if necessary.
-            if (index != m_cache.size() - 1) {
-                auto entry = WTFMove(m_cache[index]);
-                m_cache.remove(index);
-                m_cache.unsafeAppendWithoutCapacityCheck(WTFMove(entry));
+        auto* cacheBuffer = this->cacheBuffer();
+        for (size_t i = m_size; i-- > 0;) {
+            if (cacheBuffer[i].first == key) {
+                if (i < m_size - 1) {
+                    // Move entry to the end of the cache if necessary.
+                    auto entry = WTFMove(cacheBuffer[i]);
+                    do {
+                        cacheBuffer[i] = WTFMove(cacheBuffer[i + 1]);
+                    } while (++i < m_size - 1);
+                    cacheBuffer[m_size - 1] = WTFMove(entry);
+                }
+                return cacheBuffer[m_size - 1].second;
             }
-            return m_cache[m_cache.size() - 1].second;
         }
 
-        // m_cache[0] is the LRU entry, so remove it.
-        if (m_cache.size() == capacity)
-            m_cache.remove(0);
+        // cacheBuffer[0] is the LRU entry, so remove it.
+        if (m_size == capacity) {
+            for (size_t i = 0; i < m_size - 1; ++i)
+                cacheBuffer[i] = WTFMove(cacheBuffer[i + 1]);
+        } else
+            ++m_size;
 
-        m_cache.unsafeAppendWithoutCapacityCheck(std::pair { Policy::createKeyForStorage(key), Policy::createValueForKey(key) });
-        return m_cache.last().second;
+        cacheBuffer[m_size - 1] = std::pair { Policy::createKeyForStorage(key), Policy::createValueForKey(key) };
+        return cacheBuffer[m_size - 1].second;
     }
 
 private:
     using Entry = std::pair<KeyType, ValueType>;
-    using Cache = Vector<Entry, capacity>;
-    Cache m_cache;
+    Entry* cacheBuffer() { return reinterpret_cast_ptr<Entry*>(m_cacheBuffer); }
+
+    std::aligned_storage_t<sizeof(Entry), std::alignment_of_v<Entry>> m_cacheBuffer[capacity];
+    size_t m_size { 0 };
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### 95285984cfabd9efffd899980dc28e129301fb60
<pre>
Stop using Vector::unsafeAppendWithoutCapacityCheck() in TinyLRUCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=264585">https://bugs.webkit.org/show_bug.cgi?id=264585</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/TinyLRUCache.h:
(WTF::TinyLRUCache::get):
(WTF::TinyLRUCache::cacheBuffer):

Canonical link: <a href="https://commits.webkit.org/270556@main">https://commits.webkit.org/270556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a1694238d7e34b8150c408c1fbe521736319f30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23576 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1778 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28418 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23137 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29213 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/metadata/generated/audioworklet.https.sub.html, imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22396 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27075 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24959 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1130 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32400 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4281 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7049 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3350 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3298 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->