### PR TITLE
[MSE][GStreamer] Fix non-seeking flushes

### DIFF
--- a/LayoutTests/media/media-source/media-source-audio-switch-expected.txt
+++ b/LayoutTests/media/media-source/media-source-audio-switch-expected.txt
@@ -1,0 +1,27 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Appended all media segments
+RUN(video.play())
+EXPECTED (video.paused == 'false') OK
+
+EXPECTED (video.currentTime >= '1') OK
+RUN(video.currentTime = 3)
+
+EXPECTED (video.currentTime >= '4') OK
+RUN(video.pause())
+EXPECTED (video.paused == 'true') OK
+RUN(sourceBuffer.remove(0, 15))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Appended all media segments
+RUN(video.play())
+EXPECTED (video.paused == 'false') OK
+
+EXPECTED (video.currentTime >= '5') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-audio-switch.html
+++ b/LayoutTests/media/media-source/media-source-audio-switch.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-audio-switch</title>
+    <meta name="timeout" content="long">
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var oldTime = -1;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-48khz-manifest.json');
+        await loaderPromise(loader);
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+            sourceBuffer.appendBuffer(loader.mediaSegment(i));
+            await waitFor(sourceBuffer, 'update', true);
+        }
+        consoleWrite('Appended all media segments')
+
+        consoleWrite('RUN(video.play())')
+        await video.play();
+        testExpected('video.paused', false);
+
+        async function timeUpdated() {
+            if (oldTime <= video.currentTime) {
+                oldTime = video.currentTime;
+                if (video.currentTime >= 5) {
+                    consoleWrite('');
+                    testExpected('video.currentTime', 5, '>=')
+                    endTest();
+                }
+                return;
+            }
+            consoleWrite('');
+            consoleWrite("oldTime " + oldTime);
+            consoleWrite("video.currentTime " + video.currentTime);
+            failTest('oldTime <= video.currentTime');
+        }
+
+        async function audioSwitch() {
+            if (video.currentTime < 4)
+                return;
+            video.removeEventListener("timeupdate", audioSwitch);
+            video.addEventListener("timeupdate", timeUpdated);
+
+            consoleWrite('');
+            testExpected('video.currentTime', 4, '>=');
+
+            run('video.pause()');
+            testExpected('video.paused', true);
+
+            run('sourceBuffer.remove(0, 15)');
+            await waitFor(sourceBuffer, 'update');
+
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+            for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+                sourceBuffer.appendBuffer(loader.mediaSegment(i));
+                await waitFor(sourceBuffer, 'update', true);
+            }
+            consoleWrite('Appended all media segments')
+
+            consoleWrite('RUN(video.play())')
+            await video.play();
+            testExpected('video.paused', false);
+        }
+
+        function seek() {
+            if (video.currentTime < 1)
+                return;
+
+            video.removeEventListener("timeupdate", seek);
+            video.addEventListener("timeupdate", audioSwitch);
+            consoleWrite('');
+            testExpected('video.currentTime', 1, '>=');
+            run('video.currentTime = 3');
+        }
+        video.addEventListener("timeupdate", seek);
+    });
+
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -339,10 +339,13 @@ protected:
     void updateTextureMapperFlags();
 #endif
 
+    void setCachedPosition(const MediaTime&) const;
+
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     String m_referrer;
-    mutable std::optional<MediaTime> m_cachedPosition;
+    mutable MediaTime m_cachedPosition;
+    mutable bool m_isCachedPositionValid { false };
     mutable MediaTime m_cachedDuration;
     bool m_canFallBackToLastFinishedSeekPosition { false };
     bool m_isChangingRate { false };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -304,6 +304,7 @@ void MediaPlayerPrivateGStreamerMSE::sourceSetup(GstElement* sourceElement)
 {
     ASSERT(WEBKIT_IS_MEDIA_SRC(sourceElement));
     GST_DEBUG_OBJECT(pipeline(), "Source %p setup (old was: %p)", sourceElement, m_source.get());
+    webKitMediaSrcSetPlayer(WEBKIT_MEDIA_SRC(sourceElement), WeakPtr { *this });
     m_source = sourceElement;
 
     if (m_mediaSourcePrivate->hasAllTracks())

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -65,6 +65,8 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<WebCo
 
 void webKitMediaSrcFlush(WebKitMediaSrc*, const AtomString& streamName);
 
+void webKitMediaSrcSetPlayer(WebKitMediaSrc*, WeakPtr<WebCore::MediaPlayerPrivateGStreamerMSE>&&);
+
 G_END_DECLS
 
 namespace WTF {


### PR DESCRIPTION
#### 51b16e1c0134194e7d37dffdfac022f531b5b677
<pre>
[MSE][GStreamer] Fix non-seeking flushes
<a href="https://bugs.webkit.org/show_bug.cgi?id=262693">https://bugs.webkit.org/show_bug.cgi?id=262693</a>

Reviewed by Philippe Normand.

This reverts <a href="https://commits.webkit.org/269358@main">https://commits.webkit.org/269358@main</a> . Problem is that you can screw quality changes as they require a
non seeking flush with an updated segment.

We still need to change the segment to use the proper playback position and we can do it by using the player&apos;s position.

Besides, as a fly-by-fix, we are solving the problem of position going back to 0 when the sinks can&apos;t provide a proper
position while it is prerolling. For that, we use the cached position of the player even if it was supposed to be
invalidated already as a best effort.

* LayoutTests/media/media-source/media-source-audio-switch-expected.txt: Added.
* LayoutTests/media/media-source/media-source-audio-switch.html: Added.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::playbackPosition const):
(WebCore::MediaPlayerPrivateGStreamer::didEnd):
(WebCore::MediaPlayerPrivateGStreamer::setCachedPosition const):
(WebCore::MediaPlayerPrivateGStreamer::invalidateCachedPosition const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::sourceSetup):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcPlayer):
(webKitMediaSrcSetPlayer):
(webKitMediaSrcStreamFlush):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/270764@main">https://commits.webkit.org/270764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8abfdf5b0c1e3437052c52eb2191e90c6fe0247c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2367 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29012 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29677 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27570 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3419 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23363 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6330 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->