### PR TITLE
ScriptFunctionCall::call() can return an empty JSValue if the watchdog timer fires, callers should check for this

### DIFF
--- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
@@ -286,7 +286,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapObject(JSC::JSValue 
     wrapFunction.appendArgument(generatePreview);
 
     auto callResult = callFunctionWithEvalEnabled(wrapFunction);
-    if (!callResult)
+    if (!callResult || !callResult.value())
         return nullptr;
 
     auto resultValue = toInspectorValue(globalObject(), callResult.value());
@@ -309,7 +309,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapJSONString(const Str
     wrapFunction.appendArgument(generatePreview);
 
     auto callResult = callFunctionWithEvalEnabled(wrapFunction);
-    if (!callResult)
+    if (!callResult || !callResult.value())
         return nullptr;
 
     if (callResult.value().isNull())
@@ -338,7 +338,7 @@ RefPtr<Protocol::Runtime::RemoteObject> InjectedScript::wrapTable(JSC::JSValue t
         wrapFunction.appendArgument(columns);
 
     auto callResult = callFunctionWithEvalEnabled(wrapFunction);
-    if (!callResult)
+    if (!callResult || !callResult.value())
         return nullptr;
 
     auto resultValue = toInspectorValue(globalObject(), callResult.value());
@@ -359,7 +359,7 @@ RefPtr<Protocol::Runtime::ObjectPreview> InjectedScript::previewValue(JSC::JSVal
     wrapFunction.appendArgument(value);
 
     auto callResult = callFunctionWithEvalEnabled(wrapFunction);
-    if (!callResult)
+    if (!callResult || !callResult.value())
         return nullptr;
 
     auto resultValue = toInspectorValue(globalObject(), callResult.value());
@@ -411,7 +411,7 @@ JSC::JSValue InjectedScript::findObjectById(const String& objectId) const
 
     auto callResult = callFunctionWithEvalEnabled(function);
     ASSERT(callResult);
-    if (!callResult)
+    if (!callResult || !callResult.value())
         return { };
     return callResult.value();
 }
@@ -449,7 +449,7 @@ JSC::JSObject* InjectedScript::createCommandLineAPIObject(JSC::JSValue callFrame
 
     auto callResult = callFunctionWithEvalEnabled(function);
     ASSERT(callResult);
-    return callResult ? asObject(callResult.value()) : nullptr;
+    return callResult && callResult.value() ? asObject(callResult.value()) : nullptr;
 }
 
 JSC::JSValue InjectedScript::arrayFromVector(Vector<JSC::JSValue>&& vector)

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -196,10 +196,8 @@ void InjectedScriptBase::makeAsyncCall(ScriptFunctionCall& function, AsyncCallCa
     function.appendArgument(JSC::JSValue(jsFunction));
 
     auto result = callFunctionWithEvalEnabled(function);
-    ASSERT_UNUSED(result, result.value().isUndefined());
-
-    ASSERT(result);
-    if (!result) {
+    ASSERT_UNUSED(result, result && result.value() && result.value().isUndefined());
+    if (!result || !result.value()) {
         // Since `callback` is moved above, we can't call it if there's an exception while trying to
         // execute the `JSNativeStdFunction` inside InjectedScriptSource.js.
         jsFunction->function()(globalObject, nullptr);

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -76,6 +76,10 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
         WTFLogAlways("Error when calling 'hasInjectedModule' for '%s': %s (%d:%d)\n", name().utf8().data(), error->value().toWTFString(injectedScript.globalObject()).utf8().data(), line, column);
         RELEASE_ASSERT_NOT_REACHED();
     }
+    if (!hasInjectedModuleResult.value()) {
+        WTFLogAlways("VM is terminated when calling 'injectModule' for '%s'\n", name().utf8().data());
+        RELEASE_ASSERT_NOT_REACHED();
+    }
     if (!hasInjectedModuleResult.value().isBoolean() || !hasInjectedModuleResult.value().asBoolean()) {
         ScriptFunctionCall function(injectedScript.globalObject(), injectedScript.injectedScriptObject(), "injectModule"_s, injectedScriptManager->inspectorEnvironment().functionCallHandler());
         function.appendArgument(name());


### PR DESCRIPTION
#### a4eed62b176cca45404f2c11f8a3dd2c4d3fe5df
<pre>
ScriptFunctionCall::call() can return an empty JSValue if the watchdog timer fires, callers should check for this
<a href="https://bugs.webkit.org/show_bug.cgi?id=165875">https://bugs.webkit.org/show_bug.cgi?id=165875</a>

Reviewed by Devin Rousso.

ScriptFunctionCall::call() may return empty JSValue from several places,
the callers now check for emptiness first before accessing the value.

Unfortunately, I don&apos;t have a reliable repro which could be converted
to a layout test like the one in <a href="https://github.com/WebKit/WebKit/commit/11d211bca821fa4803d6da95c857a04b7f32c46a">https://github.com/WebKit/WebKit/commit/11d211bca821fa4803d6da95c857a04b7f32c46a</a>
even though the symptoms are similar.

* Source/JavaScriptCore/inspector/InjectedScript.cpp:
(Inspector::InjectedScript::wrapObject const):
(Inspector::InjectedScript::wrapJSONString const):
(Inspector::InjectedScript::wrapTable const):
(Inspector::InjectedScript::previewValue const):
(Inspector::InjectedScript::createCommandLineAPIObject const):

Canonical link: <a href="https://commits.webkit.org/270739@main">https://commits.webkit.org/270739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56026284c9f9d857e98c1eb7db69368609f05591

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28106 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23821 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23889 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28686 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29421 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22657 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27307 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25226 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1360 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32671 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4540 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7089 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6313 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->