### PR TITLE
ASSERTION FAILED: !((anchorType == PositionIsBeforeChildren || anchorType == PositionIsAfterChildren) && (is<Text>(*m_anchorNode) || editingIgnoresContent(*m_anchorNode))) in WebCore::Position::Position

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3518,9 +3518,6 @@ imported/w3c/web-platform-tests/preload/preload-type-match.html [ DumpJSConsoleL
 [ Debug ] fast/history/page-cache-closed-audiocontext.html [ Crash ]
 [ Debug ] fast/media/mq-resolution.html [ Crash ]
 [ Debug ] http/tests/loading/sizes/preload-image-sizes-2x.html [ Crash ]
-[ Debug ] http/wpt/dom-ranges-live-range/Range-mutations-deleteData.html [ Crash ]
-[ Debug ] http/wpt/dom-ranges-live-range/Range-mutations-insertData.html [ Crash ]
-[ Debug ] http/wpt/dom-ranges-live-range/Range-mutations-replaceData.html [ Crash ]
 [ Debug ] imported/blink/fast/hidpi/border-background-align.html [ Crash ]
 [ Debug ] imported/blink/svg/zoom/text/lowdpi-zoom-text.html [ Crash ]
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -204,6 +204,7 @@ public:
 
     bool isElementNode() const { return hasNodeFlag(NodeFlag::IsElement); }
     bool isContainerNode() const { return hasNodeFlag(NodeFlag::IsContainerNode); }
+    bool isCharacterData() const { return hasNodeFlag(NodeFlag::IsCharacterData); }
     bool isTextNode() const { return hasNodeFlag(NodeFlag::IsText); }
     bool isHTMLElement() const { return hasNodeFlag(NodeFlag::IsHTMLElement); }
     bool isSVGElement() const { return hasNodeFlag(NodeFlag::IsSVGElement); }

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -318,14 +318,14 @@ inline Position positionAfterNode(Node* anchorNode)
 // firstPositionInNode and lastPositionInNode return parent-anchored positions, lastPositionInNode construction is O(n) due to countChildNodes()
 inline Position firstPositionInNode(Node* anchorNode)
 {
-    if (anchorNode->isTextNode())
+    if (anchorNode->isCharacterData())
         return Position(anchorNode, 0, Position::PositionIsOffsetInAnchor);
     return Position(anchorNode, Position::PositionIsBeforeChildren);
 }
 
 inline Position lastPositionInNode(Node* anchorNode)
 {
-    if (anchorNode->isTextNode())
+    if (anchorNode->isCharacterData())
         return Position(anchorNode, anchorNode->length(), Position::PositionIsOffsetInAnchor);
     return Position(anchorNode, Position::PositionIsAfterChildren);
 }


### PR DESCRIPTION
#### 3855bdaf1c1b4a90985a9c8c4e791fec6b499569
<pre>
ASSERTION FAILED: !((anchorType == PositionIsBeforeChildren || anchorType == PositionIsAfterChildren) &amp;&amp; (is&lt;Text&gt;(*m_anchorNode) || editingIgnoresContent(*m_anchorNode))) in WebCore::Position::Position
<a href="https://bugs.webkit.org/show_bug.cgi?id=164053">https://bugs.webkit.org/show_bug.cgi?id=164053</a>

Reviewed by Ryosuke Niwa.

Since `firstPositionInNode()` and `lastPositionInNode()` take any node
as their argument, including `Comment`, we should use
`PositionIsOffsetInAnchor` for any `CharacterData`, not only for `Text`.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/dom/Node.h:
(WebCore::Node::isCharacterData const):
* Source/WebCore/dom/Position.h:
(WebCore::firstPositionInNode):
(WebCore::lastPositionInNode):

Canonical link: <a href="https://commits.webkit.org/270763@main">https://commits.webkit.org/270763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01a40366d43875c0f23782a2c7d8c176b64acb32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28262 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23986 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28837 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29527 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27419 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1481 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4683 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6331 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->