### PR TITLE
Deploy more smart pointers in CustomElementReactionQueue.cpp, DOMImplementation.cpp,

### DIFF
--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -353,7 +353,7 @@ inline void CustomElementQueue::processQueue(JSC::JSGlobalObject* state)
         return;
     }
 
-    auto& vm = state->vm();
+    Ref vm = state->vm();
     JSC::JSLockHolder lock(vm);
 
     JSC::Exception* previousException = nullptr;

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -70,6 +70,11 @@ using namespace HTMLNames;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DOMImplementation);
 
+Ref<Document> DOMImplementation::protectedDocument()
+{
+    return m_document.get();
+}
+
 DOMImplementation::DOMImplementation(Document& document)
     : m_document(document)
 {
@@ -80,7 +85,7 @@ ExceptionOr<Ref<DocumentType>> DOMImplementation::createDocumentType(const AtomS
     auto parseResult = Document::parseQualifiedName(qualifiedName);
     if (parseResult.hasException())
         return parseResult.releaseException();
-    return DocumentType::create(m_document, qualifiedName, publicId, systemId);
+    return DocumentType::create(protectedDocument(), qualifiedName, publicId, systemId);
 }
 
 static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, const Settings& settings)
@@ -98,7 +103,7 @@ static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, con
 
 ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const AtomString& namespaceURI, const AtomString& qualifiedName, DocumentType* documentType)
 {
-    auto document = createXMLDocument(namespaceURI, m_document->settings());
+    Ref document = createXMLDocument(namespaceURI, m_document->protectedSettings());
     document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     document->setContextDocument(m_document->contextDocument());
     document->setSecurityOriginPolicy(m_document->securityOriginPolicy());
@@ -131,7 +136,7 @@ Ref<CSSStyleSheet> DOMImplementation::createCSSStyleSheet(const String&, const S
 
 Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
 {
-    auto document = HTMLDocument::create(nullptr, m_document->settings(), URL(), { });
+    Ref document = HTMLDocument::create(nullptr, m_document->protectedSettings(), URL(), { });
     document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     document->open();
     document->write(nullptr, { "<!doctype html><html><head></head><body></body></html>"_s });

--- a/Source/WebCore/dom/DOMImplementation.h
+++ b/Source/WebCore/dom/DOMImplementation.h
@@ -48,6 +48,8 @@ public:
     static Ref<Document> createDocument(const String& contentType, LocalFrame*, const Settings&, const URL&, ScriptExecutionContextIdentifier = { });
 
 private:
+    Ref<Document> protectedDocument();
+
     CheckedRef<Document> m_document;
 };
 

--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -76,7 +76,8 @@ bool DeviceMotionController::hasLastData()
 
 RefPtr<Event> DeviceMotionController::getLastEvent()
 {
-    return DeviceMotionEvent::create(eventNames().devicemotionEvent, deviceMotionClient().lastMotion());
+    RefPtr lastMotion = deviceMotionClient().lastMotion();
+    return DeviceMotionEvent::create(eventNames().devicemotionEvent, lastMotion.get());
 }
 
 const char* DeviceMotionController::supplementName()

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -88,17 +88,20 @@ static RefPtr<DeviceMotionData::RotationRate> convert(std::optional<DeviceMotion
 
 std::optional<DeviceMotionEvent::Acceleration> DeviceMotionEvent::acceleration() const
 {
-    return convert(m_deviceMotionData->acceleration());
+    RefPtr acceleration = m_deviceMotionData->acceleration();
+    return convert(acceleration.get());
 }
 
 std::optional<DeviceMotionEvent::Acceleration> DeviceMotionEvent::accelerationIncludingGravity() const
 {
-    return convert(m_deviceMotionData->accelerationIncludingGravity());
+    RefPtr accelerationIncludingGravity = m_deviceMotionData->accelerationIncludingGravity();
+    return convert(accelerationIncludingGravity.get());
 }
 
 std::optional<DeviceMotionEvent::RotationRate> DeviceMotionEvent::rotationRate() const
 {
-    return convert(m_deviceMotionData->rotationRate());
+    RefPtr rotationRate = m_deviceMotionData->rotationRate();
+    return convert(rotationRate.get());
 }
 
 std::optional<double> DeviceMotionEvent::interval() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8107,6 +8107,11 @@ EditingBehavior Document::editingBehavior() const
     return EditingBehavior { settings().editingBehaviorType() };
 }
 
+Ref<Settings> Document::protectedSettings() const
+{
+    return const_cast<Settings&>(m_settings.get());
+}
+
 float Document::deviceScaleFactor() const
 {
     float deviceScaleFactor = 1.0;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -657,6 +657,7 @@ public:
     inline Page* page() const; // Defined in Page.h.
     inline CheckedPtr<Page> checkedPage() const; // Defined in Page.h.
     const Settings& settings() const { return m_settings.get(); }
+    Ref<Settings> protectedSettings() const;
     EditingBehavior editingBehavior() const;
 
     Quirks& quirks() { return m_quirks; }


### PR DESCRIPTION
#### 48c502bb91baa98f2c17e5339d25009580b3f2c2
<pre>
Deploy more smart pointers in CustomElementReactionQueue.cpp, DOMImplementation.cpp,
DeviceMotionController.cpp, and DeviceMotionEvent.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264793">https://bugs.webkit.org/show_bug.cgi?id=264793</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementQueue::processQueue):
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::protectedDocument):
(WebCore::DOMImplementation::createDocumentType):
(WebCore::DOMImplementation::createDocument):
(WebCore::DOMImplementation::createHTMLDocument):
* Source/WebCore/dom/DOMImplementation.h:
* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::getLastEvent):
* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::DeviceMotionEvent::acceleration const):
(WebCore::DeviceMotionEvent::accelerationIncludingGravity const):
(WebCore::DeviceMotionEvent::rotationRate const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedSettings const): Added.
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/270749@main">https://commits.webkit.org/270749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/629d19caca452e96ae96f9e76caca00900b1de64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2242 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24013 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-scroll-with-clip-and-abspos.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28881 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29572 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27457 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1526 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3783 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3387 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->