### PR TITLE
Generate serializers for NSArray, NSDictionary, and NSFont

### DIFF
--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO) && ENABLE(DATACUE_VALUE)
 
 #include "SerializedPlatformDataCue.h"
+#include <wtf/HashSet.h>
 
 namespace WebCore {
 
@@ -46,7 +47,7 @@ public:
 
     id nativeValue() const { return m_nativeValue.get(); }
 
-    WEBCORE_EXPORT static const Vector<Class>& allowedClassesForNativeValues();
+    WEBCORE_EXPORT static const HashSet<Class>& allowedClassesForNativeValues();
 
 private:
 

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -109,9 +109,9 @@ const SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(const Seriali
     return static_cast<const SerializedPlatformDataCueMac*>(rep);
 }
 
-const Vector<Class>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
+const HashSet<Class>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
 {
-    static NeverDestroyed<Vector<Class>> allowedClasses(Vector<Class> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
+    static NeverDestroyed<HashSet<Class>> allowedClasses(HashSet<Class> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
     return allowedClasses;
 }
 

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -32,6 +32,7 @@
 #include <wtf/Algorithms.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Function.h>
+#include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
@@ -167,14 +168,14 @@ public:
 
 #ifdef __OBJC__
     template<typename T, typename = IsObjCObject<T>>
-    std::optional<RetainPtr<T>> decodeWithAllowedClasses(const Vector<ClassStructPtr>& allowedClasses = { getClass<T>() })
+    std::optional<RetainPtr<T>> decodeWithAllowedClasses(const HashSet<ClassStructPtr>& allowedClasses = { getClass<T>() })
     {
         m_allowedClasses = allowedClasses;
         return IPC::decodeRequiringAllowedClasses<T>(*this);
     }
 
     template<typename T, typename = IsNotObjCObject<T>>
-    std::optional<T> decodeWithAllowedClasses(const Vector<ClassStructPtr>& allowedClasses)
+    std::optional<T> decodeWithAllowedClasses(const HashSet<ClassStructPtr>& allowedClasses)
     {
         m_allowedClasses = allowedClasses;
         return decode<T>();
@@ -182,7 +183,7 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
-    const Vector<ClassStructPtr>& allowedClasses() const { return m_allowedClasses; }
+    HashSet<ClassStructPtr>& allowedClasses() { return m_allowedClasses; }
 #endif
 
     std::optional<Attachment> takeLastAttachment();
@@ -204,7 +205,7 @@ private:
     ImportanceAssertion m_importanceAssertion;
 #endif
 #if PLATFORM(COCOA)
-    Vector<ClassStructPtr> m_allowedClasses;
+    HashSet<ClassStructPtr> m_allowedClasses;
 #endif
 
     uint64_t m_destinationID;

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -69,9 +69,11 @@ enum class NSType : uint8_t {
     Unknown,
 };
 NSType typeFromObject(id);
+bool isSerializableValue(id);
+
 
 void encodeObjectWithWrapper(Encoder&, id);
-std::optional<RetainPtr<id>> decodeObjectFromWrapper(Decoder&, const Vector<Class>& allowedClasses);
+std::optional<RetainPtr<id>> decodeObjectFromWrapper(Decoder&, const HashSet<Class>& allowedClasses);
 
 template<typename T> void encodeObjectDirectly(Encoder&, T *);
 template<typename T> void encodeObjectDirectly(Encoder&, T);
@@ -81,7 +83,7 @@ template<typename T, typename = IsObjCObject<T>> void encode(Encoder&, T *);
 
 #if ASSERT_ENABLED
 
-static inline bool isObjectClassAllowed(id object, const Vector<Class>& allowedClasses)
+static inline bool isObjectClassAllowed(id object, const HashSet<Class>& allowedClasses)
 {
     for (Class allowedClass : allowedClasses) {
         if ([object isKindOfClass:allowedClass])

--- a/Source/WebKit/Shared/Cocoa/CoreIPCArray.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCArray.h
@@ -29,27 +29,31 @@
 
 #include "ArgumentCodersCocoa.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/UniqueRef.h>
 
 namespace WebKit {
 
+class CoreIPCNSCFObject;
+
 class CoreIPCArray {
 public:
-    CoreIPCArray(NSArray *array)
-        : m_array(array)
+    CoreIPCArray(NSArray *);
+    CoreIPCArray(const RetainPtr<NSArray>& array)
+        : CoreIPCArray(array.get())
     {
     }
 
-    CoreIPCArray(RetainPtr<NSArray> array)
-        : m_array(WTFMove(array))
-    {
-    }
-
-    RetainPtr<id> toID() { return m_array; }
+    RetainPtr<id> toID() const;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCArray, void>;
 
-    IPC::CoreIPCRetainPtr<NSArray> m_array;
+    CoreIPCArray(Vector<UniqueRef<CoreIPCNSCFObject>>&& array)
+        : m_array(WTFMove(array))
+    {
+    }
+
+    Vector<UniqueRef<CoreIPCNSCFObject>> m_array;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCArray.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCArray.serialization.in
@@ -25,7 +25,7 @@
 webkit_platform_headers: "CoreIPCArray.h"
 
 [WebKitPlatform] class WebKit::CoreIPCArray {
-    IPC::CoreIPCRetainPtr<NSArray> m_array;
+    Vector<UniqueRef<WebKit::CoreIPCNSCFObject>> m_array;
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
@@ -43,7 +43,7 @@ public:
     {
     }
 
-    RetainPtr<id> toID() { return (__bridge id)(m_cfType.get()); }
+    RetainPtr<id> toID() const { return (__bridge id)(m_cfType.get()); }
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCCFType, void>;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCColor.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCColor.h
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    RetainPtr<id> toID()
+    RetainPtr<id> toID() const
     {
         return cocoaColor(m_color);
     }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
@@ -28,27 +28,37 @@
 #if PLATFORM(COCOA)
 
 #include <wtf/ArgumentCoder.h>
+#include <wtf/KeyValuePair.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/Vector.h>
 
 namespace WebKit {
 
+class CoreIPCNSCFObject;
+
 class CoreIPCDictionary {
 public:
-    CoreIPCDictionary(NSDictionary *dictionary)
-        : m_dictionary(dictionary)
+    CoreIPCDictionary(NSDictionary *);
+
+    CoreIPCDictionary(const RetainPtr<NSDictionary>& dictionary)
+        : CoreIPCDictionary(dictionary.get())
     {
     }
 
-    CoreIPCDictionary(RetainPtr<NSDictionary>&& dictionary)
-        : m_dictionary(WTFMove(dictionary))
-    {
-    }
-
-    RetainPtr<id> toID() { return m_dictionary; }
+    RetainPtr<id> toID() const;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCDictionary, void>;
 
-    IPC::CoreIPCRetainPtr<NSDictionary> m_dictionary;
+    using ValueType = Vector<KeyValuePair<UniqueRef<CoreIPCNSCFObject>, UniqueRef<CoreIPCNSCFObject>>>;
+
+    CoreIPCDictionary(ValueType&& keyValuePairs)
+        : m_keyValuePairs(WTFMove(keyValuePairs))
+    {
+    }
+
+    ValueType m_keyValuePairs;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in
@@ -25,7 +25,7 @@
 webkit_platform_headers: "CoreIPCDictionary.h"
 
 [WebKitPlatform] class WebKit::CoreIPCDictionary {
-    IPC::CoreIPCRetainPtr<NSDictionary> m_dictionary;
+    Vector<KeyValuePair<UniqueRef<WebKit::CoreIPCNSCFObject>, UniqueRef<WebKit::CoreIPCNSCFObject>>> m_keyValuePairs;
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCFont.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCFont.h
@@ -28,6 +28,7 @@
 #if PLATFORM(COCOA)
 
 #include "ArgumentCodersCocoa.h"
+#include "CoreIPCDictionary.h"
 #include <WebCore/FontCocoa.h>
 #include <wtf/ArgumentCoder.h>
 
@@ -35,22 +36,24 @@ namespace WebKit {
 
 class CoreIPCFont {
 public:
-    CoreIPCFont(WebCore::CocoaFont *font)
-        : m_font(font)
-    {
-    }
+    CoreIPCFont(WebCore::CocoaFont *);
 
     CoreIPCFont(RetainPtr<WebCore::CocoaFont>&& font)
-        : m_font(WTFMove(font))
+        : CoreIPCFont(font.get())
     {
     }
 
-    RetainPtr<id> toID() { return m_font; }
+    RetainPtr<id> toID() const;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCFont, void>;
 
-    IPC::CoreIPCRetainPtr<WebCore::CocoaFont> m_font;
+    CoreIPCFont(CoreIPCDictionary&& attributes)
+        : m_fontDescriptorAttributes(WTFMove(attributes))
+    {
+    }
+
+    CoreIPCDictionary m_fontDescriptorAttributes;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCFont.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCFont.mm
@@ -23,29 +23,37 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CoreIPCFont.h"
 
 #if PLATFORM(COCOA)
 
-#include "ArgumentCodersCocoa.h"
-#include <wtf/RetainPtr.h>
+#import "CoreIPCNSCFObject.h"
+#import "CoreTextHelpers.h"
+#import <wtf/BlockObjCExceptions.h>
+
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIFont.h>
+#import <UIKit/UIFontDescriptor.h>
+#endif
 
 namespace WebKit {
 
-class CoreIPCSecureCoding {
-public:
-    CoreIPCSecureCoding(NSObject<NSSecureCoding> *);
-    CoreIPCSecureCoding(RetainPtr<NSObject<NSSecureCoding>>&&);
+CoreIPCFont::CoreIPCFont(WebCore::CocoaFont *font)
+    : m_fontDescriptorAttributes(font.fontDescriptor.fontAttributes)
+{
+}
 
-    RetainPtr<id> toID() const { return m_secureCoding; }
+RetainPtr<id> CoreIPCFont::toID() const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    Class objectClass() { return m_secureCoding.get().class; }
+    return { WebKit::fontWithAttributes(m_fontDescriptorAttributes.toID().get(), 0) };
 
-private:
-    friend struct IPC::ArgumentCoder<CoreIPCSecureCoding, void>;
+    END_BLOCK_OBJC_EXCEPTIONS
 
-    IPC::CoreIPCRetainPtr<NSObject<NSSecureCoding>> m_secureCoding;
-};
+    return nullptr;
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCFont.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCFont.serialization.in
@@ -25,7 +25,7 @@
 webkit_platform_headers: "CoreIPCFont.h"
 
 [WebKitPlatform] class WebKit::CoreIPCFont {
-    IPC::CoreIPCRetainPtr<WebCore::CocoaFont> m_font;
+    WebKit::CoreIPCDictionary m_fontDescriptorAttributes;
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -43,6 +43,7 @@
 namespace WebKit {
 
 class CoreIPCNSCFObject {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     using ObjectValue = std::variant<
         std::nullptr_t,
@@ -61,7 +62,9 @@ public:
 
     CoreIPCNSCFObject(id);
 
-    RetainPtr<id> toID();
+    RetainPtr<id> toID() const;
+
+    static bool valueIsAllowed(IPC::Decoder&, ObjectValue&);
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCNSCFObject, void>;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -71,7 +71,7 @@ CoreIPCNSCFObject::CoreIPCNSCFObject(id object)
 {
 }
 
-RetainPtr<id> CoreIPCNSCFObject::toID()
+RetainPtr<id> CoreIPCNSCFObject::toID() const
 {
     RetainPtr<id> result;
 
@@ -82,6 +82,20 @@ RetainPtr<id> CoreIPCNSCFObject::toID()
     });
 
     return result;
+}
+
+bool CoreIPCNSCFObject::valueIsAllowed(IPC::Decoder& decoder, ObjectValue& value)
+{
+    // The Decoder always has a set of allowedClasses,
+    // but we only check that set when considering SecureCoding classes
+    Class objectClass;
+    WTF::switchOn(value, [&](CoreIPCSecureCoding& object) {
+        objectClass = object.objectClass();
+    }, [&](auto& object) {
+        objectClass = nullptr;
+    });
+
+    return !objectClass || decoder.allowedClasses().contains(objectClass);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -25,7 +25,7 @@
 webkit_platform_headers: "ArgumentCodersCocoa.h" "ArgumentCodersCF.h" "CoreIPCNSCFObject.h"
 
 [WebKitPlatform] class WebKit::CoreIPCNSCFObject {
-    WebKit::CoreIPCNSCFObject::ObjectValue m_value;
+    [Validator='WebKit::CoreIPCNSCFObject::valueIsAllowed(decoder, *m_value)'] WebKit::CoreIPCNSCFObject::ObjectValue m_value;
 }
 
 #endif // USE(CF)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCString.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCString.h
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    RetainPtr<id> toID() { return (NSString *)m_string; }
+    RetainPtr<id> toID() const { return (NSString *)m_string; }
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCString, void>;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCURL.h
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    RetainPtr<id> toID() { return (NSURL *)m_url; }
+    RetainPtr<id> toID() const { return (NSURL *)m_url; }
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCURL, void>;

--- a/Source/WebKit/Shared/cf/CoreIPCNumber.h
+++ b/Source/WebKit/Shared/cf/CoreIPCNumber.h
@@ -166,7 +166,7 @@ public:
         return m_numberHolder;
     }
 
-    RetainPtr<id> toID() { return bridge_cast(createCFNumber().get()); }
+    RetainPtr<id> toID() const { return bridge_cast(createCFNumber().get()); }
 
 private:
     NumberHolder m_numberHolder;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1172,6 +1172,9 @@
 		517D7B812AAA624500BAA3EB /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* WebKit.framework */; };
 		5183722223CE97410003CF83 /* APIContentWorld.h in Headers */ = {isa = PBXBuildFile; fileRef = 5183722023CE973A0003CF83 /* APIContentWorld.h */; };
 		51871B5C127CB89D00F76232 /* WebContextMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = 51871B5A127CB89D00F76232 /* WebContextMenu.h */; };
+		5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5187BDE82AFF4A3A008A6EE5 /* CoreIPCArray.mm */; };
+		5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */; };
+		5187BDF02B007445008A6EE5 /* CoreIPCFont.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5187BDEF2B007445008A6EE5 /* CoreIPCFont.mm */; };
 		518ACAEA12AEE6BB00B04B83 /* WKProtectionSpaceTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 518ACAE912AEE6BB00B04B83 /* WKProtectionSpaceTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		518ACF1112B015F800B04B83 /* WKCredentialTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 518ACF1012B015F800B04B83 /* WKCredentialTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		518D2CAE12D5153B003BB93B /* WebBackForwardListItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 518D2CAC12D5153B003BB93B /* WebBackForwardListItem.h */; };
@@ -5201,6 +5204,9 @@
 		518405282A9E861F00630A12 /* com.apple.webkit.webpushd.relocatable.mac.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.apple.webkit.webpushd.relocatable.mac.plist; sourceTree = "<group>"; };
 		51871B59127CB89D00F76232 /* WebContextMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebContextMenu.cpp; sourceTree = "<group>"; };
 		51871B5A127CB89D00F76232 /* WebContextMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebContextMenu.h; sourceTree = "<group>"; };
+		5187BDE82AFF4A3A008A6EE5 /* CoreIPCArray.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCArray.mm; sourceTree = "<group>"; };
+		5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDictionary.mm; sourceTree = "<group>"; };
+		5187BDEF2B007445008A6EE5 /* CoreIPCFont.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCFont.mm; sourceTree = "<group>"; };
 		518ACAE912AEE6BB00B04B83 /* WKProtectionSpaceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKProtectionSpaceTypes.h; sourceTree = "<group>"; };
 		518ACF1012B015F800B04B83 /* WKCredentialTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKCredentialTypes.h; sourceTree = "<group>"; };
 		518D2CAB12D5153B003BB93B /* WebBackForwardListItem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebBackForwardListItem.cpp; sourceTree = "<group>"; };
@@ -10726,6 +10732,7 @@
 				37BEC4DF19491486008B4286 /* CompletionHandlerCallChecker.h */,
 				37BEC4DE19491486008B4286 /* CompletionHandlerCallChecker.mm */,
 				5197FACD2AFD33AF009180C5 /* CoreIPCArray.h */,
+				5187BDE82AFF4A3A008A6EE5 /* CoreIPCArray.mm */,
 				5197FAD82AFD33B1009180C5 /* CoreIPCArray.serialization.in */,
 				5197FAE22AFD33B4009180C5 /* CoreIPCCFType.h */,
 				5197FAD62AFD33B1009180C5 /* CoreIPCCFType.serialization.in */,
@@ -10736,8 +10743,10 @@
 				F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */,
 				F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */,
 				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
+				5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */,
 				5197FADE2AFD33B3009180C5 /* CoreIPCDictionary.serialization.in */,
 				5197FAD72AFD33B1009180C5 /* CoreIPCFont.h */,
+				5187BDEF2B007445008A6EE5 /* CoreIPCFont.mm */,
 				5197FACA2AFD33AE009180C5 /* CoreIPCFont.serialization.in */,
 				5197FACE2AFD33AF009180C5 /* CoreIPCNSCFObject.h */,
 				5197FADC2AFD33B2009180C5 /* CoreIPCNSCFObject.mm */,
@@ -17754,6 +17763,9 @@
 				5131D5452AE9D5140016EF39 /* ArgumentCodersCF.cpp in Sources */,
 				51FFD3092AE9A9FC00B0AB70 /* ArgumentCodersCocoa.mm in Sources */,
 				5131D5442AE9D4370016EF39 /* ArgumentCodersCocoa.mm in Sources */,
+				5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */,
+				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,
+				5187BDF02B007445008A6EE5 /* CoreIPCFont.mm in Sources */,
 				5197FAF22AFD33FF009180C5 /* CoreIPCNSCFObject.mm in Sources */,
 				5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */,
 				5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */,


### PR DESCRIPTION
#### 6be1434f578ebcb90ea96a1c71bca5348812e60a
<pre>
Generate serializers for NSArray, NSDictionary, and NSFont
<a href="https://bugs.webkit.org/show_bug.cgi?id=264696">https://bugs.webkit.org/show_bug.cgi?id=264696</a>

Reviewed by Alex Christensen.

Now that we have the base CoreIPCNSCFObject wrapper and .serialization.in files for fundamental NS types, we can:
- Turn NSArray into a &quot;Vector of CoreIPCNSCFObjects&quot;
- Turn NSDictionary into a &quot;Vector of key/value pairs where the keys and values are CoreIPCNSCFObjects&quot;
- Directly serialize NSFont/UIFont, since we used an NSDictionary to do so before

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::isSerializableValue):
(IPC::encodeObjectDirectly&lt;NSArray&gt;): Deleted.
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSArray&gt;): Deleted.
(IPC::encodeObjectDirectly&lt;NSDictionary&gt;): Deleted.
(IPC::id&gt;&gt;): Deleted.
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSDictionary&gt;): Deleted.
(IPC::encodeObjectDirectly&lt;WebCore::CocoaFont&gt;): Deleted.
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;WebCore::CocoaFont&gt;): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCArray.h:
(WebKit::CoreIPCArray::CoreIPCArray):
(WebKit::CoreIPCArray::toID): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCArray.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h.
(WebKit::CoreIPCArray::CoreIPCArray):
(WebKit::CoreIPCArray::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCArray.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h:
(WebKit::CoreIPCDictionary::CoreIPCDictionary):
(WebKit::CoreIPCDictionary::toID): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h.
(WebKit::CoreIPCDictionary::CoreIPCDictionary):
(WebKit::CoreIPCDictionary::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCFont.h:
(WebKit::CoreIPCFont::CoreIPCFont):
(WebKit::CoreIPCFont::toID): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCFont.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCArray.h.
(WebKit::CoreIPCFont::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCFont.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::CoreIPCNSCFObject::valueIsAllowed):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h:
(WebKit::CoreIPCSecureCoding::objectClass):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(operator==):
(TEST):

Canonical link: <a href="https://commits.webkit.org/270624@main">https://commits.webkit.org/270624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f67fcef417335143f034668281b06e238a4cf5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28056 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28636 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29379 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27256 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1309 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4491 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6237 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->