### PR TITLE
[Site Isolation] Add a test verifying mouse event handlers are only called on the target frame

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/mainframe-prevent-default-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/mainframe-prevent-default-expected.txt
@@ -1,0 +1,5 @@
+PASS iframe received mouse event.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/mainframe-prevent-default.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/mainframe-prevent-default.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+if (window.testRunner) {
+    window.jsTestIsAsync = true;
+    testRunner.dumpAsText();
+}
+
+addEventListener("message", (event) => {
+    testPassed("iframe received mouse event.");
+    finishJSTest();
+});
+
+addEventListener("mousedown", (event) => {
+    testFailed("main frame received mouse event.");
+    event.preventDefault();
+});
+
+function onLoad() {
+    if (window.eventSender) {
+        eventSender.mouseMoveTo(100, 100);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
+}
+</script>
+<iframe onload="onLoad()" width="500" height="500" src="http://localhost:8000/site-isolation/mouse-events/resources/message-mouse-down-coordinates.html"></iframe>


### PR DESCRIPTION
#### 4f24df195cb604e75a541ce7359f027779156c97
<pre>
[Site Isolation] Add a test verifying mouse event handlers are only called on the target frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=264634">https://bugs.webkit.org/show_bug.cgi?id=264634</a>
<a href="https://rdar.apple.com/118254156">rdar://118254156</a>

Reviewed by Alex Christensen.

* LayoutTests/http/tests/site-isolation/mouse-events/mainframe-prevent-default-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/mainframe-prevent-default.html: Added.

Canonical link: <a href="https://commits.webkit.org/270580@main">https://commits.webkit.org/270580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10b92d53e95333c4249ae4dcac1f5c4884dcd168

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27904 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23627 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1846 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28484 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29254 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27124 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1187 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22947 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3411 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3312 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->