### PR TITLE
Add the ability for the IPCTestingAPI to report when a sync stream message fails to be deserialized correctly

### DIFF
--- a/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception-expected.txt
+++ b/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Sending sync stream message with incorrect parameters to the UI process shouldn't crash when IPCTestingAPI is enabled
+PASS Sending sync stream message with incorrect parameters to the GPU process shouldn't crash when IPCTestingAPI is enabled
+

--- a/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html
+++ b/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html
@@ -1,0 +1,61 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that sending invalid messages via the IPC testing StreamConnectoin API doesn't kill the receiver</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+const defaultTimeout = 1000;
+const bufferSizeLog2 = 9;
+const streamTesterID = 447;
+
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+
+    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+    streamConnection.open();
+    IPC.sendMessage("UI", 0, IPC.messages.IPCTester_CreateStreamTester.name, [
+        { type: 'uint64_t', value: streamTesterID },
+        { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
+    ]);
+    const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+    streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
+
+    // Test starts here.
+    try {
+        assert_throws_js(TypeError,
+        () => { streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageEmptyReply.name, defaultTimeout, [  ]) },
+        `failed sync message must throw error`);
+    } finally {
+        IPC.sendSyncMessage("UI", 0, IPC.messages.IPCTester_ReleaseStreamTester.name, defaultTimeout, [{ type: 'uint64_t', value: streamTesterID }]);
+        streamConnection.invalidate();
+    }
+
+}, "Sending sync stream message with incorrect parameters to the UI process shouldn't crash when IPCTestingAPI is enabled");
+
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+
+    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+    streamConnection.open();
+    IPC.sendMessage("GPU", 0, IPC.messages.IPCTester_CreateStreamTester.name, [
+        { type: 'uint64_t', value: streamTesterID },
+        { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
+    ]);
+    const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+    streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
+
+    // Test starts here.
+    try {
+        assert_throws_js(TypeError,
+        () => { streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageEmptyReply.name, defaultTimeout, [  ]) },
+        `failed sync message must throw error`);
+    } finally {
+        IPC.sendSyncMessage("GPU", 0, IPC.messages.IPCTester_ReleaseStreamTester.name, defaultTimeout, [{ type: 'uint64_t', value: streamTesterID }]);
+        streamConnection.invalidate();
+    }
+
+}, "Sending sync stream message with incorrect parameters to the GPU process shouldn't crash when IPCTestingAPI is enabled");
+
+</script>

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -597,7 +597,11 @@ RemoteImageDecoderAVFProxy& GPUConnectionToWebProcess::imageDecoderAVFProxy()
 
 void GPUConnectionToWebProcess::createRenderingBackend(RemoteRenderingBackendCreationParameters&& creationParameters, IPC::StreamServerConnection::Handle&& connectionHandle)
 {
-    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle));
+    IPC::StreamServerConnectionParameters params;
+#if ENABLE(IPC_TESTING_API)
+    params.ignoreInvalidMessageForTesting = connection().ignoreInvalidMessageForTesting();
+#endif
+    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
     auto addResult = m_remoteRenderingBackendMap.ensure(creationParameters.identifier, [&, streamConnection = WTFMove(streamConnection)] () mutable {
@@ -628,7 +632,11 @@ void GPUConnectionToWebProcess::createGraphicsContextGL(WebCore::GraphicsContext
         return;
     auto* renderingBackend = it->value.get();
 
-    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle));
+    IPC::StreamServerConnectionParameters params;
+#if ENABLE(IPC_TESTING_API)
+    params.ignoreInvalidMessageForTesting = connection().ignoreInvalidMessageForTesting();
+#endif
+    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
     auto addResult = m_remoteGraphicsContextGLMap.ensure(graphicsContextGLIdentifier, [&, streamConnection = WTFMove(streamConnection)] () mutable {
@@ -679,7 +687,11 @@ void GPUConnectionToWebProcess::createRemoteGPU(WebGPUIdentifier identifier, Ren
         return;
     auto* renderingBackend = it->value.get();
 
-    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle));
+    IPC::StreamServerConnectionParameters params;
+#if ENABLE(IPC_TESTING_API)
+    params.ignoreInvalidMessageForTesting = connection().ignoreInvalidMessageForTesting();
+#endif
+    auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
     auto addResult = m_remoteGPUMap.ensure(identifier, [&, streamConnection = WTFMove(streamConnection)] () mutable {

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -288,8 +288,12 @@ void handleMessageSynchronous(StreamServerConnection& connection, Decoder& decod
         return;
 
     auto arguments = decoder.decode<typename MessageType::Arguments>();
-    if (UNLIKELY(!arguments))
+    if (UNLIKELY(!arguments)) {
+#if ENABLE(IPC_TESTING_API)
+        connection.sendDeserializationErrorSyncReply(syncRequestID);
+#endif
         return;
+    }
 
     static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
     using CompletionHandlerType = typename ValidationType::CompletionHandlerType;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -33,13 +33,19 @@
 
 namespace IPC {
 
-RefPtr<StreamServerConnection> StreamServerConnection::tryCreate(Handle&& handle)
+RefPtr<StreamServerConnection> StreamServerConnection::tryCreate(Handle&& handle, const StreamServerConnectionParameters& params)
 {
     auto buffer = StreamServerConnectionBuffer::map(WTFMove(handle.buffer));
     if (!buffer)
         return { };
 
     auto connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(handle.outOfStreamConnection) });
+
+#if ENABLE(IPC_TESTING_API)
+    if (params.ignoreInvalidMessageForTesting)
+        connection->setIgnoreInvalidMessageForTesting();
+#endif
+
     return adoptRef(*new StreamServerConnection(WTFMove(connection), WTFMove(*buffer)));
 }
 
@@ -204,6 +210,10 @@ bool StreamServerConnection::dispatchStreamMessage(Decoder&& decoder, StreamMess
     receiver.didReceiveStreamMessage(*this, decoder);
     m_isDispatchingStreamMessage = false;
     if (!decoder.isValid()) {
+#if ENABLE(IPC_TESTING_API)
+        if (m_connection->ignoreInvalidMessageForTesting())
+            return false;
+#endif // ENABLE(IPC_TESTING_API)
         m_connection->dispatchDidReceiveInvalidMessage(decoder.messageName());
         return false;
     }
@@ -238,6 +248,10 @@ bool StreamServerConnection::dispatchOutOfStreamMessage(Decoder&& decoder)
     if (receiver) {
         receiver->didReceiveStreamMessage(*this, *message);
         if (!message->isValid()) {
+#if ENABLE(IPC_TESTING_API)
+            if (m_connection->ignoreInvalidMessageForTesting())
+                return false;
+#endif // ENABLE(IPC_TESTING_API)
             m_connection->dispatchDidReceiveInvalidMessage(message->messageName());
             return false;
         }
@@ -250,5 +264,15 @@ bool StreamServerConnection::dispatchOutOfStreamMessage(Decoder&& decoder)
         m_clientWaitSemaphore.signal();
     return true;
 }
+
+#if ENABLE(IPC_TESTING_API)
+void StreamServerConnection::sendDeserializationErrorSyncReply(Connection::SyncRequestID syncRequestID)
+{
+    auto encoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, syncRequestID.toUInt64());
+    encoder->setSyncMessageDeserializationFailure();
+    m_connection->sendSyncReply(WTFMove(encoder));
+}
+#endif
+
 
 }

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -52,6 +52,12 @@ struct StreamServerConnectionHandle {
     StreamConnectionBuffer::Handle buffer;
 };
 
+struct StreamServerConnectionParameters {
+#if ENABLE(IPC_TESTING_API)
+    bool ignoreInvalidMessageForTesting { false };
+#endif
+};
+
 // StreamServerConnection represents the connection between stream client and server, as used by the server.
 //
 // StreamServerConnection:
@@ -68,7 +74,7 @@ public:
     using AsyncReplyID = Connection::AsyncReplyID;
     using Handle = StreamServerConnectionHandle;
 
-    static RefPtr<StreamServerConnection> tryCreate(Handle&&);
+    static RefPtr<StreamServerConnection> tryCreate(Handle&&, const StreamServerConnectionParameters&);
     ~StreamServerConnection() final;
 
     void startReceivingMessages(StreamMessageReceiver&, ReceiverName, uint64_t destinationID);
@@ -90,6 +96,10 @@ public:
 
     template<typename T, typename... Arguments>
     void sendSyncReply(Connection::SyncRequestID, Arguments&&...);
+
+#if ENABLE(IPC_TESTING_API)
+    void sendDeserializationErrorSyncReply(Connection::SyncRequestID);
+#endif
 
     template<typename T, typename... Arguments>
     void sendAsyncReply(AsyncReplyID, Arguments&&...);

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -42,16 +42,16 @@
 
 namespace WebKit {
 
-RefPtr<IPCStreamTester> IPCStreamTester::create(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle)
+RefPtr<IPCStreamTester> IPCStreamTester::create(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle, bool ignoreInvalidMessageForTesting)
 {
-    auto tester = adoptRef(*new IPCStreamTester(identifier, WTFMove(connectionHandle)));
+    auto tester = adoptRef(*new IPCStreamTester(identifier, WTFMove(connectionHandle), ignoreInvalidMessageForTesting));
     tester->initialize();
     return tester;
 }
 
-IPCStreamTester::IPCStreamTester(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle)
+IPCStreamTester::IPCStreamTester(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle, bool ignoreInvalidMessageForTesting)
     : m_workQueue(IPC::StreamConnectionWorkQueue::create("IPCStreamTester work queue"))
-    , m_streamConnection(IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle)).releaseNonNull())
+    , m_streamConnection(IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), { ignoreInvalidMessageForTesting }).releaseNonNull())
     , m_identifier(identifier)
 {
 }
@@ -91,6 +91,11 @@ void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, Comp
         return WTFMove(*handle);
     }();
     completionHandler(WTFMove(result));
+}
+
+void IPCStreamTester::syncMessageEmptyReply(uint32_t, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
 }
 
 void IPCStreamTester::syncCrashOnZero(int32_t value, CompletionHandler<void(int32_t)>&& completionHandler)

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -46,19 +46,20 @@ namespace WebKit {
 // Interface to test various IPC stream related activities.
 class IPCStreamTester final : public IPC::StreamMessageReceiver {
 public:
-    static RefPtr<IPCStreamTester> create(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
+    static RefPtr<IPCStreamTester> create(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&, bool ignoreInvalidMessageForTesting);
     void stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnection);
 
     // IPC::StreamMessageReceiver overrides.
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 private:
-    IPCStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
+    IPCStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&, bool ignoreInvalidMessageForTesting);
     ~IPCStreamTester();
     void initialize();
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
 
     // Messages.
     void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&&);
+    void syncMessageEmptyReply(uint32_t, CompletionHandler<void()>&&);
     void syncCrashOnZero(int32_t, CompletionHandler<void(int32_t)>&&);
     void checkAutoreleasePool(CompletionHandler<void(int32_t)>&&);
     void asyncMessage(bool value, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -24,6 +24,7 @@
 
 messages -> IPCStreamTester NotRefCounted Stream {
     SyncMessageReturningSharedMemory1(uint32_t byteCount) -> (std::optional<WebKit::SharedMemory::Handle> handle) Synchronous NotStreamEncodableReply
+    SyncMessageEmptyReply(uint32_t value) -> () Synchronous
     SyncCrashOnZero(int32_t value) -> (int32_t sameValue) Synchronous
 
     CheckAutoreleasePool() -> (int32_t previousUseCount) Synchronous

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -134,10 +134,10 @@ void IPCTester::stopMessageTesting(CompletionHandler<void()>&& completionHandler
     completionHandler();
 }
 
-void IPCTester::createStreamTester(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& serverConnection)
+void IPCTester::createStreamTester(IPC::Connection& connection, IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& serverConnection)
 {
     auto addResult = m_streamTesters.ensure(identifier, [&] {
-        return IPC::ScopedActiveMessageReceiveQueue<IPCStreamTester> { IPCStreamTester::create(identifier, WTFMove(serverConnection)) };
+        return IPC::ScopedActiveMessageReceiveQueue<IPCStreamTester> { IPCStreamTester::create(identifier, WTFMove(serverConnection), connection.ignoreInvalidMessageForTesting()) };
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry || IPC::isTestingIPC());
 }

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -63,7 +63,7 @@ private:
     // Messages.
     void startMessageTesting(IPC::Connection&, String&& driverName);
     void stopMessageTesting(CompletionHandler<void()>&&);
-    void createStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
+    void createStreamTester(IPC::Connection&, IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
     void releaseStreamTester(IPCStreamTesterIdentifier, CompletionHandler<void()>&&);
     void createConnectionTester(IPC::Connection&, IPCConnectionTesterIdentifier, IPC::Connection::Handle&&);
     void createConnectionTesterAndSendAsyncMessages(IPC::Connection&, IPCConnectionTesterIdentifier, IPC::Connection::Handle&&, uint32_t messageCount);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6270,6 +6270,8 @@
 		86E6E357291959C3006C25CA /* SecItemRequestData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SecItemRequestData.serialization.in; sourceTree = "<group>"; };
 		86EB7201298D310900C1DC77 /* SecItemShim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SecItemShim.cpp; sourceTree = "<group>"; };
 		86EB7202298D310900C1DC77 /* SecItemShim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SecItemShim.h; sourceTree = "<group>"; };
+		86EFFA3F2B03A6B900ABE77D /* IPCStreamTester.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPCStreamTester.messages.in; sourceTree = "<group>"; };
+		86EFFA402B03A6B900ABE77D /* IPCTester.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPCTester.messages.in; sourceTree = "<group>"; };
 		86F4FE1E2A98B9AE007378EE /* RemoteGraphicsContextGLInitializationState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteGraphicsContextGLInitializationState.serialization.in; sourceTree = "<group>"; };
 		86F4FE282A98C162007378EE /* SharedVideoFrame.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SharedVideoFrame.serialization.in; sourceTree = "<group>"; };
 		86F9536018FF4FD4001DB2EF /* ProcessAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessAssertion.h; sourceTree = "<group>"; };
@@ -8435,10 +8437,12 @@
 				7BBA63DC280E93B500B04823 /* IPCConnectionTesterIdentifier.h */,
 				7BE37F9527C7CD90007A6CD3 /* IPCStreamTester.cpp */,
 				7BE37F9427C7CD51007A6CD3 /* IPCStreamTester.h */,
+				86EFFA3F2B03A6B900ABE77D /* IPCStreamTester.messages.in */,
 				7BE37F9227C7C518007A6CD3 /* IPCStreamTesterIdentifier.h */,
 				7B2DDD5E27CCD9710060ABAB /* IPCStreamTesterProxy.h */,
 				7B50E97F2771F6CE003DAAC4 /* IPCTester.cpp */,
 				7B50E9802771F6CF003DAAC4 /* IPCTester.h */,
+				86EFFA402B03A6B900ABE77D /* IPCTester.messages.in */,
 				7BF19B60290FC5B400EF322A /* IPCTesterReceiver.cpp */,
 				7BF19B5F290FC5B400EF322A /* IPCTesterReceiver.h */,
 				1A92DC1012F8BA460017AF65 /* LayerTreeContext.h */,

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -215,7 +215,7 @@ TEST_F(StreamConnectionTest, OpenConnections)
     auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
     ASSERT_TRUE(!!connectionPair);
     auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
-    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle)).releaseNonNull();
+    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
     auto cleanup = localReferenceBarrier();
     MockMessageReceiver mockClientReceiver;
     clientConnection->open(mockClientReceiver);
@@ -233,7 +233,7 @@ TEST_F(StreamConnectionTest, InvalidateUnopened)
     auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
     ASSERT_TRUE(!!connectionPair);
     auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
-    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle)).releaseNonNull();
+    auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
     auto cleanup = localReferenceBarrier();
     serverQueue().dispatch([this, serverConnection] {
         assertIsCurrent(serverQueue());
@@ -255,7 +255,7 @@ public:
         auto connectionPair = IPC::StreamClientConnection::create(bufferSizeLog2());
         ASSERT(!!connectionPair);
         auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
-        auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle)).releaseNonNull();
+        auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle), { }).releaseNonNull();
         m_clientConnection = WTFMove(clientConnection);
         m_clientConnection->setSemaphores(copyViaEncoder(serverQueue().wakeUpSemaphore()).value(), copyViaEncoder(serverConnection->clientWaitSemaphore()).value());
         m_clientConnection->open(m_mockClientReceiver);


### PR DESCRIPTION
#### 56b0d92bb3fe7fbbdd946601c98e2e5b5b68fb75
<pre>
Add the ability for the IPCTestingAPI to report when a sync stream message fails to be deserialized correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=264810">https://bugs.webkit.org/show_bug.cgi?id=264810</a>
<a href="https://rdar.apple.com/118391408">rdar://118391408</a>

Reviewed by Alex Christensen.

Add the ability for the IPCTestingAPI to report when a sync stream connection
message fails to be received correctly. The existing behaviour is that no reply
is returned for failed messages. This change records the decoder validity
on failure into a MessageSyncReply so that the IPCTestingAPI can raise
an exception.

* LayoutTests/ipc/ignoreinvalidmessagesfortesting-stream-connection-expected.txt: Added.
* LayoutTests/ipc/ignoreinvalidmessagesfortesting-stream-connection.html: Added.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::createRenderingBackend):
(WebKit::GPUConnectionToWebProcess::createGraphicsContextGL):
(WebKit::GPUConnectionToWebProcess::createRemoteGPU):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageSynchronous):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::tryCreate):
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::dispatchOutOfStreamMessage):
(IPC::StreamServerConnection::sendDeserializationErrorSyncReply):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::IPCStreamTester):
(WebKit::IPCStreamTester::syncMessageEmptyReply):
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCStreamTester.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/270892@main">https://commits.webkit.org/270892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ee24c275c80ef000add49e35b6fdca0f3dcfbed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24152 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29096 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29732 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27626 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23425 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6422 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->