### PR TITLE
[MSE] SourceBufferPrivate::didUpdateFormatDescriptionForTrackId can run out of order.

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2403,11 +2403,6 @@ webkit.org/b/255788 [ Ventura+ Debug ] tiled-drawing/scrolling/scroll-snap/scrol
 
 webkit.org/b/256108 media/video-audio-session-mode.html [ Failure ]
 
-# VP9 is not supported on all Intel HW
-[ x86_64 ] media/media-source/media-source-webm-configuration-change.html [ Pass Failure ]
-[ x86_64 ] media/media-source/media-source-webm-configuration-framerate.html [ Pass Failure ]
-[ x86_64 ] media/media-source/media-source-webm-configuration-vp9-header-color.html [ Pass Failure ]
-
 webkit.org/b/258181 [ Debug ] inspector/debugger/async-stack-trace-truncate.html [ Slow Failure ]
 
 # webkit.org/b/258328 Umbrella Bug: Batch mark expectations slowing down EWS

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -180,12 +180,17 @@ protected:
         Function<bool(InitializationSegment&)> check;
         CompletionHandler<void(ReceiveResult)> completionHandler;
     };
+    struct UpdateFormatDescriptionOperation {
+        Ref<TrackInfo> formatDescription;
+        uint64_t trackId;
+        CompletionHandler<void(Ref<TrackInfo>&&, uint64_t)> completionHandler;
+    };
     using SamplesVector = Vector<Ref<MediaSample>>;
     struct AppendCompletedOperation {
         size_t abortCount { 0 };
         Function<void()> preTask;
     };
-    using Operation = std::variant<AppendBufferOperation, InitOperation, SamplesVector, ResetParserOperation, AppendCompletedOperation, ErrorOperation>;
+    using Operation = std::variant<AppendBufferOperation, InitOperation, UpdateFormatDescriptionOperation, SamplesVector, ResetParserOperation, AppendCompletedOperation, ErrorOperation>;
     void queueOperation(Operation&&);
 
     MediaTime currentMediaTime() const;
@@ -212,6 +217,7 @@ protected:
     // that would prevent `this` to be deleted in case the SourceBufferClient detaches itself while an initialization
     // is pending. Take a WeakPtr instead.
     WEBCORE_EXPORT void didReceiveInitializationSegment(InitializationSegment&&, Function<bool(InitializationSegment&)>&&, CompletionHandler<void(ReceiveResult)>&&);
+    WEBCORE_EXPORT void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, uint64_t, CompletionHandler<void(Ref<TrackInfo>&&, uint64_t)>&&);
     WEBCORE_EXPORT void didReceiveSample(Ref<MediaSample>&&);
     WEBCORE_EXPORT void setBufferedRanges(PlatformTimeRanges&&, CompletionHandler<void()>&& completionHandler = [] { });
     void provideMediaData(const AtomString& trackID);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -527,18 +527,23 @@ bool SourceBufferPrivateAVFObjC::isMediaSampleAllowed(const MediaSample& sample)
 
 void SourceBufferPrivateAVFObjC::didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&& formatDescription, uint64_t trackId)
 {
-    if (is<VideoInfo>(formatDescription)) {
-        auto result = m_videoTracks.find(AtomString::number(trackId));
-        if (result != m_videoTracks.end())
-            result->value->setFormatDescription(downcast<VideoInfo>(formatDescription.get()));
-        return;
-    }
+    SourceBufferPrivate::didUpdateFormatDescriptionForTrackId(WTFMove(formatDescription), trackId, [weakThis = WeakPtr { *this }, this](Ref<TrackInfo>&& formatDescription, uint64_t trackId) {
+        if (!weakThis)
+            return;
 
-    if (is<AudioInfo>(formatDescription)) {
-        auto result = m_audioTracks.find(AtomString::number(trackId));
-        if (result != m_audioTracks.end())
-            result->value->setFormatDescription(downcast<AudioInfo>(formatDescription.get()));
-    }
+        if (is<VideoInfo>(formatDescription)) {
+            auto result = m_videoTracks.find(AtomString::number(trackId));
+            if (result != m_videoTracks.end())
+                result->value->setFormatDescription(downcast<VideoInfo>(formatDescription.get()));
+            return;
+        }
+
+        if (is<AudioInfo>(formatDescription)) {
+            auto result = m_audioTracks.find(AtomString::number(trackId));
+            if (result != m_audioTracks.end())
+                result->value->setFormatDescription(downcast<AudioInfo>(formatDescription.get()));
+        }
+    });
 }
 
 void SourceBufferPrivateAVFObjC::willProvideContentKeyRequestInitializationDataForTrackID(uint64_t trackID)


### PR DESCRIPTION
#### 49ba5f074748e43875482ec5182b32901017b9b9
<pre>
[MSE] SourceBufferPrivate::didUpdateFormatDescriptionForTrackId can run out of order.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264799">https://bugs.webkit.org/show_bug.cgi?id=264799</a>
<a href="https://rdar.apple.com/118380017">rdar://118380017</a>

Reviewed by Youenn Fablet.

Ensure the track format description is processed after the init segment by queuing an operation
instead of running the callback immediately.

Covered by existing tests (which were disabled)

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::didUpdateFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::processPendingOperations):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::didUpdateFormatDescriptionForTrackId):

Canonical link: <a href="https://commits.webkit.org/270703@main">https://commits.webkit.org/270703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d07f6c97dcd57464091cf7ef89f84b521bf27dff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26414 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3625 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28830 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23472 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23861 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3269 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4677 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6292 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->