### PR TITLE
[WebKit] Add an option key to prevent network loads when serializing attributed strings

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h
@@ -32,9 +32,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @abstract Indicates additional local paths WebKit can read from when loading content.
+ The value is an NSArray containing one or more NSURLs.
 */
 WK_EXTERN NSAttributedStringDocumentReadingOptionKey const _WKReadAccessFileURLsOption
     NS_SWIFT_NAME(readAccessPaths) WK_API_AVAILABLE(macos(13.1), ios(16.2));
+
+/*!
+ @abstract Whether to allow loads over the network (including subresources).
+ The value is an NSNumber, which is interpreted as a BOOL.
+*/
+WK_EXTERN NSAttributedStringDocumentReadingOptionKey const _WKAllowNetworkLoadsOption
+    NS_SWIFT_NAME(allowNetworkLoads) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*!
  @discussion Private extension of @link //apple_ref/occ/NSAttributedString NSAttributedString @/link to

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -38,6 +38,7 @@ cocoa/TestInspectorURLSchemeHandler.mm
 cocoa/TestLegacyDownloadDelegate.mm
 cocoa/TestNavigationDelegate.mm
 cocoa/TestProtocol.mm
+cocoa/TestResourceLoadDelegate.mm
 cocoa/TestUIDelegate.mm
 cocoa/TestWKWebView.mm
 cocoa/TestWebExtensionsDelegate.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3576,6 +3576,8 @@
 		F4BDA42E27F8BF2F00F9647D /* FullscreenVideoTextRecognition.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenVideoTextRecognition.mm; sourceTree = "<group>"; };
 		F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-fullscreen.html"; sourceTree = "<group>"; };
 		F4BFA68C1E4AD08000154298 /* LegacyDragAndDropTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LegacyDragAndDropTests.mm; sourceTree = "<group>"; };
+		F4C192CD2B027C93001F75CE /* TestResourceLoadDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestResourceLoadDelegate.h; path = cocoa/TestResourceLoadDelegate.h; sourceTree = "<group>"; };
+		F4C192CE2B027C93001F75CE /* TestResourceLoadDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = TestResourceLoadDelegate.mm; path = cocoa/TestResourceLoadDelegate.mm; sourceTree = "<group>"; };
 		F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "enormous-video-with-sound.html"; sourceTree = "<group>"; };
 		F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollViewInsetTests.mm; sourceTree = "<group>"; };
 		F4CB8A7B2856447F0017ECD3 /* TestPDFHostViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestPDFHostViewController.h; sourceTree = "<group>"; };
@@ -3853,6 +3855,8 @@
 				516281242325C17B00BB7E42 /* TestPDFDocument.mm */,
 				A14FC58D1B8AE36500D107EB /* TestProtocol.h */,
 				A14FC58E1B8AE36500D107EB /* TestProtocol.mm */,
+				F4C192CD2B027C93001F75CE /* TestResourceLoadDelegate.h */,
+				F4C192CE2B027C93001F75CE /* TestResourceLoadDelegate.mm */,
 				5CBAA7F324327F6B00564A8B /* TestUIDelegate.h */,
 				5CBAA7F424327F6B00564A8B /* TestUIDelegate.mm */,
 				B63EF53E2995797F00A190A3 /* TestWebExtensionsDelegate.h */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
@@ -28,6 +28,7 @@
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "TestNavigationDelegate.h"
+#import "TestResourceLoadDelegate.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKWebViewPrivate.h>
@@ -36,50 +37,6 @@
 #import <WebKit/_WKResourceLoadDelegate.h>
 #import <WebKit/_WKResourceLoadInfo.h>
 #import <wtf/RetainPtr.h>
-
-@interface TestResourceLoadDelegate : NSObject <_WKResourceLoadDelegate>
-
-@property (nonatomic, copy) void (^didSendRequest)(WKWebView *, _WKResourceLoadInfo *, NSURLRequest *);
-@property (nonatomic, copy) void (^didPerformHTTPRedirection)(WKWebView *, _WKResourceLoadInfo *, NSURLResponse *, NSURLRequest *);
-@property (nonatomic, copy) void (^didReceiveChallenge)(WKWebView *, _WKResourceLoadInfo *, NSURLAuthenticationChallenge *);
-@property (nonatomic, copy) void (^didReceiveResponse)(WKWebView *, _WKResourceLoadInfo *, NSURLResponse *);
-@property (nonatomic, copy) void (^didCompleteWithError)(WKWebView *, _WKResourceLoadInfo *, NSError *, NSURLResponse *);
-
-@end
-
-@implementation TestResourceLoadDelegate
-
-- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didSendRequest:(NSURLRequest *)request
-{
-    if (_didSendRequest)
-        _didSendRequest(webView, resourceLoad, request);
-}
-
-- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didPerformHTTPRedirection:(NSURLResponse *)response newRequest:(NSURLRequest *)request
-{
-    if (_didPerformHTTPRedirection)
-        _didPerformHTTPRedirection(webView, resourceLoad, response, request);
-}
-
-- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-{
-    if (_didReceiveChallenge)
-        _didReceiveChallenge(webView, resourceLoad, challenge);
-}
-
-- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didReceiveResponse:(NSURLResponse *)response
-{
-    if (_didReceiveResponse)
-        _didReceiveResponse(webView, resourceLoad, response);
-}
-
-- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didCompleteWithError:(NSError *)error response:(NSURLResponse *)response
-{
-    if (_didCompleteWithError)
-        _didCompleteWithError(webView, resourceLoad, error, response);
-}
-
-@end
 
 TEST(ResourceLoadDelegate, Basic)
 {

--- a/Tools/TestWebKitAPI/cocoa/TestResourceLoadDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestResourceLoadDelegate.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <WebKit/WebKit.h>
+#import <WebKit/_WKResourceLoadDelegate.h>
+
+@class _WKResourceLoadInfo;
+
+@interface TestResourceLoadDelegate : NSObject <_WKResourceLoadDelegate>
+
+@property (nonatomic, copy) void (^didSendRequest)(WKWebView *, _WKResourceLoadInfo *, NSURLRequest *);
+@property (nonatomic, copy) void (^didPerformHTTPRedirection)(WKWebView *, _WKResourceLoadInfo *, NSURLResponse *, NSURLRequest *);
+@property (nonatomic, copy) void (^didReceiveChallenge)(WKWebView *, _WKResourceLoadInfo *, NSURLAuthenticationChallenge *);
+@property (nonatomic, copy) void (^didReceiveResponse)(WKWebView *, _WKResourceLoadInfo *, NSURLResponse *);
+@property (nonatomic, copy) void (^didCompleteWithError)(WKWebView *, _WKResourceLoadInfo *, NSError *, NSURLResponse *);
+
+@end

--- a/Tools/TestWebKitAPI/cocoa/TestResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestResourceLoadDelegate.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "TestResourceLoadDelegate.h"
+
+#import <WebKit/_WKResourceLoadInfo.h>
+
+@implementation TestResourceLoadDelegate
+
+- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didSendRequest:(NSURLRequest *)request
+{
+    if (_didSendRequest)
+        _didSendRequest(webView, resourceLoad, request);
+}
+
+- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didPerformHTTPRedirection:(NSURLResponse *)response newRequest:(NSURLRequest *)request
+{
+    if (_didPerformHTTPRedirection)
+        _didPerformHTTPRedirection(webView, resourceLoad, response, request);
+}
+
+- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+    if (_didReceiveChallenge)
+        _didReceiveChallenge(webView, resourceLoad, challenge);
+}
+
+- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didReceiveResponse:(NSURLResponse *)response
+{
+    if (_didReceiveResponse)
+        _didReceiveResponse(webView, resourceLoad, response);
+}
+
+- (void)webView:(WKWebView *)webView resourceLoad:(_WKResourceLoadInfo *)resourceLoad didCompleteWithError:(NSError *)error response:(NSURLResponse *)response
+{
+    if (_didCompleteWithError)
+        _didCompleteWithError(webView, resourceLoad, error, response);
+}
+
+@end


### PR DESCRIPTION
#### 39925c5d4c4ef3ff0ba785efc1b5d46a242ecf99
<pre>
[WebKit] Add an option key to prevent network loads when serializing attributed strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=264745">https://bugs.webkit.org/show_bug.cgi?id=264745</a>
<a href="https://rdar.apple.com/118309399">rdar://118309399</a>

Reviewed by Tim Horton.

Add support for a `NSAttributedStringDocumentReadingOptionKey` which allows clients to serialize
attributed strings from web content, without loading any requests over the network. This is
particularly ideal for clients such as UIFoundation, when serializing HTML markup and/or web archive
data, which otherwise has the potential to trigger arbitrary resource loads upon conversion.

Note that we add an opt-in flag for network loads, because we want to eventually default to *not*
loading content from over the network when serializing attributed strings. Given this eventual plan,
it makes more sense for an app to need to explicitly opt _in_ to network loads, rather than opt out.

Test: WKWebView.DoNotAllowNetworkLoads

* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[_WKAttributedStringWebViewCache configuration]):

Respect the new `_WKAllowNetworkLoadsOption` option by setting `_allowedNetworkHosts` to an empty
set on the configuration, if the value is false-y.

(+[_WKAttributedStringWebViewCache maybeUpdateShouldAllowNetworkLoads:]):
(+[_WKAttributedStringWebViewCache maybeConsumeBundlePaths:]):
(+[_WKAttributedStringWebViewCache invalidateGlobalConfigurationIfNeeded:]):

Refactor this logic to update the global configuration (and clear any cached web views if needed),
if either network load disablement or the allowed file URL list changes.

(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm:

Lift the `TestResourceLoadDelegate` class out of this API test and into a separate helper file, so
that we can use it in a different API test suite (see below).

(-[TestResourceLoadDelegate webView:resourceLoad:didSendRequest:]): Deleted.
(-[TestResourceLoadDelegate webView:resourceLoad:didPerformHTTPRedirection:newRequest:]): Deleted.
(-[TestResourceLoadDelegate webView:resourceLoad:didReceiveChallenge:]): Deleted.
(-[TestResourceLoadDelegate webView:resourceLoad:didReceiveResponse:]): Deleted.
(-[TestResourceLoadDelegate webView:resourceLoad:didCompleteWithError:response:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:

Add a new API test to exercise the case where `_WKAllowNetworkLoadsOption` is set to `@NO`, by
adding a resource load delegate to the web view to listen for any attempted network access. When
this new option is set, we should never get a call to the `didSendRequest:` delegate method.

* Tools/TestWebKitAPI/cocoa/TestResourceLoadDelegate.h: Added.
* Tools/TestWebKitAPI/cocoa/TestResourceLoadDelegate.mm: Added.
(-[TestResourceLoadDelegate webView:resourceLoad:didSendRequest:]):
(-[TestResourceLoadDelegate webView:resourceLoad:didPerformHTTPRedirection:newRequest:]):
(-[TestResourceLoadDelegate webView:resourceLoad:didReceiveChallenge:]):
(-[TestResourceLoadDelegate webView:resourceLoad:didReceiveResponse:]):
(-[TestResourceLoadDelegate webView:resourceLoad:didCompleteWithError:response:]):

Canonical link: <a href="https://commits.webkit.org/270753@main">https://commits.webkit.org/270753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c65d8fa04d06942d1944bb76216b6a0ac8b56632

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24052 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28944 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29622 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27512 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1566 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4780 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6323 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->