### PR TITLE
Port PlatformMediaSession enums to the new IPC serialization format

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5916,7 +5916,7 @@ bool HTMLMediaElement::stoppedDueToErrors() const
 
 bool HTMLMediaElement::pausedForUserInteraction() const
 {
-    if (mediaSession().state() == PlatformMediaSession::Interrupted)
+    if (mediaSession().state() == PlatformMediaSession::State::Interrupted)
         return true;
 
     return false;
@@ -6406,12 +6406,12 @@ bool HTMLMediaElement::virtualHasPendingActivity() const
         if (!mediaSession)
             return false;
 
-        if (mediaSession->state() != PlatformMediaSession::Interrupted)
+        if (mediaSession->state() != PlatformMediaSession::State::Interrupted)
             return false;
 
         auto stateToRestore = mediaSession->stateToRestore();
-        return stateToRestore == PlatformMediaSession::Autoplaying
-            || stateToRestore == PlatformMediaSession::Playing;
+        return stateToRestore == PlatformMediaSession::State::Autoplaying
+            || stateToRestore == PlatformMediaSession::State::Playing;
     }();
 
     // * It is playing, and is audible to the user:
@@ -8501,7 +8501,7 @@ bool HTMLMediaElement::supportsSeeking() const
 
 bool HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType type) const
 {
-    if (type == PlatformMediaSession::EnteringBackground) {
+    if (type == PlatformMediaSession::InterruptionType::EnteringBackground) {
         if (isPlayingToExternalTarget()) {
             INFO_LOG(LOGIDENTIFIER, "returning true because isPlayingToExternalTarget() is true");
             return true;
@@ -8522,7 +8522,7 @@ bool HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction(PlatformMedia
             return true;
         }
 #endif
-    } else if (type == PlatformMediaSession::SuspendedUnderLock) {
+    } else if (type == PlatformMediaSession::InterruptionType::SuspendedUnderLock) {
         if (isPlayingToExternalTarget()) {
             INFO_LOG(LOGIDENTIFIER, "returning true because isPlayingToExternalTarget() is true");
             return true;
@@ -8881,7 +8881,7 @@ void HTMLMediaElement::updateShouldAutoplay()
     if (canAutoplay) {
         if (m_wasInterruptedForInvisibleAutoplay) {
             m_wasInterruptedForInvisibleAutoplay = false;
-            mediaSession().endInterruption(PlatformMediaSession::MayResumePlaying);
+            mediaSession().endInterruption(PlatformMediaSession::EndInterruptionFlags::MayResumePlaying);
             return;
         }
         if (!isPlaying())
@@ -8889,16 +8889,16 @@ void HTMLMediaElement::updateShouldAutoplay()
         return;
     }
 
-    if (mediaSession().state() == PlatformMediaSession::Interrupted)
+    if (mediaSession().state() == PlatformMediaSession::State::Interrupted)
         return;
 
     if (m_wasInterruptedForInvisibleAutoplay) {
         m_wasInterruptedForInvisibleAutoplay = false;
-        mediaSession().endInterruption(PlatformMediaSession::NoFlags);
+        mediaSession().endInterruption(PlatformMediaSession::EndInterruptionFlags::NoFlags);
     }
 
     m_wasInterruptedForInvisibleAutoplay = true;
-    mediaSession().beginInterruption(PlatformMediaSession::InvisibleAutoplay);
+    mediaSession().beginInterruption(PlatformMediaSession::InterruptionType::InvisibleAutoplay);
 }
 
 void HTMLMediaElement::updateShouldPlay()
@@ -8941,7 +8941,7 @@ void HTMLMediaElement::playbackControlsManagerBehaviorRestrictionsTimerFired()
 
     queueCancellableTaskKeepingObjectAlive(*this, TaskSource::MediaElement, m_playbackControlsManagerBehaviorRestrictionsTaskCancellationGroup, [this] () {
         auto& mediaElementSession = mediaSession();
-        if (isPlaying() || mediaElementSession.state() == PlatformMediaSession::Autoplaying || mediaElementSession.state() == PlatformMediaSession::Playing)
+        if (isPlaying() || mediaElementSession.state() == PlatformMediaSession::State::Autoplaying || mediaElementSession.state() == PlatformMediaSession::State::Playing)
             return;
 
         mediaElementSession.addBehaviorRestriction(MediaElementSession::RequirePlaybackToControlControlsManager);

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -275,10 +275,10 @@ void MediaElementSession::visibilityChanged()
     if (!isPlayingAudio) {
         if (elementIsHidden) {
             ALWAYS_LOG(LOGIDENTIFIER, "Suspending silent playback after page visibility: hidden");
-            beginInterruption(PlatformMediaSession::EnteringBackground);
+            beginInterruption(PlatformMediaSession::InterruptionType::EnteringBackground);
         } else {
             ALWAYS_LOG(LOGIDENTIFIER, "Resuming silent playback after page visibility: showing");
-            endInterruption(PlatformMediaSession::MayResumePlaying);
+            endInterruption(PlatformMediaSession::EndInterruptionFlags::MayResumePlaying);
         }
         return;
     }
@@ -286,10 +286,10 @@ void MediaElementSession::visibilityChanged()
     if (hasBehaviorRestriction(RequirePageVisibilityToPlayAudio)) {
         if (elementIsHidden) {
             ALWAYS_LOG(LOGIDENTIFIER, "Suspending audible playback after page visibility: hidden");
-            beginInterruption(PlatformMediaSession::EnteringBackground);
+            beginInterruption(PlatformMediaSession::InterruptionType::EnteringBackground);
         } else {
             ALWAYS_LOG(LOGIDENTIFIER, "Resuming audible playback after page visibility: showing");
-            endInterruption(PlatformMediaSession::MayResumePlaying);
+            endInterruption(PlatformMediaSession::EndInterruptionFlags::MayResumePlaying);
         }
     }
 }
@@ -324,7 +324,7 @@ void MediaElementSession::clientDataBufferingTimerFired()
 
     updateClientDataBuffering();
 
-    if (state() != Playing || !m_element.elementIsHidden())
+    if (state() != PlatformMediaSession::State::Playing || !m_element.elementIsHidden())
         return;
 
     PlatformMediaSessionManager::SessionRestrictions restrictions = PlatformMediaSessionManager::sharedManager().restrictions(mediaType());
@@ -500,7 +500,7 @@ MediaPlayer::BufferingPolicy MediaElementSession::preferredBufferingPolicy() con
     if (bufferingSuspended())
         return MediaPlayer::BufferingPolicy::LimitReadAhead;
 
-    if (state() == PlatformMediaSession::Playing)
+    if (state() == PlatformMediaSession::State::Playing)
         return MediaPlayer::BufferingPolicy::Default;
 
     if (shouldOverrideBackgroundLoadingRestriction())
@@ -1281,7 +1281,7 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
 #endif
 
     bool allowsNowPlayingControlsVisibility = page && !page->isVisibleAndActive();
-    bool isPlaying = state() == PlatformMediaSession::Playing;
+    bool isPlaying = state() == PlatformMediaSession::State::Playing;
 
     bool supportsSeeking = m_element.supportsSeeking();
     double rate = 1.0;
@@ -1347,7 +1347,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
     MediaUsageInfo usage = {
         m_element.currentSrc(),
         m_element.hasSource(),
-        state() == PlatformMediaSession::Playing,
+        state() == PlatformMediaSession::State::Playing,
         canShowControlsManager(PlaybackControlsPurpose::ControlsManager),
         !page->isVisibleAndActive(),
         m_element.isSuspended(),

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -70,6 +70,39 @@ enum class PlatformMediaSessionRemoteControlCommandType : uint8_t {
     EndScrubbingCommand,
 };
 
+enum class PlatformMediaSessionMediaType : uint8_t {
+    None,
+    Video,
+    VideoAudio,
+    Audio,
+    WebAudio,
+};
+
+enum class PlatformMediaSessionState : uint8_t {
+    Idle,
+    Autoplaying,
+    Playing,
+    Paused,
+    Interrupted,
+};
+
+enum class PlatformMediaSessionInterruptionType : uint8_t {
+    NoInterruption,
+    SystemSleep,
+    EnteringBackground,
+    SystemInterruption,
+    SuspendedUnderLock,
+    InvisibleAutoplay,
+    ProcessInactive,
+    PlaybackSuspended,
+    PageNotVisible,
+};
+
+enum class PlatformMediaSessionEndInterruptionFlags : uint8_t {
+    NoFlags = 0,
+    MayResumePlaying = 1 << 0,
+};
+
 struct PlatformMediaSessionRemoteCommandArgument {
     std::optional<double> time;
     std::optional<bool> fastSeek;
@@ -92,50 +125,28 @@ public:
 
     void setActive(bool);
 
-    enum class MediaType : uint8_t {
-        None = 0,
-        Video,
-        VideoAudio,
-        Audio,
-        WebAudio,
-    };
+    using MediaType = WebCore::PlatformMediaSessionMediaType;
+
     MediaType mediaType() const;
     MediaType presentationType() const;
 
-    enum State : uint8_t {
-        Idle,
-        Autoplaying,
-        Playing,
-        Paused,
-        Interrupted,
-    };
+    using State = PlatformMediaSessionState;
+
     State state() const { return m_state; }
     void setState(State);
 
     State stateToRestore() const { return m_stateToRestore; }
 
-    enum InterruptionType : uint8_t {
-        NoInterruption,
-        SystemSleep,
-        EnteringBackground,
-        SystemInterruption,
-        SuspendedUnderLock,
-        InvisibleAutoplay,
-        ProcessInactive,
-        PlaybackSuspended,
-        PageNotVisible,
-    };
+    using InterruptionType = PlatformMediaSessionInterruptionType;
+
     InterruptionType interruptionType() const { return m_interruptionType; }
 
-    enum EndInterruptionFlags : uint8_t {
-        NoFlags = 0,
-        MayResumePlaying = 1 << 0,
-    };
+    using EndInterruptionFlags = PlatformMediaSessionEndInterruptionFlags;
 
     virtual void clientCharacteristicsChanged(bool);
 
     void beginInterruption(InterruptionType);
-    void endInterruption(EndInterruptionFlags);
+    void endInterruption(OptionSet<EndInterruptionFlags>);
 
     virtual void clientWillBeginAutoplaying();
     virtual bool clientWillBeginPlayback();
@@ -233,9 +244,9 @@ private:
 
     PlatformMediaSessionClient& m_client;
     MediaSessionIdentifier m_mediaSessionIdentifier;
-    State m_state { Idle };
-    State m_stateToRestore { Idle };
-    InterruptionType m_interruptionType { NoInterruption };
+    State m_state { State::Idle };
+    State m_stateToRestore { State::Idle };
+    InterruptionType m_interruptionType { InterruptionType::NoInterruption };
     int m_interruptionCount { 0 };
     bool m_active { false };
     bool m_notifyingClient { false };
@@ -335,51 +346,6 @@ struct LogArgument<WebCore::PlatformMediaSession::RemoteControlCommandType> {
     {
         return convertEnumerationToString(command);
     }
-};
-
-template <> struct EnumTraits<WebCore::PlatformMediaSession::MediaType> {
-    using values = EnumValues <
-    WebCore::PlatformMediaSession::MediaType,
-    WebCore::PlatformMediaSession::MediaType::None,
-    WebCore::PlatformMediaSession::MediaType::Video,
-    WebCore::PlatformMediaSession::MediaType::VideoAudio,
-    WebCore::PlatformMediaSession::MediaType::Audio,
-    WebCore::PlatformMediaSession::MediaType::WebAudio
-    >;
-};
-
-template <> struct EnumTraits<WebCore::PlatformMediaSession::State> {
-    using values = EnumValues <
-    WebCore::PlatformMediaSession::State,
-    WebCore::PlatformMediaSession::State::Idle,
-    WebCore::PlatformMediaSession::State::Autoplaying,
-    WebCore::PlatformMediaSession::State::Playing,
-    WebCore::PlatformMediaSession::State::Paused,
-    WebCore::PlatformMediaSession::State::Interrupted
-    >;
-};
-
-template <> struct EnumTraits<WebCore::PlatformMediaSession::InterruptionType> {
-    using values = EnumValues <
-    WebCore::PlatformMediaSession::InterruptionType,
-    WebCore::PlatformMediaSession::InterruptionType::NoInterruption,
-    WebCore::PlatformMediaSession::InterruptionType::SystemSleep,
-    WebCore::PlatformMediaSession::InterruptionType::EnteringBackground,
-    WebCore::PlatformMediaSession::InterruptionType::SystemInterruption,
-    WebCore::PlatformMediaSession::InterruptionType::SuspendedUnderLock,
-    WebCore::PlatformMediaSession::InterruptionType::InvisibleAutoplay,
-    WebCore::PlatformMediaSession::InterruptionType::ProcessInactive,
-    WebCore::PlatformMediaSession::InterruptionType::PlaybackSuspended,
-    WebCore::PlatformMediaSession::InterruptionType::PageNotVisible
-    >;
-};
-
-template <> struct EnumTraits<WebCore::PlatformMediaSession::EndInterruptionFlags> {
-    using values = EnumValues <
-    WebCore::PlatformMediaSession::EndInterruptionFlags,
-    WebCore::PlatformMediaSession::EndInterruptionFlags::NoFlags,
-    WebCore::PlatformMediaSession::EndInterruptionFlags::MayResumePlaying
-    >;
 };
 
 } // namespace WTF

--- a/Source/WebCore/platform/audio/PlatformMediaSession.serialization.in
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.serialization.in
@@ -39,3 +39,36 @@ enum class WebCore::PlatformMediaSessionRemoteControlCommandType : uint8_t {
     BeginScrubbingCommand,
     EndScrubbingCommand,
 };
+
+[Nested] enum class WebCore::PlatformMediaSessionMediaType : uint8_t {
+    None,
+    Video,
+    VideoAudio,
+    Audio,
+    WebAudio,
+};
+
+[Nested] enum class WebCore::PlatformMediaSessionState : uint8_t {
+    Idle,
+    Autoplaying,
+    Playing,
+    Paused,
+    Interrupted,
+};
+
+[Nested] enum class WebCore::PlatformMediaSessionInterruptionType : uint8_t {
+    NoInterruption,
+    SystemSleep,
+    EnteringBackground,
+    SystemInterruption,
+    SuspendedUnderLock,
+    InvisibleAutoplay,
+    ProcessInactive,
+    PlaybackSuspended,
+    PageNotVisible,
+};
+
+[Nested, OptionSet] enum class WebCore::PlatformMediaSessionEndInterruptionFlags : uint8_t {
+    NoFlags,
+    MayResumePlaying,
+};

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -247,7 +247,7 @@ bool PlatformMediaSessionManager::sessionWillBeginPlayback(PlatformMediaSession&
 
     auto sessionType = session.mediaType();
     auto restrictions = this->restrictions(sessionType);
-    if (session.state() == PlatformMediaSession::Interrupted && restrictions & InterruptedPlaybackNotPermitted) {
+    if (session.state() == PlatformMediaSession::State::Interrupted && restrictions & InterruptedPlaybackNotPermitted) {
         ALWAYS_LOG(LOGIDENTIFIER, session.logIdentifier(), " returning false because session.state() is Interrupted, and InterruptedPlaybackNotPermitted");
         return false;
     }
@@ -258,12 +258,12 @@ bool PlatformMediaSessionManager::sessionWillBeginPlayback(PlatformMediaSession&
     }
 
     if (m_currentInterruption)
-        endInterruption(PlatformMediaSession::NoFlags);
+        endInterruption(PlatformMediaSession::EndInterruptionFlags::NoFlags);
 
     if (restrictions & ConcurrentPlaybackNotPermitted) {
         forEachMatchingSession([&session](auto& oneSession) {
             return &oneSession != &session
-                && oneSession.state() == PlatformMediaSession::Playing
+                && oneSession.state() == PlatformMediaSession::State::Playing
                 && !oneSession.canPlayConcurrently(session);
         }, [](auto& oneSession) {
             oneSession.pauseSession();
@@ -286,7 +286,7 @@ void PlatformMediaSessionManager::sessionWillEndPlayback(PlatformMediaSession& s
         const auto& oneSession = *m_sessions[i];
         if (&oneSession == &session)
             pausingSessionIndex = i;
-        else if (oneSession.state() == PlatformMediaSession::Playing)
+        else if (oneSession.state() == PlatformMediaSession::State::Playing)
             lastPlayingSessionIndex = i;
         else
             break;
@@ -308,7 +308,7 @@ void PlatformMediaSessionManager::sessionStateChanged(PlatformMediaSession& sess
 {
     // Call updateSessionState() synchronously if the new state is Playing to ensure
     // the audio session is active and has the correct category before playback starts.
-    if (session.state() == PlatformMediaSession::Playing)
+    if (session.state() == PlatformMediaSession::State::Playing)
         updateSessionState();
     else
         scheduleUpdateSessionState();
@@ -347,7 +347,7 @@ void PlatformMediaSessionManager::applicationWillBecomeInactive()
     forEachMatchingSession([&](auto& session) {
         return restrictions(session.mediaType()) & InactiveProcessPlaybackRestricted;
     }, [](auto& session) {
-        session.beginInterruption(PlatformMediaSession::ProcessInactive);
+        session.beginInterruption(PlatformMediaSession::InterruptionType::ProcessInactive);
     });
 }
 
@@ -358,7 +358,7 @@ void PlatformMediaSessionManager::applicationDidBecomeActive()
     forEachMatchingSession([&](auto& session) {
         return restrictions(session.mediaType()) & InactiveProcessPlaybackRestricted;
     }, [](auto& session) {
-        session.endInterruption(PlatformMediaSession::MayResumePlaying);
+        session.endInterruption(PlatformMediaSession::EndInterruptionFlags::MayResumePlaying);
     });
 }
 
@@ -373,9 +373,9 @@ void PlatformMediaSessionManager::applicationDidEnterBackground(bool suspendedUn
 
     forEachSession([&] (auto& session) {
         if (suspendedUnderLock && restrictions(session.mediaType()) & SuspendedUnderLockPlaybackRestricted)
-            session.beginInterruption(PlatformMediaSession::SuspendedUnderLock);
+            session.beginInterruption(PlatformMediaSession::InterruptionType::SuspendedUnderLock);
         else if (restrictions(session.mediaType()) & BackgroundProcessPlaybackRestricted)
-            session.beginInterruption(PlatformMediaSession::EnteringBackground);
+            session.beginInterruption(PlatformMediaSession::InterruptionType::EnteringBackground);
     });
 }
 
@@ -391,7 +391,7 @@ void PlatformMediaSessionManager::applicationWillEnterForeground(bool suspendedU
     forEachMatchingSession([&](auto& session) {
         return (suspendedUnderLock && restrictions(session.mediaType()) & SuspendedUnderLockPlaybackRestricted) || restrictions(session.mediaType()) & BackgroundProcessPlaybackRestricted;
     }, [](auto& session) {
-        session.endInterruption(PlatformMediaSession::MayResumePlaying);
+        session.endInterruption(PlatformMediaSession::EndInterruptionFlags::MayResumePlaying);
     });
 }
 
@@ -440,8 +440,8 @@ void PlatformMediaSessionManager::sessionIsPlayingToWirelessPlaybackTargetChange
     if (!m_isApplicationInBackground || !(restrictions(session.mediaType()) & BackgroundProcessPlaybackRestricted))
         return;
 
-    if (session.state() != PlatformMediaSession::Interrupted)
-        session.beginInterruption(PlatformMediaSession::EnteringBackground);
+    if (session.state() != PlatformMediaSession::State::Interrupted)
+        session.beginInterruption(PlatformMediaSession::InterruptionType::EnteringBackground);
 }
 
 void PlatformMediaSessionManager::sessionCanProduceAudioChanged()
@@ -480,7 +480,7 @@ void PlatformMediaSessionManager::processSystemWillSleep()
         return;
 
     forEachSession([] (auto& session) {
-        session.beginInterruption(PlatformMediaSession::SystemSleep);
+        session.beginInterruption(PlatformMediaSession::InterruptionType::SystemSleep);
     });
 }
 
@@ -490,7 +490,7 @@ void PlatformMediaSessionManager::processSystemDidWake()
         return;
 
     forEachSession([] (auto& session) {
-        session.endInterruption(PlatformMediaSession::MayResumePlaying);
+        session.endInterruption(PlatformMediaSession::EndInterruptionFlags::MayResumePlaying);
     });
 }
 
@@ -506,7 +506,7 @@ bool PlatformMediaSessionManager::mediaPlaybackIsPaused(MediaSessionGroupIdentif
 {
     bool mediaPlaybackIsPaused = false;
     forEachSessionInGroup(mediaSessionGroupIdentifier, [&mediaPlaybackIsPaused](auto& session) {
-        if (session.state() == PlatformMediaSession::Paused)
+        if (session.state() == PlatformMediaSession::State::Paused)
             mediaPlaybackIsPaused = true;
     });
     return mediaPlaybackIsPaused;
@@ -522,14 +522,14 @@ void PlatformMediaSessionManager::stopAllMediaPlaybackForProcess()
 void PlatformMediaSessionManager::suspendAllMediaPlaybackForGroup(MediaSessionGroupIdentifier mediaSessionGroupIdentifier)
 {
     forEachSessionInGroup(mediaSessionGroupIdentifier, [](auto& session) {
-        session.beginInterruption(PlatformMediaSession::PlaybackSuspended);
+        session.beginInterruption(PlatformMediaSession::InterruptionType::PlaybackSuspended);
     });
 }
 
 void PlatformMediaSessionManager::resumeAllMediaPlaybackForGroup(MediaSessionGroupIdentifier mediaSessionGroupIdentifier)
 {
     forEachSessionInGroup(mediaSessionGroupIdentifier, [](auto& session) {
-        session.endInterruption(PlatformMediaSession::MayResumePlaying);
+        session.endInterruption(PlatformMediaSession::EndInterruptionFlags::MayResumePlaying);
     });
 }
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -345,7 +345,7 @@ void MediaSessionManagerCocoa::sessionWillEndPlayback(PlatformMediaSession& sess
     // This allows other applications to resume playback after an "alert-like" audio
     // is played by web content.
 
-    if (!anyOfSessions([] (auto& session) { return session.state() == PlatformMediaSession::Playing; })
+    if (!anyOfSessions([] (auto& session) { return session.state() == PlatformMediaSession::State::Playing; })
         && session.presentationType() == PlatformMediaSession::MediaType::Audio
         && session.isEnded()
         && session.isLongEnoughForMainContent())

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -73,8 +73,8 @@ private:
     void sessionWillEndPlayback(PlatformMediaSession&, DelayCallingUpdateNowPlaying) final;
 
     // AudioSession::InterruptionObserver
-    void beginAudioSessionInterruption() final { beginInterruption(PlatformMediaSession::SystemInterruption); }
-    void endAudioSessionInterruption(AudioSession::MayResume mayResume) final { endInterruption(mayResume == AudioSession::MayResume::Yes ? PlatformMediaSession::MayResumePlaying : PlatformMediaSession::NoFlags); }
+    void beginAudioSessionInterruption() final { beginInterruption(PlatformMediaSession::InterruptionType::SystemInterruption); }
+    void endAudioSessionInterruption(AudioSession::MayResume mayResume) final { endInterruption(mayResume == AudioSession::MayResume::Yes ? PlatformMediaSession::EndInterruptionFlags::MayResumePlaying : PlatformMediaSession::EndInterruptionFlags::NoFlags); }
 
     // MediaSessionHelperClient
     void applicationWillEnterForeground(SuspendedUnderLock) final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -151,7 +151,7 @@ void MediaSessionManageriOS::sessionWillEndPlayback(PlatformMediaSession& sessio
     MediaSessionManagerCocoa::sessionWillEndPlayback(session, delayCallingUpdateNowPlaying);
 
 #if USE(AUDIO_SESSION)
-    if (isApplicationInBackground() && !anyOfSessions([] (auto& session) { return session.state() == PlatformMediaSession::Playing; }))
+    if (isApplicationInBackground() && !anyOfSessions([] (auto& session) { return session.state() == PlatformMediaSession::State::Playing; }))
         maybeDeactivateAudioSession();
 #endif
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4559,16 +4559,16 @@ void Internals::enableMockMediaCapabilities()
 
 ExceptionOr<void> Internals::beginMediaSessionInterruption(const String& interruptionString)
 {
-    PlatformMediaSession::InterruptionType interruption = PlatformMediaSession::SystemInterruption;
+    PlatformMediaSession::InterruptionType interruption = PlatformMediaSession::InterruptionType::SystemInterruption;
 
     if (equalLettersIgnoringASCIICase(interruptionString, "system"_s))
-        interruption = PlatformMediaSession::SystemInterruption;
+        interruption = PlatformMediaSession::InterruptionType::SystemInterruption;
     else if (equalLettersIgnoringASCIICase(interruptionString, "systemsleep"_s))
-        interruption = PlatformMediaSession::SystemSleep;
+        interruption = PlatformMediaSession::InterruptionType::SystemSleep;
     else if (equalLettersIgnoringASCIICase(interruptionString, "enteringbackground"_s))
-        interruption = PlatformMediaSession::EnteringBackground;
+        interruption = PlatformMediaSession::InterruptionType::EnteringBackground;
     else if (equalLettersIgnoringASCIICase(interruptionString, "suspendedunderlock"_s))
-        interruption = PlatformMediaSession::SuspendedUnderLock;
+        interruption = PlatformMediaSession::InterruptionType::SuspendedUnderLock;
     else
         return Exception { ExceptionCode::InvalidAccessError };
 
@@ -4578,10 +4578,10 @@ ExceptionOr<void> Internals::beginMediaSessionInterruption(const String& interru
 
 void Internals::endMediaSessionInterruption(const String& flagsString)
 {
-    PlatformMediaSession::EndInterruptionFlags flags = PlatformMediaSession::NoFlags;
+    PlatformMediaSession::EndInterruptionFlags flags = PlatformMediaSession::EndInterruptionFlags::NoFlags;
 
     if (equalLettersIgnoringASCIICase(flagsString, "mayresumeplaying"_s))
-        flags = PlatformMediaSession::MayResumePlaying;
+        flags = PlatformMediaSession::EndInterruptionFlags::MayResumePlaying;
 
     PlatformMediaSessionManager::sharedManager().endInterruption(flags);
 }


### PR DESCRIPTION
#### 362150b0a4ce0acd454616a3e58ff789b3a35492
<pre>
Port PlatformMediaSession enums to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264807">https://bugs.webkit.org/show_bug.cgi?id=264807</a>

Reviewed by Chris Dumez.

Port the enums to the serialization format, and the flags enum
to OptionSet.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::resumeRendering):
(WebCore::AudioContext::suspend):
(WebCore::AudioContext::resume):
(WebCore::AudioContext::suspendPlayback):
(WebCore::AudioContext::defaultDestinationWillBecomeConnected):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::pausedForUserInteraction const):
(WebCore::HTMLMediaElement::virtualHasPendingActivity const):
(WebCore::HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction const):
(WebCore::HTMLMediaElement::updateShouldAutoplay):
(WebCore::HTMLMediaElement::playbackControlsManagerBehaviorRestrictionsTimerFired):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::visibilityChanged):
(WebCore::MediaElementSession::clientDataBufferingTimerFired):
(WebCore::MediaElementSession::preferredBufferingPolicy const):
(WebCore::MediaElementSession::nowPlayingInfo const):
(WebCore::MediaElementSession::updateMediaUsageIfChanged):
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::convertEnumerationToString):
(WebCore::PlatformMediaSession::beginInterruption):
(WebCore::PlatformMediaSession::endInterruption):
(WebCore::PlatformMediaSession::clientWillBeginAutoplaying):
(WebCore::PlatformMediaSession::clientWillBeginPlayback):
(WebCore::PlatformMediaSession::processClientWillPausePlayback):
(WebCore::PlatformMediaSession::pauseSession):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
* Source/WebCore/platform/audio/PlatformMediaSession.serialization.in:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::sessionWillBeginPlayback):
(WebCore::PlatformMediaSessionManager::sessionWillEndPlayback):
(WebCore::PlatformMediaSessionManager::sessionStateChanged):
(WebCore::PlatformMediaSessionManager::applicationWillBecomeInactive):
(WebCore::PlatformMediaSessionManager::applicationDidBecomeActive):
(WebCore::PlatformMediaSessionManager::applicationDidEnterBackground):
(WebCore::PlatformMediaSessionManager::applicationWillEnterForeground):
(WebCore::PlatformMediaSessionManager::sessionIsPlayingToWirelessPlaybackTargetChanged):
(WebCore::PlatformMediaSessionManager::processSystemWillSleep):
(WebCore::PlatformMediaSessionManager::processSystemDidWake):
(WebCore::PlatformMediaSessionManager::mediaPlaybackIsPaused):
(WebCore::PlatformMediaSessionManager::suspendAllMediaPlaybackForGroup):
(WebCore::PlatformMediaSessionManager::resumeAllMediaPlaybackForGroup):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::sessionWillEndPlayback):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::beginMediaSessionInterruption):
(WebCore::Internals::endMediaSessionInterruption):

Canonical link: <a href="https://commits.webkit.org/270719@main">https://commits.webkit.org/270719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f43e82a1cab49b04896351501a20c16c4b6c327c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28301 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2240 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3675 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28879 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3272 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29570 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23895 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27455 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3313 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4721 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6302 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->