### PR TITLE
Begin implementing frame name handling for site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt
@@ -6,7 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 state before window.open:
 PASS openedWindow[0].customProperty is 42
 state after window.open with a frame name:
-PASS openedWindow[0].customProperty is 42
+PASS openedWindow[0].customProperty is 43
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html
+++ b/LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html
@@ -14,11 +14,11 @@ function runTestIfInTestRunner() { if (window.testRunner) { runTest() } }
 function firstSameOriginIframeOpened() {
     debug("state before window.open:")
     shouldBe("openedWindow[0].customProperty", "42");
-    windowOpenedInFrame = window.open("http://127.0.0.1:8000/site-isolation/resources/opened-iframe-2.html", "openedFrameName-remove-this-when-fixing-rdar://117092110")
+    windowOpenedInFrame = window.open("http://127.0.0.1:8000/site-isolation/resources/opened-iframe-2.html", "openedFrameName")
 }
 function secondSameOriginIframeOpened() {
     debug("state after window.open with a frame name:")
-    shouldBe("openedWindow[0].customProperty", "42"); // FIXME: When <rdar://117092110> is fixed this should be 43. Also change the frame name above so the load happens in the already-opened frame.
+    shouldBe("openedWindow[0].customProperty", "43");
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-to-opener-2.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-to-opener-2.html
@@ -1,0 +1,6 @@
+<script>
+    addEventListener("message", (event) => {
+        window.opener.postMessage("second opened window received: " + event.data, "*")
+    });
+    window.opener.postMessage("second ping", "*")
+</script>

--- a/LayoutTests/http/tests/site-isolation/window-open-with-name-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-open-with-name-expected.txt
@@ -1,0 +1,11 @@
+Verifies window.open with a target name correctly reuses a main frame
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL first opened window should have been reused
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+click to run test manually in a browser

--- a/LayoutTests/http/tests/site-isolation/window-open-with-name.html
+++ b/LayoutTests/http/tests/site-isolation/window-open-with-name.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies window.open with a target name correctly reuses a main frame");
+jsTestIsAsync = true;
+
+function runTest() {
+    firstOpenedWindow = window.open("http://localhost:8000/site-isolation/resources/post-message-to-opener.html", "frameName");
+}
+
+function runTestIfInTestRunner() { if (window.testRunner) { runTest() } }
+
+addEventListener("message", (event) => {
+    if (event.data == 'initial ping') {
+        secondOpenedWindow = window.open("http://localhost:8000/site-isolation/resources/post-message-to-opener-2.html", "frameName");
+    } else if (event.data == 'second ping') {
+        firstOpenedWindow.postMessage('sent to first window, which should be reused', '*')
+    } else if (event.data.startsWith('opened window received')) {
+        testFailed("first opened window should have been reused"); // FIXME: <rdar://118363128> Reuse the main frame and make this test not fail with site isolation enabled.
+        finishJSTest();
+    } else if (event.data.startsWith('second opened window received')) {
+        shouldBe("event.data", "'second opened window received: sent to first window, which should be reused'");
+        finishJSTest();
+    }
+});
+</script>
+<body onload="runTestIfInTestRunner()">
+<button onclick="runTest()">click to run test manually in a browser</button>
+</body>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3995,12 +3995,12 @@ RefPtr<LocalFrame> FrameLoader::findFrameForNavigation(const AtomString& name, D
     if (!activeDocument)
         return nullptr;
 
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame->tree().findBySpecifiedName(name, activeDocument->frame() ? *activeDocument->protectedFrame() : protectedFrame().get()));
-
-    if (!activeDocument->canNavigate(frame.get()))
+    RefPtr frame = m_frame->tree().findBySpecifiedName(name, activeDocument->frame() ? *activeDocument->protectedFrame() : protectedFrame().get());
+    if (!activeDocument->canNavigate(dynamicDowncast<LocalFrame>(frame.get())))
         return nullptr;
 
-    return frame;
+    // FIXME: <rdar://118363128> This should return a Frame. If a RemoteFrame with the given name exists, we should use that.
+    return dynamicDowncast<LocalFrame>(frame.get());
 }
 
 void FrameLoader::loadSameDocumentItem(HistoryItem& item)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -85,6 +85,9 @@ public:
     virtual void didFinishLoadInAnotherProcess() = 0;
 
     virtual FrameView* virtualView() const = 0;
+    virtual void disconnectView() = 0;
+    virtual const Frame* opener() const = 0;
+    virtual Frame* opener() = 0;
 
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -966,6 +966,21 @@ DOMWindow* LocalFrame::virtualWindow() const
     return window();
 }
 
+void LocalFrame::disconnectView()
+{
+    setView(nullptr);
+}
+
+const Frame* LocalFrame::opener() const
+{
+    return loader().opener();
+}
+
+Frame* LocalFrame::opener()
+{
+    return loader().opener();
+}
+
 FrameView* LocalFrame::virtualView() const
 {
     return m_view.get();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -320,7 +320,10 @@ private:
     void didFinishLoadInAnotherProcess() final;
 
     FrameView* virtualView() const final;
+    void disconnectView() final;
     DOMWindow* virtualWindow() const final;
+    const Frame* opener() const final;
+    Frame* opener();
 
     WeakHashSet<FrameDestructionObserver> m_destructionObservers;
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -73,6 +73,11 @@ RemoteDOMWindow& RemoteFrame::window() const
     return m_window.get();
 }
 
+void RemoteFrame::disconnectView()
+{
+    m_view = nullptr;
+}
+
 void RemoteFrame::didFinishLoadInAnotherProcess()
 {
     m_preventsParentFromBeingComplete = false;

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -51,7 +51,8 @@ public:
 
     // FIXME: <rdar://118263278> Move this to a pure virtual function on Frame or just a function on Frame, move LocalDOMWindow::opener to DOMWindow.
     void setOpener(Frame* opener) { m_opener = opener; }
-    Frame* opener() const { return m_opener.get(); }
+    Frame* opener() final { return m_opener.get(); }
+    const Frame* opener() const final { return m_opener.get(); }
 
     const RemoteFrameClient& client() const { return m_client.get(); }
     RemoteFrameClient& client() { return m_client.get(); }
@@ -73,6 +74,7 @@ private:
     void didFinishLoadInAnotherProcess() final;
 
     FrameView* virtualView() const final;
+    void disconnectView() final;
     DOMWindow* virtualWindow() const final;
 
     Ref<RemoteDOMWindow> m_window;

--- a/Source/WebKit/Shared/FrameTreeCreationParameters.h
+++ b/Source/WebKit/Shared/FrameTreeCreationParameters.h
@@ -33,6 +33,7 @@ namespace WebKit {
 
 struct FrameTreeCreationParameters {
     WebCore::FrameIdentifier frameID;
+    String frameName;
     Vector<FrameTreeCreationParameters> children;
 };
 

--- a/Source/WebKit/Shared/FrameTreeCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/FrameTreeCreationParameters.serialization.in
@@ -22,5 +22,6 @@
 
 struct WebKit::FrameTreeCreationParameters {
     WebCore::FrameIdentifier frameID;
+    String frameName;
     Vector<WebKit::FrameTreeCreationParameters> children;
 };

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -367,7 +367,7 @@ void WebFrameProxy::disconnect()
         m_parentFrame->m_childFrames.remove(*this);
 }
 
-void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID)
+void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, const String& frameName)
 {
     // The DecidePolicyForNavigationActionSync IPC is synchronous and may therefore get processed before the DidCreateSubframe one.
     // When this happens, decidePolicyForNavigationActionSync() calls didCreateSubframe() and we need to ignore the DidCreateSubframe
@@ -381,8 +381,9 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID)
 
     auto child = WebFrameProxy::create(*m_page, m_process, frameID);
     child->m_parentFrame = *this;
+    child->m_frameName = frameName;
     if (m_page)
-        m_page->createRemoteSubframesInOtherProcesses(child);
+        m_page->createRemoteSubframesInOtherProcesses(child, frameName);
     m_childFrames.add(WTFMove(child));
 }
 
@@ -496,6 +497,7 @@ FrameTreeCreationParameters WebFrameProxy::frameTreeCreationParameters() const
 {
     return {
         m_frameID,
+        m_frameName,
         WTF::map(m_childFrames, [] (auto& frame) {
             return frame->frameTreeCreationParameters();
         })

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -149,7 +149,7 @@ public:
     void setNavigationCallback(CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)>&&);
 
     void disconnect();
-    void didCreateSubframe(WebCore::FrameIdentifier);
+    void didCreateSubframe(WebCore::FrameIdentifier, const String& frameName);
     ProcessID processID() const;
     void prepareForProvisionalNavigationInProcess(WebProcessProxy&, const API::Navigation&, CompletionHandler<void()>&&);
 
@@ -182,6 +182,7 @@ private:
 
     String m_MIMEType;
     String m_title;
+    String m_frameName;
     bool m_containsPluginDocument { false };
     WebCore::CertificateInfo m_certificateInfo;
     RefPtr<WebFramePolicyListenerProxy> m_activeListener;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2188,7 +2188,7 @@ public:
     void addOpenedRemotePageProxy(WebPageProxyIdentifier, Ref<RemotePageProxy>&&);
     void removeOpenedRemotePageProxy(WebPageProxyIdentifier);
 
-    void createRemoteSubframesInOtherProcesses(WebFrameProxy&);
+    void createRemoteSubframesInOtherProcesses(WebFrameProxy&, const String& frameName);
     void broadcastFrameRemovalToOtherProcesses(IPC::Connection&, WebCore::FrameIdentifier);
     void broadcastMainFrameURLChangeToOtherProcesses(IPC::Connection&, const URL&);
 
@@ -2345,7 +2345,7 @@ private:
 #endif
 
     void didCreateMainFrame(WebCore::FrameIdentifier);
-    void didCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID);
+    void didCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, const String& frameName);
 
     void didStartProvisionalLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, URL&&, URL&& unreachableURL, const UserData&);
     void didReceiveServerRedirectForProvisionalLoadForFrame(WebCore::FrameIdentifier, uint64_t navigationID, WebCore::ResourceRequest&&, const UserData&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -115,7 +115,7 @@ messages -> WebPageProxy {
 
     # Frame lifetime messages
     DidCreateMainFrame(WebCore::FrameIdentifier frameID)
-    DidCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID)
+    DidCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String frameName)
 
     # Frame load messages
     DidStartProvisionalLoadForFrame(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::ResourceRequest request, uint64_t navigationID, URL url, URL unreachableURL, WebKit::UserData userData)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -83,7 +83,7 @@ class WebFrame : public API::ObjectImpl<API::Object::Type::BundleFrame>, public 
 public:
     static Ref<WebFrame> create(WebPage& page, WebCore::FrameIdentifier frameID) { return adoptRef(*new WebFrame(page, frameID)); }
     static Ref<WebFrame> createSubframe(WebPage&, WebFrame& parent, const AtomString& frameName, WebCore::HTMLFrameOwnerElement&);
-    static Ref<WebFrame> createRemoteSubframe(WebPage&, WebFrame& parent, WebCore::FrameIdentifier);
+    static Ref<WebFrame> createRemoteSubframe(WebPage&, WebFrame& parent, WebCore::FrameIdentifier, const String& frameName);
     ~WebFrame();
 
     void initWithCoreMainFrame(WebPage&, WebCore::Frame&, bool receivedMainFrameIdentifierFromUIProcess);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1052,19 +1052,19 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
 void WebPage::constructFrameTree(WebFrame& parent, const FrameTreeCreationParameters& treeCreationParameters)
 {
-    auto frame = WebFrame::createRemoteSubframe(*this, parent, treeCreationParameters.frameID);
+    auto frame = WebFrame::createRemoteSubframe(*this, parent, treeCreationParameters.frameID, treeCreationParameters.frameName);
     for (auto& parameters : treeCreationParameters.children)
         constructFrameTree(frame, parameters);
 }
 
-void WebPage::createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID)
+void WebPage::createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, const String& newChildFrameName)
 {
     RefPtr parentFrame = WebProcess::singleton().webFrame(parentID);
     if (!parentFrame) {
         ASSERT_NOT_REACHED();
         return;
     }
-    WebFrame::createRemoteSubframe(*this, *parentFrame, newChildID);
+    WebFrame::createRemoteSubframe(*this, *parentFrame, newChildID, newChildFrameName);
 }
 
 void WebPage::getFrameInfo(WebCore::FrameIdentifier frameID, CompletionHandler<void(std::optional<FrameInfoData>&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -610,7 +610,7 @@ public:
     WebCore::FrameView* mainFrameView() const; // May return nullptr.
     WebCore::LocalFrameView* localMainFrameView() const; // May return nullptr.
 
-    void createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID);
+    void createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, const String& newChildFrameName);
 
     void getFrameInfo(WebCore::FrameIdentifier, CompletionHandler<void(std::optional<FrameInfoData>&&)>&&);
     void getFrameTree(CompletionHandler<void(FrameTreeNodeData&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -194,7 +194,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     LoadData(struct WebKit::LoadParameters loadParameters)
     LoadSimulatedRequestAndResponse(struct WebKit::LoadParameters loadParameters, WebCore::ResourceResponse simulatedResponse)
     LoadAlternateHTML(struct WebKit::LoadParameters loadParameters)
-    CreateRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID)
+    CreateRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, String frameName)
 
     GetFrameInfo(WebCore::FrameIdentifier frameID) -> (std::optional<WebKit::FrameInfoData> data)
     GetFrameTree() -> (struct WebKit::FrameTreeNodeData data)


### PR DESCRIPTION
#### ee004596ca4fe4d507bb4bb9051725d8c8592655
<pre>
Begin implementing frame name handling for site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=264781">https://bugs.webkit.org/show_bug.cgi?id=264781</a>
<a href="https://rdar.apple.com/117092110">rdar://117092110</a>

Reviewed by Pascoe.

In order for the second parameter of window.open to be able to be used, the string name
must be found on the correct frame.  Most of this can be implemented simply by passing a
string around, but in order for WebFrameProxy::frameTreeCreationParameters to be able to
be used with multiple frames after instantiation, we need to store the name in the UI
process on the WebFrameProxy object.

In the web content process, a few fixes were needed.  First, when switch from RemoteFrame
to LocalFrame or the other way, the frame name should persist so we need to copy it from
the old to the new Frame subclass object.  In order for the correct frame to be found and
used when RemoteFrames are in the tree, I needed to make a few places in FrameTree and
FrameLoader work with both types of Frames.

I also had to move some RemotePageProxy cleanup from the WebPageProxy destructor to
WebPageProxy::close to get WebKitTestRunner to successfully clean up between running tests.

This seemed like a good stopping point to make a PR because something that didn&apos;t work
before works now.  I filed another bug for future work to make two more cases work:
if the named frame is a RemoteFrame and if the named frame is the main frame.

* LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt:
* LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html:
* LayoutTests/http/tests/site-isolation/resources/post-message-to-opener-2.html: Added.
* LayoutTests/http/tests/site-isolation/window-open-with-name-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-open-with-name.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::findFrameForNavigation):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::~FrameTree):
(WebCore::isFrameFamiliarWith):
(WebCore::FrameTree::find const):
(WebCore::FrameTree::firstRenderedChild const):
(WebCore::FrameTree::nextRenderedSibling const):
(WebCore::FrameTree::traverseNext const):
(WebCore::FrameTree::traverseNextInPostOrder const):
(printFrames):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::disconnectView):
(WebCore::LocalFrame::opener const):
(WebCore::LocalFrame::opener):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::disconnectView):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebKit/Shared/FrameTreeCreationParameters.h:
* Source/WebKit/Shared/FrameTreeCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCreateSubframe):
(WebKit::WebFrameProxy::frameTreeCreationParameters const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCreateSubframe):
(WebKit::WebPageProxy::createRemoteSubframesInOtherProcesses):
(WebKit::WebPageProxy::decidePolicyForNavigationActionSync):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::createRemoteSubframe):
(WebKit::WebFrame::didCommitLoadInAnotherProcess):
(WebKit::WebFrame::transitionToLocal):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::constructFrameTree):
(WebKit::WebPage::createRemoteSubframe):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/270729@main">https://commits.webkit.org/270729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0227f3f3fb4c5b0d61854680c9c5f9e8212fbfef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2278 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26505 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28923 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27491 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3343 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4760 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/23290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3816 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3379 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->