### PR TITLE
Deploy more smart pointers in ExtensionStyleSheets.cpp, FragmentDirectiveRangeFinder.cpp,

### DIFF
--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -57,6 +57,11 @@ ExtensionStyleSheets::ExtensionStyleSheets(Document& document)
 {
 }
 
+Ref<Document> ExtensionStyleSheets::protectedDocument() const
+{
+    return const_cast<Document&>(m_document.get());
+}
+
 static Ref<CSSStyleSheet> createExtensionsStyleSheet(Document& document, URL url, const String& text, UserStyleLevel level)
 {
     auto contents = StyleSheetContents::create(url.string(), CSSParserContext(document, url));
@@ -73,7 +78,7 @@ CSSStyleSheet* ExtensionStyleSheets::pageUserSheet()
     if (m_pageUserSheet)
         return m_pageUserSheet.get();
     
-    Page* owningPage = m_document.page();
+    Page* owningPage = m_document->page();
     if (!owningPage)
         return 0;
     
@@ -81,7 +86,7 @@ CSSStyleSheet* ExtensionStyleSheets::pageUserSheet()
     if (userSheetText.isEmpty())
         return 0;
     
-    m_pageUserSheet = createExtensionsStyleSheet(m_document, m_document.settings().userStyleSheetLocation(), userSheetText, UserStyleLevel::User);
+    m_pageUserSheet = createExtensionsStyleSheet(protectedDocument().get(), m_document->settings().userStyleSheetLocation(), userSheetText, UserStyleLevel::User);
 
     return m_pageUserSheet.get();
 }
@@ -90,7 +95,7 @@ void ExtensionStyleSheets::clearPageUserSheet()
 {
     if (m_pageUserSheet) {
         m_pageUserSheet = nullptr;
-        m_document.styleScope().didChangeStyleSheetEnvironment();
+        protectedDocument()->checkedStyleScope()->didChangeStyleSheetEnvironment();
     }
 }
 
@@ -98,7 +103,7 @@ void ExtensionStyleSheets::updatePageUserSheet()
 {
     clearPageUserSheet();
     if (pageUserSheet())
-        m_document.styleScope().didChangeStyleSheetEnvironment();
+        protectedDocument()->checkedStyleScope()->didChangeStyleSheetEnvironment();
 }
 
 const Vector<RefPtr<CSSStyleSheet>>& ExtensionStyleSheets::injectedUserStyleSheets() const
@@ -123,12 +128,12 @@ void ExtensionStyleSheets::updateInjectedStyleSheetCache() const
     m_injectedAuthorStyleSheets.clear();
     m_injectedStyleSheetToSource.clear();
 
-    Page* owningPage = m_document.page();
+    CheckedPtr owningPage = m_document->page();
     if (!owningPage)
         return;
 
     auto addStyleSheet = [&](const UserStyleSheet& userStyleSheet) {
-        auto sheet = createExtensionsStyleSheet(const_cast<Document&>(m_document), userStyleSheet.url(), userStyleSheet.source(), userStyleSheet.level());
+        Ref sheet = createExtensionsStyleSheet(protectedDocument().get(), userStyleSheet.url(), userStyleSheet.source(), userStyleSheet.level());
 
         m_injectedStyleSheetToSource.set(sheet.copyRef(), userStyleSheet.source());
 
@@ -145,10 +150,10 @@ void ExtensionStyleSheets::updateInjectedStyleSheetCache() const
         if (userStyleSheet.pageID())
             return;
 
-        if (userStyleSheet.injectedFrames() == UserContentInjectedFrames::InjectInTopFrameOnly && m_document.ownerElement())
+        if (userStyleSheet.injectedFrames() == UserContentInjectedFrames::InjectInTopFrameOnly && m_document->ownerElement())
             return;
 
-        if (!UserContentURLPattern::matchesPatterns(m_document.url(), userStyleSheet.allowlist(), userStyleSheet.blocklist()))
+        if (!UserContentURLPattern::matchesPatterns(m_document->url(), userStyleSheet.allowlist(), userStyleSheet.blocklist()))
             return;
 
         addStyleSheet(userStyleSheet);
@@ -174,21 +179,21 @@ void ExtensionStyleSheets::removePageSpecificUserStyleSheet(const UserStyleSheet
 void ExtensionStyleSheets::invalidateInjectedStyleSheetCache()
 {
     m_injectedStyleSheetCacheValid = false;
-    m_document.styleScope().didChangeStyleSheetEnvironment();
+    protectedDocument()->checkedStyleScope()->didChangeStyleSheetEnvironment();
 }
 
 void ExtensionStyleSheets::addUserStyleSheet(Ref<StyleSheetContents>&& userSheet)
 {
     ASSERT(userSheet.get().isUserStyleSheet());
-    m_userStyleSheets.append(CSSStyleSheet::create(WTFMove(userSheet), m_document));
-    m_document.styleScope().didChangeStyleSheetEnvironment();
+    m_userStyleSheets.append(CSSStyleSheet::create(WTFMove(userSheet), protectedDocument().get()));
+    protectedDocument()->checkedStyleScope()->didChangeStyleSheetEnvironment();
 }
 
 void ExtensionStyleSheets::addAuthorStyleSheetForTesting(Ref<StyleSheetContents>&& authorSheet)
 {
     ASSERT(!authorSheet.get().isUserStyleSheet());
-    m_authorStyleSheetsForTesting.append(CSSStyleSheet::create(WTFMove(authorSheet), m_document));
-    m_document.styleScope().didChangeStyleSheetEnvironment();
+    m_authorStyleSheetsForTesting.append(CSSStyleSheet::create(WTFMove(authorSheet), protectedDocument().get()));
+    protectedDocument()->checkedStyleScope()->didChangeStyleSheetEnvironment();
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -196,12 +201,12 @@ void ExtensionStyleSheets::addDisplayNoneSelector(const String& identifier, cons
 {
     auto result = m_contentExtensionSelectorSheets.add(identifier, nullptr);
     if (result.isNewEntry) {
-        result.iterator->value = ContentExtensionStyleSheet::create(m_document);
+        result.iterator->value = ContentExtensionStyleSheet::create(protectedDocument().get());
         m_userStyleSheets.append(&result.iterator->value->styleSheet());
     }
 
     if (result.iterator->value->addDisplayNoneSelector(selector, selectorID))
-        m_document.styleScope().didChangeStyleSheetEnvironment();
+        protectedDocument()->checkedStyleScope()->didChangeStyleSheetEnvironment();
 }
 
 void ExtensionStyleSheets::maybeAddContentExtensionSheet(const String& identifier, StyleSheetContents& sheet)
@@ -211,10 +216,10 @@ void ExtensionStyleSheets::maybeAddContentExtensionSheet(const String& identifie
     if (m_contentExtensionSheets.contains(identifier))
         return;
 
-    Ref<CSSStyleSheet> cssSheet = CSSStyleSheet::create(sheet, m_document);
+    Ref<CSSStyleSheet> cssSheet = CSSStyleSheet::create(sheet, protectedDocument().get());
     m_contentExtensionSheets.set(identifier, &cssSheet.get());
     m_userStyleSheets.append(adoptRef(cssSheet.leakRef()));
-    m_document.styleScope().didChangeStyleSheetEnvironment();
+    protectedDocument()->checkedStyleScope()->didChangeStyleSheetEnvironment();
 
 }
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -81,7 +81,9 @@ public:
     void detachFromDocument();
 
 private:
-    Document& m_document;
+    Ref<Document> protectedDocument() const;
+
+    CheckedRef<Document> m_document;
 
     RefPtr<CSSStyleSheet> m_pageUserSheet;
 

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -228,8 +228,8 @@ static std::optional<SimpleRange> rangeOfStringInRange(const String& query, Simp
             } while (is<DocumentType>(currentNode));
             continue;
         }
-        
-        auto& blockAncestor = nearestBlockAncestor(*currentNode);
+
+        Ref blockAncestor = nearestBlockAncestor(*currentNode);
         Vector<Ref<Text>> textNodeList;
         // FIXME: this is O^2 since treeOrder will also do traversal, optimize.
         while (currentNode && currentNode->isDescendantOf(blockAncestor) && is_lteq(treeOrder(BoundaryPoint(*currentNode, 0), searchRange.end))) {
@@ -267,13 +267,13 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
 {
     auto newRange = range;
     while (!newRange.collapsed()) {
-        auto& node = newRange.startContainer();
+        Ref node = newRange.startContainer();
         auto offset = newRange.startOffset();
         
         // This check is not in the spec.
         // I believe there is an error in the spec which I have filed an issue for
         // https://github.com/WICG/scroll-to-text-fragment/issues/189
-        if (offset == node.length()) {
+        if (offset == node->length()) {
             if (auto newStart = NodeTraversal::next(node)) {
                 newRange.start = { *newStart, 0 };
                 continue;
@@ -297,7 +297,7 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
             continue;
         }
 
-        auto string = node.textContent();
+        auto string = node->textContent();
 
         if (string.substringSharingImpl(offset, 6) == "&nbsp;"_s)
             offset += 6;
@@ -308,14 +308,14 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
         if (!isUnicodeWhitespace(string[offset]))
             return newRange;
         offset++;
-        
-        if (offset >= node.length()) {
+
+        if (offset >= node->length()) {
             if (auto newStart = NodeTraversal::next(node))
                 newRange.start = { *newStart, 0 };
             else
                 return newRange;
         } else
-            newRange.start = { node, offset };
+            newRange.start = { node.get(), offset };
     }
     return newRange;
 }

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -72,6 +72,11 @@ Element* FullscreenManager::fullscreenElement() const
     return nullptr;
 }
 
+Ref<Document> FullscreenManager::protectedTopDocument()
+{
+    return topDocument();
+}
+
 // https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
 void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefPtr<DeferredPromise>&& promise, FullscreenCheckType checkType)
 {
@@ -414,8 +419,8 @@ void FullscreenManager::finishExitFullscreen(Document& currentDocument, ExitMode
 
     // Let descendantDocs be an ordered set consisting of doc’s descendant browsing contexts' active documents whose fullscreen element is non-null, if any, in tree order.
     Deque<Ref<Document>> descendantDocuments;
-    for (auto* descendant = currentDocument.frame() ? currentDocument.frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
-        auto* localFrame = dynamicDowncast<LocalFrame>(descendant);
+    for (RefPtr descendant = currentDocument.frame() ? currentDocument.frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(descendant);
         if (!localFrame || !localFrame->document())
             continue;
         if (localFrame->document()->fullscreenManager().fullscreenElement())
@@ -607,7 +612,7 @@ bool FullscreenManager::didExitFullscreen()
     }
     INFO_LOG(LOGIDENTIFIER);
 
-    finishExitFullscreen(topDocument(), ExitMode::Resize);
+    finishExitFullscreen(protectedTopDocument(), ExitMode::Resize);
 
     if (m_fullscreenElement)
         m_fullscreenElement->didStopBeingFullscreenElement();

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -111,6 +111,7 @@ private:
 #endif
 
     Document& topDocument() { return m_topDocument ? *m_topDocument : document().topDocument(); }
+    Ref<Document> protectedTopDocument();
 
     CheckedRef<Document> m_document;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_topDocument;

--- a/Source/WebCore/dom/IdleDeadline.cpp
+++ b/Source/WebCore/dom/IdleDeadline.cpp
@@ -39,9 +39,9 @@ DOMHighResTimeStamp IdleDeadline::timeRemaining(Document& document) const
     RefPtr window { document.domWindow() };
     if (!window || m_didTimeout == DidTimeout::Yes)
         return 0;
-    auto& performance = window->performance();
-    auto now = performance.now();
-    auto deadline = performance.relativeTimeFromTimeOriginInReducedResolution(document.windowEventLoop().computeIdleDeadline() - performance.timeResolution());
+    Ref performance = window->performance();
+    auto now = performance->now();
+    auto deadline = performance->relativeTimeFromTimeOriginInReducedResolution(document.windowEventLoop().computeIdleDeadline() - performance->timeResolution());
     return deadline < now ? 0 : deadline - now;
 }
 

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -231,7 +231,7 @@ IntRect containerRect(HTMLElement& element)
 static void installImageOverlayStyleSheet(ShadowRoot& shadowRoot)
 {
     static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(imageOverlayUserAgentStyleSheet, sizeof(imageOverlayUserAgentStyleSheet)));
-    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, shadowRoot.document(), false);
+    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, shadowRoot.protectedDocument(), false);
     style->setTextContent(String { shadowStyle });
     shadowRoot.appendChild(WTFMove(style));
 }
@@ -406,8 +406,9 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
             }
 
             if (line.hasTrailingNewline) {
-                lineElements.lineBreak = HTMLBRElement::create(document.get());
-                lineContainer->appendChild(*lineElements.lineBreak);
+                Ref lineBreak = HTMLBRElement::create(document.get());
+                lineContainer->appendChild(lineBreak.get());
+                lineElements.lineBreak = WTFMove(lineBreak);
             }
 
             elements.lines.append(WTFMove(lineElements));


### PR DESCRIPTION
#### e2b769dba64ecedffc809cfd1bf07f08d7abe9a4
<pre>
Deploy more smart pointers in ExtensionStyleSheets.cpp, FragmentDirectiveRangeFinder.cpp,
FullscreenManager.cpp, IdleDeadline.cpp, and ImageOverlay.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264797">https://bugs.webkit.org/show_bug.cgi?id=264797</a>

Reviewed by Chris Dumez.

Deployed more smart pointers as warned by the clang static analyzer.

* Source/WebCore/dom/ExtensionStyleSheets.cpp:
(WebCore::ExtensionStyleSheets::pageUserSheet):
(WebCore::ExtensionStyleSheets::clearPageUserSheet):
(WebCore::ExtensionStyleSheets::updatePageUserSheet):
(WebCore::ExtensionStyleSheets::updateInjectedStyleSheetCache const):
(WebCore::ExtensionStyleSheets::invalidateInjectedStyleSheetCache):
(WebCore::ExtensionStyleSheets::addUserStyleSheet):
(WebCore::ExtensionStyleSheets::addAuthorStyleSheetForTesting):
(WebCore::ExtensionStyleSheets::addDisplayNoneSelector):
(WebCore::ExtensionStyleSheets::maybeAddContentExtensionSheet):
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::rangeOfStringInRange):
(WebCore::FragmentDirectiveRangeFinder::advanceRangeStartToNextNonWhitespace):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::protectedTopDocument):
(WebCore::FullscreenManager::finishExitFullscreen):
(WebCore::FullscreenManager::didExitFullscreen):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/dom/IdleDeadline.cpp:
(WebCore::IdleDeadline::timeRemaining const):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::installImageOverlayStyleSheet):
(WebCore::ImageOverlay::updateSubtree):

Canonical link: <a href="https://commits.webkit.org/270750@main">https://commits.webkit.org/270750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50445968bcb6a7638e4eb6f9eab9c3708a243670

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28346 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24040 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28924 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29601 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1552 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3817 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3388 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->