### PR TITLE
Avoid divide-by-zero in webrtc::StreamStatisticianImpl::BitrateReceived

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/receive_statistics_impl.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/receive_statistics_impl.cc
@@ -313,7 +313,7 @@ bool StreamStatisticianImpl::IsRetransmitOfOldPacket(
     const RtpPacketReceived& packet,
     int64_t now_ms) const {
   uint32_t frequency_khz = packet.payload_type_frequency() / 1000;
-  RTC_DCHECK_GT(frequency_khz, 0);
+  RTC_CHECK_GT(frequency_khz, 0);
 
   int64_t time_diff_ms = now_ms - last_receive_time_ms_;
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc
@@ -187,6 +187,8 @@ void RtpReplayer::ReplayPackets(
       RTC_LOG(LS_ERROR) << "Packet error, corrupt packets or incorrect setup?";
       break;
     }
+    // Set the clock rate - always 90K for video
+    received_packet.set_payload_type_frequency(kVideoPayloadTypeFrequency);
 
     call->Receiver()->DeliverRtpPacket(
         MediaType::VIDEO, std::move(received_packet),


### PR DESCRIPTION
#### 01dea93c203eba29a991917b2c9c77c427c0b166
<pre>
Avoid divide-by-zero in webrtc::StreamStatisticianImpl::BitrateReceived
<a href="https://bugs.webkit.org/show_bug.cgi?id=264718">https://bugs.webkit.org/show_bug.cgi?id=264718</a>
&lt;<a href="https://rdar.apple.com/117912996">rdar://117912996</a>&gt;

Reviewed by Youenn Fablet.

Merge upstream 7dbf55437f109cb13d131d91ba645029686fa247 by
Harald Alvestrand &lt;hta@webrtc.org&gt;.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/receive_statistics_impl.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc:

--

Ensure payload type frequency does not cause divide-by-zero

This CL does 2 things:
- Change the DCHECK for payload_type_frequency to a CHECK (so that
this error will be a crash not a divide-by-zero)
- Change the replay helper that was used by the fuzzer to set the
frequency of the packets to the video value (90K).

Bug: chromium:1466826
Change-Id: I39941f250b1782b36a3bcddfd347a016591466ec
Reviewed-on: <a href="https://webrtc-review.googlesource.com/c/src/+/312700">https://webrtc-review.googlesource.com/c/src/+/312700</a>
Commit-Queue: Harald Alvestrand &lt;hta@webrtc.org&gt;
Reviewed-by: Danil Chapovalov &lt;danilchap@webrtc.org&gt;
Cr-Commit-Position: refs/heads/main@{#40468}
Canonical link: <a href="https://commits.webkit.org/270656@main">https://commits.webkit.org/270656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1bffb895eb368feea4dd6082bdd2e61d732d84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23823 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23891 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28688 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29424 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27302 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1362 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3610 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3341 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->