### PR TITLE
[WGSL] Add tests and code generation for all texture functions

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -986,6 +986,62 @@ static void emitTextureDimensions(FunctionDefinitionWriter* writer, AST::CallExp
     writer->stringBuilder().append(")");
 }
 
+static void emitTextureGather(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    ASSERT(call.arguments().size() > 1);
+    unsigned offset = 0;
+    const char* component = nullptr;
+    bool hasOffset = true;
+    auto& firstArgument = call.arguments()[0];
+    if (std::holds_alternative<Types::Primitive>(*firstArgument.inferredType())) {
+        offset = 1;
+        switch (firstArgument.constantValue()->integerValue()) {
+        case 0:
+            component = "x";
+            break;
+        case 1:
+            component = "y";
+            break;
+        case 2:
+            component = "z";
+            break;
+        case 3:
+            component = "w";
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        auto& textureType = std::get<Types::Texture>(*call.arguments()[1].inferredType());
+        if (textureType.kind == Types::Texture::Kind::Texture2d || textureType.kind == Types::Texture::Kind::Texture2dArray) {
+            auto& lastArgument = call.arguments().last();
+            auto* vectorType = std::get_if<Types::Vector>(lastArgument.inferredType());
+            if (!vectorType || !satisfies(vectorType->element, Constraints::Integer))
+                hasOffset = false;
+        }
+    }
+    writer->visit(call.arguments()[offset]);
+    writer->stringBuilder().append(".gather(");
+    for (unsigned i = offset + 1; i < call.arguments().size(); ++i) {
+        if (i != offset + 1)
+            writer->stringBuilder().append(", ");
+        writer->visit(call.arguments()[i]);
+    }
+    if (!hasOffset)
+        writer->stringBuilder().append(", int2(0)");
+    if (component)
+        writer->stringBuilder().append(", component::", component);
+    writer->stringBuilder().append(")");
+}
+
+static void emitTextureGatherCompare(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    ASSERT(call.arguments().size() > 1);
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(".gather_compare");
+    visitArguments(writer, call, 1);
+}
+
 static void emitTextureLoad(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     auto& texture = call.arguments()[0];
@@ -1196,10 +1252,19 @@ static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallEx
     writer->stringBuilder().append(")");
 }
 
-static void emitTextureSampleClampToEdge(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+static void emitTextureSampleBaseClampToEdge(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    // FIXME: we need to handle `texture2d<T>` here too, not only `texture_external`
     auto& texture = call.arguments()[0];
+    auto* textureType = std::get_if<Types::Texture>(texture.inferredType());
+
+    if (textureType) {
+        // FIXME: this needs to clamp the coordinates
+        writer->visit(texture);
+        writer->stringBuilder().append(".sample");
+        visitArguments(writer, call, 1);
+        return;
+    }
+
     auto& sampler = call.arguments()[1];
     auto& coordinates = call.arguments()[2];
     writer->stringBuilder().append("({\n");
@@ -1236,10 +1301,58 @@ static void emitTextureSampleClampToEdge(FunctionDefinitionWriter* writer, AST::
     writer->stringBuilder().append(writer->indent(), "})");
 }
 
+static void emitTextureSampleBias(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    auto& texture = call.arguments()[0];
+    auto& textureType = std::get<Types::Texture>(*texture.inferredType());
+    bool isArray = false;
+    switch (textureType.kind) {
+    case Types::Texture::Kind::Texture2dArray:
+    case Types::Texture::Kind::TextureCubeArray:
+        isArray = true;
+        break;
+    case Types::Texture::Kind::Texture1d:
+    case Types::Texture::Kind::Texture2d:
+    case Types::Texture::Kind::Texture3d:
+    case Types::Texture::Kind::TextureCube:
+    case Types::Texture::Kind::TextureMultisampled2d:
+        break;
+    }
+
+    unsigned biasIndex = isArray ? 4 : 3;
+    writer->visit(texture);
+    writer->stringBuilder().append(".sample(");
+    for (unsigned i = 1; i < biasIndex; ++i) {
+        if (i != 1)
+            writer->stringBuilder().append(", ");
+        writer->visit(call.arguments()[i]);
+    }
+    writer->stringBuilder().append(", bias(");
+    writer->visit(call.arguments()[biasIndex]);
+    writer->stringBuilder().append(")");
+    for (unsigned i = biasIndex + 1; i < call.arguments().size(); ++i) {
+        writer->stringBuilder().append(", ");
+        writer->visit(call.arguments()[i]);
+    }
+    writer->stringBuilder().append(")");
+}
+
+static void emitTextureNumLayers(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(".get_array_size()");
+}
+
 static void emitTextureNumLevels(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     writer->visit(call.arguments()[0]);
     writer->stringBuilder().append(".get_num_mip_levels()");
+}
+
+static void emitTextureNumSamples(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(".get_num_samples()");
 }
 
 static void emitTextureStore(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1456,10 +1569,15 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "distance", emitDistance },
             { "storageBarrier", emitStorageBarrier },
             { "textureDimensions", emitTextureDimensions },
+            { "textureGather", emitTextureGather },
+            { "textureGatherCompare", emitTextureGatherCompare },
             { "textureLoad", emitTextureLoad },
+            { "textureNumLayers", emitTextureNumLayers },
             { "textureNumLevels", emitTextureNumLevels },
+            { "textureNumSamples", emitTextureNumSamples },
             { "textureSample", emitTextureSample },
-            { "textureSampleBaseClampToEdge", emitTextureSampleClampToEdge },
+            { "textureSampleBaseClampToEdge", emitTextureSampleBaseClampToEdge },
+            { "textureSampleBias", emitTextureSampleBias },
             { "textureSampleCompare", emitTextureSampleCompare },
             { "textureSampleCompareLevel", emitTextureSampleCompare },
             { "textureSampleGrad", emitTextureSampleGrad },

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2417,6 +2417,8 @@ fn testTextureDimensions()
 }
 
 // 16.7.2
+// RUN: %metal-compile testTextureGather
+@compute @workgroup_size(1)
 fn testTextureGather()
 {
     // [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, Texture2d], Sampler, Vector[F32, 2]) => Vector[S, 4],
@@ -2457,6 +2459,8 @@ fn testTextureGather()
 }
 
 // 16.7.3 textureGatherCompare
+// RUN: %metal-compile testTextureGatherCompare
+@compute @workgroup_size(1)
 fn testTextureGatherCompare()
 {
     // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => vec4[f32],
@@ -2624,6 +2628,8 @@ fn testTextureLoad()
 }
 
 // 16.7.5
+// RUN: %metal-compile testTextureNumLayers
+@compute @workgroup_size(1)
 fn testTextureNumLayers()
 {
     // [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => U32,
@@ -2679,6 +2685,8 @@ fn testTextureNumLevels()
 }
 
 // 16.7.7
+// RUN: %metal-compile testTextureNumSamples
+@compute @workgroup_size(1)
 fn testTextureNumSamples()
 {
     // [S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d]) => U32,
@@ -2689,6 +2697,8 @@ fn testTextureNumSamples()
 }
 
 // 16.7.8
+// RUN: %metal-compile testTextureSample
+@compute @workgroup_size(1)
 fn testTextureSample()
 {
     // [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
@@ -2739,6 +2749,8 @@ fn testTextureSample()
 
 
 // 16.7.9
+// RUN: %metal-compile testTextureSampleBias
+@compute @workgroup_size(1)
 fn testTextureSampleBias()
 {
     // [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32) => Vector[F32, 4],
@@ -2893,7 +2905,10 @@ fn testTextureSampleLevel()
 }
 
 // 16.7.14
-fn testTextureSampleBaseClampToEdge() {
+// RUN: %metal-compile testTextureSampleBaseClampToEdge
+@compute @workgroup_size(1)
+fn testTextureSampleBaseClampToEdge()
+{
     // [].(TextureExternal, Sampler, Vector[F32, 2]) => Vector[F32, 4],
     _ = textureSampleBaseClampToEdge(te, s, vec2f(0));
 


### PR DESCRIPTION
#### 05a4a1b100789fc092a5f8c6f13e77e2aa4150e8
<pre>
[WGSL] Add tests and code generation for all texture functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=264602">https://bugs.webkit.org/show_bug.cgi?id=264602</a>
<a href="https://rdar.apple.com/118239571">rdar://118239571</a>

Reviewed by Mike Wyrzykowski.

Add extra tests for all functions and add code generation. There&apos;s still a
FIXME for textureSampleBaseClampToEdge, but that is a bit more complex and
will be addressed in a later patch.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitTextureGather):
(WGSL::Metal::emitTextureGatherCompare):
(WGSL::Metal::emitTextureSampleBaseClampToEdge):
(WGSL::Metal::emitTextureSampleBias):
(WGSL::Metal::emitTextureNumLayers):
(WGSL::Metal::emitTextureNumSamples):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitTextureSampleClampToEdge): Deleted.
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270553@main">https://commits.webkit.org/270553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d53fff33f51a6beb7a320ea05f7063eacc21ada

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23591 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1798 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28435 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27086 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1148 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4299 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->