### PR TITLE
Port CredentialPersistence to the new serialization format

### DIFF
--- a/Source/WebCore/platform/network/CredentialBase.cpp
+++ b/Source/WebCore/platform/network/CredentialBase.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 CredentialBase::CredentialBase()
     : m_user(emptyString())
     , m_password(emptyString())
-    , m_persistence(CredentialPersistenceNone)
+    , m_persistence(CredentialPersistence::None)
 {
 }
    

--- a/Source/WebCore/platform/network/CredentialBase.h
+++ b/Source/WebCore/platform/network/CredentialBase.h
@@ -25,17 +25,16 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class Credential;
 
-enum CredentialPersistence {
-    CredentialPersistenceNone,
-    CredentialPersistenceForSession,
-    CredentialPersistencePermanent
+enum class CredentialPersistence : uint8_t {
+    None,
+    ForSession,
+    Permanent
 };
 
 class CredentialBase {
@@ -69,16 +68,3 @@ private:
 inline bool operator==(const Credential& a, const Credential& b) { return CredentialBase::compare(a, b); }
     
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CredentialPersistence> {
-    using values = EnumValues<
-        WebCore::CredentialPersistence,
-        WebCore::CredentialPersistence::CredentialPersistenceNone,
-        WebCore::CredentialPersistence::CredentialPersistenceForSession,
-        WebCore::CredentialPersistence::CredentialPersistencePermanent
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
@@ -31,11 +31,11 @@ namespace WebCore {
 static NSURLCredentialPersistence toNSURLCredentialPersistence(CredentialPersistence persistence)
 {
     switch (persistence) {
-    case CredentialPersistenceNone:
+    case CredentialPersistence::None:
         return NSURLCredentialPersistenceNone;
-    case CredentialPersistenceForSession:
+    case CredentialPersistence::ForSession:
         return NSURLCredentialPersistenceForSession;
-    case CredentialPersistencePermanent:
+    case CredentialPersistence::Permanent:
         return NSURLCredentialPersistencePermanent;
     }
 
@@ -47,16 +47,16 @@ static CredentialPersistence toCredentialPersistence(NSURLCredentialPersistence 
 {
     switch (persistence) {
     case NSURLCredentialPersistenceNone:
-        return CredentialPersistenceNone;
+        return CredentialPersistence::None;
     case NSURLCredentialPersistenceForSession:
-        return CredentialPersistenceForSession;
+        return CredentialPersistence::ForSession;
     case NSURLCredentialPersistencePermanent:
     case NSURLCredentialPersistenceSynchronizable:
-        return CredentialPersistencePermanent;
+        return CredentialPersistence::Permanent;
     }
 
     ASSERT_NOT_REACHED();
-    return CredentialPersistenceNone;
+    return CredentialPersistence::None;
 }
 
 Credential::Credential(const Credential& original, CredentialPersistence persistence)

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -154,7 +154,7 @@ void ResourceHandle::createNSURLConnection(id delegate, bool shouldUseCredential
             // This makes it possible to implement logout by sending an XMLHttpRequest with known incorrect credentials, and aborting it immediately
             // (so that an authentication dialog doesn't pop up).
             if (auto* networkStorageSession = d->m_context->storageSession())
-                networkStorageSession->credentialStorage().set(firstRequest().cachePartition(), Credential(d->m_user, d->m_password, CredentialPersistenceNone), firstRequest().url());
+                networkStorageSession->credentialStorage().set(firstRequest().cachePartition(), Credential(d->m_user, d->m_password, CredentialPersistence::None), firstRequest().url());
         }
     }
         
@@ -554,7 +554,7 @@ bool ResourceHandle::tryHandlePasswordBasedAuthentication(const AuthenticationCh
             if (auto* networkStorageSession = d->m_context->storageSession())
                 credential = networkStorageSession->credentialStorage().get(d->m_partition, challenge.protectionSpace());
             if (!credential.isEmpty() && credential != d->m_initialCredential) {
-                ASSERT(credential.persistence() == CredentialPersistenceNone);
+                ASSERT(credential.persistence() == CredentialPersistence::None);
                 if (challenge.failureResponse().httpStatusCode() == 401) {
                     // Store the credential back, possibly adding it as a default for this directory.
                     if (auto* networkStorageSession = d->m_context->storageSession())
@@ -593,10 +593,10 @@ void ResourceHandle::receivedCredential(const AuthenticationChallenge& challenge
         return;
     }
 
-    if (credential.persistence() == CredentialPersistenceForSession && challenge.protectionSpace().authenticationScheme() != ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested) {
+    if (credential.persistence() == CredentialPersistence::ForSession && challenge.protectionSpace().authenticationScheme() != ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested) {
         // Manage per-session credentials internally, because once NSURLCredentialPersistenceForSession is used, there is no way
         // to ignore it for a particular request (short of removing it altogether).
-        Credential webCredential(credential, CredentialPersistenceNone);
+        Credential webCredential(credential, CredentialPersistence::None);
         URL urlToStore;
         if (challenge.failureResponse().httpStatusCode() == 401)
             urlToStore = challenge.failureResponse().url();

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -203,7 +203,7 @@ void NetworkStorageSession::getCredentialFromPersistentStorage(const ProtectionS
             size_t length;
             GRefPtr<SecretValue> secretValue = adoptGRef(secret_item_get_secret(secretItem.get()));
             const char* passwordData = secret_value_get(secretValue.get(), &length);
-            data->completionHandler(Credential(user, String::fromUTF8(passwordData, length), CredentialPersistencePermanent));
+            data->completionHandler(Credential(user, String::fromUTF8(passwordData, length), CredentialPersistence::Permanent));
         }, data.release());
 #else
     UNUSED_PARAM(protectionSpace);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -204,7 +204,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
             if (m_user.isEmpty() && m_password.isEmpty())
                 m_initialCredential = storageSession->credentialStorage().get(m_partition, url);
             else
-                storageSession->credentialStorage().set(m_partition, WebCore::Credential(m_user, m_password, WebCore::CredentialPersistenceNone), url);
+                storageSession->credentialStorage().set(m_partition, WebCore::Credential(m_user, m_password, WebCore::CredentialPersistence::None), url);
         }
     }
 
@@ -498,7 +498,7 @@ bool NetworkDataTaskCocoa::tryPasswordBasedAuthentication(const WebCore::Authent
         return false;
     
     if (!m_user.isEmpty() || !m_password.isEmpty()) {
-        auto persistence = m_storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use ? WebCore::CredentialPersistenceForSession : WebCore::CredentialPersistenceNone;
+        auto persistence = m_storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use ? WebCore::CredentialPersistence::ForSession : WebCore::CredentialPersistence::None;
         completionHandler(AuthenticationChallengeDisposition::UseCredential, WebCore::Credential(m_user, m_password, persistence));
         m_user = String();
         m_password = String();
@@ -517,7 +517,7 @@ bool NetworkDataTaskCocoa::tryPasswordBasedAuthentication(const WebCore::Authent
         if (!challenge.previousFailureCount()) {
             auto credential = m_session->networkStorageSession() ? m_session->networkStorageSession()->credentialStorage().get(m_partition, challenge.protectionSpace()) : WebCore::Credential();
             if (!credential.isEmpty() && credential != m_initialCredential) {
-                ASSERT(credential.persistence() == WebCore::CredentialPersistenceNone);
+                ASSERT(credential.persistence() == WebCore::CredentialPersistence::None);
                 if (challenge.failureResponse().httpStatusCode() == 401) {
                     // Store the credential back, possibly adding it as a default for this directory.
                     if (auto* storageSession = m_session->networkStorageSession())

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1807,8 +1807,8 @@ static CompletionHandler<void(WebKit::AuthenticationChallengeDisposition disposi
 #else
         UNUSED_PARAM(taskIdentifier);
 #endif
-        if (credential.persistence() == WebCore::CredentialPersistenceForSession && authenticationChallenge.protectionSpace().isPasswordBased()) {
-            WebCore::Credential nonPersistentCredential(credential.user(), credential.password(), WebCore::CredentialPersistenceNone);
+        if (credential.persistence() == WebCore::CredentialPersistence::ForSession && authenticationChallenge.protectionSpace().isPasswordBased()) {
+            WebCore::Credential nonPersistentCredential(credential.user(), credential.password(), WebCore::CredentialPersistence::None);
             URL urlToStore;
             if (authenticationChallenge.failureResponse().httpStatusCode() == 401)
                 urlToStore = authenticationChallenge.failureResponse().url();

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -72,7 +72,7 @@ NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTas
             if (m_user.isEmpty() && m_password.isEmpty())
                 m_initialCredential = m_session->networkStorageSession()->credentialStorage().get(m_partition, request.url());
             else
-                m_session->networkStorageSession()->credentialStorage().set(m_partition, Credential(m_user, m_password, CredentialPersistenceNone), request.url());
+                m_session->networkStorageSession()->credentialStorage().set(m_partition, Credential(m_user, m_password, CredentialPersistence::None), request.url());
         }
     }
 
@@ -416,7 +416,7 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
 void NetworkDataTaskCurl::tryHttpAuthentication(AuthenticationChallenge&& challenge)
 {
     if (!m_user.isNull() && !m_password.isNull()) {
-        auto persistence = m_storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use ? WebCore::CredentialPersistenceForSession : WebCore::CredentialPersistenceNone;
+        auto persistence = m_storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use ? WebCore::CredentialPersistence::ForSession : WebCore::CredentialPersistence::None;
         restartWithCredential(challenge.protectionSpace(), Credential(m_user, m_password, persistence));
         m_user = String();
         m_password = String();
@@ -434,7 +434,7 @@ void NetworkDataTaskCurl::tryHttpAuthentication(AuthenticationChallenge&& challe
         if (!challenge.previousFailureCount()) {
             auto credential = m_session->networkStorageSession()->credentialStorage().get(m_partition, challenge.protectionSpace());
             if (!credential.isEmpty() && credential != m_initialCredential) {
-                ASSERT(credential.persistence() == CredentialPersistenceNone);
+                ASSERT(credential.persistence() == CredentialPersistence::None);
                 if (challenge.failureResponse().isUnauthorized()) {
                     // Store the credential back, possibly adding it as a default for this directory.
                     m_session->networkStorageSession()->credentialStorage().set(m_partition, credential, challenge.protectionSpace(), challenge.failureResponse().url());
@@ -457,7 +457,7 @@ void NetworkDataTaskCurl::tryHttpAuthentication(AuthenticationChallenge&& challe
 
         if (disposition == AuthenticationChallengeDisposition::UseCredential && !credential.isEmpty()) {
             if (m_storedCredentialsPolicy == StoredCredentialsPolicy::Use) {
-                if (credential.persistence() == CredentialPersistenceForSession || credential.persistence() == CredentialPersistencePermanent)
+                if (credential.persistence() == CredentialPersistence::ForSession || credential.persistence() == CredentialPersistence::Permanent)
                     m_session->networkStorageSession()->credentialStorage().set(m_partition, credential, challenge.protectionSpace(), challenge.failureResponse().url());
             }
 
@@ -485,7 +485,7 @@ void NetworkDataTaskCurl::tryProxyAuthentication(WebCore::AuthenticationChalleng
             CurlContext::singleton().setProxyUserPass(credential.user(), credential.password());
             CurlContext::singleton().setDefaultProxyAuthMethod();
 
-            auto requestCredential = m_curlRequest ? Credential(m_curlRequest->user(), m_curlRequest->password(), CredentialPersistenceNone) : Credential();
+            auto requestCredential = m_curlRequest ? Credential(m_curlRequest->user(), m_curlRequest->password(), CredentialPersistence::None) : Credential();
             restartWithCredential(challenge.protectionSpace(), requestCredential);
             return;
         }
@@ -501,7 +501,7 @@ void NetworkDataTaskCurl::tryServerTrustEvaluation(AuthenticationChallenge&& cha
             return;
 
         if (disposition == AuthenticationChallengeDisposition::UseCredential && !credential.isEmpty()) {
-            auto requestCredential = m_curlRequest ? Credential(m_curlRequest->user(), m_curlRequest->password(), CredentialPersistenceNone) : Credential();
+            auto requestCredential = m_curlRequest ? Credential(m_curlRequest->user(), m_curlRequest->password(), CredentialPersistence::None) : Credential();
             restartWithCredential(challenge.protectionSpace(), requestCredential);
             return;
         }

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -80,7 +80,7 @@ NetworkDataTaskSoup::NetworkDataTaskSoup(NetworkSession& session, NetworkDataTas
             if (m_user.isEmpty() && m_password.isEmpty())
                 m_initialCredential = m_session->networkStorageSession()->credentialStorage().get(m_partition, request.url());
             else
-                m_session->networkStorageSession()->credentialStorage().set(m_partition, Credential(m_user, m_password, CredentialPersistenceNone), request.url());
+                m_session->networkStorageSession()->credentialStorage().set(m_partition, Credential(m_user, m_password, CredentialPersistence::None), request.url());
         }
         applyAuthenticationToRequest(request);
     }
@@ -742,7 +742,7 @@ void NetworkDataTaskSoup::authenticate(AuthenticationChallenge&& challenge)
         if (!challenge.previousFailureCount()) {
             auto credential = m_session->networkStorageSession()->credentialStorage().get(m_partition, challenge.protectionSpace());
             if (!credential.isEmpty() && credential != m_initialCredential) {
-                ASSERT(credential.persistence() == CredentialPersistenceNone);
+                ASSERT(credential.persistence() == CredentialPersistence::None);
 
                 if (isAuthenticationFailureStatusCode(challenge.failureResponse().httpStatusCode())) {
                     // Store the credential back, possibly adding it as a default for this directory.
@@ -801,10 +801,10 @@ void NetworkDataTaskSoup::continueAuthenticate(AuthenticationChallenge&& challen
                 // because once we authenticate via libsoup, there is no way to ignore it for a particular request. Right now,
                 // we place the credentials in the store even though libsoup will never fire the authenticate signal again for
                 // this protection space.
-                if (credential.persistence() == CredentialPersistenceForSession || credential.persistence() == CredentialPersistencePermanent)
+                if (credential.persistence() == CredentialPersistence::ForSession || credential.persistence() == CredentialPersistence::Permanent)
                     m_session->networkStorageSession()->credentialStorage().set(m_partition, credential, challenge.protectionSpace(), challenge.failureResponse().url());
 
-                if (credential.persistence() == CredentialPersistencePermanent && persistentCredentialStorageEnabled()) {
+                if (credential.persistence() == CredentialPersistence::Permanent && persistentCredentialStorageEnabled()) {
                     m_protectionSpaceForPersistentStorage = challenge.protectionSpace();
                     m_credentialForPersistentStorage = credential;
                 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6690,3 +6690,9 @@ enum class WebCore::ResourceErrorBaseType : uint8_t {
      Cancellation,
      Timeout,
 }
+
+enum class WebCore::CredentialPersistence : uint8_t {
+     None,
+     ForSession,
+     Permanent,
+}

--- a/Source/WebKit/UIProcess/API/C/WKAPICast.h
+++ b/Source/WebKit/UIProcess/API/C/WKAPICast.h
@@ -347,13 +347,13 @@ inline WebCore::CredentialPersistence toCredentialPersistence(WKCredentialPersis
 {
     switch (type) {
     case kWKCredentialPersistenceNone:
-        return WebCore::CredentialPersistenceNone;
+        return WebCore::CredentialPersistence::None;
     case kWKCredentialPersistenceForSession:
-        return WebCore::CredentialPersistenceForSession;
+        return WebCore::CredentialPersistence::ForSession;
     case kWKCredentialPersistencePermanent:
-        return WebCore::CredentialPersistencePermanent;
+        return WebCore::CredentialPersistence::Permanent;
     default:
-        return WebCore::CredentialPersistenceNone;
+        return WebCore::CredentialPersistence::None;
     }
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitCredential.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCredential.cpp
@@ -50,11 +50,11 @@ G_DEFINE_BOXED_TYPE(WebKitCredential, webkit_credential, webkit_credential_copy,
 static inline WebKitCredentialPersistence toWebKitCredentialPersistence(WebCore::CredentialPersistence corePersistence)
 {
     switch (corePersistence) {
-    case WebCore::CredentialPersistenceNone:
+    case WebCore::CredentialPersistence::None:
         return WEBKIT_CREDENTIAL_PERSISTENCE_NONE;
-    case WebCore::CredentialPersistenceForSession:
+    case WebCore::CredentialPersistence::ForSession:
         return WEBKIT_CREDENTIAL_PERSISTENCE_FOR_SESSION;
-    case WebCore::CredentialPersistencePermanent:
+    case WebCore::CredentialPersistence::Permanent:
         return WEBKIT_CREDENTIAL_PERSISTENCE_PERMANENT;
     default:
         ASSERT_NOT_REACHED();
@@ -66,14 +66,14 @@ static inline WebCore::CredentialPersistence toWebCoreCredentialPersistence(WebK
 {
     switch (kitPersistence) {
     case WEBKIT_CREDENTIAL_PERSISTENCE_NONE:
-        return WebCore::CredentialPersistenceNone;
+        return WebCore::CredentialPersistence::None;
     case WEBKIT_CREDENTIAL_PERSISTENCE_FOR_SESSION:
-        return WebCore::CredentialPersistenceForSession;
+        return WebCore::CredentialPersistence::ForSession;
     case WEBKIT_CREDENTIAL_PERSISTENCE_PERMANENT:
-        return WebCore::CredentialPersistencePermanent;
+        return WebCore::CredentialPersistence::Permanent;
     default:
         ASSERT_NOT_REACHED();
-        return WebCore::CredentialPersistenceNone;
+        return WebCore::CredentialPersistence::None;
     }
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.cpp
@@ -67,7 +67,7 @@ static void okButtonClicked(GtkButton*, WebKitAuthenticationDialog* authDialog)
 #endif
 
     WebCore::CredentialPersistence persistence = rememberPassword && priv->credentialStorageMode == AllowPersistentStorage ?
-        WebCore::CredentialPersistencePermanent : WebCore::CredentialPersistenceForSession;
+        WebCore::CredentialPersistence::Permanent : WebCore::CredentialPersistence::ForSession;
 
     // FIXME: Use a stack allocated WebKitCredential.
     WebKitCredential* credential = webkitCredentialCreate(WebCore::Credential(String::fromUTF8(username), String::fromUTF8(password), persistence));


### PR DESCRIPTION
#### 0ddbf5c0c6b8f939705ff74f6008467bc92fad3f
<pre>
Port CredentialPersistence to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264661">https://bugs.webkit.org/show_bug.cgi?id=264661</a>

Reviewed by Chris Dumez.

Remove EnumTraits for CredentialPersistence and
port the enum to a serializable format.

* Source/WebCore/platform/network/CredentialBase.cpp:
(WebCore::CredentialBase::CredentialBase):
* Source/WebCore/platform/network/CredentialBase.h:
(): Deleted.
* Source/WebCore/platform/network/cocoa/CredentialCocoa.mm:
(WebCore::toNSURLCredentialPersistence):
(WebCore::toCredentialPersistence):
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::createNSURLConnection):
(WebCore::ResourceHandle::tryHandlePasswordBasedAuthentication):
(WebCore::ResourceHandle::receivedCredential):
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::getCredentialFromPersistentStorage):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::tryPasswordBasedAuthentication):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::CompletionHandler&lt;void):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::NetworkDataTaskCurl):
(WebKit::NetworkDataTaskCurl::tryHttpAuthentication):
(WebKit::NetworkDataTaskCurl::tryProxyAuthentication):
(WebKit::NetworkDataTaskCurl::tryServerTrustEvaluation):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::NetworkDataTaskSoup):
(WebKit::NetworkDataTaskSoup::authenticate):
(WebKit::NetworkDataTaskSoup::continueAuthenticate):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/WKAPICast.h:
(WebKit::toCredentialPersistence):
* Source/WebKit/UIProcess/API/glib/WebKitCredential.cpp:
(toWebKitCredentialPersistence):
(toWebCoreCredentialPersistence):
* Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.cpp:
(okButtonClicked):

Canonical link: <a href="https://commits.webkit.org/270599@main">https://commits.webkit.org/270599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/474c4c96fcf87002642089a3e38f186ac0d271f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1930 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28571 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23260 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23630 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27198 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4428 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6222 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->