### PR TITLE
Don't make the decision to cache a DisplayList for a TextRun depend on the rendering update frame rate

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3376,7 +3376,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
     bool selectionAndBackgroundsOnly = paintingInfo.paintBehavior.contains(PaintBehavior::SelectionAndBackgroundsOnly);
     bool selectionOnly = paintingInfo.paintBehavior.contains(PaintBehavior::SelectionOnly);
 
-    SinglePaintFrequencyTracking singlePaintFrequencyTracking(m_paintFrequencyTracker, page().lastRenderingUpdateTimestamp());
+    m_paintFrequencyTracker.track(page().lastRenderingUpdateTimestamp());
 
     LayerFragments layerFragments;
     RenderObject* subtreePaintRootForRenderer = nullptr;
@@ -5866,7 +5866,7 @@ bool RenderLayer::isBitmapOnly() const
 
 void RenderLayer::simulateFrequentPaint()
 {
-    SinglePaintFrequencyTracking { m_paintFrequencyTracker, page().lastRenderingUpdateTimestamp() };
+    m_paintFrequencyTracker.track(page().lastRenderingUpdateTimestamp());
 }
 
 RenderLayerScrollableArea* RenderLayer::scrollableArea() const


### PR DESCRIPTION
#### 42af8a3d2bb43e40c07b83ce1c6c3a32ab7e08f4
<pre>
Don&apos;t make the decision to cache a DisplayList for a TextRun depend on the rendering update frame rate
<a href="https://bugs.webkit.org/show_bug.cgi?id=264654">https://bugs.webkit.org/show_bug.cgi?id=264654</a>
<a href="https://rdar.apple.com/118259180">rdar://118259180</a>

Reviewed by Simon Fraser.

Caching a DisplayList for a TextRun should happen if this TextRun is displayed
very often (say &gt;= 20) regardless of the current frame rate.

* Source/WebCore/rendering/PaintFrequencyTracker.h:
(WebCore::PaintFrequencyTracker::track):
(WebCore::PaintFrequencyTracker::begin): Deleted.
(WebCore::PaintFrequencyTracker::end): Deleted.
(WebCore::SinglePaintFrequencyTracking::SinglePaintFrequencyTracking): Deleted.
(WebCore::SinglePaintFrequencyTracking::~SinglePaintFrequencyTracking): Deleted.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/270781@main">https://commits.webkit.org/270781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4001360cb95a5ee8cb1e0355641009d11f3bbf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23757 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28523 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29286 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27159 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1213 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4382 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6340 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->