### PR TITLE
Add remaining support for the browser.scripting API.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -39,7 +39,6 @@
 #import "WebExtensionContextProxy.h"
 #import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionScriptInjectionParameters.h"
-#import "WebExtensionScriptInjectionResultParameters.h"
 #import "WebExtensionTab.h"
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
@@ -73,8 +72,10 @@ void WebExtensionContext::scriptingExecuteScript(const WebExtensionScriptInjecti
         return;
     }
 
-    // FIXME: <https://webkit.org/b/259954> Implement scripting.executeScript().
-    completionHandler({ }, std::nullopt);
+    auto scriptPairs = getSourcePairsForParameters(parameters, m_extension);
+    executeScript(scriptPairs, webView, *m_contentScriptWorld, tab.get(), parameters, *this, [completionHandler = WTFMove(completionHandler)](InjectionResultHolder& injectionResults) mutable {
+        completionHandler(injectionResults.results, std::nullopt);
+    });
 }
 
 void WebExtensionContext::scriptingInsertCSS(const WebExtensionScriptInjectionParameters& parameters, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&& completionHandler)
@@ -100,7 +101,7 @@ void WebExtensionContext::scriptingInsertCSS(const WebExtensionScriptInjectionPa
     // FIXME: <https://webkit.org/b/262491> There is currently no way to inject CSS in specific frames based on ID's. If 'frameIds' is passed, default to the main frame.
     auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
-    SourcePairs styleSheetPairs = getSourcePairsForResource(parameters.files, parameters.css, m_extension);
+    auto styleSheetPairs = getSourcePairsForParameters(parameters, m_extension);
     injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, injectedFrames, *this);
 
     completionHandler(std::nullopt);
@@ -134,8 +135,8 @@ void WebExtensionContext::scriptingRemoveCSS(const WebExtensionScriptInjectionPa
     // FIXME: <https://webkit.org/b/262491> There is currently no way to inject CSS in specific frames based on ID's. If 'frameIds' is passed, default to the main frame.
     auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
-    Vector<std::optional<SourcePair>> styleSheetPairs = getSourcePairsForResource(parameters.files, parameters.css, m_extension);
-    removeStyleSheets(styleSheetPairs, injectedFrames, *this);
+    auto styleSheetPairs = getSourcePairsForParameters(parameters, m_extension);
+    removeStyleSheets(styleSheetPairs, webView, injectedFrames, *this);
 
     completionHandler(std::nullopt);
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -40,6 +40,7 @@ namespace WebKit {
 
 class WebExtension;
 class WebExtensionContext;
+class WebExtensionTab;
 
 namespace WebExtensionDynamicScripts {
 
@@ -66,11 +67,12 @@ public:
 };
 
 std::optional<SourcePair> sourcePairForResource(String path, RefPtr<WebExtension>);
-SourcePairs getSourcePairsForResource(std::optional<Vector<String>> files, std::optional<String> code, RefPtr<WebExtension>);
+SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParameters&, RefPtr<WebExtension>);
 Vector<RetainPtr<_WKFrameTreeNode>> getFrames(_WKFrameTreeNode *, std::optional<Vector<WebExtensionFrameIdentifier>>);
 
+void executeScript(std::optional<SourcePairs>, WKWebView *, API::ContentWorld&, WebExtensionTab*, const WebExtensionScriptInjectionParameters&, WebExtensionContext&, CompletionHandler<void(InjectionResultHolder&)>&&);
 void injectStyleSheets(SourcePairs, WKWebView *, API::ContentWorld&, WebCore::UserContentInjectedFrames, WebExtensionContext&);
-void removeStyleSheets(SourcePairs, WebCore::UserContentInjectedFrames, WebExtensionContext&);
+void removeStyleSheets(SourcePairs, WKWebView *, WebCore::UserContentInjectedFrames, WebExtensionContext&);
 
 WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resultOfExecution, WKFrameInfo *, NSString *errorMessage);
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -54,6 +54,8 @@ private:
     bool validateScript(NSDictionary *, NSString **outExceptionString);
     bool validateTarget(NSDictionary *, NSString **outExceptionString);
     bool validateCSS(NSDictionary *, NSString **outExceptionString);
+
+    NSArray* toWebAPI(Vector<WebExtensionScriptInjectionResultParameters>& parametersVector);
 #endif
 };
 


### PR DESCRIPTION
#### 8f5f542c3b969fc0e112188544b4ddefa0b8a182
<pre>
Add remaining support for the browser.scripting API.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259956">https://bugs.webkit.org/show_bug.cgi?id=259956</a>

Reviewed by Timothy Hatcher.

This patch moves the code used for tabs.executeScript into the WebExtensionDynamicScripts so that
the code can be shared with the scripting.executeScript API.

Also adds tests for executeScript(), insertCSS(), and removeCSS().

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingExecuteScript):
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::scriptingRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::getSourcePairsForParameters):
(WebKit::WebExtensionDynamicScripts::executeScript):
(WebKit::WebExtensionDynamicScripts::injectStyleSheets):
(WebKit::WebExtensionDynamicScripts::removeStyleSheets):
(WebKit::WebExtensionDynamicScripts::getSourcePairsForResource): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::parseTargetInjectionOptions):
(WebKit::WebExtensionAPIScripting::executeScript):
(WebKit::WebExtensionAPIScripting::toWebAPI):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270576@main">https://commits.webkit.org/270576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e52f4137944d60dc276909c4248e413a78786504

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23650 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26148 "Failed to checkout and rebase branch from PR 20324") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6199 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/1868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26083 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28511 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/2948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2979 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/1868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3435 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3309 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->