### PR TITLE
jsc_fuz/wktr: RELEASE_ASSERT(!m_count); in WebCore::RenderObject::~RenderObject()

### DIFF
--- a/LayoutTests/fast/dom/load-offsetWidth-expected.txt
+++ b/LayoutTests/fast/dom/load-offsetWidth-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: This test should not crash
+

--- a/LayoutTests/fast/dom/load-offsetWidth.html
+++ b/LayoutTests/fast/dom/load-offsetWidth.html
@@ -1,0 +1,15 @@
+<style>
+    body {
+        content: url();
+        overflow-y: -webkit-paged-y;
+    }
+</style>
+<script>
+  onload = () => {
+      if (window.testRunner)
+        testRunner.dumpAsText();
+    document.body.offsetWidth;
+    console.log("This test should not crash");
+  };
+</script>
+<div>This test should not crash</div>


### PR DESCRIPTION
#### 834ac739e6035e29f4558a196ba5f4f6e25cf64e
<pre>
jsc_fuz/wktr: RELEASE_ASSERT(!m_count); in WebCore::RenderObject::~RenderObject()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264828">https://bugs.webkit.org/show_bug.cgi?id=264828</a>
<a href="https://rdar.apple.com/117994923">rdar://117994923</a>

Reviewed by Chris Dumez.

Hitting release assert in CheckedPtr from `~RenderObject()` because `CheckedPtr renderer =
element.renderer()`is outliving the renderer (RenderObject). Limited the scope so it gets
destroyed first.

* LayoutTests/fast/dom/load-offsetWidth-expected.txt: Added.
* LayoutTests/fast/dom/load-offsetWidth.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayoutIfDimensionsOutOfDate): limited the scope of `CheckedPtr
renderer = element.renderer()` so that it would be destroyed after being used instead of
staying available for the whole method

Canonical link: <a href="https://commits.webkit.org/270747@main">https://commits.webkit.org/270747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abae14248287fd3cda2849598939dbbb806411a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24026 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28907 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29586 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27471 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23282 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6320 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->