### PR TITLE
[web-animations] `KeyframeValue` and `AcceleratedEffectKeyframe` should derive from a shared base class

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -677,6 +677,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/IterationCompositeOperation.h
     animation/KeyframeAnimationOptions.h
     animation/KeyframeEffectOptions.h
+    animation/KeyframeInterpolation.h
     animation/PlaybackDirection.h
     animation/WebAnimationTypes.h
 

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CompositeOperation.h"
+#include "WebAnimationTypes.h"
+#include <optional>
+#include <wtf/Seconds.h>
+
+namespace WebCore {
+
+class KeyframeInterpolation {
+public:
+    using Property = std::variant<AnimatableCSSProperty, AcceleratedEffectProperty>;
+
+    class Keyframe {
+    public:
+        virtual double offset() const = 0;
+        virtual std::optional<CompositeOperation> compositeOperation() const = 0;
+        virtual bool animatesProperty(Property) const = 0;
+
+        virtual bool isAcceleratedEffectKeyframe() const { return false; }
+        virtual bool isKeyframeValue() const { return false; }
+
+        virtual ~Keyframe() = default;
+    };
+};
+
+} // namespace WebCore
+
+#define SPECIALIZE_TYPE_TRAITS_KEYFRAME_INTERPOLATION_KEYFRAME(ToValueTypeName, predicate) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
+static bool isType(const WebCore::KeyframeInterpolation::Keyframe& value) { return value.predicate; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -72,6 +72,24 @@ using CSSAnimationCollection = ListHashSet<Ref<CSSAnimation>>;
 using AnimatableCSSProperty = std::variant<CSSPropertyID, AtomString>;
 using AnimatableCSSPropertyToTransitionMap = HashMap<AnimatableCSSProperty, Ref<CSSTransition>>;
 
+enum class AcceleratedEffectProperty : uint16_t {
+    Invalid = 1 << 0,
+    Opacity = 1 << 1,
+    Transform = 1 << 2,
+    Translate = 1 << 3,
+    Rotate = 1 << 4,
+    Scale = 1 << 5,
+    OffsetPath = 1 << 6,
+    OffsetDistance = 1 << 7,
+    OffsetPosition = 1 << 8,
+    OffsetAnchor = 1 << 9,
+    OffsetRotate = 1 << 10,
+    Filter = 1 << 11,
+#if ENABLE(FILTERS_LEVEL_2)
+    BackdropFilter = 1 << 12
+#endif
+};
+
 struct CSSPropertiesBitSet {
     WTF::BitSet<numCSSProperties> m_properties { };
 };

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -132,7 +132,7 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
             auto& style = *blendingKeyframe.style();
 
             auto keyframePayload = Protocol::Animation::Keyframe::create()
-                .setOffset(blendingKeyframe.key())
+                .setOffset(blendingKeyframe.offset())
                 .release();
 
             RefPtr<TimingFunction> timingFunction;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3987,34 +3987,34 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& anim
 
     for (auto& currentKeyframe : keyframes) {
         const RenderStyle* keyframeStyle = currentKeyframe.style();
-        double key = currentKeyframe.key();
+        double offset = currentKeyframe.offset();
 
         if (!keyframeStyle)
             continue;
             
         auto* tf = currentKeyframe.timingFunction();
-        
-        if (currentKeyframe.containsProperty(CSSPropertyRotate))
-            rotateVector.insert(makeUnique<TransformAnimationValue>(key, keyframeStyle->rotate(), tf));
 
-        if (currentKeyframe.containsProperty(CSSPropertyScale))
-            scaleVector.insert(makeUnique<TransformAnimationValue>(key, keyframeStyle->scale(), tf));
+        if (currentKeyframe.animatesProperty(CSSPropertyRotate))
+            rotateVector.insert(makeUnique<TransformAnimationValue>(offset, keyframeStyle->rotate(), tf));
 
-        if (currentKeyframe.containsProperty(CSSPropertyTranslate))
-            translateVector.insert(makeUnique<TransformAnimationValue>(key, keyframeStyle->translate(), tf));
+        if (currentKeyframe.animatesProperty(CSSPropertyScale))
+            scaleVector.insert(makeUnique<TransformAnimationValue>(offset, keyframeStyle->scale(), tf));
 
-        if (currentKeyframe.containsProperty(CSSPropertyTransform))
-            transformVector.insert(makeUnique<TransformAnimationValue>(key, keyframeStyle->transform(), tf));
+        if (currentKeyframe.animatesProperty(CSSPropertyTranslate))
+            translateVector.insert(makeUnique<TransformAnimationValue>(offset, keyframeStyle->translate(), tf));
 
-        if (currentKeyframe.containsProperty(CSSPropertyOpacity))
-            opacityVector.insert(makeUnique<FloatAnimationValue>(key, keyframeStyle->opacity(), tf));
+        if (currentKeyframe.animatesProperty(CSSPropertyTransform))
+            transformVector.insert(makeUnique<TransformAnimationValue>(offset, keyframeStyle->transform(), tf));
 
-        if (currentKeyframe.containsProperty(CSSPropertyFilter))
-            filterVector.insert(makeUnique<FilterAnimationValue>(key, keyframeStyle->filter(), tf));
+        if (currentKeyframe.animatesProperty(CSSPropertyOpacity))
+            opacityVector.insert(makeUnique<FloatAnimationValue>(offset, keyframeStyle->opacity(), tf));
+
+        if (currentKeyframe.animatesProperty(CSSPropertyFilter))
+            filterVector.insert(makeUnique<FilterAnimationValue>(offset, keyframeStyle->filter(), tf));
 
 #if ENABLE(FILTERS_LEVEL_2)
-        if (currentKeyframe.containsProperty(CSSPropertyWebkitBackdropFilter) || currentKeyframe.containsProperty(CSSPropertyBackdropFilter))
-            backdropFilterVector.insert(makeUnique<FilterAnimationValue>(key, keyframeStyle->backdropFilter(), tf));
+        if (currentKeyframe.animatesProperty(CSSPropertyWebkitBackdropFilter) || currentKeyframe.animatesProperty(CSSPropertyBackdropFilter))
+            backdropFilterVector.insert(makeUnique<FilterAnimationValue>(offset, keyframeStyle->backdropFilter(), tf));
 #endif
     }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -443,7 +443,7 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
         for (auto key : keyframeRule->keys()) {
             KeyframeValue keyframeValue(0, nullptr);
             keyframeValue.setStyle(styleForKeyframe(element, elementStyle, context, keyframeRule.get(), keyframeValue));
-            keyframeValue.setKey(key);
+            keyframeValue.setOffset(key);
             if (auto timingFunctionCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationTimingFunction))
                 keyframeValue.setTimingFunction(TimingFunction::createFromCSSValue(*timingFunctionCSSValue.get()));
             if (auto compositeOperationCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationComposition)) {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5790,17 +5790,17 @@ struct WebCore::AnimationEffectTiming {
 };
 
 header: <WebCore/AcceleratedEffect.h>
-[CustomHeader] struct WebCore::AcceleratedEffectKeyframe {
-    double offset;
-    WebCore::AcceleratedEffectValues values;
-    RefPtr<WebCore::TimingFunction> timingFunction;
-    std::optional<WebCore::CompositeOperation> compositeOperation;
-    OptionSet<WebCore::AcceleratedEffectProperty> animatedProperties;
+[CustomHeader, Nested] class WebCore::AcceleratedEffect::Keyframe {
+    double offset();
+    WebCore::AcceleratedEffectValues values();
+    RefPtr<WebCore::TimingFunction> timingFunction();
+    std::optional<WebCore::CompositeOperation> compositeOperation();
+    OptionSet<WebCore::AcceleratedEffectProperty> animatedProperties();
 };
 
 [RefCounted] class WebCore::AcceleratedEffect {
     WebCore::AnimationEffectTiming timing();
-    Vector<WebCore::AcceleratedEffectKeyframe> keyframes();
+    Vector<WebCore::AcceleratedEffect::Keyframe> keyframes();
     WebCore::WebAnimationType animationType();
     WebCore::CompositeOperation compositeOperation();
     RefPtr<WebCore::TimingFunction> defaultKeyframeTimingFunction();


### PR DESCRIPTION
#### 893f4b23e527ed71d0d970a9adeb78a111870d00
<pre>
[web-animations] `KeyframeValue` and `AcceleratedEffectKeyframe` should derive from a shared base class
<a href="https://bugs.webkit.org/show_bug.cgi?id=264747">https://bugs.webkit.org/show_bug.cgi?id=264747</a>

Reviewed by Dean Jackson.

As part of the work on threaded animation resolution (see bug 250970), we will need to have the keyframe
interpolation logic currently contained in `KeyframeEffect` also apply to `AcceleratedEffect`. This will
require a fair amount of refactoring to move all the relevant code in a shared base class for both
`KeyframeEffect` and `AcceleratedEffect`.

The first step towards this goal is to have the keyframe class backing those animation effect classes,
`KeyframeValue` and `AcceleratedEffectKeyframe`, use a shared base class. In this patch we introduce a
new `KeyframeInterpolation` class, which is currently empty except for the nested `KeyframeInterpolation::Keyframe`.
It exposes a simple set of methods that `KeyframeValue` and `AcceleratedEffectKeyframe` now override:

    double offset() const;
    std::optional&lt;CompositeOperation&gt; compositeOperation() const;
    bool animatesProperty(Property) const;

We also add a new abstract `AnimatedProperty` which can be either `AnimatableCSSProperty` or `AcceleratedEffectProperty`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::computeExtentOfTransformAnimation const):
(WebCore::KeyframeEffect::progressUntilNextStep const):
(WebCore::KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty):
* Source/WebCore/animation/KeyframeInterpolation.h: Added.
(WebCore::KeyframeInterpolation::Keyframe::isAcceleratedEffectKeyframe const):
(WebCore::KeyframeInterpolation::Keyframe::isKeyframeValue const):
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::Keyframe::Keyframe):
(WebCore::AcceleratedEffect::Keyframe::animatesProperty const):
(WebCore::AcceleratedEffect::Keyframe::clone const):
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::AcceleratedEffect):
(WebCore::AcceleratedEffectKeyframe::clone const): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::keyframes const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::startAnimation):
* Source/WebCore/rendering/style/KeyframeList.cpp:
(WebCore::KeyframeList::operator== const):
(WebCore::KeyframeList::insert):
(WebCore::KeyframeList::hasImplicitKeyframes const):
(WebCore::KeyframeList::copyKeyframes):
(WebCore::KeyframeList::fillImplicitKeyframes):
(WebCore::KeyframeValue::animatesProperty const):
(WebCore::KeyframeValue::containsProperty const): Deleted.
* Source/WebCore/rendering/style/KeyframeList.h:
(WebCore::KeyframeValue::KeyframeValue): Deleted.
(WebCore::KeyframeValue::properties const): Deleted.
(WebCore::KeyframeValue::key const): Deleted.
(WebCore::KeyframeValue::setKey): Deleted.
(WebCore::KeyframeValue::style const): Deleted.
(WebCore::KeyframeValue::setStyle): Deleted.
(WebCore::KeyframeValue::timingFunction const): Deleted.
(WebCore::KeyframeValue::setTimingFunction): Deleted.
(WebCore::KeyframeValue::compositeOperation const): Deleted.
(WebCore::KeyframeValue::setCompositeOperation): Deleted.
(WebCore::KeyframeValue::containsDirectionAwareProperty const): Deleted.
(WebCore::KeyframeValue::setContainsDirectionAwareProperty): Deleted.
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270648@main">https://commits.webkit.org/270648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d8ca7d2aa01ec355fbf3a2ef528a8c30036e1a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26022 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2063 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26276 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28702 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3624 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3337 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->