### PR TITLE
Sync 'setSelectionRange' in 'HTMLTextAreaElement.idl' with WebIDL Specification

### DIFF
--- a/LayoutTests/fast/dom/non-numeric-values-numeric-parameters-expected.txt
+++ b/LayoutTests/fast/dom/non-numeric-values-numeric-parameters-expected.txt
@@ -37,7 +37,7 @@ PASS nonNumericPolicy('createHTMLTableRowElement().deleteCell(x)') is 'any type 
 PASS nonNumericPolicy('createHTMLTableSectionElement().insertRow(x)') is 'any type allowed'
 PASS nonNumericPolicy('createHTMLTableSectionElement().deleteRow(x)') is 'any type allowed (but not omitted)'
 PASS nonNumericPolicy('document.createElement("textarea").setSelectionRange(x, 0)') is 'any type allowed'
-PASS nonNumericPolicy('document.createElement("textarea").setSelectionRange(0, x)') is 'any type allowed'
+PASS nonNumericPolicy('document.createElement("textarea").setSelectionRange(0, x)') is 'any type allowed (but not omitted)'
 PASS nonNumericPolicy('document.createEvent("KeyboardEvent").initKeyboardEvent("a", false, false, null, "b", x, false, false, false, false, false)') is 'any type allowed'
 PASS nonNumericPolicy('createMediaList().item(x)') is 'any type allowed (but not omitted)'
 PASS nonNumericPolicy('document.createEvent("MouseEvent").initMouseEvent("a", false, false, null, x, 0, 0, 0, 0, false, false, false, false, 0, null)') is 'any type allowed'

--- a/LayoutTests/fast/dom/non-numeric-values-numeric-parameters.html
+++ b/LayoutTests/fast/dom/non-numeric-values-numeric-parameters.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -275,7 +275,7 @@ shouldBe("nonNumericPolicy('createHTMLTableSectionElement().deleteRow(x)')", "'a
 // HTMLInputElement
 
 shouldBe("nonNumericPolicy('document.createElement(\"textarea\").setSelectionRange(x, 0)')", "'any type allowed'");
-shouldBe("nonNumericPolicy('document.createElement(\"textarea\").setSelectionRange(0, x)')", "'any type allowed'");
+shouldBe("nonNumericPolicy('document.createElement(\"textarea\").setSelectionRange(0, x)')", "'any type allowed (but not omitted)'");
 
 // KeyboardEvent
 
@@ -653,6 +653,5 @@ Here are other examples of numeric types in function parameters and settable att
 
 */
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -3423,7 +3423,7 @@ PASS HTMLTextAreaElement interface: attribute selectionEnd
 PASS HTMLTextAreaElement interface: attribute selectionDirection
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString)
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)
-FAIL HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString) assert_equals: property has wrong .length expected 2 but got 0
+PASS HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString)
 PASS HTMLTextAreaElement must be primary interface of document.createElement("textarea")
 PASS Stringification of document.createElement("textarea")
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "autocomplete" with the proper type
@@ -3460,9 +3460,7 @@ PASS HTMLTextAreaElement interface: calling setRangeText(DOMString) on document.
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)" with the proper type
 PASS HTMLTextAreaElement interface: calling setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setSelectionRange(unsigned long, unsigned long, optional DOMString)" with the proper type
-FAIL HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
-            fn.apply(obj, args);
-        }" did not throw
+PASS HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLOutputElement interface: existence and properties of interface object
 PASS HTMLOutputElement interface object length
 PASS HTMLOutputElement interface object name

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -3423,7 +3423,7 @@ PASS HTMLTextAreaElement interface: attribute selectionEnd
 PASS HTMLTextAreaElement interface: attribute selectionDirection
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString)
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)
-FAIL HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString) assert_equals: property has wrong .length expected 2 but got 0
+PASS HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString)
 PASS HTMLTextAreaElement must be primary interface of document.createElement("textarea")
 PASS Stringification of document.createElement("textarea")
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "autocomplete" with the proper type
@@ -3460,9 +3460,7 @@ PASS HTMLTextAreaElement interface: calling setRangeText(DOMString) on document.
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)" with the proper type
 PASS HTMLTextAreaElement interface: calling setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setSelectionRange(unsigned long, unsigned long, optional DOMString)" with the proper type
-FAIL HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
-            fn.apply(obj, args);
-        }" did not throw
+PASS HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLOutputElement interface: existence and properties of interface object
 PASS HTMLOutputElement interface object length
 PASS HTMLOutputElement interface object name

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -3423,7 +3423,7 @@ PASS HTMLTextAreaElement interface: attribute selectionEnd
 PASS HTMLTextAreaElement interface: attribute selectionDirection
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString)
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)
-FAIL HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString) assert_equals: property has wrong .length expected 2 but got 0
+PASS HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString)
 PASS HTMLTextAreaElement must be primary interface of document.createElement("textarea")
 PASS Stringification of document.createElement("textarea")
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "autocomplete" with the proper type
@@ -3460,9 +3460,7 @@ PASS HTMLTextAreaElement interface: calling setRangeText(DOMString) on document.
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)" with the proper type
 PASS HTMLTextAreaElement interface: calling setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setSelectionRange(unsigned long, unsigned long, optional DOMString)" with the proper type
-FAIL HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
-            fn.apply(obj, args);
-        }" did not throw
+PASS HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLOutputElement interface: existence and properties of interface object
 PASS HTMLOutputElement interface object length
 PASS HTMLOutputElement interface object name

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -3423,7 +3423,7 @@ PASS HTMLTextAreaElement interface: attribute selectionEnd
 PASS HTMLTextAreaElement interface: attribute selectionDirection
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString)
 PASS HTMLTextAreaElement interface: operation setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)
-FAIL HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString) assert_equals: property has wrong .length expected 2 but got 0
+PASS HTMLTextAreaElement interface: operation setSelectionRange(unsigned long, unsigned long, optional DOMString)
 PASS HTMLTextAreaElement must be primary interface of document.createElement("textarea")
 PASS Stringification of document.createElement("textarea")
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "autocomplete" with the proper type
@@ -3460,9 +3460,7 @@ PASS HTMLTextAreaElement interface: calling setRangeText(DOMString) on document.
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode)" with the proper type
 PASS HTMLTextAreaElement interface: calling setRangeText(DOMString, unsigned long, unsigned long, optional SelectionMode) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "setSelectionRange(unsigned long, unsigned long, optional DOMString)" with the proper type
-FAIL HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
-            fn.apply(obj, args);
-        }" did not throw
+PASS HTMLTextAreaElement interface: calling setSelectionRange(unsigned long, unsigned long, optional DOMString) on document.createElement("textarea") with too few arguments must throw TypeError
 PASS HTMLOutputElement interface: existence and properties of interface object
 PASS HTMLOutputElement interface object length
 PASS HTMLOutputElement interface object name

--- a/Source/WebCore/html/HTMLTextAreaElement.idl
+++ b/Source/WebCore/html/HTMLTextAreaElement.idl
@@ -19,6 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://html.spec.whatwg.org/multipage/form-elements.html#htmltextareaelement
+
 [
     Exposed=Window
 ] interface HTMLTextAreaElement : HTMLElement {
@@ -57,7 +59,7 @@
     undefined setRangeText(DOMString replacement);
     undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional DOMString selectionMode);
 
-    [ImplementedAs=setSelectionRangeForBindings] undefined setSelectionRange(optional unsigned long start = 0, optional unsigned long end = 0, optional DOMString direction);
+    [ImplementedAs=setSelectionRangeForBindings] undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
     [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
 };


### PR DESCRIPTION
#### 3a15e783eb813a35b1fe3c651a0c5fc0c131e05d
<pre>
Sync &apos;setSelectionRange&apos; in &apos;HTMLTextAreaElement.idl&apos; with WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=264673">https://bugs.webkit.org/show_bug.cgi?id=264673</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Blink / Chromium, Gecko / Firefox and Web-Specification [1].

[1] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmltextareaelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmltextareaelement</a>

This patch removes &apos;optional&apos; and &apos;=0&apos; from &apos;setSelectionRange&apos; arguments as stated.

* Source/WebCore/html/HTMLTextAreaElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt: Rebaselined
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt: Rebaselined
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt: Rebaselined
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt: Rebaselined
* LayoutTests/fast/dom/non-numeric-values-numeric-parameters.html: Rebaselined
* LayoutTests/fast/dom/non-numeric-values-numeric-parameters-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/270605@main">https://commits.webkit.org/270605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/796092a628088c2f32bbb5ae9ee88870461439d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23783 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28562 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29314 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27189 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1243 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6226 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->