### PR TITLE
LocalFrameView: Use a weak reference for embedded objects during update

### DIFF
--- a/LayoutTests/fast/dom/move-embedded-during-update-expected.txt
+++ b/LayoutTests/fast/dom/move-embedded-during-update-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash. AA

--- a/LayoutTests/fast/dom/move-embedded-during-update.html
+++ b/LayoutTests/fast/dom/move-embedded-during-update.html
@@ -1,0 +1,24 @@
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+}
+
+function eventhandler1() {
+    label.removeEventListener("DOMSubtreeModified", eventhandler1);
+    label.appendChild(embed);
+}
+
+function eventhandler2() {
+    label.addEventListener("DOMSubtreeModified", eventhandler1);
+    label.appendChild(embed);
+}
+
+function eventhandler3() {
+    embed.align = "Right";
+    setTimeout(eventhandler3, 0);
+}
+</script>
+
+<style onload="setTimeout(eventhandler3, 0)">AA</style>
+<label id="label">This test passes if it doesn't crash.</label>
+<embed id="embed" src="data:text/html,foo" onload="eventhandler2()">AA</embed>

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -880,7 +880,7 @@ private:
 
     void updateEmbeddedObjectsTimerFired();
     bool updateEmbeddedObjects();
-    void updateEmbeddedObject(RenderEmbeddedObject&);
+    void updateEmbeddedObject(const WeakPtr<RenderEmbeddedObject>&);
 
     void updateWidgetPositionsTimerFired();
 


### PR DESCRIPTION
#### 2d41e7df7e956440d7df6ed59e3a3e898b50f1c1
<pre>
LocalFrameView: Use a weak reference for embedded objects during update
<a href="https://bugs.webkit.org/show_bug.cgi?id=263179">https://bugs.webkit.org/show_bug.cgi?id=263179</a>
<a href="https://rdar.apple.com/116715302">rdar://116715302</a>

Reviewed by Chris Dumez.

Embedded objects can be remove during update, so it&apos;s safer to
use a weak reference to avoid leaking one.

* LayoutTests/fast/dom/move-embedded-during-update-expected.txt: Added.
* LayoutTests/fast/dom/move-embedded-during-update.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateEmbeddedObject):
(WebCore::LocalFrameView::updateEmbeddedObjects):
* Source/WebCore/page/LocalFrameView.h:

Co-authored-by: Žan Doberšek &lt;zdobersek@igalia.com&gt;
Canonical link: <a href="https://commits.webkit.org/270541@main">https://commits.webkit.org/270541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/895f12bcb3eddc283f83f89925800ae275f49836

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1779 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28419 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23138 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27072 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1132 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6181 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->