### PR TITLE
New test: imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html is a consistent/flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html
@@ -21,7 +21,10 @@ promise_test(async t => {
   ctx.fillStyle = "blue";
   const drawCanvas = () => {
     ctx.fillRect(0, 0, canvas.width, canvas.height);
+    setTimeout(drawCanvas, 50);
   };
+
+  drawCanvas();
 
   let pc1 = new RTCPeerConnection();
   let pc2 = new RTCPeerConnection();
@@ -32,6 +35,7 @@ promise_test(async t => {
 
   const destVideo = document.createElement('video');
   destVideo.autoplay = true;
+  destVideo.muted = true;
   const onVideoChange = async () => {
     const start = performance.now();
     const width = destVideo.videoWidth;
@@ -41,10 +45,9 @@ promise_test(async t => {
       if (performance.now() - start > 5000) {
         throw new Error("Timeout waiting for video size change");
       }
-      drawCanvas();
       await Promise.race([
         resizeEvent,
-        new Promise(r => requestAnimationFrame(r)),
+        new Promise(r => setTimeout(r, 50)),
       ]);
     }
   };
@@ -69,7 +72,7 @@ promise_test(async t => {
   destVideo.srcObject = new MediaStream([(await haveTrackEvent).track]);
 
   // Wait for video on the other side.
-  await onVideoChange();
+  await destVideo.play();
   const color = getVideoSignal(destVideo);
   assert_not_equals(color, 0);
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1804,8 +1804,6 @@ webkit.org/b/259740 [ Ventura Release arm64 ] css3/color-filters/color-filter-ou
 
 webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pass Failure ]
 
-webkit.org/b/260225 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html [ Pass Failure ]
-
 # rdar://102425691 ([ New Test ](256068@main): [ Ventura+ ] http/wpt/webcodecs/videoFrame-colorSpace.html is a consistent failure)
 [ Ventura+ ] http/wpt/webcodecs/videoFrame-colorSpace.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 4777271bc3152771c7bb4e7a25d700863de12bd4
<pre>
New test: imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html is a consistent/flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260225">https://bugs.webkit.org/show_bug.cgi?id=260225</a>
<a href="https://rdar.apple.com/113932040">rdar://113932040</a>

Reviewed by Jean-Yves Avenard.

The test was assuming that after the resize event, it would be possible to draw the video element in the canvas.
This is not guaranteed since the resize event may fire in HAVE_METADATA.

We replace the first call of onVideoChange by calling HTMLMediaElement.play().
To make it work, we trigger a canvas frame every 50 ms, instead of triggering frames when checking for the resize event.
We mute the media element to make the HTMLMediaElement.play() call work in all browsers.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270875@main">https://commits.webkit.org/270875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b484178f1c05dfb2904c6994c72bfff99017c5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23966 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23995 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23888 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29541 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3287 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1496 "Found 1 new test failure: compositing/absolute-inside-out-of-view-fixed.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27432 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6407 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->