### PR TITLE
REGRESSION (270339@main): [ iOS17 ] TestWebKitAPI.WebKit.InvalidConfiguration is a crash failure

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
@@ -52,7 +52,7 @@
         return nil;
 
 #if ENABLE(WKPDFVIEW)
-    if (!configuration.preferences->_preferences->unifiedPDFEnabled()) {
+    if (!configuration.preferences || !configuration.preferences->_preferences->unifiedPDFEnabled()) {
         for (auto& type : WebCore::MIMETypeRegistry::pdfMIMETypes())
             [self registerProvider:[WKPDFView class] forMIMEType:@(type.characters())];
     }


### PR DESCRIPTION
#### 29d1f69555f62b76db48809ab344b369e4e31603
<pre>
REGRESSION (270339@main): [ iOS17 ] TestWebKitAPI.WebKit.InvalidConfiguration is a crash failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=264609">https://bugs.webkit.org/show_bug.cgi?id=264609</a>
<a href="https://rdar.apple.com/118242512">rdar://118242512</a>

Reviewed by Alex Christensen.

* Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm:
(-[WKWebViewContentProviderRegistry initWithConfiguration:]):
ObjC null rules stop applying when you start using C++ ivars.

Canonical link: <a href="https://commits.webkit.org/270603@main">https://commits.webkit.org/270603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/545d2e6dfa8cc6399225f36f92b04039f9188847

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23716 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1938 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28579 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3021 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29331 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27206 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1260 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4435 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6224 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->