### PR TITLE
Add _WKIconLoadingDelegate to request loading for multiple icons in one block.

### DIFF
--- a/Source/WebKit/UIProcess/API/APIIconLoadingClient.h
+++ b/Source/WebKit/UIProcess/API/APIIconLoadingClient.h
@@ -28,6 +28,7 @@
 #include <WebCore/LinkIcon.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
+#include <wtf/Vector.h>
 
 namespace API {
 
@@ -38,9 +39,10 @@ class IconLoadingClient {
 public:
     virtual ~IconLoadingClient() { }
 
-    virtual void getLoadDecisionForIcon(const WebCore::LinkIcon&, CompletionHandler<void(CompletionHandler<void(API::Data*)>&&)>&& completionHandler)
+    virtual void getLoadDecisionsForIcons(const Vector<std::pair<WebCore::LinkIcon, uint64_t>>& linkIconIdentifierPairs, Function<void(uint64_t, CompletionHandler<void(API::Data*)>&&)>&& callback)
     {
-        completionHandler(nullptr);
+        for (auto& linkIconIdentifierPair : linkIconIdentifierPairs)
+            callback(linkIconIdentifierPair.second, nullptr);
     }
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKIconLoadingDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKIconLoadingDelegate.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 - (void)webView:(WKWebView *)webView shouldLoadIconWithParameters:(_WKLinkIconParameters *)parameters completionHandler:(void (^)(void (^)(NSData*)))completionHandler;
+- (void)webView:(WKWebView *)webView shouldLoadIconsWithParameters:(NSArray<_WKLinkIconParameters *> *)parameterIcons completionHandler:(void (^)(NSSet<_WKLinkIconParameters *> *iconsToLoad, void (^didFinishLoadingIcon)(_WKLinkIconParameters *, NSData *)))completionHandler;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm
@@ -28,6 +28,18 @@
 
 #import <WebCore/LinkIcon.h>
 
+static NSString *stringFromLinkIconType(WKLinkIconType type)
+{
+    switch (type) {
+    case WKLinkIconTypeFavicon:
+        return @"Favicon";
+    case WKLinkIconTypeTouchIcon:
+        return @"TouchIcon";
+    case WKLinkIconTypeTouchPrecomposedIcon:
+        return @"TouchPrecomposedIcon";
+    }
+}
+
 @implementation _WKLinkIconParameters {
     RetainPtr<NSURL> _url;
     WKLinkIconType _iconType;
@@ -89,6 +101,11 @@
 - (NSDictionary *)attributes
 {
     return _attributes.get();
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; url: %@; mimeType: %@; size: %@; iconType: %@; attributes: %@>", self.class, self, self.url, self.mimeType, self.size, stringFromLinkIconType(_iconType), self.attributes];
 }
 
 @end

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
@@ -55,7 +55,7 @@ private:
         ~IconLoadingClient();
 
     private:
-        void getLoadDecisionForIcon(const WebCore::LinkIcon&, CompletionHandler<void(CompletionHandler<void(API::Data*)>&&)>&&) override;
+        void getLoadDecisionsForIcons(const Vector<std::pair<WebCore::LinkIcon, uint64_t>>&, Function<void(uint64_t, CompletionHandler<void(API::Data*)>&&)>&&) override;
 
         IconLoadingDelegate& m_iconLoadingDelegate;
     };
@@ -65,6 +65,7 @@ private:
 
     struct {
         bool webViewShouldLoadIconWithParametersCompletionHandler : 1;
+        bool webViewShouldLoadIconsWithParametersCompletionHandler : 1;
     } m_delegateMethods;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11530,9 +11530,12 @@ void WebPageProxy::didRestoreScrollPosition()
     pageClient().didRestoreScrollPosition();
 }
 
-void WebPageProxy::getLoadDecisionForIcon(const WebCore::LinkIcon& icon, CallbackID loadIdentifier)
+void WebPageProxy::getLoadDecisionsForIcons(const Vector<std::pair<WebCore::LinkIcon, CallbackID>>& linkIcons)
 {
-    m_iconLoadingClient->getLoadDecisionForIcon(icon, [this, protectedThis = Ref { *this }, loadIdentifier] (CompletionHandler<void(API::Data*)>&& callback) {
+    auto iconIdentifierPairs = WTF::map(linkIcons, [&](auto& iconIdentifierPair) -> std::pair<WebCore::LinkIcon, uint64_t> {
+        return { iconIdentifierPair.first, iconIdentifierPair.second.toInteger() };
+    });
+    m_iconLoadingClient->getLoadDecisionsForIcons(WTFMove(iconIdentifierPairs), [this, protectedThis = Ref { *this }] (uint64_t loadIdentifier, CompletionHandler<void(API::Data*)>&& callback) {
         if (!hasRunningProcess()) {
             if (callback)
                 callback(nullptr);
@@ -11540,10 +11543,10 @@ void WebPageProxy::getLoadDecisionForIcon(const WebCore::LinkIcon& icon, Callbac
         }
 
         if (!callback) {
-            sendWithAsyncReply(Messages::WebPage::DidGetLoadDecisionForIcon(false, loadIdentifier), [](auto) { });
+            sendWithAsyncReply(Messages::WebPage::DidGetLoadDecisionForIcon(false, CallbackID::fromInteger(loadIdentifier)), [](auto) { });
             return;
         }
-        sendWithAsyncReply(Messages::WebPage::DidGetLoadDecisionForIcon(true, loadIdentifier), [callback = WTFMove(callback)](const IPC::SharedBufferReference& iconData) mutable {
+        sendWithAsyncReply(Messages::WebPage::DidGetLoadDecisionForIcon(true, CallbackID::fromInteger(loadIdentifier)), [callback = WTFMove(callback)](const IPC::SharedBufferReference& iconData) mutable {
             callback(API::Data::create(iconData.data(), iconData.size()).ptr());
         });
     });

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1793,7 +1793,7 @@ public:
 
     void didRestoreScrollPosition();
 
-    void getLoadDecisionForIcon(const WebCore::LinkIcon&, CallbackID);
+    void getLoadDecisionsForIcons(const Vector<std::pair<WebCore::LinkIcon, CallbackID>>&);
 
     void focusFromServiceWorker(CompletionHandler<void()>&&);
     void setFocus(bool focused);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -489,7 +489,7 @@ messages -> WebPageProxy {
     
     RequestScrollToRect(WebCore::FloatRect targetRect, WebCore::FloatPoint origin)
 
-    GetLoadDecisionForIcon(struct WebCore::LinkIcon icon, WebKit::CallbackID callbackID)
+    GetLoadDecisionsForIcons(Vector<std::pair<WebCore::LinkIcon, WebKit::CallbackID>> iconCallbackIDs)
 
 #if PLATFORM(MAC)
     DidHandleAcceptedCandidate()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1884,8 +1884,10 @@ void WebLocalFrameLoaderClient::getLoadDecisionForIcons(const Vector<std::pair<W
     if (!webPage)
         return;
 
-    for (auto& icon : icons)
-        webPage->send(Messages::WebPageProxy::GetLoadDecisionForIcon(icon.first, CallbackID::fromInteger(icon.second)));
+    auto iconCallbackIDPairs = WTF::map(icons, [&](auto& iconIdentifierPair) -> std::pair<WebCore::LinkIcon, CallbackID> {
+        return { iconIdentifierPair.first, CallbackID::fromInteger(iconIdentifierPair.second) };
+    });
+    webPage->send(Messages::WebPageProxy::GetLoadDecisionsForIcons(WTFMove(iconCallbackIDPairs)));
 }
 
 void WebLocalFrameLoaderClient::broadcastFrameRemovalToOtherProcesses()


### PR DESCRIPTION
#### ced6b78b2b5d8c8e56f51fe9131cf82ac0523e49
<pre>
Add _WKIconLoadingDelegate to request loading for multiple icons in one block.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264775">https://bugs.webkit.org/show_bug.cgi?id=264775</a>
&lt;<a href="https://rdar.apple.com/problem/118262973">rdar://problem/118262973</a>&gt;

Reviewed by NOBODY (OOPS!).

WebKit parses the web page for all the icons in the page when the document is done loading
and then sends a _WKIconLoadingDelegate call for each of them to see which one the delegate
would like to download. Instead of one-by-one, this commit adds a new SPI that sends the
entire array of icons at once, and takes a set of icon parameters to load. Icon loading is
still performed one icon at a time with the block provided by the delegate.

* Source/WebKit/UIProcess/API/APIIconLoadingClient.h:
(API::IconLoadingClient::getLoadDecisionsForIcons):
  Renamed from API::IconLoadingClient::getLoadDecisionForIcon. Take an array of icon/identifier
  pairs so they can all be handled.

* Source/WebKit/UIProcess/API/Cocoa/_WKIconLoadingDelegate.h:
  Add the SPI allowing multiple loads at once.

* Source/WebKit/UIProcess/API/Cocoa/_WKLinkIconParameters.mm:
(stringFromLinkIconType):
  Debug function to generate a string representation of the icon type.

(-[_WKLinkIconParameters description]):
  Add description for debugging purposes.

* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h:
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm:
(WebKit::IconLoadingDelegate::setDelegate):
  Check if the delegate implements the new method.

(WebKit::IconLoadingDelegate::IconLoadingClient::getLoadDecisionsForIcons):
  Renamed from WebKit::IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon.
  Support the new delegate method, reject all loading if none of the method are implemented
  or if the delegate is nil. If the new SPI is not implemented by the delegate fallback to
  the old one and call the method once for each icon received. Otherwise, call the new method
  and load only the icons that are in the received set.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::getLoadDecisionsForIcons):
  Renamed from WebKit::WebPageProxy::getLoadDecisionForIcon. Support multiple icons at once.
  Convert CallbackIDs to identifiers to be handled by the SPI.

* Source/WebKit/UIProcess/WebPageProxy.h:

* Source/WebKit/UIProcess/WebPageProxy.messages.in:

* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::getLoadDecisionForIcons):
  Convert identifiers to CallbackIDs to be sent to the UI process.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced6b78b2b5d8c8e56f51fe9131cf82ac0523e49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23959 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3585 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22482 "1 api test failed or timed out") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28794 "Hash ced6b78b for PR 20443 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3194 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/28794 "Hash ced6b78b for PR 20443 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23812 "Found 3 new API test failures: TestWebKitAPI.IconLoading.IconLoadCancelledCallback2, TestWebKitAPI.IconLoading.IconLoadCancelledCallback, TestWebKitAPI.IconLoading.DefaultFavicon (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23827 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/28794 "Hash ced6b78b for PR 20443 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3237 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1435 "Found 1 new test failure: accessibility/custom-elements/autocomplete.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->