### PR TITLE
Use dynamicDowncast<T> even more in the DOM

### DIFF
--- a/Source/WebCore/dom/ElementTraversal.h
+++ b/Source/WebCore/dom/ElementTraversal.h
@@ -97,20 +97,22 @@ template <>
 template <typename CurrentType>
 inline Element* Traversal<Element>::nextTemplate(CurrentType& current)
 {
-    Node* node = NodeTraversal::next(current);
-    while (node && !is<Element>(*node))
-        node = NodeTraversal::nextSkippingChildren(*node);
-    return downcast<Element>(node);
+    for (auto* node = NodeTraversal::next(current); node; node = NodeTraversal::nextSkippingChildren(*node)) {
+        if (auto* element = dynamicDowncast<Element>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <>
 template <typename CurrentType>
 inline Element* Traversal<Element>::nextTemplate(CurrentType& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::next(current, stayWithin);
-    while (node && !is<Element>(*node))
-        node = NodeTraversal::nextSkippingChildren(*node, stayWithin);
-    return downcast<Element>(node);
+    for (auto* node = NodeTraversal::next(current, stayWithin); node; node = NodeTraversal::nextSkippingChildren(*node, stayWithin)) {
+        if (auto* element = dynamicDowncast<Element>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 // Generic versions.
@@ -118,114 +120,126 @@ template <typename ElementType>
 template <typename CurrentType>
 inline ElementType* Traversal<ElementType>::firstChildTemplate(CurrentType& current)
 {
-    Node* node = current.firstChild();
-    while (node && !is<ElementType>(*node))
-        node = node->nextSibling();
-    return downcast<ElementType>(node);
+    for (auto* node = current.firstChild(); node; node = node->nextSibling()) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 template <typename CurrentType>
 inline ElementType* Traversal<ElementType>::lastChildTemplate(CurrentType& current)
 {
-    Node* node = current.lastChild();
-    while (node && !is<ElementType>(*node))
-        node = node->previousSibling();
-    return downcast<ElementType>(node);
+    for (auto* node = current.lastChild(); node; node = node->previousSibling()) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 template <typename CurrentType>
 inline ElementType* Traversal<ElementType>::firstWithinTemplate(CurrentType& current)
 {
-    Node* node = current.firstChild();
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::next(*node, &current);
-    return downcast<ElementType>(node);
+    for (auto* node = current.firstChild(); node; node = NodeTraversal::next(*node, &current)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 template <typename CurrentType>
 inline ElementType* Traversal<ElementType>::lastWithinTemplate(CurrentType& current)
 {
-    Node* node = NodeTraversal::last(current);
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::previous(*node, &current);
-    return downcast<ElementType>(node);
+    for (auto* node = NodeTraversal::last(current); node; node = NodeTraversal::previous(*node, &current)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 template <typename CurrentType>
 inline ElementType* Traversal<ElementType>::nextTemplate(CurrentType& current)
 {
-    Node* node = NodeTraversal::next(current);
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::next(*node);
-    return downcast<ElementType>(node);
+    for (auto* node = NodeTraversal::next(current); node; node = NodeTraversal::next(*node)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 template <typename CurrentType>
 inline ElementType* Traversal<ElementType>::nextTemplate(CurrentType& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::next(current, stayWithin);
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::next(*node, stayWithin);
-    return downcast<ElementType>(node);
+    for (auto* node = NodeTraversal::next(current, stayWithin); node; node = NodeTraversal::next(*node, stayWithin)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::previous(const Node& current)
 {
-    Node* node = NodeTraversal::previous(current);
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::previous(*node);
-    return downcast<ElementType>(node);
+    for (auto* node = NodeTraversal::previous(current); node; node = NodeTraversal::previous(*node)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::previous(const Node& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::previous(current, stayWithin);
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::previous(*node, stayWithin);
-    return downcast<ElementType>(node);
+    for (auto* node = NodeTraversal::previous(current, stayWithin); node; node = NodeTraversal::previous(*node, stayWithin)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::nextSibling(const Node& current)
 {
-    Node* node = current.nextSibling();
-    while (node && !is<ElementType>(*node))
-        node = node->nextSibling();
-    return downcast<ElementType>(node);
+    for (auto* node = current.nextSibling(); node; node = node->nextSibling()) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::previousSibling(const Node& current)
 {
-    Node* node = current.previousSibling();
-    while (node && !is<ElementType>(*node))
-        node = node->previousSibling();
-    return downcast<ElementType>(node);
+    for (auto* node = current.previousSibling(); node; node = node->previousSibling()) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::nextSkippingChildren(const Node& current)
 {
-    Node* node = NodeTraversal::nextSkippingChildren(current);
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::nextSkippingChildren(*node);
-    return downcast<ElementType>(node);
+    for (auto* node = NodeTraversal::nextSkippingChildren(current); node; node = NodeTraversal::nextSkippingChildren(*node)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::nextSkippingChildren(const Node& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::nextSkippingChildren(current, stayWithin);
-    while (node && !is<ElementType>(*node))
-        node = NodeTraversal::nextSkippingChildren(*node, stayWithin);
-    return downcast<ElementType>(node);
+    for (auto* node = NodeTraversal::nextSkippingChildren(current, stayWithin); node; node = NodeTraversal::nextSkippingChildren(*node, stayWithin)) {
+        if (auto* element = dynamicDowncast<ElementType>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 template <typename ElementType>
@@ -241,32 +255,32 @@ inline ElementType* Traversal<ElementType>::lastChild(const Node& current) { ret
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::inclusiveFirstWithin(ContainerNode& current)
 {
-    if (is<ElementType>(current))
-        return &downcast<ElementType>(current);
+    if (auto* element = dynamicDowncast<ElementType>(current))
+        return element;
     return firstWithin(current);
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::inclusiveFirstWithin(Node& current)
 {
-    if (is<ElementType>(current))
-        return &downcast<ElementType>(current);
+    if (auto* element = dynamicDowncast<ElementType>(current))
+        return element;
     return firstWithin(current);
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::inclusiveLastWithin(ContainerNode& current)
 {
-    if (is<ElementType>(current))
-        return &downcast<ElementType>(current);
+    if (auto* element = dynamicDowncast<ElementType>(current))
+        return element;
     return lastWithin(current);
 }
 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::inclusiveLastWithin(Node& current)
 {
-    if (is<ElementType>(current))
-        return &downcast<ElementType>(current);
+    if (auto* element = dynamicDowncast<ElementType>(current))
+        return element;
     return lastWithin(current);
 }
 
@@ -292,34 +306,38 @@ inline ElementType* Traversal<ElementType>::next(const Node& current, const Node
 // FIXME: These should go somewhere else.
 inline Element* ElementTraversal::previousIncludingPseudo(const Node& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::previousIncludingPseudo(current, stayWithin);
-    while (node && !is<Element>(*node))
-        node = NodeTraversal::previousIncludingPseudo(*node, stayWithin);
-    return downcast<Element>(node);
+    for (auto* node = NodeTraversal::previousIncludingPseudo(current, stayWithin); node; node = NodeTraversal::previousIncludingPseudo(*node, stayWithin)) {
+        if (auto* element = dynamicDowncast<Element>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 inline Element* ElementTraversal::nextIncludingPseudo(const Node& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::nextIncludingPseudo(current, stayWithin);
-    while (node && !is<Element>(*node))
-        node = NodeTraversal::nextIncludingPseudo(*node, stayWithin);
-    return downcast<Element>(node);
+    for (auto* node = NodeTraversal::nextIncludingPseudo(current, stayWithin); node; node = NodeTraversal::nextIncludingPseudo(*node, stayWithin)) {
+        if (auto* element = dynamicDowncast<Element>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 inline Element* ElementTraversal::nextIncludingPseudoSkippingChildren(const Node& current, const Node* stayWithin)
 {
-    Node* node = NodeTraversal::nextIncludingPseudoSkippingChildren(current, stayWithin);
-    while (node && !is<Element>(*node))
-        node = NodeTraversal::nextIncludingPseudoSkippingChildren(*node, stayWithin);
-    return downcast<Element>(node);
+    for (auto* node = NodeTraversal::nextIncludingPseudoSkippingChildren(current, stayWithin); node; node = NodeTraversal::nextIncludingPseudoSkippingChildren(*node, stayWithin)) {
+        if (auto* element = dynamicDowncast<Element>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 inline Element* ElementTraversal::pseudoAwarePreviousSibling(const Node& current)
 {
-    Node* node = current.pseudoAwarePreviousSibling();
-    while (node && !is<Element>(*node))
-        node = node->pseudoAwarePreviousSibling();
-    return downcast<Element>(node);
+    for (auto* node = current.pseudoAwarePreviousSibling(); node; node = node->pseudoAwarePreviousSibling()) {
+        if (auto* element = dynamicDowncast<Element>(*node))
+            return element;
+    }
+    return nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -90,8 +90,11 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
     if (!m_node->hasEventTargetData())
         return;
 
-    if (event.isTrusted() && is<Element>(m_node) && downcast<Element>(*m_node).isDisabledFormControl() && event.isMouseEvent() && !event.isWheelEvent() && !m_node->document().settings().sendMouseEventsToDisabledFormControlsEnabled())
-        return;
+    if (event.isTrusted()) {
+        auto* element = dynamicDowncast<Element>(m_node.get());
+        if (element && element->isDisabledFormControl() && event.isMouseEvent() && !event.isWheelEvent() && !m_node->document().settings().sendMouseEventsToDisabledFormControlsEnabled())
+            return;
+    }
 
     protectedNode()->fireEventListeners(event, phase);
 }
@@ -112,7 +115,8 @@ void EventContext::initializeTouchLists()
 bool EventContext::isUnreachableNode(EventTarget* target) const
 {
     // FIXME: Checks also for SVG elements.
-    return is<Node>(target) && !downcast<Node>(*target).isSVGElement() && m_node && m_node->isClosedShadowHidden(downcast<Node>(*target));
+    auto* node = dynamicDowncast<Node>(target);
+    return node && !node->isSVGElement() && m_node && m_node->isClosedShadowHidden(*node);
 }
 
 #endif

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -425,7 +425,7 @@ inline bool EventNames::isTouchScrollBlockingEventType(const AtomString& eventTy
 inline bool EventNames::isTouchRelatedEventType(const AtomString& eventType, const EventTarget& target) const
 {
 #if ENABLE(TOUCH_EVENTS)
-    if (is<Node>(target) && downcast<Node>(target).document().quirks().shouldDispatchSimulatedMouseEvents(&target)) {
+    if (auto* targetNode = dynamicDowncast<Node>(target); targetNode && targetNode->document().quirks().shouldDispatchSimulatedMouseEvents(&target)) {
         if (eventType == mousedownEvent || eventType == mousemoveEvent || eventType == mouseupEvent)
             return true;
     }

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -64,12 +64,12 @@ private:
 
 inline Node* EventPath::eventTargetRespectingTargetRules(Node& referenceNode)
 {
-    if (is<PseudoElement>(referenceNode))
-        return downcast<PseudoElement>(referenceNode).hostElement();
+    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(referenceNode))
+        return pseudoElement->hostElement();
 
     // Events sent to elements inside an SVG use element's shadow tree go to the use element.
-    if (is<SVGElement>(referenceNode)) {
-        if (auto useElement = downcast<SVGElement>(referenceNode).correspondingUseElement())
+    if (auto* svgElement = dynamicDowncast<SVGElement>(referenceNode)) {
+        if (auto useElement = svgElement->correspondingUseElement())
             return useElement.get();
     }
 

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -216,14 +216,14 @@ void removeOverlaySoonIfNeeded(HTMLElement& element)
 
 IntRect containerRect(HTMLElement& element)
 {
-    CheckedPtr renderer = element.renderer();
-    if (!is<RenderImage>(renderer))
+    CheckedPtr renderer = dynamicDowncast<RenderImage>(element.renderer());
+    if (!renderer)
         return { };
 
     if (!renderer->opacity())
         return { 0, 0, element.offsetWidth(), element.offsetHeight() };
 
-    return enclosingIntRect(downcast<RenderImage>(*renderer).replacedContentRect());
+    return enclosingIntRect(renderer->replacedContentRect());
 }
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -102,6 +102,14 @@ static inline KeyboardEvent::KeyLocationCode keyLocationCode(const PlatformKeybo
 
 inline KeyboardEvent::KeyboardEvent() = default;
 
+static bool viewIsCompositing(WindowProxy* view)
+{
+    if (!view)
+        return false;
+    auto* window = dynamicDowncast<LocalDOMWindow>(view->window());
+    return window && window->frame() && window->frame()->editor().hasComposition();
+}
+
 inline KeyboardEvent::KeyboardEvent(const PlatformKeyboardEvent& key, RefPtr<WindowProxy>&& view)
     : UIEventWithKeyState(eventTypeForKeyboardEventType(key.type()), CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
         key.timestamp().approximateMonotonicTime(), view.copyRef(), 0, key.modifiers(), IsTrusted::Yes)
@@ -111,7 +119,7 @@ inline KeyboardEvent::KeyboardEvent(const PlatformKeyboardEvent& key, RefPtr<Win
     , m_keyIdentifier(AtomString { key.keyIdentifier() })
     , m_location(keyLocationCode(key))
     , m_repeat(key.isAutoRepeat())
-    , m_isComposing(view && is<LocalDOMWindow>(view->window()) && downcast<LocalDOMWindow>(*view->window()).frame() && downcast<LocalDOMWindow>(*view->window()).frame()->editor().hasComposition())
+    , m_isComposing(viewIsCompositing(view.get()))
 #if USE(APPKIT) || PLATFORM(IOS_FAMILY)
     , m_handledByInputMethod(key.handledByInputMethod())
 #endif
@@ -205,9 +213,9 @@ int KeyboardEvent::charCode() const
     // Firefox: 0 for keydown/keyup events, character code for keypress
     // We match Firefox, unless in backward compatibility mode, where we always return the character code.
     bool backwardCompatibilityMode = false;
-    RefPtr window = view() ? view()->window() : nullptr;
-    if (is<LocalDOMWindow>(window) && downcast<LocalDOMWindow>(*window).frame())
-        backwardCompatibilityMode = downcast<LocalDOMWindow>(*window).frame()->eventHandler().needsKeyboardEventDisambiguationQuirks();
+    RefPtr window = dynamicDowncast<LocalDOMWindow>(view() ? view()->window() : nullptr);
+    if (window && window->frame())
+        backwardCompatibilityMode = window->frame()->eventHandler().needsKeyboardEventDisambiguationQuirks();
 
     if (!m_underlyingPlatformEvent || (type() != eventNames().keypressEvent && !backwardCompatibilityMode))
         return 0;

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -178,7 +178,10 @@ bool MouseEvent::isMouseEvent() const
 
 bool MouseEvent::canTriggerActivationBehavior(const Event& event)
 {
-    return event.type() == eventNames().clickEvent && (!is<MouseEvent>(event) || downcast<MouseEvent>(event).button() != MouseButton::Right);
+    if (event.type() != eventNames().clickEvent)
+        return false;
+    auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+    return !mouseEvent || mouseEvent->button() != MouseButton::Right;
 }
 
 MouseButton MouseEvent::button() const

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -106,10 +106,14 @@ void MouseRelatedEvent::initCoordinates()
 
 LocalFrameView* MouseRelatedEvent::frameViewFromWindowProxy(WindowProxy* windowProxy)
 {
-    if (!windowProxy || !is<LocalDOMWindow>(windowProxy->window()))
+    if (!windowProxy)
         return nullptr;
 
-    auto* frame = downcast<LocalDOMWindow>(*windowProxy->window()).frame();
+    auto* window = dynamicDowncast<LocalDOMWindow>(windowProxy->window());
+    if (!window)
+        return nullptr;
+
+    auto* frame = window->frame();
     return frame ? frame->view() : nullptr;
 }
 


### PR DESCRIPTION
#### 7b68c9b9e188caabb240fde9d0884d0343a45e81
<pre>
Use dynamicDowncast&lt;T&gt; even more in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=264792">https://bugs.webkit.org/show_bug.cgi?id=264792</a>

Reviewed by Darin Adler.

Use dynamicDowncast&lt;T&gt; even more in the DOM instead of is&lt;T&gt;() + downcast&lt;T&gt;().
It is less error-prone and often results in more concise code. I am also hoping
to have downcast&lt;&gt;() do a type check on release builds in the future. It is
currently too expensive to do so but it may become affordable if we use
dynamicDowncast&lt;T&gt;() instead when possible.

* Source/WebCore/dom/ElementTraversal.h:
(WebCore::Traversal&lt;Element&gt;::nextTemplate):
(WebCore::Traversal&lt;ElementType&gt;::firstChildTemplate):
(WebCore::Traversal&lt;ElementType&gt;::lastChildTemplate):
(WebCore::Traversal&lt;ElementType&gt;::firstWithinTemplate):
(WebCore::Traversal&lt;ElementType&gt;::lastWithinTemplate):
(WebCore::Traversal&lt;ElementType&gt;::nextTemplate):
(WebCore::Traversal&lt;ElementType&gt;::previous):
(WebCore::Traversal&lt;ElementType&gt;::nextSibling):
(WebCore::Traversal&lt;ElementType&gt;::previousSibling):
(WebCore::Traversal&lt;ElementType&gt;::nextSkippingChildren):
(WebCore::Traversal&lt;ElementType&gt;::inclusiveFirstWithin):
(WebCore::Traversal&lt;ElementType&gt;::inclusiveLastWithin):
(WebCore::ElementTraversal::previousIncludingPseudo):
(WebCore::ElementTraversal::nextIncludingPseudo):
(WebCore::ElementTraversal::nextIncludingPseudoSkippingChildren):
(WebCore::ElementTraversal::pseudoAwarePreviousSibling):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::setCurrentTarget):
(WebCore::Event::timeStampForBindings const):
* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::handleLocalEvents const):
(WebCore::EventContext::isUnreachableNode const):
* Source/WebCore/dom/EventNames.h:
(WebCore::EventNames::isTouchRelatedEventType const):
* Source/WebCore/dom/EventPath.cpp:
(WebCore::shouldEventCrossShadowBoundary):
(WebCore::nodeOrHostIfPseudoElement):
(WebCore::EventPath::EventPath):
(WebCore::EventPath::buildPath):
(WebCore::EventPath::retargetTouch):
* Source/WebCore/dom/EventPath.h:
(WebCore::EventPath::eventTargetRespectingTargetRules):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::addEventListener):
(WebCore::EventTarget::innerInvokeEventListeners):
(WebCore::EventTarget::invalidateEventListenerRegions):
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::boundaryPointAtIndexInNodes):
(WebCore::FragmentDirectiveRangeFinder::isVisibleTextNode):
(WebCore::FragmentDirectiveRangeFinder::findRangeFromNodeList):
(WebCore::FragmentDirectiveRangeFinder::rangeOfStringInRange):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::markRendererDirtyAfterTopLayerChange):
(WebCore::FullscreenManager::dispatchFullscreenChangeOrErrorEvent):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::containerRect):
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::viewIsCompositing):
(WebCore::KeyboardEvent::charCode const):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::dispatchMessages):
(WebCore::MessagePort::dispatchEvent):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::canTriggerActivationBehavior):
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::frameViewFromWindowProxy):

Canonical link: <a href="https://commits.webkit.org/270710@main">https://commits.webkit.org/270710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2642477275ff45a7a63e6a44e9301f8fdbf9f654

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23962 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28803 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29502 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1444 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3712 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3370 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->