### PR TITLE
Sort the two Theme::userPrefers* methods

### DIFF
--- a/Source/WebCore/platform/Theme.cpp
+++ b/Source/WebCore/platform/Theme.cpp
@@ -79,17 +79,6 @@ void Theme::inflateControlPaintRect(StyleAppearance, const ControlStates&, Float
 {
 }
 
-bool Theme::userPrefersReducedMotion() const
-{
-    return false;
-}
-
-bool Theme::userPrefersContrast() const
-{
-    return false;
-}
-
-
 LengthBox Theme::controlBorder(StyleAppearance appearance, const FontCascade&, const LengthBox& zoomedBox, float) const
 {
     switch (appearance) {

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -81,8 +81,8 @@ public:
 
     virtual void drawNamedImage(const String&, GraphicsContext&, const FloatSize&) const;
 
-    virtual bool userPrefersContrast() const;
-    virtual bool userPrefersReducedMotion() const;
+    virtual bool userPrefersContrast() const { return false; }
+    virtual bool userPrefersReducedMotion() const { return false; }
 
 protected:
     Theme() = default;

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
@@ -595,11 +595,6 @@ Color ThemeAdwaita::accentColor()
     return m_accentColor;
 }
 
-bool ThemeAdwaita::userPrefersReducedMotion() const
-{
-    return m_prefersReducedMotion;
-}
-
 bool ThemeAdwaita::userPrefersContrast() const
 {
 #if !USE(GTK4)
@@ -607,6 +602,11 @@ bool ThemeAdwaita::userPrefersContrast() const
 #else
     return false;
 #endif
+}
+
+bool ThemeAdwaita::userPrefersReducedMotion() const
+{
+    return m_prefersReducedMotion;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.h
@@ -49,8 +49,8 @@ public:
 
     virtual void platformColorsDidChange() { };
 
-    bool userPrefersReducedMotion() const final;
     bool userPrefersContrast() const final;
+    bool userPrefersReducedMotion() const final;
 
     void setAccentColor(const Color&);
     Color accentColor();

--- a/Source/WebCore/platform/ios/ThemeIOS.h
+++ b/Source/WebCore/platform/ios/ThemeIOS.h
@@ -33,8 +33,8 @@ namespace WebCore {
 
 class ThemeIOS final : public ThemeCocoa {
 private:
-    bool userPrefersReducedMotion() const final;
     bool userPrefersContrast() const final;
+    bool userPrefersReducedMotion() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/ThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ThemeIOS.mm
@@ -39,14 +39,14 @@ Theme& Theme::singleton()
     return theme;
 }
 
-bool ThemeIOS::userPrefersReducedMotion() const
-{
-    return PAL::softLink_UIKit_UIAccessibilityIsReduceMotionEnabled();
-}
-
 bool ThemeIOS::userPrefersContrast() const
 {
     return PAL::softLink_UIKit_UIAccessibilityDarkerSystemColorsEnabled();
+}
+
+bool ThemeIOS::userPrefersReducedMotion() const
+{
+    return PAL::softLink_UIKit_UIAccessibilityIsReduceMotionEnabled();
 }
 
 }

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -58,8 +58,8 @@ private:
 
     void inflateControlPaintRect(StyleAppearance, const ControlStates&, FloatRect&, float zoomFactor) const final;
 
-    bool userPrefersReducedMotion() const final;
     bool userPrefersContrast() const final;
+    bool userPrefersReducedMotion() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -711,14 +711,14 @@ void ThemeMac::inflateControlPaintRect(StyleAppearance appearance, const Control
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-bool ThemeMac::userPrefersReducedMotion() const
-{
-    return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion];
-}
-
 bool ThemeMac::userPrefersContrast() const
 {
     return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
+}
+
+bool ThemeMac::userPrefersReducedMotion() const
+{
+    return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion];
 }
 
 bool ThemeMac::supportsLargeFormControls()


### PR DESCRIPTION
#### 19e0a37f75482d982ec3c2b312540dee28382268
<pre>
Sort the two Theme::userPrefers* methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=264809">https://bugs.webkit.org/show_bug.cgi?id=264809</a>
<a href="https://rdar.apple.com/118389508">rdar://118389508</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/platform/Theme.cpp:
(WebCore::Theme::userPrefersReducedMotion const): Deleted.
(WebCore::Theme::userPrefersContrast const): Deleted.
* Source/WebCore/platform/Theme.h:
(WebCore::Theme::userPrefersContrast const):
(WebCore::Theme::userPrefersReducedMotion const):
* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
(WebCore::ThemeAdwaita::userPrefersReducedMotion const):
* Source/WebCore/platform/adwaita/ThemeAdwaita.h:
* Source/WebCore/platform/ios/ThemeIOS.h:
* Source/WebCore/platform/ios/ThemeIOS.mm:
(WebCore::ThemeIOS::userPrefersContrast const):
(WebCore::ThemeIOS::userPrefersReducedMotion const):
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::userPrefersContrast const):
(WebCore::ThemeMac::userPrefersReducedMotion const):

Canonical link: <a href="https://commits.webkit.org/270711@main">https://commits.webkit.org/270711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75f818a2e69528aef38dbf2f6a7d199bc22cfea7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26504 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/6597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23994 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28848 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3247 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29538 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27430 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1495 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4694 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6297 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->