### PR TITLE
[WGSL] Fix compound assignment for matrix

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -141,30 +141,42 @@ fn testAddEq() {
   }
 }
 
-fn testMultiply() {
-  {
+// RUN: %metal-compile testMultiply
+@compute @workgroup_size(1)
+fn testMultiply()
+{
     _ = 0 * 0;
     _ = 0i * 0i;
     _ = 0u * 0u;
     _ = 0.0 * 0.0;
     _ = 0.0f * 0.0f;
-  }
 
-  let v2 = vec2<f32>(0, 0);
-  let v4 = vec4<f32>(0, 0, 0, 0);
-  let m = mat2x4<f32>(0, 0, 0, 0, 0, 0, 0, 0);
-  _ = m * v2;
-  _ = v4 * m;
-  _ = vec2(1, 1) * 1;
-  _ = 1 * vec2(1, 1);
-  _ = vec2(1, 1) * vec2(1, 1);
+    var v2 = vec2<f32>(0, 0);
+    var v4 = vec4<f32>(0, 0, 0, 0);
+    var m = mat2x4<f32>(0, 0, 0, 0, 0, 0, 0, 0);
+    _ = m * v2;
+    _ = v4 * m;
+    _ = vec2(1, 1) * 1;
+    _ = 1 * vec2(1, 1);
+    _ = vec2(1, 1) * vec2(1, 1);
 
-  _ = m * 2;
-  _ = 2 * m;
+    _ = m * 2;
+    _ = 2 * m;
 
-  _ = mat2x2(0, 0, 0, 0) * mat2x2(0, 0, 0, 0);
-  _ = mat2x2(0, 0, 0, 0) * mat3x2(0, 0, 0, 0, 0, 0);
-  _ = mat2x2(0, 0, 0, 0) * mat4x2(0, 0, 0, 0, 0, 0, 0, 0);
+    v2 *= v2;
+    v2 *= 2;
+
+    v4 *= v4;
+    v4 *= 2;
+
+    var m2 = mat2x2<f32>(0, 0, 0, 0);
+    m2 *= m2;
+    // FIXME: this requires type checking compound assignment
+    // m2 *= 2;
+
+    _ = mat2x2(0, 0, 0, 0) * mat2x2(0, 0, 0, 0);
+    _ = mat2x2(0, 0, 0, 0) * mat3x2(0, 0, 0, 0, 0, 0);
+    _ = mat2x2(0, 0, 0, 0) * mat4x2(0, 0, 0, 0, 0, 0, 0, 0);
 }
 
 fn testDivision() {


### PR DESCRIPTION
#### 7a0271a0a95d61258733c44320a1163335b9dd45
<pre>
[WGSL] Fix compound assignment for matrix
<a href="https://bugs.webkit.org/show_bug.cgi?id=264606">https://bugs.webkit.org/show_bug.cgi?id=264606</a>
<a href="https://rdar.apple.com/118240280">rdar://118240280</a>

Reviewed by Mike Wyrzykowski.

MSL doesn&apos;t like compound multiplication of matrices. So instead we simplify the
code and merge the implementation of CompoundAssignment and BinaryExpression by
serializing all CompoundAssignments as regular assignments plus a binary expression.
e.g. `a *= b` becomes `a = a * b`

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeBinaryExpression):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270641@main">https://commits.webkit.org/270641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d43eb173ea7b430c6dcdfcb61183720bf5c4f4c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2042 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28681 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3113 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29418 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27296 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1355 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4535 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6254 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->