### PR TITLE
[TextureMapper] Move applyFilters from BitmapTexture to TextureMapper

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -24,7 +24,6 @@
 
 #if USE(TEXTURE_MAPPER)
 
-#include "FilterOperations.h"
 #include "GLContext.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
@@ -74,7 +73,7 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
     m_flags = flags;
     m_shouldClear = true;
     m_colorConvertFlags = { };
-    m_filterInfo = FilterInfo();
+    m_filterOperation = nullptr;
     if (m_size != size) {
         m_size = size;
         glBindTexture(GL_TEXTURE_2D, m_id);
@@ -178,27 +177,6 @@ void BitmapTexture::updateContents(GraphicsLayer* sourceLayer, const IntRect& ta
         return;
 
     updateContents(image.get(), targetRect, IntPoint());
-}
-
-RefPtr<BitmapTexture> BitmapTexture::applyFilters(TextureMapper& textureMapper, const FilterOperations& filters, bool defersLastFilterPass)
-{
-    if (filters.isEmpty())
-        return this;
-
-    RefPtr<BitmapTexture> previousSurface = textureMapper.currentSurface();
-    RefPtr<BitmapTexture> surface = this;
-
-    for (size_t i = 0; i < filters.size(); ++i) {
-        RefPtr<FilterOperation> filter = filters.operations()[i];
-        ASSERT(filter);
-
-        bool lastFilter = (i == filters.size() - 1);
-
-        surface = textureMapper.applyFilter(surface, filter, defersLastFilterPass && lastFilter);
-    }
-
-    textureMapper.bindSurface(previousSurface.get());
-    return surface;
 }
 
 void BitmapTexture::initializeStencil()

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -38,7 +38,6 @@
 
 namespace WebCore {
 
-class FilterOperations;
 class GraphicsLayer;
 class NativeImage;
 class TextureMapper;
@@ -82,16 +81,8 @@ public:
 
     int numberOfBytes() const { return size().width() * size().height() * 32 >> 3; }
 
-    RefPtr<BitmapTexture> applyFilters(TextureMapper&, const FilterOperations&, bool defersLastFilterPass);
-    struct FilterInfo {
-        RefPtr<const FilterOperation> filter;
-
-        FilterInfo(RefPtr<const FilterOperation>&& f = nullptr)
-            : filter(WTFMove(f))
-            { }
-    };
-    const FilterInfo* filterInfo() const { return &m_filterInfo; }
-    void setFilterInfo(FilterInfo&& filterInfo) { m_filterInfo = WTFMove(filterInfo); }
+    RefPtr<const FilterOperation> filterOperation() const { return m_filterOperation; }
+    void setFilterOperation(RefPtr<const FilterOperation>&& filterOperation) { m_filterOperation = WTFMove(filterOperation); }
 
     ClipStack& clipStack() { return m_clipStack; }
 
@@ -116,7 +107,7 @@ private:
     bool m_shouldClear { true };
     ClipStack m_clipStack;
     OptionSet<TextureMapperFlags> m_colorConvertFlags;
-    FilterInfo m_filterInfo;
+    RefPtr<const FilterOperation> m_filterOperation;
     GLint m_internalFormat { 0 };
     GLenum m_format { 0 };
 };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -88,7 +88,7 @@ public:
     void setWrapMode(WrapMode m) { m_wrapMode = m; }
     void setPatternTransform(const TransformationMatrix& p) { m_patternTransform = p; }
 
-    RefPtr<BitmapTexture> applyFilter(RefPtr<BitmapTexture> sourceTexture, const RefPtr<const FilterOperation>&, bool defersLastPass);
+    RefPtr<BitmapTexture> applyFilters(RefPtr<BitmapTexture>&, const FilterOperations&, bool defersLastPass);
 
     WEBCORE_EXPORT RefPtr<BitmapTexture> acquireTextureFromPool(const IntSize&, OptionSet<BitmapTexture::Flags>);
 
@@ -104,9 +104,10 @@ private:
 
     enum class Direction { X, Y };
 
-    RefPtr<BitmapTexture> applyBlurFilter(RefPtr<BitmapTexture> sourceTexture, const BlurFilterOperation&);
-    RefPtr<BitmapTexture> applyDropShadowFilter(RefPtr<BitmapTexture> sourceTexture, const DropShadowFilterOperation&);
-    RefPtr<BitmapTexture> applySinglePassFilter(RefPtr<BitmapTexture> sourceTexture, const RefPtr<const FilterOperation>&, bool shouldDefer);
+    RefPtr<BitmapTexture> applyFilter(RefPtr<BitmapTexture>&, const RefPtr<const FilterOperation>&, bool defersLastPass);
+    RefPtr<BitmapTexture> applyBlurFilter(RefPtr<BitmapTexture>&, const BlurFilterOperation&);
+    RefPtr<BitmapTexture> applyDropShadowFilter(RefPtr<BitmapTexture>&, const DropShadowFilterOperation&);
+    RefPtr<BitmapTexture> applySinglePassFilter(RefPtr<BitmapTexture>&, const RefPtr<const FilterOperation>&, bool shouldDefer);
 
     void drawTextureCopy(const BitmapTexture& sourceTexture, const FloatRect& sourceRect, const FloatRect& targetRect);
     void drawBlurred(const BitmapTexture& sourceTexture, const FloatRect&, float radius, Direction, bool alphaBlur = false);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -679,7 +679,7 @@ void TextureMapperLayer::paintIntoSurface(TextureMapperPaintOptions& options)
     bool hasMask = !!m_state.maskLayer;
     bool hasReplicaMask = options.replicaLayer == this && m_state.replicaLayer->m_state.maskLayer;
     bool defersLastFilterPass = !hasMask && !hasReplicaMask;
-    options.surface = options.surface->applyFilters(options.textureMapper, m_currentFilters, defersLastFilterPass);
+    options.surface = options.textureMapper.applyFilters(options.surface, m_currentFilters, defersLastFilterPass);
     options.textureMapper.bindSurface(options.surface.get());
     if (hasMask)
         m_state.maskLayer->applyMask(options);


### PR DESCRIPTION
#### fc091abb0db77674f3b63fbd6b2d3e46c023c808
<pre>
[TextureMapper] Move applyFilters from BitmapTexture to TextureMapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=264740">https://bugs.webkit.org/show_bug.cgi?id=264740</a>

Reviewed by Fujii Hironori.

It&apos;s TextureMapper the one applying filters. Also remove FilterInfo and
use FilterOperation direclty instead.

* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::applyFilters): Deleted.
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawTexture):
(WebCore::TextureMapper::drawTexturePlanarYUV):
(WebCore::TextureMapper::drawTextureSemiPlanarYUV):
(WebCore::TextureMapper::drawTexturePackedYUV):
(WebCore::TextureMapper::applyBlurFilter):
(WebCore::TextureMapper::applyDropShadowFilter):
(WebCore::TextureMapper::applySinglePassFilter):
(WebCore::TextureMapper::applyFilters):
(WebCore::TextureMapper::applyFilter):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintIntoSurface):

Canonical link: <a href="https://commits.webkit.org/270699@main">https://commits.webkit.org/270699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5811f647e62e7c9dd699c45b7fa391c9a3040bd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25992 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23878 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28672 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29410 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27288 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1345 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4526 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3594 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3365 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->