### PR TITLE
[Cocoa] Allow two syscalls found by sandbox telemetry

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2023 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -1179,6 +1179,9 @@
 
 (when (defined? 'syscall-unix)
     (deny syscall-unix)
+    (when (defined? 'SYS_crossarch_trap)
+        (deny syscall-unix (with no-report) (syscall-number
+            SYS_crossarch_trap)))
     (allow syscall-unix (syscall-number
         SYS___channel_open
         SYS___disable_threadsignal

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -588,6 +588,9 @@
 
 (when (defined? 'syscall-unix)
     (deny syscall-unix)
+    (when (defined? 'SYS_crossarch_trap)
+        (deny syscall-unix (with no-report) (syscall-number
+            SYS_crossarch_trap)))
     (allow syscall-unix (syscall-number
         SYS___channel_get_info
         SYS___channel_open
@@ -618,6 +621,7 @@
         SYS_fileport_makeport
         SYS_flistxattr
         SYS_flock
+        SYS_fsctl
         SYS_fsetattrlist
         SYS_fsgetpath
         SYS_fstat

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2023 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -774,6 +774,9 @@
     (deny syscall-unix (with telemetry))
     (deny syscall-unix (with no-report) (syscall-number
         SYS_faccessat))
+    (when (defined? 'SYS_crossarch_trap)
+        (deny syscall-unix (with no-report) (syscall-number
+            SYS_crossarch_trap)))
     (allow syscall-unix (syscall-number
         SYS___disable_threadsignal
         SYS___mac_syscall

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2014-2023 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -736,6 +736,9 @@
 
 (when (defined? 'syscall-unix)
     (deny syscall-unix (with telemetry))
+    (when (defined? 'SYS_crossarch_trap)
+        (deny syscall-unix (with no-report) (syscall-number
+            SYS_crossarch_trap)))
     (allow syscall-unix (syscall-number
         SYS___channel_get_info
         SYS___channel_open
@@ -768,6 +771,7 @@
         SYS_ffsctl
         SYS_fileport_makefd
         SYS_fileport_makeport
+        SYS_fsctl
         SYS_fsgetpath
         SYS_fstat64
         SYS_fstat64_extended

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2023 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -1167,6 +1167,10 @@
     SYS_sigreturn
 #endif
     SYS_socket))
+
+(when (defined? 'SYS_crossarch_trap)
+    (deny syscall-unix (with no-report) (syscall-number
+        SYS_crossarch_trap)))
 
 (when (defined? 'SYS_map_with_linking_np)
     (allow syscall-unix (syscall-number SYS_map_with_linking_np)))

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+; Copyright (C) 2010-2023 Apple Inc. All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -2006,6 +2006,9 @@
         SYS_unlink))
 
 (deny syscall-unix)
+(when (defined? 'SYS_crossarch_trap)
+    (deny syscall-unix (with no-report) (syscall-number
+        SYS_crossarch_trap)))
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))


### PR DESCRIPTION
#### b627d2e0516ab8e62054fbdb5087f579841fe90b
<pre>
[Cocoa] Allow two syscalls found by sandbox telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=264632">https://bugs.webkit.org/show_bug.cgi?id=264632</a>
&lt;<a href="https://rdar.apple.com/problem/118254040">rdar://problem/118254040</a>&gt;

Reviewed by Per Arne Vollan.

Telemetry on iOS and macOS shows that we need to allow access to SYS_fsctl in
the Network process, and silence the SYS_crossarch_trap syscall in all sandboxes.
This was discussed with the larger security team, and the need confirmed with the
components that require these syscalls.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/270661@main">https://commits.webkit.org/270661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc0f92c2461f04c156e09253d8a493605878a8c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23828 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28695 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3126 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29428 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27308 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3157 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4549 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6267 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->