### PR TITLE
[Cairo] Use CAIRO_FILTER_BILINEAR for low interpolation quality

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -52,12 +52,7 @@ static std::atomic<size_t> s_activePixelMemory { 0 };
 
 namespace WebCore {
 
-#if USE(CG)
 constexpr InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Low;
-#else
-constexpr InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Medium;
-#endif
-
 static std::optional<size_t> maxCanvasAreaForTesting;
 
 CanvasBase::CanvasBase(IntSize size, const std::optional<NoiseInjectionHashSalt>& noiseHashSalt)

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -900,8 +900,10 @@ void drawSurface(GraphicsContextCairo& platformContext, cairo_surface_t* surface
 
     switch (imageInterpolationQuality) {
     case InterpolationQuality::DoNotInterpolate:
-    case InterpolationQuality::Low:
         cairo_pattern_set_filter(pattern.get(), CAIRO_FILTER_FAST);
+        break;
+    case InterpolationQuality::Low:
+        cairo_pattern_set_filter(pattern.get(), CAIRO_FILTER_BILINEAR);
         break;
     case InterpolationQuality::Medium:
     case InterpolationQuality::Default:


### PR DESCRIPTION
#### 135e0e4dacf5144efba3e163cafbbc231cb49760
<pre>
[Cairo] Use CAIRO_FILTER_BILINEAR for low interpolation quality
<a href="https://bugs.webkit.org/show_bug.cgi?id=264605">https://bugs.webkit.org/show_bug.cgi?id=264605</a>

Reviewed by Fujii Hironori.

We currently use CAIRO_FILTER_FAST which is the same as no
interpolation. Bilinear provides reasonable quality with good enough
performance. Also change the default interpolation quality of the canvas
to Low (like CG does) which drastically improves the performance of
downscaling high resolution images in the canvas with a reasonable
output. See for example <a href="https://vsynctester.com">https://vsynctester.com</a>

* Source/WebCore/html/CanvasBase.cpp:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawSurface):

Canonical link: <a href="https://commits.webkit.org/270586@main">https://commits.webkit.org/270586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638acb258d5d42f2995263f765a32d8f99b1096a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28440 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29224 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27088 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1150 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3370 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3314 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->