### PR TITLE
Port WebPreferencesStore to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -432,6 +432,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/WebPageGroupData.serialization.in
     Shared/WebPageNetworkParameters.serialization.in
     Shared/WebPopupItem.serialization.in
+    Shared/WebPreferencesStore.serialization.in
     Shared/WebProcessCreationParameters.serialization.in
     Shared/WebProcessDataStoreParameters.serialization.in
     Shared/WebPushDaemonConnectionConfiguration.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -352,6 +352,7 @@ $(PROJECT_DIR)/Shared/WebPageCreationParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebPageGroupData.serialization.in
 $(PROJECT_DIR)/Shared/WebPageNetworkParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebPopupItem.serialization.in
+$(PROJECT_DIR)/Shared/WebPreferencesStore.serialization.in
 $(PROJECT_DIR)/Shared/WebProcessCreationParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebProcessDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebPushDaemonConnectionConfiguration.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -617,6 +617,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebPageNetworkParameters.serialization.in \
 	Shared/WebPageGroupData.serialization.in \
 	Shared/WebPopupItem.serialization.in \
+	Shared/WebPreferencesStore.serialization.in \
 	Shared/WebProcessCreationParameters.serialization.in \
 	Shared/WebProcessDataStoreParameters.serialization.in \
 	Shared/WebPushDaemonConnectionConfiguration.serialization.in \

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -49,6 +49,11 @@ header: <wtf/text/AtomString.h>
     String string()
 }
 
+header: <wtf/CheckedRef.h>
+[CustomHeader, Nested] class WTF::CanMakeCheckedPtr {
+    [NotSerialized] uint32_t ptrCount();
+}
+
 [WebKitPlatform] class WTF::UUID {
     uint64_t high();
     [Validator='((static_cast<UInt128>(*high) << 64) | *low) != WTF::UUID::deletedValue'] uint64_t low();

--- a/Source/WebKit/Shared/WebPreferencesStore.cpp
+++ b/Source/WebKit/Shared/WebPreferencesStore.cpp
@@ -40,32 +40,6 @@ static BoolOverridesMap& boolTestRunnerOverridesMap()
     return map;
 }
 
-WebPreferencesStore::WebPreferencesStore()
-{
-}
-
-void WebPreferencesStore::encode(IPC::Encoder& encoder) const
-{
-    encoder << m_values;
-    encoder << m_overriddenDefaults;
-}
-
-bool WebPreferencesStore::decode(IPC::Decoder& decoder, WebPreferencesStore& result)
-{
-    std::optional<ValueMap> values;
-    decoder >> values;
-    if (!values)
-        return false;
-    result.m_values = WTFMove(*values);
-
-    std::optional<ValueMap> overriddenDefaults;
-    decoder >> overriddenDefaults;
-    if (!overriddenDefaults)
-        return false;
-    result.m_overriddenDefaults = WTFMove(*overriddenDefaults);
-    return true;
-}
-
 void WebPreferencesStore::overrideBoolValueForKey(const String& key, bool value)
 {
     boolTestRunnerOverridesMap().set(key, value);

--- a/Source/WebKit/Shared/WebPreferencesStore.h
+++ b/Source/WebKit/Shared/WebPreferencesStore.h
@@ -36,18 +36,8 @@
 namespace WebKit {
 
 struct WebPreferencesStore : public CanMakeCheckedPtr {
-    WebPreferencesStore();
-
     using Value = std::variant<String, bool, uint32_t, double>;
     using ValueMap = MemoryCompactRobinHoodHashMap<String, Value>;
-    WebPreferencesStore(ValueMap&& values, ValueMap&& overriddenDefaults)
-        : m_values(WTFMove(values))
-        , m_overriddenDefaults(WTFMove(overriddenDefaults))
-    {
-    }
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, WebPreferencesStore&);
 
     // NOTE: The getters in this class have non-standard names to aid in the use of the preference macros.
 
@@ -74,11 +64,11 @@ struct WebPreferencesStore : public CanMakeCheckedPtr {
     static void overrideBoolValueForKey(const String& key, bool value);
     static void removeTestRunnerOverrides();
 
-    ValueMap m_values;
-    ValueMap m_overriddenDefaults;
+    ValueMap m_values { };
+    ValueMap m_overriddenDefaults { };
 
-    WebPreferencesStore isolatedCopy() const & { return { crossThreadCopy(m_values), crossThreadCopy(m_overriddenDefaults) }; }
-    WebPreferencesStore isolatedCopy() && { return { crossThreadCopy(WTFMove(m_values)), crossThreadCopy(WTFMove(m_overriddenDefaults)) }; }
+    WebPreferencesStore isolatedCopy() const & { return { CanMakeCheckedPtr { }, crossThreadCopy(m_values), crossThreadCopy(m_overriddenDefaults) }; }
+    WebPreferencesStore isolatedCopy() && { return { CanMakeCheckedPtr { }, crossThreadCopy(WTFMove(m_values)), crossThreadCopy(WTFMove(m_overriddenDefaults)) }; }
 
     static ValueMap& defaults();
 };

--- a/Source/WebKit/Shared/WebPreferencesStore.serialization.in
+++ b/Source/WebKit/Shared/WebPreferencesStore.serialization.in
@@ -1,0 +1,26 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+struct WebKit::WebPreferencesStore : WTF::CanMakeCheckedPtr {
+    WebKit::WebPreferencesStore::ValueMap m_values;
+    WebKit::WebPreferencesStore::ValueMap m_overriddenDefaults;
+};

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4949,6 +4949,7 @@
 		4689B90F2756D1430007C651 /* RemoteWebLockRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWebLockRegistry.h; sourceTree = "<group>"; };
 		4689B9102756D1430007C651 /* RemoteWebLockRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteWebLockRegistry.cpp; sourceTree = "<group>"; };
 		4691CB9A27B2DD1800B29AAF /* RemoteWorkerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWorkerType.h; sourceTree = "<group>"; };
+		4692071A2AFEE3B800CBC22D /* WebPreferencesStore.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebPreferencesStore.serialization.in; sourceTree = "<group>"; };
 		46943DCB2763F834004B610E /* WebSharedWorkerObjectConnection.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebSharedWorkerObjectConnection.messages.in; sourceTree = "<group>"; };
 		469DE802273ECC5D00930276 /* ProcessLauncherCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessLauncherCocoa.mm; sourceTree = "<group>"; };
 		46A2B6061E5675A200C3DEDA /* BackgroundProcessResponsivenessTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BackgroundProcessResponsivenessTimer.cpp; sourceTree = "<group>"; };
@@ -8529,6 +8530,7 @@
 				7CDE73A01F9DA37B00390312 /* WebPreferencesDefaultValues.h */,
 				BCD598AB112B7FDF00EC8C23 /* WebPreferencesStore.cpp */,
 				BCD598AA112B7FDF00EC8C23 /* WebPreferencesStore.h */,
+				4692071A2AFEE3B800CBC22D /* WebPreferencesStore.serialization.in */,
 				BC306822125A6B9400E71278 /* WebProcessCreationParameters.h */,
 				BC306823125A6B9400E71278 /* WebProcessCreationParameters.serialization.in */,
 				467E43E72243FF6D00B13924 /* WebProcessDataStoreParameters.h */,


### PR DESCRIPTION
#### 87f0462fef5bff3516ba5a98f98d3506df61708f
<pre>
Port WebPreferencesStore to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264629">https://bugs.webkit.org/show_bug.cgi?id=264629</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/WebPreferencesStore.cpp:
(WebKit::WebPreferencesStore::WebPreferencesStore): Deleted.
(WebKit::WebPreferencesStore::encode const): Deleted.
(WebKit::WebPreferencesStore::decode): Deleted.
* Source/WebKit/Shared/WebPreferencesStore.h:
* Source/WebKit/Shared/WebPreferencesStore.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270584@main">https://commits.webkit.org/270584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67425158f07edbadf5f07cc6cd2dbcfea22cc524

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1857 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28498 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2955 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29265 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27136 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1196 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3424 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3313 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->