### PR TITLE
Rework ArgumentCodersCocoa to get us much closer to generated serializers

### DIFF
--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
@@ -46,7 +46,7 @@ public:
 
     id nativeValue() const { return m_nativeValue.get(); }
 
-    WEBCORE_EXPORT static NSArray *allowedClassesForNativeValues();
+    WEBCORE_EXPORT static const Vector<Class>& allowedClassesForNativeValues();
 
 private:
 

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -109,10 +109,10 @@ const SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(const Seriali
     return static_cast<const SerializedPlatformDataCueMac*>(rep);
 }
 
-NSArray *SerializedPlatformDataCueMac::allowedClassesForNativeValues()
+const Vector<Class>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
 {
-    static NeverDestroyed<RetainPtr<NSArray>> allowedClasses(@[ [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] ]);
-    return allowedClasses.get().get();
+    static NeverDestroyed<Vector<Class>> allowedClasses(Vector<Class> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
+    return allowedClasses;
 }
 
 SerializedPlatformDataCueValue SerializedPlatformDataCueMac::encodableValue() const

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -192,8 +192,17 @@ $(PROJECT_DIR)/Shared/AuxiliaryProcessCreationParameters.serialization.in
 $(PROJECT_DIR)/Shared/BackgroundFetchState.serialization.in
 $(PROJECT_DIR)/Shared/CallbackID.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCArray.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFType.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCColor.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCData.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDate.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCDictionary.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCFont.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCString.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/InsertTextOptions.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -539,8 +539,17 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/AlternativeTextClient.serialization.in \
 	Shared/AppPrivacyReportTestingData.serialization.in \
 	Shared/Cocoa/CacheStoragePolicy.serialization.in \
+	Shared/Cocoa/CoreIPCArray.serialization.in \
+	Shared/Cocoa/CoreIPCCFType.serialization.in \
+	Shared/Cocoa/CoreIPCColor.serialization.in \
 	Shared/Cocoa/CoreIPCData.serialization.in \
 	Shared/Cocoa/CoreIPCDate.serialization.in \
+	Shared/Cocoa/CoreIPCDictionary.serialization.in \
+	Shared/Cocoa/CoreIPCFont.serialization.in \
+	Shared/Cocoa/CoreIPCNSCFObject.serialization.in \
+	Shared/Cocoa/CoreIPCSecureCoding.serialization.in \
+	Shared/Cocoa/CoreIPCString.serialization.in \
+	Shared/Cocoa/CoreIPCURL.serialization.in \
 	Shared/Cocoa/DataDetectionResult.serialization.in \
 	Shared/Cocoa/InsertTextOptions.serialization.in \
 	Shared/Cocoa/RevealItem.serialization.in \

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -632,7 +632,7 @@ def decode_type(type):
         if len(decodable_classes) == 1:
             match = re.search("RetainPtr<(.*)>", member.type)
             assert match
-            result.append('    auto ' + sanitized_variable_name + ' = decoder.decodeWithAllowedClasses<' + match.groups()[0] + '>(@[ ' + decodable_classes[0] + ' ]);')
+            result.append('    auto ' + sanitized_variable_name + ' = decoder.decodeWithAllowedClasses<' + match.groups()[0] + '>({ ' + decodable_classes[0] + ' });')
         elif member.is_subclass:
             result.append('    if (type == ' + type.subclass_enum_name() + "::" + member.name + ') {')
             typename = member.namespace + "::" + member.name

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -204,7 +204,7 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
 {
     auto a = decoder.decode<int>();
     auto b = decoder.decode<bool>();
-    auto dataDetectorResults = decoder.decodeWithAllowedClasses<NSArray>(@[ NSArray.class, PAL::getDDScannerResultClass() ]);
+    auto dataDetectorResults = decoder.decodeWithAllowedClasses<NSArray>({ NSArray.class, PAL::getDDScannerResultClass() });
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {
@@ -563,8 +563,8 @@ void ArgumentCoder<SoftLinkedMember>::encode(Encoder& encoder, const SoftLinkedM
 
 std::optional<SoftLinkedMember> ArgumentCoder<SoftLinkedMember>::decode(Decoder& decoder)
 {
-    auto firstMember = decoder.decodeWithAllowedClasses<DDActionContext>(@[ PAL::getDDActionContextClass() ]);
-    auto secondMember = decoder.decodeWithAllowedClasses<DDActionContext>(@[ PAL::getDDActionContextClass() ]);
+    auto firstMember = decoder.decodeWithAllowedClasses<DDActionContext>({ PAL::getDDActionContextClass() });
+    auto secondMember = decoder.decodeWithAllowedClasses<DDActionContext>({ PAL::getDDActionContextClass() });
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #import "ArgumentCoders.h"
 
 #if PLATFORM(COCOA)
@@ -32,16 +34,56 @@
 namespace IPC {
 
 #ifdef __OBJC__
-void encodeObject(Encoder&, id);
-std::optional<RetainPtr<id>> decodeObject(Decoder&, NSArray<Class> *allowedClasses);
+
+template<typename T>
+class CoreIPCRetainPtr : public RetainPtr<T> {
+public:
+    CoreIPCRetainPtr()
+        : RetainPtr<T>()
+    {
+    }
+
+    CoreIPCRetainPtr(T *object)
+        : RetainPtr<T>(object)
+    {
+    }
+
+    CoreIPCRetainPtr(RetainPtr<T>&& object)
+        : RetainPtr<T>(WTFMove(object))
+    {
+    }
+};
+
+enum class NSType : uint8_t {
+    Array,
+    Color,
+    Data,
+    Date,
+    Dictionary,
+    Font,
+    Number,
+    SecureCoding,
+    String,
+    URL,
+    CF,
+    Unknown,
+};
+NSType typeFromObject(id);
+
+void encodeObjectWithWrapper(Encoder&, id);
+std::optional<RetainPtr<id>> decodeObjectFromWrapper(Decoder&, const Vector<Class>& allowedClasses);
+
+template<typename T> void encodeObjectDirectly(Encoder&, T *);
+template<typename T> void encodeObjectDirectly(Encoder&, T);
+template<typename T> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClasses(Decoder&);
 
 template<typename T, typename = IsObjCObject<T>> void encode(Encoder&, T *);
 
 #if ASSERT_ENABLED
 
-static inline bool isObjectClassAllowed(id object, NSArray<Class> *allowedClasses)
+static inline bool isObjectClassAllowed(id object, const Vector<Class>& allowedClasses)
 {
-    for (Class allowedClass in allowedClasses) {
+    for (Class allowedClass : allowedClasses) {
         if ([object isKindOfClass:allowedClass])
             return true;
     }
@@ -51,12 +93,22 @@ static inline bool isObjectClassAllowed(id object, NSArray<Class> *allowedClasse
 #endif // ASSERT_ENABLED
 
 template<typename T, typename>
-std::optional<RetainPtr<T>> decodeWithAllowedClasses(Decoder& decoder, NSArray<Class> *allowedClasses)
+std::optional<RetainPtr<T>> decodeRequiringAllowedClasses(Decoder& decoder)
 {
-    auto result = decodeObject(decoder, allowedClasses);
+    auto result = decodeObjectFromWrapper(decoder, decoder.allowedClasses());
     if (!result)
         return std::nullopt;
-    ASSERT(!*result || isObjectClassAllowed((*result).get(), allowedClasses));
+    ASSERT(!*result || isObjectClassAllowed((*result).get(), decoder.allowedClasses()));
+    return { *result };
+}
+
+template<typename T, typename>
+std::optional<T> decodeRequiringAllowedClasses(Decoder& decoder)
+{
+    auto result = decodeObjectFromWrapper(decoder, decoder.allowedClasses());
+    if (!result)
+        return std::nullopt;
+    ASSERT(!*result || isObjectClassAllowed((*result).get(), decoder.allowedClasses()));
     return { *result };
 }
 
@@ -64,7 +116,21 @@ template<typename T> struct ArgumentCoder<T *> {
     template<typename U = T, typename = IsObjCObject<U>>
     static void encode(Encoder& encoder, U *object)
     {
-        encodeObject(encoder, object);
+        encodeObjectWithWrapper(encoder, object);
+    }
+};
+
+template<typename T> struct ArgumentCoder<CoreIPCRetainPtr<T>> {
+    template<typename U = T>
+    static void encode(Encoder& encoder, const CoreIPCRetainPtr<U>& object)
+    {
+        encodeObjectDirectly<U>(encoder, object.get());
+    }
+
+    template<typename U = T>
+    static std::optional<RetainPtr<U>> decode(Decoder& decoder)
+    {
+        return decodeObjectDirectlyRequiringAllowedClasses<U>(decoder);
     }
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCArray.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCArray.h
@@ -27,55 +27,31 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
+#include "ArgumentCodersCocoa.h"
 #include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCArray {
 public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    CoreIPCArray(NSArray *array)
+        : m_array(array)
     {
     }
 
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
+    CoreIPCArray(RetainPtr<NSArray> array)
+        : m_array(WTFMove(array))
     {
     }
 
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
+    RetainPtr<id> toID() { return m_array; }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCArray, void>;
+
+    IPC::CoreIPCRetainPtr<NSArray> m_array;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCArray.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCArray.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCArray.h"
+
+[WebKitPlatform] class WebKit::CoreIPCArray {
+    IPC::CoreIPCRetainPtr<NSArray> m_array;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
@@ -27,55 +27,30 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
+#include <wtf/ArgumentCoder.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCCFType {
 public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    CoreIPCCFType(CFTypeRef cfType)
+        : m_cfType(cfType)
     {
     }
 
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
+    CoreIPCCFType(RetainPtr<CFTypeRef>&& cfType)
+        : m_cfType(WTFMove(cfType))
     {
     }
 
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
+    RetainPtr<id> toID() { return (__bridge id)(m_cfType.get()); }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCCFType, void>;
+
+    IPC::CoreIPCRetainPtr<CFTypeRef> m_cfType;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(CF)
+
+webkit_platform_headers: "CoreIPCCFType.h"
+
+[WebKitPlatform] class WebKit::CoreIPCCFType {
+    IPC::CoreIPCRetainPtr<CFTypeRef> m_cfType;
+}
+
+#endif // USE(CF)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCColor.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCColor.h
@@ -27,55 +27,34 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
+#include <WebCore/ColorCocoa.h>
+#include <wtf/ArgumentCoder.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCColor {
 public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    CoreIPCColor(WebCore::CocoaColor *color)
+        : m_color(WebCore::colorFromCocoaColor(color))
     {
     }
 
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
+    CoreIPCColor(WebCore::Color&& color)
+        : m_color(WTFMove(color))
     {
     }
 
-    RetainPtr<CFDataRef> createData() const
+    RetainPtr<id> toID()
     {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
+        return cocoaColor(m_color);
     }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCColor, void>;
+
+    WebCore::Color m_color;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCColor.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCColor.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCColor.h"
+
+[WebKitPlatform] class WebKit::CoreIPCColor {
+    WebCore::Color m_color;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDate.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDate.h
@@ -34,6 +34,14 @@ namespace WebKit {
 
 class CoreIPCDate {
 public:
+
+#ifdef __OBJC__
+    CoreIPCDate(NSDate *date)
+        : CoreIPCDate(bridge_cast(date))
+    {
+    }
+#endif
+
     CoreIPCDate(const CFDateRef date)
         : m_absoluteTime(CFDateGetAbsoluteTime(date))
     {
@@ -52,6 +60,11 @@ public:
     double get() const
     {
         return m_absoluteTime;
+    }
+
+    RetainPtr<id> toID() const
+    {
+        return bridge_cast(createDate().get());
     }
 
 private:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
@@ -27,55 +27,30 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
+#include <wtf/ArgumentCoder.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCDictionary {
 public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    CoreIPCDictionary(NSDictionary *dictionary)
+        : m_dictionary(dictionary)
     {
     }
 
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
+    CoreIPCDictionary(RetainPtr<NSDictionary>&& dictionary)
+        : m_dictionary(WTFMove(dictionary))
     {
     }
 
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
+    RetainPtr<id> toID() { return m_dictionary; }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCDictionary, void>;
+
+    IPC::CoreIPCRetainPtr<NSDictionary> m_dictionary;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCDictionary.h"
+
+[WebKitPlatform] class WebKit::CoreIPCDictionary {
+    IPC::CoreIPCRetainPtr<NSDictionary> m_dictionary;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCFont.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCFont.h
@@ -27,55 +27,32 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
+#include "ArgumentCodersCocoa.h"
+#include <WebCore/FontCocoa.h>
+#include <wtf/ArgumentCoder.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCFont {
 public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    CoreIPCFont(WebCore::CocoaFont *font)
+        : m_font(font)
     {
     }
 
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
+    CoreIPCFont(RetainPtr<WebCore::CocoaFont>&& font)
+        : m_font(WTFMove(font))
     {
     }
 
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
+    RetainPtr<id> toID() { return m_font; }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCFont, void>;
+
+    IPC::CoreIPCRetainPtr<WebCore::CocoaFont> m_font;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCFont.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCFont.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCFont.h"
+
+[WebKitPlatform] class WebKit::CoreIPCFont {
+    IPC::CoreIPCRetainPtr<WebCore::CocoaFont> m_font;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCNSCFObject.h"
+
+#if PLATFORM(COCOA)
+
+#import "ArgumentCodersCocoa.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+namespace WebKit {
+
+static CoreIPCNSCFObject::ObjectValue valueFromID(id object)
+{
+    if (!object)
+        return nullptr;
+
+    switch (IPC::typeFromObject(object)) {
+    case IPC::NSType::Array:
+        return CoreIPCArray((NSArray *)object);
+    case IPC::NSType::Color:
+        return CoreIPCColor((WebCore::CocoaColor *)object);
+    case IPC::NSType::Data:
+        return CoreIPCData((NSData *)object);
+    case IPC::NSType::Date:
+        return CoreIPCDate(bridge_cast((NSDate *)object));
+    case IPC::NSType::Dictionary:
+        return CoreIPCDictionary((NSDictionary *)object);
+    case IPC::NSType::Font:
+        return CoreIPCFont((WebCore::CocoaFont *)object);
+    case IPC::NSType::Number:
+        return CoreIPCNumber(bridge_cast((NSNumber *)object));
+    case IPC::NSType::SecureCoding:
+        return CoreIPCSecureCoding((NSObject<NSSecureCoding> *)object);
+    case IPC::NSType::String:
+        return CoreIPCString((NSString *)object);
+    case IPC::NSType::URL:
+        return CoreIPCURL((NSURL *)object);
+    case IPC::NSType::CF:
+        return CoreIPCCFType((CFTypeRef)object);
+    case IPC::NSType::Unknown:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+CoreIPCNSCFObject::CoreIPCNSCFObject(id object)
+    : m_value(valueFromID(object))
+{
+}
+
+RetainPtr<id> CoreIPCNSCFObject::toID()
+{
+    RetainPtr<id> result;
+
+    WTF::switchOn(m_value, [&](auto& object) {
+        result = object.toID();
+    }, [](std::nullptr_t) {
+        // result should be nil, which is the default value initialized above.
+    });
+
+    return result;
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(CF)
+
+webkit_platform_headers: "ArgumentCodersCocoa.h" "ArgumentCodersCF.h" "CoreIPCNSCFObject.h"
+
+[WebKitPlatform] class WebKit::CoreIPCNSCFObject {
+    WebKit::CoreIPCNSCFObject::ObjectValue m_value;
+}
+
+#endif // USE(CF)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
@@ -27,55 +27,24 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
+#include "ArgumentCodersCocoa.h"
 #include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCSecureCoding {
 public:
+    CoreIPCSecureCoding(NSObject<NSSecureCoding> *);
+    CoreIPCSecureCoding(RetainPtr<NSObject<NSSecureCoding>>&&);
 
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
-    {
-    }
-
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
-    {
-    }
-
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
+    RetainPtr<id> toID() { return m_secureCoding; }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCSecureCoding, void>;
+
+    IPC::CoreIPCRetainPtr<NSObject<NSSecureCoding>> m_secureCoding;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -23,59 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
+#import "config.h"
+#import "CoreIPCSecureCoding.h"
 
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
+#import "ArgumentCodersCocoa.h"
 
 namespace WebKit {
 
-class CoreIPCData {
-public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
-    {
-    }
-
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
-    {
-    }
-
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
-
-private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
-};
-
+CoreIPCSecureCoding::CoreIPCSecureCoding(NSObject<NSSecureCoding> *object)
+    : m_secureCoding(object)
+{
+    RELEASE_ASSERT(!m_secureCoding || IPC::typeFromObject(object) == IPC::NSType::SecureCoding);
 }
+
+CoreIPCSecureCoding::CoreIPCSecureCoding(RetainPtr<NSObject<NSSecureCoding>>&& object)
+    : m_secureCoding(WTFMove(object))
+{
+    RELEASE_ASSERT(!m_secureCoding || IPC::typeFromObject(m_secureCoding.get()) == IPC::NSType::SecureCoding);
+}
+
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCSecureCoding.h"
+
+[WebKitPlatform] class WebKit::CoreIPCSecureCoding {
+    IPC::CoreIPCRetainPtr<NSObject<NSSecureCoding>> m_secureCoding;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCString.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCString.h
@@ -27,55 +27,31 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
+#include <wtf/ArgumentCoder.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCString  {
 public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    CoreIPCString(NSString *string)
+        : m_string(string)
     {
     }
 
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
+    CoreIPCString(String&& string)
+        : m_string(WTFMove(string))
     {
     }
 
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
+    RetainPtr<id> toID() { return (NSString *)m_string; }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCString, void>;
+
+    String m_string;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCString.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCString.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCString.h"
+
+[WebKitPlatform] class WebKit::CoreIPCString {
+    String m_string;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
@@ -27,55 +27,31 @@
 
 #if PLATFORM(COCOA)
 
-#include "DataReference.h"
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/cocoa/TypeCastsCocoa.h>
+#include <wtf/ArgumentCoder.h>
+#include <wtf/URL.h>
 
 namespace WebKit {
 
-class CoreIPCData {
+class CoreIPCURL {
 public:
-
-#ifdef __OBJC__
-    CoreIPCData(NSData *nsData)
-        : CoreIPCData(bridge_cast(nsData))
-    {
-    }
-#endif
-
-    CoreIPCData(CFDataRef cfData)
-        : m_cfData(cfData)
-        , m_reference(CFDataGetBytePtr(cfData), CFDataGetLength(cfData))
+    CoreIPCURL(NSURL *url)
+        : m_url(url)
     {
     }
 
-    CoreIPCData(const IPC::DataReference& data)
-        : m_reference(data)
+    CoreIPCURL(URL&& url)
+        : m_url(WTFMove(url))
     {
     }
 
-    RetainPtr<CFDataRef> createData() const
-    {
-        return adoptCF(CFDataCreate(0, m_reference.data(), m_reference.size()));
-    }
-
-    IPC::DataReference get() const
-    {
-        return m_reference;
-    }
-
-    RetainPtr<id> toID() const
-    {
-        return bridge_cast(createData().get());
-    }
+    RetainPtr<id> toID() { return (NSURL *)m_url; }
 
 private:
-    RetainPtr<CFDataRef> m_cfData;
-    IPC::DataReference m_reference;
+    friend struct IPC::ArgumentCoder<CoreIPCURL, void>;
+
+    URL m_url;
 };
 
-}
+} // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCURL.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCURL.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCURL.h"
+
+[WebKitPlatform] class WebKit::CoreIPCURL {
+    URL m_url;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
@@ -40,6 +40,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreMedia/CoreMedia.h>
 #import <ImageIO/ImageIO.h>
+#import <WebCore/PlatformImage.h>
 #import <wtf/MathExtras.h>
 #import <wtf/RetainPtr.h>
 

--- a/Source/WebKit/Shared/cf/CoreIPCNumber.h
+++ b/Source/WebKit/Shared/cf/CoreIPCNumber.h
@@ -104,6 +104,11 @@ public:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
+    CoreIPCNumber(NSNumber *number)
+        : CoreIPCNumber(bridge_cast(number))
+    {
+    }
+
     CoreIPCNumber(CFNumberRef number)
         : m_numberHolder(numberHolderForNumber(number))
     {
@@ -160,6 +165,8 @@ public:
     {
         return m_numberHolder;
     }
+
+    RetainPtr<id> toID() { return bridge_cast(createCFNumber().get()); }
 
 private:
     NumberHolder m_numberHolder;

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -209,7 +209,7 @@ void ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::encodePlatformData(
 {
     ASSERT(value.platformType() == WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC);
     if (value.platformType() == WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC)
-        encodeObject(encoder, value.nativeValue().get());
+        encodeObjectWithWrapper(encoder, value.nativeValue().get());
 }
 
 std::optional<WebCore::SerializedPlatformDataCueValue>  ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::decodePlatformData(Decoder& decoder, WebCore::SerializedPlatformDataCueValue::PlatformType platformType)
@@ -219,7 +219,7 @@ std::optional<WebCore::SerializedPlatformDataCueValue>  ArgumentCoder<WebCore::S
     if (platformType != WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC)
         return std::nullopt;
 
-    auto object = decodeObject(decoder, WebCore::SerializedPlatformDataCueMac::allowedClassesForNativeValues());
+    auto object = decodeObjectFromWrapper(decoder, WebCore::SerializedPlatformDataCueMac::allowedClassesForNativeValues());
     if (!object)
         return std::nullopt;
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -149,7 +149,6 @@ Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
 Shared/Cocoa/APIDataCocoa.mm
 Shared/Cocoa/APIObject.mm
 Shared/Cocoa/ARKitSoftLink.mm
-Shared/Cocoa/ArgumentCodersCocoa.mm
 Shared/Cocoa/AuxiliaryProcessCocoa.mm
 Shared/Cocoa/CodeSigning.mm
 Shared/Cocoa/CompletionHandlerCallChecker.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1179,6 +1179,17 @@
 		519261782950EA3F00A975D1 /* WKSecurityOriginPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 519261772950EA3E00A975D1 /* WKSecurityOriginPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5192DDB92AB54ED700E88DE7 /* WebPushMessageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F98275EC600002DC22D /* WebPushMessageCocoa.mm */; };
 		51933DEF1965EB31008AC3EA /* MenuUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51933DEB1965EB24008AC3EA /* MenuUtilities.h */; };
+		5197FAE32AFD33CF009180C5 /* CoreIPCFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FAD72AFD33B1009180C5 /* CoreIPCFont.h */; };
+		5197FAE42AFD33CF009180C5 /* CoreIPCNSCFObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FACE2AFD33AF009180C5 /* CoreIPCNSCFObject.h */; };
+		5197FAE52AFD33CF009180C5 /* CoreIPCString.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FACC2AFD33AE009180C5 /* CoreIPCString.h */; };
+		5197FAE62AFD33CF009180C5 /* CoreIPCURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FADB2AFD33B2009180C5 /* CoreIPCURL.h */; };
+		5197FAE72AFD33CF009180C5 /* CoreIPCCFType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FAE22AFD33B4009180C5 /* CoreIPCCFType.h */; };
+		5197FAE82AFD33CF009180C5 /* CoreIPCColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FAD32AFD33B0009180C5 /* CoreIPCColor.h */; };
+		5197FAE92AFD33CF009180C5 /* CoreIPCSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FAD92AFD33B2009180C5 /* CoreIPCSecureCoding.h */; };
+		5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */; };
+		5197FAEB2AFD33CF009180C5 /* CoreIPCArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 5197FACD2AFD33AF009180C5 /* CoreIPCArray.h */; };
+		5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5197FADA2AFD33B2009180C5 /* CoreIPCSecureCoding.mm */; };
+		5197FAF22AFD33FF009180C5 /* CoreIPCNSCFObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5197FADC2AFD33B2009180C5 /* CoreIPCNSCFObject.mm */; };
 		519DFBE7281387C1003FF6AD /* WKNotificationPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 519DFBE528138756003FF6AD /* WKNotificationPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A555F4128C6C47009ABCEC /* WKContextMenuItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51A55601128C6D92009ABCEC /* WKContextMenuItemTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A55600128C6D92009ABCEC /* WKContextMenuItemTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5201,6 +5212,26 @@
 		51933DEB1965EB24008AC3EA /* MenuUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuUtilities.h; sourceTree = "<group>"; };
 		51933DEC1965EB24008AC3EA /* MenuUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MenuUtilities.mm; sourceTree = "<group>"; };
 		5194B3861F192FB900FA4708 /* CookieStorageUtilsCF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CookieStorageUtilsCF.h; sourceTree = "<group>"; };
+		5197FAC92AFD33AE009180C5 /* CoreIPCURL.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCURL.serialization.in; sourceTree = "<group>"; };
+		5197FACA2AFD33AE009180C5 /* CoreIPCFont.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCFont.serialization.in; sourceTree = "<group>"; };
+		5197FACC2AFD33AE009180C5 /* CoreIPCString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCString.h; sourceTree = "<group>"; };
+		5197FACD2AFD33AF009180C5 /* CoreIPCArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCArray.h; sourceTree = "<group>"; };
+		5197FACE2AFD33AF009180C5 /* CoreIPCNSCFObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSCFObject.h; sourceTree = "<group>"; };
+		5197FAD02AFD33AF009180C5 /* CoreIPCNSCFObject.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCNSCFObject.serialization.in; sourceTree = "<group>"; };
+		5197FAD12AFD33B0009180C5 /* CoreIPCSecureCoding.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCSecureCoding.serialization.in; sourceTree = "<group>"; };
+		5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDictionary.h; sourceTree = "<group>"; };
+		5197FAD32AFD33B0009180C5 /* CoreIPCColor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCColor.h; sourceTree = "<group>"; };
+		5197FAD42AFD33B0009180C5 /* CoreIPCString.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCString.serialization.in; sourceTree = "<group>"; };
+		5197FAD62AFD33B1009180C5 /* CoreIPCCFType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCCFType.serialization.in; sourceTree = "<group>"; };
+		5197FAD72AFD33B1009180C5 /* CoreIPCFont.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCFont.h; sourceTree = "<group>"; };
+		5197FAD82AFD33B1009180C5 /* CoreIPCArray.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCArray.serialization.in; sourceTree = "<group>"; };
+		5197FAD92AFD33B2009180C5 /* CoreIPCSecureCoding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecureCoding.h; sourceTree = "<group>"; };
+		5197FADA2AFD33B2009180C5 /* CoreIPCSecureCoding.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCSecureCoding.mm; sourceTree = "<group>"; };
+		5197FADB2AFD33B2009180C5 /* CoreIPCURL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCURL.h; sourceTree = "<group>"; };
+		5197FADC2AFD33B2009180C5 /* CoreIPCNSCFObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSCFObject.mm; sourceTree = "<group>"; };
+		5197FADD2AFD33B3009180C5 /* CoreIPCColor.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCColor.serialization.in; sourceTree = "<group>"; };
+		5197FADE2AFD33B3009180C5 /* CoreIPCDictionary.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCDictionary.serialization.in; sourceTree = "<group>"; };
+		5197FAE22AFD33B4009180C5 /* CoreIPCCFType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCCFType.h; sourceTree = "<group>"; };
 		519DFBE528138756003FF6AD /* WKNotificationPrivateMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKNotificationPrivateMac.h; path = mac/WKNotificationPrivateMac.h; sourceTree = "<group>"; };
 		519DFBE628138756003FF6AD /* WKNotificationPrivateMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKNotificationPrivateMac.mm; path = mac/WKNotificationPrivateMac.mm; sourceTree = "<group>"; };
 		51A555F3128C6C47009ABCEC /* WKContextMenuItem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKContextMenuItem.cpp; sourceTree = "<group>"; };
@@ -10694,10 +10725,30 @@
 				CE11AD4F1CBC47F800681EE5 /* CodeSigning.mm */,
 				37BEC4DF19491486008B4286 /* CompletionHandlerCallChecker.h */,
 				37BEC4DE19491486008B4286 /* CompletionHandlerCallChecker.mm */,
+				5197FACD2AFD33AF009180C5 /* CoreIPCArray.h */,
+				5197FAD82AFD33B1009180C5 /* CoreIPCArray.serialization.in */,
+				5197FAE22AFD33B4009180C5 /* CoreIPCCFType.h */,
+				5197FAD62AFD33B1009180C5 /* CoreIPCCFType.serialization.in */,
+				5197FAD32AFD33B0009180C5 /* CoreIPCColor.h */,
+				5197FADD2AFD33B3009180C5 /* CoreIPCColor.serialization.in */,
 				F48C81E32AE0BA6E00073850 /* CoreIPCData.h */,
 				F48C81E52AE0E1DF00073850 /* CoreIPCData.serialization.in */,
 				F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */,
 				F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */,
+				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
+				5197FADE2AFD33B3009180C5 /* CoreIPCDictionary.serialization.in */,
+				5197FAD72AFD33B1009180C5 /* CoreIPCFont.h */,
+				5197FACA2AFD33AE009180C5 /* CoreIPCFont.serialization.in */,
+				5197FACE2AFD33AF009180C5 /* CoreIPCNSCFObject.h */,
+				5197FADC2AFD33B2009180C5 /* CoreIPCNSCFObject.mm */,
+				5197FAD02AFD33AF009180C5 /* CoreIPCNSCFObject.serialization.in */,
+				5197FAD92AFD33B2009180C5 /* CoreIPCSecureCoding.h */,
+				5197FADA2AFD33B2009180C5 /* CoreIPCSecureCoding.mm */,
+				5197FAD12AFD33B0009180C5 /* CoreIPCSecureCoding.serialization.in */,
+				5197FACC2AFD33AE009180C5 /* CoreIPCString.h */,
+				5197FAD42AFD33B0009180C5 /* CoreIPCString.serialization.in */,
+				5197FADB2AFD33B2009180C5 /* CoreIPCURL.h */,
+				5197FAC92AFD33AE009180C5 /* CoreIPCURL.serialization.in */,
 				1C739E872347BD0F00C621EC /* CoreTextHelpers.h */,
 				1C739E852347BCF600C621EC /* CoreTextHelpers.mm */,
 				C55F916C1C595E440029E92D /* DataDetectionResult.h */,
@@ -14877,9 +14928,18 @@
 				CA05397923EE324400A553DC /* ContentAsStringIncludesChildFrames.h in Headers */,
 				5129EB1223D0DE7B00AF1CD7 /* ContentWorldShared.h in Headers */,
 				5106D7C418BDBE73000AB166 /* ContextMenuContextData.h in Headers */,
+				5197FAEB2AFD33CF009180C5 /* CoreIPCArray.h in Headers */,
+				5197FAE72AFD33CF009180C5 /* CoreIPCCFType.h in Headers */,
+				5197FAE82AFD33CF009180C5 /* CoreIPCColor.h in Headers */,
 				F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */,
 				F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */,
+				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
+				5197FAE32AFD33CF009180C5 /* CoreIPCFont.h in Headers */,
+				5197FAE42AFD33CF009180C5 /* CoreIPCNSCFObject.h in Headers */,
 				F4EFF36D2AF0267300479AB8 /* CoreIPCNumber.h in Headers */,
+				5197FAE92AFD33CF009180C5 /* CoreIPCSecureCoding.h in Headers */,
+				5197FAE52AFD33CF009180C5 /* CoreIPCString.h in Headers */,
+				5197FAE62AFD33CF009180C5 /* CoreIPCURL.h in Headers */,
 				A15799BC2584433200528236 /* CoreMediaWrapped.h in Headers */,
 				37C21CAE1E994C0C0029D5F9 /* CorePredictionSPI.h in Headers */,
 				1C62900D28EE2CD300C26B60 /* CoreSVGSPI.h in Headers */,
@@ -17694,6 +17754,8 @@
 				5131D5452AE9D5140016EF39 /* ArgumentCodersCF.cpp in Sources */,
 				51FFD3092AE9A9FC00B0AB70 /* ArgumentCodersCocoa.mm in Sources */,
 				5131D5442AE9D4370016EF39 /* ArgumentCodersCocoa.mm in Sources */,
+				5197FAF22AFD33FF009180C5 /* CoreIPCNSCFObject.mm in Sources */,
+				5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */,
 				5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */,
 				7B9FC5D128A53014007570E7 /* PlatformUnifiedSource1-mm.mm in Sources */,
 				7B9FC5A828A38D1E007570E7 /* PlatformUnifiedSource1.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -130,7 +130,9 @@ struct ObjCHolderForTesting {
         RetainPtr<NSString>,
         RetainPtr<NSURL>,
         RetainPtr<NSData>,
-        RetainPtr<NSNumber>
+        RetainPtr<NSNumber>,
+        RetainPtr<NSArray>,
+        RetainPtr<NSDictionary>
     > ValueType;
 
     ValueType value;
@@ -288,4 +290,7 @@ TEST(IPCSerialization, Basic)
     runTestNS({ [NSNumber numberWithInteger: NSIntegerMax] });
     runTestNS({ [NSNumber numberWithInteger: NSIntegerMin] });
     runTestNS({ [NSNumber numberWithUnsignedInteger: NSUIntegerMax] });
+
+    runTestNS({ @[ @"Array test" ] });
+    runTestNS({ @{ @"Dictionary": @"Test"   } });
 }


### PR DESCRIPTION
#### f10ee49ef636c10dd181239c2b624bf85a954ebc
<pre>
Rework ArgumentCodersCocoa to get us much closer to generated serializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=264588">https://bugs.webkit.org/show_bug.cgi?id=264588</a>
<a href="https://rdar.apple.com/118236121">rdar://118236121</a>

Reviewed by Alex Christensen.

This changes introduces ObjC object wrappers.
Encoding an ObjC object directly creates a typed wrapper around it.

For wrappers around a type that we still do directly via ObjC (e.g. NSArray), encoding the wrapper
then ends up going down the old &quot;encode ObjC directly&quot; path.

This change has the following benefits:
1 - We now broadly use serialization.in files for all ObjC types.
2 - For catch-all types like SecureCoding, we can now easily break out individual types into
    their own individual wrappers with individual serialization.
3 - So it follows, over time, the complicated logic in ArgumentCodersCocoa.mm can be whittled away.
4 - Having wrappers enables us to directly serialize collection types (like NSArray) without
    relying on the existing ObjC code path

* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::SerializedPlatformDataCueMac::allowedClassesForNativeValues):
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decodeWithAllowedClasses):
(IPC::Decoder::allowedClasses const):
* Source/WebKit/Scripts/generate-serializers.py:
(decode_type):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
(IPC::CoreIPCRetainPtr::CoreIPCRetainPtr):
(IPC::isObjectClassAllowed):
(IPC::decodeRequiringAllowedClasses):
(IPC::ArgumentCoder&lt;T::encode):
(IPC::ArgumentCoder&lt;CoreIPCRetainPtr&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;CoreIPCRetainPtr&lt;T&gt;&gt;::decode):
(IPC::decodeWithAllowedClasses): Deleted.
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
(IPC::encodeObjectDirectly&lt;NSArray&gt;):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSArray&gt;):
(IPC::encodeObjectDirectly&lt;NSDictionary&gt;):
(IPC::id&gt;&gt;):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSDictionary&gt;):
(IPC::encodeObjectDirectly&lt;WebCore::CocoaFont&gt;):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;WebCore::CocoaFont&gt;):
(IPC::encodeObjectDirectly&lt;NSObject&lt;NSSecureCoding&gt;&gt;):
(IPC::shouldEnableStrictMode):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSObject&lt;NSSecureCoding&gt;&gt;):
(IPC::encodeObjectDirectly&lt;CFTypeRef&gt;):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;CFTypeRef&gt;):
(IPC::encodeObjectWithWrapper):
(IPC::decodeObjectFromWrapper):
(IPC::encodeArrayInternal): Deleted.
(IPC::decodeArrayInternal): Deleted.
(IPC::encodeColorInternal): Deleted.
(IPC::decodeColorInternal): Deleted.
(IPC::encodeDataInternal): Deleted.
(IPC::decodeDataInternal): Deleted.
(IPC::encodeDateInternal): Deleted.
(IPC::decodeDateInternal): Deleted.
(IPC::encodeDictionaryInternal): Deleted.
(IPC::decodeDictionaryInternal): Deleted.
(IPC::encodeFontInternal): Deleted.
(IPC::decodeFontInternal): Deleted.
(IPC::encodeNumberInternal): Deleted.
(IPC::decodeNumberInternal): Deleted.
(IPC::encodeSecureCodingInternal): Deleted.
(IPC::decodeSecureCodingInternal): Deleted.
(IPC::encodeStringInternal): Deleted.
(IPC::decodeStringInternal): Deleted.
(IPC::encodeURLInternal): Deleted.
(IPC::decodeURLInternal): Deleted.
(IPC::encodeCFInternal): Deleted.
(IPC::decodeCFInternal): Deleted.
(IPC::encodeObject): Deleted.
(IPC::decodeObject): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCArray.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCArray::CoreIPCArray):
(WebKit::CoreIPCArray::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCArray.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCCFType.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCCFType::CoreIPCCFType):
(WebKit::CoreIPCCFType::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCCFType.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCColor.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCColor::CoreIPCColor):
(WebKit::CoreIPCColor::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCColor.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCData.h:
(WebKit::CoreIPCData::CoreIPCData):
(WebKit::CoreIPCData::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDate.h:
(WebKit::CoreIPCDate::CoreIPCDate):
(WebKit::CoreIPCDate::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCDictionary::CoreIPCDictionary):
(WebKit::CoreIPCDictionary::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCFont.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCFont::CoreIPCFont):
(WebKit::CoreIPCFont::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCFont.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCData.h.
(WebKit::CoreIPCNSCFObject::CoreIPCNSCFObject):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm: Added.
(WebKit::valueFromID):
(WebKit::CoreIPCNSCFObject::CoreIPCNSCFObject):
(WebKit::CoreIPCNSCFObject::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCSecureCoding::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCSecureCoding::CoreIPCSecureCoding):
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCString.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCString::CoreIPCString):
(WebKit::CoreIPCString::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCString.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCURL.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDate.h.
(WebKit::CoreIPCURL::CoreIPCURL):
(WebKit::CoreIPCURL::toID):
* Source/WebKit/Shared/Cocoa/CoreIPCURL.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/WebIconUtilities.mm:
* Source/WebKit/Shared/cf/CoreIPCNumber.h:
(WebKit::CoreIPCNumber::CoreIPCNumber):
(WebKit::CoreIPCNumber::toID):
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;WebCore::SerializedPlatformDataCueValue&gt;::encodePlatformData):
(IPC::ArgumentCoder&lt;WebCore::SerializedPlatformDataCueValue&gt;::decodePlatformData):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/270587@main">https://commits.webkit.org/270587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe74be7745d6a7610495fa636417dfae964deb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1885 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28528 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/26013 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23224 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27163 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1217 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4387 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6213 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->