### PR TITLE
Generate IPC serialization for enumerations under WebCore/page

### DIFF
--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -35,17 +35,19 @@ namespace WebCore {
 
 class Event;
 
-class ContextMenuContext {
-public:
-    enum class Type : uint8_t {
-        ContextMenu,
+enum class ContextMenuContextType : uint8_t {
+    ContextMenu,
 #if ENABLE(SERVICE_CONTROLS)
-        ServicesMenu,
+    ServicesMenu,
 #endif // ENABLE(SERVICE_CONTROLS)
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-        MediaControls,
+    MediaControls,
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-    };
+};
+
+class ContextMenuContext {
+public:
+    using Type = ContextMenuContextType;
 
     ContextMenuContext();
     ContextMenuContext(Type, const HitTestResult&, Event*);
@@ -95,22 +97,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ContextMenuContext::Type> {
-    using values = EnumValues<
-        WebCore::ContextMenuContext::Type,
-        WebCore::ContextMenuContext::Type::ContextMenu
-#if ENABLE(SERVICE_CONTROLS)
-        , WebCore::ContextMenuContext::Type::ServicesMenu
-#endif // ENABLE(SERVICE_CONTROLS)
-#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-        , WebCore::ContextMenuContext::Type::MediaControls
-#endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebCore/page/CrossSiteNavigationDataTransfer.h
+++ b/Source/WebCore/page/CrossSiteNavigationDataTransfer.h
@@ -30,24 +30,15 @@
 
 namespace WebCore {
 
+enum class CrossSiteNavigationDataTransferFlag : uint8_t {
+    DestinationLinkDecoration = 1 << 1,
+    ReferrerLinkDecoration = 1 << 2,
+};
+
 struct CrossSiteNavigationDataTransfer {
-    enum class Flag : uint8_t {
-        DestinationLinkDecoration = 1 << 1,
-        ReferrerLinkDecoration = 1 << 2,
-    };
+    using Flag = CrossSiteNavigationDataTransferFlag;
 };
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CrossSiteNavigationDataTransfer::Flag> {
-    using values = EnumValues<
-        WebCore::CrossSiteNavigationDataTransfer::Flag,
-        WebCore::CrossSiteNavigationDataTransfer::Flag::DestinationLinkDecoration,
-        WebCore::CrossSiteNavigationDataTransfer::Flag::ReferrerLinkDecoration
-    >;
-};
-
-} // namespace WTF
 #endif // ENABLE(TRACKING_PREVENTION)

--- a/Source/WebCore/page/DebugOverlayRegions.h
+++ b/Source/WebCore/page/DebugOverlayRegions.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class DebugOverlayRegions : uint8_t {
@@ -38,18 +36,3 @@ enum class DebugOverlayRegions : uint8_t {
 };
 
 }
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::DebugOverlayRegions> {
-    using values = EnumValues<
-        WebCore::DebugOverlayRegions,
-        WebCore::DebugOverlayRegions::NonFastScrollableRegion,
-        WebCore::DebugOverlayRegions::WheelEventHandlerRegion,
-        WebCore::DebugOverlayRegions::TouchActionRegion,
-        WebCore::DebugOverlayRegions::EditableElementRegion,
-        WebCore::DebugOverlayRegions::InteractionRegion
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/LoggedInStatus.h
+++ b/Source/WebCore/page/LoggedInStatus.h
@@ -27,7 +27,6 @@
 
 #include "ExceptionOr.h"
 #include "RegistrableDomain.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WallTime.h>
@@ -70,16 +69,3 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::LoggedInStatus::AuthenticationType> {
-    using values = EnumValues<
-        WebCore::LoggedInStatus::AuthenticationType,
-        WebCore::LoggedInStatus::AuthenticationType::WebAuthn,
-        WebCore::LoggedInStatus::AuthenticationType::PasswordManager,
-        WebCore::LoggedInStatus::AuthenticationType::Unmanaged
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/ModalContainerTypes.h
+++ b/Source/WebCore/page/ModalContainerTypes.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class ModalContainerControlType : uint8_t {
@@ -44,17 +42,3 @@ enum class ModalContainerDecision : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ModalContainerControlType> {
-    using values = EnumValues<
-        WebCore::ModalContainerControlType,
-        WebCore::ModalContainerControlType::Neutral,
-        WebCore::ModalContainerControlType::Positive,
-        WebCore::ModalContainerControlType::Negative,
-        WebCore::ModalContainerControlType::Other
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -28,7 +28,6 @@
 #include "FloatPoint.h"
 #include "KeyboardScroll.h"
 #include "ScrollTypes.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -217,51 +216,3 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollUpdateType);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const RequestedScrollData&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SynchronousScrollingReason> {
-    using values = EnumValues<
-        WebCore::SynchronousScrollingReason,
-        WebCore::SynchronousScrollingReason::ForcedOnMainThread,
-        WebCore::SynchronousScrollingReason::HasViewportConstrainedObjectsWithoutSupportingFixedLayers,
-        WebCore::SynchronousScrollingReason::HasNonLayerViewportConstrainedObjects,
-        WebCore::SynchronousScrollingReason::IsImageDocument,
-        WebCore::SynchronousScrollingReason::HasSlowRepaintObjects,
-        WebCore::SynchronousScrollingReason::DescendantScrollersHaveSynchronousScrolling
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ScrollRequestType> {
-    using values = EnumValues<
-        WebCore::ScrollRequestType,
-        WebCore::ScrollRequestType::PositionUpdate,
-        WebCore::ScrollRequestType::DeltaUpdate,
-        WebCore::ScrollRequestType::CancelAnimatedScroll
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ScrollingNodeType> {
-    using values = EnumValues<
-        WebCore::ScrollingNodeType,
-        WebCore::ScrollingNodeType::MainFrame,
-        WebCore::ScrollingNodeType::Subframe,
-        WebCore::ScrollingNodeType::FrameHosting,
-        WebCore::ScrollingNodeType::Overflow,
-        WebCore::ScrollingNodeType::OverflowProxy,
-        WebCore::ScrollingNodeType::Fixed,
-        WebCore::ScrollingNodeType::Sticky,
-        WebCore::ScrollingNodeType::Positioned
-    >;
-};
-
-template<> struct EnumTraits<WebCore::KeyboardScrollAction> {
-    using values = EnumValues<
-        WebCore::KeyboardScrollAction,
-        WebCore::KeyboardScrollAction::StartAnimation,
-        WebCore::KeyboardScrollAction::StopWithAnimation,
-        WebCore::KeyboardScrollAction::StopImmediately
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6725,3 +6725,48 @@ enum class WebCore::MediationRequirement : uint8_t {
     Conditional,
 };
 #endif
+
+#if ENABLE(CONTEXT_MENUS)
+header: <WebCore/ContextMenuContext.h>
+enum class WebCore::ContextMenuContextType : uint8_t {
+    ContextMenu,
+#if ENABLE(SERVICE_CONTROLS)
+    ServicesMenu,
+#endif
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
+    MediaControls,
+#endif
+};
+#endif
+
+#if ENABLE(TRACKING_PREVENTION)
+header: <WebCore/CrossSiteNavigationDataTransfer.h>
+[OptionSet] enum class WebCore::CrossSiteNavigationDataTransferFlag : uint8_t {
+    DestinationLinkDecoration,
+    ReferrerLinkDecoration
+};
+#endif
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[Nested, OptionSet] enum class WebCore::SynchronousScrollingReason : uint8_t {
+    ForcedOnMainThread,
+    HasViewportConstrainedObjectsWithoutSupportingFixedLayers,
+    HasNonLayerViewportConstrainedObjects,
+    IsImageDocument,
+    HasSlowRepaintObjects,
+    DescendantScrollersHaveSynchronousScrolling
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[Nested] enum class WebCore::ScrollRequestType : uint8_t {
+    PositionUpdate,
+    DeltaUpdate,
+    CancelAnimatedScroll
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[Nested] enum class WebCore::KeyboardScrollAction : uint8_t {
+    StartAnimation,
+    StopWithAnimation,
+    StopImmediately
+};


### PR DESCRIPTION
#### f770edcb4761c91545ef81b5a88f12a479b725aa
<pre>
Generate IPC serialization for enumerations under WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=264724">https://bugs.webkit.org/show_bug.cgi?id=264724</a>

Reviewed by Chris Dumez.

Remove remaining EnumTraits specializations under WebCore/page in favor of
using IPC serialization specifications in the WebCoreArgumentCoders
serialization input file.

* Source/WebCore/page/ContextMenuContext.h:
* Source/WebCore/page/CrossSiteNavigationDataTransfer.h:
* Source/WebCore/page/DebugOverlayRegions.h:
* Source/WebCore/page/LoggedInStatus.h:
* Source/WebCore/page/ModalContainerTypes.h:
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270697@main">https://commits.webkit.org/270697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fddc460635e6d1f1162a3afee7870b00fc296acc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28815 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23461 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27399 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1456 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4662 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6287 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->