### PR TITLE
[web-animations] determining the interpolation interval should be shared in `KeyframeInterpolation`

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -575,6 +575,7 @@ animation/ElementAnimationRareData.cpp
 animation/FrameRateAligner.cpp
 animation/KeyframeEffect.cpp
 animation/KeyframeEffectStack.cpp
+animation/KeyframeInterpolation.cpp
 animation/ScrollTimeline.cpp
 animation/ViewTimeline.cpp
 animation/WebAnimation.cpp

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1504,96 +1504,21 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
     KeyframeValue propertySpecificKeyframeWithOneOffset(1, RenderStyle::clonePtr(targetStyle));
 
     auto blendProperty = [&](AnimatableCSSProperty property) {
-        // 1. If iteration progress is unresolved abort this procedure.
-        // 2. Let target property be the longhand property for which the effect value is to be calculated.
-        // 3. If animation type of the target property is not animatable abort this procedure since the effect cannot be applied.
-        // 4. Define the neutral value for composition as a value which, when combined with an underlying value using the add composite operation,
-        //    produces the underlying value.
+        auto interval = interpolationKeyframes(property, iterationProgress, propertySpecificKeyframeWithZeroOffset, propertySpecificKeyframeWithOneOffset);
 
-        // 5. Let property-specific keyframes be the result of getting the set of computed keyframes for this keyframe effect.
-        // 6. Remove any keyframes from property-specific keyframes that do not have a property value for target property.
-        unsigned numberOfKeyframesWithZeroOffset = 0;
-        unsigned numberOfKeyframesWithOneOffset = 0;
-        Vector<const KeyframeValue*> propertySpecificKeyframes;
-        for (auto& keyframe : m_blendingKeyframes) {
-            auto offset = keyframe.offset();
-            if (!keyframe.animatesProperty(property))
-                continue;
-            if (!offset)
-                numberOfKeyframesWithZeroOffset++;
-            if (offset == 1)
-                numberOfKeyframesWithOneOffset++;
-            propertySpecificKeyframes.append(&keyframe);
-        }
+        auto* startKeyframe = interval.endpoints.first();
+        auto* endKeyframe = interval.endpoints.last();
 
-        // 7. If property-specific keyframes is empty, return underlying value.
-        if (propertySpecificKeyframes.isEmpty())
+        if (!is<KeyframeValue>(startKeyframe) || !is<KeyframeValue>(endKeyframe)) {
+            ASSERT_NOT_REACHED();
             return;
-
-        auto hasImplicitZeroKeyframe = !numberOfKeyframesWithZeroOffset;
-        auto hasImplicitOneKeyframe = !numberOfKeyframesWithOneOffset;
-
-        // 8. If there is no keyframe in property-specific keyframes with a computed keyframe offset of 0, create a new keyframe with a computed keyframe
-        //    offset of 0, a property value set to the neutral value for composition, and a composite operation of add, and prepend it to the beginning of
-        //    property-specific keyframes.
-        if (hasImplicitZeroKeyframe) {
-            propertySpecificKeyframes.insert(0, &propertySpecificKeyframeWithZeroOffset);
-            numberOfKeyframesWithZeroOffset = 1;
         }
 
-        // 9. Similarly, if there is no keyframe in property-specific keyframes with a computed keyframe offset of 1, create a new keyframe with a computed
-        //    keyframe offset of 1, a property value set to the neutral value for composition, and a composite operation of add, and append it to the end of
-        //    property-specific keyframes.
-        if (hasImplicitOneKeyframe) {
-            propertySpecificKeyframes.append(&propertySpecificKeyframeWithOneOffset);
-            numberOfKeyframesWithOneOffset = 1;
-        }
+        auto& startKeyframeValue = downcast<KeyframeValue>(*startKeyframe);
+        auto& endKeyframeValue = downcast<KeyframeValue>(*endKeyframe);
 
-        // 10. Let interval endpoints be an empty sequence of keyframes.
-        Vector<const KeyframeValue*> intervalEndpoints;
-
-        // 11. Populate interval endpoints by following the steps from the first matching condition from below:
-        if (iterationProgress < 0 && numberOfKeyframesWithZeroOffset > 1) {
-            // If iteration progress < 0 and there is more than one keyframe in property-specific keyframes with a computed keyframe offset of 0,
-            // Add the first keyframe in property-specific keyframes to interval endpoints.
-            intervalEndpoints.append(propertySpecificKeyframes.first());
-        } else if (iterationProgress >= 1 && numberOfKeyframesWithOneOffset > 1) {
-            // If iteration progress ≥ 1 and there is more than one keyframe in property-specific keyframes with a computed keyframe offset of 1,
-            // Add the last keyframe in property-specific keyframes to interval endpoints.
-            intervalEndpoints.append(propertySpecificKeyframes.last());
-        } else {
-            // Otherwise,
-            // 1. Append to interval endpoints the last keyframe in property-specific keyframes whose computed keyframe offset is less than or equal
-            //    to iteration progress and less than 1. If there is no such keyframe (because, for example, the iteration progress is negative),
-            //    add the last keyframe whose computed keyframe offset is 0.
-            // 2. Append to interval endpoints the next keyframe in property-specific keyframes after the one added in the previous step.
-            size_t indexOfLastKeyframeWithZeroOffset = 0;
-            int indexOfFirstKeyframeToAddToIntervalEndpoints = -1;
-            for (size_t i = 0; i < propertySpecificKeyframes.size(); ++i) {
-                auto offset = propertySpecificKeyframes[i]->offset();
-                if (!offset)
-                    indexOfLastKeyframeWithZeroOffset = i;
-                if (offset <= iterationProgress && offset < 1)
-                    indexOfFirstKeyframeToAddToIntervalEndpoints = i;
-                else
-                    break;
-            }
-
-            if (indexOfFirstKeyframeToAddToIntervalEndpoints >= 0) {
-                intervalEndpoints.append(propertySpecificKeyframes[indexOfFirstKeyframeToAddToIntervalEndpoints]);
-                intervalEndpoints.append(propertySpecificKeyframes[indexOfFirstKeyframeToAddToIntervalEndpoints + 1]);
-            } else {
-                ASSERT(indexOfLastKeyframeWithZeroOffset < propertySpecificKeyframes.size() - 1);
-                intervalEndpoints.append(propertySpecificKeyframes[indexOfLastKeyframeWithZeroOffset]);
-                intervalEndpoints.append(propertySpecificKeyframes[indexOfLastKeyframeWithZeroOffset + 1]);
-            }
-        }
-
-        auto& startKeyframe = *intervalEndpoints.first();
-        auto& endKeyframe = *intervalEndpoints.last();
-
-        auto startKeyframeStyle = RenderStyle::clone(*startKeyframe.style());
-        auto endKeyframeStyle = RenderStyle::clone(*endKeyframe.style());
+        auto startKeyframeStyle = RenderStyle::clone(*startKeyframeValue.style());
+        auto endKeyframeStyle = RenderStyle::clone(*endKeyframeValue.style());
 
         auto usedBlendingForAccumulativeIteration = false;
 
@@ -1610,19 +1535,19 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
             // Only do this for the 0 keyframe if it was provided explicitly, since otherwise we want to use the "neutral value
             // for composition" which really means we don't want to do anything but rather just use the underlying style which
             // is already set on startKeyframe.
-            if (startKeyframe.offset() || !hasImplicitZeroKeyframe) {
-                auto startKeyframeCompositeOperation = startKeyframe.compositeOperation().value_or(m_compositeOperation);
+            if (startKeyframeValue.offset() || !interval.hasImplicitZeroKeyframe) {
+                auto startKeyframeCompositeOperation = startKeyframeValue.compositeOperation().value_or(m_compositeOperation);
                 if (startKeyframeCompositeOperation != CompositeOperation::Replace)
-                    CSSPropertyAnimation::blendProperty(*this, property, startKeyframeStyle, targetStyle, *startKeyframe.style(), 1, startKeyframeCompositeOperation);
+                    CSSPropertyAnimation::blendProperty(*this, property, startKeyframeStyle, targetStyle, *startKeyframeValue.style(), 1, startKeyframeCompositeOperation);
             }
 
             // Only do this for the 1 keyframe if it was provided explicitly, since otherwise we want to use the "neutral value
             // for composition" which really means we don't want to do anything but rather just use the underlying style which
             // is already set on endKeyframe.
-            if (endKeyframe.offset() != 1 || !hasImplicitOneKeyframe) {
-                auto endKeyframeCompositeOperation = endKeyframe.compositeOperation().value_or(m_compositeOperation);
+            if (endKeyframeValue.offset() != 1 || !interval.hasImplicitOneKeyframe) {
+                auto endKeyframeCompositeOperation = endKeyframeValue.compositeOperation().value_or(m_compositeOperation);
                 if (endKeyframeCompositeOperation != CompositeOperation::Replace)
-                    CSSPropertyAnimation::blendProperty(*this, property, endKeyframeStyle, targetStyle, *endKeyframe.style(), 1, endKeyframeCompositeOperation);
+                    CSSPropertyAnimation::blendProperty(*this, property, endKeyframeStyle, targetStyle, *endKeyframeValue.style(), 1, endKeyframeCompositeOperation);
             }
 
             // If this keyframe effect has an iteration composite operation of accumulate,
@@ -1633,25 +1558,25 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
                     // replace the property value of target property on keyframe with the result of combining the
                     // property value on the final keyframe in property-specific keyframes (Va) with the property
                     // value on keyframe (Vb) using the accumulation procedure defined for target property.
-                    if (!startKeyframe.offset() && !hasImplicitZeroKeyframe)
-                        CSSPropertyAnimation::blendProperty(*this, property, startKeyframeStyle, *endKeyframe.style(), startKeyframeStyle, 1, CompositeOperation::Accumulate);
-                    if (endKeyframe.offset() == 1 && !hasImplicitOneKeyframe)
-                        CSSPropertyAnimation::blendProperty(*this, property, endKeyframeStyle, *endKeyframe.style(), endKeyframeStyle, 1, CompositeOperation::Accumulate);
+                    if (!startKeyframeValue.offset() && !interval.hasImplicitZeroKeyframe)
+                        CSSPropertyAnimation::blendProperty(*this, property, startKeyframeStyle, *endKeyframeValue.style(), startKeyframeStyle, 1, CompositeOperation::Accumulate);
+                    if (endKeyframeValue.offset() == 1 && !interval.hasImplicitOneKeyframe)
+                        CSSPropertyAnimation::blendProperty(*this, property, endKeyframeStyle, *endKeyframeValue.style(), endKeyframeStyle, 1, CompositeOperation::Accumulate);
                 }
             }
         }
 
         // 13. If there is only one keyframe in interval endpoints return the property value of target property on that keyframe.
-        if (intervalEndpoints.size() == 1) {
+        if (interval.endpoints.size() == 1) {
             CSSPropertyAnimation::blendProperty(*this, property, targetStyle, startKeyframeStyle, startKeyframeStyle, 0, CompositeOperation::Replace);
             return;
         }
 
         // 14. Let start offset be the computed keyframe offset of the first keyframe in interval endpoints.
-        auto startOffset = startKeyframe.offset();
+        auto startOffset = startKeyframeValue.offset();
 
         // 15. Let end offset be the computed keyframe offset of last keyframe in interval endpoints.
-        auto endOffset = endKeyframe.offset();
+        auto endOffset = endKeyframeValue.offset();
 
         // 16. Let interval distance be the result of evaluating (iteration progress - start offset) / (end offset - start offset).
         auto intervalDistance = (iterationProgress - startOffset) / (endOffset - startOffset);
@@ -1661,7 +1586,7 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
         auto transformedDistance = intervalDistance;
         if (auto duration = iterationDuration()) {
             auto rangeDuration = (endOffset - startOffset) * duration.seconds();
-            if (auto* timingFunction = timingFunctionForBlendingKeyframe(startKeyframe))
+            if (auto* timingFunction = timingFunctionForBlendingKeyframe(startKeyframeValue))
                 transformedDistance = timingFunction->transformProgress(intervalDistance, rangeDuration);
         }
 
@@ -2859,5 +2784,11 @@ void KeyframeEffect::updateAssociatedThreadedEffectStack(const std::optional<con
         animation->acceleratedStateDidChange();
 }
 #endif
+
+const KeyframeInterpolation::Keyframe& KeyframeEffect::keyframeAtIndex(size_t index) const
+{
+    ASSERT(index < m_blendingKeyframes.size());
+    return m_blendingKeyframes[index];
+}
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -54,7 +54,7 @@ namespace Style {
 struct ResolutionContext;
 }
 
-class KeyframeEffect final : public AnimationEffect, public CSSPropertyBlendingClient {
+class KeyframeEffect final : public AnimationEffect, public CSSPropertyBlendingClient, public KeyframeInterpolation {
     WTF_MAKE_ISO_ALLOCATED(KeyframeEffect);
 public:
     static ExceptionOr<Ref<KeyframeEffect>> create(JSC::JSGlobalObject&, Document&, Element*, JSC::Strong<JSC::JSObject>&&, std::optional<std::variant<double, KeyframeEffectOptions>>&&);
@@ -263,6 +263,10 @@ private:
     bool ticksContinouslyWhileActive() const final;
     std::optional<double> progressUntilNextStep(double) const final;
     bool preventsAnimationReadiness() const final;
+
+    // KeyframeInterpolation
+    const KeyframeInterpolation::Keyframe& keyframeAtIndex(size_t) const final;
+    size_t numberOfKeyframes() const final { return m_blendingKeyframes.size(); }
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 

--- a/Source/WebCore/animation/KeyframeInterpolation.cpp
+++ b/Source/WebCore/animation/KeyframeInterpolation.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "KeyframeInterpolation.h"
+
+namespace WebCore {
+
+const KeyframeInterpolation::KeyframeInterval KeyframeInterpolation::interpolationKeyframes(Property property, double iterationProgress, const Keyframe& defaultStartKeyframe, const Keyframe& defaultEndKeyframe) const
+{
+    // 1. If iteration progress is unresolved abort this procedure.
+    // 2. Let target property be the longhand property for which the effect value is to be calculated.
+    // 3. If animation type of the target property is not animatable abort this procedure since the effect cannot be applied.
+    // 4. Define the neutral value for composition as a value which, when combined with an underlying value using the add composite operation,
+    //    produces the underlying value.
+
+    // 5. Let property-specific keyframes be the result of getting the set of computed keyframes for this keyframe effect.
+    // 6. Remove any keyframes from property-specific keyframes that do not have a property value for target property.
+    unsigned numberOfKeyframesWithZeroOffset = 0;
+    unsigned numberOfKeyframesWithOneOffset = 0;
+
+    Vector<const Keyframe*> propertySpecificKeyframes;
+
+    for (size_t i = 0; i < numberOfKeyframes(); ++i) {
+        auto& keyframe = keyframeAtIndex(i);
+        auto offset = keyframe.offset();
+        if (!keyframe.animatesProperty(property))
+            continue;
+        if (!offset)
+            numberOfKeyframesWithZeroOffset++;
+        if (offset == 1)
+            numberOfKeyframesWithOneOffset++;
+        propertySpecificKeyframes.append(&keyframe);
+    }
+
+    // 7. If property-specific keyframes is empty, return underlying value.
+    if (propertySpecificKeyframes.isEmpty())
+        return { };
+
+    auto hasImplicitZeroKeyframe = !numberOfKeyframesWithZeroOffset;
+    auto hasImplicitOneKeyframe = !numberOfKeyframesWithOneOffset;
+
+    // 8. If there is no keyframe in property-specific keyframes with a computed keyframe offset of 0, create a new keyframe with a computed keyframe
+    //    offset of 0, a property value set to the neutral value for composition, and a composite operation of add, and prepend it to the beginning of
+    //    property-specific keyframes.
+    if (hasImplicitZeroKeyframe) {
+        propertySpecificKeyframes.insert(0, &defaultStartKeyframe);
+        numberOfKeyframesWithZeroOffset = 1;
+    }
+
+    // 9. Similarly, if there is no keyframe in property-specific keyframes with a computed keyframe offset of 1, create a new keyframe with a computed
+    //    keyframe offset of 1, a property value set to the neutral value for composition, and a composite operation of add, and append it to the end of
+    //    property-specific keyframes.
+    if (hasImplicitOneKeyframe) {
+        propertySpecificKeyframes.append(&defaultEndKeyframe);
+        numberOfKeyframesWithOneOffset = 1;
+    }
+
+    // 10. Let interval endpoints be an empty sequence of keyframes.
+    Vector<const Keyframe*> intervalEndpoints;
+
+    // 11. Populate interval endpoints by following the steps from the first matching condition from below:
+    if (iterationProgress < 0 && numberOfKeyframesWithZeroOffset > 1) {
+        // If iteration progress < 0 and there is more than one keyframe in property-specific keyframes with a computed keyframe offset of 0,
+        // Add the first keyframe in property-specific keyframes to interval endpoints.
+        intervalEndpoints.append(propertySpecificKeyframes.first());
+    } else if (iterationProgress >= 1 && numberOfKeyframesWithOneOffset > 1) {
+        // If iteration progress ≥ 1 and there is more than one keyframe in property-specific keyframes with a computed keyframe offset of 1,
+        // Add the last keyframe in property-specific keyframes to interval endpoints.
+        intervalEndpoints.append(propertySpecificKeyframes.last());
+    } else {
+        // Otherwise,
+        // 1. Append to interval endpoints the last keyframe in property-specific keyframes whose computed keyframe offset is less than or equal
+        //    to iteration progress and less than 1. If there is no such keyframe (because, for example, the iteration progress is negative),
+        //    add the last keyframe whose computed keyframe offset is 0.
+        // 2. Append to interval endpoints the next keyframe in property-specific keyframes after the one added in the previous step.
+        size_t indexOfLastKeyframeWithZeroOffset = 0;
+        int indexOfFirstKeyframeToAddToIntervalEndpoints = -1;
+        for (size_t i = 0; i < propertySpecificKeyframes.size(); ++i) {
+            auto offset = propertySpecificKeyframes[i]->offset();
+            if (!offset)
+                indexOfLastKeyframeWithZeroOffset = i;
+            if (offset <= iterationProgress && offset < 1)
+                indexOfFirstKeyframeToAddToIntervalEndpoints = i;
+            else
+                break;
+        }
+
+        if (indexOfFirstKeyframeToAddToIntervalEndpoints >= 0) {
+            intervalEndpoints.append(propertySpecificKeyframes[indexOfFirstKeyframeToAddToIntervalEndpoints]);
+            intervalEndpoints.append(propertySpecificKeyframes[indexOfFirstKeyframeToAddToIntervalEndpoints + 1]);
+        } else {
+            ASSERT(indexOfLastKeyframeWithZeroOffset < propertySpecificKeyframes.size() - 1);
+            intervalEndpoints.append(propertySpecificKeyframes[indexOfLastKeyframeWithZeroOffset]);
+            intervalEndpoints.append(propertySpecificKeyframes[indexOfLastKeyframeWithZeroOffset + 1]);
+        }
+    }
+
+    return { intervalEndpoints, hasImplicitZeroKeyframe, hasImplicitOneKeyframe };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -47,6 +47,19 @@ public:
 
         virtual ~Keyframe() = default;
     };
+
+    virtual const Keyframe& keyframeAtIndex(size_t) const = 0;
+    virtual size_t numberOfKeyframes() const = 0;
+
+    struct KeyframeInterval {
+        const Vector<const Keyframe*> endpoints;
+        bool hasImplicitZeroKeyframe { false };
+        bool hasImplicitOneKeyframe { false };
+    };
+
+    const KeyframeInterval interpolationKeyframes(Property, double iterationProgress, const Keyframe& defaultStartKeyframe, const Keyframe& defaultEndKeyframe) const;
+
+    virtual ~KeyframeInterpolation() = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -263,6 +263,12 @@ bool AcceleratedEffect::animatesTransformRelatedProperty() const
     });
 }
 
+const KeyframeInterpolation::Keyframe& AcceleratedEffect::keyframeAtIndex(size_t index) const
+{
+    ASSERT(index < m_keyframes.size());
+    return m_keyframes[index];
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -43,7 +43,7 @@ namespace WebCore {
 class IntRect;
 class KeyframeEffect;
 
-class AcceleratedEffect : public RefCounted<AcceleratedEffect> {
+class AcceleratedEffect : public RefCounted<AcceleratedEffect>, public KeyframeInterpolation {
     WTF_MAKE_ISO_ALLOCATED(AcceleratedEffect);
 public:
 
@@ -97,6 +97,10 @@ private:
     AcceleratedEffect(const KeyframeEffect&, const IntRect&);
     explicit AcceleratedEffect(AnimationEffectTiming, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WTF::Seconds> startTime, std::optional<WTF::Seconds> holdTime);
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
+
+    // KeyframeInterpolation
+    const KeyframeInterpolation::Keyframe& keyframeAtIndex(size_t) const final;
+    size_t numberOfKeyframes() const final { return m_keyframes.size(); }
 
     AnimationEffectTiming m_timing;
     Vector<Keyframe> m_keyframes;


### PR DESCRIPTION
#### 9bafc5fbd3e0fe24a0598b7c69102b14c3e1eafd
<pre>
[web-animations] determining the interpolation interval should be shared in `KeyframeInterpolation`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264756">https://bugs.webkit.org/show_bug.cgi?id=264756</a>

Reviewed by Dean Jackson.

Currently the code to determine the interpolation interval, the &quot;from&quot; and &quot;to&quot; keyframes, is contained
within `KeyframeEffect::setAnimatedPropertiesInStyle()`. As part of the work on threaded animation
resolution (see bug 250970), we will need to share this logic with `AcceleratedEffect` as well.

Now that we have a shared concept of a keyframe (see bug 264747), we add a new method on `KeyframeInterpolation`
to determine that interval as well as some new virtual methods to support this purpose:

    virtual const Keyframe&amp; keyframeAtIndex(size_t) const = 0;
    virtual size_t numberOfKeyframes() const = 0;

    struct KeyframeInterval {
        const Vector&lt;const Keyframe*&gt; endpoints;
        bool hasImplicitZeroKeyframe { false };
        bool hasImplicitOneKeyframe { false };
    };

    const KeyframeInterval interpolationKeyframes(Property, double iterationProgress, const Keyframe&amp; defaultStartKeyframe, const Keyframe&amp; defaultEndKeyframe) const;

We also make `AcceleratedEffect` and `KeyframeEffect` inherit from `KeyframeInterpolation` such that we may
refactor out of `KeyframeEffect::setAnimatedPropertiesInStyle()` and into the implementation of
`KeyframeInterpolation::interpolationKeyframes()`.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::keyframeAtIndex const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeInterpolation.cpp: Added.
(WebCore::KeyframeInterpolation::interpolationKeyframes const):
* Source/WebCore/animation/KeyframeInterpolation.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::keyframeAtIndex const):
* Source/WebCore/platform/animation/AcceleratedEffect.h:

Canonical link: <a href="https://commits.webkit.org/270692@main">https://commits.webkit.org/270692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/092e2d1d791af0108d9e9a61808aedea64ca9603

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23907 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28707 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29439 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1378 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3629 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3364 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->