### PR TITLE
Simplify logic in Node::defaultEventHandler()

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2533,17 +2533,13 @@ void Node::defaultEventHandler(Event& event)
             if (enclosingLinkEventParentOrSelf())
                 return;
 
-            RenderBox* renderBox = nullptr;
-            for (RenderObject* renderer = this->renderer(); renderer; renderer = renderer->parent()) {
-                auto* maybeRenderBox = dynamicDowncast<RenderBox>(*renderer);
-                if (maybeRenderBox && maybeRenderBox->canBeScrolledAndHasScrollableArea()) {
-                    renderBox = maybeRenderBox;
+            for (auto* renderer = this->renderer(); renderer; renderer = renderer->parent()) {
+                CheckedPtr renderBox = dynamicDowncast<RenderBox>(*renderer);
+                if (renderBox && renderBox->canBeScrolledAndHasScrollableArea()) {
+                    if (RefPtr frame = document().frame())
+                        frame->checkedEventHandler()->startPanScrolling(*renderBox);
                     break;
                 }
-            }
-            if (renderBox) {
-                if (RefPtr frame = document().frame())
-                    frame->eventHandler().startPanScrolling(*renderBox);
             }
         }
 #endif


### PR DESCRIPTION
#### 808409e969bb24741f0caf7b0438376c0731fe78
<pre>
Simplify logic in Node::defaultEventHandler()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264761">https://bugs.webkit.org/show_bug.cgi?id=264761</a>

Reviewed by Ryosuke Niwa.

Simplify logic in Node::defaultEventHandler() to address Ryosuke&apos;s
feedback after 270654@main.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::defaultEventHandler):

Canonical link: <a href="https://commits.webkit.org/270680@main">https://commits.webkit.org/270680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc0a2ec224a0aac065ea054c9f43b978a63a2e7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2076 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3524 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28715 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3144 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-sizing/button-min-width.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html, imported/w3c/web-platform-tests/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23390 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27328 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1384 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3636 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3355 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->