### PR TITLE
Port media capabilities enums to new serialization format

### DIFF
--- a/Source/WebCore/platform/mediacapabilities/ColorGamut.h
+++ b/Source/WebCore/platform/mediacapabilities/ColorGamut.h
@@ -36,16 +36,3 @@ enum class ColorGamut : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ColorGamut> {
-    using values = EnumValues<
-        WebCore::ColorGamut,
-        WebCore::ColorGamut::SRGB,
-        WebCore::ColorGamut::P3,
-        WebCore::ColorGamut::Rec2020
-    >;
-};
-
-}

--- a/Source/WebCore/platform/mediacapabilities/HdrMetadataType.h
+++ b/Source/WebCore/platform/mediacapabilities/HdrMetadataType.h
@@ -36,16 +36,3 @@ enum class HdrMetadataType : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::HdrMetadataType> {
-    using values = EnumValues<
-        WebCore::HdrMetadataType,
-        WebCore::HdrMetadataType::SmpteSt2086,
-        WebCore::HdrMetadataType::SmpteSt209410,
-        WebCore::HdrMetadataType::SmpteSt209440
-    >;
-};
-
-}

--- a/Source/WebCore/platform/mediacapabilities/TransferFunction.h
+++ b/Source/WebCore/platform/mediacapabilities/TransferFunction.h
@@ -34,16 +34,3 @@ enum class TransferFunction : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::TransferFunction> {
-    using values = EnumValues<
-        WebCore::TransferFunction,
-        WebCore::TransferFunction::SRGB,
-        WebCore::TransferFunction::PQ,
-        WebCore::TransferFunction::HLG
-    >;
-};
-
-}

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6707,3 +6707,21 @@ enum class WebCore::PaginationMode : uint8_t {
 
 header: <WebCore/RenderObject.h>
 enum class WebCore::RepaintRectCalculation : bool;
+
+[Nested] enum class WebCore::HdrMetadataType : uint8_t {
+    SmpteSt2086,
+    SmpteSt209410,
+    SmpteSt209440,
+};
+
+[Nested] enum class WebCore::TransferFunction : uint8_t {
+     SRGB,
+     PQ,
+     HLG,
+};
+
+[Nested] enum class WebCore::ColorGamut : uint8_t {
+    SRGB,
+    P3,
+    Rec2020,
+};


### PR DESCRIPTION
#### 279959ad2c2cfe9b4f0dd82bfbe631ac6f56c446
<pre>
Port media capabilities enums to new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264679">https://bugs.webkit.org/show_bug.cgi?id=264679</a>

Reviewed by Chris Dumez.

Do away with the EnumTraits for these enums and use
the generator for their IPC serialization.

* Source/WebCore/platform/mediacapabilities/ColorGamut.h:
* Source/WebCore/platform/mediacapabilities/HdrMetadataType.h:
* Source/WebCore/platform/mediacapabilities/TransferFunction.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270639@main">https://commits.webkit.org/270639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccfb24e112b26ca3836472786a3cfdee7d62abd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23862 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28652 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29391 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27268 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1325 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4506 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6250 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->