### PR TITLE
Make some JSC stress tests less chatty.

### DIFF
--- a/JSTests/stress/date-set-time-purify-nan.js
+++ b/JSTests/stress/date-set-time-purify-nan.js
@@ -15,7 +15,8 @@ function main() {
     uint64_array[0] = 0xfffe000000001234n;
     opt(date, float64_array);
 
-    print(date.getTime());
+    if (String(date.getTime()) != "NaN")
+        throw "FAILED";
 }
 
 main();

--- a/JSTests/stress/regress-109102631.js
+++ b/JSTests/stress/regress-109102631.js
@@ -17,7 +17,9 @@ function main() {
     for (let i = 0; i < 14; i++) {
         opt(arr, marr)
     }
-    print(opt(arr2, marr))
+
+    if (typeof(opt(arr2, marr)) !== "undefined")
+        throw "FAILED";
 }
 noDFG(main);
 noFTL(main);


### PR DESCRIPTION
#### aabc9b41ae910e7fd00bce6c7908580f07fa05f6
<pre>
Make some JSC stress tests less chatty.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264659">https://bugs.webkit.org/show_bug.cgi?id=264659</a>
<a href="https://rdar.apple.com/118266600">rdar://118266600</a>

Reviewed by Alexey Shvayka.

Convert their prints into silent result checks, and throw on failure.

* JSTests/stress/date-set-time-purify-nan.js:
* JSTests/stress/regress-109102631.js:

Canonical link: <a href="https://commits.webkit.org/270592@main">https://commits.webkit.org/270592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34a10350aee570bada546263686c8128501bbe71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28533 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2979 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29293 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22505 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27168 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25074 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1222 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32518 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4392 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7067 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3457 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3317 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->