### PR TITLE
Expose hasInjectedContent property on _WKWebExtension and _WKWebExtensionContext.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -207,7 +207,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 
 /*!
  @abstract A Boolean value indicating whether the extension has background content that can run when needed.
- @discussion If this property is `YES`, the extension can run in the background even when no web pages are open.
+ @discussion If this property is `YES`, the extension can run in the background even when no webpages are open.
  */
 @property (nonatomic, readonly) BOOL hasBackgroundContent;
 
@@ -217,6 +217,13 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  error will be reported on iOS if an attempt is made to load a persistent extension.
  */
 @property (nonatomic, readonly) BOOL backgroundContentIsPersistent;
+
+/*!
+ @abstract A Boolean value indicating whether the extension has script or stylesheet content that can be injected into webpages.
+ @discussion If this property is `YES`, the extension has content that can be injected by matching against the extension's requested match patterns.
+ @note Once the extension is loaded, use the `hasInjectedContent` property on the extension context, as the injectable content can change after the extension is loaded.
+ */
+@property (nonatomic, readonly) BOOL hasInjectedContent;
 
 /*!
  @abstract A Boolean value indicating whether the extension has an options page.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -255,6 +255,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return _webExtension->backgroundContentIsPersistent();
 }
 
+- (BOOL)hasInjectedContent
+{
+    return _webExtension->hasStaticInjectedContent();
+}
+
 - (BOOL)hasOptionsPage
 {
     return _webExtension->hasOptionsPage();
@@ -278,13 +283,6 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 - (BOOL)_backgroundContentUsesModules
 {
     return _webExtension->backgroundContentUsesModules();
-}
-
-- (BOOL)_hasStaticInjectedContentForURL:(NSURL *)url
-{
-    NSParameterAssert([url isKindOfClass:NSURL.class]);
-
-    return _webExtension->hasStaticInjectedContentForURL(url);
 }
 
 #pragma mark WKObject protocol implementation
@@ -436,6 +434,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return NO;
 }
 
+- (BOOL)hasInjectedContent
+{
+    return NO;
+}
+
 - (BOOL)hasOptionsPage
 {
     return NO;
@@ -457,11 +460,6 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 }
 
 - (BOOL)_backgroundContentUsesModules
-{
-    return NO;
-}
-
-- (BOOL)_hasStaticInjectedContentForURL:(NSURL *)url
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -330,7 +330,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 - (BOOL)hasAccessToURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(hasAccess(to:in:));
 
 /*!
- @abstract Checks if the currently granted permission match patterns set contains the `<all_urls>` pattern.
+ @abstract A Boolean value indicating if the currently granted permission match patterns set contains the `<all_urls>` pattern.
  @discussion This does not check for any `*` host patterns. In most cases you should use the broader `hasAccessToAllHosts`.
  @seealso currentPermissionMatchPatterns
  @seealso hasAccessToAllHosts
@@ -338,11 +338,18 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @property (nonatomic, readonly) BOOL hasAccessToAllURLs;
 
 /*!
- @abstract Checks if the currently granted permission match patterns set contains the `<all_urls>` pattern or any `*` host patterns.
+ @abstract A Boolean value indicating if the currently granted permission match patterns set contains the `<all_urls>` pattern or any `*` host patterns.
  @seealso currentPermissionMatchPatterns
  @seealso hasAccessToAllURLs
  */
 @property (nonatomic, readonly) BOOL hasAccessToAllHosts;
+
+/*!
+ @abstract A Boolean value indicating whether the extension has script or stylesheet content that can be injected into webpages.
+ @discussion If this property is `YES`, the extension has content that can be injected by matching against the extension's requested match patterns.
+ @seealso hasInjectedContentForURL:
+ */
+@property (nonatomic, readonly) BOOL hasInjectedContent;
 
 /*!
  @abstract Checks if the extension has script or stylesheet content that can be injected into the specified URL.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -497,6 +497,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return _webExtensionContext->hasAccessToAllHosts();
 }
 
+- (BOOL)hasInjectedContent
+{
+    return _webExtensionContext->hasInjectedContent();
+}
+
 - (BOOL)hasInjectedContentForURL:(NSURL *)url
 {
     NSParameterAssert([url isKindOfClass:NSURL.class]);
@@ -1003,6 +1008,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (BOOL)hasAccessToAllHosts
+{
+    return NO;
+}
+
+- (BOOL)hasInjectedContent
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
@@ -40,14 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @abstract A Boolean value indicating whether the extension use modules for the background content. */
 @property (readonly, nonatomic) BOOL _backgroundContentUsesModules;
 
-/*!
- @abstract Checks if the extension has script or stylesheet content that can be injected into the specified URL.
- @param url The webpage URL to check.
- @result Returns `YES` if the extension has content that can be injected by matching the `url` against the extension's requested match patterns.
- @discussion The extension will still need to be loaded and have granted website permissions for its content to actually be injected.
- */
-- (BOOL)_hasStaticInjectedContentForURL:(NSURL *)url;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1595,6 +1595,12 @@ bool WebExtension::hasStaticInjectedContentForURL(NSURL *url)
     return false;
 }
 
+bool WebExtension::hasStaticInjectedContent()
+{
+    populateContentScriptPropertiesIfNeeded();
+    return !m_staticInjectedContents.isEmpty();
+}
+
 NSArray *WebExtension::InjectedContentData::expandedIncludeMatchPatternStrings() const
 {
     NSMutableArray<NSString *> *result = [NSMutableArray array];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -395,10 +395,8 @@ const WebExtensionContext::InjectedContentVector& WebExtensionContext::injectedC
     return m_extension->staticInjectedContents();
 }
 
-bool WebExtensionContext::hasInjectedContentForURL(NSURL *url)
+bool WebExtensionContext::hasInjectedContentForURL(const URL& url)
 {
-    ASSERT(url);
-
     for (auto& injectedContent : injectedContents()) {
         // FIXME: <https://webkit.org/b/246492> Add support for exclude globs.
         bool isExcluded = false;
@@ -420,6 +418,11 @@ bool WebExtensionContext::hasInjectedContentForURL(NSURL *url)
     }
 
     return false;
+}
+
+bool WebExtensionContext::hasInjectedContent()
+{
+    return !injectedContents().isEmpty();
 }
 
 URL WebExtensionContext::optionsPageURL() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -207,6 +207,7 @@ public:
     CocoaImage *actionIcon(CGSize idealSize);
     NSString *displayActionLabel();
     NSString *actionPopupPath();
+
     bool hasAction();
     bool hasBrowserAction();
     bool hasPageAction();
@@ -236,6 +237,7 @@ public:
 
     const InjectedContentVector& staticInjectedContents();
     bool hasStaticInjectedContentForURL(NSURL *);
+    bool hasStaticInjectedContent();
 
     // Permissions requested by the extension in their manifest.
     // These are not the currently allowed permissions.

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -215,7 +215,8 @@ public:
     void setInspectable(bool);
 
     const InjectedContentVector& injectedContents();
-    bool hasInjectedContentForURL(NSURL *);
+    bool hasInjectedContentForURL(const URL&);
+    bool hasInjectedContent();
 
     URL optionsPageURL() const;
     URL overrideNewTabPageURL() const;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -206,28 +206,22 @@ TEST(WKWebExtension, ContentScriptsParsing)
     NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" } mutableCopy];
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ] } ];
-    auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-
-    auto webkitURL = [NSURL URLWithString:@"https://webkit.org/"];
-    auto exampleURL = [NSURL URLWithString:@"https://example.com/"];
+    auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
-    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
-    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
+    EXPECT_TRUE(testExtension.hasInjectedContent);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ], @"exclude_matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
-    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
+    EXPECT_TRUE(testExtension.hasInjectedContent);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
-    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
+    EXPECT_TRUE(testExtension.hasInjectedContent);
 
     // Invalid cases
 
@@ -236,32 +230,28 @@ TEST(WKWebExtension, ContentScriptsParsing)
 
     EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE(testExtension.hasInjectedContent);
 
     testManifestDictionary[@"content_scripts"] = @{ @"invalid": @YES };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE(testExtension.hasInjectedContent);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE(testExtension.hasInjectedContent);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"run_at": @"invalid" } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NE(testExtension.errors.count, 0ul);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
-    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
+    EXPECT_TRUE(testExtension.hasInjectedContent);
 }
 
 TEST(WKWebExtension, PermissionsParsing)


### PR DESCRIPTION
#### 38bdd661a9bf051ed1b3176b609f470c76540b78
<pre>
Expose hasInjectedContent property on _WKWebExtension and _WKWebExtensionContext.
<a href="https://webkit.org/b/264762">https://webkit.org/b/264762</a>
<a href="https://rdar.apple.com/problem/118347650">rdar://problem/118347650</a>

Reviewed by Brian Weinstein.

Drop the previous _hasStaticInjectedContentForURL: method that was only used for testing
and add hasInjectedContent to _WKWebExtension and _WKWebExtensionContext.

Added new tests for _WKWebExtensionContext that uses hasInjectedContentForURL: there
instead of the previous private _WKWebExtension method.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension hasInjectedContent]): Added.
(-[_WKWebExtension _hasStaticInjectedContentForURL:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext hasInjectedContent]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::hasStaticInjectedContent):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::hasInjectedContentForURL): Use URL type.
(WebKit::WebExtensionContext::hasInjectedContent): Added.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270675@main">https://commits.webkit.org/270675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36c343a0040166990e047b11d8818c390e4552fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2080 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3528 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28719 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29443 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23768 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1388 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3640 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3350 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->