### PR TITLE
Clear activeTab and action tab customization when tab navigates.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -176,6 +176,20 @@ WebExtensionContext* WebExtensionAction::extensionContext() const
     return m_extensionContext.get();
 }
 
+void WebExtensionAction::clearCustomizations()
+{
+    if (!m_customIcons && !m_customPopupPath.isNull() && !m_customLabel.isNull() && !m_customBadgeText.isNull() && !m_customEnabled)
+        return;
+
+    m_customIcons = nil;
+    m_customPopupPath = nullString();
+    m_customLabel = nullString();
+    m_customBadgeText = nullString();
+    m_customEnabled = std::nullopt;
+
+    propertiesDidChange();
+}
+
 void WebExtensionAction::propertiesDidChange()
 {
     dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
@@ -226,6 +240,9 @@ String WebExtensionAction::popupPath() const
 
 void WebExtensionAction::setPopupPath(String path)
 {
+    if (m_customPopupPath == path)
+        return;
+
     m_customPopupPath = path;
 
     propertiesDidChange();
@@ -362,6 +379,9 @@ String WebExtensionAction::label(FallbackWhenEmpty fallback) const
 
 void WebExtensionAction::setLabel(String label)
 {
+    if (m_customLabel == label)
+        return;
+
     m_customLabel = label;
 
     propertiesDidChange();
@@ -386,6 +406,9 @@ String WebExtensionAction::badgeText() const
 
 void WebExtensionAction::setBadgeText(String badgeText)
 {
+    if (m_customBadgeText == badgeText)
+        return;
+
     m_customBadgeText = badgeText;
 
     propertiesDidChange();
@@ -410,6 +433,9 @@ bool WebExtensionAction::isEnabled() const
 
 void WebExtensionAction::setEnabled(std::optional<bool> enabled)
 {
+    if (m_customEnabled == enabled)
+        return;
+
     m_customEnabled = enabled;
 
     propertiesDidChange();

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -259,104 +259,28 @@ WebExtensionController::WebExtensionSet WebExtensionController::extensions() con
     return extensions;
 }
 
-// MARK: Web Navigation
-
 void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& targetURL, WallTime timestamp)
 {
-    auto eventType = WebExtensionEventListenerType::WebNavigationOnBeforeNavigate;
-    auto listenerTypes = WebExtensionContext::EventListenerTypeSet { eventType };
-
-    for (auto& context : m_extensionContexts) {
-        if (!context->hasPermission(_WKWebExtensionPermissionWebNavigation))
-            continue;
-
-        if (!context->hasPermission(targetURL))
-            continue;
-
-        auto tab = context->getTab(pageID);
-        if (!tab)
-            continue;
-
-        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, parentFrameID, targetURL, timestamp));
-        });
-    }
+    for (auto& context : m_extensionContexts)
+        context->didStartProvisionalLoadForFrame(pageID, frameID, parentFrameID, targetURL, timestamp);
 }
 
 void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
 {
-    auto committedEventType = WebExtensionEventListenerType::WebNavigationOnCommitted;
-    auto contentLoadedtype = WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded;
-    auto listenerTypes = WebExtensionContext::EventListenerTypeSet { committedEventType, contentLoadedtype };
-
-    for (auto& context : m_extensionContexts) {
-        if (!context->hasPermission(_WKWebExtensionPermissionWebNavigation))
-            continue;
-
-        if (!context->hasPermission(frameURL))
-            continue;
-
-        for (auto& styleSheet : context->dynamicallyInjectedUserStyleSheets()) {
-            auto page = WebProcessProxy::webPage(pageID);
-            WebUserContentControllerProxy& controller = page.get()->userContentController();
-            controller.removeUserStyleSheet(styleSheet);
-        }
-
-        context->dynamicallyInjectedUserStyleSheets().clear();
-
-        auto tab = context->getTab(pageID);
-        if (!tab)
-            continue;
-
-        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(committedEventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(committedEventType, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
-            context->sendToProcessesForEvent(contentLoadedtype, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(contentLoadedtype, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
-        });
-    }
+    for (auto& context : m_extensionContexts)
+        context->didCommitLoadForFrame(pageID, frameID, parentFrameID, frameURL, timestamp);
 }
 
 void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
 {
-    auto eventType = WebExtensionEventListenerType::WebNavigationOnCompleted;
-    auto listenerTypes = WebExtensionContext::EventListenerTypeSet { eventType };
-
-    for (auto& context : m_extensionContexts) {
-        if (!context->hasPermission(_WKWebExtensionPermissionWebNavigation))
-            continue;
-
-        if (!context->hasPermission(frameURL))
-            continue;
-
-        auto tab = context->getTab(pageID);
-        if (!tab)
-            continue;
-
-        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
-        });
-    }
+    for (auto& context : m_extensionContexts)
+        context->didFinishLoadForFrame(pageID, frameID, parentFrameID, frameURL, timestamp);
 }
 
 void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& frameURL, WallTime timestamp)
 {
-    auto eventType = WebExtensionEventListenerType::WebNavigationOnErrorOccurred;
-    auto listenerTypes = WebExtensionContext::EventListenerTypeSet { eventType };
-
-    for (auto& context : m_extensionContexts) {
-        if (!context->hasPermission(_WKWebExtensionPermissionWebNavigation))
-            continue;
-
-        if (!context->hasPermission(frameURL))
-            continue;
-
-        auto tab = context->getTab(pageID);
-        if (!tab)
-            continue;
-
-        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
-            context->sendToProcessesForEvent(eventType, Messages::WebExtensionContextProxy::DispatchWebNavigationEvent(eventType, tab->identifier(), frameID, parentFrameID, frameURL, timestamp));
-        });
-    }
+    for (auto& context : m_extensionContexts)
+        context->didFailLoadForFrame(pageID, frameID, parentFrameID, frameURL, timestamp);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -144,6 +144,9 @@ WebExtensionTabParameters WebExtensionTab::parameters() const
 
 WebExtensionTabParameters WebExtensionTab::changedParameters(OptionSet<ChangedProperties> changedProperties) const
 {
+    if (changedProperties.isEmpty())
+        changedProperties = this->changedProperties();
+
     bool hasPermission = extensionHasPermission();
 
     return {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -69,6 +69,8 @@ public:
     WebExtensionTab* tab() { return m_tab.get(); }
     WebExtensionWindow* window() { return m_window.get(); }
 
+    void clearCustomizations();
+
     void propertiesDidChange();
 
     CocoaImage *icon(CGSize);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -67,7 +67,6 @@
 
 OBJC_CLASS NSDate;
 OBJC_CLASS NSDictionary;
-OBJC_CLASS NSMapTable;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
@@ -242,14 +241,14 @@ public:
     void grantPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
     void denyPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
 
-    void grantPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity());
-    void denyPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity());
+    void grantPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity(), EqualityOnly = EqualityOnly::Yes);
+    void denyPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity(), EqualityOnly = EqualityOnly::Yes);
 
     bool removeGrantedPermissions(PermissionsSet&);
-    bool removeGrantedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
+    bool removeGrantedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly = EqualityOnly::Yes);
 
     bool removeDeniedPermissions(PermissionsSet&);
-    bool removeDeniedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
+    bool removeDeniedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly = EqualityOnly::Yes);
 
     PermissionsMap::KeysConstIteratorRange currentPermissions() { return grantedPermissions().keys(); }
     PermissionMatchPatternsMap::KeysConstIteratorRange currentPermissionMatchPatterns() { return grantedPermissionMatchPatterns().keys(); }
@@ -296,7 +295,12 @@ public:
 
     void didMoveTab(const WebExtensionTab&, size_t oldIndex, const WebExtensionWindow* oldWindow = nullptr);
     void didReplaceTab(const WebExtensionTab& oldTab, const WebExtensionTab& newTab);
-    void didChangeTabProperties(const WebExtensionTab&, OptionSet<WebExtensionTab::ChangedProperties> = { });
+    void didChangeTabProperties(WebExtensionTab&, OptionSet<WebExtensionTab::ChangedProperties> = { });
+
+    void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didCommitLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didFinishLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
+    void didFailLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
 
     WebExtensionAction& defaultAction();
     Ref<WebExtensionAction> getAction(WebExtensionWindow*);
@@ -560,8 +564,6 @@ private:
 
     ListHashSet<URL> m_cachedPermissionURLs;
     HashMap<URL, PermissionState> m_cachedPermissionStates;
-
-    RetainPtr<NSMapTable> m_temporaryTabPermissionMatchPatterns;
 
     bool m_requestedOptionalAccessToAllHosts { false };
     bool m_hasAccessInPrivateBrowsing { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -132,7 +132,6 @@ private:
     void addUserContentController(WebUserContentControllerProxy&, ForPrivateBrowsing);
     void removeUserContentController(WebUserContentControllerProxy&);
 
-    // Web Navigation
     void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
     void didCommitLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
     void didFinishLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -42,6 +42,7 @@ OBJC_PROTOCOL(_WKWebExtensionTab);
 namespace WebKit {
 
 class WebExtensionContext;
+class WebExtensionMatchPattern;
 class WebExtensionWindow;
 class WebProcessProxy;
 struct WebExtensionTabParameters;
@@ -88,7 +89,7 @@ public:
 
     WebExtensionTabIdentifier identifier() const { return m_identifier; }
     WebExtensionTabParameters parameters() const;
-    WebExtensionTabParameters changedParameters(OptionSet<ChangedProperties>) const;
+    WebExtensionTabParameters changedParameters(OptionSet<ChangedProperties> = { }) const;
 
     WebExtensionContext* extensionContext() const;
 
@@ -98,6 +99,16 @@ public:
 
     bool extensionHasAccess() const;
     bool extensionHasPermission() const;
+
+    bool hasActiveUserGesture() { return m_activeUserGesture; }
+    void setActiveUserGesture(bool activeUserGesture) { m_activeUserGesture = activeUserGesture; }
+
+    RefPtr<WebExtensionMatchPattern> temporaryPermissionMatchPattern() { return m_temporaryPermissionMatchPattern; }
+    void setTemporaryPermissionMatchPattern(RefPtr<WebExtensionMatchPattern>&& matchPattern) { m_temporaryPermissionMatchPattern = WTFMove(matchPattern); }
+
+    OptionSet<ChangedProperties> changedProperties() const { return m_changedProperties; }
+    void addChangedProperties(OptionSet<ChangedProperties> properties) { m_changedProperties.add(properties); }
+    void clearChangedProperties() { m_changedProperties = { }; }
 
     RefPtr<WebExtensionWindow> window(SkipContainsCheck = SkipContainsCheck::No) const;
     size_t index() const;
@@ -171,6 +182,9 @@ private:
     WebExtensionTabIdentifier m_identifier;
     WeakPtr<WebExtensionContext> m_extensionContext;
     WeakObjCPtr<_WKWebExtensionTab> m_delegate;
+    RefPtr<WebExtensionMatchPattern> m_temporaryPermissionMatchPattern;
+    OptionSet<ChangedProperties> m_changedProperties;
+    bool m_activeUserGesture : 1 { false };
     mutable bool m_private : 1 { false };
     mutable bool m_cachedPrivate : 1 { false };
     bool m_respondsToWindow : 1 { false };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -39,6 +39,8 @@ static auto *actionPopupManifest = @{
     @"description": @"Action Test",
     @"version": @"1",
 
+    @"permissions": @[ @"webNavigation" ],
+
     @"background": @{
         @"scripts": @[ @"background.js" ],
         @"type": @"module",
@@ -125,7 +127,7 @@ TEST(WKWebExtensionAPIAction, ClickedEvent)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIAction, presentPopupForAction)
+TEST(WKWebExtensionAPIAction, PresentPopupForAction)
 {
     auto *popupPage = @"<b>Hello World!</b>";
 
@@ -183,11 +185,21 @@ TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)
     auto *popupPage = @"<b>Hello World!</b>";
 
     auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(await browser.action.getTitle({ }), 'Test Action', 'Title should be')",
+        @"browser.test.assertEq(await browser.action.getPopup({ }), 'popup.html', 'Popup should be')",
+        @"browser.test.assertEq(await browser.action.getBadgeText({ }), '', 'Badge text should be')",
+        @"browser.test.assertTrue(await browser.action.isEnabled({ }), 'Action should be enabled')",
+
         @"await browser.action.setTitle({ title: 'Modified Title' })",
         @"await browser.action.setIcon({ path: 'toolbar-48.png' })",
         @"await browser.action.setPopup({ popup: 'alt-popup.html' })",
         @"await browser.action.setBadgeText({ text: '42' })",
         @"await browser.action.disable()",
+
+        @"browser.test.assertEq(await browser.action.getTitle({ }), 'Modified Title', 'Title should be')",
+        @"browser.test.assertEq(await browser.action.getPopup({ }), 'alt-popup.html', 'Popup should be')",
+        @"browser.test.assertEq(await browser.action.getBadgeText({ }), '42', 'Badge text should be')",
+        @"browser.test.assertFalse(await browser.action.isEnabled({ }), 'Action should be disabled')",
 
         @"browser.action.openPopup()"
     ]);
@@ -247,11 +259,21 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
     auto *backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
 
+        @"browser.test.assertEq(await browser.action.getTitle({ tabId: currentTab.id }), 'Test Action', 'Title should be')",
+        @"browser.test.assertEq(await browser.action.getPopup({ tabId: currentTab.id }), 'popup.html', 'Popup should be')",
+        @"browser.test.assertEq(await browser.action.getBadgeText({ tabId: currentTab.id }), '', 'Badge text should be')",
+        @"browser.test.assertTrue(await browser.action.isEnabled({ tabId: currentTab.id }), 'Action should be enabled')",
+
         @"browser.action.setTitle({ title: 'Tab Title', tabId: currentTab.id })",
         @"browser.action.setIcon({ path: 'toolbar-48.png', tabId: currentTab.id })",
         @"browser.action.setPopup({ popup: 'alt-popup.html', tabId: currentTab.id })",
         @"browser.action.setBadgeText({ text: '42', tabId: currentTab.id })",
         @"browser.action.disable(currentTab.id)",
+
+        @"browser.test.assertEq(await browser.action.getTitle({ tabId: currentTab.id }), 'Tab Title', 'Title should be')",
+        @"browser.test.assertEq(await browser.action.getPopup({ tabId: currentTab.id }), 'alt-popup.html', 'Popup should be')",
+        @"browser.test.assertEq(await browser.action.getBadgeText({ tabId: currentTab.id }), '42', 'Badge text should be')",
+        @"browser.test.assertFalse(await browser.action.isEnabled({ tabId: currentTab.id }), 'Action should be disabled')",
 
         @"browser.action.openPopup({ windowId: currentTab.windowId })"
     ]);
@@ -353,10 +375,18 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
         @"const currentWindowId = currentTab.windowId",
 
+        @"browser.test.assertEq(await browser.action.getTitle({ windowId: currentWindowId }), 'Test Action', 'Title should be')",
+        @"browser.test.assertEq(await browser.action.getPopup({ windowId: currentWindowId }), 'popup.html', 'Popup should be')",
+        @"browser.test.assertEq(await browser.action.getBadgeText({ windowId: currentWindowId }), '', 'Badge text should be')",
+
         @"browser.action.setTitle({ title: 'Window Title', windowId: currentWindowId })",
         @"browser.action.setIcon({ path: 'window-toolbar-48.png', windowId: currentWindowId })",
         @"browser.action.setPopup({ popup: 'window-popup.html', windowId: currentWindowId })",
         @"browser.action.setBadgeText({ text: 'W', windowId: currentWindowId })",
+
+        @"browser.test.assertEq(await browser.action.getTitle({ windowId: currentWindowId }), 'Window Title', 'Title should be')",
+        @"browser.test.assertEq(await browser.action.getPopup({ windowId: currentWindowId }), 'window-popup.html', 'Popup should be')",
+        @"browser.test.assertEq(await browser.action.getBadgeText({ windowId: currentWindowId }), 'W', 'Badge text should be')",
 
         @"browser.action.openPopup({ windowId: currentWindowId })"
     ]);
@@ -831,6 +861,74 @@ TEST(WKWebExtensionAPIAction, PageAction)
     };
 
     [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, ClearTabSpecificActionPropertiesOnNavigation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
+
+        @"browser.action.setTitle({ title: 'Tab Title', tabId: currentTab.id })",
+        @"browser.action.setIcon({ path: 'toolbar-48.png', tabId: currentTab.id })",
+        @"browser.action.setPopup({ popup: 'alt-popup.html', tabId: currentTab.id })",
+        @"browser.action.setBadgeText({ text: '42', tabId: currentTab.id })",
+        @"browser.action.disable(currentTab.id)",
+
+        @"browser.test.assertEq(await browser.action.getTitle({ tabId: currentTab.id }), 'Tab Title', 'Title should be before navigation')",
+        @"browser.test.assertEq(await browser.action.getPopup({ tabId: currentTab.id }), 'alt-popup.html', 'Popup should be before navigation')",
+        @"browser.test.assertEq(await browser.action.getBadgeText({ tabId: currentTab.id }), '42', 'Badge text should be before navigation')",
+        @"browser.test.assertFalse(await browser.action.isEnabled({ tabId: currentTab.id }), 'Action should be disabled before navigation')",
+
+        @"browser.webNavigation.onCompleted.addListener(async (details) => {",
+        @"  browser.test.assertEq(details.tabId, currentTab.id, 'Only the tab we expect should be changing')",
+        @"  browser.test.assertEq(details.frameId, 0, 'Only main frame should be changing')",
+
+        @"  browser.test.assertEq(await browser.action.getTitle({ tabId: currentTab.id }), 'Test Action', 'Title should be after navigation')",
+        @"  browser.test.assertEq(await browser.action.getPopup({ tabId: currentTab.id }), 'popup.html', 'Popup should be after navigation')",
+        @"  browser.test.assertEq(await browser.action.getBadgeText({ tabId: currentTab.id }), '', 'Badge text should be after navigation')",
+        @"  browser.test.assertTrue(await browser.action.isEnabled({ tabId: currentTab.id }), 'Action should be enabled after navigation')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')",
+    ]);
+
+    auto *smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"toolbar-16.png": smallToolbarIcon,
+        @"toolbar-32.png": largeToolbarIcon,
+        @"toolbar-48.png": extraLargeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionWebNavigation];
+
+    auto *localhostRequest = server.requestWithLocalhost();
+    auto *addressRequest = server.request();
+
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:localhostRequest.URL];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:addressRequest.URL];
+
+    [manager.get().defaultTab.mainWebView loadRequest:localhostRequest];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.mainWebView loadRequest:addressRequest];
+
+    [manager run];
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -370,7 +370,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)webView:(WKWebView *)webView didCommitNavigation:(WKNavigation *)navigation
 {
-    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesURL forTab:self];
+    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesTitle | _WKWebExtensionTabChangedPropertiesURL forTab:self];
 }
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation


### PR DESCRIPTION
#### dfe319166e75f999730302ef7d9309a21a6ac1cd
<pre>
Clear activeTab and action tab customization when tab navigates.
<a href="https://webkit.org/b/263918">https://webkit.org/b/263918</a>
<a href="https://rdar.apple.com/problem/117704349">rdar://problem/117704349</a>

Reviewed by Brian Weinstein.

Moves the webNavigation load events to WebExtensionContext, since more things will
need to tie into these hooks.

Fixes injected style removal when webPageID is used, so it only removes the styles
when the page they apply to is navigated. Also this was incorrectly behind the
webNavigation permission checks before, when it needs to always happen.

Properly clears the activeTb permission on tab navigation, and fires the onUpdated
events for URL and Title when activeTab comes and goes, as well as any pattern grant.
This matches what Safari currently does when permissions are granted.

Clears the action customizations if the tab navigates. This matches the other browsers
and what Safari currently does.

Fixes the match pattern notifications to use the right constant.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::clearCustomizations):
(WebKit::WebExtensionAction::setPopupPath):
(WebKit::WebExtensionAction::setLabel):
(WebKit::WebExtensionAction::setBadgeText):
(WebKit::WebExtensionAction::setEnabled):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::postAsyncNotification):
(WebKit::WebExtensionContext::grantPermissionMatchPatterns):
(WebKit::WebExtensionContext::denyPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeDeniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::setPermissionState):
(WebKit::WebExtensionContext::didChangeTabProperties):
(WebKit::WebExtensionContext::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionContext::didCommitLoadForFrame):
(WebKit::WebExtensionContext::didFinishLoadForFrame):
(WebKit::WebExtensionContext::didFailLoadForFrame):
(WebKit::WebExtensionContext::performAction):
(WebKit::WebExtensionContext::performCommand):
(WebKit::WebExtensionContext::userGesturePerformed):
(WebKit::WebExtensionContext::hasActiveUserGesture const):
(WebKit::WebExtensionContext::clearUserGesture):
(WebKit::WebExtensionContext::loadBackgroundPageListenersFromStorage):
(WebKit::WebExtensionContext::saveBackgroundPageListenersToStorage):
(WebKit::WebExtensionContext::removeInjectedContent):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionController::didCommitLoadForFrame):
(WebKit::WebExtensionController::didFinishLoadForFrame):
(WebKit::WebExtensionController::didFailLoadForFrame):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::changedParameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::didChangeTabProperties):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
(WebKit::WebExtensionTab::changedParameters):
(WebKit::WebExtensionTab::hasActiveUserGesture):
(WebKit::WebExtensionTab::setActiveUserGesture):
(WebKit::WebExtensionTab::temporaryPermissionMatchPattern):
(WebKit::WebExtensionTab::setTemporaryPermissionMatchPattern):
(WebKit::WebExtensionTab::changedProperties const):
(WebKit::WebExtensionTab::addChangedProperties):
(WebKit::WebExtensionTab::clearChangedProperties):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab webView:didCommitNavigation:]):

Canonical link: <a href="https://commits.webkit.org/270722@main">https://commits.webkit.org/270722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b75c18531727ac89fc283a6eb1b6ee89f336a595

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3546 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28751 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29459 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27342 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1405 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3667 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3375 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->