### PR TITLE
[macOS] Block IOKit related syscalls in the WebContent process

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2141,8 +2141,6 @@
     io_server_version
     io_service_add_interest_notification_64
     io_service_add_notification_bin_64
-    io_service_get_matching_service_bin
-    io_service_get_matching_services_bin
     io_service_open_extended
     mach_exception_raise
     mach_memory_entry_ownership
@@ -2176,6 +2174,10 @@
     io_connect_method
     io_connect_method_var_output
     io_connect_set_notification_port_64))
+
+(define (kernel-mig-routines-iokit-service) (kernel-mig-routine
+    io_service_get_matching_service_bin
+    io_service_get_matching_services_bin))
 
 (define (kernel-mig-routines-blocked-in-lockdown-mode) (kernel-mig-routine
     task_threads_from_user
@@ -2221,6 +2223,12 @@
                 (allow mach-message-send (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))
 #endif
 #if HAVE(SANDBOX_STATE_FLAGS)
+#if ENABLE(IOKIT_SERVICE_SYSCALL_BLOCKING_IN_WEBCONTENT)
+            (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+                (allow mach-message-send (kernel-mig-routines-iokit-service)))
+#else
+            (allow mach-message-send (kernel-mig-routines-iokit-service))
+#endif
             (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
                 (allow mach-message-send (kernel-mig-routines-downlevels))
                 (allow mach-message-send (kernel-mig-routines-iokit)))
@@ -2228,6 +2236,7 @@
                 (allow mach-message-send (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))
 #else
             (allow mach-message-send (kernel-mig-routines-iokit))
+            (allow mach-message-send (kernel-mig-routines-iokit-service))
 #endif
 #if HAVE(SANDBOX_STATE_FLAGS) && HAVE(MACH_RANGE_CREATE)
             ;; <rdar://105161083>


### PR DESCRIPTION
#### 1a5eaa84ec99b3e2ccafb2e38bae6992dc4721a8
<pre>
[macOS] Block IOKit related syscalls in the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=264812">https://bugs.webkit.org/show_bug.cgi?id=264812</a>
<a href="https://rdar.apple.com/116582311">rdar://116582311</a>

Reviewed by Sihui Liu.

These can be blocked when IOKit is blocked in the WebContent process sandbox.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/270743@main">https://commits.webkit.org/270743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d91d03dbab7f43369e1f84e22bfe1e10a824a3fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24025 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24031 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28917 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29593 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27481 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1548 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4755 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6316 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->