### PR TITLE
Deploy smart pointers in DeviceOrientationAndMotionAccessController.cpp,

### DIFF
--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -51,8 +51,9 @@ DeviceOrientationOrMotionPermissionState DeviceOrientationAndMotionAccessControl
         return iterator->value;
 
     // Check per-site setting.
-    if (&document == m_topDocument.ptr() || document.securityOrigin().isSameOriginAs(m_topDocument->securityOrigin())) {
-        RefPtr frame = m_topDocument->frame();
+    Ref topDocument = m_topDocument.get();
+    if (&document == topDocument.ptr() || document.securityOrigin().isSameOriginAs(topDocument->securityOrigin())) {
+        RefPtr frame = topDocument->frame();
         if (RefPtr documentLoader = frame ? frame->loader().documentLoader() : nullptr)
             return documentLoader->deviceOrientationAndMotionAccessState();
     }

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -76,7 +76,8 @@ bool DeviceOrientationController::hasLastData()
 
 RefPtr<Event> DeviceOrientationController::getLastEvent()
 {
-    return DeviceOrientationEvent::create(eventNames().deviceorientationEvent, deviceOrientationClient().lastOrientation());
+    RefPtr orientation = deviceOrientationClient().lastOrientation();
+    return DeviceOrientationEvent::create(eventNames().deviceorientationEvent, orientation.get());
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -82,14 +82,14 @@ std::optional<bool> DocumentStorageAccess::hasStorageAccessQuickCheck()
     if (frame && hasFrameSpecificStorageAccess())
         return true;
 
-    auto& securityOrigin = document->securityOrigin();
-    if (!frame || securityOrigin.isOpaque())
+    Ref securityOrigin = document->securityOrigin();
+    if (!frame || securityOrigin->isOpaque())
         return false;
 
     if (frame->isMainFrame())
         return true;
 
-    if (securityOrigin.equal(&document->topOrigin()))
+    if (securityOrigin->equal(&document->topOrigin()))
         return true;
 
     if (!frame->page())

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -159,13 +159,14 @@ EventLoopTimerHandle::EventLoopTimerHandle(EventLoopTimerHandle&&) = default;
 
 EventLoopTimerHandle::~EventLoopTimerHandle()
 {
-    if (!m_timer)
+    RefPtr timer = std::exchange(m_timer, nullptr);
+    if (!timer)
         return;
-    if (auto* group = m_timer->group(); group && m_timer->refCount() == 1) {
-        if (m_timer->type() == EventLoopTimer::Type::OneShot)
-            group->removeScheduledTimer(*m_timer);
+    if (auto* group = timer->group(); group && timer->refCount() == 1) {
+        if (timer->type() == EventLoopTimer::Type::OneShot)
+            group->removeScheduledTimer(*timer);
         else
-            group->removeRepeatingTimer(*m_timer);
+            group->removeRepeatingTimer(*timer);
     }
 }
 


### PR DESCRIPTION
#### 13add0386bd884ecf80d1a1386a19b4e5dd3c995
<pre>
Deploy smart pointers in DeviceOrientationAndMotionAccessController.cpp,
DeviceOrientationController.cpp, DocumentStorageAccess.cpp, EventLoop.cpp, and EventPath.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=264798">https://bugs.webkit.org/show_bug.cgi?id=264798</a>

Reviewed by Chris Dumez.

Deploy more smart pointers as warned by the clang static analyzer.

* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp:
(WebCore::DeviceOrientationAndMotionAccessController::accessState const):
* Source/WebCore/dom/DeviceOrientationController.cpp:
(WebCore::DeviceOrientationController::getLastEvent):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::hasStorageAccessQuickCheck):
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTimerHandle::~EventLoopTimerHandle):
* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::setRelatedTarget):
(WebCore::EventPath::retargetTouch):
(WebCore::RelatedNodeRetargeter::RelatedNodeRetargeter):

Canonical link: <a href="https://commits.webkit.org/270756@main">https://commits.webkit.org/270756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89b778dc2eccd8becd5e29e9d4dfc102155f9498

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24081 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2333 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28986 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29658 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27549 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1597 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3871 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3389 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->