### PR TITLE
[GStreamer] Video goes blank on some platforms after playback ends

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -150,7 +150,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
     , m_preload(player->preload())
     , m_maxTimeLoadedAtLastDidLoadingProgress(MediaTime::zeroTime())
     , m_drawTimer(RunLoop::main(), this, &MediaPlayerPrivateGStreamer::repaint)
-    , m_readyTimerHandler(RunLoop::main(), this, &MediaPlayerPrivateGStreamer::readyTimerFired)
+    , m_pausedTimerHandler(RunLoop::main(), this, &MediaPlayerPrivateGStreamer::pausedTimerFired)
 #if USE(TEXTURE_MAPPER_GL) && !USE(NICOSIA)
     , m_platformLayerProxy(adoptRef(new TextureMapperPlatformLayerProxyGL))
 #endif
@@ -164,7 +164,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
     , m_loader(player->createResourceLoader())
 {
 #if USE(GLIB)
-    m_readyTimerHandler.setPriority(G_PRIORITY_DEFAULT_IDLE);
+    m_pausedTimerHandler.setPriority(G_PRIORITY_DEFAULT_IDLE);
 #endif
     m_isPlayerShuttingDown.store(false);
 
@@ -203,7 +203,7 @@ MediaPlayerPrivateGStreamer::~MediaPlayerPrivateGStreamer()
     if (m_fillTimer.isActive())
         m_fillTimer.stop();
 
-    m_readyTimerHandler.stop();
+    m_pausedTimerHandler.stop();
 
     if (m_videoSink) {
         GRefPtr<GstPad> videoSinkPad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
@@ -938,12 +938,13 @@ bool MediaPlayerPrivateGStreamer::changePipelineState(GstState newState)
 
     // Create a timer when entering the READY state so that we can free resources if we stay for too long on READY.
     // Also lets remove the timer if we request a state change for any state other than READY. See also https://bugs.webkit.org/show_bug.cgi?id=117354
-    if (newState == GST_STATE_READY && !m_readyTimerHandler.isActive()) {
-        // Max interval in seconds to stay in the READY state on manual state change requests.
-        static const Seconds readyStateTimerDelay { 1_min };
-        m_readyTimerHandler.startOneShot(readyStateTimerDelay);
-    } else if (newState != GST_STATE_READY)
-        m_readyTimerHandler.stop();
+    if (newState == GST_STATE_PAUSED && m_isEndReached && m_player.get() && !m_player.get()->isLooping()
+        && !isMediaSource() && !m_pausedTimerHandler.isActive()) {
+        // Max interval in seconds to stay in the PAUSED state after video finished on manual state change requests.
+        static const Seconds readyStateTimerDelay { 5_min };
+        m_pausedTimerHandler.startOneShot(readyStateTimerDelay);
+    } else if (newState != GST_STATE_PAUSED)
+        m_pausedTimerHandler.stop();
 
     return true;
 }
@@ -1260,7 +1261,7 @@ void MediaPlayerPrivateGStreamer::loadingFailed(MediaPlayer::NetworkState networ
     }
 
     // Loading failed, remove ready timer.
-    m_readyTimerHandler.stop();
+    m_pausedTimerHandler.stop();
 }
 
 GstElement* MediaPlayerPrivateGStreamer::createAudioSink()
@@ -2750,7 +2751,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
 
     if (player && !player->isLooping() && !isMediaSource()) {
         m_isPaused = true;
-        changePipelineState(GST_STATE_READY);
+        changePipelineState(GST_STATE_PAUSED);
         m_didDownloadFinish = false;
         configureMediaStreamAudioTracks();
     }
@@ -3139,9 +3140,9 @@ bool MediaPlayerPrivateGStreamer::canSaveMediaData() const
     return false;
 }
 
-void MediaPlayerPrivateGStreamer::readyTimerFired()
+void MediaPlayerPrivateGStreamer::pausedTimerFired()
 {
-    GST_DEBUG_OBJECT(pipeline(), "In READY for too long. Releasing pipeline resources.");
+    GST_DEBUG_OBJECT(pipeline(), "In PAUSED for too long. Releasing pipeline resources.");
     changePipelineState(GST_STATE_NULL);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -316,7 +316,7 @@ protected:
     static void volumeChangedCallback(MediaPlayerPrivateGStreamer*);
     static void muteChangedCallback(MediaPlayerPrivateGStreamer*);
 
-    void readyTimerFired();
+    void pausedTimerFired();
 
     template <typename TrackPrivateType> void notifyPlayerOfTrack();
 
@@ -543,7 +543,7 @@ private:
     Condition m_drawCondition;
     Lock m_drawLock;
     RunLoop::Timer m_drawTimer WTF_GUARDED_BY_LOCK(m_drawLock);
-    RunLoop::Timer m_readyTimerHandler;
+    RunLoop::Timer m_pausedTimerHandler;
 #if USE(TEXTURE_MAPPER_GL)
 #if USE(NICOSIA)
     RefPtr<Nicosia::ContentLayer> m_nicosiaLayer;


### PR DESCRIPTION
#### e062421ac00d6f0f6b72d6278c5791eb35c5de18
<pre>
[GStreamer] Video goes blank on some platforms after playback ends
<a href="https://bugs.webkit.org/show_bug.cgi?id=264739">https://bugs.webkit.org/show_bug.cgi?id=264739</a>

Reviewed by NOBODY (OOPS!).

On some downstream platforms, the video gets black after playback finishes.

This happens because <a href="https://bugs.webkit.org/show_bug.cgi?id=89122">https://bugs.webkit.org/show_bug.cgi?id=89122</a> used to set
the pipeline to NULL, although later <a href="https://bugs.webkit.org/show_bug.cgi?id=117354">https://bugs.webkit.org/show_bug.cgi?id=117354</a>
set it to READY. This change deinitializes a big part of the pipeline, which
should otherwise stay in a working state if the state was PAUSED as it should
be without those changes. While on desktop platforms the last video frame is
still kept and shown, on some downstream platforms using a custom multimedia
subsystem the deinitialization destroys internal resources and makes that last
video frame not to be visible anymore.

The original purpose of the mentioned bugs was to avoid having the audio device
opened after the video finished. This was relevant in 2012, when many
platforms still used ALSA as a sound system, but it&apos;s not so relevant nowadays,
when PulseAudio is the usual choice on desktop.

This patch reworks the readyTimerHandler and readyTimerFired into
pausedTimerHandler and pausedTimerFired, because now the pipeline stays in
PAUSED and having a timer to eventually releasing resources by transitioning
to NULL still makes sense. The timeout has been increased to 5 minutes and
maybe it would eventually need to be even larger.

Original author: suresh-khurdiya-epam &lt;skhurdiya.contractor@libertyglobal.com&gt;

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1205">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1205</a>

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer): Renamed m_readyTimerHandler to m_pausedTimerHandler.
(WebCore::MediaPlayerPrivateGStreamer::~MediaPlayerPrivateGStreamer): Ditto.
(WebCore::MediaPlayerPrivateGStreamer::changePipelineState): Ditto, and added extra conditions to only start the timer on PAUSE at end.
(WebCore::MediaPlayerPrivateGStreamer::loadingFailed): Ditto.
(WebCore::MediaPlayerPrivateGStreamer::didEnd): Set the pipeline to PAUSED on end, instead of setting it to READY.
(WebCore::MediaPlayerPrivateGStreamer::pausedTimerFired): Renamed from readyTimerFired.
(WebCore::MediaPlayerPrivateGStreamer::readyTimerFired): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: Renamed m_readyTimerHandler to m_pausedTimerHandler and readyTimerFired() to pausedTimerFired().
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e062421ac00d6f0f6b72d6278c5791eb35c5de18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26178 "Failed to checkout and rebase branch from PR 20480") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4789 "Failed to checkout and rebase branch from PR 20480") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27453 "Failed to checkout and rebase branch from PR 20480") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28275 "Failed to checkout and rebase branch from PR 20480") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23967 "Failed to checkout and rebase branch from PR 20480") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26506 "Failed to checkout and rebase branch from PR 20480") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6572 "Failed to checkout and rebase branch from PR 20480") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2210 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/28275 "Failed to checkout and rebase branch from PR 20480") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26435 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/6572 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/27453 "Failed to checkout and rebase branch from PR 20480") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28850 "Failed to checkout and rebase branch from PR 20480") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/6572 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/27453 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/28850 "Failed to checkout and rebase branch from PR 20480") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/6572 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/27453 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/28850 "Failed to checkout and rebase branch from PR 20480") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3288 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/2210 "Failed to checkout and rebase branch from PR 20480") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4696 "Failed to checkout and rebase branch from PR 20480") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/27453 "Failed to checkout and rebase branch from PR 20480") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3755 "Failed to checkout and rebase branch from PR 20480") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3610 "Failed to checkout and rebase branch from PR 20480") | | | 
<!--EWS-Status-Bubble-End-->