### PR TITLE
[ iOS ] imported/w3c/web-platform-tests/screen-orientation/active-lock.html is a flaky failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
@@ -44,13 +44,12 @@
     await test_driver.bless("request full screen", null, iframe.contentWindow);
     await iframe.contentDocument.documentElement.requestFullscreen();
     const orientation = getOppositeOrientation();
-    const p = iframe.contentWindow.screen.orientation.lock(orientation);
+    const lockPromise = iframe.contentWindow.screen.orientation.lock(orientation);
     const frameDOMException = iframe.contentWindow.DOMException;
     await new Promise((r) => {
       iframe.addEventListener("load", r, { once: true });
-      iframe.contentWindow.location.href =
-        "./resources/empty.html?" + Math.random();
+      iframe.contentWindow.location.href = "about:blank";
     });
-    await promise_rejects_dom(t, "AbortError", frameDOMException, p);
+    await promise_rejects_dom(t, "AbortError", frameDOMException, lockPromise);
   }, "Unloading an iframe by navigating it must abort the lock promise");
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4647,9 +4647,6 @@ imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scro
 #rdar://118015813 ([ iOS ]imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html is a flaky text failure (264281))
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html [ Pass Failure ]
 
-#rdar://118018816 ([ iOS ] imported/w3c/web-platform-tests/screen-orientation/active-lock.html is a flaky failure (264287))
-imported/w3c/web-platform-tests/screen-orientation/active-lock.html [ Pass Failure ]
-
 # Failing word-break: auto-phrase tests.
 webkit.org/b/257698 imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase/word-break-auto-phrase-004.html [ ImageOnlyFailure ]
 webkit.org/b/257698 imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase/word-break-auto-phrase-005.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### c093fd4a7c8c0a1d509f280354deacac5a1b1110
<pre>
[ iOS ] imported/w3c/web-platform-tests/screen-orientation/active-lock.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=264287">https://bugs.webkit.org/show_bug.cgi?id=264287</a>
<a href="https://rdar.apple.com/118018816">rdar://118018816</a>

Reviewed by Chris Dumez.

Switching to about:blank instead, as it&apos;s technically the same and seems to address the flakiness.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270744@main">https://commits.webkit.org/270744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/210febd1c0e79936f73e8438c1efbb2efb23eb38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23774 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23851 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28639 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23318 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29384 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27261 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1312 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23066 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6317 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->