### PR TITLE
[web-animations] interpolating keyframes should be shared in `KeyframeInterpolation`

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -35,6 +35,7 @@
 #include "Element.h"
 #include "IterationCompositeOperation.h"
 #include "KeyframeEffectOptions.h"
+#include "KeyframeInterpolation.h"
 #include "KeyframeList.h"
 #include "RenderStyle.h"
 #include "Styleable.h"
@@ -211,8 +212,8 @@ private:
     bool isCompletelyAccelerated() const { return m_acceleratedPropertiesState == AcceleratedProperties::All; }
     void updateAcceleratedActions();
     void setAnimatedPropertiesInStyle(RenderStyle&, double iterationProgress, double currentIteration);
-    TimingFunction* timingFunctionForKeyframeAtIndex(size_t) const;
-    TimingFunction* timingFunctionForBlendingKeyframe(const KeyframeValue&) const;
+    const TimingFunction* timingFunctionForKeyframeAtIndex(size_t) const;
+    const TimingFunction* timingFunctionForBlendingKeyframe(const KeyframeValue&) const;
     Ref<const Animation> backingAnimationForCompositedRenderer() const;
     void computedNeedsForcedLayout();
     void computeStackingContextImpact();
@@ -265,8 +266,12 @@ private:
     bool preventsAnimationReadiness() const final;
 
     // KeyframeInterpolation
+    CompositeOperation compositeOperation() const final { return m_compositeOperation; }
+    IterationCompositeOperation iterationCompositeOperation() const final { return m_iterationCompositeOperation; }
     const KeyframeInterpolation::Keyframe& keyframeAtIndex(size_t) const final;
     size_t numberOfKeyframes() const final { return m_blendingKeyframes.size(); }
+    const TimingFunction* timingFunctionForKeyframe(const KeyframeInterpolation::Keyframe&) const final;
+    bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "CompositeOperation.h"
+#include "IterationCompositeOperation.h"
+#include "TimingFunction.h"
 #include "WebAnimationTypes.h"
 #include <optional>
 #include <wtf/Seconds.h>
@@ -48,8 +50,12 @@ public:
         virtual ~Keyframe() = default;
     };
 
+    virtual CompositeOperation compositeOperation() const = 0;
+    virtual bool isPropertyAdditiveOrCumulative(Property) const = 0;
+    virtual IterationCompositeOperation iterationCompositeOperation() const { return IterationCompositeOperation::Replace; }
     virtual const Keyframe& keyframeAtIndex(size_t) const = 0;
     virtual size_t numberOfKeyframes() const = 0;
+    virtual const TimingFunction* timingFunctionForKeyframe(const Keyframe&) const = 0;
 
     struct KeyframeInterval {
         const Vector<const Keyframe*> endpoints;
@@ -58,6 +64,12 @@ public:
     };
 
     const KeyframeInterval interpolationKeyframes(Property, double iterationProgress, const Keyframe& defaultStartKeyframe, const Keyframe& defaultEndKeyframe) const;
+
+    using CompositionCallback = Function<void(const Keyframe&, CompositeOperation)>;
+    using AccumulationCallback = Function<void(const Keyframe&)>;
+    using InterpolationCallback = Function<void(double intervalProgress, double currentIteration, IterationCompositeOperation)>;
+    using RequiresBlendingForAccumulativeIterationCallback = Function<bool()>;
+    void interpolateKeyframes(Property, const KeyframeInterval&, double iterationProgress, double currentIteration, Seconds iterationDuration, const CompositionCallback&, const AccumulationCallback&, const InterpolationCallback&, const RequiresBlendingForAccumulativeIterationCallback&) const;
 
     virtual ~KeyframeInterpolation() = default;
 };

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -83,7 +83,7 @@ public:
     AnimationEffectTiming timing() const { return m_timing; }
     const Vector<Keyframe>& keyframes() const { return m_keyframes; }
     WebAnimationType animationType() const { return m_animationType; }
-    CompositeOperation compositeOperation() const { return m_compositeOperation; }
+    CompositeOperation compositeOperation() const final { return m_compositeOperation; }
     const RefPtr<TimingFunction>& defaultKeyframeTimingFunction() const { return m_defaultKeyframeTimingFunction; }
     const OptionSet<AcceleratedEffectProperty>& animatedProperties() const { return m_animatedProperties; }
     bool paused() const { return m_paused; }
@@ -99,8 +99,10 @@ private:
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 
     // KeyframeInterpolation
+    bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;
     const KeyframeInterpolation::Keyframe& keyframeAtIndex(size_t) const final;
     size_t numberOfKeyframes() const final { return m_keyframes.size(); }
+    const TimingFunction* timingFunctionForKeyframe(const KeyframeInterpolation::Keyframe&) const final;
 
     AnimationEffectTiming m_timing;
     Vector<Keyframe> m_keyframes;


### PR DESCRIPTION
#### 5dfffd1d9c0cdf683b9302cd72303bf9e6700921
<pre>
[web-animations] interpolating keyframes should be shared in `KeyframeInterpolation`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264796">https://bugs.webkit.org/show_bug.cgi?id=264796</a>

Reviewed by Dean Jackson.

Until now, the code to interpolate keyframes was contained within `KeyframeEffect::setAnimatedPropertiesInStyle()`.
As part of the work on threaded animation resolution (see bug 250970), we will need to share this logic with
`AcceleratedEffect` as well. Now that we have a shared concept of a keyframe (see bug 264747) and shared code to
determine the interpolation interval (see bug 264756), we add a method to `KeyframeInterpolation` for the
purpose of interpolation and whatever virtual methods are required to support it.

During interpolation, we need additional information from the `KeyframeInterpolation` subclasses such that we can
determine what composite operation to use and how to apply it, as well as the timing function to use to compute
the final interpolation progress:

    CompositeOperation compositeOperation() const;
    bool isPropertyAdditiveOrCumulative(Property) const;
    IterationCompositeOperation iterationCompositeOperation() const;
    const TimingFunction* timingFunctionForKeyframe(const Keyframe&amp;) const;

With that information, we can add a new `interpolateKeyframes()` method which will take several callbacks as parameters
to let the `KeyframeInterpolation` subclass perform the actual interpolation based on the value types it manipulates
(`RenderStyle` objects for `KeyframeEffect` and `AcceleratedEffectValues` for `AcceleratedEffect`):

    using CompositionCallback = Function&lt;void(const Keyframe&amp;, CompositeOperation)&gt;;
    using AccumulationCallback = Function&lt;void(const Keyframe&amp;)&gt;;
    using InterpolationCallback = Function&lt;void(double intervalProgress, double currentIteration, IterationCompositeOperation)&gt;;
    using RequiresBlendingForAccumulativeIterationCallback = Function&lt;bool()&gt;;
    void interpolateKeyframes(Property, const KeyframeInterval&amp;, double iterationProgress, double currentIteration, Seconds iterationDuration, const CompositionCallback&amp;, const AccumulationCallback&amp;, const InterpolationCallback&amp;, const RequiresBlendingForAccumulativeIterationCallback&amp;) const;

Finally, we move much of the remaining code from `KeyframeEffect::setAnimatedPropertiesInStyle` into the new
`KeyframeInterpolation::interpolateKeyframes()` method.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::timingFunctionForBlendingKeyframe const):
(WebCore::KeyframeEffect::timingFunctionForKeyframeAtIndex const):
(WebCore::KeyframeEffect::progressUntilNextStep const):
(WebCore::KeyframeEffect::timingFunctionForKeyframe const):
(WebCore::KeyframeEffect::isPropertyAdditiveOrCumulative const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeInterpolation.cpp:
(WebCore::KeyframeInterpolation::interpolateKeyframes const):
* Source/WebCore/animation/KeyframeInterpolation.h:
(WebCore::KeyframeInterpolation::iterationCompositeOperation const):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::cssPropertyFromAcceleratedProperty):
(WebCore::AcceleratedEffect::timingFunctionForKeyframe const):
(WebCore::AcceleratedEffect::isPropertyAdditiveOrCumulative const):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::compositeOperation const): Deleted.

Canonical link: <a href="https://commits.webkit.org/270700@main">https://commits.webkit.org/270700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8005aaaeb3826b3ee36d1ff4fec9094a8535668d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2165 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28814 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23460 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23847 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1454 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4661 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3720 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3366 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->