### PR TITLE
Non-unified build fixes, early November 2023 edition

### DIFF
--- a/Source/WebCore/animation/AnimationEffectTiming.cpp
+++ b/Source/WebCore/animation/AnimationEffectTiming.cpp
@@ -23,10 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #include "config.h"
 #include "AnimationEffectTiming.h"
+
+#include "WebAnimationUtilities.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "CSSFontFaceRule.h"
 
+#include "MutableStyleProperties.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSPendingSubstitutionValue.h"
 
+#include "CSSProperty.h"
 #include "CSSPropertyParser.h"
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -65,6 +65,7 @@
 #include "CSSPaintImageValue.h"
 #include "CSSPendingSubstitutionValue.h"
 #include "CSSPrimitiveValue.h"
+#include "CSSProperty.h"
 #include "CSSQuadValue.h"
 #include "CSSRayValue.h"
 #include "CSSRectValue.h"

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -27,6 +27,7 @@
 #include "MainThreadStylePropertyMapReadOnly.h"
 
 #include "CSSPendingSubstitutionValue.h"
+#include "CSSProperty.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
 #include "CSSStyleValue.h"

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -23,7 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
 #include "config.h"
 
 #if ENABLE(WEBGL)

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
@@ -32,8 +32,9 @@
 namespace WebCore {
 namespace Layout {
 
-class Line;
 class InlineFormattingContext;
+class InlineLevelBox;
+class Line;
 struct InlineItemRange;
 
 class RubyFormattingContext {

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -38,7 +38,7 @@
 #include "CrossOriginAccessControl.h"
 #include "CrossOriginPreflightChecker.h"
 #include "CrossOriginPreflightResultCache.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "DocumentLoader.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -45,6 +45,7 @@ namespace WebCore {
     class ContentSecurityPolicy;
     class Document;
     class ThreadableLoaderClient;
+    class WeakPtrImplWithEventTargetData;
 
     class DocumentThreadableLoader : public RefCounted<DocumentThreadableLoader>, public ThreadableLoader, public CachedRawResourceClient {
         WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -27,6 +27,7 @@
 #include "NavigationHistoryEntry.h"
 
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -34,6 +34,7 @@
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
 #include "LegacyRenderSVGResource.h"
+#include "RenderElementInlines.h"
 #include "RenderGeometryMap.h"
 #include "RenderLayer.h"
 #include "RenderLayerInlines.h"

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(TRACKING_PREVENTION)
 
+#include "ITPThirdPartyData.h"
 #include "Logging.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ProcessThrottler.h"
 
+#include "AuxiliaryProcessProxy.h"
 #include "Logging.h"
 #include "ProcessThrottlerClient.h"
 #include <optional>

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -105,7 +105,7 @@ static WebCore::ScreenOrientationType resolveScreenOrientationLockType(WebCore::
 void WebScreenOrientationManagerProxy::lock(WebCore::ScreenOrientationLockType lockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
     if (m_currentLockRequest)
-        m_currentLockRequest(WebCore::Exception { ExceptionCode::AbortError, "A new lock request was started"_s });
+        m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::AbortError, "A new lock request was started"_s });
 
     if (auto exception = platformShouldRejectLockRequest()) {
         completionHandler(*exception);
@@ -121,14 +121,14 @@ void WebScreenOrientationManagerProxy::lock(WebCore::ScreenOrientationLockType l
 #if ENABLE(FULLSCREEN_API)
         if (m_page.fullScreenManager() && m_page.fullScreenManager()->isFullScreen()) {
             if (!m_page.fullScreenManager()->lockFullscreenOrientation(resolvedLockedOrientation)) {
-                m_currentLockRequest(WebCore::Exception { ExceptionCode::NotSupportedError, "Screen orientation locking is not supported"_s });
+                m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::NotSupportedError, "Screen orientation locking is not supported"_s });
                 return;
             }
             didLockOrientation = true;
         }
 #endif
         if (!didLockOrientation && !m_page.uiClient().lockScreenOrientation(m_page, resolvedLockedOrientation)) {
-            m_currentLockRequest(WebCore::Exception { ExceptionCode::NotSupportedError, "Screen orientation locking is not supported"_s });
+            m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::NotSupportedError, "Screen orientation locking is not supported"_s });
             return;
         }
     }
@@ -143,7 +143,7 @@ void WebScreenOrientationManagerProxy::unlock()
         return;
 
     if (m_currentLockRequest)
-        m_currentLockRequest(WebCore::Exception { ExceptionCode::AbortError, "Unlock request was received"_s });
+        m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::AbortError, "Unlock request was received"_s });
 
     bool didUnlockOrientation = false;
 #if ENABLE(FULLSCREEN_API)
@@ -168,7 +168,7 @@ void WebScreenOrientationManagerProxy::unlockIfNecessary()
     if (m_currentlyLockedOrientation)
         unlock();
     if (m_currentLockRequest)
-        m_currentLockRequest(WebCore::Exception { ExceptionCode::AbortError, "Screen lock request was aborted"_s });
+        m_currentLockRequest(WebCore::Exception { WebCore::ExceptionCode::AbortError, "Screen lock request was aborted"_s });
 }
 
 #if !PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 2bcfd8571d24d97c08743a23e71f35b34c7f4a03
<pre>
Non-unified build fixes, early November 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=264638">https://bugs.webkit.org/show_bug.cgi?id=264638</a>

Unreviewed non-unified build fix.

* Source/WebCore/animation/AnimationEffectTiming.cpp:
* Source/WebCore/css/CSSFontFaceRule.cpp:
* Source/WebCore/css/CSSPendingSubstitutionValue.cpp:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp:
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::lock):
(WebKit::WebScreenOrientationManagerProxy::unlock):
(WebKit::WebScreenOrientationManagerProxy::unlockIfNecessary):

Canonical link: <a href="https://commits.webkit.org/270650@main">https://commits.webkit.org/270650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe4d1df1682c235c0bd650f878dad44ef0c83480

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23733 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28488 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2935 "Too many flaky failures: imported/w3c/web-platform-tests/beacon/beacon-cors.https.window.html, imported/w3c/web-platform-tests/css/css-sizing/button-min-width.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html, imported/w3c/web-platform-tests/fetch/range/non-matching-range-response.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video.html, imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video_size_preserved_after_ended.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html, imported/w3c/web-platform-tests/paint-timing/fcp-only/fcp-video-frame.html, imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html, imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-parallel.html, imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-analysernode-interface/test-analyser-minimum.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-getoutputtimestamp-cross-realm.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-state-change.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/constructor-allowed-to-start.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/processing-after-resume.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-with-navigation.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-denormals.https.window.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-throw-onmessage.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-output-channel-count.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-process-frozen-array.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-process-zero-outputs.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-promises.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/process-getter.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/process-parameters.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/processor-construction-port.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/active-processing.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https.html, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/realtime-conv.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html, imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https.html, imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html, imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29260 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27131 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1195 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4349 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6261 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->