### PR TITLE
Remove 'LegacyNullToEmptyString' from `autocapitalize` in HTMLElement.idl

### DIFF
--- a/LayoutTests/platform/ios/ios/fast/forms/autocapitalize-null-expected.txt
+++ b/LayoutTests/platform/ios/ios/fast/forms/autocapitalize-null-expected.txt
@@ -5,16 +5,16 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS form.getAttribute('autocapitalize') is null
 form.autocapitalize = null
-PASS form.getAttribute('autocapitalize') is ""
-PASS form.autocapitalize is ""
+PASS form.getAttribute('autocapitalize') is "null"
+PASS form.autocapitalize is "sentences"
 PASS input.getAttribute('autocapitalize') is null
 input.autocapitalize = null
-PASS input.getAttribute('autocapitalize') is ""
-PASS input.autocapitalize is ""
+PASS input.getAttribute('autocapitalize') is "null"
+PASS input.autocapitalize is "sentences"
 PASS textarea.getAttribute('autocapitalize') is null
 textarea.autocapitalize = null
-PASS textarea.getAttribute('autocapitalize') is ""
-PASS textarea.autocapitalize is ""
+PASS textarea.getAttribute('autocapitalize') is "null"
+PASS textarea.autocapitalize is "sentences"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/ios/ios/fast/forms/autocapitalize-null.html
+++ b/LayoutTests/platform/ios/ios/fast/forms/autocapitalize-null.html
@@ -1,28 +1,27 @@
 <!DOCTYPE html>
 <html>
 <body>
-<script src="../../../../../resources/js-test-pre.js"></script>
+<script src="../../../../../resources/js-test.js"></script>
 <script>
 description("Test null handling on the autocapitalize attribute");
 
 var form = document.createElement("form");
 shouldBeNull("form.getAttribute('autocapitalize')");
 evalAndLog("form.autocapitalize = null");
-shouldBeEqualToString("form.getAttribute('autocapitalize')", "");
-shouldBeEqualToString("form.autocapitalize", "");
+shouldBeEqualToString("form.getAttribute('autocapitalize')", "null");
+shouldBeEqualToString("form.autocapitalize", "sentences");
 
 var input = document.createElement("input");
 shouldBeNull("input.getAttribute('autocapitalize')");
 evalAndLog("input.autocapitalize = null");
-shouldBeEqualToString("input.getAttribute('autocapitalize')", "");
-shouldBeEqualToString("input.autocapitalize", "");
+shouldBeEqualToString("input.getAttribute('autocapitalize')", "null");
+shouldBeEqualToString("input.autocapitalize", "sentences");
 
 var textarea = document.createElement("textarea");
 shouldBeNull("textarea.getAttribute('autocapitalize')");
 evalAndLog("textarea.autocapitalize = null");
-shouldBeEqualToString("textarea.getAttribute('autocapitalize')", "");
-shouldBeEqualToString("textarea.autocapitalize", "");
+shouldBeEqualToString("textarea.getAttribute('autocapitalize')", "null");
+shouldBeEqualToString("textarea.autocapitalize", "sentences");
 </script>
-<script src="../../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -18,6 +18,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://html.spec.whatwg.org/multipage/dom.html#htmlelement
+
 [
     CustomPushEventHandlerScope,
     CustomToJSObject,
@@ -45,8 +47,7 @@
     readonly attribute DOMString accessKeyLabel;
     [CEReactions=Needed] attribute boolean draggable;
     [CEReactions=Needed] attribute boolean spellcheck;
-    // FIXME: 'autocapitalize' should not be [LegacyNullToEmptyString].
-    [Conditional=AUTOCAPITALIZE, CEReactions=Needed] attribute [LegacyNullToEmptyString, AtomString] DOMString autocapitalize;
+    [Conditional=AUTOCAPITALIZE, CEReactions=Needed] attribute [AtomString] DOMString autocapitalize;
 
     [CEReactions=Needed] attribute [LegacyNullToEmptyString] DOMString innerText;
 


### PR DESCRIPTION
#### 0870ffbbc0d9b858e44807348b24ffe2b27bb8c0
<pre>
Remove &apos;LegacyNullToEmptyString&apos; from `autocapitalize` in HTMLElement.idl

<a href="https://bugs.webkit.org/show_bug.cgi?id=264678">https://bugs.webkit.org/show_bug.cgi?id=264678</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Web-Specification [1] by removing &apos;LegacyNullToEmptyString&apos; from &apos;autocapitalize&apos;:

[1] <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a>

* Source/WebCore/html/HTMLElement.idl:
* LayoutTests/platform/ios/ios/fast/forms/autocapitalize-null.html: Rebaselined
* LayoutTests/platform/ios/ios/fast/forms/autocapitalize-null-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/271005@main">https://commits.webkit.org/271005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49729b3ef9035fe2cb8232da8774cb80c780b99c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3920 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30205 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4017 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28121 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23948 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4482 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3501 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->