### PR TITLE
[WebRTC] Add missing assertion to rtp_format_h265.cc

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
@@ -310,6 +310,9 @@ void RtpPacketizerH265::NextAggregatePacket(RtpPacketToSend* rtp_packet,
   while (packet->aggregated) {
     // Add NAL unit length field.
     rtc::ArrayView<const uint8_t> fragment = packet->source_fragment;
+#ifdef WEBRTC_WEBKIT_BUILD
+    RTC_CHECK_LE(index + kHevcLengthFieldSize + fragment.size(), payload_capacity);
+#endif
     ByteWriter<uint16_t>::WriteBigEndian(&buffer[index], fragment.size());
     index += kHevcLengthFieldSize;
     // Add NAL unit.

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Add-missing-assertion-to-rtp_format_h265.cc.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Add-missing-assertion-to-rtp_format_h265.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
+index b354bb84f16e..9865d7cb8244 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
+@@ -310,6 +310,9 @@ void RtpPacketizerH265::NextAggregatePacket(RtpPacketToSend* rtp_packet,
+   while (packet->aggregated) {
+     // Add NAL unit length field.
+     rtc::ArrayView<const uint8_t> fragment = packet->source_fragment;
++#ifdef WEBRTC_WEBKIT_BUILD
++    RTC_CHECK_LE(index + kHevcLengthFieldSize + fragment.size(), payload_capacity);
++#endif
+     ByteWriter<uint16_t>::WriteBigEndian(&buffer[index], fragment.size());
+     index += kHevcLengthFieldSize;
+     // Add NAL unit.


### PR DESCRIPTION
#### 746712ecb50e6e54931848615ec1ce3d11654482
<pre>
[WebRTC] Add missing assertion to rtp_format_h265.cc
<a href="https://bugs.webkit.org/show_bug.cgi?id=264648">https://bugs.webkit.org/show_bug.cgi?id=264648</a>
&lt;<a href="https://rdar.apple.com/118259276">rdar://118259276</a>&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc:
(webrtc::RtpPacketizerH265::NextAggregatePacket):
- Add RTC_CHECK_LE() bounds check to match the one in
  webrtc::RtpPacketizerH264::NextAggregatePacket().

* Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Add-missing-assertion-to-rtp_format_h265.cc.patch: Add.

Canonical link: <a href="https://commits.webkit.org/270677@main">https://commits.webkit.org/270677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cac085892fb57ba8e503c108d7579e590b58d556

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26074 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/4684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/27348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/28170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/23875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/6449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/28170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26329 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/6449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/27348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28746 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/6449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/27348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/6449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/27348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/4598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/27348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3353 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->