### PR TITLE
Stop using `-handleKeyInputMethodCommandForCurrentEvent` to defer key events to IME

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1247,6 +1247,10 @@ typedef struct {
 
 #endif // !defined(UI_DIRECTIONAL_TEXT_RANGE_STRUCT)
 
+@interface UIKeyEventContext (Staging_118307536)
+@property (nonatomic, assign, readwrite) BOOL shouldEvaluateForInputSystemHandling;
+@end
+
 #endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
 
 WTF_EXTERN_C_BEGIN


### PR DESCRIPTION
#### 11908a5f5e62f24cf13ab414337b346d8f6996f5
<pre>
Stop using `-handleKeyInputMethodCommandForCurrentEvent` to defer key events to IME
<a href="https://bugs.webkit.org/show_bug.cgi?id=264749">https://bugs.webkit.org/show_bug.cgi?id=264749</a>
<a href="https://rdar.apple.com/118337970">rdar://118337970</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Stop calling into `-[UIKeyboardImpl handleKeyInputMethodCommandForCurrentEvent]` directly, to defer
key events to IME; instead, use `-[UIAsyncTextInputDelegate deferEventHandlingToSystemWithContext:]`
with an event handling context that has both the `documentIsEditable` property as well as the new
`shouldEvaluateForInputSystemHandling` property set.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _deferKeyEventToInputMethodEditing:]):

Pull out logic to defer key event handling to IME into a separate helper method, which uses the
`UIAsyncTextInputDelegate` when the feature flag is enabled, and otherwise falls back to calling
`-handleKeyInputMethodCommandForCurrentEvent`.

(-[WKContentView _internalHandleKeyWebEvent:withCompletionHandler:]):

Canonical link: <a href="https://commits.webkit.org/270768@main">https://commits.webkit.org/270768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e2f184969aae59285df0d325a8a45ce0279e599

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24090 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28996 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3368 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29662 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1607 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4827 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6334 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->