### PR TITLE
Incorrect caret position in empty elements with a vertical writing mode

### DIFF
--- a/LayoutTests/editing/selection/caret-in-empty-block-vertical-horizontal-rtl-text-indent-padding-expected.txt
+++ b/LayoutTests/editing/selection/caret-in-empty-block-vertical-horizontal-rtl-text-indent-padding-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that an empty block contenteditable element with indented text and padding, and right-to-left text direction, gets a valid caret rect.
+
+
+PASS caretRect.left is correct.
+PASS caretRect.top is correct.
+PASS caretRect.width is correct.
+PASS caretRect.height is correct.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/caret-in-empty-block-vertical-horizontal-rtl-text-indent-padding.html
+++ b/LayoutTests/editing/selection/caret-in-empty-block-vertical-horizontal-rtl-text-indent-padding.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js" type="text/javascript"></script>
+<style>
+
+.hidden {
+    display: none;
+}
+
+#text, #emptyBlock {
+    border: 1px solid black;
+    inline-size: 100px;
+    text-indent: 20px;
+    padding: 10px 20px 30px 40px;
+    direction: rtl;
+}
+</style>
+</head>
+<body>
+<p>This test verifies that an empty block contenteditable element with indented text and padding, and right-to-left text direction, gets a valid caret rect.</p>
+<div id="text" contenteditable>Some text.</div>
+<div id="emptyBlock" contenteditable></div><br>
+<div id="console"></div>
+</body>
+<script>
+    var text = document.getElementById("text");
+    var emptyBlock = document.getElementById("emptyBlock");
+
+    if (window.internals) {
+        emptyBlock.classList.toggle("hidden");
+        getSelection().collapse(text, 0);
+        var textCaretRect = internals.absoluteCaretBounds();
+
+        text.classList.toggle("hidden");
+        emptyBlock.classList.toggle("hidden");
+
+        getSelection().collapse(emptyBlock, 0);
+        var emptyBlockCaretRect = internals.absoluteCaretBounds();
+
+        ['left', 'top', 'width', 'height'].forEach((property) => {
+            if (Math.abs(emptyBlockCaretRect[property] - textCaretRect[property]) <= 1)
+                testPassed(`caretRect.${property} is correct.`);
+            else
+                testFailed(`caretRect.${property} is incorrect.`);
+        });
+    }
+</script>
+</html>

--- a/LayoutTests/editing/selection/caret-in-empty-block-vertical-rl-rtl-expected.txt
+++ b/LayoutTests/editing/selection/caret-in-empty-block-vertical-rl-rtl-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that an empty block contenteditable element with a vertical writing mode, and right-to-left text direction, gets a valid caret rect.
+
+
+PASS caretRect.left is correct.
+PASS caretRect.top is correct.
+PASS caretRect.width is correct.
+PASS caretRect.height is correct.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/caret-in-empty-block-vertical-rl-rtl.html
+++ b/LayoutTests/editing/selection/caret-in-empty-block-vertical-rl-rtl.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js" type="text/javascript"></script>
+<style>
+
+.hidden {
+    display: none;
+}
+
+#text, #emptyBlock {
+    border: 1px solid black;
+    inline-size: 100px;
+    writing-mode: vertical-rl;
+    direction: rtl;
+}
+</style>
+</head>
+<body>
+<p>This test verifies that an empty block contenteditable element with a vertical writing mode, and right-to-left text direction, gets a valid caret rect.</p>
+<div id="text" contenteditable>Some text.</div>
+<div id="emptyBlock" contenteditable></div><br>
+<div id="console"></div>
+</body>
+<script>
+    var text = document.getElementById("text");
+    var emptyBlock = document.getElementById("emptyBlock");
+
+    if (window.internals) {
+        emptyBlock.classList.toggle("hidden");
+        getSelection().collapse(text, 0);
+        var textCaretRect = internals.absoluteCaretBounds();
+
+        text.classList.toggle("hidden");
+        emptyBlock.classList.toggle("hidden");
+
+        getSelection().collapse(emptyBlock, 0);
+        var emptyBlockCaretRect = internals.absoluteCaretBounds();
+
+        ['left', 'top', 'width', 'height'].forEach((property) => {
+            if (Math.abs(emptyBlockCaretRect[property] - textCaretRect[property]) <= 1)
+                testPassed(`caretRect.${property} is correct.`);
+            else
+                testFailed(`caretRect.${property} is incorrect.`);
+        });
+    }
+</script>
+</html>

--- a/LayoutTests/editing/selection/caret-in-empty-inline-vertical-rl-rtl-expected.txt
+++ b/LayoutTests/editing/selection/caret-in-empty-inline-vertical-rl-rtl-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that an empty inline contenteditable element with a vertical writing mode, and right-to-left text direction, gets a valid caret rect.
+
+
+PASS caretRect.left is correct.
+PASS caretRect.top is correct.
+PASS caretRect.width is correct.
+PASS caretRect.height is correct.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/caret-in-empty-inline-vertical-rl-rtl.html
+++ b/LayoutTests/editing/selection/caret-in-empty-inline-vertical-rl-rtl.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js" type="text/javascript"></script>
+<style>
+
+.hidden {
+    display: none;
+}
+
+#text, #emptyInline {
+    border: 1px solid black;
+    inline-size: 100px;
+    writing-mode: vertical-rl;
+    direction: rtl;
+}
+</style>
+</head>
+<body>
+<p>This test verifies that an empty inline contenteditable element with a vertical writing mode, and right-to-left text direction, gets a valid caret rect.</p>
+<div id="text" contenteditable>Some text.</div>
+<div id="emptyInline" contenteditable></div><br>
+<div id="console"></div>
+</body>
+<script>
+    var text = document.getElementById("text");
+    var emptyInline = document.getElementById("emptyInline");
+
+    if (window.internals) {
+        emptyInline.classList.toggle("hidden");
+        getSelection().collapse(text, 0);
+        var textCaretRect = internals.absoluteCaretBounds();
+
+        text.classList.toggle("hidden");
+        emptyInline.classList.toggle("hidden");
+
+        getSelection().collapse(emptyInline, 0);
+        var emptyInlineCaretRect = internals.absoluteCaretBounds();
+
+        ['left', 'top', 'width', 'height'].forEach((property) => {
+            if (Math.abs(emptyInlineCaretRect[property] - textCaretRect[property]) <= 1)
+                testPassed(`caretRect.${property} is correct.`);
+            else
+                testFailed(`caretRect.${property} is incorrect.`);
+        });
+    }
+</script>
+</html>

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -54,7 +54,7 @@ int caretWidth()
 #endif
 }
 
-static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& renderer, LayoutUnit width, LayoutUnit textIndentOffset, CaretRectMode caretRectMode)
+static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& renderer, LayoutUnit logicalWidth, LayoutUnit textIndentOffset, CaretRectMode caretRectMode)
 {
     ASSERT(!renderer.firstChild() || renderer.firstChild()->isPseudoElement());
 
@@ -91,8 +91,8 @@ static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& re
         break;
     }
 
-    LayoutUnit x = renderer.borderLeft() + renderer.paddingLeft();
-    LayoutUnit maxX = width - renderer.borderRight() - renderer.paddingRight();
+    LayoutUnit x = renderer.borderAndPaddingLogicalLeft();
+    LayoutUnit maxX = logicalWidth - renderer.borderAndPaddingLogicalRight();
 
     switch (alignment) {
     case AlignLeft:
@@ -116,12 +116,12 @@ static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& re
 
     auto lineHeight = renderer.lineHeight(true, currentStyle.isHorizontalWritingMode() ? HorizontalLine : VerticalLine, PositionOfInteriorLineBoxes);
     auto height = std::min(lineHeight, LayoutUnit { currentStyle.metricsOfPrimaryFont().height() });
-    auto y = renderer.paddingTop() + renderer.borderTop() + (lineHeight > height ? (lineHeight - height) / 2 : LayoutUnit { });
+    auto y = renderer.borderAndPaddingBefore() + (lineHeight > height ? (lineHeight - height) / 2 : LayoutUnit { });
 
     auto rect = LayoutRect(x, y, caretWidth(), height);
 
     if (caretRectMode == CaretRectMode::ExpandToEndOfLine)
-        rect.shiftMaxXEdgeTo(width);
+        rect.shiftMaxXEdgeTo(logicalWidth);
 
     return currentStyle.isHorizontalWritingMode() ? rect : rect.transposedRect();
 }
@@ -302,7 +302,7 @@ static LayoutRect computeCaretRectForBlock(const RenderBlock& renderer, const In
     if (renderer.firstChild() && !renderer.firstChild()->isPseudoElement())
         return computeCaretRectForBox(renderer, boxAndOffset, caretRectMode);
 
-    return computeCaretRectForEmptyElement(renderer, renderer.width(), renderer.textIndentOffset(), caretRectMode);
+    return computeCaretRectForEmptyElement(renderer, renderer.logicalWidth(), renderer.textIndentOffset(), caretRectMode);
 }
 
 static LayoutRect computeCaretRectForInline(const RenderInline& renderer)
@@ -316,7 +316,7 @@ static LayoutRect computeCaretRectForInline(const RenderInline& renderer)
         return { };
     }
 
-    LayoutRect caretRect = computeCaretRectForEmptyElement(renderer, renderer.horizontalBorderAndPaddingExtent(), 0, CaretRectMode::Normal);
+    LayoutRect caretRect = computeCaretRectForEmptyElement(renderer, renderer.borderAndPaddingLogicalWidth(), 0, CaretRectMode::Normal);
 
     if (auto firstInlineBox = InlineIterator::firstInlineBoxFor(renderer))
         caretRect.moveBy(LayoutPoint { firstInlineBox->visualRectIgnoringBlockDirection().location() });

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -138,6 +138,7 @@ public:
     virtual inline LayoutUnit borderEnd() const;
 
     inline LayoutUnit borderAndPaddingStart() const;
+    inline LayoutUnit borderAndPaddingEnd() const;
     inline LayoutUnit borderAndPaddingBefore() const;
     inline LayoutUnit borderAndPaddingAfter() const;
 
@@ -151,6 +152,7 @@ public:
     inline LayoutUnit borderAndPaddingLogicalHeight() const;
     inline LayoutUnit borderAndPaddingLogicalWidth() const;
     inline LayoutUnit borderAndPaddingLogicalLeft() const;
+    inline LayoutUnit borderAndPaddingLogicalRight() const;
 
     inline LayoutUnit borderLogicalLeft() const;
     inline LayoutUnit borderLogicalRight() const;

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -29,9 +29,11 @@ inline LayoutUnit RenderBoxModelObject::borderAfter() const { return LayoutUnit(
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingAfter() const { return borderAfter() + paddingAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingBefore() const { return borderBefore() + paddingBefore(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalHeight() const { return borderAndPaddingBefore() + borderAndPaddingAfter(); }
-inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalLeft() const { return style().isHorizontalWritingMode() ? borderLeft() + paddingLeft() : borderTop() + paddingTop(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalWidth() const { return borderStart() + borderEnd() + paddingStart() + paddingEnd(); }
+inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalLeft() const { return style().isHorizontalWritingMode() ? borderLeft() + paddingLeft() : borderTop() + paddingTop(); }
+inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalRight() const { return style().isHorizontalWritingMode() ? borderRight() + paddingRight() : borderBottom() + paddingBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingStart() const { return borderStart() + paddingStart(); }
+inline LayoutUnit RenderBoxModelObject::borderAndPaddingEnd() const { return borderEnd() + paddingEnd(); }
 inline LayoutUnit RenderBoxModelObject::borderBefore() const { return LayoutUnit(style().borderBeforeWidth()); }
 inline LayoutUnit RenderBoxModelObject::borderBottom() const { return LayoutUnit(style().borderBottomWidth()); }
 inline LayoutUnit RenderBoxModelObject::borderEnd() const { return LayoutUnit(style().borderEndWidth()); }


### PR DESCRIPTION
#### 3931fcef84e408738e94e3a8dea06f611a68b6ec
<pre>
Incorrect caret position in empty elements with a vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248322">https://bugs.webkit.org/show_bug.cgi?id=248322</a>
<a href="https://rdar.apple.com/102652127">rdar://102652127</a>

Reviewed by Tim Nguyen.

Caret rect computation for empty elements does not fully account for vertical
writing mode. Fix by consistently using logical values.

* LayoutTests/editing/selection/caret-in-empty-block-vertical-horizontal-rtl-text-indent-padding-expected.txt: Added.
* LayoutTests/editing/selection/caret-in-empty-block-vertical-horizontal-rtl-text-indent-padding.html: Added.
* LayoutTests/editing/selection/caret-in-empty-block-vertical-rl-rtl-expected.txt: Added.
* LayoutTests/editing/selection/caret-in-empty-block-vertical-rl-rtl.html: Added.
* LayoutTests/editing/selection/caret-in-empty-inline-vertical-rl-rtl-expected.txt: Added.
* LayoutTests/editing/selection/caret-in-empty-inline-vertical-rl-rtl.html: Added.
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForEmptyElement):
(WebCore::computeCaretRectForBlock):
(WebCore::computeCaretRectForInline):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
(WebCore::RenderBoxModelObject::borderAndPaddingLogicalHeight const):
(WebCore::RenderBoxModelObject::borderAndPaddingLogicalLeft const):
(WebCore::RenderBoxModelObject::borderAndPaddingLogicalRight const):
(WebCore::RenderBoxModelObject::borderAndPaddingEnd const):

Canonical link: <a href="https://commits.webkit.org/270707@main">https://commits.webkit.org/270707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f41d6a49408a83f778ff4feeb2ccc94e0706786

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23961 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28798 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29497 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27388 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1439 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6296 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->