### PR TITLE
Clean up EnumTraits specializations under WebCore/Modules

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -346,6 +346,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/cookie-store/CookieStoreGetOptions.h
 
+    Modules/credentialmanagement/CredentialRequestOptions.h
+
     Modules/encryptedmedia/CDMClient.h
     Modules/encryptedmedia/MediaKeySystemClient.h
     Modules/encryptedmedia/MediaKeySystemController.h

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::ShapeDetection {
 
@@ -37,17 +36,3 @@ enum class LandmarkType : uint8_t {
 };
 
 } // namespace WebCore::ShapeDetection
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ShapeDetection::LandmarkType> {
-    using values = EnumValues<
-        WebCore::ShapeDetection::LandmarkType,
-        WebCore::ShapeDetection::LandmarkType::Mouth,
-        WebCore::ShapeDetection::LandmarkType::Eye,
-        WebCore::ShapeDetection::LandmarkType::Nose
-    >;
-};
-
-} // namespace WTF
-

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -47,19 +47,4 @@ struct CredentialRequestOptions {
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CredentialRequestOptions::MediationRequirement> {
-    using values = EnumValues<
-        WebCore::CredentialRequestOptions::MediationRequirement,
-        WebCore::CredentialRequestOptions::MediationRequirement::Silent,
-        WebCore::CredentialRequestOptions::MediationRequirement::Optional,
-        WebCore::CredentialRequestOptions::MediationRequirement::Required,
-        WebCore::CredentialRequestOptions::MediationRequirement::Conditional
-    >;
-};
-
-} // namespace WTF
-
-
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/mediastream/MediaAccessDenialReason.h
+++ b/Source/WebCore/Modules/mediastream/MediaAccessDenialReason.h
@@ -43,23 +43,4 @@ enum class MediaAccessDenialReason : uint8_t {
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::MediaAccessDenialReason> {
-    using values = EnumValues<
-    WebCore::MediaAccessDenialReason,
-    WebCore::MediaAccessDenialReason::NoReason,
-    WebCore::MediaAccessDenialReason::NoConstraints,
-    WebCore::MediaAccessDenialReason::UserMediaDisabled,
-    WebCore::MediaAccessDenialReason::NoCaptureDevices,
-    WebCore::MediaAccessDenialReason::InvalidConstraint,
-    WebCore::MediaAccessDenialReason::HardwareError,
-    WebCore::MediaAccessDenialReason::PermissionDenied,
-    WebCore::MediaAccessDenialReason::InvalidAccess,
-    WebCore::MediaAccessDenialReason::OtherFailure
-    >;
-};
-
-} // namespace WTF
-
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6725,3 +6725,13 @@ enum class WebCore::RepaintRectCalculation : bool;
     P3,
     Rec2020,
 };
+
+#if ENABLE(WEB_AUTHN)
+header: <WebCore/CredentialRequestOptions.h>
+enum class WebCore::MediationRequirement : uint8_t {
+    Silent,
+    Optional,
+    Required,
+    Conditional,
+};
+#endif


### PR DESCRIPTION
#### 6f7a02c6d3df83c93962290913fd496ee022ef62
<pre>
Clean up EnumTraits specializations under WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=264723">https://bugs.webkit.org/show_bug.cgi?id=264723</a>

Reviewed by Chris Dumez.

Remove redundant EnumTraits specializations for the ShapeDetection::LandmarkType
and MediaAccessDenialReason enumerations. Also remove the specialization for the
CredentialRequestOptions::MediationRequirement enumeration, replacing it with an
IPC serialization specification in the WebCoreArgumentCoders serialization input
file.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h:
* Source/WebCore/Modules/mediastream/MediaAccessDenialReason.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270655@main">https://commits.webkit.org/270655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b658dbd258c8a7d4f5fda6557e3fc767d0cc662

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2061 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28700 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23375 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23753 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1372 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4554 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6263 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->