### PR TITLE
[build.webkit.org] Allow non-buildbot builders

### DIFF
--- a/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/Main.js
+++ b/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/Main.js
@@ -222,8 +222,23 @@ function documentReady()
         row.appendChild(cell);
 
         cell = document.createElement("td");
-        var view = new BuildbotBuilderQueueView(platformQueues.builders);
-        cell.appendChild(view.element);
+        var queues = {};
+        var generators = [];
+
+        // FIXME: Only required as long as we are mixing XCode Cloud and buildbot builder queues
+        platformQueues.builders.forEach(function(queue) {
+            var generator = queue.viewGenerator ? queue.viewGenerator : BuildbotBuilderQueueView;
+            if (!queues[String(generator)]) {
+                queues[String(generator)] = [];
+                generators.push(generator);
+            }
+            queues[String(generator)].push(queue);
+        });
+
+        generators.forEach(function(generator) {
+            var view = new generator(queues[String(generator)]);
+            cell.appendChild(view.element);
+        });
         row.appendChild(cell);
 
         if ("builderCombinedQueues" in platformQueues) {


### PR DESCRIPTION
#### 6c526fb9c1f21a9bf63c63f5936ac988b1a1b60e
<pre>
[build.webkit.org] Allow non-buildbot builders
<a href="https://bugs.webkit.org/show_bug.cgi?id=264645">https://bugs.webkit.org/show_bug.cgi?id=264645</a>
<a href="https://rdar.apple.com/118257502">rdar://118257502</a>

Reviewed by Alexey Proskuryakov.

The bot watcher&apos;s dashboard should not assume that all builder queues
are Buildbot builder queues.

* Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/Main.js:
(documentReady):

Canonical link: <a href="https://commits.webkit.org/270667@main">https://commits.webkit.org/270667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7292bc5b09646b5c9462e4db4285e8c9e49d149a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26061 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/4670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/27336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/28157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/23862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26383 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/6434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/28157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26316 "Failed to checkout and rebase branch from PR 20349") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/6434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/27336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/28733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/6434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/27336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/28733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/6434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/27336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/28733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/25829 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/4585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/27336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3348 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->