### PR TITLE
Use dynamicDowncast<T> more in the DOM

### DIFF
--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -37,7 +37,9 @@ namespace WebCore {
 static inline ScriptExecutionContext* suitableScriptExecutionContext(ScriptExecutionContext* scriptExecutionContext)
 {
     // For detached documents, make sure we observe their context document instead.
-    return is<Document>(scriptExecutionContext) ? &downcast<Document>(*scriptExecutionContext).contextDocument() : scriptExecutionContext;
+    if (auto* document = dynamicDowncast<Document>(scriptExecutionContext))
+        return &document->contextDocument();
+    return scriptExecutionContext;
 }
 
 inline ActiveDOMObject::ActiveDOMObject(ScriptExecutionContext* context, CheckedScriptExecutionContextType)

--- a/Source/WebCore/dom/ComposedTreeIterator.cpp
+++ b/Source/WebCore/dom/ComposedTreeIterator.cpp
@@ -59,9 +59,8 @@ ComposedTreeIterator::ComposedTreeIterator(ContainerNode& root, FirstChildTag)
 {
     ASSERT(!is<ShadowRoot>(root));
 
-    if (is<HTMLSlotElement>(root)) {
-        auto& slot = downcast<HTMLSlotElement>(root);
-        if (auto* assignedNodes = slot.assignedNodes()) {
+    if (auto* slot = dynamicDowncast<HTMLSlotElement>(root)) {
+        if (auto* assignedNodes = slot->assignedNodes()) {
             initializeContextStack(root, *assignedNodes->at(0));
             return;
         }
@@ -101,12 +100,11 @@ void ComposedTreeIterator::initializeContextStack(ContainerNode& root, Node& cur
             *this = { };
             return;
         }
-        if (is<ShadowRoot>(*parent)) {
-            auto& shadowRoot = downcast<ShadowRoot>(*parent);
-            m_contextStack.append(Context(shadowRoot, *contextCurrent));
+        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*parent)) {
+            m_contextStack.append(Context(*shadowRoot, *contextCurrent));
             m_contextStack.last().slotNodeIndex = currentSlotNodeIndex;
 
-            node = shadowRoot.host();
+            node = shadowRoot->host();
             contextCurrent = node;
             currentSlotNodeIndex = notFound;
             continue;
@@ -161,9 +159,8 @@ void ComposedTreeIterator::traverseNextInShadowTree()
 {
     ASSERT(m_contextStack.size() > 1 || m_rootIsInShadowTree);
 
-    if (is<HTMLSlotElement>(current())) {
-        auto& slot = downcast<HTMLSlotElement>(current());
-        if (auto* assignedNodes = slot.assignedNodes()) {
+    if (auto* slot = dynamicDowncast<HTMLSlotElement>(current())) {
+        if (auto* assignedNodes = slot->assignedNodes()) {
             context().slotNodeIndex = 0;
             auto* assignedNode = assignedNodes->at(0).get();
             ASSERT(assignedNode);

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -264,11 +264,12 @@ static ContainerNode::ChildChange makeChildChangeForInsertion(ContainerNode& con
         return ContainerNode::ChildChange::Type::NonContentsChildInserted;
     }();
 
+    auto* beforeChildElement = dynamicDowncast<Element>(beforeChild);
     return {
         changeType,
         dynamicDowncast<Element>(child),
         beforeChild ? ElementTraversal::previousSibling(*beforeChild) : ElementTraversal::lastChild(containerNode),
-        !beforeChild || is<Element>(*beforeChild) ? downcast<Element>(beforeChild) : ElementTraversal::nextSibling(*beforeChild),
+        !beforeChild || beforeChildElement ? beforeChildElement : ElementTraversal::nextSibling(*beforeChild),
         source,
         changeType == ContainerNode::ChildChange::Type::ElementInserted ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No
     };
@@ -926,8 +927,8 @@ void ContainerNode::cloneChildNodes(ContainerNode& clone)
 
             hadElement = hadElement || is<Element>(clonedChild);
         }
-        if (is<ContainerNode>(*child))
-            downcast<ContainerNode>(*child).cloneChildNodes(downcast<ContainerNode>(clonedChild));
+        if (RefPtr childAsContainerNode = dynamicDowncast<ContainerNode>(*child))
+            childAsContainerNode->cloneChildNodes(downcast<ContainerNode>(clonedChild));
     }
     clone.childrenChanged(makeChildChangeForCloneInsertion(hadElement ? ClonedChildIncludesElements::Yes : ClonedChildIncludesElements::No));
 

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -50,18 +50,20 @@ static void notifyNodeInsertedIntoDocument(ContainerNode& parentOfInsertedTree, 
     if (node.insertedIntoAncestor(Node::InsertionType { /* connectedToDocument */ true, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree) == Node::InsertedIntoAncestorResult::NeedsPostInsertionCallback)
         postInsertionNotificationTargets.append(node);
 
-    if (!is<ContainerNode>(node))
+    auto* containerNode = dynamicDowncast<ContainerNode>(node);
+    if (!containerNode)
         return;
 
-    for (RefPtr child = downcast<ContainerNode>(node).firstChild(); child; child = child->nextSibling()) {
+    for (RefPtr child = containerNode->firstChild(); child; child = child->nextSibling()) {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(node.isConnected() && child->parentNode() == &node);
         notifyNodeInsertedIntoDocument(parentOfInsertedTree, *child, treeScopeChange, postInsertionNotificationTargets);
     }
 
-    if (!is<Element>(node))
+    auto* element = dynamicDowncast<Element>(*containerNode);
+    if (!element)
         return;
 
-    if (RefPtr root = downcast<Element>(node).shadowRoot()) {
+    if (RefPtr root = element->shadowRoot()) {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(node.isConnected() && root->host() == &node);
         notifyNodeInsertedIntoDocument(parentOfInsertedTree, *root, TreeScopeChange::DidNotChange, postInsertionNotificationTargets);
     }
@@ -75,16 +77,18 @@ static void notifyNodeInsertedIntoTree(ContainerNode& parentOfInsertedTree, Node
     if (node.insertedIntoAncestor(Node::InsertionType { /* connectedToDocument */ false, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree) == Node::InsertedIntoAncestorResult::NeedsPostInsertionCallback)
         postInsertionNotificationTargets.append(node);
 
-    if (!is<ContainerNode>(node))
+    auto* containerNode = dynamicDowncast<ContainerNode>(node);
+    if (!containerNode)
         return;
 
-    for (RefPtr child = downcast<ContainerNode>(node).firstChild(); child; child = child->nextSibling())
+    for (RefPtr child = containerNode->firstChild(); child; child = child->nextSibling())
         notifyNodeInsertedIntoTree(parentOfInsertedTree, *child, treeScopeChange, postInsertionNotificationTargets);
 
-    if (!is<Element>(node))
+    auto* element = dynamicDowncast<Element>(*containerNode);
+    if (!element)
         return;
 
-    if (RefPtr root = downcast<Element>(node).shadowRoot())
+    if (RefPtr root = element->shadowRoot())
         notifyNodeInsertedIntoTree(parentOfInsertedTree, *root, TreeScopeChange::DidNotChange, postInsertionNotificationTargets);
 }
 
@@ -126,18 +130,20 @@ static RemovedSubtreeObservability notifyNodeRemovedFromDocument(ContainerNode& 
     node.removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ true, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
 
     auto observability = observabilityOfRemovedNode(node);
-    if (!is<ContainerNode>(node))
+    auto* containerNode = dynamicDowncast<ContainerNode>(node);
+    if (!containerNode)
         return observability;
 
-    for (RefPtr child = downcast<ContainerNode>(node).firstChild(); child; child = child->nextSibling()) {
+    for (RefPtr child = containerNode->firstChild(); child; child = child->nextSibling()) {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!node.isConnected() && child->parentNode() == &node);
         updateObservability(observability, notifyNodeRemovedFromDocument(oldParentOfRemovedTree, treeScopeChange, *child.get()));
     }
 
-    if (!is<Element>(node))
+    auto* element = dynamicDowncast<Element>(*containerNode);
+    if (!element)
         return observability;
 
-    if (RefPtr root = downcast<Element>(node).shadowRoot()) {
+    if (RefPtr root = element->shadowRoot()) {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!node.isConnected() && root->host() == &node);
         updateObservability(observability, notifyNodeRemovedFromDocument(oldParentOfRemovedTree, TreeScopeChange::DidNotChange, *root.get()));
     }
@@ -151,16 +157,18 @@ static RemovedSubtreeObservability notifyNodeRemovedFromTree(ContainerNode& oldP
     node.removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ false, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
 
     auto observability = observabilityOfRemovedNode(node);
-    if (!is<ContainerNode>(node))
+    auto* containerNode = dynamicDowncast<ContainerNode>(node);
+    if (!containerNode)
         return observability;
 
-    for (RefPtr child = downcast<ContainerNode>(node).firstChild(); child; child = child->nextSibling())
+    for (RefPtr child = containerNode->firstChild(); child; child = child->nextSibling())
         updateObservability(observability, notifyNodeRemovedFromTree(oldParentOfRemovedTree, treeScopeChange, *child));
 
-    if (!is<Element>(node))
+    auto* element  = dynamicDowncast<Element>(*containerNode);
+    if (!element)
         return observability;
 
-    if (RefPtr root = downcast<Element>(node).shadowRoot())
+    if (RefPtr root = element->shadowRoot())
         updateObservability(observability, notifyNodeRemovedFromTree(oldParentOfRemovedTree, TreeScopeChange::DidNotChange, *root));
 
     return observability;
@@ -207,11 +215,12 @@ static unsigned assertConnectedSubrameCountIsConsistent(ContainerNode& node)
 {
     unsigned count = 0;
 
-    if (is<Element>(node)) {
-        if (is<HTMLFrameOwnerElement>(node) && downcast<HTMLFrameOwnerElement>(node).contentFrame())
+    if (auto* element = dynamicDowncast<Element>(node)) {
+        auto* frameOwnerElement = dynamicDowncast<HTMLFrameOwnerElement>(*element);
+        if (frameOwnerElement && frameOwnerElement->contentFrame())
             ++count;
 
-        if (ShadowRoot* root = downcast<Element>(node).shadowRoot())
+        if (RefPtr root = element->shadowRoot())
             count += assertConnectedSubrameCountIsConsistent(*root);
     }
 
@@ -243,8 +252,8 @@ static void collectFrameOwners(Vector<Ref<HTMLFrameOwnerElement>>& frameOwners, 
             continue;
         }
 
-        if (is<HTMLFrameOwnerElement>(element))
-            frameOwners.append(downcast<HTMLFrameOwnerElement>(element));
+        if (RefPtr frameOwnerElement = dynamicDowncast<HTMLFrameOwnerElement>(element))
+            frameOwners.append(frameOwnerElement.releaseNonNull());
 
         if (ShadowRoot* shadowRoot = element.shadowRoot())
             collectFrameOwners(frameOwners, *shadowRoot);
@@ -262,8 +271,8 @@ void disconnectSubframes(ContainerNode& root, SubframeDisconnectPolicy policy)
     Vector<Ref<HTMLFrameOwnerElement>> frameOwners;
 
     if (policy == SubframeDisconnectPolicy::RootAndDescendants) {
-        if (is<HTMLFrameOwnerElement>(root))
-            frameOwners.append(downcast<HTMLFrameOwnerElement>(root));
+        if (RefPtr rootElement = dynamicDowncast<HTMLFrameOwnerElement>(root))
+            frameOwners.append(rootElement.releaseNonNull());
     }
 
     collectFrameOwners(frameOwners, root);

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -158,13 +158,15 @@ static void upgradeElementsInShadowIncludingDescendants(ContainerNode& root)
 
 void CustomElementRegistry::upgrade(Node& root)
 {
-    if (!is<ContainerNode>(root))
+    auto* containerNode = dynamicDowncast<ContainerNode>(root);
+    if (!containerNode)
         return;
 
-    if (is<Element>(root) && downcast<Element>(root).isCustomElementUpgradeCandidate())
-        CustomElementReactionQueue::tryToUpgradeElement(downcast<Element>(root));
+    auto* element = dynamicDowncast<Element>(*containerNode);
+    if (element && element->isCustomElementUpgradeCandidate())
+        CustomElementReactionQueue::tryToUpgradeElement(*element);
 
-    upgradeElementsInShadowIncludingDescendants(downcast<ContainerNode>(root));
+    upgradeElementsInShadowIncludingDescendants(*containerNode);
 }
 
 template<typename Visitor>

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -539,8 +539,8 @@ void DataTransfer::setDragImage(Element& element, int x, int y)
         return;
 
     CachedResourceHandle<CachedImage> image;
-    if (is<HTMLImageElement>(element) && !element.isConnected())
-        image = downcast<HTMLImageElement>(element).cachedImage();
+    if (auto* imageElement = dynamicDowncast<HTMLImageElement>(element); imageElement && !imageElement->isConnected())
+        image = imageElement->cachedImage();
 
     m_dragLocation = IntPoint(x, y);
 

--- a/Source/WebCore/dom/DocumentTouch.cpp
+++ b/Source/WebCore/dom/DocumentTouch.cpp
@@ -40,9 +40,9 @@ namespace WebCore {
 Ref<Touch> DocumentTouch::createTouch(Document& document, RefPtr<WindowProxy>&& window, EventTarget* target, int identifier, int pageX, int pageY, int screenX, int screenY, int radiusX, int radiusY, float rotationAngle, float force)
 {
     RefPtr<LocalFrame> frame;
-    if (window && is<LocalFrame>(window->frame()))
-        frame = downcast<LocalFrame>(window->frame());
-    else
+    if (window)
+        frame = dynamicDowncast<LocalFrame>(window->frame());
+    if (!frame)
         frame = document.frame();
 
     // FIXME: It's not clear from the documentation at


### PR DESCRIPTION
#### b1c357dd6e0f3eede4100c8152dc5be930a2b55d
<pre>
Use dynamicDowncast&lt;T&gt; more in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=264695">https://bugs.webkit.org/show_bug.cgi?id=264695</a>

Reviewed by Ryosuke Niwa.

Use dynamicDowncast&lt;T&gt; more in the DOM instead of is&lt;T&gt;() + downcast&lt;T&gt;(). It is
less error-prone and often results in more concise code. I am also hoping to
have downcast&lt;&gt;() do a type check on release builds in the future. It is
currently too expensive to do so but it may become affordable if we use
dynamicDowncast&lt;T&gt;() instead when possible.

* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::suitableScriptExecutionContext):
* Source/WebCore/dom/ComposedTreeIterator.cpp:
(WebCore::ComposedTreeIterator::ComposedTreeIterator):
(WebCore::ComposedTreeIterator::initializeContextStack):
(WebCore::ComposedTreeIterator::traverseNextInShadowTree):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::makeChildChangeForInsertion):
(WebCore::ContainerNode::cloneChildNodes):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyNodeInsertedIntoDocument):
(WebCore::notifyNodeInsertedIntoTree):
(WebCore::notifyNodeRemovedFromDocument):
(WebCore::notifyNodeRemovedFromTree):
(WebCore::assertConnectedSubrameCountIsConsistent):
(WebCore::collectFrameOwners):
(WebCore::disconnectSubframes):
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::upgrade):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::setDragImage):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::doctype const):
(WebCore::Document::childrenChanged):
(WebCore::Document::adoptNode):
(WebCore::selectNewTitleElement):
(WebCore::Document::updateLayoutIfDimensionsOutOfDate):
(WebCore::Document::willBeRemovedFromFrame):
(WebCore::Document::setFocusedElement):
(WebCore::Document::focusNavigationStartingNode const):
(WebCore::Document::getCSSCanvasContext):
(WebCore::Document::serviceRequestVideoFrameCallbacks):
(WebCore::Document::absoluteEventRegionForNode):
(WebCore::eventTargetElementForDocument):
(WebCore::Document::updateHoverActiveState):
(WebCore::Document::dir const):
(WebCore::Document::setDir):
(WebCore::Document::keyframesRuleDidChange):
(WebCore::Document::addTopLayerElement):
(WebCore::Document::activeModalDialog const):
(WebCore::Document::handlePopoverLightDismiss):
(WebCore::Document::canvasChanged):
(WebCore::Document::canvasDestroyed):
* Source/WebCore/dom/DocumentTouch.cpp:
(WebCore::DocumentTouch::createTouch):
(WebCore::DocumentTouch::createTouchList): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cloneShadowTreeIfPossible):
(WebCore::Element::synchronizeAllAttributes const):
(WebCore::Element::synchronizeAttribute const):
(WebCore::listBoxElementScrollIntoView):
(WebCore::Element::absoluteEventBounds):
(WebCore::listBoxElementBoundingBox):
(WebCore::Element::removeAttribute):
(WebCore::Element::setOuterHTML):
(WebCore::Element::setInnerHTML):
(WebCore::forEachRenderLayer):
(WebCore::Element::resolveComputedStyle):
(WebCore::Element::childShouldCreateRenderer const):
(WebCore::Element::fastAttributeLookupAllowed const):
(WebCore::Element::updateName):
(WebCore::Element::updateId):
(WebCore::Element::cloneAttributesFromElement):
(WebCore::contextElementForInsertion):

Canonical link: <a href="https://commits.webkit.org/270617@main">https://commits.webkit.org/270617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/387bc6ca9fef541dcbfedb40d345e93e52cf2067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23810 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28591 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29342 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27217 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1270 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3512 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3328 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->