### PR TITLE
[UIAsyncTextInput] Adopt `-[UIAsyncTextInteractionDelegate selection(Will|Did)Change:]`

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1667,3 +1667,7 @@
 #if __has_include(<UIKit/UIAsyncTextInteraction.h>)
 #define HAVE_UI_ASYNC_TEXT_INTERACTION 1
 #endif
+
+#if __has_include(<UIKit/UIAsyncTextInteractionDelegate.h>)
+#define HAVE_UI_ASYNC_TEXT_INTERACTION_DELEGATE 1
+#endif

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -125,6 +125,10 @@
 #import <UIKit/UIKeyEventContext.h>
 #endif
 
+#if HAVE(UI_ASYNC_TEXT_INTERACTION_DELEGATE)
+#import <UIKit/UIAsyncTextInteractionDelegate.h>
+#endif
+
 #if HAVE(UI_ASYNC_DRAG_INTERACTION)
 #import <UIKit/UIDragInteraction_AsyncSupport.h>
 #import <UIKit/_UIAsyncDragInteraction.h>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -593,6 +593,9 @@ struct ImageAnalysisContextMenuActionData {
 #elif ENABLE(DRAG_SUPPORT)
     , UIDragInteractionDelegate
 #endif
+#if HAVE(UI_ASYNC_TEXT_INTERACTION_DELEGATE)
+    , UIAsyncTextInteractionDelegate
+#endif
 >
 
 @property (nonatomic, readonly) CGPoint lastInteractionLocation;

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -53,9 +53,12 @@ SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
     static bool hasAsyncTextInteraction = !!getUIAsyncTextInteractionClass();
     if (hasAsyncTextInteraction && view.shouldUseAsyncInteractions) {
         _asyncTextInteraction = adoptNS([allocUIAsyncTextInteractionInstance() init]);
+#if HAVE(UI_ASYNC_TEXT_INTERACTION_DELEGATE)
+        [_asyncTextInteraction setDelegate:view];
+#endif
         [view addInteraction:_asyncTextInteraction.get()];
     } else
-#endif
+#endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
         _textInteractionAssistant = adoptNS([[UIWKTextInteractionAssistant alloc] initWithView:view]);
     _view = view;
     return self;


### PR DESCRIPTION
#### 513928cfe121683ce95b1928b4407bf49c8b7365
<pre>
[UIAsyncTextInput] Adopt `-[UIAsyncTextInteractionDelegate selection(Will|Did)Change:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264589">https://bugs.webkit.org/show_bug.cgi?id=264589</a>

Reviewed by Megan Gardner.

Adopt two `UIAsyncTextInteractionDelegate` methods:

```
-[UIAsyncTextInteractionDelegate selectionWillChange:]
-[UIAsyncTextInteractionDelegate selectionDidChange:]
```

...in place of these two methods currently on `UITextInputAdditions`:

```
-[UITextInputAdditions beginSelectionChange]
-[UITextInputAdditions endSelectionChange]
```

These method hooks allow `WKContentView` to implement some bookkeeping when UIKit is driving
selection changes (e.g. during text interactions, such as tapping to change an editable caret
selection). Note that while clients of the latter currently need to call `-selectionWillChange:` and
`-selectionDidChange:`, the new API does not require this (and instead calls these methods from
underneath the async text input).

* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Add a new compile-time flag to guard the availability of `UIAsyncTextInteractionDelegate`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Conform to `UIAsyncTextInteractionDelegate` when possible.

(-[WKContentView moveByOffset:]):
(-[WKContentView accessoryView:tabInDirection:]):
(-[WKContentView beginSelectionChange]):
(-[WKContentView _internalBeginSelectionChange]):

We invoke `-(begin|end)SelectionChange` in various places, from within WebKit code; to avoid our own
release assertions, split this out into `_internal`-prefixed methods, for use within the engine.

(-[WKContentView _updateInternalStateBeforeSelectionChange]):
(-[WKContentView endSelectionChange]):

Add assertions as well to enforce that the system doesn&apos;t call into these internal hooks when the
input delegate is a `UIAsyncTextInput`.

(-[WKContentView _internalEndSelectionChange]):
(-[WKContentView _updateInternalStateAfterSelectionChange]):
(-[WKContentView executeEditCommandWithCallback:]):
(-[WKContentView _selectionChanged]):
(-[WKContentView selectWordForReplacement]):
(-[WKContentView selectionWillChange:]):
(-[WKContentView selectionDidChange:]):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper initWithView:]):

Canonical link: <a href="https://commits.webkit.org/270563@main">https://commits.webkit.org/270563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63b0c79dd1fe831faae0c44170855229a1db7d21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23587 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1793 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28431 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23152 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22409 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27094 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24973 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1145 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32413 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4294 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7050 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6197 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->