### PR TITLE
[iOS] Fix appearance of date inputs in vertical writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/date-input-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/date-input-appearance-native-computed-style-expected.txt
@@ -1,0 +1,9 @@
+
+
+PASS horizontal-empty block size should match height and inline size should match width
+PASS horizontal-with-value block size should match height and inline size should match width
+PASS vertical-lr-empty block size should match width and inline size should match height
+PASS vertical-lr-with-value block size should match width and inline size should match height
+PASS vertical-rl-empty block size should match width and inline size should match height
+PASS vertical-rl-with-value block size should match width and inline size should match height
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/date-input-appearance-native-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/date-input-appearance-native-computed-style.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow">
+<title>Date input appearance native writing mode computed style</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input type="date" id="horizontal-empty">
+<input type="date" id="horizontal-with-value" value="2023-11-10">
+<input type="date" id="vertical-lr-empty" style="writing-mode: vertical-lr">
+<input type="date" id="vertical-lr-with-value" value="2023-11-10" style="writing-mode: vertical-lr">
+<input type="date" id="vertical-rl-empty" style="writing-mode: vertical-rl">
+<input type="date" id="vertical-rl-with-value" value="2023-11-10" style="writing-mode: vertical-rl">
+
+<script>
+for (const element of document.querySelectorAll("[id^='horizontal-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.height);
+        assert_equals(style.inlineSize, style.width);
+    }, `${element.id} block size should match height and inline size should match width`);
+}
+
+for (const element of document.querySelectorAll("[id^='vertical-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.width);
+        assert_equals(style.inlineSize, style.height);
+    }, `${element.id} block size should match width and inline size should match height`);
+}
+</script>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -501,7 +501,8 @@ input:is([type="date"], [type="time"], [type="datetime-local"], [type="month"], 
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     border: 1px solid -webkit-control-background;
     font-family: system-ui;
-    padding: 0.2em 0.5em;
+    padding-block: 0.2em;
+    padding-inline: 0.5em;
 #if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
     background-color: rgba(0, 0, 0, 0.04);
     color: CanvasText;

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -808,7 +808,7 @@ static void adjustInputElementButtonStyle(RenderStyle& style, const HTMLInputEle
     applyCommonButtonPaddingToStyle(style, inputElement);
 
     // Don't adjust the style if the width is specified.
-    if (style.width().isFixed() && style.width().value() > 0)
+    if (style.logicalWidth().isFixed() && style.logicalWidth().value() > 0)
         return;
 
     // Don't adjust for unsupported date input types.
@@ -829,7 +829,7 @@ static void adjustInputElementButtonStyle(RenderStyle& style, const HTMLInputEle
         if (inputElement.document().settings().iOSFormControlRefreshEnabled())
             width = static_cast<int>(std::ceil(maximumWidth));
 #endif
-        style.setWidth(Length(width, LengthType::Fixed));
+        style.setLogicalWidth(Length(width, LengthType::Fixed));
         style.setBoxSizing(BoxSizing::ContentBox);
     }
 }


### PR DESCRIPTION
#### 30625a91933c33f8c716c60411979de862577f22
<pre>
[iOS] Fix appearance of date inputs in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=264617">https://bugs.webkit.org/show_bug.cgi?id=264617</a>
<a href="https://rdar.apple.com/118248730">rdar://118248730</a>

Reviewed by Megan Gardner.

Use logical properties to ensure the `inline-size` is greater than the
`block-size` by default.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/date-input-appearance-native-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/date-input-appearance-native-computed-style.html: Added.
* Source/WebCore/css/html.css:
(input:is([type=&quot;date&quot;], [type=&quot;time&quot;], [type=&quot;datetime-local&quot;], [type=&quot;month&quot;], [type=&quot;week&quot;])):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::adjustInputElementButtonStyle):

Canonical link: <a href="https://commits.webkit.org/270574@main">https://commits.webkit.org/270574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43981c873e4757310eeb250e868e1b4b2d69c85c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23718 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28462 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29240 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27109 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1169 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6207 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->