### PR TITLE
Add missing 'optional' for 'setConfiguration' in 'RTCPeerConnection.idl' as per WebIDL Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
@@ -40,7 +40,7 @@ PASS RTCPeerConnection interface: attribute connectionState
 PASS RTCPeerConnection interface: attribute canTrickleIceCandidates
 PASS RTCPeerConnection interface: operation restartIce()
 PASS RTCPeerConnection interface: operation getConfiguration()
-FAIL RTCPeerConnection interface: operation setConfiguration(optional RTCConfiguration) assert_equals: property has wrong .length expected 0 but got 1
+PASS RTCPeerConnection interface: operation setConfiguration(optional RTCConfiguration)
 PASS RTCPeerConnection interface: operation close()
 PASS RTCPeerConnection interface: attribute onnegotiationneeded
 PASS RTCPeerConnection interface: attribute onicecandidate

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
@@ -31,6 +31,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#interface-definition
+
 typedef RTCRtpTransceiverDirection RtpTransceiverDirection;
 
 [
@@ -103,7 +105,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
 
     undefined restartIce();
     RTCConfiguration getConfiguration();
-    undefined setConfiguration(RTCConfiguration configuration);
+    undefined setConfiguration(optional RTCConfiguration configuration = {});
     undefined close();
 
     attribute EventHandler onnegotiationneeded;


### PR DESCRIPTION
#### 4a22b9997c9a0303a898d7b4838f70b5a0abfdda
<pre>
Add missing &apos;optional&apos; for &apos;setConfiguration&apos; in &apos;RTCPeerConnection.idl&apos; as per WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=264565">https://bugs.webkit.org/show_bug.cgi?id=264565</a>

Reviewed by Eric Carlson.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification [1].

[1] <a href="https://w3c.github.io/webrtc-pc/#interface-definition">https://w3c.github.io/webrtc-pc/#interface-definition</a>

This PR is adding missing &apos;optional&apos; in &apos;setConfiguration&apos; as required by web specification.

* Source/WebCore/Modules/mediastream/RTCPeerConnection.idl:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/270607@main">https://commits.webkit.org/270607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6887292e16559ef38f2423568eca2f7f0e968f9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23739 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28500 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29269 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27137 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1199 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4361 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6229 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->