### PR TITLE
[WebXR] Add support for the new transient-pointer targetRayMode

### DIFF
--- a/LayoutTests/http/wpt/webxr/events_transient_pointer_input_source.https-expected.txt
+++ b/LayoutTests/http/wpt/webxr/events_transient_pointer_input_source.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Transient-pointer input sources fire events in the right order - webgl
+PASS Transient-pointer input sources fire events in the right order - webgl2
+

--- a/LayoutTests/http/wpt/webxr/events_transient_pointer_input_source.https.html
+++ b/LayoutTests/http/wpt/webxr/events_transient_pointer_input_source.https.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="resources/webxr_util.js"></script>
+<script src="resources/webxr_test_constants_single_view.js"></script>
+
+<script>
+let testName = "Transient-pointer input sources fire events in the right order";
+
+let watcherDone = new Event("watcherdone");
+
+let fakeDeviceInitParams = TRACKED_IMMERSIVE_DEVICE;
+
+let testFunction = function(session, fakeDeviceController, t) {
+  let eventWatcher = new EventWatcher(
+    t, session, ["inputsourceschange", "selectstart", "select", "selectend", "watcherdone"]);
+  let eventPromise = eventWatcher.wait_for(
+    ["inputsourceschange", "selectstart", "select", "selectend", "inputsourceschange", "watcherdone"]);
+
+  let inputChangeEvents = 0;
+  let cached_input_source = null;
+  function onInputSourcesChange(event) {
+    t.step(() => {
+      inputChangeEvents++;
+      assert_equals(event.session, session);
+      validateSameObject(event);
+
+      // The first change event should be adding our controller.
+      if (inputChangeEvents === 1) {
+        validateAdded(event.added, 1);
+        validateRemoved(event.removed, 0);
+        cached_input_source = session.inputSources[0];
+        assert_not_equals(cached_input_source, null);
+      } else if (inputChangeEvents === 2) {
+        // The second event should be removing our controller.
+        validateAdded(event.added, 0);
+        validateRemoved(event.removed, 1);
+        assert_true(event.removed.includes(cached_input_source));
+        session.dispatchEvent(watcherDone);
+      }
+    });
+  }
+
+  function validateAdded(added, length) {
+    t.step(() => {
+      assert_not_equals(added, null);
+      assert_equals(added.length, length,
+          "Added length matches expectations");
+
+      let currentSources = Array.from(session.inputSources.values());
+      added.forEach((source) => {
+        assert_true(currentSources.includes(source),
+          "Every element in added should be in the input source list");
+      });
+    });
+  }
+
+  function validateRemoved(removed, length) {
+    t.step(() => {
+      assert_not_equals(removed, null);
+        assert_equals(removed.length, length,
+            "Removed length matches expectations");
+
+      let currentSources = Array.from(session.inputSources.values());
+      removed.forEach((source) => {
+        assert_false(currentSources.includes(source),
+          "No element in removed should be in the input source list");
+      });
+    });
+  }
+
+  // Verifies that the same object is returned each time attributes are accessed
+  // on an XRInputSourcesChangeEvent, as required by the spec.
+  function validateSameObject(event) {
+    let eventSession = event.session;
+    let added = event.added;
+    let removed = event.removed;
+
+    t.step(() => {
+      assert_equals(eventSession, event.session,
+        "XRInputSourcesChangeEvent.session returns the same object.");
+      assert_equals(added, event.added,
+        "XRInputSourcesChangeEvent.added returns the same object.");
+      assert_equals(removed, event.removed,
+        "XRInputSourcesChangeEvent.removed returns the same object.");
+    });
+  }
+
+  session.addEventListener('inputsourceschange', onInputSourcesChange, false);
+
+  // Create our transient-pointer input source with touched and pressed values
+  // equal to true, and pressedValue equal to 1.0. Then disconnect the input source.
+  // select and selectend events should be fired for that input source before
+  // it's removed from the active input sources list.
+  let input_source = fakeDeviceController.simulateInputSourceConnection({
+    handedness: "none",
+    targetRayMode: "transient-pointer",
+    pointerOrigin: VALID_POINTER_TRANSFORM,
+    profiles: [],
+    selectionStarted: true
+  });
+
+  // Make our input source disappear after one frame, and wait an additional
+  // frame for that disappearance to propogate.
+  requestSkipAnimationFrame(session, (time, xrFrame) => {
+    input_source.disconnect();
+    session.requestAnimationFrame((time, xrFrame) => {});
+  });
+
+  return eventPromise;
+};
+
+xr_session_promise_test(
+  testName, testFunction, fakeDeviceInitParams, 'immersive-vr');
+</script>

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -136,8 +136,11 @@ void WebXRInputSource::pollEvents(Vector<Ref<XRInputSourceEvent>>& events)
     if (!m_connected) {
         // A user agent MUST dispatch a selectend event on an XRSession when one of its XRInputSources ends 
         // when an XRInputSource that has begun a primary select action is disconnected.
-        if (m_selectStarted)
+        if (m_selectStarted) {
+            if (targetRayMode() == PlatformXR::XRTargetRayMode::TransientPointer)
+                events.append(createEvent(eventNames().selectEvent));
             events.append(createEvent(eventNames().selectendEvent));
+        }
 
         // A user agent MUST dispatch a squeezeend event on an XRSession when one of its XRInputSources ends 
         // when an XRInputSource that has begun a primary squeeze action is disconnected.

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -81,10 +81,11 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
 {
     Vector<RefPtr<WebXRInputSource>> added;
     Vector<RefPtr<WebXRInputSource>> removed;
+    Vector<RefPtr<WebXRInputSource>> removedWithInputEvents;
     Vector<Ref<XRInputSourceEvent>> inputEvents;
 
-    handleRemovedInputSources(inputSources, removed, inputEvents);
-    handleAddedOrUpdatedInputSources(timestamp, inputSources, added, removed, inputEvents);
+    handleRemovedInputSources(inputSources, removed, removedWithInputEvents, inputEvents);
+    handleAddedOrUpdatedInputSources(timestamp, inputSources, added, removed, removedWithInputEvents, inputEvents);
 
     if (!added.isEmpty() || !removed.isEmpty()) {
         // A user agent MUST dispatch an inputsourceschange event on an XRSession when the session’s list of active XR input sources has changed.
@@ -113,10 +114,22 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
             });
         }
     }
+
+    // If any input sources being removed need to fire any input source events, we need to
+    // make sure the inputsourceschange event for the removal happen after the input source events.
+    if (!removedWithInputEvents.isEmpty()) {
+        // A user agent MUST dispatch an inputsourceschange event on an XRSession when the session’s list of active XR input sources has changed.
+        XRInputSourcesChangeEvent::Init init;
+        init.session = &m_session;
+        init.removed = WTFMove(removedWithInputEvents);
+
+        auto event = XRInputSourcesChangeEvent::create(eventNames().inputsourceschangeEvent, init);
+        ActiveDOMObject::queueTaskToDispatchEvent(m_session, TaskSource::WebXR, WTFMove(event));
+    }
 }
 
 // https://immersive-web.github.io/webxr/#list-of-active-xr-input-sources
-void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inputSources, Vector<RefPtr<WebXRInputSource>>& removed, Vector<Ref<XRInputSourceEvent>>& inputEvents)
+void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inputSources, Vector<RefPtr<WebXRInputSource>>& removed, Vector<RefPtr<WebXRInputSource>>& removedWithInputEvents, Vector<Ref<XRInputSourceEvent>>& inputEvents)
 {
     // When any previously added XR input sources are no longer available for XRSession session, the user agent MUST run the following steps:
     // 1. If session's promise resolved flag is not set, abort these steps.
@@ -124,11 +137,16 @@ void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inp
     // 3. For each XR input source that is no longer available:
     //  3.1 Let inputSource be the XRInputSource in session's list of active XR input sources associated with the XR input source.
     //  3.2 Add inputSource to removed.
-    m_inputSources.removeAllMatching([&inputSources, &removed, &inputEvents](auto& source) {
+    m_inputSources.removeAllMatching([&inputSources, &removed, &removedWithInputEvents, &inputEvents](auto& source) {
         if (!WTF::anyOf(inputSources, [&source](auto& item) { return item.handle == source->handle(); })) {
-            removed.append(source.copyRef());
+            Vector<Ref<XRInputSourceEvent>> sourceInputEvents;
             source->disconnect();
-            source->pollEvents(inputEvents);
+            source->pollEvents(sourceInputEvents);
+            if (sourceInputEvents.isEmpty())
+                removed.append(source.copyRef());
+            else
+                removedWithInputEvents.append(source.copyRef());
+            inputEvents.appendVector(sourceInputEvents);
             return true;
         }
         return false;
@@ -136,7 +154,7 @@ void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inp
 }
 
 // https://immersive-web.github.io/webxr/#list-of-active-xr-input-sources
-void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList& inputSources, Vector<RefPtr<WebXRInputSource>>& added, Vector<RefPtr<WebXRInputSource>>& removed, Vector<Ref<XRInputSourceEvent>>& inputEvents)
+void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList& inputSources, Vector<RefPtr<WebXRInputSource>>& added, Vector<RefPtr<WebXRInputSource>>& removed, Vector<RefPtr<WebXRInputSource>>& removedWithInputEvents, Vector<Ref<XRInputSourceEvent>>& inputEvents)
 {
     RefPtr document = downcast<Document>(m_session.scriptExecutionContext());
     if (!document)
@@ -171,9 +189,14 @@ void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, c
         auto& input = m_inputSources[index];
 
         if (input->requiresInputSourceChange(inputSource)) {
-            removed.append(input.copyRef());
+            Vector<Ref<XRInputSourceEvent>> sourceInputEvents;
             input->disconnect();
-            input->pollEvents(inputEvents);
+            input->pollEvents(sourceInputEvents);
+            if (sourceInputEvents.isEmpty())
+                removed.append(input.copyRef());
+            else
+                removedWithInputEvents.append(input.copyRef());
+            inputEvents.appendVector(sourceInputEvents);
             m_inputSources.remove(index);
 
             auto newInputSource = WebXRInputSource::create(*document, m_session, timestamp, inputSource);

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
@@ -65,8 +65,8 @@ public:
 private:
     WebXRInputSourceArray(WebXRSession&);
 
-    void handleRemovedInputSources(const InputSourceList&, Vector<RefPtr<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
-    void handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList&, Vector<RefPtr<WebXRInputSource>>&, Vector<RefPtr<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
+    void handleRemovedInputSources(const InputSourceList&, Vector<RefPtr<WebXRInputSource>>&, Vector<RefPtr<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
+    void handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList&, Vector<RefPtr<WebXRInputSource>>&, Vector<RefPtr<WebXRInputSource>>&, Vector<RefPtr<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
 
     WebXRSession& m_session;
     Vector<Ref<WebXRInputSource>> m_inputSources;

--- a/Source/WebCore/Modules/webxr/XRTargetRayMode.idl
+++ b/Source/WebCore/Modules/webxr/XRTargetRayMode.idl
@@ -31,5 +31,6 @@
 ] enum XRTargetRayMode {
     "gaze",
     "tracked-pointer",
-    "screen"
+    "screen",
+    "transient-pointer"
 };

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -94,6 +94,7 @@ enum class XRTargetRayMode {
     Gaze,
     TrackedPointer,
     Screen,
+    TransientPointer,
 };
 
 // https://immersive-web.github.io/webxr/#feature-descriptor
@@ -833,7 +834,8 @@ template<> struct EnumTraits<PlatformXR::XRTargetRayMode> {
         PlatformXR::XRTargetRayMode,
         PlatformXR::XRTargetRayMode::Gaze,
         PlatformXR::XRTargetRayMode::TrackedPointer,
-        PlatformXR::XRTargetRayMode::Screen
+        PlatformXR::XRTargetRayMode::Screen,
+        PlatformXR::XRTargetRayMode::TransientPointer
     >;
 };
 

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -234,8 +234,11 @@ public:
 
 #if ENABLE(WEBXR) && PLATFORM(COCOA)
     virtual void requestPermissionOnXRSessionFeatures(WebKit::WebPageProxy&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler) { completionHandler(granted); }
-    virtual void startXRSession(WebKit::WebPageProxy&, CompletionHandler<void(RetainPtr<id>)>&& completionHandler) { completionHandler(nil); }
+
+#if PLATFORM(IOS_FAMILY)
+    virtual void startXRSession(WebKit::WebPageProxy&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&& completionHandler) { completionHandler(nil, nil); }
     virtual void endXRSession(WebKit::WebPageProxy&) { }
+#endif
 #endif
 
     virtual void updateAppBadge(WebKit::WebPageProxy&, const WebCore::SecurityOriginData&, std::optional<uint64_t>) { }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -275,6 +275,8 @@ struct UIEdgeInsets;
 - (BOOL)_webView:(WKWebView *)webView touchEventsMustRequireGestureRecognizerToFail:(UIGestureRecognizer *)gestureRecognizer WK_API_AVAILABLE(ios(15.0));
 - (BOOL)_webView:(WKWebView *)webView gestureRecognizerCanBePreventedByTouchEvents:(UIGestureRecognizer *)gestureRecognizer WK_API_AVAILABLE(ios(16.5));
 
+- (void)_webView:(WKWebView *)webView startXRSessionWithFeatures:(_WKXRSessionFeatureFlags)features completionHandler:(void (^)(id, UIViewController *))completionHandler WK_API_AVAILABLE(ios(WK_IOS_TBA));
+
 #else // !TARGET_OS_IPHONE
 
 - (NSViewController *)_presentingViewControllerForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(13.0));

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -184,8 +184,10 @@ private:
 
 #if ENABLE(WEBXR)
         void requestPermissionOnXRSessionFeatures(WebPageProxy&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& /* granted */, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&) final;
-        void startXRSession(WebPageProxy&, CompletionHandler<void(RetainPtr<id>)>&&) final;
+#if PLATFORM(IOS_FAMILY)
+        void startXRSession(WebPageProxy&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&&) final;
         void endXRSession(WebPageProxy&) final;
+#endif
 #endif
 
         void updateAppBadge(WebPageProxy&, const WebCore::SecurityOriginData&, std::optional<uint64_t>) final;


### PR DESCRIPTION
#### 324a294aa828cf2710b6792a2930fabd829e3e42
<pre>
[WebXR] Add support for the new transient-pointer targetRayMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=264791">https://bugs.webkit.org/show_bug.cgi?id=264791</a>
<a href="https://rdar.apple.com/118342599">rdar://118342599</a>

Reviewed by Dean Jackson.

Spec: <a href="https://www.w3.org/TR/webxr/#dom-xrtargetraymode-transient-pointer">https://www.w3.org/TR/webxr/#dom-xrtargetraymode-transient-pointer</a>

- Add transient-pointer to the list of targetRayModes
- Since the transient input source is connected only during the transient
action, we need to fire a select event when that input source is no longer
connected.
- Fix the event order such that all XRInputSourceEvents for an input source
are ordered before the XRInputSourcesChangedEvent indicating its removal.
- Update the startXRSession UIClient API to take in the feature requested
and add a PlatformViewController parameter in its completion handler.
Add a new version of the startXRSession WKUIDelegatePrivate method that
takes in the requested feature list and adds a view controller to the
completion handler. Update the platform guards on the startXRSession and
endXRSession methods in UIClient.

* LayoutTests/http/wpt/webxr/events_transient_pointer_input_source.https-expected.txt: Added.
* LayoutTests/http/wpt/webxr/events_transient_pointer_input_source.https.html: Added.
Simulate connecting and disconnecting a transient-pointer input source, and
verify the expected list of events fire in the right order.
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::pollEvents):
Fire a select event when the transient-pointer input source is disconnected
during the primary action.
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::update):
Add a new local input source array to track input sources that are being
removed but have other input source events that need to fire. This way
we can fire the XRInputSourcesChangedEvent for the removal after the
XRInputSourceEvents have been fired.
(WebCore::WebXRInputSourceArray::handleRemovedInputSources):
Add any input source being removed to removedWithInputEvents if it also
generates XRInputSourceEvents.
(WebCore::WebXRInputSourceArray::handleAddedOrUpdatedInputSources):
Ditto.
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.h:
* Source/WebCore/Modules/webxr/XRTargetRayMode.idl:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::startXRSession):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::startXRSession):

Canonical link: <a href="https://commits.webkit.org/270730@main">https://commits.webkit.org/270730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/476d22e35c24bfb958807645d01d6fd63e3c20d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28810 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29505 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27396 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1448 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6309 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->