### PR TITLE
[WebGPU] Expand metal capture to capture a number of calls to submit

### DIFF
--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -128,6 +128,7 @@ public:
     uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const;
 
     static bool isStencilOnlyFormat(MTLPixelFormat);
+    bool shouldStopCaptureAfterSubmit();
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -62,10 +62,14 @@ struct GPUFrameCapture {
     {
         // Allow GPU frame capture "notifyutil -p com.apple.WebKit.WebGPU.CaptureFrame" when process is
         // run with __XPC_METAL_CAPTURE_ENABLED=1
+        // notifyutil -s com.apple.WebKit.WebGPU.CaptureFrame 10 --> captures 10 GPUQueue.submit calls
         static std::once_flag onceFlag;
         std::call_once(onceFlag, [] {
             int captureFrameToken;
-            notify_register_dispatch("com.apple.WebKit.WebGPU.CaptureFrame", &captureFrameToken, dispatch_get_main_queue(), ^(int) {
+            notify_register_dispatch("com.apple.WebKit.WebGPU.CaptureFrame", &captureFrameToken, dispatch_get_main_queue(), ^(int token) {
+                uint64_t state;
+                notify_get_state(token, &state);
+                maxSubmitCallsToCapture = std::max<int>(1, state);
                 enabled = true;
             });
 
@@ -78,6 +82,17 @@ struct GPUFrameCapture {
         if (captureFirstFrame)
             captureFrame(captureObject);
     }
+
+    static bool shouldStopCaptureAfterSubmit()
+    {
+        ++submitCallsCaptured;
+        auto result = submitCallsCaptured >= maxSubmitCallsToCapture;
+        if (result)
+            submitCallsCaptured = 0;
+
+        return result;
+    }
+
 private:
     static void captureFrame(id<MTLDevice> captureObject)
     {
@@ -99,10 +114,19 @@ private:
 
     static bool captureFirstFrame;
     static bool enabled;
+    static int submitCallsCaptured;
+    static int maxSubmitCallsToCapture;
 };
 
 bool GPUFrameCapture::captureFirstFrame = false;
 bool GPUFrameCapture::enabled = false;
+int GPUFrameCapture::submitCallsCaptured = 0;
+int GPUFrameCapture::maxSubmitCallsToCapture = 1;
+
+bool Device::shouldStopCaptureAfterSubmit()
+{
+    return GPUFrameCapture::shouldStopCaptureAfterSubmit();
+}
 
 Ref<Device> Device::create(id<MTLDevice> device, String&& deviceLabel, HardwareCapabilities&& capabilities, Adapter& adapter)
 {

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -191,7 +191,7 @@ void Queue::submit(Vector<std::reference_wrapper<CommandBuffer>>&& commands)
     for (id<MTLCommandBuffer> commandBuffer in commandBuffersToSubmit)
         commitMTLCommandBuffer(commandBuffer);
 
-    if ([MTLCaptureManager sharedCaptureManager].isCapturing)
+    if ([MTLCaptureManager sharedCaptureManager].isCapturing && m_device.shouldStopCaptureAfterSubmit())
         [[MTLCaptureManager sharedCaptureManager] stopCapture];
 }
 


### PR DESCRIPTION
#### a3979565d4436eb9d167edb50629feb7cfd223e4
<pre>
[WebGPU] Expand metal capture to capture a number of calls to submit
<a href="https://bugs.webkit.org/show_bug.cgi?id=264601">https://bugs.webkit.org/show_bug.cgi?id=264601</a>
<a href="https://rdar.apple.com/118237625">rdar://118237625</a>

Reviewed by Dan Glastonbury.

Some websites may call GPUQueue.submit several times per frame so
to capture the entire list of submissions we need to allow the capture
to continue across multiple calls to GPUQueue.submit.

Allow specifying the state of CaptureFrame like so:
notifyutil -s com.apple.WebKit.WebGPU.CaptureFrame 10

to capture 10 submit calls.

* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::GPUFrameCapture::registerForFrameCapture):
(WebGPU::GPUFrameCapture::shouldStopCaptureAfterSubmit):
(WebGPU::Device::shouldStopCaptureAfterSubmit):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::submit):

Canonical link: <a href="https://commits.webkit.org/270620@main">https://commits.webkit.org/270620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/422c585d5560e2eea727424feb842d3337901a63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23595 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23708 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28441 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2900 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29227 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27091 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1151 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4305 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6233 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->