### PR TITLE
Move `hasExplicitlySetColorScheme` from `RenderStyle::NonInheritedFlags` into `StyleMiscNonInheritedData`

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -402,9 +402,6 @@ inline void RenderStyle::NonInheritedFlags::copyNonInheritedFrom(const NonInheri
     textDecorationLine = other.textDecorationLine;
     hasExplicitlySetDirection = other.hasExplicitlySetDirection;
     hasExplicitlySetWritingMode = other.hasExplicitlySetWritingMode;
-#if ENABLE(DARK_MODE_CSS)
-    hasExplicitlySetColorScheme = other.hasExplicitlySetColorScheme;
-#endif
     usesViewportUnits = other.usesViewportUnits;
     usesContainerUnits = other.usesContainerUnits;
     hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
@@ -1564,7 +1561,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // unicodeBidi
         // hasExplicitlySetDirection
         // hasExplicitlySetWritingMode
-        // hasExplicitlySetColorScheme
         // usesViewportUnits
         // usesContainerUnits
         // hasExplicitlyInheritedProperties
@@ -1810,6 +1806,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // Non animated styles are followings.
         // deprecatedFlexibleBox
         // hasAttrContent
+        // hasExplicitlySetColorScheme
         // appearance
         // effectiveAppearance
         // userDrag

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -868,8 +868,8 @@ public:
 
 #if ENABLE(DARK_MODE_CSS)
     inline StyleColorScheme colorScheme() const;
-    void setHasExplicitlySetColorScheme(bool v) { m_nonInheritedFlags.hasExplicitlySetColorScheme = v; }
-    bool hasExplicitlySetColorScheme() const { return m_nonInheritedFlags.hasExplicitlySetColorScheme; };
+    inline void setHasExplicitlySetColorScheme();
+    inline bool hasExplicitlySetColorScheme() const;
 #endif
 
     inline TextOrientation textOrientation() const;
@@ -2169,9 +2169,6 @@ private:
 
         unsigned hasExplicitlySetDirection : 1;
         unsigned hasExplicitlySetWritingMode : 1;
-#if ENABLE(DARK_MODE_CSS)
-        unsigned hasExplicitlySetColorScheme : 1;
-#endif
         unsigned usesViewportUnits : 1;
         unsigned usesContainerUnits : 1;
         unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -761,6 +761,7 @@ constexpr CursorVisibility RenderStyle::initialCursorVisibility() { return Curso
 #if ENABLE(DARK_MODE_CSS)
 inline StyleColorScheme RenderStyle::colorScheme() const { return m_rareInheritedData->colorScheme; }
 constexpr StyleColorScheme RenderStyle::initialColorScheme() { return { }; }
+inline bool RenderStyle::hasExplicitlySetColorScheme() const { return m_nonInheritedData->miscData->hasExplicitlySetColorScheme; }
 #endif
 
 #if ENABLE(FILTERS_LEVEL_2)

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -351,6 +351,7 @@ inline void RenderStyle::setBoxDecorationBreak(BoxDecorationBreak value) { SET_N
 
 #if ENABLE(DARK_MODE_CSS)
 inline void RenderStyle::setColorScheme(StyleColorScheme scheme) { SET(m_rareInheritedData, colorScheme, scheme); }
+inline void RenderStyle::setHasExplicitlySetColorScheme() { SET_NESTED(m_nonInheritedData, miscData, hasExplicitlySetColorScheme, true); }
 #endif
 
 #if ENABLE(FILTERS_LEVEL_2)

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -98,6 +98,9 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData(const StyleMiscNonInherited
     , objectPosition(o.objectPosition)
     , order(o.order)
     , hasAttrContent(o.hasAttrContent)
+#if ENABLE(DARK_MODE_CSS)
+    , hasExplicitlySetColorScheme(o.hasExplicitlySetColorScheme)
+#endif
     , aspectRatioType(o.aspectRatioType)
     , appearance(o.appearance)
     , effectiveAppearance(o.effectiveAppearance)
@@ -141,6 +144,9 @@ bool StyleMiscNonInheritedData::operator==(const StyleMiscNonInheritedData& o) c
         && objectPosition == o.objectPosition
         && order == o.order
         && hasAttrContent == o.hasAttrContent
+#if ENABLE(DARK_MODE_CSS)
+        && hasExplicitlySetColorScheme == o.hasExplicitlySetColorScheme
+#endif
         && aspectRatioType == o.aspectRatioType
         && appearance == o.appearance
         && effectiveAppearance == o.effectiveAppearance

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -91,6 +91,9 @@ public:
     int order;
 
     unsigned hasAttrContent : 1 { false };
+#if ENABLE(DARK_MODE_CSS)
+    unsigned hasExplicitlySetColorScheme : 1 { false };
+#endif
     unsigned aspectRatioType : 2; // AspectRatioType
     unsigned appearance : appearanceBitWidth; // EAppearance
     unsigned effectiveAppearance : appearanceBitWidth; // EAppearance

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -852,7 +852,7 @@ inline void BuilderCustom::applyValueWebkitTextZoom(BuilderState& builderState, 
 inline void BuilderCustom::applyValueColorScheme(BuilderState& builderState, CSSValue& value)
 {
     builderState.style().setColorScheme(BuilderConverter::convertColorScheme(builderState, value));
-    builderState.style().setHasExplicitlySetColorScheme(true);
+    builderState.style().setHasExplicitlySetColorScheme();
 }
 #endif
 


### PR DESCRIPTION
#### 5c50677827c04de8cafca536febb6d01d9a7549c
<pre>
Move `hasExplicitlySetColorScheme` from `RenderStyle::NonInheritedFlags` into `StyleMiscNonInheritedData`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264794">https://bugs.webkit.org/show_bug.cgi?id=264794</a>
<a href="https://rdar.apple.com/118374921">rdar://118374921</a>

Reviewed by Simon Fraser.

Move the `hasExplicitlySetColorScheme` into `StyleMiscNonInheritedData` to free
up an additional bit for new pseudo-elements in `RenderStyle::NonInheritedFlags`.

There are currently 6 bits of unused space (5 following this patch) in
`StyleMiscNonInheritedData`. Additionally, `hasExplicitlySetColorScheme` is not
expected to be too common, as in most use cases it will simply be specified on
the `:root`, and inherited on children.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::NonInheritedFlags::copyNonInheritedFrom):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::setHasExplicitlySetColorScheme): Deleted.
(WebCore::RenderStyle::hasExplicitlySetColorScheme const): Deleted.
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasExplicitlySetColorScheme const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setHasExplicitlySetColorScheme):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp:
(WebCore::StyleMiscNonInheritedData::StyleMiscNonInheritedData):
(WebCore::StyleMiscNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueColorScheme):

Canonical link: <a href="https://commits.webkit.org/270715@main">https://commits.webkit.org/270715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccb9d771e051ef408937819585800276c857f625

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23970 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28812 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29506 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1450 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4659 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->