### PR TITLE
[UnifiedPDF] Re-enable the PDF HUD

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -27,9 +27,7 @@
 
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
 
-#include "DataReference.h"
 #include "PDFPluginBase.h"
-#include "PDFPluginIdentifier.h"
 #include "WebMouseEvent.h"
 #include <WebCore/NetscapePlugInStreamLoader.h>
 #include <wtf/HashMap.h>
@@ -82,8 +80,6 @@ class ShareableBitmap;
 class WebFrame;
 class WebKeyboardEvent;
 class WebWheelEvent;
-
-struct FrameInfoData;
 struct WebHitTestResultData;
 
 class PDFPlugin final : public PDFPluginBase {
@@ -91,7 +87,7 @@ public:
     static bool pdfKitLayerControllerIsAvailable();
 
     static Ref<PDFPlugin> create(WebCore::HTMLPlugInElement&);
-    ~PDFPlugin();
+    virtual ~PDFPlugin() = default;
 
     void didMutatePDFDocument() { m_pdfDocumentWasMutated = true; }
 
@@ -104,11 +100,13 @@ public:
     void notifySelectionChanged(PDFSelection *);
     void notifyCursorChanged(uint64_t /* PDFLayerControllerCursorType */);
 
-    void zoomIn();
-    void zoomOut();
-    void save(CompletionHandler<void(const String&, const URL&, const IPC::DataReference&)>&&);
-    void openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, const IPC::DataReference&, const String&)>&&);
-    PDFPluginIdentifier identifier() const { return m_identifier; }
+    // HUD Actions.
+#if ENABLE(PDF_HUD)
+    void zoomIn() final;
+    void zoomOut() final;
+    void save(CompletionHandler<void(const String&, const URL&, const IPC::DataReference&)>&&) final;
+    void openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, const IPC::DataReference&, const String&)>&&) final;
+#endif
 
     void clickedLink(NSURL *);
 
@@ -121,10 +119,6 @@ public:
     void focusPreviousAnnotation();
 
     void attemptToUnlockPDF(const String& password);
-
-    WebCore::FloatRect convertFromPDFViewToScreen(const WebCore::FloatRect&) const;
-    WebCore::IntPoint convertFromRootViewToPDFView(const WebCore::IntPoint&) const;
-    WebCore::IntRect boundsOnScreen() const;
 
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
 
@@ -177,7 +171,6 @@ private:
     WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
 
     void geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform) override;
-    void visibilityDidChange(bool) override;
     void contentsScaleFactorChanged(float) override;
 
     WebCore::IntSize contentsSize() const override;
@@ -216,13 +209,7 @@ private:
     bool incrementalPDFStreamDidFinishLoading() override;
     void incrementalPDFStreamDidFail() override;
 
-    void updatePDFHUDLocation();
-
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
-    WebCore::IntPoint convertFromPluginToPDFView(const WebCore::IntPoint&) const;
-    WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
-    WebCore::IntRect convertFromPDFViewToRootView(const WebCore::IntRect&) const;
-    WebCore::IntRect frameForHUD() const;
 
     bool supportsForms();
 
@@ -230,8 +217,6 @@ private:
     void updatePageAndDeviceScaleFactors();
 
     void createPasswordEntryForm();
-
-    bool hudEnabled() const;
 
 #ifdef __OBJC__
     NSData *liveData() const;
@@ -352,8 +337,6 @@ private:
 #endif
 
 #endif // HAVE(INCREMENTAL_PDF_APIS)
-
-    PDFPluginIdentifier m_identifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -31,8 +31,11 @@
 #import "PluginView.h"
 #import "WebEventConversion.h"
 #import "WebFrame.h"
+#import "WebPage.h"
 #import <CoreFoundation/CoreFoundation.h>
+#import <WebCore/AXObjectCache.h>
 #import <WebCore/ArchiveResource.h>
+#import <WebCore/Chrome.h>
 #import <WebCore/Document.h>
 #import <WebCore/FocusController.h>
 #import <WebCore/Frame.h>
@@ -79,7 +82,22 @@ PluginInfo PDFPluginBase::pluginInfo()
 
 PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
     : m_frame(*WebFrame::fromCoreFrame(*element.document().frame()))
+    , m_identifier(PDFPluginIdentifier::generate())
 {
+}
+
+PDFPluginBase::~PDFPluginBase()
+{
+#if ENABLE(PDF_HUD)
+    if (auto* page = m_frame ? m_frame->page() : nullptr)
+        page->removePDFHUD(*this);
+#endif
+}
+
+void PDFPluginBase::teardown()
+{
+    destroyScrollbar(ScrollbarOrientation::Horizontal);
+    destroyScrollbar(ScrollbarOrientation::Vertical);
 }
 
 Page* PDFPluginBase::page() const
@@ -193,6 +211,22 @@ void PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTra
 {
     m_size = pluginSize;
     m_rootViewToPluginTransform = valueOrDefault(pluginToRootViewTransform.inverse());
+
+#if ENABLE(PDF_HUD)
+    updatePDFHUDLocation();
+#endif
+}
+
+void PDFPluginBase::visibilityDidChange(bool visible)
+{
+#if ENABLE(PDF_HUD)
+    if (!m_frame || !hudEnabled())
+        return;
+    if (visible)
+        m_frame->page()->createPDFHUD(*this, frameForHUD());
+    else
+        m_frame->page()->removePDFHUD(*this);
+#endif
 }
 
 void PDFPluginBase::invalidateRect(const IntRect& rect)
@@ -206,6 +240,53 @@ void PDFPluginBase::invalidateRect(const IntRect& rect)
 IntPoint PDFPluginBase::convertFromRootViewToPlugin(const IntPoint& point) const
 {
     return m_rootViewToPluginTransform.mapPoint(point);
+}
+
+IntPoint PDFPluginBase::convertFromPluginToPDFView(const IntPoint& point) const
+{
+    return IntPoint(point.x(), size().height() - point.y());
+}
+
+IntPoint PDFPluginBase::convertFromPDFViewToRootView(const IntPoint& point) const
+{
+    IntPoint pointInPluginCoordinates(point.x(), size().height() - point.y());
+    return valueOrDefault(m_rootViewToPluginTransform.inverse()).mapPoint(pointInPluginCoordinates);
+}
+
+IntRect PDFPluginBase::convertFromPDFViewToRootView(const IntRect& rect) const
+{
+    IntRect rectInPluginCoordinates(rect.x(), rect.y(), rect.width(), rect.height());
+    return valueOrDefault(m_rootViewToPluginTransform.inverse()).mapRect(rectInPluginCoordinates);
+}
+
+IntPoint PDFPluginBase::convertFromRootViewToPDFView(const IntPoint& point) const
+{
+    IntPoint pointInPluginCoordinates = m_rootViewToPluginTransform.mapPoint(point);
+    return IntPoint(pointInPluginCoordinates.x(), size().height() - pointInPluginCoordinates.y());
+}
+
+FloatRect PDFPluginBase::convertFromPDFViewToScreen(const FloatRect& rect) const
+{
+    return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::FloatRect>([&] () -> WebCore::FloatRect {
+        FloatRect updatedRect = rect;
+        updatedRect.setLocation(convertFromPDFViewToRootView(IntPoint(updatedRect.location())));
+        CheckedPtr page = this->page();
+        if (!page)
+            return { };
+        return page->chrome().rootViewToScreen(enclosingIntRect(updatedRect));
+    });
+}
+
+IntRect PDFPluginBase::boundsOnScreen() const
+{
+    return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::IntRect>([&] () -> WebCore::IntRect {
+        FloatRect bounds = FloatRect(FloatPoint(), size());
+        FloatRect rectInRootViewCoordinates = valueOrDefault(m_rootViewToPluginTransform.inverse()).mapRect(bounds);
+        CheckedPtr page = this->page();
+        if (!page)
+            return { };
+        return page->chrome().rootViewToScreen(enclosingIntRect(rectInRootViewCoordinates));
+    });
 }
 
 void PDFPluginBase::updateControlTints(GraphicsContext& graphicsContext)
@@ -436,6 +517,29 @@ void PDFPluginBase::destroyScrollbar(ScrollbarOrientation orientation)
     scrollbar->removeFromParent();
     scrollbar = nullptr;
 }
+
+#if ENABLE(PDF_HUD)
+
+void PDFPluginBase::updatePDFHUDLocation()
+{
+    if (isLocked() || !m_frame || !m_frame->page())
+        return;
+    m_frame->protectedPage()->updatePDFHUDLocation(*this, frameForHUD());
+}
+
+IntRect PDFPluginBase::frameForHUD() const
+{
+    return convertFromPDFViewToRootView(IntRect(IntPoint(), size()));
+}
+
+bool PDFPluginBase::hudEnabled() const
+{
+    if (CheckedPtr page = this->page())
+        return page->settings().pdfPluginHUDEnabled();
+    return false;
+}
+
+#endif // ENABLE(PDF_HUD)
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -104,6 +104,14 @@ private:
     void invalidateScrollbarRect(WebCore::Scrollbar&, const WebCore::IntRect&) override;
     void invalidateScrollCornerRect(const WebCore::IntRect&) override;
 
+    // HUD Actions.
+#if ENABLE(PDF_HUD)
+    void zoomIn() final;
+    void zoomOut() final;
+    void save(CompletionHandler<void(const String&, const URL&, const IPC::DataReference&)>&&) final;
+    void openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, const IPC::DataReference&, const String&)>&&) final;
+#endif
+
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, GraphicsLayer::Type);
 
     PDFDocumentLayout m_documentLayout;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -60,6 +60,8 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
 
 void UnifiedPDFPlugin::teardown()
 {
+    PDFPluginBase::teardown();
+
     if (m_rootLayer)
         m_rootLayer->removeFromParent();
 }
@@ -341,12 +343,12 @@ FloatRect UnifiedPDFPlugin::rectForSelectionInRootView(PDFSelection *) const
     return { };
 }
 
-unsigned UnifiedPDFPlugin::countFindMatches(const String& target, FindOptions, unsigned maxMatchCount)
+unsigned UnifiedPDFPlugin::countFindMatches(const String& target, WebCore::FindOptions, unsigned maxMatchCount)
 {
     return 0;
 }
 
-bool UnifiedPDFPlugin::findString(const String& target, FindOptions, unsigned maxMatchCount)
+bool UnifiedPDFPlugin::findString(const String& target, WebCore::FindOptions, unsigned maxMatchCount)
 {
     return false;
 }
@@ -381,6 +383,25 @@ id UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement(Element*) con
     return nil;
 }
 
+#if ENABLE(PDF_HUD)
+
+void UnifiedPDFPlugin::zoomIn()
+{
+}
+
+void UnifiedPDFPlugin::zoomOut()
+{
+}
+
+void UnifiedPDFPlugin::save(CompletionHandler<void(const String&, const URL&, const IPC::DataReference&)>&& completionHandler)
+{
+}
+
+void UnifiedPDFPlugin::openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, const IPC::DataReference&, const String&)>&& completionHandler)
+{
+}
+
+#endif // ENABLE(PDF_HUD)
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -307,7 +307,7 @@ class LayerHostingContext;
 class MediaDeviceSandboxExtensions;
 class MediaKeySystemPermissionRequestManager;
 class NotificationPermissionRequestManager;
-class PDFPlugin;
+class PDFPluginBase;
 class PageBanner;
 class PluginView;
 class RemoteMediaSessionCoordinator;
@@ -443,9 +443,9 @@ public:
     void centerSelectionInVisibleArea();
 
 #if ENABLE(PDF_HUD)
-    void createPDFHUD(PDFPlugin&, const WebCore::IntRect&);
-    void updatePDFHUDLocation(PDFPlugin&, const WebCore::IntRect&);
-    void removePDFHUD(PDFPlugin&);
+    void createPDFHUD(PDFPluginBase&, const WebCore::IntRect&);
+    void updatePDFHUDLocation(PDFPluginBase&, const WebCore::IntRect&);
+    void removePDFHUD(PDFPluginBase&);
 #endif
 
 #if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
@@ -2164,8 +2164,7 @@ private:
     WeakHashSet<PluginView> m_pluginViews;
 #endif
 #if ENABLE(PDF_HUD)
-    // FIXME: Needs to be PDFPluginBase.
-    HashMap<PDFPluginIdentifier, WeakPtr<PDFPlugin>> m_pdfPlugInsWithHUD;
+    HashMap<PDFPluginIdentifier, WeakPtr<PDFPluginBase>> m_pdfPlugInsWithHUD;
 #endif
 
     WTF::Function<void()> m_selectionChangedHandler;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1135,20 +1135,20 @@ void WebPage::openPDFWithPreview(PDFPluginIdentifier identifier, CompletionHandl
     pdfPlugin->openWithPreview(WTFMove(completionHandler));
 }
 
-void WebPage::createPDFHUD(PDFPlugin& plugin, const IntRect& boundingBox)
+void WebPage::createPDFHUD(PDFPluginBase& plugin, const IntRect& boundingBox)
 {
     auto addResult = m_pdfPlugInsWithHUD.add(plugin.identifier(), plugin);
     if (addResult.isNewEntry)
         send(Messages::WebPageProxy::CreatePDFHUD(plugin.identifier(), boundingBox));
 }
 
-void WebPage::updatePDFHUDLocation(PDFPlugin& plugin, const IntRect& boundingBox)
+void WebPage::updatePDFHUDLocation(PDFPluginBase& plugin, const IntRect& boundingBox)
 {
     if (m_pdfPlugInsWithHUD.contains(plugin.identifier()))
         send(Messages::WebPageProxy::UpdatePDFHUDLocation(plugin.identifier(), boundingBox));
 }
 
-void WebPage::removePDFHUD(PDFPlugin& plugin)
+void WebPage::removePDFHUD(PDFPluginBase& plugin)
 {
     if (m_pdfPlugInsWithHUD.remove(plugin.identifier()))
         send(Messages::WebPageProxy::RemovePDFHUD(plugin.identifier()));


### PR DESCRIPTION
#### 77b692aefd85b2b8896817c2198f1f6cec4e0042
<pre>
[UnifiedPDF] Re-enable the PDF HUD
<a href="https://bugs.webkit.org/show_bug.cgi?id=264608">https://bugs.webkit.org/show_bug.cgi?id=264608</a>
&lt;<a href="https://rdar.apple.com/problem/118154838">rdar://problem/118154838</a>&gt;

Reviewed by Richard Robinson and Simon Fraser.

Hoist PDFPlugin&apos;s HUD creation/destruction code into PDFPluginBase, and add
empty implementations of the actions.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::PDFPlugin):
(WebKit::PDFPlugin::teardown):
(WebKit::PDFPlugin::~PDFPlugin): Deleted.
(WebKit::PDFPlugin::hudEnabled const): Deleted.
(WebKit::PDFPlugin::frameForHUD const): Deleted.
(WebKit::PDFPlugin::updatePDFHUDLocation): Deleted.
(WebKit::PDFPlugin::convertFromPluginToPDFView const): Deleted.
(WebKit::PDFPlugin::convertFromPDFViewToRootView const): Deleted.
(WebKit::PDFPlugin::convertFromRootViewToPDFView const): Deleted.
(WebKit::PDFPlugin::convertFromPDFViewToScreen const): Deleted.
(WebKit::PDFPlugin::boundsOnScreen const): Deleted.
(WebKit::PDFPlugin::visibilityDidChange): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::identifier const):
(WebKit::PDFPluginBase::visibilityDidChange): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::~PDFPluginBase):
(WebKit::PDFPluginBase::teardown):
(WebKit::PDFPluginBase::geometryDidChange):
(WebKit::PDFPluginBase::visibilityDidChange):
(WebKit::PDFPluginBase::convertFromPluginToPDFView const):
(WebKit::PDFPluginBase::convertFromPDFViewToRootView const):
(WebKit::PDFPluginBase::convertFromRootViewToPDFView const):
(WebKit::PDFPluginBase::convertFromPDFViewToScreen const):
(WebKit::PDFPluginBase::boundsOnScreen const):
(WebKit::PDFPluginBase::updatePDFHUDLocation):
(WebKit::PDFPluginBase::frameForHUD const):
(WebKit::PDFPluginBase::hudEnabled const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::countFindMatches):
(WebKit::UnifiedPDFPlugin::findString):
(WebKit::UnifiedPDFPlugin::zoomIn):
(WebKit::UnifiedPDFPlugin::zoomOut):
(WebKit::UnifiedPDFPlugin::save):
(WebKit::UnifiedPDFPlugin::openWithPreview):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::createPDFHUD):
(WebKit::WebPage::updatePDFHUDLocation):
(WebKit::WebPage::removePDFHUD):

Canonical link: <a href="https://commits.webkit.org/270560@main">https://commits.webkit.org/270560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33b12963ab51cc328c6d7506ac8dd8b5946ba84c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27868 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/23601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1812 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28448 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27098 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1158 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4312 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6196 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->