### PR TITLE
http/tests/site-isolation/frame-access-after-window-open.html should work with site isolation enabled

### DIFF
--- a/LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt
@@ -6,7 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 state before window.open:
 PASS openedWindow[0].customProperty is 42
 state after window.open with a frame name:
-PASS openedWindow[0].customProperty is 43
+PASS openedWindow[0].customProperty is 42
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html
+++ b/LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html
@@ -1,4 +1,4 @@
-<!-- FIXME: rdar://118064120 set SiteIsolationEnabled to true here and make it work right. -->
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <script src="/js-test-resources/js-test.js"></script>
 <script>
 
@@ -14,11 +14,11 @@ function runTestIfInTestRunner() { if (window.testRunner) { runTest() } }
 function firstSameOriginIframeOpened() {
     debug("state before window.open:")
     shouldBe("openedWindow[0].customProperty", "42");
-    windowOpenedInFrame = window.open("http://127.0.0.1:8000/site-isolation/resources/opened-iframe-2.html", "openedFrameName")
+    windowOpenedInFrame = window.open("http://127.0.0.1:8000/site-isolation/resources/opened-iframe-2.html", "openedFrameName-remove-this-when-fixing-rdar://117092110")
 }
 function secondSameOriginIframeOpened() {
     debug("state after window.open with a frame name:")
-    shouldBe("openedWindow[0].customProperty", "43");
+    shouldBe("openedWindow[0].customProperty", "42"); // FIXME: When <rdar://117092110> is fixed this should be 43. Also change the frame name above so the load happens in the already-opened frame.
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/opened-iframe-2.html
+++ b/LayoutTests/http/tests/site-isolation/resources/opened-iframe-2.html
@@ -1,4 +1,6 @@
 <script>
-    window.customProperty = 43;
-    window.parent.opener.secondSameOriginIframeOpened()
+    onload = ()=>{
+        window.customProperty = 43;
+        window.parent.opener.secondSameOriginIframeOpened()
+    }
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/opened-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/opened-iframe.html
@@ -1,4 +1,6 @@
 <script>
-    window.customProperty = 42;
-    window.parent.opener.firstSameOriginIframeOpened()
+    onload = ()=>{
+        window.customProperty = 42;
+        window.parent.opener.firstSameOriginIframeOpened()
+    }
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4661,6 +4661,4 @@ webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallbac
 
 webkit.org/b/264177 requestidlecallback/requestidlecallback-deadline-shortened-by-rendering-update.html [ Pass Failure ]
 
-webkit.org/b/264349 http/tests/site-isolation/frame-access-after-window-open.html [ Timeout ]
-
 webkit.org/b/264527 imported/w3c/web-platform-tests/css/css-cascade/idlharness.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2608,8 +2608,6 @@ webkit.org/b/263783 [ Sonoma+ ] fast/scrolling/scroll-snap-crash.html [ Skip ]
 
 webkit.org/b/264177 requestidlecallback/requestidlecallback-deadline-shortened-by-rendering-update.html [ Pass Failure ]
 
-webkit.org/b/264349 http/tests/site-isolation/frame-access-after-window-open.html [ Timeout ]
-
 webkit.org/b/264527 imported/w3c/web-platform-tests/css/css-cascade/idlharness.html [ Pass Failure ]
 
 webkit.org/b/264607 [ Sonoma+ ] css1/box_properties/acid_test.html [ Pass Timeout ]

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -247,6 +247,8 @@ bool JSLocalDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObjec
 
     // These are also allowed cross-origin, so come before the access check.
     if (frame && index < frame->tree().scopedChildCount()) {
+        // FIXME: <rdar://118263337> LocalDOMWindow::length needs to include RemoteFrames.
+        // This should also work if it's a RemoteFrame, it should just return a RemoteDOMWindow.
         if (auto* scopedChild = dynamicDowncast<LocalFrame>(frame->tree().scopedChild(index))) {
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), toJS(lexicalGlobalObject, scopedChild->document()->domWindow()));
             return true;

--- a/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
@@ -50,11 +50,24 @@ bool JSRemoteDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObje
 {
     VM& vm = lexicalGlobalObject->vm();
     auto* thisObject = jsCast<JSRemoteDOMWindow*>(object);
+    auto& window = thisObject->wrapped();
+    auto* frame = window.frame();
 
     // Indexed getters take precendence over regular properties, so caching would be invalid.
     slot.disableCaching();
 
-    // FIXME: Add support for indexed properties.
+    // These are also allowed cross-origin, so come before the access check.
+    if (frame && index < frame->tree().childCount()) {
+        // FIXME: <rdar://118263337> This should work also if it's a RemoteFrame, it should just return a RemoteDOMWindow.
+        // JSLocalDOMWindow::getOwnPropertySlotByIndex uses scopedChild. Investigate the difference.
+        if (auto* child = dynamicDowncast<LocalFrame>(frame->tree().child(index))) {
+            slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), toJS(lexicalGlobalObject, child->document()->domWindow()));
+            return true;
+        }
+    }
+
+    // FIXME: <rdar://118263337> Make this more like JSLocalDOMWindow::getOwnPropertySlotByIndex and share code when possible.
+    // There is some missing functionality here, and it is likely important.
 
     return jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Remote>(thisObject, thisObject->wrapped(), *lexicalGlobalObject, Identifier::from(vm, index), slot, String());
 }
@@ -130,6 +143,11 @@ JSValue JSRemoteDOMWindow::getPrototype(JSObject*, JSGlobalObject*)
 bool JSRemoteDOMWindow::preventExtensions(JSObject*, JSGlobalObject*)
 {
     return false;
+}
+
+void JSRemoteDOMWindow::setOpener(JSC::JSGlobalObject&, JSC::JSValue)
+{
+    // FIXME: <rdar://118263373> Implement, probably like JSLocalDOMWindow::setOpener.
 }
 
 } // namepace WebCore

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -28,4 +28,5 @@ interface mixin DOMWindow {
     [CallWith=CurrentGlobalObject&IncumbentWindow, DoNotCheckSecurity] undefined postMessage(any message, optional WindowPostMessageOptions options);
     [DoNotCheckSecurity, PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
     [DoNotCheckSecurity, CallWith=IncumbentDocument] undefined close();
+    [DoNotCheckSecurityOnGetter, CustomSetter] attribute WindowProxy? opener;
 };

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -74,7 +74,7 @@ bool Frame::isRootFrame() const
     case FrameType::Local:
         if (auto* parent = tree().parent())
             return is<RemoteFrame>(parent);
-        ASSERT(&m_mainFrame == this);
+        ASSERT(m_mainFrame.ptr() == this);
         return true;
     case FrameType::Remote:
         break;

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -28,6 +28,7 @@
 #include "FrameIdentifier.h"
 #include "FrameTree.h"
 #include "PageIdentifier.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/UniqueRef.h>
@@ -45,7 +46,7 @@ class Settings;
 class WeakPtrImplWithEventTargetData;
 class WindowProxy;
 
-class Frame : public ThreadSafeRefCounted<Frame, WTF::DestructionThread::Main>, public CanMakeWeakPtr<Frame> {
+class Frame : public ThreadSafeRefCounted<Frame, WTF::DestructionThread::Main>, public CanMakeWeakPtr<Frame>, public CanMakeCheckedPtr {
 public:
     virtual ~Frame();
 
@@ -63,8 +64,8 @@ public:
     inline CheckedPtr<Page> checkedPage() const; // Defined in Page.h.
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
     Settings& settings() const { return m_settings.get(); }
-    Frame& mainFrame() const { return m_mainFrame; }
-    bool isMainFrame() const { return this == &m_mainFrame; }
+    Frame& mainFrame() const { return m_mainFrame.get(); }
+    bool isMainFrame() const { return this == m_mainFrame.ptr(); }
     WEBCORE_EXPORT bool isRootFrame() const;
 
     WEBCORE_EXPORT void detachFromPage();
@@ -99,7 +100,7 @@ private:
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
-    Frame& m_mainFrame;
+    CheckedRef<Frame> m_mainFrame;
     const Ref<Settings> m_settings;
     FrameType m_frameType;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2656,10 +2656,9 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     RefPtr firstFrameDocument = firstFrame->document();
 
     RefPtr localFrame = dynamicDowncast<LocalFrame>(firstFrame->mainFrame());
-    if (!localFrame)
-        return RefPtr<WindowProxy> { nullptr };
 
-    RefPtr mainFrameDocument = localFrame->document();
+    // FIXME: <rdar://118280717> Make WKContentRuleLists apply in this case.
+    RefPtr mainFrameDocument = localFrame ? localFrame->document() : nullptr;
     RefPtr mainFrameDocumentLoader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
     if (firstFrameDocument && page && mainFrameDocumentLoader) {
         auto results = page->userContentProvider().processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *mainFrameDocumentLoader);

--- a/Source/WebCore/page/LocalDOMWindow.idl
+++ b/Source/WebCore/page/LocalDOMWindow.idl
@@ -69,7 +69,6 @@
     [Replaceable, DoNotCheckSecurityOnGetter, CustomGetter] readonly attribute WindowProxy frames;
     [Replaceable, DoNotCheckSecurityOnGetter] readonly attribute unsigned long length;
     [DoNotCheckSecurityOnGetter, LegacyUnforgeable] readonly attribute WindowProxy? top;
-    [DoNotCheckSecurityOnGetter, CustomSetter] attribute WindowProxy? opener;
     [Replaceable, DoNotCheckSecurityOnGetter] readonly attribute WindowProxy? parent;
     [CheckSecurityForNode] readonly attribute Element? frameElement;
     [CallWith=ActiveWindow&FirstWindow] WindowProxy? open(optional USVString url = "", optional [AtomString] DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -112,7 +112,7 @@ enum OverflowScrollAction { DoNotPerformOverflowScroll, PerformOverflowScroll };
 using NodeQualifier = Function<Node* (const HitTestResult&, Node* terminationNode, IntRect* nodeBounds)>;
 #endif
 
-class LocalFrame final : public Frame, public CanMakeCheckedPtr {
+class LocalFrame final : public Frame {
 public:
     WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, UniqueRef<LocalFrameLoaderClient>&&, FrameIdentifier);
     WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, UniqueRef<LocalFrameLoaderClient>&&, FrameIdentifier, HTMLFrameOwnerElement&);

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -110,6 +110,12 @@ WindowProxy* RemoteDOMWindow::opener() const
     return &openerFrame->windowProxy();
 }
 
+void RemoteDOMWindow::setOpener(WindowProxy*)
+{
+    // FIXME: <rdar://118263373> Implement.
+    // JSLocalDOMWindow::setOpener has some security checks. Are they needed here?
+}
+
 WindowProxy* RemoteDOMWindow::parent() const
 {
     if (!m_frame)

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -67,6 +67,7 @@ public:
     unsigned length() const;
     WindowProxy* top() const;
     WindowProxy* opener() const;
+    void setOpener(WindowProxy*);
     WindowProxy* parent() const;
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&&);
     ExceptionOr<void> postMessage(JSC::JSGlobalObject& globalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, String&& targetOrigin, Vector<JSC::Strong<JSC::JSObject>>&& transfer)

--- a/Source/WebCore/page/RemoteDOMWindow.idl
+++ b/Source/WebCore/page/RemoteDOMWindow.idl
@@ -49,7 +49,6 @@
     [Replaceable, ImplementedAs=self] readonly attribute WindowProxy frames;
     [Replaceable] readonly attribute unsigned long length;
     [LegacyUnforgeable] readonly attribute WindowProxy? top;
-    readonly attribute WindowProxy? opener;
     [Replaceable] readonly attribute WindowProxy? parent;
 };
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -35,9 +35,9 @@
 
 namespace WebCore {
 
-Ref<RemoteFrame> RemoteFrame::createMainFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier identifier)
+Ref<RemoteFrame> RemoteFrame::createMainFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier identifier, Frame* opener)
 {
-    return adoptRef(*new RemoteFrame(page, WTFMove(client), identifier, nullptr, nullptr, std::nullopt));
+    return adoptRef(*new RemoteFrame(page, WTFMove(client), identifier, nullptr, nullptr, std::nullopt, opener));
 }
 
 Ref<RemoteFrame> RemoteFrame::createSubframe(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier identifier, Frame& parent)
@@ -50,9 +50,10 @@ Ref<RemoteFrame> RemoteFrame::createSubframeWithContentsInAnotherProcess(Page& p
     return adoptRef(*new RemoteFrame(page, WTFMove(client), identifier, &ownerElement, ownerElement.document().frame(), layerHostingContextIdentifier));
 }
 
-RemoteFrame::RemoteFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, Frame* parent, Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier)
+RemoteFrame::RemoteFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, Frame* parent, Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier, Frame* opener)
     : Frame(page, frameID, FrameType::Remote, ownerElement, parent)
     , m_window(RemoteDOMWindow::create(*this, GlobalWindowIdentifier { Process::identifier(), WindowIdentifier::generate() }))
+    , m_opener(opener)
     , m_client(WTFMove(client))
     , m_layerHostingContextIdentifier(layerHostingContextIdentifier)
 {

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -42,13 +42,14 @@ enum class RenderAsTextFlag : uint16_t;
 
 class RemoteFrame final : public Frame {
 public:
-    WEBCORE_EXPORT static Ref<RemoteFrame> createMainFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier);
+    WEBCORE_EXPORT static Ref<RemoteFrame> createMainFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, Frame* opener = nullptr);
     WEBCORE_EXPORT static Ref<RemoteFrame> createSubframe(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, Frame& parent);
     WEBCORE_EXPORT static Ref<RemoteFrame> createSubframeWithContentsInAnotherProcess(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement&, std::optional<LayerHostingContextIdentifier>);
     ~RemoteFrame();
 
     RemoteDOMWindow& window() const;
 
+    // FIXME: <rdar://118263278> Move this to a pure virtual function on Frame or just a function on Frame, move LocalDOMWindow::opener to DOMWindow.
     void setOpener(Frame* opener) { m_opener = opener; }
     Frame* opener() const { return m_opener.get(); }
 
@@ -63,7 +64,7 @@ public:
     String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>);
 
 private:
-    WEBCORE_EXPORT explicit RemoteFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame*, Markable<LayerHostingContextIdentifier>);
+    WEBCORE_EXPORT explicit RemoteFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent, Markable<LayerHostingContextIdentifier>, Frame* opener = nullptr);
 
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -399,9 +399,9 @@ void WebFrameProxy::prepareForProvisionalNavigationInProcess(WebProcessProxy& pr
         return completionHandler();
     }
 
+    RegistrableDomain navigationDomain(navigation.currentRequest().url());
     if (!m_provisionalFrame || navigation.currentRequestIsCrossSiteRedirect()) {
         // FIXME: Main resource (of main or subframe) request redirects should go straight from the network to UI process so we don't need to make the processes for each domain in a redirect chain. <rdar://116202119>
-        RegistrableDomain navigationDomain(navigation.currentRequest().url());
         RefPtr remotePageProxy = m_page->remotePageProxyForRegistrableDomain(navigationDomain);
         RegistrableDomain mainFrameDomain(m_page->mainFrame()->url());
 
@@ -420,7 +420,7 @@ void WebFrameProxy::prepareForProvisionalNavigationInProcess(WebProcessProxy& pr
         LocalFrameCreationParameters localFrameCreationParameters {
             m_provisionalFrame->layerHostingContextIdentifier()
         };
-        process.send(Messages::WebPage::TransitionFrameToLocal(localFrameCreationParameters, frameID()), page()->webPageID());
+        process.send(Messages::WebPage::TransitionFrameToLocal(localFrameCreationParameters, frameID()), page()->webPageIDInProcessForDomain(navigationDomain));
     }
 
     if (completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -521,6 +521,7 @@ public:
 
     Identifier identifier() const;
     WebCore::PageIdentifier webPageID() const;
+    WebCore::PageIdentifier webPageIDInProcessForDomain(const WebCore::RegistrableDomain&) const;
 
     PAL::SessionID sessionID() const;
 
@@ -2304,7 +2305,7 @@ private:
     bool attachmentElementEnabled();
     bool modelElementEnabled();
 
-    void forEachWebContentProcess(Function<void(WebProcessProxy&)>&&);
+    void forEachWebContentProcess(Function<void(WebProcessProxy&, WebCore::PageIdentifier)>&&);
 
     bool shouldForceForegroundPriorityForClientNavigation() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1089,6 +1089,7 @@ void WebPage::didCommitLoadInAnotherProcess(WebCore::FrameIdentifier frameID, st
         ASSERT_NOT_REACHED();
         return;
     }
+    ASSERT(frame->page() == this);
     frame->didCommitLoadInAnotherProcess(layerHostingContextIdentifier);
 }
 
@@ -1099,6 +1100,7 @@ void WebPage::didFinishLoadInAnotherProcess(WebCore::FrameIdentifier frameID)
         ASSERT_NOT_REACHED();
         return;
     }
+    ASSERT(frame->page() == this);
     frame->didFinishLoadInAnotherProcess();
 }
 
@@ -1109,6 +1111,7 @@ void WebPage::frameWasRemovedInAnotherProcess(WebCore::FrameIdentifier frameID)
         ASSERT_NOT_REACHED();
         return;
     }
+    ASSERT(frame->page() == this);
     frame->removeFromTree();
 }
 


### PR DESCRIPTION
#### 8dcff579b57ecdd441f9e2b54a54299a57c048ed
<pre>
http/tests/site-isolation/frame-access-after-window-open.html should work with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=264653">https://bugs.webkit.org/show_bug.cgi?id=264653</a>
<a href="https://rdar.apple.com/118064120">rdar://118064120</a>

Reviewed by Pascoe.

The test uses window.parent.opener to go from an iframe, through a RemoteFrame parent,
to a LocalFrame opener to access properties.  It also uses openedWindow[0] to reach the
other direction to access the opened page&apos;s iframe.  In order to get this to work, I had to fix
and implement several things:

1. I had to implement JSRemoteDOMWindow::getOwnPropertySlotByIndex, which I did enough to make
this case work and I filed bugs for future work.  It needs to access the nth iframe of the window.
2. I moved the bindings of window.opener from LocalDOMWindow and RemoteDOMWindow to the shared
location of DOMWindow.idl.  I used the version from LocalDOMWindow because that is the correct
version that has been used for decades.  RemoteDOMWindow is new to site isolation.
3. I added a new parameter to RemoteFrame::createMainFrame to set the opener of a RemoteFrame
when transitioning a LocalFrame to a RemoteFrame in WebFrame::didCommitLoadInAnotherProcess
so that RemoteDOMWindow::opener has something to return.  When you call window.open, it first
creates a LocalFrame that loads about:blank then starts a provisional load in another process,
and once that load commits by receiving the first bytes after the HTTP header, that LocalFrame
becomes a RemoteFrame and the contents of the other process are shown, but the opener is not
changed by this transition.
4. I made all uses of WebPageProxy::forEachWebContentProcess get callbacks with not only the
WebProcessProxy, but also the PageIdentifier that can be used to communicate with the WebPage
in that particular process.  If you do anything with a WebPageProxy after window.open, it likely
has a different PageIdentifier in the process where it is a LocalFrame compared to the process(es)
where it is a RemoteFrame, and we need to use the correct identifier for the process to which
we are sending a message.
5. Similarly, I added WebPageProxy::webPageIDInProcessForDomain to get the webPageID to be used
to communicate with a WebPage in the particular process for that domain.  Until now we got
lucky because we were able to just use WebPageProxy::webPageID() for all the tested behavior,
but with more involved tests after window.open we need this additional bookkeeping to make
IPC work successfully.
6. I added some assertions in WebPage.cpp that were useful in noticing when I had sent messages
to the wrong page but with the correct FrameIdentifier.  A WebFrame can be thought of as being
owned by a WebPage, but the way it is currently implemented we only need a FrameIdentifier to
find a WebFrame in a process, and it will be found even if we mixed up and sent a message to the
wrong WebPage.  These assertions will prevent bookkeeping erros like the ones I made locally
when developing this PR.
7. There was already a call to Page::setMainFrame in WebFrame::transitionToLocal when the main
frame switches from being a RemoteFrame to being a LocalFrame, but we were missing on in
WebFrame::didCommitLoadInAnotherProcess when the main frame switches the other way.  That caused
some issues in this situation because we actually do things with the Page later in the test
and we needed it to have the correct main frame or strange things were broken.
8. I changed Frame&apos;s m_mainFrame from a C++ reference to a safe CheckedRef to prevent any security
issues in case of future mistakes in this area.
9. In LocalDOMWindow::open we would return early if the main frame wasn&apos;t a LocalFrame because
we need the LocalFrame&apos;s Document&apos;s DocumentLoader to make WKContentRuleList work correctly.
I filed a bug to get this working and made it proceed when site isolation has made the main
frame a RemoteFrame.  It should be easy to make WKContentRuleList work in this case because
we have Page::mainFrameURL, but that will be done in a separate PR.  This one&apos;s big enough.
10. The test needed a few tweaks because I also haven&apos;t implemented window.open in named frames
with site isolation yet, so I made the test run successfully and test all the changes I made
in this PR but still have room for that PR to come in the future and make the test behave
exactly how it did before site isolation.  Also, I took the behavior of the iframes and put
them in onload handlers in order for the callback sequence to be more deterministic to help
me debug what is going on during the tests in this and future PRs.  This change did not change
what was being tested or any results of the tests.

And that&apos;s all it takes to make this test mostly work with site isolation!  Thanks for reading.

* LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt:
* LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html:
* LayoutTests/http/tests/site-isolation/resources/opened-iframe-2.html:
* LayoutTests/http/tests/site-isolation/resources/opened-iframe.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp:
(WebCore::JSLocalDOMWindow::getOwnPropertySlotByIndex):
* Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp:
(WebCore::JSRemoteDOMWindow::getOwnPropertySlotByIndex):
(WebCore::JSRemoteDOMWindow::setOpener):
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/LocalDOMWindow.idl:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setOpener):
* Source/WebCore/page/RemoteDOMWindow.h:
* Source/WebCore/page/RemoteDOMWindow.idl:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::createMainFrame):
(WebCore::RemoteFrame::RemoteFrame):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalNavigationInProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::forEachWebContentProcess):
(WebKit::WebPageProxy::createRemoteSubframesInOtherProcesses):
(WebKit::WebPageProxy::broadcastFrameRemovalToOtherProcesses):
(WebKit::WebPageProxy::broadcastMainFrameURLChangeToOtherProcesses):
(WebKit::WebPageProxy::webPageIDInProcessForDomain const):
(WebKit::WebPageProxy::broadcastFocusedFrameToOtherProcesses):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createRemoteSubframe):
(WebKit::WebFrame::didCommitLoadInAnotherProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoadInAnotherProcess):
(WebKit::WebPage::didFinishLoadInAnotherProcess):
(WebKit::WebPage::frameWasRemovedInAnotherProcess):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::didStartProvisionalLoadForFrame):

Canonical link: <a href="https://commits.webkit.org/270643@main">https://commits.webkit.org/270643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9458e6b4d2da1173f6e615b234cb5c1af9baa58b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23802 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28581 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29335 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23640 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27210 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1263 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23018 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3502 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3335 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->