### PR TITLE
Ignore the “title” argument to history.pushState()/history.replaceState()

### DIFF
--- a/LayoutTests/loader/stateobjects/pushstate-size-expected.txt
+++ b/LayoutTests/loader/stateobjects/pushstate-size-expected.txt
@@ -20,5 +20,19 @@ Successfully added item: 17 times
 Successfully added item: 18 times
 Successfully added item: 19 times
 Successfully added item: 20 times
+Successfully added item: 21 times
+Successfully added item: 22 times
+Successfully added item: 23 times
+Successfully added item: 24 times
+Successfully added item: 25 times
+Successfully added item: 26 times
+Successfully added item: 27 times
+Successfully added item: 28 times
+Successfully added item: 29 times
+Successfully added item: 30 times
+Successfully added item: 31 times
+Successfully added item: 32 times
+Successfully added item: 33 times
+Successfully added item: 34 times
 User gesture: QuotaExceededError: Attempt to store more data than allowed using history.pushState()
 

--- a/LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt
+++ b/LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt
@@ -26,5 +26,19 @@ iFrame successfully added item: 7 times
 iFrame successfully added item: 8 times
 iFrame successfully added item: 9 times
 iFrame successfully added item: 10 times
+iFrame successfully added item: 11 times
+iFrame successfully added item: 12 times
+iFrame successfully added item: 13 times
+iFrame successfully added item: 14 times
+iFrame successfully added item: 15 times
+iFrame successfully added item: 16 times
+iFrame successfully added item: 17 times
+iFrame successfully added item: 18 times
+iFrame successfully added item: 19 times
+iFrame successfully added item: 20 times
+iFrame successfully added item: 21 times
+iFrame successfully added item: 22 times
+iFrame successfully added item: 23 times
+iFrame successfully added item: 24 times
 Expected exception: QuotaExceededError: Attempt to store more data than allowed using history.pushState()
 

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -50,11 +50,9 @@ int64_t HistoryItem::generateSequenceNumber()
     return ++next;
 }
 
-HistoryItem::HistoryItem(Client& client, const String& urlString, const String& title, const String& alternateTitle, std::optional<BackForwardItemIdentifier> identifier)
+HistoryItem::HistoryItem(Client& client, const String& urlString, std::optional<BackForwardItemIdentifier> identifier)
     : m_urlString(urlString)
     , m_originalURLString(urlString)
-    , m_title(title)
-    , m_displayTitle(alternateTitle)
     , m_pruningReason(PruningReason::None)
     , m_identifier(identifier ? *identifier : BackForwardItemIdentifier::generate())
     , m_client(client)
@@ -73,8 +71,6 @@ HistoryItem::HistoryItem(const HistoryItem& item)
     , m_originalURLString(item.m_originalURLString)
     , m_referrer(item.m_referrer)
     , m_target(item.m_target)
-    , m_title(item.m_title)
-    , m_displayTitle(item.m_displayTitle)
     , m_scrollPosition(item.m_scrollPosition)
     , m_pageScaleFactor(item.m_pageScaleFactor)
     , m_children(item.m_children.map([](auto& child) { return child->copy(); }))
@@ -106,8 +102,6 @@ void HistoryItem::reset()
     m_originalURLString = String();
     m_referrer = String();
     m_target = nullAtom();
-    m_title = String();
-    m_displayTitle = String();
 
     m_lastVisitWasFailure = false;
     m_isTargetItem = false;
@@ -133,16 +127,6 @@ const String& HistoryItem::urlString() const
 const String& HistoryItem::originalURLString() const
 {
     return m_originalURLString;
-}
-
-const String& HistoryItem::title() const
-{
-    return m_title;
-}
-
-const String& HistoryItem::alternateTitle() const
-{
-    return m_displayTitle;
 }
 
 bool HistoryItem::hasCachedPageExpired() const
@@ -186,12 +170,6 @@ const AtomString& HistoryItem::target() const
     return m_target;
 }
 
-void HistoryItem::setAlternateTitle(const String& alternateTitle)
-{
-    m_displayTitle = alternateTitle;
-    notifyChanged();
-}
-
 void HistoryItem::setURLString(const String& urlString)
 {
     m_urlString = urlString;
@@ -214,12 +192,6 @@ void HistoryItem::setOriginalURLString(const String& urlString)
 void HistoryItem::setReferrer(const String& referrer)
 {
     m_referrer = referrer;
-    notifyChanged();
-}
-
-void HistoryItem::setTitle(const String& title)
-{
-    m_title = title;
     notifyChanged();
 }
 

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -72,9 +72,9 @@ class HistoryItem : public RefCounted<HistoryItem>, public CanMakeWeakPtr<Histor
 
 public:
     using Client = HistoryItemClient;
-    static Ref<HistoryItem> create(Client& client, const String& urlString = { }, const String& title = { }, const String& alternateTitle = { }, std::optional<BackForwardItemIdentifier> identifier = { })
+    static Ref<HistoryItem> create(Client& client, const String& urlString = { }, std::optional<BackForwardItemIdentifier> identifier = { })
     {
-        return adoptRef(*new HistoryItem(client, urlString, title, alternateTitle, identifier));
+        return adoptRef(*new HistoryItem(client, urlString, identifier));
     }
     
     WEBCORE_EXPORT ~HistoryItem();
@@ -88,13 +88,10 @@ public:
     
     WEBCORE_EXPORT const String& originalURLString() const;
     WEBCORE_EXPORT const String& urlString() const;
-    WEBCORE_EXPORT const String& title() const;
     
     bool isInBackForwardCache() const { return m_cachedPage.get(); }
     WEBCORE_EXPORT bool hasCachedPageExpired() const;
 
-    WEBCORE_EXPORT void setAlternateTitle(const String&);
-    WEBCORE_EXPORT const String& alternateTitle() const;
     
     WEBCORE_EXPORT URL url() const;
     WEBCORE_EXPORT URL originalURL() const;
@@ -129,7 +126,6 @@ public:
     WEBCORE_EXPORT void setOriginalURLString(const String&);
     WEBCORE_EXPORT void setReferrer(const String&);
     WEBCORE_EXPORT void setTarget(const AtomString&);
-    WEBCORE_EXPORT void setTitle(const String&);
     WEBCORE_EXPORT void setIsTargetItem(bool);
     
     WEBCORE_EXPORT void setStateObject(RefPtr<SerializedScriptValue>&&);
@@ -215,7 +211,7 @@ public:
     void setPolicyContainer(const PolicyContainer& policyContainer) { m_policyContainer = policyContainer; }
 
 private:
-    WEBCORE_EXPORT HistoryItem(Client&, const String& urlString, const String& title, const String& alternateTitle, std::optional<BackForwardItemIdentifier>);
+    WEBCORE_EXPORT HistoryItem(Client&, const String& urlString, std::optional<BackForwardItemIdentifier>);
 
     void setCachedPage(std::unique_ptr<CachedPage>&&);
     std::unique_ptr<CachedPage> takeCachedPage();
@@ -230,8 +226,6 @@ private:
     String m_originalURLString;
     String m_referrer;
     AtomString m_target;
-    String m_title;
-    String m_displayTitle;
     
     IntPoint m_scrollPosition;
     float m_pageScaleFactor { 0 }; // 0 indicates "unset".

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4362,8 +4362,6 @@ void FrameLoader::didChangeTitle(DocumentLoader* loader)
     m_client->didChangeTitle(loader);
 
     if (loader == m_documentLoader) {
-        // Must update the entries in the back-forward list too.
-        history().setCurrentItemTitle(loader->title());
         // This must go through the WebFrame because it has the right notion of the current b/f item.
         m_client->setTitle(loader->title(), loader->urlForHistory());
         m_client->setMainFrameDocumentReady(true); // update observers with new DOMDocument

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -635,13 +635,6 @@ void HistoryController::setCurrentItem(Ref<HistoryItem>&& item)
     m_previousItem = std::exchange(m_currentItem, WTFMove(item));
 }
 
-void HistoryController::setCurrentItemTitle(const StringWithDirection& title)
-{
-    // FIXME: This ignores the title's direction.
-    if (RefPtr currentItem = m_currentItem)
-        currentItem->setTitle(title.string);
-}
-
 bool HistoryController::currentItemShouldBeReplaced() const
 {
     // From the HTML5 spec for location.assign():
@@ -693,12 +686,8 @@ void HistoryController::initializeItem(HistoryItem& item)
     if (originalURL.isEmpty())
         originalURL = aboutBlankURL();
     
-    StringWithDirection title = documentLoader->title();
-
     item.setURL(url);
     item.setTarget(m_frame->tree().uniqueName());
-    // FIXME: Should store the title direction as well.
-    item.setTitle(title.string);
     item.setOriginalURLString(originalURL.string());
 
     if (!unreachableURL.isEmpty() || documentLoader->response().httpStatusCode() >= 400)
@@ -892,7 +881,7 @@ void HistoryController::updateCurrentItem()
     }
 }
 
-void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, const String& title, const String& urlString)
+void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString)
 {
     if (!m_currentItem)
         return;
@@ -920,7 +909,6 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
     // Override data in the current item (created by createItemTree) to reflect
     // the pushState() arguments.
     RefPtr currentItem = m_currentItem;
-    currentItem->setTitle(title);
     currentItem->setStateObject(WTFMove(stateObject));
     currentItem->setURLString(urlString);
     currentItem->setShouldRestoreScrollPosition(shouldRestoreScrollPosition);
@@ -936,7 +924,7 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
     frame->checkedLoader()->client().updateGlobalHistory();
 }
 
-void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& title, const String& urlString)
+void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString)
 {
     RefPtr currentItem = m_currentItem;
     if (!currentItem)
@@ -946,7 +934,6 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
 
     if (!urlString.isEmpty())
         currentItem->setURLString(urlString);
-    currentItem->setTitle(title);
     currentItem->setStateObject(WTFMove(stateObject));
     currentItem->setFormData(nullptr);
     currentItem->setFormContentType(String());

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -76,7 +76,6 @@ public:
     HistoryItem* currentItem() const { return m_currentItem.get(); }
     RefPtr<HistoryItem> protectedCurrentItem() const;
     WEBCORE_EXPORT void setCurrentItem(Ref<HistoryItem>&&);
-    void setCurrentItemTitle(const StringWithDirection&);
     bool currentItemShouldBeReplaced() const;
     WEBCORE_EXPORT void replaceCurrentItem(RefPtr<HistoryItem>&&);
 
@@ -88,8 +87,8 @@ public:
     RefPtr<HistoryItem> protectedProvisionalItem() const;
     void setProvisionalItem(RefPtr<HistoryItem>&&);
 
-    void pushState(RefPtr<SerializedScriptValue>&&, const String& title, const String& url);
-    void replaceState(RefPtr<SerializedScriptValue>&&, const String& title, const String& url);
+    void pushState(RefPtr<SerializedScriptValue>&&, const String& url);
+    void replaceState(RefPtr<SerializedScriptValue>&&, const String& url);
 
     void setDefersLoading(bool);
 

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -185,7 +185,7 @@ URL History::urlForState(const String& urlString)
     return frame->document()->completeURL(urlString);
 }
 
-ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data, const String& title, const String& urlString, StateObjectType stateObjectType)
+ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data, const String& urlString, StateObjectType stateObjectType)
 {
     m_cachedState.clear();
 
@@ -248,14 +248,10 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
         return Exception { ExceptionCode::SecurityError, makeString("Attempt to use history.pushState() more than ", perStateObjectTimeSpanLimit, " times per ", stateObjectTimeSpan.seconds(), " seconds") };
     }
 
-    Checked<unsigned> titleSize = title.length();
-    titleSize *= 2;
-
     Checked<unsigned> urlSize = fullURL.string().length();
     urlSize *= 2;
 
-    Checked<uint64_t> payloadSize = titleSize;
-    payloadSize += urlSize;
+    Checked<uint64_t> payloadSize = urlSize;
     payloadSize += data ? data->wireBytes().size() : 0;
 
     Checked<uint64_t> newTotalUsage = mainHistory.m_totalStateObjectUsage;
@@ -279,10 +275,10 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
         frame->document()->updateURLForPushOrReplaceState(fullURL);
 
     if (stateObjectType == StateObjectType::Push) {
-        frame->loader().history().pushState(WTFMove(data), title, fullURL.string());
+        frame->loader().history().pushState(WTFMove(data), fullURL.string());
         frame->loader().client().dispatchDidPushStateWithinPage();
     } else if (stateObjectType == StateObjectType::Replace) {
-        frame->loader().history().replaceState(WTFMove(data), title, fullURL.string());
+        frame->loader().history().replaceState(WTFMove(data), fullURL.string());
         frame->loader().client().dispatchDidReplaceStateWithinPage();
     }
 

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -65,14 +65,14 @@ public:
 
     bool isSameAsCurrentState(SerializedScriptValue*) const;
 
-    ExceptionOr<void> pushState(RefPtr<SerializedScriptValue>&& data, const String& title, const String& urlString);
-    ExceptionOr<void> replaceState(RefPtr<SerializedScriptValue>&& data, const String& title, const String& urlString);
+    ExceptionOr<void> pushState(RefPtr<SerializedScriptValue>&& data, const String&, const String& urlString);
+    ExceptionOr<void> replaceState(RefPtr<SerializedScriptValue>&& data, const String&, const String& urlString);
 
 private:
     explicit History(LocalDOMWindow&);
 
     enum class StateObjectType { Push, Replace };
-    ExceptionOr<void> stateObjectAdded(RefPtr<SerializedScriptValue>&&, const String& title, const String& url, StateObjectType);
+    ExceptionOr<void> stateObjectAdded(RefPtr<SerializedScriptValue>&&, const String& url, StateObjectType);
     bool stateChanged() const;
 
     URL urlForState(const String& url);
@@ -92,14 +92,14 @@ private:
     uint64_t m_mostRecentStateObjectUsage { 0 };
 };
 
-inline ExceptionOr<void> History::pushState(RefPtr<SerializedScriptValue>&& data, const String& title, const String& urlString)
+inline ExceptionOr<void> History::pushState(RefPtr<SerializedScriptValue>&& data, const String&, const String& urlString)
 {
-    return stateObjectAdded(WTFMove(data), title, urlString, StateObjectType::Push);
+    return stateObjectAdded(WTFMove(data), urlString, StateObjectType::Push);
 }
 
-inline ExceptionOr<void> History::replaceState(RefPtr<SerializedScriptValue>&& data, const String& title, const String& urlString)
+inline ExceptionOr<void> History::replaceState(RefPtr<SerializedScriptValue>&& data, const String&, const String& urlString)
 {
-    return stateObjectAdded(WTFMove(data), title, urlString, StateObjectType::Replace);
+    return stateObjectAdded(WTFMove(data), urlString, StateObjectType::Replace);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/History.idl
+++ b/Source/WebCore/page/History.idl
@@ -36,9 +36,8 @@
     [CallWith=RelevantDocument] undefined forward();
     [CallWith=RelevantDocument] undefined go(optional long delta = 0);
 
-    // FIXME: title should not be nullable as per the HTML specification.
-    undefined pushState(SerializedScriptValue data, DOMString? title, optional USVString? url = null);
-    undefined replaceState(SerializedScriptValue data, DOMString? title, optional USVString? url = null);
+    undefined pushState(SerializedScriptValue data, DOMString unused, optional USVString? url = null);
+    undefined replaceState(SerializedScriptValue data, DOMString unused, optional USVString? url = null);
 };
 
 enum ScrollRestoration { "auto", "manual" };

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -68,7 +68,6 @@ public:
 
     const String& originalURL() const { return m_itemState.pageState.mainFrameState.originalURLString; }
     const String& url() const { return m_itemState.pageState.mainFrameState.urlString; }
-    const String& title() const { return m_itemState.pageState.title; }
     bool wasCreatedByJSWithoutUserInteraction() const { return m_itemState.pageState.wasCreatedByJSWithoutUserInteraction; }
 
     const URL& resourceDirectoryURL() const { return m_resourceDirectoryURL; }

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp
@@ -27,6 +27,7 @@
 #include "WKBackForwardListItemRef.h"
 
 #include "WKAPICast.h"
+#include "WKString.h"
 #include "WebBackForwardListItem.h"
 
 using namespace WebKit;
@@ -43,7 +44,7 @@ WKURLRef WKBackForwardListItemCopyURL(WKBackForwardListItemRef itemRef)
 
 WKStringRef WKBackForwardListItemCopyTitle(WKBackForwardListItemRef itemRef)
 {
-    return WebKit::toCopiedAPI(toImpl(itemRef)->title());
+    return WKStringCreateWithUTF8CString("");
 }
 
 WKURLRef WKBackForwardListItemCopyOriginalURL(WKBackForwardListItemRef itemRef)

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.h
@@ -27,6 +27,7 @@
 #define WKBackForwardListItemRef_h
 
 #include <WebKit/WKBase.h>
+#include <WebKit/WKDeprecated.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,7 +36,7 @@ extern "C" {
 WK_EXPORT WKTypeID WKBackForwardListItemGetTypeID(void);
 
 WK_EXPORT WKURLRef WKBackForwardListItemCopyURL(WKBackForwardListItemRef item);
-WK_EXPORT WKStringRef WKBackForwardListItemCopyTitle(WKBackForwardListItemRef item);
+WK_EXPORT WKStringRef WKBackForwardListItemCopyTitle(WKBackForwardListItemRef item) WK_C_API_DEPRECATED;
 WK_EXPORT WKURLRef WKBackForwardListItemCopyOriginalURL(WKBackForwardListItemRef item);
 
 #ifdef __cplusplus

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h
@@ -40,9 +40,9 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  */
 @property (readonly, copy) NSURL *URL;
 
-/*! @abstract The title of the webpage represented by this item.
+/*! @abstract Deprecated. Always returns nil.
  */
-@property (nullable, readonly, copy) NSString *title;
+@property (nullable, readonly, copy) NSString *title WK_API_DEPRECATED("No longer supported", macOS(10.10, WK_MAC_TBA), iOS(8.0, WK_IOS_TBA));
 
 /*! @abstract The URL of the initial request that created this item.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -50,10 +50,7 @@
 
 - (NSString *)title
 {
-    if (!_item->title())
-        return nil;
-
-    return _item->title();
+    return nil;
 }
 
 - (NSURL *)initialURL

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp
@@ -119,22 +119,16 @@ const gchar* webkit_back_forward_list_item_get_uri(WebKitBackForwardListItem* li
  * webkit_back_forward_list_item_get_title:
  * @list_item: a #WebKitBackForwardListItem
  *
- * Obtain the title of the item.
+ * Since 2.44, page titles are no longer stored in history. This function now returns an empty string.
  *
- * Returns: the page title of @list_item or %NULL
- *    when the title is empty.
+ * Returns: an empty string
+ *
+ * Deprecated: 2.44
  */
 const gchar* webkit_back_forward_list_item_get_title(WebKitBackForwardListItem* listItem)
 {
     g_return_val_if_fail(WEBKIT_IS_BACK_FORWARD_LIST_ITEM(listItem), 0);
-
-    WebKitBackForwardListItemPrivate* priv = listItem->priv;
-    String title = priv->webListItem->title();
-    if (title.isEmpty())
-        return 0;
-
-    priv->title = title.utf8();
-    return priv->title.data();
+    return "";
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in
@@ -51,7 +51,7 @@ WEBKIT_DECLARE_FINAL_TYPE (WebKitBackForwardListItem, webkit_back_forward_list_i
 WEBKIT_API const gchar *
 webkit_back_forward_list_item_get_uri          (WebKitBackForwardListItem* list_item);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_back_forward_list_item_get_title        (WebKitBackForwardListItem* list_item);
 
 WEBKIT_API const gchar *

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -109,11 +109,8 @@ static FrameState toFrameState(const HistoryItem& historyItem)
 
 BackForwardListItemState toBackForwardListItemState(const WebCore::HistoryItem& historyItem)
 {
-    static constexpr unsigned maxTitleLength = 1000; // Closest power of 10 above the W3C recommendation for Title length.
-
     BackForwardListItemState state;
     state.identifier = historyItem.identifier();
-    state.pageState.title = historyItem.title().left(maxTitleLength);
     state.pageState.mainFrameState = toFrameState(historyItem);
     state.pageState.shouldOpenExternalURLsPolicy = historyItem.shouldOpenExternalURLsPolicy();
     state.pageState.sessionStateObject = historyItem.stateObject();
@@ -176,7 +173,7 @@ static void applyFrameState(WebCore::HistoryItemClient& client, HistoryItem& his
 #endif
 
     for (const auto& childFrameState : frameState.children) {
-        Ref<HistoryItem> childHistoryItem = HistoryItem::create(client, childFrameState.urlString, { }, { });
+        Ref<HistoryItem> childHistoryItem = HistoryItem::create(client, childFrameState.urlString, { });
         applyFrameState(client, childHistoryItem, childFrameState);
 
         historyItem.addChildItem(WTFMove(childHistoryItem));
@@ -185,7 +182,7 @@ static void applyFrameState(WebCore::HistoryItemClient& client, HistoryItem& his
 
 Ref<HistoryItem> toHistoryItem(WebCore::HistoryItemClient& client, const BackForwardListItemState& itemState)
 {
-    Ref<HistoryItem> historyItem = HistoryItem::create(client, itemState.pageState.mainFrameState.urlString, itemState.pageState.title, { }, itemState.identifier);
+    Ref<HistoryItem> historyItem = HistoryItem::create(client, itemState.pageState.mainFrameState.urlString, itemState.identifier);
     historyItem->setShouldOpenExternalURLsPolicy(itemState.pageState.shouldOpenExternalURLsPolicy);
     historyItem->setStateObject(itemState.pageState.sessionStateObject.get());
     applyFrameState(client, historyItem, itemState.pageState.mainFrameState);

--- a/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
+++ b/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
@@ -86,17 +86,11 @@ void HistoryPropertyListWriter::writeHistoryItem(BinaryPropertyListObjectStream&
 
     size_t itemDictionaryStart = stream.writeDictionaryStart();
 
-    const String& title = item->title();
-    const String& displayTitle = item->alternateTitle();
     double lastVisitedDate = webHistoryItem->_private->_lastVisitedTime;
     Vector<String>* redirectURLs = webHistoryItem->_private->_redirectURLs.get();
 
     // keys
     stream.writeString(m_urlKey);
-    if (!title.isEmpty())
-        stream.writeString(m_titleKey);
-    if (!displayTitle.isEmpty())
-        stream.writeString(m_displayTitleKey);
     if (lastVisitedDate)
         stream.writeString(m_lastVisitedDateKey);
     if (item->lastVisitWasFailure())
@@ -106,10 +100,6 @@ void HistoryPropertyListWriter::writeHistoryItem(BinaryPropertyListObjectStream&
 
     // values
     stream.writeUniqueString(item->urlString());
-    if (!title.isEmpty())
-        stream.writeString(title);
-    if (!displayTitle.isEmpty())
-        stream.writeString(displayTitle);
     if (lastVisitedDate) {
         char buffer[32];
         snprintf(buffer, sizeof(buffer), "%.1lf", lastVisitedDate);

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -291,8 +291,8 @@ static inline WebHistoryDateKey dateKey(NSTimeInterval date)
         // as seen in <rdar://problem/6570573>.
         BOOL itemWasInDateCaches = [self removeItemFromDateCaches:entry.get()];
         ASSERT_UNUSED(itemWasInDateCaches, itemWasInDateCaches);
+        [entry _visited];
 
-        [entry _visitedWithTitle:title];
     } else {
         LOG(History, "Adding new global history entry for %@", url);
         entry = adoptNS([[WebHistoryItem alloc] initWithURLString:URLString title:title lastVisitedTimeInterval:[NSDate timeIntervalSinceReferenceDate]]);

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -141,7 +141,7 @@ void WKNotifyHistoryItemChanged()
 {
     WebCoreThreadViolationCheckRoundOne();
 
-    WebHistoryItem *item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title)];
+    WebHistoryItem *item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString)];
     item->_private->_lastVisitedTime = time;
 
     return item;
@@ -181,21 +181,6 @@ void WKNotifyHistoryItemChanged()
 - (NSString *)originalURLString
 {
     return nsStringNilIfEmpty(core(_private)->originalURLString());
-}
-
-- (NSString *)title
-{
-    return nsStringNilIfEmpty(core(_private)->title());
-}
-
-- (void)setAlternateTitle:(NSString *)alternateTitle
-{
-    core(_private)->setAlternateTitle(alternateTitle);
-}
-
-- (NSString *)alternateTitle
-{
-    return nsStringNilIfEmpty(core(_private)->alternateTitle());
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -281,7 +266,7 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (id)initWithURLString:(NSString *)URLString title:(NSString *)title displayTitle:(NSString *)displayTitle lastVisitedTimeInterval:(NSTimeInterval)time
 {
-    auto item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title, displayTitle)];
+    auto item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString)];
     if (!item)
         return nil;
     item->_private->_lastVisitedTime = time;
@@ -301,11 +286,6 @@ WebHistoryItem *kit(HistoryItem* item)
     ASSERT(!historyItemWrappers().get(*core(_private)));
     historyItemWrappers().set(*core(_private), self);
     return self;
-}
-
-- (void)setTitle:(NSString *)title
-{
-    core(_private)->setTitle(title);
 }
 
 - (void)setViewState:(id)statePList
@@ -369,9 +349,8 @@ WebHistoryItem *kit(HistoryItem* item)
     return core(_private)->scrollPosition();
 }
 
-- (void)_visitedWithTitle:(NSString *)title
+- (void)_visited
 {
-    core(_private)->setTitle(title);
     _private->_lastVisitedTime = [NSDate timeIntervalSinceReferenceDate];
 }
 
@@ -402,10 +381,6 @@ WebHistoryItem *kit(HistoryItem* item)
     
     if (!coreItem->urlString().isEmpty())
         [dict setObject:(NSString*)coreItem->urlString() forKey:@""];
-    if (!coreItem->title().isEmpty())
-        [dict setObject:(NSString*)coreItem->title() forKey:titleKey];
-    if (!coreItem->alternateTitle().isEmpty())
-        [dict setObject:(NSString*)coreItem->alternateTitle() forKey:displayTitleKey];
     if (_private->_lastVisitedTime) {
         // Store as a string to maintain backward compatibility. (See 3245793)
         [dict setObject:[NSString stringWithFormat:@"%.1lf", _private->_lastVisitedTime]

--- a/Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h
@@ -48,9 +48,7 @@ extern void WKNotifyHistoryItemChanged();
 - (id)initWithURLString:(NSString *)URLString title:(NSString *)title displayTitle:(NSString *)displayTitle lastVisitedTimeInterval:(NSTimeInterval)time;
 - (id)initFromDictionaryRepresentation:(NSDictionary *)dict;
 - (id)initWithWebCoreHistoryItem:(Ref<WebCore::HistoryItem>&&)item;
-
-- (void)setTitle:(NSString *)title;
-- (void)_visitedWithTitle:(NSString *)title;
+- (void)_visited;
 
 @end
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1343,7 +1343,6 @@ void WebFrameLoaderClient::setTitle(const WebCore::StringWithDirection& title, c
     if ([[nsURL absoluteString] isEqualToString:@"about:blank"])
         return;
 #endif
-    [[[WebHistory optionalSharedHistory] itemForURL:nsURL] setTitle:title.string];
 }
 
 void WebFrameLoaderClient::savePlatformDataToCachedFrame(WebCore::CachedFrame* cachedFrame)

--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -228,9 +228,7 @@ static void browserWindowCreateBackForwardMenu(BrowserWindow *window, GList *lis
     GList *listItem;
     for (listItem = list; listItem; listItem = g_list_next(listItem)) {
         WebKitBackForwardListItem *item = (WebKitBackForwardListItem *)listItem->data;
-        const char *title = webkit_back_forward_list_item_get_title(item);
-        if (!title || !*title)
-            title = webkit_back_forward_list_item_get_uri(item);
+        const char *title = webkit_back_forward_list_item_get_uri(item);
 
         char *displayTitle;
 #define MAX_TITLE 100

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -808,20 +808,3 @@ TEST(WKBackForwardList, BackNavigationHijacking)
 
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, url1.absoluteString.UTF8String);
 }
-
-TEST(WKBackForwardList, SessionStateTitleTruncation)
-{
-    TestWebKitAPI::HTTPServer server({
-        { "/"_s, { "<script>document.title='a'.repeat(10000);window.history.pushState({}, '', window.location+'?a=b');</script>"_s } }
-    });
-
-    auto webView = adoptNS([WKWebView new]);
-    [webView loadRequest:server.request()];
-    while (!webView.get().canGoBack)
-        TestWebKitAPI::Util::spinRunLoop();
-    while (webView.get()._sessionState.data.length < 1000u)
-        TestWebKitAPI::Util::spinRunLoop();
-    _WKSessionState *sessionState = webView.get()._sessionState;
-    NSData *stateData = sessionState.data;
-    EXPECT_LT(stateData.length, 2000u);
-}

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
@@ -69,11 +69,11 @@ public:
         RemovedItems = 1 << 2
     };
 
-    static void checkItem(WebKitBackForwardListItem* item, const char* title, const char* uri, const char* originalURI)
+    static void checkItem(WebKitBackForwardListItem* item, const char* uri, const char* originalURI)
     {
         g_assert_nonnull(item);
         g_assert_cmpstr(webkit_back_forward_list_item_get_uri(item), ==, uri);
-        g_assert_cmpstr(webkit_back_forward_list_item_get_title(item), == , title);
+        g_assert_cmpstr(webkit_back_forward_list_item_get_title(item), == , "");
         g_assert_cmpstr(webkit_back_forward_list_item_get_original_uri(item), ==, originalURI);
     }
 
@@ -181,7 +181,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 1);
     WebKitBackForwardListItem* itemPage1 = webkit_back_forward_list_get_current_item(test->m_list);
-    BackForwardListTest::checkItem(itemPage1, "Page1", uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(itemPage1, uriPage1.data(), uriPage1.data());
     g_assert_null(webkit_back_forward_list_get_back_item(test->m_list));
     g_assert_null(webkit_back_forward_list_get_forward_item(test->m_list));
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -199,7 +199,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     WebKitBackForwardListItem* itemPage2 = webkit_back_forward_list_get_current_item(test->m_list);
-    BackForwardListTest::checkItem(itemPage2, "Page2", uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(itemPage2, uriPage2.data(), uriPage2.data());
     g_assert_true(webkit_back_forward_list_get_back_item(test->m_list) == itemPage1);
     g_assert_null(webkit_back_forward_list_get_forward_item(test->m_list));
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -216,7 +216,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     g_assert_true(itemPage1 == webkit_back_forward_list_get_current_item(test->m_list));
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), "Page1", uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), uriPage1.data(), uriPage1.data());
     g_assert_null(webkit_back_forward_list_get_back_item(test->m_list));
     g_assert_true(webkit_back_forward_list_get_forward_item(test->m_list) == itemPage2);
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -233,7 +233,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     g_assert_true(itemPage2 == webkit_back_forward_list_get_current_item(test->m_list));
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), "Page2", uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), uriPage2.data(), uriPage2.data());
     g_assert_true(webkit_back_forward_list_get_back_item(test->m_list) == itemPage1);
     g_assert_null(webkit_back_forward_list_get_forward_item(test->m_list));
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -315,9 +315,9 @@ static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpoint
     webkit_web_view_restore_session_state(view.get(), state);
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 3);
 
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), "Page1", uriPage1.data(), uriPage1.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), "Page2", uriPage2.data(), uriPage2.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), "Page3", uriPage3.data(), uriPage3.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), uriPage3.data(), uriPage3.data());
 
     data = adoptGRef(webkit_web_view_session_state_serialize(state));
     g_assert_nonnull(data);
@@ -332,9 +332,9 @@ static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpoint
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 3);
     webkit_web_view_session_state_unref(state);
 
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), "Page1", uriPage1.data(), uriPage1.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), "Page2", uriPage2.data(), uriPage2.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), "Page3", uriPage3.data(), uriPage3.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), uriPage3.data(), uriPage3.data());
 
     static const char* invalidSessionData = "invalid session data";
     data = adoptGRef(g_bytes_new_static(invalidSessionData, strlen(invalidSessionData)));


### PR DESCRIPTION
#### 4ef4b65d33f45734ad3c6cbc7f2fe0dda17051bc
<pre>
Ignore the “title” argument to history.pushState()/history.replaceState()
<a href="https://bugs.webkit.org/show_bug.cgi?id=223190">https://bugs.webkit.org/show_bug.cgi?id=223190</a>

Reviewed by Chris Dumez and Michael Catanzaro.

This change causes WebKit to ignore the second argument to history.pushState()
and history.replaceState(), making WebKit consistent with the current behavior
in Gecko and Blink, and consistent with the current spec.

That argument previously set the title for the history item, but in
<a href="https://github.com/whatwg/html/pull/6482">https://github.com/whatwg/html/pull/6482</a> was removed from the spec –
which now at <a href="https://html.spec.whatwg.org/#the-history-interface">https://html.spec.whatwg.org/#the-history-interface</a>:dom-history-pushstate
defines the argument as “unused”, and specifies no processing
requirements for it.

Otherwise, without this change, the WebKit behavior is inconsistent with
the current behavior in Gecko and Blink, and inconsistent with the
current requirements defined in the spec.

Note that this change also reverts <a href="https://commits.webkit.org/259367@main">https://commits.webkit.org/259367@main</a> —
because, since the title is being removed from history items, and no
longer used, there’s no longer any need to truncate it, nor any need for
the associated test.

* LayoutTests/loader/stateobjects/pushstate-size-expected.txt:
* LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::HistoryItem):
(WebCore::HistoryItem::reset):
(WebCore::HistoryItem::title const): Deleted.
(WebCore::HistoryItem::alternateTitle const): Deleted.
(WebCore::HistoryItem::setAlternateTitle): Deleted.
(WebCore::HistoryItem::setTitle): Deleted.
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::create):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didChangeTitle):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::initializeItem):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
(WebCore::HistoryController::setCurrentItemTitle): Deleted.
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/History.h:
(WebCore::History::pushState):
(WebCore::History::replaceState):
* Source/WebCore/page/History.idl:
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::url const):
(WebKit::WebBackForwardListItem::title const): Deleted.
* Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp:
(WKBackForwardListItemCopyTitle):
* Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem title]):
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp:
(webkit_back_forward_list_item_get_title):
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in:
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toBackForwardListItemState):
(WebKit::applyFrameState):
(WebKit::toHistoryItem):
* Source/WebKitLegacy/mac/History/HistoryPropertyList.mm:
(HistoryPropertyListWriter::writeHistoryItem):
* Source/WebKitLegacy/mac/History/WebHistory.mm:
(-[WebHistoryPrivate visitedURL:withTitle:]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(-[WebHistoryItem initWithURLString:title:lastVisitedTimeInterval:]):
(-[WebHistoryItem initWithURLString:title:displayTitle:lastVisitedTimeInterval:]):
(-[WebHistoryItem _visited]):
(-[WebHistoryItem title]): Deleted.
(-[WebHistoryItem setAlternateTitle:]): Deleted.
(-[WebHistoryItem alternateTitle]): Deleted.
(-[WebHistoryItem setTitle:]): Deleted.
(-[WebHistoryItem _visitedWithTitle:]): Deleted.
* Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::setTitle):
* Tools/MiniBrowser/gtk/BrowserWindow.c:
(browserWindowCreateBackForwardMenu):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp:
(testBackForwardListNavigation):
(testWebKitWebViewSessionState):

Canonical link: <a href="https://commits.webkit.org/273650@main">https://commits.webkit.org/273650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05c7bff7c4383600a473a5fcfbffe80488f05d79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40199 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30540 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37203 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35296 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13188 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8222 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->