### PR TITLE
Generate IPC serialization for enumerations under WebKit/UIProcess/Extensions

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -218,6 +218,7 @@ $(PROJECT_DIR)/Shared/EditorState.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionAlarmParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionCommandParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionContentWorldType.serialization.in
+$(PROJECT_DIR)/Shared/Extensions/WebExtensionContext.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionControllerParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionDynamicScripts.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -539,6 +539,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Extensions/WebExtensionAlarmParameters.serialization.in \
 	Shared/Extensions/WebExtensionCommandParameters.serialization.in \
 	Shared/Extensions/WebExtensionContentWorldType.serialization.in \
+	Shared/Extensions/WebExtensionContext.serialization.in \
 	Shared/Extensions/WebExtensionContextParameters.serialization.in \
 	Shared/Extensions/WebExtensionControllerParameters.serialization.in \
 	Shared/Extensions/WebExtensionDynamicScripts.serialization.in \

--- a/Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,41 +22,13 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-headers: "WebExtensionWindow.h"
+headers: "WebExtensionContext.h"
 
-struct WebKit::WebExtensionWindowParameters {
-    std::optional<WebKit::WebExtensionWindowIdentifier> identifier;
-
-    std::optional<WebKit::WebExtensionWindow::State> state;
-    std::optional<WebKit::WebExtensionWindow::Type> type;
-
-    std::optional<Vector<WebKit::WebExtensionTabParameters>> tabs;
-
-    std::optional<CGRect> frame;
-
-    std::optional<bool> focused;
-    std::optional<bool> privateBrowsing;
-};
-
-[Nested] enum class WebKit::WebExtensionWindow::PopulateTabs : bool;
-
-[Nested] enum class WebKit::WebExtensionWindow::Type : uint8_t {
-    Normal,
-    Popup,
-};
-
-[OptionSet] enum class WebKit::WebExtensionWindowTypeFilter : uint8_t {
+enum class WebKit::WebExtensionContextInstallReason : uint8_t {
     None,
-    Normal,
-    Popup,
-    All,
-};
-
-[Nested] enum class WebKit::WebExtensionWindow::State : uint8_t {
-    Normal,
-    Minimized,
-    Maximized,
-    Fullscreen,
+    ExtensionInstall,
+    ExtensionUpdate,
+    BrowserUpdate,
 };
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
@@ -66,7 +66,7 @@ struct WebKit::WebExtensionTabQueryParameters {
     std::optional<bool> selected;
 }
 
-[Nested, CustomHeader] enum class WebKit::WebExtensionTab::ImageFormat : uint8_t {
+enum class WebKit::WebExtensionTabImageFormat : uint8_t {
     PNG,
     JPEG,
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -86,6 +86,13 @@ class WebExtension;
 class WebUserContentControllerProxy;
 struct WebExtensionContextParameters;
 
+enum class WebExtensionContextInstallReason : uint8_t {
+    None,
+    ExtensionInstall,
+    ExtensionUpdate,
+    BrowserUpdate,
+};
+
 class WebExtensionContext : public API::ObjectImpl<API::Object::Type::WebExtensionContext>, public IPC::MessageReceiver {
     WTF_MAKE_NONCOPYABLE(WebExtensionContext);
 
@@ -168,12 +175,7 @@ public:
         SkipRequestedPermissions    = 1 << 1, // Don't check requested permissions.
     };
 
-    enum class InstallReason : uint8_t {
-        None,
-        ExtensionInstall,
-        ExtensionUpdate,
-        BrowserUpdate,
-    };
+    using InstallReason = WebExtensionContextInstallReason;
 
     enum class WebViewPurpose : uint8_t {
         Any,
@@ -630,19 +632,5 @@ void WebExtensionContext::sendToContentScriptProcessesForEvent(WebExtensionEvent
 }
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::WebExtensionContext::InstallReason> {
-    using values = EnumValues<
-        WebKit::WebExtensionContext::InstallReason,
-        WebKit::WebExtensionContext::InstallReason::None,
-        WebKit::WebExtensionContext::InstallReason::ExtensionInstall,
-        WebKit::WebExtensionContext::InstallReason::ExtensionUpdate,
-        WebKit::WebExtensionContext::InstallReason::BrowserUpdate
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -48,6 +48,11 @@ class WebProcessProxy;
 struct WebExtensionTabParameters;
 struct WebExtensionTabQueryParameters;
 
+enum class WebExtensionTabImageFormat : uint8_t {
+    PNG,
+    JPEG,
+};
+
 class WebExtensionTab : public RefCounted<WebExtensionTab>, public CanMakeWeakPtr<WebExtensionTab> {
     WTF_MAKE_NONCOPYABLE(WebExtensionTab);
     WTF_MAKE_FAST_ALLOCATED;
@@ -75,10 +80,7 @@ public:
         All        = Audible | Loading | Muted | Pinned | ReaderMode | Size | Title | URL | ZoomFactor,
     };
 
-    enum class ImageFormat : uint8_t {
-        PNG,
-        JPEG,
-    };
+    using ImageFormat = WebExtensionTabImageFormat;
 
     enum class AssumeWindowMatches : bool { No, Yes };
     enum class SkipContainsCheck : bool { No, Yes };
@@ -225,17 +227,5 @@ private:
 };
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::WebExtensionTab::ImageFormat> {
-    using values = EnumValues<
-        WebKit::WebExtensionTab::ImageFormat,
-        WebKit::WebExtensionTab::ImageFormat::PNG,
-        WebKit::WebExtensionTab::ImageFormat::JPEG
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -45,6 +45,13 @@ class WebExtensionTab;
 struct WebExtensionTabQueryParameters;
 struct WebExtensionWindowParameters;
 
+enum class WebExtensionWindowTypeFilter : uint8_t {
+    None   = 0,
+    Normal = 1 << 0,
+    Popup  = 1 << 1,
+    All    = Normal | Popup,
+};
+
 class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow> {
     WTF_MAKE_NONCOPYABLE(WebExtensionWindow);
     WTF_MAKE_FAST_ALLOCATED;
@@ -63,12 +70,7 @@ public:
         Popup,
     };
 
-    enum class TypeFilter : uint8_t {
-        None   = 0,
-        Normal = 1 << 0,
-        Popup  = 1 << 1,
-        All    = Normal | Popup,
-    };
+    using TypeFilter = WebExtensionWindowTypeFilter;
 
     enum class State : uint8_t {
         Normal,
@@ -151,19 +153,5 @@ _WKWebExtensionWindowState toAPI(WebExtensionWindow::State);
 #endif
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::WebExtensionWindow::TypeFilter> {
-    using values = EnumValues<
-        WebKit::WebExtensionWindow::TypeFilter,
-        WebKit::WebExtensionWindow::TypeFilter::None,
-        WebKit::WebExtensionWindow::TypeFilter::Normal,
-        WebKit::WebExtensionWindow::TypeFilter::Popup,
-        WebKit::WebExtensionWindow::TypeFilter::All
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4444,6 +4444,7 @@
 		2DA049B2180CCCD300AAFA9E /* PlatformCALayerRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformCALayerRemote.h; sourceTree = "<group>"; };
 		2DA049B5180CCD0A00AAFA9E /* GraphicsLayerCARemote.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GraphicsLayerCARemote.mm; sourceTree = "<group>"; };
 		2DA049B6180CCD0A00AAFA9E /* GraphicsLayerCARemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphicsLayerCARemote.h; sourceTree = "<group>"; };
+		2DA301A92B036CDA00F3B129 /* WebExtensionContext.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionContext.serialization.in; sourceTree = "<group>"; };
 		2DA3E37D2A33C98900F7799D /* UserInterfaceIdiom.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserInterfaceIdiom.serialization.in; sourceTree = "<group>"; };
 		2DA6731920C754B1003CB401 /* DynamicViewportSizeUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DynamicViewportSizeUpdate.h; path = ios/DynamicViewportSizeUpdate.h; sourceTree = "<group>"; };
 		2DA7FDCB18F88625008DDED0 /* FindIndicatorOverlayClientIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FindIndicatorOverlayClientIOS.h; path = ios/FindIndicatorOverlayClientIOS.h; sourceTree = "<group>"; };
@@ -12483,6 +12484,7 @@
 				1C8ECFEF2AFC8363007BAA62 /* WebExtensionCommandParameters.serialization.in */,
 				1C4A14C92ABCB8F500A1018C /* WebExtensionContentWorldType.h */,
 				1C4A14CC2ABCB94400A1018C /* WebExtensionContentWorldType.serialization.in */,
+				2DA301A92B036CDA00F3B129 /* WebExtensionContext.serialization.in */,
 				1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */,
 				1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */,
 				1C3BEB482887415100E66E38 /* WebExtensionControllerIdentifier.h */,


### PR DESCRIPTION
#### ec22469b07e5e15cc6d3d28a992abf19e5430206
<pre>
Generate IPC serialization for enumerations under WebKit/UIProcess/Extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=264801">https://bugs.webkit.org/show_bug.cgi?id=264801</a>

Reviewed by Timothy Hatcher and Chris Dumez.

Adjust IPC serialization specification for WebExtensionTab::ImageFormat and
WebExtensionWindow::TypeFilter enums so that the generated code can also cover
all cases even when the EnumTraits for the two enums are removed.

WebExtensionContext::InstallReason enum is similarly adjusted, along with the
new serialization input file.

WebExtension::ModifierFlags enum is left there for now since it&apos;s been added
only a few days ago, so removing it could unintentionally break some ongoing
changes.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in: Copied from Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in.
* Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270725@main">https://commits.webkit.org/270725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95d543d497ef61939619847d2ac4d9bd958b14e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26156 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23980 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28827 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3248 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29519 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1468 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4674 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6305 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->