### PR TITLE
[UnifiedPDF] Move back to PDFKit/PDFPage rendering (instead of CGPDF)

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -161,7 +161,6 @@ private:
     void teardown() override;
     bool isComposited() const override { return true; }
 
-    void createPDFDocument() override;
     void installPDFDocument() override;
     void tryRunScriptsInPDFDocument() override;
 
@@ -175,8 +174,6 @@ private:
 
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
-
-    bool isLocked() const override;
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
@@ -218,11 +215,7 @@ private:
 
     void createPasswordEntryForm();
 
-#ifdef __OBJC__
     NSData *liveData() const;
-    NSData *rawData() const { return (__bridge NSData *)m_data.get(); }
-#endif
-
     JSObjectRef makeJSPDFDoc(JSContextRef);
     static JSClassRef jsPDFDocClass();
     static JSValueRef jsPDFDocPrint(JSContextRef, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
@@ -251,8 +244,6 @@ private:
     RetainPtr<WKPDFLayerControllerDelegate> m_pdfLayerControllerDelegate;
 
     URL m_sourceURL;
-
-    RetainPtr<PDFDocument> m_pdfDocument;
 
 #if HAVE(INCREMENTAL_PDF_APIS)
     void threadEntry(Ref<PDFPlugin>&&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1576,12 +1576,6 @@ unsigned PDFPlugin::firstPageHeight() const
     return static_cast<unsigned>(CGCeiling([[m_pdfDocument pageAtIndex:0] boundsForBox:kPDFDisplayBoxCropBox].size.height));
 }
 
-bool PDFPlugin::isLocked() const
-{
-    return [m_pdfDocument isLocked];
-}
-
-
 void PDFPlugin::setView(PluginView& view)
 {
     PDFPluginBase::setView(view);
@@ -1614,11 +1608,6 @@ void PDFPlugin::teardown()
     
     [m_scrollCornerLayer removeFromSuperlayer];
     [m_contentLayer removeFromSuperlayer];
-}
-
-void PDFPlugin::createPDFDocument()
-{
-    m_pdfDocument = adoptNS([allocPDFDocumentInstance() initWithData:rawData()]);
 }
 
 void PDFPlugin::paintControlForLayerInContext(CALayer *layer, CGContextRef context)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -42,7 +42,6 @@
 #include <wtf/TypeTraits.h>
 #include <wtf/WeakPtr.h>
 
-// FIXME: These Objective-C classes should only appear in PDFPlugin, not here in the base class.
 OBJC_CLASS NSDictionary;
 OBJC_CLASS PDFDocument;
 OBJC_CLASS PDFSelection;
@@ -96,9 +95,8 @@ public:
 
     virtual CGFloat scaleFactor() const = 0;
 
-    virtual bool isLocked() const = 0;
+    bool isLocked() const;
 
-    // FIXME: Can we use PDFDocument here?
     virtual RetainPtr<PDFDocument> pdfDocumentForPrinting() const = 0;
     virtual WebCore::FloatSize pdfDocumentSizeForPrinting() const = 0;
 
@@ -174,7 +172,7 @@ protected:
 
     virtual void teardown();
 
-    virtual void createPDFDocument() = 0;
+    void createPDFDocument();
     virtual void installPDFDocument() = 0;
     virtual void tryRunScriptsInPDFDocument() { }
 
@@ -183,6 +181,8 @@ protected:
     virtual void incrementalPDFStreamDidFail() { }
 
     virtual unsigned firstPageHeight() const = 0;
+
+    NSData *rawData() const;
 
     void ensureDataBufferLength(uint64_t);
     void addArchiveResource();
@@ -232,6 +232,7 @@ protected:
     PDFPluginIdentifier m_identifier;
 
     RetainPtr<CFMutableDataRef> m_data;
+    RetainPtr<PDFDocument> m_pdfDocument;
 
     String m_suggestedFilename;
     uint64_t m_streamedBytes { 0 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -48,6 +48,8 @@
 #import <WebCore/ScrollAnimator.h>
 #import <WebCore/SharedBuffer.h>
 
+#import "PDFKitSoftLink.h"
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -126,6 +128,11 @@ void PDFPluginBase::destroy()
     m_view = nullptr;
 }
 
+void PDFPluginBase::createPDFDocument()
+{
+    m_pdfDocument = adoptNS([allocPDFDocumentInstance() initWithData:rawData()]);
+}
+
 bool PDFPluginBase::isFullFramePlugin() const
 {
     // <object> or <embed> plugins will appear to be in their parent frame, so we have to
@@ -137,6 +144,16 @@ bool PDFPluginBase::isFullFramePlugin() const
     if (!is<PluginDocument>(document))
         return false;
     return downcast<PluginDocument>(*document).pluginWidget() == m_view;
+}
+
+bool PDFPluginBase::isLocked() const
+{
+    return [m_pdfDocument isLocked];
+}
+
+NSData *PDFPluginBase::rawData() const
+{
+    return (__bridge NSData *)m_data.get();
 }
 
 void PDFPluginBase::ensureDataBufferLength(uint64_t targetLength)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -27,10 +27,12 @@
 
 #if ENABLE(UNIFIED_PDF)
 
-#include <CoreGraphics/CoreGraphics.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/IntDegrees.h>
 #include <wtf/RetainPtr.h>
+
+OBJC_CLASS PDFDocument;
+OBJC_CLASS PDFPage;
 
 namespace WebCore {
 class GraphicsContext;
@@ -53,13 +55,11 @@ public:
     PDFDocumentLayout();
     ~PDFDocumentLayout();
 
-    void setPDFDocument(RetainPtr<CGPDFDocumentRef>&&);
-    CGPDFDocumentRef pdfDocument() const { return m_pdfDocument.get(); }
+    void setPDFDocument(PDFDocument *document) { m_pdfDocument = document; }
 
-    bool hasPDFDocument() const;
     size_t pageCount() const;
 
-    RetainPtr<CGPDFPageRef> pageAtIndex(PageIndex) const;
+    RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
     WebCore::FloatRect boundsForPageAtIndex(PageIndex) const;
     // Returns 0, 90, 180, 270.
     IntDegrees rotationForPageAtIndex(PageIndex) const;
@@ -84,7 +84,7 @@ private:
         IntDegrees rotation { 0 };
     };
 
-    RetainPtr<CGPDFDocumentRef> m_pdfDocument;
+    RetainPtr<PDFDocument> m_pdfDocument;
     Vector<PageGeometry> m_pageGeometry;
     WebCore::FloatRect m_documentBounds;
     float m_scale { 1 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -23,14 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "PDFDocumentLayout.h"
+#import "config.h"
+#import "PDFDocumentLayout.h"
 
 #if ENABLE(UNIFIED_PDF)
 
-#include "Logging.h"
-#include <CoreGraphics/CoreGraphics.h>
-#include <wtf/text/TextStream.h>
+#import "Logging.h"
+#import <wtf/text/TextStream.h>
+
+#import "PDFKitSoftLink.h"
 
 namespace WebKit {
 using namespace WebCore;
@@ -50,20 +51,9 @@ FloatSize PDFDocumentLayout::pageMargin()
 PDFDocumentLayout::PDFDocumentLayout() = default;
 PDFDocumentLayout::~PDFDocumentLayout() = default;
 
-void PDFDocumentLayout::setPDFDocument(RetainPtr<CGPDFDocumentRef>&& pdfDocument)
+RetainPtr<PDFPage> PDFDocumentLayout::pageAtIndex(PageIndex index) const
 {
-    m_pdfDocument = WTFMove(pdfDocument);
-}
-
-bool PDFDocumentLayout::hasPDFDocument() const
-{
-    return !!m_pdfDocument;
-}
-
-RetainPtr<CGPDFPageRef> PDFDocumentLayout::pageAtIndex(PageIndex index) const
-{
-    RetainPtr page = CGPDFDocumentGetPage(m_pdfDocument.get(), index + 1); // CG Page index is 1-based
-    return page;
+    return [m_pdfDocument pageAtIndex:index];
 }
 
 void PDFDocumentLayout::updateLayout(IntSize pluginSize)
@@ -103,8 +93,8 @@ void PDFDocumentLayout::updateLayout(IntSize pluginSize)
             continue;
         }
 
-        auto pageCropBox = FloatRect { CGPDFPageGetBoxRect(page.get(), kCGPDFCropBox) };
-        auto rotation = normalizeRotation(CGPDFPageGetRotationAngle(page.get()));
+        auto pageCropBox = FloatRect { [page boundsForBox:kPDFDisplayBoxCropBox] };
+        auto rotation = normalizeRotation([page rotation]);
 
         LOG_WITH_STREAM(Plugins, stream << "PDFDocumentLayout::updateLayout() - page " << i << " crop box " << pageCropBox << " rotation " << rotation);
 
@@ -238,10 +228,10 @@ void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidt
 
 size_t PDFDocumentLayout::pageCount() const
 {
-    if (!hasPDFDocument())
+    if (!m_pdfDocument)
         return 0;
 
-    return CGPDFDocumentGetNumberOfPages(m_pdfDocument.get());
+    return [m_pdfDocument pageCount];
 }
 
 WebCore::FloatRect PDFDocumentLayout::boundsForPageAtIndex(PageIndex index) const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -48,15 +48,12 @@ private:
 
     void teardown() override;
 
-    void createPDFDocument() override;
     void installPDFDocument() override;
 
     CGFloat scaleFactor() const override;
 
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
-
-    bool isLocked() const override;
 
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const override;
     WebCore::FloatSize pdfDocumentSizeForPrinting() const override;


### PR DESCRIPTION
#### 42d74b74eedd1cc519a729cc86b5568b4e5be315
<pre>
[UnifiedPDF] Move back to PDFKit/PDFPage rendering (instead of CGPDF)
<a href="https://bugs.webkit.org/show_bug.cgi?id=264614">https://bugs.webkit.org/show_bug.cgi?id=264614</a>
&lt;<a href="https://rdar.apple.com/problem/118155116">rdar://problem/118155116</a>&gt;

Reviewed by Simon Fraser.

We&apos;re likely to need lots of PDFKit conveniences, and it&apos;s available
cross-platform, so we should just use PDFKit.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::isLocked const): Deleted.
(WebKit::PDFPlugin::createPDFDocument): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::createPDFDocument):
(WebKit::PDFPluginBase::isLocked const):
(WebKit::PDFPluginBase::rawData const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::createPDFDocument): Deleted.
(WebKit::UnifiedPDFPlugin::isLocked const): Deleted.
Hoist PDFDocument creation, isLocked(), rawData(), and m_pdfDocument.

(WebKit::UnifiedPDFPlugin::paintContents):
Use PDFPage painting.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::setPDFDocument):
(WebKit::PDFDocumentLayout::pdfDocument const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::pageAtIndex const):
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::pageCount const):
(WebKit::PDFDocumentLayout::setPDFDocument): Deleted.
(WebKit::PDFDocumentLayout::hasPDFDocument const): Deleted.
Use PDFDocument and PDFPage for retrieving pages and page layout information.

Canonical link: <a href="https://commits.webkit.org/270572@main">https://commits.webkit.org/270572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab93192d835b6bc36a430ed8448149befb04b23f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23604 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28455 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2915 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23527 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27112 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1165 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4319 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6203 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->