### PR TITLE
MediaPlayerPrivateMediaStreamAVFObjC should ensure to have HTMLMediaElement and VideoFrame size in sync even in case of resize event

### DIFF
--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Video element and VideoFrame size should be in sync after a resize event
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <video id='video' width=100px muted autoplay playsinline></video>
+    <br>
+    <script>
+
+var counter = 0;
+async function waitForResize(video)
+{
+    ++counter;
+    await new Promise((resolve, reject) => {
+        video.onresize = resolve;
+        setTimeout(() => reject("validateVideoFrameSize timed out " + counter), 5000);
+    });
+}
+
+async function validateVideoFrameSize(video, width)
+{
+    do {
+        await waitForResize(video);
+    } while (video.videoWidth !== width);
+
+    const frame = new VideoFrame(video);
+    const result = frame.codedWidth == video.videoWidth;
+    frame.close();
+    return result
+}
+
+promise_test(async (t) => {
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { width: 1280 } });
+    if (video.requestVideoFrameCallback)
+        await new Promise((resolve, reject) => {
+            video.requestVideoFrameCallback(resolve);
+            setTimeout(() => reject("video.requestVideoFrameCallback timed out"), 5000);
+        });
+    else {
+       while (!video.videoWidth)
+           await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    video.srcObject.getVideoTracks()[0].applyConstraints({ width: 640 });
+    assert_true(await validateVideoFrameSize(video, 640), "test 1");
+
+    video.srcObject.getVideoTracks()[0].applyConstraints({ width: 1280 });
+    assert_true(await validateVideoFrameSize(video, 1280), "test 2");
+}, "Video element and VideoFrame size should be in sync after a resize event");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1832,6 +1832,8 @@ webkit.org/b/79203 fast/mediastream/video-srcObject-fit-fill.html [ Pass Timeout
 webkit.org/b/230415 fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html [ Timeout ]
 webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Timeout Failure Pass ]
 
+webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ Failure ]
+
 webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address.html [ Failure ]
 webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html [ Failure ]
 webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Failure ]

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -181,6 +181,8 @@ private:
     void checkSelectedVideoTrack();
     void updateDisplayLayer();
 
+    enum class SizeChanged : bool { No, Yes };
+    void scheduleTaskForCharacteristicsChanged(SizeChanged);
     void scheduleDeferredTask(Function<void ()>&&);
 
     void layersAreInitialized(IntSize, bool);
@@ -301,7 +303,6 @@ private:
     uint64_t m_sampleCount { 0 };
     uint64_t m_lastVideoFrameMetadataSampleCount { 0 };
     Seconds m_presentationTime { 0 };
-    FloatSize m_videoFrameSize;
     VideoFrameTimeMetadata m_sampleMetadata;
 
     std::optional<CGRect> m_storedBounds;


### PR DESCRIPTION
#### 5be4440813a33d3ef35b4ec5d27521a692b589ad
<pre>
MediaPlayerPrivateMediaStreamAVFObjC should ensure to have HTMLMediaElement and VideoFrame size in sync even in case of resize event
<a href="https://bugs.webkit.org/show_bug.cgi?id=264803">https://bugs.webkit.org/show_bug.cgi?id=264803</a>
<a href="https://rdar.apple.com/118383141">rdar://118383141</a>

Reviewed by Eric Carlson.

When a video track size is changing, we want to make sure to fire the resize event when we receive a VideoFrame with the new size.
This ensures that creating a VideoFrame when resize event is fired will create a VideoFrame with the given size.

There are two cases where we want to keep doing what we are doing:
1. When no video frame has yet been received, the media element is in HAVE_METADATA and it is fine to fire the event more proacively when we know the size.
2. When the media stream is inactive (size is 0, 0), aka all tracks are ended, no video frame will be received but we still want to notify of the size change.
Chrome and Firefox do not follow this behavior, but we stick to it since this is preexisting behavior.

According testing, Chrome and Firefox both seem to ensure that the resize event is synchronized with creating VideoFrames with the new size.

* LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::m_videoLayerManager):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::scheduleTaskForCharacteristicsChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::videoFrameMetadata):

Canonical link: <a href="https://commits.webkit.org/270767@main">https://commits.webkit.org/270767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63d9047ca54a75b71744c6c1fc1a01541c0fcb84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24091 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29003 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29671 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27564 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1619 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23359 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6333 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->