### PR TITLE
Use dynamicDowncast<T> even more in the DOM

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -225,9 +225,9 @@ void Node::dumpStatistics()
         auto& node = *nodePtr.get();
         if (node.hasRareData()) {
             ++nodesWithRareData;
-            if (is<Element>(node)) {
+            if (auto* element = dynamicDowncast<Element>(node)) {
                 ++elementsWithRareData;
-                if (downcast<Element>(node).hasNamedNodeMap())
+                if (element->hasNamedNodeMap())
                     ++elementsWithNamedNodeMap;
             }
             auto* rareData = node.rareData();
@@ -500,8 +500,8 @@ void Node::setNodeValue(const String&)
 
 RefPtr<NodeList> Node::childNodes()
 {
-    if (is<ContainerNode>(*this))
-        return ensureRareData().ensureNodeLists().ensureChildNodeList(downcast<ContainerNode>(*this));
+    if (auto* containerNode = dynamicDowncast<ContainerNode>(*this))
+        return ensureRareData().ensureNodeLists().ensureChildNodeList(*containerNode);
     return ensureRareData().ensureNodeLists().ensureEmptyChildNodeList(*this);
 }
 
@@ -533,30 +533,30 @@ Element* Node::nextElementSibling() const
 
 ExceptionOr<void> Node::insertBefore(Node& newChild, RefPtr<Node>&& refChild)
 {
-    if (!is<ContainerNode>(*this))
-        return Exception { ExceptionCode::HierarchyRequestError };
-    return downcast<ContainerNode>(*this).insertBefore(newChild, WTFMove(refChild));
+    if (auto* containerNode = dynamicDowncast<ContainerNode>(*this))
+        return containerNode->insertBefore(newChild, WTFMove(refChild));
+    return Exception { ExceptionCode::HierarchyRequestError };
 }
 
 ExceptionOr<void> Node::replaceChild(Node& newChild, Node& oldChild)
 {
-    if (!is<ContainerNode>(*this))
-        return Exception { ExceptionCode::HierarchyRequestError };
-    return downcast<ContainerNode>(*this).replaceChild(newChild, oldChild);
+    if (auto* containerNode = dynamicDowncast<ContainerNode>(*this))
+        return containerNode->replaceChild(newChild, oldChild);
+    return Exception { ExceptionCode::HierarchyRequestError };
 }
 
 ExceptionOr<void> Node::removeChild(Node& oldChild)
 {
-    if (!is<ContainerNode>(*this))
-        return Exception { ExceptionCode::NotFoundError };
-    return downcast<ContainerNode>(*this).removeChild(oldChild);
+    if (auto* containerNode = dynamicDowncast<ContainerNode>(*this))
+        return containerNode->removeChild(oldChild);
+    return Exception { ExceptionCode::NotFoundError };
 }
 
 ExceptionOr<void> Node::appendChild(Node& newChild)
 {
-    if (!is<ContainerNode>(*this))
-        return Exception { ExceptionCode::HierarchyRequestError };
-    return downcast<ContainerNode>(*this).appendChild(newChild);
+    if (auto* containerNode = dynamicDowncast<ContainerNode>(*this))
+        return containerNode->appendChild(newChild);
+    return Exception { ExceptionCode::HierarchyRequestError };
 }
 
 static HashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVector(const FixedVector<NodeOrString>& vector)
@@ -699,19 +699,18 @@ void Node::normalize()
     while (RefPtr firstChild = node->firstChild())
         node = WTFMove(firstChild);
     while (node) {
-        NodeType type = node->nodeType();
-        if (type == ELEMENT_NODE)
-            downcast<Element>(*node).normalizeAttributes();
+        if (auto* element = dynamicDowncast<Element>(*node))
+            element->normalizeAttributes();
 
         if (node == this)
             break;
 
-        if (type != TEXT_NODE) {
+        if (node->nodeType() != TEXT_NODE) {
             node = NodeTraversal::nextPostOrder(*node);
             continue;
         }
 
-        RefPtr text = downcast<Text>(node.get());
+        Ref text = downcast<Text>(*node);
 
         // Remove empty text nodes.
         if (!text->length()) {
@@ -844,7 +843,9 @@ Node::Editability Node::computeEditabilityWithStyle(const RenderStyle* incomingS
             return incomingStyle;
         if (isDocumentNode())
             return renderStyle();
-        auto* element = is<Element>(this) ? downcast<Element>(this) : parentElementInComposedTree();
+        auto* element = dynamicDowncast<Element>(*this);
+        if (!element)
+            element = parentElementInComposedTree();
         return element ? const_cast<Element&>(*element).computedStyleForEditability() : nullptr;
     }();
 
@@ -872,10 +873,11 @@ RenderBoxModelObject* Node::renderBoxModelObject() const
 LayoutRect Node::renderRect(bool* isReplaced)
 {
     RenderObject* hitRenderer = this->renderer();
-    if (!hitRenderer && is<HTMLAreaElement>(*this)) {
-        auto& area = downcast<HTMLAreaElement>(*this);
-        if (RefPtr imageElement = area.imageElement())
-            hitRenderer = imageElement->renderer();
+    if (!hitRenderer) {
+        if (auto* area = dynamicDowncast<HTMLAreaElement>(*this)) {
+            if (RefPtr imageElement = area->imageElement())
+                hitRenderer = imageElement->renderer();
+        }
     }
     RenderObject* renderer = hitRenderer;
     while (renderer && !renderer->isBody() && !renderer->isDocumentElementRenderer()) {
@@ -1128,7 +1130,8 @@ bool Node::containsIncludingShadowDOM(const Node* node) const
 
 Node* Node::pseudoAwarePreviousSibling() const
 {
-    Element* parentOrHost = is<PseudoElement>(*this) ? downcast<PseudoElement>(*this).hostElement() : parentElement();
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
+    Element* parentOrHost = pseudoElement ? pseudoElement->hostElement() : parentElement();
     if (parentOrHost && !previousSibling()) {
         if (isAfterPseudoElement() && parentOrHost->lastChild())
             return parentOrHost->lastChild();
@@ -1140,7 +1143,8 @@ Node* Node::pseudoAwarePreviousSibling() const
 
 Node* Node::pseudoAwareNextSibling() const
 {
-    Element* parentOrHost = is<PseudoElement>(*this) ? downcast<PseudoElement>(*this).hostElement() : parentElement();
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
+    Element* parentOrHost = pseudoElement ? pseudoElement->hostElement() : parentElement();
     if (parentOrHost && !nextSibling()) {
         if (isBeforePseudoElement() && parentOrHost->firstChild())
             return parentOrHost->firstChild();
@@ -1152,14 +1156,13 @@ Node* Node::pseudoAwareNextSibling() const
 
 Node* Node::pseudoAwareFirstChild() const
 {
-    if (is<Element>(*this)) {
-        const Element& currentElement = downcast<Element>(*this);
-        Node* first = currentElement.beforePseudoElement();
+    if (auto* currentElement = dynamicDowncast<Element>(*this)) {
+        Node* first = currentElement->beforePseudoElement();
         if (first)
             return first;
-        first = currentElement.firstChild();
+        first = currentElement->firstChild();
         if (!first)
-            first = currentElement.afterPseudoElement();
+            first = currentElement->afterPseudoElement();
         return first;
     }
     return firstChild();
@@ -1167,14 +1170,13 @@ Node* Node::pseudoAwareFirstChild() const
 
 Node* Node::pseudoAwareLastChild() const
 {
-    if (is<Element>(*this)) {
-        const Element& currentElement = downcast<Element>(*this);
-        Node* last = currentElement.afterPseudoElement();
+    if (auto* currentElement = dynamicDowncast<Element>(*this)) {
+        Node* last = currentElement->afterPseudoElement();
         if (last)
             return last;
-        last = currentElement.lastChild();
+        last = currentElement->lastChild();
         if (!last)
-            last = currentElement.beforePseudoElement();
+            last = currentElement->beforePseudoElement();
         return last;
     }
     return lastChild();
@@ -1242,8 +1244,8 @@ bool Node::isClosedShadowHidden(const Node& otherNode) const
                 return false; // treeScopeThatCanAccessOtherNode is a shadow-including inclusive ancestor of this node.
             }
         }
-        auto& root = treeScopeThatCanAccessOtherNode->rootNode();
-        if (is<ShadowRoot>(root) && downcast<ShadowRoot>(root).mode() != ShadowRootMode::Open)
+        auto* shadowRoot = dynamicDowncast<ShadowRoot>(treeScopeThatCanAccessOtherNode->rootNode());
+        if (shadowRoot && shadowRoot->mode() != ShadowRootMode::Open)
             break;
     }
 
@@ -1305,8 +1307,8 @@ ContainerNode* Node::parentInComposedTree() const
     ASSERT(isMainThreadOrGCThread());
     if (auto* slot = assignedSlot())
         return slot;
-    if (is<ShadowRoot>(*this))
-        return downcast<ShadowRoot>(*this).host();
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*this))
+        return shadowRoot->host();
     return parentNode();
 }
 
@@ -1314,13 +1316,13 @@ Element* Node::parentElementInComposedTree() const
 {
     if (auto* slot = assignedSlot())
         return slot;
-    if (is<PseudoElement>(*this))
-        return downcast<PseudoElement>(*this).hostElement();
+    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(*this))
+        return pseudoElement->hostElement();
     if (auto* parent = parentNode()) {
-        if (is<ShadowRoot>(*parent))
-            return downcast<ShadowRoot>(*parent).host();
-        if (is<Element>(*parent))
-            return downcast<Element>(parent);
+        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*parent))
+            return shadowRoot->host();
+        if (auto* element = dynamicDowncast<Element>(*parent))
+            return element;
     }
     return nullptr;
 }
@@ -1365,17 +1367,14 @@ ContainerNode* Node::nonShadowBoundaryParentNode() const
 
 Element* Node::parentOrShadowHostElement() const
 {
-    ContainerNode* parent = parentOrShadowHostNode();
+    auto* parent = parentOrShadowHostNode();
     if (!parent)
         return nullptr;
 
-    if (is<ShadowRoot>(*parent))
-        return downcast<ShadowRoot>(*parent).host();
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*parent))
+        return shadowRoot->host();
 
-    if (!is<Element>(*parent))
-        return nullptr;
-
-    return downcast<Element>(parent);
+    return dynamicDowncast<Element>(*parent);
 }
 
 Node& Node::traverseToRootNode() const
@@ -1390,11 +1389,12 @@ Node& Node::traverseToRootNode() const
 // https://dom.spec.whatwg.org/#concept-shadow-including-root
 Node& Node::shadowIncludingRoot() const
 {
-    auto& root = rootNode();
-    if (!is<ShadowRoot>(root))
-        return root;
-    auto* host = downcast<ShadowRoot>(root).host();
-    return host ? host->shadowIncludingRoot() : root;
+    auto& root = this->rootNode();
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(root)) {
+        auto* host = shadowRoot->host();
+        return host ? host->shadowIncludingRoot() : root;
+    }
+    return root;
 }
 
 Node& Node::getRootNode(const GetRootNodeOptions& options) const
@@ -1450,8 +1450,8 @@ Element* Node::rootEditableElement() const
 {
     Element* result = nullptr;
     for (Node* node = const_cast<Node*>(this); node && node->hasEditableStyle(); node = node->parentNode()) {
-        if (is<Element>(*node))
-            result = downcast<Element>(node);
+        if (auto* element = dynamicDowncast<Element>(*node))
+            result = element;
         if (document().body() == node)
             break;
     }
@@ -1897,10 +1897,11 @@ String Node::debugDescription() const
 
 static void appendAttributeDesc(const Node* node, StringBuilder& stringBuilder, const QualifiedName& name, const char* attrDesc)
 {
-    if (!is<Element>(*node))
+    auto* element = dynamicDowncast<Element>(*node);
+    if (!element)
         return;
 
-    const AtomString& attr = downcast<Element>(*node).getAttribute(name);
+    const AtomString& attr = element->getAttribute(name);
     if (attr.isEmpty())
         return;
 
@@ -1939,9 +1940,9 @@ void Node::showNodePathForThis() const
     }
     for (unsigned index = chain.size(); index > 0; --index) {
         const Node* node = chain[index - 1];
-        if (is<ShadowRoot>(*node)) {
+        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*node)) {
             int count = 0;
-            for (const ShadowRoot* shadowRoot = downcast<ShadowRoot>(node); shadowRoot && shadowRoot != node; shadowRoot = shadowRoot->shadowRoot())
+            for (; shadowRoot && shadowRoot != node; shadowRoot = shadowRoot->shadowRoot())
                 ++count;
             fprintf(stderr, "/#shadow-root[%d]", count);
             continue;
@@ -2104,16 +2105,16 @@ static void traverseSubtreeToUpdateTreeScope(Node& root, MoveNodeFunction moveNo
     for (Node* node = &root; node; node = NodeTraversal::next(*node, &root)) {
         moveNode(*node);
 
-        if (!is<Element>(*node))
+        auto* element = dynamicDowncast<Element>(*node);
+        if (!element)
             continue;
-        Element& element = downcast<Element>(*node);
 
-        if (element.hasSyntheticAttrChildNodes()) {
-            for (auto& attr : element.attrNodeList())
+        if (element->hasSyntheticAttrChildNodes()) {
+            for (auto& attr : element->attrNodeList())
                 moveNode(*attr);
         }
 
-        if (auto* shadow = element.shadowRoot())
+        if (auto* shadow = element->shadowRoot())
             moveShadowRoot(*shadow);
     }
 }
@@ -2261,8 +2262,8 @@ void Node::moveNodeToNewDocument(Document& oldDocument, Document& newDocument)
 #endif
 #endif
 
-    if (is<Element>(*this))
-        downcast<Element>(*this).didMoveToNewDocument(oldDocument, newDocument);
+    if (auto* element = dynamicDowncast<Element>(*this))
+        element->didMoveToNewDocument(oldDocument, newDocument);
 }
 
 static inline bool tryAddEventListener(Node* targetNode, const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)
@@ -2487,8 +2488,9 @@ void Node::dispatchSubtreeModifiedEvent()
 void Node::dispatchDOMActivateEvent(Event& underlyingClickEvent)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
-    int detail = is<UIEvent>(underlyingClickEvent) ? downcast<UIEvent>(underlyingClickEvent).detail() : 0;
-    auto event = UIEvent::create(eventNames().DOMActivateEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes, document().windowProxy(), detail);
+    auto* uiEvent = dynamicDowncast<UIEvent>(underlyingClickEvent);
+    int detail = uiEvent ? uiEvent->detail() : 0;
+    Ref event = UIEvent::create(eventNames().DOMActivateEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes, document().windowProxy(), detail);
     event->setUnderlyingEvent(&underlyingClickEvent);
     dispatchScopedEvent(event);
     if (event->defaultHandled())
@@ -2507,9 +2509,9 @@ void Node::defaultEventHandler(Event& event)
     auto& eventType = event.type();
     auto& eventNames = WebCore::eventNames();
     if (eventType == eventNames.keydownEvent || eventType == eventNames.keypressEvent || eventType == eventNames.keyupEvent) {
-        if (is<KeyboardEvent>(event)) {
+        if (RefPtr keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
             if (RefPtr frame = document().frame())
-                frame->eventHandler().defaultKeyboardEventHandler(downcast<KeyboardEvent>(event));
+                frame->eventHandler().defaultKeyboardEventHandler(*keyboardEvent);
         }
     } else if (eventType == eventNames.clickEvent) {
         dispatchDOMActivateEvent(event);
@@ -2521,27 +2523,31 @@ void Node::defaultEventHandler(Event& event)
         }
 #endif
     } else if (eventType == eventNames.textInputEvent) {
-        if (is<TextEvent>(event)) {
+        if (RefPtr textEvent = dynamicDowncast<TextEvent>(event)) {
             if (RefPtr frame = document().frame())
-                frame->eventHandler().defaultTextInputEventHandler(downcast<TextEvent>(event));
+                frame->eventHandler().defaultTextInputEventHandler(*textEvent);
         }
 #if ENABLE(PAN_SCROLLING)
-    } else if (eventType == eventNames.mousedownEvent && is<MouseEvent>(event)) {
-        if (downcast<MouseEvent>(event).button() == MouseButton::Middle) {
+    } else if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && eventType == eventNames.mousedownEvent) {
+        if (mouseEvent->button() == MouseButton::Middle) {
             if (enclosingLinkEventParentOrSelf())
                 return;
 
-            RenderObject* renderer = this->renderer();
-            while (renderer && (!is<RenderBox>(*renderer) || !downcast<RenderBox>(*renderer).canBeScrolledAndHasScrollableArea()))
-                renderer = renderer->parent();
-
-            if (renderer) {
+            RenderBox* renderBox = nullptr;
+            for (RenderObject* renderer = this->renderer(); renderer; renderer = renderer->parent()) {
+                auto* maybeRenderBox = dynamicDowncast<RenderBox>(*renderer);
+                if (maybeRenderBox && maybeRenderBox->canBeScrolledAndHasScrollableArea()) {
+                    renderBox = maybeRenderBox;
+                    break;
+                }
+            }
+            if (renderBox) {
                 if (RefPtr frame = document().frame())
-                    frame->eventHandler().startPanScrolling(downcast<RenderBox>(*renderer));
+                    frame->eventHandler().startPanScrolling(*renderBox);
             }
         }
 #endif
-    } else if (eventNames.isWheelEventType(eventType) && is<WheelEvent>(event)) {
+    } else if (auto* wheelEvent = dynamicDowncast<WheelEvent>(event); wheelEvent && eventNames.isWheelEventType(eventType)) {
         // If we don't have a renderer, send the wheel event to the first node we find with a renderer.
         // This is needed for <option> and <optgroup> elements so that <select>s get a wheel scroll.
         Node* startNode = this;
@@ -2550,29 +2556,32 @@ void Node::defaultEventHandler(Event& event)
         
         if (startNode && startNode->renderer()) {
             if (RefPtr frame = document().frame())
-                frame->eventHandler().defaultWheelEventHandler(RefPtr { startNode }.get(), downcast<WheelEvent>(event));
+                frame->eventHandler().defaultWheelEventHandler(RefPtr { startNode }.get(), *wheelEvent);
         }
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
-    } else if (is<TouchEvent>(event) && eventNames.isTouchRelatedEventType(eventType, *this)) {
+    } else if (auto* touchEvent = dynamicDowncast<TouchEvent>(event); touchEvent && eventNames.isTouchRelatedEventType(eventType, *this)) {
         // Capture the target node's visibility state before dispatching touchStart.
-        if (is<Element>(*this) && eventType == eventNames.touchstartEvent) {
+        if (auto* element = dynamicDowncast<Element>(*this); element && eventType == eventNames.touchstartEvent) {
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
             auto& contentChangeObserver = document().contentChangeObserver();
             if (ContentChangeObserver::isVisuallyHidden(*this))
-                contentChangeObserver.setHiddenTouchTarget(downcast<Element>(*this));
+                contentChangeObserver.setHiddenTouchTarget(*element);
             else
                 contentChangeObserver.resetHiddenTouchTarget();
 #endif
         }
 
         RenderObject* renderer = this->renderer();
-        while (renderer && (!is<RenderBox>(*renderer) || !downcast<RenderBox>(*renderer).canBeScrolledAndHasScrollableArea()))
-            renderer = renderer->parent();
+        for (; renderer; renderer = renderer->parent()) {
+            auto* renderBox = dynamicDowncast<RenderBox>(*renderer);
+            if (renderBox && renderBox->canBeScrolledAndHasScrollableArea())
+                break;
+        }
 
         if (renderer && renderer->node()) {
             if (RefPtr frame = document().frame()) {
                 RefPtr rendererNode = renderer->node();
-                frame->eventHandler().defaultTouchEventHandler(*rendererNode, downcast<TouchEvent>(event));
+                frame->eventHandler().defaultTouchEventHandler(*rendererNode, *touchEvent);
             }
         }
 #endif
@@ -2583,9 +2592,10 @@ bool Node::willRespondToMouseMoveEvents() const
 {
     // FIXME: Why is the iOS code path different from the non-iOS code path?
 #if !PLATFORM(IOS_FAMILY)
-    if (!is<Element>(*this))
+    auto* element = dynamicDowncast<Element>(*this);
+    if (!element)
         return false;
-    if (downcast<Element>(*this).isDisabledFormControl())
+    if (element->isDisabledFormControl())
         return false;
 #endif
     auto& eventNames = WebCore::eventNames();
@@ -2623,9 +2633,10 @@ bool Node::willRespondToMouseClickEventsWithEditability(Editability editability)
 {
     // FIXME: Why is the iOS code path different from the non-iOS code path?
 #if !PLATFORM(IOS_FAMILY)
-    if (!is<Element>(*this))
+    auto* element = dynamicDowncast<Element>(*this);
+    if (!element)
         return false;
-    if (downcast<Element>(*this).isDisabledFormControl())
+    if (element->isDisabledFormControl())
         return false;
 #endif
     if (editability != Editability::ReadOnly)
@@ -2646,16 +2657,16 @@ void Node::removedLastRef()
     // An explicit check for Document here is better than a virtual function since it is
     // faster for non-Document nodes, and because the call to removedLastRef that is inlined
     // at all deref call sites is smaller if it's a non-virtual function.
-    if (is<Document>(*this)) {
-        downcast<Document>(*this).removedLastRef();
+    if (auto* document = dynamicDowncast<Document>(*this)) {
+        document->removedLastRef();
         return;
     }
 
     // Now it is time to detach the SVGElement from all its properties. These properties
     // may outlive the SVGElement. The only difference after the detach is no commit will
     // be carried out unless these properties are attached to another owner.
-    if (is<SVGElement>(*this))
-        downcast<SVGElement>(*this).detachAllProperties();
+    if (auto* svgElement = dynamicDowncast<SVGElement>(*this))
+        svgElement->detachAllProperties();
 
 #if ASSERT_ENABLED
     m_deletionHasBegun = true;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -896,16 +896,18 @@ inline void Node::setTreeScopeRecursively(TreeScope& newTreeScope)
 
 inline void EventTarget::ref()
 {
-    if (LIKELY(isNode()))
-        downcast<Node>(*this).ref();
+    auto* node = dynamicDowncast<Node>(*this);
+    if (LIKELY(node))
+        node->ref();
     else
         refEventTarget();
 }
 
 inline void EventTarget::deref()
 {
-    if (LIKELY(isNode()))
-        downcast<Node>(*this).deref();
+    auto* node = dynamicDowncast<Node>(*this);
+    if (LIKELY(node))
+        node->deref();
     else
         derefEventTarget();
 }

--- a/Source/WebCore/dom/NodeTraversal.cpp
+++ b/Source/WebCore/dom/NodeTraversal.cpp
@@ -41,7 +41,8 @@ Node* previousIncludingPseudo(const Node& current, const Node* stayWithin)
             previous = previous->pseudoAwareLastChild();
         return previous;
     }
-    return is<PseudoElement>(current) ? downcast<PseudoElement>(current).hostElement() : current.parentNode();
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(current);
+    return pseudoElement ? pseudoElement->hostElement() : current.parentNode();
 }
 
 Node* nextIncludingPseudo(const Node& current, const Node* stayWithin)
@@ -53,7 +54,8 @@ Node* nextIncludingPseudo(const Node& current, const Node* stayWithin)
         return nullptr;
     if ((next = current.pseudoAwareNextSibling()))
         return next;
-    const Node* ancestor = is<PseudoElement>(current) ? downcast<PseudoElement>(current).hostElement() : current.parentNode();
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(current);
+    const Node* ancestor = pseudoElement ? pseudoElement->hostElement() : current.parentNode();
     for (; ancestor; ancestor = ancestor->parentNode()) {
         if (ancestor == stayWithin)
             return nullptr;
@@ -70,7 +72,8 @@ Node* nextIncludingPseudoSkippingChildren(const Node& current, const Node* stayW
         return nullptr;
     if ((next = current.pseudoAwareNextSibling()))
         return next;
-    const Node* ancestor = is<PseudoElement>(current) ? downcast<PseudoElement>(current).hostElement() : current.parentNode();
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(current);
+    const Node* ancestor = pseudoElement ? pseudoElement->hostElement() : current.parentNode();
     for (; ancestor; ancestor = ancestor->parentNode()) {
         if (ancestor == stayWithin)
             return nullptr;

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -332,8 +332,8 @@ inline Position lastPositionInNode(Node* anchorNode)
 
 inline bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode)
 {
-    if (is<CharacterData>(*anchorNode))
-        return offset < downcast<CharacterData>(*anchorNode).length();
+    if (auto* characterData = dynamicDowncast<CharacterData>(*anchorNode))
+        return offset < characterData->length();
 
     unsigned currentOffset = 0;
     for (Node* node = anchorNode->firstChild(); node && currentOffset < offset; node = node->nextSibling())

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -167,8 +167,8 @@ bool PositionIterator::isCandidate() const
     if (renderer->isBR())
         return Position(*this).isCandidate();
 
-    if (is<RenderText>(*renderer))
-        return !Position::nodeIsUserSelectNone(anchorNode.get()) && downcast<RenderText>(*renderer).containsCaretOffset(m_offsetInAnchor);
+    if (auto* renderText = dynamicDowncast<RenderText>(*renderer))
+        return !Position::nodeIsUserSelectNone(anchorNode.get()) && renderText->containsCaretOffset(m_offsetInAnchor);
 
     if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
         return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(anchorNode->parentNode());

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -348,11 +348,9 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
         m_isExternalScript = true;
         Ref script = LoadableModuleScript::create(nonce, element->attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriorityHint(), crossOriginMode,
             scriptCharset(), element->localName(), element->isInUserAgentShadowTree());
-        m_loadableScript = WTFMove(script);
-        if (RefPtr frame = element->document().frame()) {
-            Ref script = downcast<LoadableModuleScript>(*m_loadableScript);
+        m_loadableScript = script.copyRef();
+        if (RefPtr frame = element->document().frame())
             frame->checkedScript()->loadModuleScript(script, moduleScriptRootURL, script->parameters());
-        }
         return true;
     }
 
@@ -371,9 +369,9 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
             return false;
     }
 
-    m_loadableScript = WTFMove(script);
+    m_loadableScript = script.copyRef();
     if (RefPtr frame = document->frame())
-        frame->checkedScript()->loadModuleScript(downcast<LoadableModuleScript>(*m_loadableScript), sourceCode);
+        frame->checkedScript()->loadModuleScript(script, sourceCode);
     return true;
 }
 
@@ -617,8 +615,8 @@ bool isScriptElement(Element& element)
 
 ScriptElement& downcastScriptElement(Element& element)
 {
-    if (is<HTMLScriptElement>(element))
-        return downcast<HTMLScriptElement>(element);
+    if (auto* htmlElement = dynamicDowncast<HTMLScriptElement>(element))
+        return *htmlElement;
     return downcast<SVGScriptElement>(element);
 }
 

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -278,8 +278,8 @@ static ALWAYS_INLINE bool localNameMatches(const Element& element, const AtomStr
 template<typename OutputType>
 static inline void elementsForLocalName(const ContainerNode& rootNode, const AtomString& localName, const AtomString& lowercaseLocalName, OutputType& output)
 {
-    if (is<Document>(rootNode) && lowercaseLocalName == HTMLNames::baseTag->localName()) {
-        RefPtr firstBaseElement = downcast<Document>(rootNode).firstBaseElement();
+    if (auto* rootDocument = dynamicDowncast<Document>(rootNode); rootDocument && lowercaseLocalName == HTMLNames::baseTag->localName()) {
+        RefPtr firstBaseElement = rootDocument->firstBaseElement();
         if (!firstBaseElement)
             return;
         if constexpr (std::is_same_v<OutputType, Element*>) {

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -177,14 +177,15 @@ inline Element* ShadowRoot::activeElement() const
 
 inline bool Node::isUserAgentShadowRoot() const
 {
-    return isShadowRoot() && downcast<ShadowRoot>(*this).mode() == ShadowRootMode::UserAgent;
+    auto* shadowRoot = dynamicDowncast<ShadowRoot>(*this);
+    return shadowRoot && shadowRoot->mode() == ShadowRootMode::UserAgent;
 }
 
 inline ContainerNode* Node::parentOrShadowHostNode() const
 {
     ASSERT(isMainThreadOrGCThread());
-    if (is<ShadowRoot>(*this))
-        return downcast<ShadowRoot>(*this).host();
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*this))
+        return shadowRoot->host();
     return parentNode();
 }
 

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -54,10 +54,9 @@ private:
     {
         setUnderlyingEvent(underlyingEvent.get());
 
-        if (is<MouseEvent>(this->underlyingEvent())) {
-            MouseEvent& mouseEvent = downcast<MouseEvent>(*this->underlyingEvent());
-            m_screenLocation = mouseEvent.screenLocation();
-            initCoordinates(mouseEvent.clientLocation());
+        if (auto* mouseEvent = dynamicDowncast<MouseEvent>(this->underlyingEvent())) {
+            m_screenLocation = mouseEvent->screenLocation();
+            initCoordinates(mouseEvent->clientLocation());
         } else if (source == SimulatedClickSource::UserAgent) {
             // If there is no underlying event, we only populate the coordinates for events coming
             // from the user agent (e.g. accessibility). For those coming from JavaScript (e.g.

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -73,14 +73,16 @@ static HTMLSlotElement* findSlotElement(ShadowRoot& shadowRoot, const AtomString
 
 static HTMLSlotElement* nextSlotElementSkippingSubtree(ContainerNode& startingNode, ContainerNode* skippedSubtree)
 {
-    Node* node = &startingNode;
-    do {
-        if (UNLIKELY(node == skippedSubtree))
-            node = NodeTraversal::nextSkippingChildren(*node);
-        else
-            node = NodeTraversal::next(*node);
-    } while (node && !is<HTMLSlotElement>(node));
-    return downcast<HTMLSlotElement>(node);
+    auto nextNode = [&](Node& node) {
+        if (UNLIKELY(&node == skippedSubtree))
+            return NodeTraversal::nextSkippingChildren(node);
+        return NodeTraversal::next(node);
+    };
+    for (auto* node = nextNode(startingNode); node; node = nextNode(*node)) {
+        if (auto* slotElement = dynamicDowncast<HTMLSlotElement>(*node))
+            return slotElement;
+    }
+    return nullptr;
 }
 
 NamedSlotAssignment::NamedSlotAssignment() = default;

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -85,9 +85,10 @@ static const Text* earliestLogicallyAdjacentTextNode(const Text* text)
 {
     const Node* node = text;
     while ((node = node->previousSibling())) {
-        if (!is<Text>(*node))
+        if (auto* maybeText = dynamicDowncast<Text>(*node))
+            text = maybeText;
+        else
             break;
-        text = downcast<Text>(node);
     }
     return text;
 }
@@ -96,9 +97,10 @@ static const Text* latestLogicallyAdjacentTextNode(const Text* text)
 {
     const Node* node = text;
     while ((node = node->nextSibling())) {
-        if (!is<Text>(*node))
+        if (auto* maybeText = dynamicDowncast<Text>(*node))
+            text = maybeText;
+        else
             break;
-        text = downcast<Text>(node);
     }
     return text;
 }
@@ -164,16 +166,16 @@ Ref<Node> Text::cloneNodeInternal(Document& targetDocument, CloningOperation)
 
 static bool isSVGShadowText(const Text& text)
 {
-    auto* parentNode = text.parentNode();
-    ASSERT(parentNode);
-    return is<ShadowRoot>(*parentNode) && downcast<ShadowRoot>(*parentNode).host()->hasTagName(SVGNames::trefTag);
+    ASSERT(text.parentNode());
+    auto* parentShadowRoot = dynamicDowncast<ShadowRoot>(*text.parentNode());
+    return parentShadowRoot && parentShadowRoot->host()->hasTagName(SVGNames::trefTag);
 }
 
 static bool isSVGText(const Text& text)
 {
-    auto* parentNode = text.parentNode();
-    ASSERT(parentNode);
-    return is<SVGElement>(*parentNode) && !downcast<SVGElement>(*parentNode).hasTagName(SVGNames::foreignObjectTag);
+    ASSERT(text.parentNode());
+    auto* parentElement = dynamicDowncast<SVGElement>(*text.parentNode());
+    return parentElement && !parentElement->hasTagName(SVGNames::foreignObjectTag);
 }
 
 RenderPtr<RenderText> Text::createTextRenderer(const RenderStyle& style)

--- a/Source/WebCore/dom/TextNodeTraversal.h
+++ b/Source/WebCore/dom/TextNodeTraversal.h
@@ -65,10 +65,11 @@ namespace TextNodeTraversal {
 template <class NodeType>
 inline Text* firstTextChildTemplate(NodeType& current)
 {
-    Node* node = current.firstChild();
-    while (node && !is<Text>(*node))
-        node = node->nextSibling();
-    return downcast<Text>(node);
+    for (auto* node = current.firstChild(); node; node = node->nextSibling()) {
+        if (auto* text = dynamicDowncast<Text>(*node))
+            return text;
+    }
+    return nullptr;
 }
 inline Text* firstChild(const Node& current) { return firstTextChildTemplate(current); }
 inline Text* firstChild(const ContainerNode& current) { return firstTextChildTemplate(current); }
@@ -76,10 +77,11 @@ inline Text* firstChild(const ContainerNode& current) { return firstTextChildTem
 template <class NodeType>
 inline Text* firstTextWithinTemplate(NodeType& current)
 {
-    Node* node = current.firstChild();
-    while (node && !is<Text>(*node))
-        node = NodeTraversal::next(*node, &current);
-    return downcast<Text>(node);
+    for (auto* node = current.firstChild(); node; node = NodeTraversal::next(*node, &current)) {
+        if (auto* text = dynamicDowncast<Text>(*node))
+            return text;
+    }
+    return nullptr;
 }
 inline Text* firstWithin(const Node& current) { return firstTextWithinTemplate(current); }
 inline Text* firstWithin(const ContainerNode& current) { return firstTextWithinTemplate(current); }
@@ -87,10 +89,11 @@ inline Text* firstWithin(const ContainerNode& current) { return firstTextWithinT
 template <class NodeType>
 inline Text* traverseNextTextTemplate(NodeType& current)
 {
-    Node* node = NodeTraversal::next(current);
-    while (node && !is<Text>(*node))
-        node = NodeTraversal::next(*node);
-    return downcast<Text>(node);
+    for (auto* node = NodeTraversal::next(current); node; node = NodeTraversal::next(*node)) {
+        if (auto* text = dynamicDowncast<Text>(*node))
+            return text;
+    }
+    return nullptr;
 }
 inline Text* next(const Node& current) { return traverseNextTextTemplate(current); }
 inline Text* next(const Text& current) { return traverseNextTextTemplate(current); }
@@ -98,20 +101,22 @@ inline Text* next(const Text& current) { return traverseNextTextTemplate(current
 template <class NodeType>
 inline Text* traverseNextTextTemplate(NodeType& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::next(current, stayWithin);
-    while (node && !is<Text>(*node))
-        node = NodeTraversal::next(*node, stayWithin);
-    return downcast<Text>(node);
+    for (auto* node = NodeTraversal::next(current, stayWithin); node; node = NodeTraversal::next(*node, stayWithin)) {
+        if (auto* text = dynamicDowncast<Text>(*node))
+            return text;
+    }
+    return nullptr;
 }
 inline Text* next(const Node& current, const Node* stayWithin) { return traverseNextTextTemplate(current, stayWithin); }
 inline Text* next(const Text& current, const Node* stayWithin) { return traverseNextTextTemplate(current, stayWithin); }
 
 inline Text* nextSibling(const Node& current)
 {
-    Node* node = current.nextSibling();
-    while (node && !is<Text>(*node))
-        node = node->nextSibling();
-    return downcast<Text>(node);
+    for (auto* node = current.nextSibling(); node; node = node->nextSibling()) {
+        if (auto* text = dynamicDowncast<Text>(*node))
+            return text;
+    }
+    return nullptr;
 }
 
 } // namespace TextNodeTraversal

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -486,8 +486,8 @@ Vector<RefPtr<Element>> TreeScope::elementsFromPoint(double clientX, double clie
         lastNode = node;
     }
 
-    if (m_rootNode.isDocumentNode()) {
-        if (Element* rootElement = downcast<Document>(m_rootNode).documentElement()) {
+    if (auto* rootDocument = dynamicDowncast<Document>(m_rootNode)) {
+        if (Element* rootElement = rootDocument->documentElement()) {
             if (elements.isEmpty() || elements.last() != rootElement)
                 elements.append(rootElement);
         }
@@ -530,8 +530,11 @@ RefPtr<Element> TreeScope::findAnchor(StringView name)
 static Element* focusedFrameOwnerElement(Frame* focusedFrame, LocalFrame* currentFrame)
 {
     for (; focusedFrame; focusedFrame = focusedFrame->tree().parent()) {
-        if (focusedFrame->tree().parent() == currentFrame)
-            return is<LocalFrame>(focusedFrame) ? downcast<LocalFrame>(focusedFrame)->ownerElement() : nullptr;
+        if (focusedFrame->tree().parent() == currentFrame) {
+            if (auto* localFrame = dynamicDowncast<LocalFrame>(focusedFrame))
+                return localFrame->ownerElement();
+            return nullptr;
+        }
     }
     return nullptr;
 }

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -193,7 +193,8 @@ RefPtr<Element> TreeScopeOrderedMap::getElementByName(const AtomString& key, con
 RefPtr<HTMLMapElement> TreeScopeOrderedMap::getElementByMapName(const AtomString& key, const TreeScope& scope) const
 {
     return downcast<HTMLMapElement>(get(key, scope, [] (const AtomString& key, const Element& element) {
-        return is<HTMLMapElement>(element) && downcast<HTMLMapElement>(element).getName() == key;
+        auto* mapElement = dynamicDowncast<HTMLMapElement>(element);
+        return mapElement && mapElement->getName() == key;
     }));
 }
 
@@ -201,7 +202,8 @@ RefPtr<HTMLImageElement> TreeScopeOrderedMap::getElementByUsemap(const AtomStrin
 {
     return downcast<HTMLImageElement>(get(key, scope, [] (const AtomString& key, const Element& element) {
         // FIXME: HTML5 specification says we should match both image and object elements.
-        return is<HTMLImageElement>(element) && downcast<HTMLImageElement>(element).matchesUsemap(key);
+        auto* imageElement = dynamicDowncast<HTMLImageElement>(element);
+        return imageElement && imageElement->matchesUsemap(key);
     }));
 }
 


### PR DESCRIPTION
#### 3d8458014db3038a39b984ce5763cc66c79af7fc
<pre>
Use dynamicDowncast&lt;T&gt; even more in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=264715">https://bugs.webkit.org/show_bug.cgi?id=264715</a>

Reviewed by Brent Fulgham.

Use dynamicDowncast&lt;T&gt; even more in the DOM instead of is&lt;T&gt;() + downcast&lt;T&gt;().
It is less error-prone and often results in more concise code. I am also hoping
to have downcast&lt;&gt;() do a type check on release builds in the future. It is
currently too expensive to do so but it may become affordable if we use
dynamicDowncast&lt;T&gt;() instead when possible.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::dumpStatistics):
(WebCore::Node::childNodes):
(WebCore::Node::insertBefore):
(WebCore::Node::replaceChild):
(WebCore::Node::removeChild):
(WebCore::Node::appendChild):
(WebCore::Node::normalize):
(WebCore::Node::computeEditabilityWithStyle const):
(WebCore::Node::renderRect):
(WebCore::Node::pseudoAwarePreviousSibling const):
(WebCore::Node::pseudoAwareNextSibling const):
(WebCore::Node::pseudoAwareFirstChild const):
(WebCore::Node::pseudoAwareLastChild const):
(WebCore::Node::isClosedShadowHidden const):
(WebCore::Node::parentInComposedTree const):
(WebCore::Node::parentElementInComposedTree const):
(WebCore::Node::parentOrShadowHostElement const):
(WebCore::Node::shadowIncludingRoot const):
(WebCore::Node::rootEditableElement const):
(WebCore::appendAttributeDesc):
(WebCore::Node::showNodePathForThis const):
(WebCore::traverseSubtreeToUpdateTreeScope):
(WebCore::Node::moveNodeToNewDocument):
(WebCore::Node::dispatchDOMActivateEvent):
(WebCore::Node::defaultEventHandler):
(WebCore::Node::willRespondToMouseMoveEvents const):
(WebCore::Node::willRespondToMouseClickEventsWithEditability const):
(WebCore::Node::removedLastRef):
* Source/WebCore/dom/Node.h:
(WebCore::EventTarget::ref):
(WebCore::EventTarget::deref):
* Source/WebCore/dom/NodeTraversal.cpp:
(WebCore::NodeTraversal::previousIncludingPseudo):
(WebCore::NodeTraversal::nextIncludingPseudo):
(WebCore::NodeTraversal::nextIncludingPseudoSkippingChildren):
* Source/WebCore/dom/Position.cpp:
(WebCore::hasInlineRun):
(WebCore::Position::containerOrParentElement const):
(WebCore::Position::anchorElementAncestor const):
(WebCore::Position::upstream const):
(WebCore::Position::downstream const):
(WebCore::Position::hasRenderedNonAnonymousDescendantsWithHeight):
(WebCore::Position::isCandidate const):
(WebCore::Position::isRenderedCharacter const):
(WebCore::Position::rendersInDifferentPosition const):
(WebCore::Position::leadingWhitespacePosition const):
(WebCore::isNonTextLeafChild):
(WebCore::searchAheadForBetterMatch):
(WebCore::Position::inlineBoxAndOffset const):
* Source/WebCore/dom/Position.h:
(WebCore::offsetIsBeforeLastNodeOffset):
* Source/WebCore/dom/PositionIterator.cpp:
(WebCore::PositionIterator::isCandidate const):
* Source/WebCore/dom/Range.cpp:
(WebCore::processContentsBetweenOffsets):
(WebCore::Range::insertNode):
(WebCore::Range::toString const):
(WebCore::Range::createContextualFragment):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestModuleScript):
(WebCore::downcastScriptElement):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::reportUnhandledPromiseRejection):
(WebCore::ScriptExecutionContext::ensureRejectedPromiseTrackerSlow):
(WebCore::ScriptExecutionContext::globalObject const):
(WebCore::ScriptExecutionContext::allowsMediaDevices const):
(WebCore::ScriptExecutionContext::serviceWorkerContainer):
(WebCore::ScriptExecutionContext::ensureServiceWorkerContainer):
(WebCore::ScriptExecutionContext::postTaskToResponsibleDocument):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::elementsForLocalName):
* Source/WebCore/dom/ShadowRoot.h:
(WebCore::Node::isUserAgentShadowRoot const):
(WebCore::Node::parentOrShadowHostNode const):
* Source/WebCore/dom/SimulatedClick.cpp:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::nextSlotElementSkippingSubtree):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::ensureMutableInlineStyle):
(WebCore::StyledElement::setInlineStyleFromString):
* Source/WebCore/dom/Text.cpp:
(WebCore::earliestLogicallyAdjacentTextNode):
(WebCore::latestLogicallyAdjacentTextNode):
(WebCore::isSVGShadowText):
(WebCore::isSVGText):
* Source/WebCore/dom/TextNodeTraversal.h:
(WebCore::TextNodeTraversal::firstTextChildTemplate):
(WebCore::TextNodeTraversal::firstTextWithinTemplate):
(WebCore::TextNodeTraversal::traverseNextTextTemplate):
(WebCore::TextNodeTraversal::nextSibling):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::elementsFromPoint):
(WebCore::focusedFrameOwnerElement):
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::getElementByMapName const):
(WebCore::TreeScopeOrderedMap::getElementByUsemap const):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::createImageControls):
(WebCore::ImageControlsMac::imageFromImageElementNode):
(WebCore::ImageControlsMac::handleEvent):
(WebCore::ImageControlsMac::destroyImageControls):

Canonical link: <a href="https://commits.webkit.org/270654@main">https://commits.webkit.org/270654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5849a92ddb4dc520b4d1cc798ceab72ca1605087

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28058 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23852 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28638 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29382 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27259 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1311 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3560 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3340 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->