### PR TITLE
[GPU][macOS] Allow access to virtualization user client

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -64,7 +64,6 @@
     "AppleIntelMEClientController"
     "AppleMobileADBE0"
     "AppleUpstreamUserClientDriver"
-    "AppleVideoToolboxParavirtualizationDriver"
     "AudioAUUCDriver"
     "IOAudioSelectorControl"
     "IOMobileFramebufferShim"))
@@ -84,16 +83,16 @@
         "AppleM2ScalerCSCDriver"
         "IOPMrootDomain"))
 
+
+;; FIXME: Add check `(with-filter (system-attribute virtual-device)` when this is supported. See rdar://118274636.
+(allow iokit-open-service (iokit-registry-entry-class "AppleVideoToolboxParavirtualizationDriver"))
+(allow iokit-open-user-client (iokit-user-client-class "AppleVideoToolboxParavirtualizationUserClient"))
+
 (deny darwin-notification-post (with no-report))
 (deny nvram-get (with no-report))
 #endif // USE(SANDBOX_VERSION_3)
 
 (deny (with no-report) necp-client-open)
-
-;;;
-;;; The following rules were originally contained in 'system.sb'. We are duplicating them here so we can
-;;; remove unneeded sandbox extensions.
-;;;
 
 ;;; Allow read access to standard system paths.
 (allow file-read*
@@ -186,10 +185,6 @@
         (iokit-property "rgcs")
         (iokit-property "ggcs")
         (iokit-property "bgcs")))))
-
-;;;
-;;; End rules originally copied from 'system.sb'
-;;;
 
 ;;; process-info* defaults to allow; deny it and then allow operations we actually need.
 (deny process-info*)


### PR DESCRIPTION
#### 9bf476276bf857187e10f043a7be7c4d9d2f4071
<pre>
[GPU][macOS] Allow access to virtualization user client
<a href="https://bugs.webkit.org/show_bug.cgi?id=264675">https://bugs.webkit.org/show_bug.cgi?id=264675</a>
<a href="https://rdar.apple.com/99067275">rdar://99067275</a>

Reviewed by Alexey Proskuryakov.

This patch also removes an obsolete comment.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/271582@main">https://commits.webkit.org/271582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c43406531eb7252949d9c3c10d051800e1e1e321

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25076 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24882 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4208 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4355 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2520 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28455 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5843 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6902 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->