### PR TITLE
Remove enums from ColorInterpolationMethod.h in favor of the serializer

### DIFF
--- a/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
+++ b/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
@@ -29,7 +29,6 @@
 #include "ColorTypes.h"
 #include <optional>
 #include <variant>
-#include <wtf/EnumTraits.h>
 #include <wtf/Hasher.h>
 
 namespace WTF {
@@ -151,35 +150,5 @@ String serializationForCSS(const ColorInterpolationMethod&);
 WTF::TextStream& operator<<(WTF::TextStream&, ColorInterpolationColorSpace);
 WTF::TextStream& operator<<(WTF::TextStream&, HueInterpolationMethod);
 WTF::TextStream& operator<<(WTF::TextStream&, const ColorInterpolationMethod&);
-
-}
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::HueInterpolationMethod> {
-    using values = EnumValues<
-        WebCore::HueInterpolationMethod,
-        WebCore::HueInterpolationMethod::Shorter,
-        WebCore::HueInterpolationMethod::Longer,
-        WebCore::HueInterpolationMethod::Increasing,
-        WebCore::HueInterpolationMethod::Decreasing
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ColorInterpolationColorSpace> {
-    using values = EnumValues<
-        WebCore::ColorInterpolationColorSpace,
-        WebCore::ColorInterpolationColorSpace::HSL,
-        WebCore::ColorInterpolationColorSpace::HWB,
-        WebCore::ColorInterpolationColorSpace::LCH,
-        WebCore::ColorInterpolationColorSpace::Lab,
-        WebCore::ColorInterpolationColorSpace::OKLCH,
-        WebCore::ColorInterpolationColorSpace::OKLab,
-        WebCore::ColorInterpolationColorSpace::SRGB,
-        WebCore::ColorInterpolationColorSpace::SRGBLinear,
-        WebCore::ColorInterpolationColorSpace::XYZD50,
-        WebCore::ColorInterpolationColorSpace::XYZD65
-    >;
-};
 
 }


### PR DESCRIPTION
#### a4d1a5b4a4e40b927cb3dd5a5862cb2a090f979a
<pre>
Remove enums from ColorInterpolationMethod.h in favor of the serializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=264599">https://bugs.webkit.org/show_bug.cgi?id=264599</a>

Reviewed by Tim Nguyen.

259829@main added the serializer for the enums removed in this PR but
they were never removed from the header.

* Source/WebCore/platform/graphics/ColorInterpolationMethod.h:

Canonical link: <a href="https://commits.webkit.org/270570@main">https://commits.webkit.org/270570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71202de7ce0aa5062cbd5c894bd5bfd8850cdfcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23698 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28429 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29219 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27082 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1143 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3361 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3305 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->