### PR TITLE
Update WebVTT region setting parser algorithm to match the spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/header-regions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/header-regions.html
@@ -39,7 +39,7 @@ async_test(function(t) {
     var testTrack = document.createElement('track');
     testTrack.onload = t.step_func_done(function() {
         var track = testTrack.track;
-        assert_equals(track.cues.length, 9);
+        assert_equals(track.cues.length, 10);
         checkCueRegions(track.cues);
     });
     testTrack.src = 'support/header-regions.vtt';

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-id-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-id-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL regions, id null is not an object (evaluating 'region3.lines')
+PASS regions, id
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/header-regions.vtt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/header-regions.vtt
@@ -24,6 +24,10 @@ REGION
 invalid_settings values but region still created
 : Invalid Header
 
+REGION
+id:region_split_by_ascii_whitespace			width:10%
+lines:5regionanchor:40%,20%    viewportanchor:30%,80% 	scroll:up
+
 00:00:00.000 --> 00:00:02.500 region:someregionattributeid
 "no region"
 
@@ -50,3 +54,6 @@ invalid_settings values but region still created
 
 00:00:07.000 --> 00:00:08.000 region:
 "no region"
+
+00:00:08.000 --> 00:00:09.000 region:region_split_by_ascii_whitespace
+{"width":10,"lines":5,"regionAnchorX":40,"regionAnchorY":20,"viewportAnchorX":30,"viewportAnchorY":80,"scroll":"up"}


### PR DESCRIPTION
#### 30dd17f24fc4e398458539e2f696b0a72f5e415e
<pre>
Update WebVTT region setting parser algorithm to match the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=264736">https://bugs.webkit.org/show_bug.cgi?id=264736</a>

Reviewed by Eric Carlson.

The current WebVTT parser incorrectly interprets the region id setting string `&apos;id: foo&apos;`
as a region with an id of `&apos;&apos;`. However, this behavior deviates from the specification.
According to the spec, the parser should initially split the input string based on ascii spaces.
Then if the first `&apos;:&apos;` in a setting string is either the first or last character of that string,
it should proceed to the next string. In the case of `&apos;id: foo&apos;`, it should be parsed as `&apos;id:&apos;` and `&apos;foo&apos;`,
both of which are considered invalid id strings.

This patch aligns the parser algorithm with the spec, which processes each setting string split by spaces.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/header-regions.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-id-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/header-regions.vtt:
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::setRegionSettings):
(WebCore::VTTRegion::scanSettingName):

Canonical link: <a href="https://commits.webkit.org/270868@main">https://commits.webkit.org/270868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b7e740419979ff1f9c9877082cbd1841a45fca6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24106 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29686 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27579 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23374 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->