### PR TITLE
Sync 'HTMLIFrameElement.idl' with WebIDL Specification

### DIFF
--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -18,34 +18,34 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement
+
 [
     Exposed=Window,
     JSGenerateToNativeObject
 ] interface HTMLIFrameElement : HTMLElement {
-    [Reflect, CEReactions=NotNeeded] attribute DOMString align;
-    [Reflect, CEReactions=NotNeeded] attribute DOMString frameBorder;
-    [Reflect, CEReactions=NotNeeded] attribute DOMString height;
-    [Reflect, URL, CEReactions=NotNeeded] attribute USVString longDesc;
-    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginHeight;
-    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginWidth;
-    [Reflect, CEReactions=NotNeeded] attribute DOMString name;
-
-    [PutForwards=value] readonly attribute DOMTokenList sandbox;
-    [Reflect, CEReactions=NotNeeded] attribute boolean allowFullscreen;
-    [Reflect, CEReactions=NotNeeded] attribute DOMString allow;
-
-    [Reflect, CEReactions=NotNeeded] attribute DOMString scrolling;
     [Reflect, URL, CEReactions=NotNeeded] attribute USVString src;
     [Reflect, CEReactions=NotNeeded] attribute DOMString srcdoc;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString name;
+    [SameObject, PutForwards=value] readonly attribute DOMTokenList sandbox;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString allow;
+    [Reflect, CEReactions=NotNeeded] attribute boolean allowFullscreen;
     [Reflect, CEReactions=NotNeeded] attribute DOMString width;
-
-    [CheckSecurityForNode] readonly attribute Document contentDocument;
-
-    readonly attribute WindowProxy contentWindow;
-
-    [CheckSecurityForNode] Document getSVGDocument();
-
+    [Reflect, CEReactions=NotNeeded] attribute DOMString height;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
-
     [CEReactions=NotNeeded, EnabledBySetting=LazyIframeLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
+    [CheckSecurityForNode] readonly attribute Document? contentDocument;
+    readonly attribute WindowProxy? contentWindow;
+    [CheckSecurityForNode] Document? getSVGDocument();
+
+    // also has obsolete members
+    // https://html.spec.whatwg.org/multipage/obsolete.html#HTMLIFrameElement-partial
+    [Reflect, CEReactions=NotNeeded] attribute DOMString align;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString scrolling;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString frameBorder;
+    [Reflect, URL, CEReactions=NotNeeded] attribute USVString longDesc;
+
+    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginHeight;
+    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginWidth;
+
 };


### PR DESCRIPTION
#### 1149eaa3c4cb38346440415943f4567ad52b0e5f
<pre>
Sync &apos;HTMLIFrameElement.idl&apos; with WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=264682">https://bugs.webkit.org/show_bug.cgi?id=264682</a>

Reviewed by Chris Dumez.

This patch just aligns WebKit with Web-Specifications [1] &amp; [2] and also add any missing &apos;?&apos; and &apos;SameObject&apos;.

[1] <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a>
[2] <a href="https://html.spec.whatwg.org/multipage/obsolete.html#HTMLIFrameElement-partial">https://html.spec.whatwg.org/multipage/obsolete.html#HTMLIFrameElement-partial</a>

* Source/WebCore/html/HTMLIFrameElement.idl:

Canonical link: <a href="https://commits.webkit.org/270604@main">https://commits.webkit.org/270604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c78bc960f2e83b3b65bce31e7eab00c048c0a70a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28573 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29325 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27200 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4430 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6225 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->