### PR TITLE
Port the VTT enums to the new IPC serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -556,6 +556,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/speech/SpeechRecognitionResultData.h
     Modules/speech/SpeechRecognitionUpdate.h
     Modules/speech/SpeechRecognizer.h
+    Modules/speech/SpeechSynthesisErrorCode.h
+    Modules/speech/SpeechSynthesisUtterance.h
+    Modules/speech/SpeechSynthesisVoice.h
 
     Modules/storage/DummyStorageProvider.h
     Modules/storage/StorageConnection.h
@@ -1274,6 +1277,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/track/TextTrackCue.h
     html/track/TrackBase.h
     html/track/VTTCue.h
+    html/track/VTTRegion.h
     html/track/VideoTrack.h
     html/track/VideoTrackClient.h
 

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -73,12 +73,12 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(VTTCueBox);
 static const CSSValueID displayWritingModeMap[] = {
     CSSValueHorizontalTb, CSSValueVerticalRl, CSSValueVerticalLr
 };
-static_assert(std::size(displayWritingModeMap) == static_cast<size_t>(WTF::EnumTraits<VTTCue::DirectionSetting>::values::max) + 1, "displayWritingModeMap has wrong size");
+static_assert(std::size(displayWritingModeMap) == static_cast<size_t>(WebCore::VTTDirectionSetting::MaxValue) + 1, "displayWritingModeMap has wrong size");
 
 static const CSSValueID displayAlignmentMap[] = {
     CSSValueStart, CSSValueCenter, CSSValueEnd, CSSValueLeft, CSSValueRight
 };
-static_assert(std::size(displayAlignmentMap) == static_cast<size_t>(WTF::EnumTraits<VTTCue::AlignSetting>::values::max) + 1, "displayAlignmentMap has wrong size");
+static_assert(std::size(displayAlignmentMap) == static_cast<size_t>(WebCore::VTTAlignSetting::MaxValue) + 1, "displayAlignmentMap has wrong size");
 
 static const String& startKeyword()
 {

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -58,6 +58,9 @@ enum class VTTDirectionSetting : uint8_t {
     EmptyString = Horizontal,
     Rl = VerticalGrowingLeft,
     Lr = VerticalGrowingRight,
+
+    // For static-assert convenience.
+    MaxValue = VerticalGrowingRight,
 };
 
 enum class VTTLineAlignSetting : uint8_t {
@@ -79,6 +82,9 @@ enum class VTTAlignSetting : uint8_t {
     End,
     Left,
     Right,
+
+    // For static-assert convenience.
+    MaxValue = Right,
 };
 
 // ----------------------------
@@ -301,45 +307,6 @@ private:
 namespace WTF {
 
 template<> struct LogArgument<WebCore::VTTCue> : LogArgument<WebCore::TextTrackCue> { };
-
-template<> struct EnumTraits<WebCore::VTTCue::DirectionSetting> {
-    using values = EnumValues<
-        WebCore::VTTCue::DirectionSetting,
-        WebCore::VTTCue::DirectionSetting::Horizontal,
-        WebCore::VTTCue::DirectionSetting::VerticalGrowingLeft,
-        WebCore::VTTCue::DirectionSetting::VerticalGrowingRight
-    >;
-};
-
-template<> struct EnumTraits<WebCore::VTTCue::LineAlignSetting> {
-    using values = EnumValues<
-        WebCore::VTTCue::LineAlignSetting,
-        WebCore::VTTCue::LineAlignSetting::Start,
-        WebCore::VTTCue::LineAlignSetting::Center,
-        WebCore::VTTCue::LineAlignSetting::End
-    >;
-};
-
-template<> struct EnumTraits<WebCore::VTTCue::PositionAlignSetting> {
-    using values = EnumValues<
-        WebCore::VTTCue::PositionAlignSetting,
-        WebCore::VTTCue::PositionAlignSetting::LineLeft,
-        WebCore::VTTCue::PositionAlignSetting::Center,
-        WebCore::VTTCue::PositionAlignSetting::LineRight,
-        WebCore::VTTCue::PositionAlignSetting::Auto
-    >;
-};
-
-template<> struct EnumTraits<WebCore::VTTCue::AlignSetting> {
-    using values = EnumValues<
-        WebCore::VTTCue::AlignSetting,
-        WebCore::VTTCue::AlignSetting::Start,
-        WebCore::VTTCue::AlignSetting::Center,
-        WebCore::VTTCue::AlignSetting::End,
-        WebCore::VTTCue::AlignSetting::Left,
-        WebCore::VTTCue::AlignSetting::Right
-    >;
-};
 
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6724,6 +6724,35 @@ enum class WebCore::MediationRequirement : uint8_t {
     Required,
     Conditional,
 };
+
+#if ENABLE(VIDEO)
+header: <WebCore/VTTCue.h>
+[Nested] enum class WebCore::VTTDirectionSetting : uint8_t {
+    Horizontal,
+    VerticalGrowingLeft,
+    VerticalGrowingRight,
+};
+
+[Nested] enum class WebCore::VTTLineAlignSetting : uint8_t {
+    Start,
+    Center,
+    End,
+};
+
+[Nested] enum class WebCore::VTTPositionAlignSetting : uint8_t {
+    LineLeft,
+    Center,
+    LineRight,
+    Auto,
+};
+
+[Nested] enum class WebCore::VTTAlignSetting : uint8_t {
+    Start,
+    Center,
+    End,
+    Left,
+    Right,
+};
 #endif
 
 #if ENABLE(CONTEXT_MENUS)


### PR DESCRIPTION
#### dfde53f43eaf15437997cc11e539b2bce32acbd6
<pre>
Port the VTT enums to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264768">https://bugs.webkit.org/show_bug.cgi?id=264768</a>

Reviewed by Chris Dumez.

Remove the EnumTraits enums in favor of the new IPC serialization
format.

Needed to pull a few headers included from VTTCue.h to the private
headers for this to work. Also added an alias to the last item
in two of the enums, for convenience when doing static-asserts.

* Source/WebCore/Headers.cmake:
* Source/WebCore/html/track/VTTCue.cpp:
* Source/WebCore/html/track/VTTCue.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270698@main">https://commits.webkit.org/270698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6a6c4f4411ecca6582349d736134108c3a88e1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28168 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23929 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28744 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29455 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27337 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4596 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->