### PR TITLE
[WGSL] Add validation to integer modulo

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -245,6 +245,23 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         m_stringBuilder.append(m_indent, "}\n\n");
     }
 
+    if (m_callGraph.ast().usesModulo()) {
+        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n");
+        m_stringBuilder.append(m_indent, "V __wgslMod(T lhs, U rhs)\n");
+        m_stringBuilder.append(m_indent, "{\n");
+        {
+            IndentationScope scope(m_indent);
+            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n");
+            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<U>)\n");
+            {
+                IndentationScope scope(m_indent);
+                m_stringBuilder.append(m_indent, "predicate = predicate || (V(lhs) == V(numeric_limits<T>::lowest()) && V(rhs) == V(-1));\n");
+            }
+            m_stringBuilder.append(m_indent, "return select(lhs % V(rhs), V(0), predicate);\n");
+        }
+        m_stringBuilder.append(m_indent, "}\n\n");
+    }
+
 
     if (m_callGraph.ast().usesFrexp()) {
         m_stringBuilder.append(m_indent, "template<typename T, typename U>\n");
@@ -1666,12 +1683,18 @@ void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)
         }
     }
 
-    if (binary.operation() == AST::BinaryOperation::Divide) {
+    const char* helperFunction = nullptr;
+    if (binary.operation() == AST::BinaryOperation::Divide)
+        helperFunction = "__wgslDiv";
+    else if (binary.operation() == AST::BinaryOperation::Modulo)
+        helperFunction = "__wgslMod";
+
+    if (helperFunction) {
         auto* resultType = binary.inferredType();
         if (auto* vectorType = std::get_if<Types::Vector>(resultType))
             resultType = vectorType->element;
         if (satisfies(resultType, Constraints::Integer)) {
-            m_stringBuilder.append("__wgslDiv(");
+            m_stringBuilder.append(helperFunction, "(");
             visit(binary.leftExpression());
             m_stringBuilder.append(", ");
             visit(binary.rightExpression());
@@ -1837,13 +1860,19 @@ void FunctionDefinitionWriter::visit(AST::CallStatement& statement)
 
 void FunctionDefinitionWriter::visit(AST::CompoundAssignmentStatement& statement)
 {
-    if (statement.operation() == AST::BinaryOperation::Divide) {
+    const char* helperFunction = nullptr;
+    if (statement.operation() == AST::BinaryOperation::Divide)
+        helperFunction = "__wgslDiv";
+    else if (statement.operation() == AST::BinaryOperation::Modulo)
+        helperFunction = "__wgslMod";
+
+    if (helperFunction) {
         auto* rightType = statement.rightExpression().inferredType();
         if (auto* vectorType = std::get_if<Types::Vector>(rightType))
             rightType = vectorType->element;
         if (satisfies(rightType, Constraints::Integer)) {
             visit(statement.leftExpression());
-            m_stringBuilder.append(" = __wgslDiv(");
+            m_stringBuilder.append(" = ", helperFunction, "(");
             visit(statement.leftExpression());
             m_stringBuilder.append(", ");
             visit(statement.rightExpression());

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -82,6 +82,9 @@ public:
     bool usesDivision() const { return m_usesDivision; }
     void setUsesDivision() { m_usesDivision = true; }
 
+    bool usesModulo() const { return m_usesModulo; }
+    void setUsesModulo() { m_usesModulo = true; }
+
     bool usesFrexp() const { return m_usesFrexp; }
     void setUsesFrexp() { m_usesFrexp = true; }
 
@@ -224,6 +227,7 @@ private:
     bool m_usesUnpackArray { false };
     bool m_usesWorkgroupUniformLoad { false };
     bool m_usesDivision { false };
+    bool m_usesModulo { false };
     bool m_usesFrexp { false };
     Configuration m_configuration;
     AST::Directive::List m_directives;

--- a/Source/WebGPU/WGSL/tests/invalid/modulo.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/modulo.wgsl
@@ -1,0 +1,210 @@
+// RUN: %not %wgslc | %check
+
+fn testAbstractInt()
+{
+    // CHECK-L: modulo by zero
+    _ = 42 % 0;
+    // CHECK-L: modulo by zero
+    _ = 42 % vec2(1, 0);
+    // CHECK-L: modulo by zero
+    _ = vec2(42) % 0;
+    // CHECK-L: modulo by zero
+    _ = vec2(42) % vec2(1, 0);
+
+    let x = 42;
+    // CHECK-L: modulo by zero
+    _ = x % 0;
+    // CHECK-L: modulo by zero
+    _ = x % vec2(1, 0);
+    // CHECK-L: modulo by zero
+    _ = vec2(x) % 0;
+    // CHECK-L: modulo by zero
+    _ = vec2(x) % vec2(1, 0);
+
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = (-2147483647 - 1) % -1;
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = vec2(-2147483647 - 1, 1) % vec2(-1, 1);
+
+    // CHECK-L: invalid modulo overflow
+    _ = (-9223372036854775807 - 1) % -1;
+    // CHECK-L: invalid modulo overflow
+    _ = vec2(-9223372036854775807 - 1, 1) % vec2(-1, 1);
+}
+
+fn testI32()
+{
+    // CHECK-L: modulo by zero
+    _ = 42i % 0i;
+    // CHECK-L: modulo by zero
+    _ = 42i % vec2(1i, 0i);
+    // CHECK-L: modulo by zero
+    _ = vec2(42i) % 0i;
+    // CHECK-L: modulo by zero
+    _ = vec2(42i) % vec2(1i, 0i);
+
+    let x = 42i;
+    // CHECK-L: modulo by zero
+    _ = x % 0i;
+    // CHECK-L: modulo by zero
+    _ = x % vec2(1i, 0i);
+    // CHECK-L: modulo by zero
+    _ = vec2(x) % 0i;
+    // CHECK-L: modulo by zero
+    _ = vec2(x) % vec2(1i, 0i);
+
+    // CHECK-L: invalid modulo overflow
+    _ = (-2147483647i - 1i) % -1i;
+    // CHECK-L: invalid modulo overflow
+    _ = vec2(-2147483647i - 1i, 1i) % vec2(-1i, 1i);
+}
+
+fn testU32()
+{
+    // CHECK-L: modulo by zero
+    _ = 42u % 0u;
+    // CHECK-L: modulo by zero
+    _ = 42u % vec2(1u, 0u);
+    // CHECK-L: modulo by zero
+    _ = vec2(42u) % 0u;
+    // CHECK-L: modulo by zero
+    _ = vec2(42u) % vec2(1u, 0u);
+
+    let x = 42u;
+    // CHECK-L: modulo by zero
+    _ = x % 0u;
+    // CHECK-L: modulo by zero
+    _ = x % vec2(1u, 0u);
+    // CHECK-L: modulo by zero
+    _ = vec2(x) % 0u;
+    // CHECK-L: modulo by zero
+    _ = vec2(x) % vec2(1u, 0u);
+}
+
+fn testAbstractFloat()
+{
+    // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
+    _ = 42.0 % 0.0;
+    // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
+    _ = 42.0 % vec2(1.0, 0.0);
+    // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
+    _ = vec2(42.0) % 0.0;
+    // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
+    _ = vec2(42.0) % vec2(1.0, 0.0);
+
+    // CHECK-NOT-L: modulo by zero
+    let x = 42.0;
+    // CHECK-NOT-L: modulo by zero
+    _ = x % 0.0;
+    // CHECK-NOT-L: modulo by zero
+    _ = x % vec2(1.0, 0.0);
+    // CHECK-NOT-L: modulo by zero
+    _ = vec2(x) % 0.0;
+    // CHECK-NOT-L: modulo by zero
+    _ = vec2(x) % vec2(1.0, 0.0);
+
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = (-2147483647.0 - 1.0) % -1.0;
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = vec2(-2147483647.0 - 1.0, 1.0) % vec2(-1.0, 1.0);
+
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = (-9223372036854775807.0 - 1.0) % -1.0;
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = vec2(-9223372036854775807.0 - 1.0, 1.0) % vec2(-1.0, 1.0);
+
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = -340282346638528859811704183484516925440.0 - 1.0 % -1.0;
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = vec2(-340282346638528859811704183484516925440.0 - 1.0, 1.0) % vec2(-1.0, 1.0);
+}
+
+fn testF32()
+{
+    // CHECK-L: value NaN cannot be represented as 'f32'
+    _ = 42f % 0f;
+    // CHECK-L: value NaN cannot be represented as 'f32'
+    _ = 42f % vec2(1f, 0f);
+    // CHECK-L: value NaN cannot be represented as 'f32'
+    _ = vec2(42f) % 0f;
+    // CHECK-L: value NaN cannot be represented as 'f32'
+    _ = vec2(42f) % vec2(1f, 0f);
+
+    let x = 42f;
+    // CHECK-NOT-L: modulo by zero
+    _ = x % 0f;
+    // CHECK-NOT-L: modulo by zero
+    _ = x % vec2(1f, 0f);
+    // CHECK-NOT-L: modulo by zero
+    _ = vec2(x) % 0f;
+    // CHECK-NOT-L: modulo by zero
+    _ = vec2(x) % vec2(1f, 0f);
+
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = (-2147483647f - 1f) % -1f;
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = vec2(-2147483647f - 1f, 1f) % vec2(-1f, 1f);
+
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = (-9223372036854775807.f - 1.f) % -1.f;
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = vec2(-9223372036854775807.f - 1.f, 1.f) % vec2(-1.f, 1.f);
+
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = (-340282346638528859811704183484516925439.f - 1f) % -1f;
+    // CHECK-NOT-L: invalid modulo overflow
+    _ = vec2(-340282346638528859811704183484516925439.f - 1f, 1f) % vec2(-1f, 1f);
+}
+
+fn testI32Compound()
+{
+    var y: vec2<i32>;
+    // CHECK-L: modulo by zero
+    y %= 0;
+    // CHECK-L: modulo by zero
+    y %= vec2(1, 0);
+    // CHECK-L: modulo by zero
+    y[0] %= 0;
+    // CHECK-L: modulo by zero
+    y[0] %= vec2(1, 0);
+}
+
+fn testU32Compound()
+{
+    var y: vec2<u32>;
+    // CHECK-L: modulo by zero
+    y %= 0;
+    // CHECK-L: modulo by zero
+    y %= vec2(1, 0);
+    // CHECK-L: modulo by zero
+    y[0] %= 0;
+    // CHECK-L: modulo by zero
+    y[0] %= vec2(1, 0);
+}
+
+fn testF32Compound()
+{
+    // FIXME: these depende on proper typing for compound statements
+    // var y: vec2<f32>;
+    // skip-CHECK-NOT-L: modulo by zero
+    // y %= 0;
+    // skip-CHECK-NOT-L: modulo by zero
+    // y %= vec2(1, 0);
+    // skip-CHECK-NOT-L: modulo by zero
+    // y[0] %= 0;
+    // skip-CHECK-NOT-L: modulo by zero
+    // y[0] %= vec2(1, 0);
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    testAbstractInt();
+    testI32();
+    testU32();
+    testAbstractFloat();
+    testF32();
+
+    testI32Compound();
+    testU32Compound();
+    testF32Compound();
+}


### PR DESCRIPTION
#### e99d13b4e5e12d838104c09e3c3206a431314880
<pre>
[WGSL] Add validation to integer modulo
<a href="https://bugs.webkit.org/show_bug.cgi?id=264603">https://bugs.webkit.org/show_bug.cgi?id=264603</a>
<a href="https://rdar.apple.com/118239748">rdar://118239748</a>

Reviewed by Mike Wyrzykowski.

Similar to division, we need to check for modulo with zero or
INT_MIN and -1.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::BINARY_OPERATION):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesModulo const):
(WGSL::ShaderModule::setUsesModulo):
* Source/WebGPU/WGSL/tests/invalid/modulo.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/270636@main">https://commits.webkit.org/270636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be45f8d44ba428d01d2986e9fc714f77504ad5b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23596 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23705 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28442 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2922 "Too many flaky failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html, imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html, imported/w3c/web-platform-tests/FileAPI/file/File-constructor-endings.html, imported/w3c/web-platform-tests/FileAPI/filelist-section/filelist.html, imported/w3c/web-platform-tests/FileAPI/reading-data-section/Determining-Encoding.any.html, imported/w3c/web-platform-tests/css/css-sizing/button-min-width.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html (failure)") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29228 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27092 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1152 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4306 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6248 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->