### PR TITLE
[Site Isolation] Begin implementing window.focus()

### DIFF
--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -28,5 +28,6 @@ interface mixin DOMWindow {
     [CallWith=CurrentGlobalObject&IncumbentWindow, DoNotCheckSecurity] undefined postMessage(any message, optional WindowPostMessageOptions options);
     [DoNotCheckSecurity, PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
     [DoNotCheckSecurity, CallWith=IncumbentDocument] undefined close();
+    [DoNotCheckSecurity, CallWith=IncumbentWindow] undefined focus();
     [DoNotCheckSecurityOnGetter, CustomSetter] attribute WindowProxy? opener;
 };

--- a/Source/WebCore/page/LocalDOMWindow.idl
+++ b/Source/WebCore/page/LocalDOMWindow.idl
@@ -62,7 +62,6 @@
     attribute DOMString status;
     [DoNotCheckSecurity] readonly attribute boolean closed;
     undefined stop();
-    [DoNotCheckSecurity, CallWith=IncumbentWindow] undefined focus();
     [DoNotCheckSecurity] undefined blur();
 
     // other browsing contexts

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -74,7 +74,9 @@ bool RemoteDOMWindow::closed() const
 
 void RemoteDOMWindow::focus(LocalDOMWindow&)
 {
-    // FIXME: Implemented this. <rdar://116203970>
+    // FIXME(264713): Add security checks here equivalent to LocalDOMWindow::focus().
+    if (m_frame && m_frame->isMainFrame())
+        m_frame->client().focus();
 }
 
 void RemoteDOMWindow::blur()

--- a/Source/WebCore/page/RemoteDOMWindow.idl
+++ b/Source/WebCore/page/RemoteDOMWindow.idl
@@ -44,7 +44,6 @@
     [LegacyUnforgeable, ImplementedAs=self] readonly attribute WindowProxy window;
     [Replaceable] readonly attribute WindowProxy self;
     readonly attribute boolean closed;
-    [CallWith=IncumbentWindow] undefined focus();
     undefined blur();
     [Replaceable, ImplementedAs=self] readonly attribute WindowProxy frames;
     [Replaceable] readonly attribute unsigned long length;

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -47,6 +47,7 @@ public:
     virtual String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>) = 0;
     virtual void broadcastFrameRemovalToOtherProcesses() = 0;
     virtual void close() = 0;
+    virtual void focus() = 0;
     virtual ~RemoteFrameClient() { }
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2292,6 +2292,8 @@ public:
     bool shouldAllowAutoFillForCellularIdentifiers() const;
 #endif
 
+    void broadcastFocusedFrameToOtherProcesses(IPC::Connection&, const WebCore::FrameIdentifier&);
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -2846,8 +2848,6 @@ private:
     bool useGPUProcessForDOMRenderingEnabled() const;
 
     void dispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier);
-
-    void broadcastFocusedFrameToOtherProcesses(IPC::Connection&, const WebCore::FrameIdentifier&);
 
     struct Internals;
     Internals& internals() { return m_internals; }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1405,6 +1405,22 @@ void WebProcessProxy::closeRemoteFrame(WebCore::FrameIdentifier frameID)
         page->closePage();
 }
 
+void WebProcessProxy::focusRemoteFrame(WebCore::FrameIdentifier frameID)
+{
+    // FIXME: <rdar://117383252> This, postMessageToRemote, renderTreeAsText, etc. should be messages to the WebPageProxy instead of the process.
+    // They are more the page doing things than the process.
+    RefPtr destinationFrame = WebFrameProxy::webFrame(frameID);
+    if (!destinationFrame || !destinationFrame->isMainFrame())
+        return;
+
+    RefPtr page = destinationFrame->page();
+    if (!page)
+        return;
+
+    page->broadcastFocusedFrameToOtherProcesses(*connection(), frameID);
+    page->setFocus(true);
+}
+
 void WebProcessProxy::renderTreeAsText(WebCore::FrameIdentifier frameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior, CompletionHandler<void(String&&)>&& completionHandler)
 {
     RefPtr frame = WebFrameProxy::webFrame(frameIdentifier);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -546,6 +546,7 @@ private:
     void didDestroyUserGestureToken(uint64_t);
     void postMessageToRemote(WebCore::FrameIdentifier, std::optional<WebCore::SecurityOriginData>, const WebCore::MessageWithMessagePorts&);
     void closeRemoteFrame(WebCore::FrameIdentifier);
+    void focusRemoteFrame(WebCore::FrameIdentifier);
     void renderTreeAsText(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
 
     bool canBeAddedToWebProcessCache() const;

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -90,6 +90,7 @@ messages -> WebProcessProxy LegacyReceiver {
 
     PostMessageToRemote(WebCore::FrameIdentifier identifier, std::optional<WebCore::SecurityOriginData> target, struct WebCore::MessageWithMessagePorts message)
     CloseRemoteFrame(WebCore::FrameIdentifier identifier)
+    FocusRemoteFrame(WebCore::FrameIdentifier identifier)
 
     RenderTreeAsText(WebCore::FrameIdentifier identifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -104,4 +104,9 @@ void WebRemoteFrameClient::close()
     WebProcess::singleton().send(Messages::WebProcessProxy::CloseRemoteFrame(m_frame->frameID()), 0);
 }
 
+void WebRemoteFrameClient::focus()
+{
+    WebProcess::singleton().send(Messages::WebProcessProxy::FocusRemoteFrame(m_frame->frameID()), 0);
+}
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -50,6 +50,7 @@ private:
     String renderTreeAsText(size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>) final;
     void broadcastFrameRemovalToOtherProcesses() final;
     void close() final;
+    void focus() final;
 
     ScopeExit<Function<void()>> m_frameInvalidator;
 };


### PR DESCRIPTION
#### 32658f61dd123b88df26069f7746c44e6676c8aa
<pre>
[Site Isolation] Begin implementing window.focus()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264714">https://bugs.webkit.org/show_bug.cgi?id=264714</a>
<a href="https://rdar.apple.com/118307699">rdar://118307699</a>

Reviewed by Alex Christensen.

Begin implementing window.focus() such that it works as expected when called on a cross-origin opened
window. I filed bugs for future work, like adding the correct security checks.

* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/LocalDOMWindow.idl:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::focus):
* Source/WebCore/page/RemoteDOMWindow.idl:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::focusRemoteFrame):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::focus):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270673@main">https://commits.webkit.org/270673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d610ac4e84660be9ebab3a5ae142ccd919358c35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2074 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28713 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23384 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23763 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1383 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4566 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3634 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3351 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->