### PR TITLE
Move enums under WebCore/rendering/ to use the serializer

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -168,7 +168,7 @@ Pagination::Mode paginationModeForRenderStyle(const RenderStyle& style)
 {
     auto overflow = style.overflowY();
     if (overflow != Overflow::PagedX && overflow != Overflow::PagedY)
-        return Unpaginated;
+        return Pagination::Mode::Unpaginated;
 
     bool isHorizontalWritingMode = style.isHorizontalWritingMode();
     auto textDirection = style.direction();
@@ -179,16 +179,16 @@ Pagination::Mode paginationModeForRenderStyle(const RenderStyle& style)
     // is vertical, then the block flow direction dictates the choice.
     if (overflow == Overflow::PagedX) {
         if ((isHorizontalWritingMode && textDirection == TextDirection::LTR) || blockFlowDirection == BlockFlowDirection::LeftToRight)
-            return LeftToRightPaginated;
-        return RightToLeftPaginated;
+            return Pagination::Mode::LeftToRightPaginated;
+        return Pagination::Mode::RightToLeftPaginated;
     }
 
     // paged-y always corresponds to TopToBottomPaginated or BottomToTopPaginated. If the WritingMode
     // is horizontal, then the block flow direction dictates the choice. If the WritingMode
     // is vertical, then we use TextDirection to choose between those options. 
     if (blockFlowDirection == BlockFlowDirection::TopToBottom || (!isHorizontalWritingMode && textDirection == TextDirection::RTL))
-        return TopToBottomPaginated;
-    return BottomToTopPaginated;
+        return Pagination::Mode::TopToBottomPaginated;
+    return Pagination::Mode::BottomToTopPaginated;
 }
 
 LocalFrameView::LocalFrameView(LocalFrame& frame)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1643,7 +1643,7 @@ void Page::setPagination(const Pagination& pagination)
 
 unsigned Page::pageCount() const
 {
-    if (m_pagination.mode == Unpaginated)
+    if (m_pagination.mode == Pagination::Mode::Unpaginated)
         return 0;
 
     auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
@@ -1655,7 +1655,7 @@ unsigned Page::pageCount() const
 
 unsigned Page::pageCountAssumingLayoutIsUpToDate() const
 {
-    if (m_pagination.mode == Unpaginated)
+    if (m_pagination.mode == Pagination::Mode::Unpaginated)
         return 0;
 
     auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());

--- a/Source/WebCore/rendering/Pagination.h
+++ b/Source/WebCore/rendering/Pagination.h
@@ -25,36 +25,19 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
-enum PaginationMode : uint8_t { Unpaginated, LeftToRightPaginated, RightToLeftPaginated, TopToBottomPaginated, BottomToTopPaginated };
+enum class PaginationMode : uint8_t { Unpaginated, LeftToRightPaginated, RightToLeftPaginated, TopToBottomPaginated, BottomToTopPaginated };
 
 struct Pagination {
     using Mode = PaginationMode;
 
     friend bool operator==(const Pagination&, const Pagination&) = default;
 
-    Mode mode { Unpaginated };
+    Mode mode { Pagination::Mode::Unpaginated };
     bool behavesLikeColumns { false };
     unsigned pageLength { 0 };
     unsigned gap { 0 };
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::Pagination::Mode> {
-    using values = EnumValues<
-        WebCore::Pagination::Mode,
-        WebCore::Pagination::Mode::Unpaginated,
-        WebCore::Pagination::Mode::LeftToRightPaginated,
-        WebCore::Pagination::Mode::RightToLeftPaginated,
-        WebCore::Pagination::Mode::TopToBottomPaginated,
-        WebCore::Pagination::Mode::BottomToTopPaginated
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4258,7 +4258,7 @@ void RenderBlockFlow::checkForPaginationLogicalHeightChange(bool& relayoutChildr
     // We don't actually update any of the variables. We just subclassed to adjust our column height.
     if (RenderMultiColumnFlow* fragmentedFlow = multiColumnFlow()) {
         LayoutUnit newColumnHeight;
-        if (hasDefiniteLogicalHeight() || view().frameView().pagination().mode != Unpaginated) {
+        if (hasDefiniteLogicalHeight() || view().frameView().pagination().mode != Pagination::Mode::Unpaginated) {
             auto computedValues = computeLogicalHeight(0_lu, logicalTop());
             newColumnHeight = std::max<LayoutUnit>(computedValues.m_extent - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight(), 0);
             if (fragmentedFlow->columnHeightAvailable() != newColumnHeight)

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -95,7 +95,7 @@ namespace Style {
 class PseudoElementRequest;
 }
 
-enum class RepaintRectCalculation { Fast, Accurate };
+enum class RepaintRectCalculation : bool { Fast, Accurate };
 
 // Base class for all rendering tree objects.
 class RenderObject : public CachedImageClient, public CanMakeCheckedPtr {
@@ -1446,15 +1446,3 @@ void showNodeTree(const WebCore::RenderObject*);
 void showLineTree(const WebCore::RenderObject*);
 void showRenderTree(const WebCore::RenderObject*);
 #endif
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::RepaintRectCalculation> {
-    using values = EnumValues<
-        WebCore::RepaintRectCalculation,
-        WebCore::RepaintRectCalculation::Fast,
-        WebCore::RepaintRectCalculation::Accurate
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -114,7 +114,7 @@ void RenderView::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
     bool directionChanged = oldStyle && style().direction() != oldStyle->direction();
 
     if ((writingModeChanged || directionChanged) && multiColumnFlow()) {
-        if (frameView().pagination().mode != Unpaginated)
+        if (frameView().pagination().mode != Pagination::Mode::Unpaginated)
             updateColumnProgressionFromStyle(style());
         updateStylesForColumnChildren(oldStyle);
     }
@@ -341,7 +341,7 @@ void RenderView::mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode> mode, Tra
 
 bool RenderView::requiresColumns(int) const
 {
-    return frameView().pagination().mode != Unpaginated;
+    return frameView().pagination().mode != Pagination::Mode::Unpaginated;
 }
 
 void RenderView::computeColumnCountAndWidth()
@@ -362,7 +362,7 @@ void RenderView::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     ASSERT(LayoutPoint(IntPoint(paintOffset.x(), paintOffset.y())) == paintOffset);
 
     // This avoids painting garbage between columns if there is a column gap.
-    if (frameView().pagination().mode != Unpaginated && paintInfo.shouldPaintWithinRoot(*this))
+    if (frameView().pagination().mode != Pagination::Mode::Unpaginated && paintInfo.shouldPaintWithinRoot(*this))
         paintInfo.context().fillRect(paintInfo.rect, frameView().baseBackgroundColor());
 
     paintObject(paintInfo, paintOffset);
@@ -1056,7 +1056,7 @@ unsigned RenderView::pageNumberForBlockProgressionOffset(int offset) const
 {
     int columnNumber = 0;
     const Pagination& pagination = page().pagination();
-    if (pagination.mode == Unpaginated)
+    if (pagination.mode == Pagination::Mode::Unpaginated)
         return columnNumber;
     
     bool progressionIsInline = false;
@@ -1081,7 +1081,7 @@ unsigned RenderView::pageNumberForBlockProgressionOffset(int offset) const
 unsigned RenderView::pageCount() const
 {
     const Pagination& pagination = page().pagination();
-    if (pagination.mode == Unpaginated)
+    if (pagination.mode == Pagination::Mode::Unpaginated)
         return 0;
     
     if (multiColumnFlow() && multiColumnFlow()->firstMultiColumnSet())

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3464,41 +3464,41 @@ void RenderStyle::setBorderImageVerticalRule(NinePieceImageRule rule)
 
 void RenderStyle::setColumnStylesFromPaginationMode(PaginationMode paginationMode)
 {
-    if (paginationMode == Unpaginated)
+    if (paginationMode == Pagination::Mode::Unpaginated)
         return;
     
     setColumnFill(ColumnFill::Auto);
     
     switch (paginationMode) {
-    case LeftToRightPaginated:
+    case Pagination::Mode::LeftToRightPaginated:
         setColumnAxis(ColumnAxis::Horizontal);
         if (isHorizontalWritingMode())
             setColumnProgression(isLeftToRightDirection() ? ColumnProgression::Normal : ColumnProgression::Reverse);
         else
             setColumnProgression(isFlippedBlocksWritingMode() ? ColumnProgression::Reverse : ColumnProgression::Normal);
         break;
-    case RightToLeftPaginated:
+    case Pagination::Mode::RightToLeftPaginated:
         setColumnAxis(ColumnAxis::Horizontal);
         if (isHorizontalWritingMode())
             setColumnProgression(isLeftToRightDirection() ? ColumnProgression::Reverse : ColumnProgression::Normal);
         else
             setColumnProgression(isFlippedBlocksWritingMode() ? ColumnProgression::Normal : ColumnProgression::Reverse);
         break;
-    case TopToBottomPaginated:
+    case Pagination::Mode::TopToBottomPaginated:
         setColumnAxis(ColumnAxis::Vertical);
         if (isHorizontalWritingMode())
             setColumnProgression(isFlippedBlocksWritingMode() ? ColumnProgression::Reverse : ColumnProgression::Normal);
         else
             setColumnProgression(isLeftToRightDirection() ? ColumnProgression::Normal : ColumnProgression::Reverse);
         break;
-    case BottomToTopPaginated:
+    case Pagination::Mode::BottomToTopPaginated:
         setColumnAxis(ColumnAxis::Vertical);
         if (isHorizontalWritingMode())
             setColumnProgression(isFlippedBlocksWritingMode() ? ColumnProgression::Normal : ColumnProgression::Reverse);
         else
             setColumnProgression(isLeftToRightDirection() ? ColumnProgression::Reverse : ColumnProgression::Normal);
         break;
-    case Unpaginated:
+    case Pagination::Mode::Unpaginated:
         ASSERT_NOT_REACHED();
         break;
     }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -98,7 +98,7 @@ class WillChangeData;
 enum CSSPropertyID : uint16_t;
 enum GridAutoFlow : uint8_t;
 enum PageSizeType : uint8_t;
-enum PaginationMode : uint8_t;
+enum class PaginationMode : uint8_t;
 
 enum class ApplePayButtonStyle : uint8_t;
 enum class ApplePayButtonType : uint8_t;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -27,7 +27,6 @@
 #include "LayoutRepainter.h"
 #include "LegacyRenderSVGResource.h"
 #include "RenderBoxModelObjectInlines.h"
-#include "RenderObject.h"
 #include "RenderSVGBlockInlines.h"
 #include "RenderView.h"
 #include "SVGElementTypeHelpers.h"

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
@@ -44,7 +44,7 @@ enum class RenderSVGResourceMode {
     ApplyToText    = 1 << 2 // used in combination with ApplyTo{Fill|Stroke}Mode
 };
 
-enum class RepaintRectCalculation;
+enum class RepaintRectCalculation : bool;
 
 class Color;
 class FloatRect;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -95,7 +95,7 @@ private:
     bool drawContentIntoMaskImage(ImageBuffer&, const FloatRect& objectBoundingBox, float effectiveZoom);
     void calculateClipContentRepaintRect(RepaintRectCalculation);
 
-    EnumeratedArray<RepaintRectCalculation, FloatRect> m_clipBoundaries;
+    EnumeratedArray<RepaintRectCalculation, FloatRect, RepaintRectCalculation::Accurate> m_clipBoundaries;
     HashMap<const RenderObject*, std::unique_ptr<ClipperData>> m_clipperMap;
 };
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -65,7 +65,7 @@ private:
     bool drawContentIntoMaskImage(MaskerData*, const DestinationColorSpace&, RenderObject*);
     void calculateMaskContentRepaintRect(RepaintRectCalculation);
 
-    EnumeratedArray<RepaintRectCalculation, FloatRect> m_maskContentBoundaries;
+    EnumeratedArray<RepaintRectCalculation, FloatRect, RepaintRectCalculation::Accurate> m_maskContentBoundaries;
     HashMap<RenderObject*, std::unique_ptr<MaskerData>> m_masker;
 };
 

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -73,7 +73,7 @@ RenderStyle resolveForDocument(const Document& document)
     Adjuster::adjustEventListenerRegionTypesForRootStyle(documentStyle, document);
     
     const Pagination& pagination = renderView.frameView().pagination();
-    if (pagination.mode != Unpaginated) {
+    if (pagination.mode != Pagination::Mode::Unpaginated) {
         documentStyle.setColumnStylesFromPaginationMode(pagination.mode);
         documentStyle.setColumnGap(GapLength(Length((int) pagination.gap, LengthType::Fixed)));
         if (renderView.multiColumnFlow())

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2162,15 +2162,15 @@ ExceptionOr<void> Internals::setPagination(const String& mode, int gap, int page
 
     Pagination pagination;
     if (mode == "Unpaginated"_s)
-        pagination.mode = Unpaginated;
+        pagination.mode = Pagination::Mode::Unpaginated;
     else if (mode == "LeftToRightPaginated"_s)
-        pagination.mode = LeftToRightPaginated;
+        pagination.mode = Pagination::Mode::LeftToRightPaginated;
     else if (mode == "RightToLeftPaginated"_s)
-        pagination.mode = RightToLeftPaginated;
+        pagination.mode = Pagination::Mode::RightToLeftPaginated;
     else if (mode == "TopToBottomPaginated"_s)
-        pagination.mode = TopToBottomPaginated;
+        pagination.mode = Pagination::Mode::TopToBottomPaginated;
     else if (mode == "BottomToTopPaginated"_s)
-        pagination.mode = BottomToTopPaginated;
+        pagination.mode = Pagination::Mode::BottomToTopPaginated;
     else
         return Exception { ExceptionCode::SyntaxError };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6696,3 +6696,14 @@ enum class WebCore::CredentialPersistence : uint8_t {
      ForSession,
      Permanent,
 }
+header: <WebCore/Pagination.h>
+enum class WebCore::PaginationMode : uint8_t {
+    Unpaginated,
+    LeftToRightPaginated,
+    RightToLeftPaginated,
+    TopToBottomPaginated,
+    BottomToTopPaginated
+};
+
+header: <WebCore/RenderObject.h>
+enum class WebCore::RepaintRectCalculation : bool;

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -815,19 +815,19 @@ void WKPageSetPaginationMode(WKPageRef pageRef, WKPaginationMode paginationMode)
     WebCore::Pagination::Mode mode;
     switch (paginationMode) {
     case kWKPaginationModeUnpaginated:
-        mode = WebCore::Unpaginated;
+        mode = WebCore::Pagination::Mode::Unpaginated;
         break;
     case kWKPaginationModeLeftToRight:
-        mode = WebCore::LeftToRightPaginated;
+        mode = WebCore::Pagination::Mode::LeftToRightPaginated;
         break;
     case kWKPaginationModeRightToLeft:
-        mode = WebCore::RightToLeftPaginated;
+        mode = WebCore::Pagination::Mode::RightToLeftPaginated;
         break;
     case kWKPaginationModeTopToBottom:
-        mode = WebCore::TopToBottomPaginated;
+        mode = WebCore::Pagination::Mode::TopToBottomPaginated;
         break;
     case kWKPaginationModeBottomToTop:
-        mode = WebCore::BottomToTopPaginated;
+        mode = WebCore::Pagination::Mode::BottomToTopPaginated;
         break;
     default:
         return;
@@ -838,15 +838,15 @@ void WKPageSetPaginationMode(WKPageRef pageRef, WKPaginationMode paginationMode)
 WKPaginationMode WKPageGetPaginationMode(WKPageRef pageRef)
 {
     switch (toImpl(pageRef)->paginationMode()) {
-    case WebCore::Unpaginated:
+    case WebCore::Pagination::Mode::Unpaginated:
         return kWKPaginationModeUnpaginated;
-    case WebCore::LeftToRightPaginated:
+    case WebCore::Pagination::Mode::LeftToRightPaginated:
         return kWKPaginationModeLeftToRight;
-    case WebCore::RightToLeftPaginated:
+    case WebCore::Pagination::Mode::RightToLeftPaginated:
         return kWKPaginationModeRightToLeft;
-    case WebCore::TopToBottomPaginated:
+    case WebCore::Pagination::Mode::TopToBottomPaginated:
         return kWKPaginationModeTopToBottom;
-    case WebCore::BottomToTopPaginated:
+    case WebCore::Pagination::Mode::BottomToTopPaginated:
         return kWKPaginationModeBottomToTop;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -654,19 +654,19 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     WebCore::Pagination::Mode mode;
     switch (paginationMode) {
     case WKPaginationModeUnpaginated:
-        mode = WebCore::Unpaginated;
+        mode = WebCore::PaginationMode::Unpaginated;
         break;
     case WKPaginationModeLeftToRight:
-        mode = WebCore::LeftToRightPaginated;
+        mode = WebCore::PaginationMode::LeftToRightPaginated;
         break;
     case WKPaginationModeRightToLeft:
-        mode = WebCore::RightToLeftPaginated;
+        mode = WebCore::PaginationMode::RightToLeftPaginated;
         break;
     case WKPaginationModeTopToBottom:
-        mode = WebCore::TopToBottomPaginated;
+        mode = WebCore::PaginationMode::TopToBottomPaginated;
         break;
     case WKPaginationModeBottomToTop:
-        mode = WebCore::BottomToTopPaginated;
+        mode = WebCore::PaginationMode::BottomToTopPaginated;
         break;
     default:
         return;
@@ -678,15 +678,15 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (WKBrowsingContextPaginationMode)paginationMode
 {
     switch (_page->paginationMode()) {
-    case WebCore::Unpaginated:
+    case WebCore::PaginationMode::Unpaginated:
         return WKPaginationModeUnpaginated;
-    case WebCore::LeftToRightPaginated:
+    case WebCore::PaginationMode::LeftToRightPaginated:
         return WKPaginationModeLeftToRight;
-    case WebCore::RightToLeftPaginated:
+    case WebCore::PaginationMode::RightToLeftPaginated:
         return WKPaginationModeRightToLeft;
-    case WebCore::TopToBottomPaginated:
+    case WebCore::PaginationMode::TopToBottomPaginated:
         return WKPaginationModeTopToBottom;
-    case WebCore::BottomToTopPaginated:
+    case WebCore::PaginationMode::BottomToTopPaginated:
         return WKPaginationModeBottomToTop;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3409,15 +3409,15 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 - (_WKPaginationMode)_paginationMode
 {
     switch (_page->paginationMode()) {
-    case WebCore::Unpaginated:
+    case WebCore::PaginationMode::Unpaginated:
         return _WKPaginationModeUnpaginated;
-    case WebCore::LeftToRightPaginated:
+    case WebCore::PaginationMode::LeftToRightPaginated:
         return _WKPaginationModeLeftToRight;
-    case WebCore::RightToLeftPaginated:
+    case WebCore::PaginationMode::RightToLeftPaginated:
         return _WKPaginationModeRightToLeft;
-    case WebCore::TopToBottomPaginated:
+    case WebCore::PaginationMode::TopToBottomPaginated:
         return _WKPaginationModeTopToBottom;
-    case WebCore::BottomToTopPaginated:
+    case WebCore::PaginationMode::BottomToTopPaginated:
         return _WKPaginationModeBottomToTop;
     }
 
@@ -3431,19 +3431,19 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
     WebCore::Pagination::Mode mode;
     switch (paginationMode) {
     case _WKPaginationModeUnpaginated:
-        mode = WebCore::Unpaginated;
+        mode = WebCore::PaginationMode::Unpaginated;
         break;
     case _WKPaginationModeLeftToRight:
-        mode = WebCore::LeftToRightPaginated;
+        mode = WebCore::PaginationMode::LeftToRightPaginated;
         break;
     case _WKPaginationModeRightToLeft:
-        mode = WebCore::RightToLeftPaginated;
+        mode = WebCore::PaginationMode::RightToLeftPaginated;
         break;
     case _WKPaginationModeTopToBottom:
-        mode = WebCore::TopToBottomPaginated;
+        mode = WebCore::PaginationMode::TopToBottomPaginated;
         break;
     case _WKPaginationModeBottomToTop:
-        mode = WebCore::BottomToTopPaginated;
+        mode = WebCore::PaginationMode::BottomToTopPaginated;
         break;
     default:
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -129,7 +129,7 @@ class TextCheckingRequestData;
 class ValidationBubble;
 
 enum class LayoutMilestone : uint16_t;
-enum PaginationMode : uint8_t;
+enum class PaginationMode : uint8_t;
 enum class ScrollDirection : uint8_t;
 enum ScrollbarOverlayStyle : uint8_t;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2778,7 +2778,7 @@ void WebPage::setBackgroundExtendsBeyondPage(bool backgroundExtendsBeyondPage)
         m_page->settings().setBackgroundShouldExtendBeyondPage(backgroundExtendsBeyondPage);
 }
 
-void WebPage::setPaginationMode(uint32_t mode)
+void WebPage::setPaginationMode(Pagination::Mode mode)
 {
     Pagination pagination = m_page->pagination();
     pagination.mode = static_cast<Pagination::Mode>(mode);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -258,6 +258,7 @@ enum class UserInterfaceLayoutDirection : bool;
 enum class ViolationReportType : uint8_t;
 enum class WheelEventProcessingSteps : uint8_t;
 enum class WritingDirection : uint8_t;
+enum class PaginationMode : uint8_t;
 
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 using MediaProducerMutedStateFlags = OptionSet<MediaProducerMutedState>;
@@ -682,7 +683,7 @@ public:
 
     void setBackgroundExtendsBeyondPage(bool);
 
-    void setPaginationMode(uint32_t /* WebCore::Pagination::Mode */);
+    void setPaginationMode(WebCore::PaginationMode);
     void setPaginationBehavesLikeColumns(bool);
     void setPageLength(double);
     void setGapBetweenPages(double);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -319,7 +319,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     SetBackgroundExtendsBeyondPage(bool backgroundExtendsBeyondPage)
 
-    SetPaginationMode(uint32_t mode)
+    SetPaginationMode(WebCore::Pagination::Mode mode)
     SetPaginationBehavesLikeColumns(bool behavesLikeColumns)
     SetPageLength(double pageLength)
     SetGapBetweenPages(double gap)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -4461,19 +4461,19 @@ IGNORE_WARNINGS_END
     auto pagination = page->pagination();
     switch (paginationMode) {
     case WebPaginationModeUnpaginated:
-        pagination.mode = WebCore::Unpaginated;
+        pagination.mode = WebCore::PaginationMode::Unpaginated;
         break;
     case WebPaginationModeLeftToRight:
-        pagination.mode = WebCore::LeftToRightPaginated;
+        pagination.mode = WebCore::PaginationMode::LeftToRightPaginated;
         break;
     case WebPaginationModeRightToLeft:
-        pagination.mode = WebCore::RightToLeftPaginated;
+        pagination.mode = WebCore::PaginationMode::RightToLeftPaginated;
         break;
     case WebPaginationModeTopToBottom:
-        pagination.mode = WebCore::TopToBottomPaginated;
+        pagination.mode = WebCore::PaginationMode::TopToBottomPaginated;
         break;
     case WebPaginationModeBottomToTop:
-        pagination.mode = WebCore::BottomToTopPaginated;
+        pagination.mode = WebCore::PaginationMode::BottomToTopPaginated;
         break;
     default:
         return;
@@ -4489,15 +4489,15 @@ IGNORE_WARNINGS_END
         return WebPaginationModeUnpaginated;
 
     switch (page->pagination().mode) {
-    case WebCore::Unpaginated:
+    case WebCore::PaginationMode::Unpaginated:
         return WebPaginationModeUnpaginated;
-    case WebCore::LeftToRightPaginated:
+    case WebCore::PaginationMode::LeftToRightPaginated:
         return WebPaginationModeLeftToRight;
-    case WebCore::RightToLeftPaginated:
+    case WebCore::PaginationMode::RightToLeftPaginated:
         return WebPaginationModeRightToLeft;
-    case WebCore::TopToBottomPaginated:
+    case WebCore::PaginationMode::TopToBottomPaginated:
         return WebPaginationModeTopToBottom;
-    case WebCore::BottomToTopPaginated:
+    case WebCore::PaginationMode::BottomToTopPaginated:
         return WebPaginationModeBottomToTop;
     }
 


### PR DESCRIPTION
#### d53d6d23b888ad7f49bd058a9d8e233983e40f07
<pre>
Move enums under WebCore/rendering/ to use the serializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=264623">https://bugs.webkit.org/show_bug.cgi?id=264623</a>

Reviewed by Chris Dumez.

This patch covers the enums in Pagination.h (WebCore::PaginationMode) and
in RenderObject.h (WebCore::RepaintRectCalculation).

The patch mostly just adds the necessary scopes given that the enums now
are enum classes. The only exception is the EnumeratedArray in the
rendering/svg/legacy/ headers, which needed an extra argument, the last
value in the enum; without it EnumeratedArray tries to call
EnumTraits&lt;Key&gt;::values::max&gt; and fails

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::paginationModeForRenderStyle):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::pageCount const):
(WebCore::Page::pageCountAssumingLayoutIsUpToDate const):
* Source/WebCore/rendering/Pagination.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::checkForPaginationLogicalHeightChange):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::styleDidChange):
(WebCore::RenderView::requiresColumns const):
(WebCore::RenderView::paint):
(WebCore::RenderView::pageNumberForBlockProgressionOffset const):
(WebCore::RenderView::pageCount const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setColumnStylesFromPaginationMode):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setPagination):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPaginationMode):
(WKPageGetPaginationMode):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setPaginationMode):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/270613@main">https://commits.webkit.org/270613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10908ea2d90333e336703147eb6f8aeee33389b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28034 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23829 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28614 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3050 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29361 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27237 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1288 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4470 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6232 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->