### PR TITLE
Implement several new `UIAsyncTextInput` / `UIAsyncTextInputClient` APIs

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1238,6 +1238,15 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 @end
 
+#if !defined(UI_DIRECTIONAL_TEXT_RANGE_STRUCT)
+
+typedef struct {
+    NSInteger offset;
+    NSInteger length;
+} UIDirectionalTextRange;
+
+#endif // !defined(UI_DIRECTIONAL_TEXT_RANGE_STRUCT)
+
 #endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
 
 WTF_EXTERN_C_BEGIN


### PR DESCRIPTION
#### 7575255c4d4d29755ed87522053153c46f7b456c
<pre>
Implement several new `UIAsyncTextInput` / `UIAsyncTextInputClient` APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=264753">https://bugs.webkit.org/show_bug.cgi?id=264753</a>
<a href="https://rdar.apple.com/118393726">rdar://118393726</a>

Reviewed by Megan Gardner.

Implement these four methods on `UIAsyncTextInput` and `UIAsyncTextInputClient`:

```
- (void)adjustSelection:(UIDirectionalTextRange)range completionHandler:(void (^)(void))completionHandler;
- (BOOL)selectionAtDocumentStart;
- (void)transposeCharacters;
- (BOOL)shouldSuppressEditMenu;
```

...and refactor their existing private and internal UITextInput counterparts to call into
these new methods.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _selectionClipRect]):
(-[WKContentView canPerformAction:withSender:]):
(-[WKContentView _selectionAtDocumentStart]):
(-[WKContentView _transpose]):
(-[WKContentView _shouldSuppressSelectionCommands]):
(-[WKContentView _internalAdjustSelectionWithOffset:lengthDelta:completionHandler:]):
(-[WKContentView adjustSelectionWithDelta:completionHandler:]):
(-[WKContentView adjustSelection:completionHandler:]):
(-[WKContentView selectionClipRect]):
(-[WKContentView transposeCharacters]):
(-[WKContentView selectionAtDocumentStart]):
(-[WKContentView shouldSuppressEditMenu]):
(-[WKContentView _selectionClipRectInternal]): Deleted.

Canonical link: <a href="https://commits.webkit.org/270746@main">https://commits.webkit.org/270746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce2a187e9da8fb4a4dbf78314b650b7ceb66c6a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24035 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28926 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3306 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29604 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27492 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1555 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4763 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6319 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->