### PR TITLE
Generate IPC serialization for iOS-specific enumerations under WebKit

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -382,6 +382,7 @@ $(PROJECT_DIR)/Shared/cf/CFTypes.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCBoolean.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCNumber.serialization.in
 $(PROJECT_DIR)/Shared/ios/DynamicViewportSizeUpdate.serialization.in
+$(PROJECT_DIR)/Shared/ios/GestureTypes.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationRequest.serialization.in
 $(PROJECT_DIR)/Shared/ios/WebAutocorrectionContext.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -559,6 +559,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/GPUProcessPreferencesForWebProcess.serialization.in \
 	Shared/GoToBackForwardItemParameters.serialization.in \
 	Shared/ios/DynamicViewportSizeUpdate.serialization.in \
+	Shared/ios/GestureTypes.serialization.in \
 	Shared/ios/InteractionInformationAtPosition.serialization.in \
 	Shared/ios/InteractionInformationRequest.serialization.in \
 	Shared/ios/WebAutocorrectionContext.serialization.in \

--- a/Source/WebKit/Shared/ios/GestureTypes.h
+++ b/Source/WebKit/Shared/ios/GestureTypes.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebKit {
 
 enum class GestureType : uint8_t {
@@ -65,7 +63,7 @@ enum class SheetAction : uint8_t {
     PlayAnimation
 };
 
-enum SelectionFlags : uint8_t {
+enum class SelectionFlags : uint8_t {
     WordIsNearTap = 1 << 0,
     SelectionFlipped = 1 << 1,
     PhraseBoundaryChanged = 1 << 2,
@@ -74,54 +72,3 @@ enum SelectionFlags : uint8_t {
 enum class RespectSelectionAnchor : bool { No, Yes };
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::GestureRecognizerState> {
-    using values = EnumValues<
-        WebKit::GestureRecognizerState,
-        WebKit::GestureRecognizerState::Possible,
-        WebKit::GestureRecognizerState::Began,
-        WebKit::GestureRecognizerState::Changed,
-        WebKit::GestureRecognizerState::Ended,
-        WebKit::GestureRecognizerState::Cancelled,
-        WebKit::GestureRecognizerState::Failed
-    >;
-};
-
-template<> struct EnumTraits<WebKit::GestureType> {
-    using values = EnumValues<
-        WebKit::GestureType,
-        WebKit::GestureType::Loupe,
-        WebKit::GestureType::OneFingerTap,
-        WebKit::GestureType::TapAndAHalf,
-        WebKit::GestureType::DoubleTap,
-        WebKit::GestureType::OneFingerDoubleTap,
-        WebKit::GestureType::OneFingerTripleTap,
-        WebKit::GestureType::TwoFingerSingleTap,
-        WebKit::GestureType::PhraseBoundary
-    >;
-};
-
-template<> struct EnumTraits<WebKit::SelectionFlags> {
-    using values = EnumValues<
-        WebKit::SelectionFlags,
-        WebKit::SelectionFlags::WordIsNearTap,
-        WebKit::SelectionFlags::SelectionFlipped,
-        WebKit::SelectionFlags::PhraseBoundaryChanged
-    >;
-};
-
-template<> struct EnumTraits<WebKit::SelectionTouch> {
-    using values = EnumValues<
-        WebKit::SelectionTouch,
-        WebKit::SelectionTouch::Started,
-        WebKit::SelectionTouch::Moved,
-        WebKit::SelectionTouch::Ended,
-        WebKit::SelectionTouch::EndedMovingForward,
-        WebKit::SelectionTouch::EndedMovingBackward,
-        WebKit::SelectionTouch::EndedNotMoving
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/ios/GestureTypes.serialization.in
+++ b/Source/WebKit/Shared/ios/GestureTypes.serialization.in
@@ -1,0 +1,62 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(IOS_FAMILY)
+
+header: "GestureTypes.h"
+
+enum class WebKit::GestureRecognizerState : uint8_t {
+    Possible,
+    Began,
+    Changed,
+    Ended,
+    Cancelled,
+    Failed
+};
+
+enum class WebKit::GestureType : uint8_t {
+    Loupe,
+    OneFingerTap,
+    TapAndAHalf,
+    DoubleTap,
+    OneFingerDoubleTap,
+    OneFingerTripleTap,
+    TwoFingerSingleTap,
+    PhraseBoundary
+};
+
+[OptionSet] enum class WebKit::SelectionFlags : uint8_t {
+    WordIsNearTap,
+    SelectionFlipped,
+    PhraseBoundaryChanged,
+};
+
+enum class WebKit::SelectionTouch : uint8_t {
+    Started,
+    Moved,
+    Ended,
+    EndedMovingForward,
+    EndedMovingBackward,
+    EndedNotMoving
+};
+
+#endif

--- a/Source/WebKit/Shared/ios/TapHandlingResult.h
+++ b/Source/WebKit/Shared/ios/TapHandlingResult.h
@@ -27,8 +27,6 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebKit {
 
 enum class TapHandlingResult : uint8_t  {
@@ -38,18 +36,5 @@ enum class TapHandlingResult : uint8_t  {
 };
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::TapHandlingResult> {
-    using values = EnumValues <
-    WebKit::TapHandlingResult,
-    WebKit::TapHandlingResult::DidNotHandleTapAsClick,
-    WebKit::TapHandlingResult::NonMeaningfulClick,
-    WebKit::TapHandlingResult::MeaningfulClick
-    >;
-};
-
-} // namespace WTF
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -455,8 +455,6 @@ struct WebPreferencesStore;
 struct WebSpeechSynthesisVoice;
 struct WebsitePoliciesData;
 
-enum SelectionFlags : uint8_t;
-
 enum class ContentAsStringIncludesChildFrames : bool;
 enum class DragControllerAction : uint8_t;
 enum class FindDecorationStyle : uint8_t;
@@ -474,6 +472,7 @@ enum class QuickLookPreviewActivity : uint8_t;
 enum class RespectSelectionAnchor : bool;
 enum class SOAuthorizationLoadPolicy : bool;
 enum class SameDocumentNavigationType : uint8_t;
+enum class SelectionFlags : uint8_t;
 enum class SelectionTouch : uint8_t;
 enum class ShouldDelayClosingUntilFirstLayerFlush : bool;
 enum class SyntheticEditingCommandType : uint8_t;

--- a/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h
+++ b/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h
@@ -27,7 +27,6 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import <wtf/EnumTraits.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RefCounted.h>
 #import <wtf/WeakObjCPtr.h>
@@ -55,18 +54,5 @@ private:
 };
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::RevealFocusedElementDeferralReason> {
-    using values = EnumValues<
-        WebKit::RevealFocusedElementDeferralReason,
-        WebKit::RevealFocusedElementDeferralReason::EditorState,
-        WebKit::RevealFocusedElementDeferralReason::KeyboardWillShow,
-        WebKit::RevealFocusedElementDeferralReason::KeyboardDidShow
-    >;
-};
-
-} // namespace WTF
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4741,11 +4741,11 @@ static TextStream& operator<<(TextStream& stream, WebKit::GestureRecognizerState
 static inline UIWKSelectionFlags toUIWKSelectionFlags(OptionSet<WebKit::SelectionFlags> flags)
 {
     NSInteger uiFlags = UIWKNone;
-    if (flags.contains(WebKit::WordIsNearTap))
+    if (flags.contains(WebKit::SelectionFlags::WordIsNearTap))
         uiFlags |= UIWKWordIsNearTap;
-    if (flags.contains(WebKit::SelectionFlipped))
+    if (flags.contains(WebKit::SelectionFlags::SelectionFlipped))
         uiFlags |= UIWKSelectionFlipped;
-    if (flags.contains(WebKit::PhraseBoundaryChanged))
+    if (flags.contains(WebKit::SelectionFlags::PhraseBoundaryChanged))
         uiFlags |= UIWKPhraseBoundaryChanged;
 
     return static_cast<UIWKSelectionFlags>(uiFlags);
@@ -4755,11 +4755,11 @@ static inline OptionSet<WebKit::SelectionFlags> toSelectionFlags(UIWKSelectionFl
 {
     OptionSet<WebKit::SelectionFlags> flags;
     if (uiFlags & UIWKWordIsNearTap)
-        flags.add(WebKit::WordIsNearTap);
+        flags.add(WebKit::SelectionFlags::WordIsNearTap);
     if (uiFlags & UIWKSelectionFlipped)
-        flags.add(WebKit::SelectionFlipped);
+        flags.add(WebKit::SelectionFlags::SelectionFlipped);
     if (uiFlags & UIWKPhraseBoundaryChanged)
-        flags.add(WebKit::PhraseBoundaryChanged);
+        flags.add(WebKit::SelectionFlags::PhraseBoundaryChanged);
     return flags;
 }
 
@@ -4776,9 +4776,9 @@ static TextStream& operator<<(TextStream& stream, OptionSet<WebKit::SelectionFla
         didAppend = true;
     };
 
-    appendIf(WebKit::WordIsNearTap, "WordIsNearTap");
-    appendIf(WebKit::SelectionFlipped, "SelectionFlipped");
-    appendIf(WebKit::PhraseBoundaryChanged, "PhraseBoundaryChanged");
+    appendIf(WebKit::SelectionFlags::WordIsNearTap, "WordIsNearTap");
+    appendIf(WebKit::SelectionFlags::SelectionFlipped, "SelectionFlipped");
+    appendIf(WebKit::SelectionFlags::PhraseBoundaryChanged, "PhraseBoundaryChanged");
 
     if (!didAppend)
         stream << "None";

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4446,6 +4446,7 @@
 		2DA049B5180CCD0A00AAFA9E /* GraphicsLayerCARemote.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GraphicsLayerCARemote.mm; sourceTree = "<group>"; };
 		2DA049B6180CCD0A00AAFA9E /* GraphicsLayerCARemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphicsLayerCARemote.h; sourceTree = "<group>"; };
 		2DA301A92B036CDA00F3B129 /* WebExtensionContext.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionContext.serialization.in; sourceTree = "<group>"; };
+		2DA301AD2B0385F700F3B129 /* GestureTypes.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = GestureTypes.serialization.in; path = ios/GestureTypes.serialization.in; sourceTree = "<group>"; };
 		2DA3E37D2A33C98900F7799D /* UserInterfaceIdiom.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserInterfaceIdiom.serialization.in; sourceTree = "<group>"; };
 		2DA6731920C754B1003CB401 /* DynamicViewportSizeUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DynamicViewportSizeUpdate.h; path = ios/DynamicViewportSizeUpdate.h; sourceTree = "<group>"; };
 		2DA7FDCB18F88625008DDED0 /* FindIndicatorOverlayClientIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FindIndicatorOverlayClientIOS.h; path = ios/FindIndicatorOverlayClientIOS.h; sourceTree = "<group>"; };
@@ -10070,6 +10071,7 @@
 				A7E93CEB192531AA00A1DC48 /* AuxiliaryProcessIOS.mm */,
 				2DA6731920C754B1003CB401 /* DynamicViewportSizeUpdate.h */,
 				2DA9449D1884E4F000ED86DB /* GestureTypes.h */,
+				2DA301AD2B0385F700F3B129 /* GestureTypes.serialization.in */,
 				C5BCE5DA1C50761D00CDE3FA /* InteractionInformationAtPosition.h */,
 				C5BCE5DB1C50761D00CDE3FA /* InteractionInformationAtPosition.mm */,
 				86DA60CA28EB11830044FE4D /* InteractionInformationAtPosition.serialization.in */,

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1466,9 +1466,9 @@ void WebPage::selectWithGesture(const IntPoint& point, GestureType gestureType, 
         auto startPosition = VisiblePosition { makeDeprecatedLegacyPosition(markedRange->start) };
         position = std::clamp(position, startPosition, VisiblePosition { makeDeprecatedLegacyPosition(markedRange->end) });
         if (wkGestureState != GestureRecognizerState::Began)
-            flags = distanceBetweenPositions(startPosition, frame->selection().selection().start()) != distanceBetweenPositions(startPosition, position) ? PhraseBoundaryChanged : OptionSet<SelectionFlags> { };
+            flags = distanceBetweenPositions(startPosition, frame->selection().selection().start()) != distanceBetweenPositions(startPosition, position) ? SelectionFlags::PhraseBoundaryChanged : OptionSet<SelectionFlags> { };
         else
-            flags = PhraseBoundaryChanged;
+            flags = SelectionFlags::PhraseBoundaryChanged;
         range = makeSimpleRange(position);
         break;
     }
@@ -1476,7 +1476,7 @@ void WebPage::selectWithGesture(const IntPoint& point, GestureType gestureType, 
     case GestureType::OneFingerTap: {
         auto [adjustedPosition, withinWordBoundary] = wordBoundaryForPositionWithoutCrossingLine(position);
         if (withinWordBoundary == WithinWordBoundary::Yes)
-            flags = WordIsNearTap;
+            flags = SelectionFlags::WordIsNearTap;
         range = makeSimpleRange(adjustedPosition);
         break;
     }
@@ -1865,7 +1865,7 @@ void WebPage::updateSelectionWithTouches(const IntPoint& point, SelectionTouch s
         frame->selection().setSelectedRange(range, position.affinity(), WebCore::FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
     
     if (selectionFlipped == SelectionWasFlipped::Yes)
-        flags = SelectionFlipped;
+        flags = SelectionFlags::SelectionFlipped;
 
     completionHandler(point, selectionTouch, flags);
 }


### PR DESCRIPTION
#### 8c9520c1b7e154eac1d5b0b8f52559c1a4047f62
<pre>
Generate IPC serialization for iOS-specific enumerations under WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=264806">https://bugs.webkit.org/show_bug.cgi?id=264806</a>

Reviewed by Chris Dumez.

Provide IPC serialization specification for enums in the iOS-specific
GestureTypes.h header in the new serialization input file. EnumTraits
specializations can be removed, and the SelectionFlags enumeration has to be
converted into a scoped variant.

EnumTraits specializations for the RevealFocusedElementDeferralReason and
TapHandlingResult enumerations can be removed as they are not used.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/ios/GestureTypes.h:
(): Deleted.
* Source/WebKit/Shared/ios/GestureTypes.serialization.in: Added.
* Source/WebKit/Shared/ios/TapHandlingResult.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(toUIWKSelectionFlags):
(toSelectionFlags):
(operator&lt;&lt;):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::selectWithGesture):
(WebKit::WebPage::updateSelectionWithTouches):

Canonical link: <a href="https://commits.webkit.org/270755@main">https://commits.webkit.org/270755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d554b1dd2a48456a19ffe623d138426c7dee06f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24086 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2341 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3772 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28991 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27546 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3399 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4823 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6325 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->