### PR TITLE
Add remaining 'legend' UA stylesheet rules from HTML Web Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-align-justify-self-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-align-justify-self-expected.txt
@@ -13,12 +13,12 @@ x
 x
 
 PASS <fieldset><legend>x</legend></fieldset>
-FAIL <fieldset><legend align="left">x</legend></fieldset> assert_equals: expected "left" but got "auto"
-FAIL <fieldset><legend align="center">x</legend></fieldset> assert_equals: expected "center" but got "auto"
-FAIL <fieldset><legend align="right">x</legend></fieldset> assert_equals: expected "right" but got "auto"
-FAIL <fieldset><legend align="lEfT">x</legend></fieldset> assert_equals: expected "left" but got "auto"
-FAIL <fieldset><legend align="cEnTeR">x</legend></fieldset> assert_equals: expected "center" but got "auto"
-FAIL <fieldset><legend align="rIgHt">x</legend></fieldset> assert_equals: expected "right" but got "auto"
+PASS <fieldset><legend align="left">x</legend></fieldset>
+PASS <fieldset><legend align="center">x</legend></fieldset>
+PASS <fieldset><legend align="right">x</legend></fieldset>
+PASS <fieldset><legend align="lEfT">x</legend></fieldset>
+PASS <fieldset><legend align="cEnTeR">x</legend></fieldset>
+PASS <fieldset><legend align="rIgHt">x</legend></fieldset>
 PASS <fieldset><legend align="justify">x</legend></fieldset>
 PASS <fieldset><legend align="left ">x</legend></fieldset>
 PASS <fieldset><legend dir="ltr">x</legend></fieldset>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -377,10 +377,24 @@ label {
     cursor: default;
 }
 
+/* https://html.spec.whatwg.org/#the-fieldset-and-legend-elements */
+
 legend {
     padding-inline-start: 2px;
     padding-inline-end: 2px;
     border: none;
+}
+
+legend[align=left i] {
+    justify-self: left;
+}
+  
+legend[align=center i] {
+    justify-self: center;
+}
+
+legend[align=right i] {
+    justify-self: right;
 }
 
 fieldset {


### PR DESCRIPTION
<pre>
Add remaining 'legend' UA stylesheet rules from HTML Web Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=264676">https://bugs.webkit.org/show_bug.cgi?id=264676</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Web-Specification [1] by adding UA stylesheet rules (i.e., 'justify-self') for legend element:

[1] <a href="https://html.spec.whatwg.org/#the-fieldset-and-legend-elements">https://html.spec.whatwg.org/#the-fieldset-and-legend-elements</a>

* Source/WebCore/css/html.css:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-align-justify-self-expected.txt: Rebaselined
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7db75daf9463abee9b3d0030e2b79c5d6e4f5f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23700 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23784 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28563 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29315 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27190 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1245 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->