### PR TITLE
REGRESSION(270035@main): Introduced test timeouts in WPE/GTK ports

### DIFF
--- a/LayoutTests/platform/glib/fast/dom/object-load-pdf-data-url-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/object-load-pdf-data-url-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: webviewerloaded: SecurityError: Blocked a frame with origin "webkit-pdfjs-viewer://pdfjs" from accessing a cross-origin frame. Protocols, domains, and ports must match.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'webkit-pdfjs-viewer://pdfjs' and allow attribute ''.
-CONSOLE MESSAGE: Invalid or corrupted PDF file.
-
-PDF.js v4.0.189 (build: 50f52b43a)
-Message: Invalid PDF structure.
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidPDFException: Invalid PDF structure.
 Tests that loading a data URL with a PDF MIME type inside an does not dispatch an error event.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -118,7 +118,7 @@ const TestFeatures& TestOptions::defaults()
             { "NeedsStorageAccessFromFileURLsQuirk", false },
             { "OfflineWebApplicationCacheEnabled", true },
             { "PageVisibilityBasedProcessSuppressionEnabled", false },
-            { "PdfJSViewerEnabled", false },
+            { "PDFJSViewerEnabled", false },
             { "PluginsEnabled", true },
             { "PushAPIEnabled", true },
             { "RequiresUserGestureForAudioPlayback", false },


### PR DESCRIPTION
#### ecf416c989d65a6cfed8592f00acadb479ebe334
<pre>
REGRESSION(270035@main): Introduced test timeouts in WPE/GTK ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=264698">https://bugs.webkit.org/show_bug.cgi?id=264698</a>

Reviewed by Carlos Garcia Campos.

* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults): Adapt TestOptions to the new name of the PDFJS setting.

Canonical link: <a href="https://commits.webkit.org/270625@main">https://commits.webkit.org/270625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be7d5422d6d34ed8b12a7b569ea00d864600dce5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23820 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28603 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29352 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1279 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4459 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6238 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3525 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->