### PR TITLE
[UIAsyncTextInput] Adopt APIs to delete, move and extend the selection

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1233,6 +1233,16 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 @end
 
+@protocol UIAsyncTextInput_Staging_117155812 <UIAsyncTextInput>
+
+- (void)deleteInDirection:(UITextStorageDirection)direction toGranularity:(UITextGranularity)granularity;
+- (void)moveInDirection:(UITextStorageDirection)direction byGranularity:(UITextGranularity)granularity;
+- (void)extendInDirection:(UITextStorageDirection)direction byGranularity:(UITextGranularity)granularity;
+- (void)moveInLayoutDirection:(UITextLayoutDirection)direction;
+- (void)extendInLayoutDirection:(UITextLayoutDirection)direction;
+
+@end
+
 #endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
 
 WTF_EXTERN_C_BEGIN


### PR DESCRIPTION
#### a81c6d7c94db5858e90a21b05149eaee5357d773
<pre>
[UIAsyncTextInput] Adopt APIs to delete, move and extend the selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=264711">https://bugs.webkit.org/show_bug.cgi?id=264711</a>
<a href="https://rdar.apple.com/118304457">rdar://118304457</a>

Reviewed by Aditya Keerthi.

Adopt the following methods for moving or extending the selection, or deleting text:

```
@protocol UIAsyncTextInput
- (void)deleteInDirection:(UITextStorageDirection)direction toGranularity:(UITextGranularity)granularity;
- (void)moveInDirection:(UITextStorageDirection)direction byGranularity:(UITextGranularity)granularity;
- (void)extendInDirection:(UITextStorageDirection)direction byGranularity:(UITextGranularity)granularity;
- (void)moveInLayoutDirection:(UITextLayoutDirection)direction;
- (void)extendInLayoutDirection:(UITextLayoutDirection)direction;
@end
```

This takes the place of the following SPI and IPI selectors in UIKit:

```
-_deleteByWord
-_deleteForwardByWord
-_deleteToStartOfLine
-_deleteToEndOfLine
-_deleteToEndOfParagraph
-_deleteForwardAndNotify:
-_moveUp:withHistory:
-_moveDown:withHistory:
-_moveLeft:withHistory:
-_moveRight:withHistory:
-_moveToStartOfWord:withHistory:
-_moveToStartOfParagraph:withHistory:
-_moveToStartOfLine:withHistory:
-_moveToStartOfDocument:withHistory:
-_moveToEndOfWord:withHistory:
-_moveToEndOfParagraph:withHistory:
-_moveToEndOfLine:withHistory:
-_moveToEndOfDocument:withHistory:
```

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Add staging declarations for the new API methods.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformAction:withSender:]):
(-[WKContentView cutForWebView:]):
(-[WKContentView toggleBoldfaceForWebView:]):
(-[WKContentView toggleItalicsForWebView:]):
(-[WKContentView toggleUnderlineForWebView:]):
(-[WKContentView _executeEditCommand:]):

Rename `-executeEditCommandWithCallback:` to `-_executeEditCommand:`; the existing name is a bit
misleading, since it doesn&apos;t take a callback.

(-[WKContentView _deleteByWord]):
(-[WKContentView _deleteForwardByWord]):
(-[WKContentView _deleteToStartOfLine]):
(-[WKContentView _deleteToEndOfLine]):
(-[WKContentView _deleteForwardAndNotify:]):
(-[WKContentView _deleteToEndOfParagraph]):
(-[WKContentView _transpose]):
(-[WKContentView _moveUp:withHistory:]):
(-[WKContentView _moveDown:withHistory:]):
(-[WKContentView _moveLeft:withHistory:]):
(-[WKContentView _moveRight:withHistory:]):
(-[WKContentView _moveToStartOfWord:withHistory:]):
(-[WKContentView _moveToStartOfParagraph:withHistory:]):
(-[WKContentView _moveToStartOfLine:withHistory:]):
(-[WKContentView _moveToStartOfDocument:withHistory:]):
(-[WKContentView _moveToEndOfWord:withHistory:]):
(-[WKContentView _moveToEndOfParagraph:withHistory:]):
(-[WKContentView _moveToEndOfLine:withHistory:]):
(-[WKContentView _moveToEndOfDocument:withHistory:]):
(moveSelectionCommand):
(extendSelectionCommand):

Add helper methods to return a command (or list of commands) to execute, given `UITextGranularity`,
`UITextStorageDirection` and `UITextLayoutDirection`.

(-[WKContentView deleteInDirection:toGranularity:]):
(-[WKContentView moveInDirection:byGranularity:]):
(-[WKContentView moveInLayoutDirection:]):
(-[WKContentView extendInDirection:byGranularity:]):
(-[WKContentView extendInLayoutDirection:]):
(-[WKContentView executeEditCommandWithCallback:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/270671@main">https://commits.webkit.org/270671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/925253212605475b1bb0d1d3eadd39f9bc771fb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28038 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23754 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23832 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28618 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3052 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29364 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27240 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1292 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4474 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6273 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->