### PR TITLE
REGRESSION(270320@main): Speedometer3/Editor-TipTap 4-6%

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -30,6 +30,7 @@
 #include "RenderingResourceIdentifier.h"
 #include <variant>
 #include <wtf/BitVector.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Hasher.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
@@ -74,7 +75,7 @@ bool fontHasEitherTable(CTFontRef, unsigned tableTag1, unsigned tableTag2);
 #endif
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Font);
-class Font : public RefCounted<Font>, public CanMakeWeakPtr<Font> {
+class Font : public RefCounted<Font>, public CanMakeWeakPtr<Font>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Font);
 public:
     // Used to create platform fonts.

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1224,7 +1224,7 @@ int FontCascade::emphasisMarkAscent(const AtomString& mark) const
     if (!markGlyphData)
         return 0;
 
-    WeakPtr markFontData = markGlyphData.value().font;
+    CheckedPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return 0;
@@ -1238,7 +1238,7 @@ int FontCascade::emphasisMarkDescent(const AtomString& mark) const
     if (!markGlyphData)
         return 0;
 
-    WeakPtr markFontData = markGlyphData.value().font;
+    CheckedPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return 0;
@@ -1402,7 +1402,7 @@ void FontCascade::drawEmphasisMarks(GraphicsContext& context, const GlyphBuffer&
     if (!markGlyphData)
         return;
 
-    WeakPtr markFontData = markGlyphData.value().font;
+    CheckedPtr markFontData = markGlyphData.value().font;
     ASSERT(markFontData);
     if (!markFontData)
         return;

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -63,7 +63,7 @@ private:
     {
         ASSERT_WITH_SECURITY_IMPLICATION(index < GlyphPage::size);
         m_glyphs[index] = glyphData.glyph;
-        m_fonts[index] = glyphData.font;
+        m_fonts[index] = glyphData.font.get();
     }
 
     Glyph m_glyphs[GlyphPage::size] { };

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -55,7 +55,7 @@ struct GlyphData {
 
     Glyph glyph;
     ColorGlyphType colorGlyphType;
-    WeakPtr<const Font> font;
+    CheckedPtr<const Font> font;
 };
 
 // A GlyphPage contains a fixed-size set of GlyphData mappings for a contiguous

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -123,14 +123,14 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     else if (characters[length - 1] == 0xFE0F)
         preferColoredFont = true;
 
-    WeakPtr baseFont = glyphDataForCharacter(character, false, NormalVariant).font;
+    CheckedPtr baseFont = glyphDataForCharacter(character, false, NormalVariant).font;
     if (baseFont
         && (clusterLength == length || baseFont->canRenderCombiningCharacterSequence(normalizedString.view))
         && (!preferColoredFont || baseFont->platformData().isColorBitmapFont()))
         return baseFont.get();
 
     for (unsigned i = 0; !fallbackRangesAt(i).isNull(); ++i) {
-        WeakPtr fallbackFont = fallbackRangesAt(i).fontForCharacter(character);
+        CheckedPtr fallbackFont = fallbackRangesAt(i).fontForCharacter(character);
         if (!fallbackFont || fallbackFont == baseFont)
             continue;
 


### PR DESCRIPTION
#### 7c1250d993d60925c2fd8185e0976e32b7bcd592
<pre>
REGRESSION(270320@main): Speedometer3/Editor-TipTap 4-6%
<a href="https://bugs.webkit.org/show_bug.cgi?id=264744">https://bugs.webkit.org/show_bug.cgi?id=264744</a>
<a href="https://rdar.apple.com/118312367">rdar://118312367</a>

Unreviewed, partial revert of 270320@main to address the Speedometer
regression. In 270320@main, I had converted all remaining
CheckedPtr&lt;Font&gt; to WeakPtr&lt;Font&gt; to address crashes. However, we
didn&apos;t need to convert GlyphData&apos;s font data member. Reverting this
part of the change doesn&apos;t regress the layout test introduced in
270320@main but I have confirmed that it resolves the Speedometer
regression.

* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::emphasisMarkAscent const):
(WebCore::FontCascade::emphasisMarkDescent const):
(WebCore::FontCascade::drawEmphasisMarks const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::MixedFontGlyphPage::setGlyphDataForIndex):
* Source/WebCore/platform/graphics/GlyphPage.h:

Canonical link: <a href="https://commits.webkit.org/270646@main">https://commits.webkit.org/270646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b69ac78262ff2c746f29bd141902cf081f62f569

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2043 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28682 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3114 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29423 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23730 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27301 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4536 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6257 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->