### PR TITLE
Propagate ignoreInvalidMessageForTesting to the NetworkProcess

### DIFF
--- a/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception-expected.txt
+++ b/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception-expected.txt
@@ -1,4 +1,3 @@
 
-PASS Sending sync message to the UI process with incorrect parameters must throw error
-PASS Sending sync message to the GPU process with incorrect parameters must throw error
+PASS Sending sync message with incorrect parameters must throw error
 

--- a/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception.html
+++ b/LayoutTests/ipc/send-invalid-sync-message-empty-reply-check-exception.html
@@ -10,19 +10,12 @@ promise_test(async t => {
     if (!window.IPC)
         return;
     
-    assert_throws_js(TypeError,
-        () => { IPC.sendSyncMessage("UI", 0, IPC.messages.IPCTester_SyncPingEmptyReply.name, defaultTimeout, []); },
-        `failed sync message must throw error`);
-}, "Sending sync message to the UI process with incorrect parameters must throw error");
-
-promise_test(async t => {
-    if (!window.IPC)
-        return;
-    
-    assert_throws_js(TypeError,
-        () => { IPC.sendSyncMessage("GPU", 0, IPC.messages.IPCTester_SyncPingEmptyReply.name, defaultTimeout, []); },
-        `failed sync message must throw error`);
-}, "Sending sync message to the GPU process with incorrect parameters must throw error");
+    for (const processTarget of IPC.processTargets) {
+        assert_throws_js(TypeError,
+        () => { IPC.sendSyncMessage(processTarget, 0, IPC.messages.IPCTester_SyncPingEmptyReply.name, defaultTimeout, []); },
+            `failed sync message must throw error`);
+    }
+}, "Sending sync message with incorrect parameters must throw error");
 
 </script>
 </body>

--- a/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception-expected.txt
+++ b/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception-expected.txt
@@ -1,4 +1,3 @@
 
-PASS Sending sync stream message with incorrect parameters to the UI process shouldn't crash when IPCTestingAPI is enabled
-PASS Sending sync stream message with incorrect parameters to the GPU process shouldn't crash when IPCTestingAPI is enabled
+PASS Sending sync stream message with incorrect parameters shouldn't crash when IPCTestingAPI is enabled
 

--- a/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html
+++ b/LayoutTests/ipc/send-invalid-sync-stream-message-empty-reply-check-exception.html
@@ -12,50 +12,27 @@ promise_test(async t => {
     if (!window.IPC)
         return;
 
-    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
-    streamConnection.open();
-    IPC.sendMessage("UI", 0, IPC.messages.IPCTester_CreateStreamTester.name, [
-        { type: 'uint64_t', value: streamTesterID },
-        { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
-    ]);
-    const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
-    streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
+    for (const processTarget of IPC.processTargets) {
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+        streamConnection.open();
+        IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
+            { type: 'uint64_t', value: streamTesterID },
+            { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
+        ]);
+        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+        streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
 
-    // Test starts here.
-    try {
-        assert_throws_js(TypeError,
-        () => { streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageEmptyReply.name, defaultTimeout, [  ]) },
-        `failed sync message must throw error`);
-    } finally {
-        IPC.sendSyncMessage("UI", 0, IPC.messages.IPCTester_ReleaseStreamTester.name, defaultTimeout, [{ type: 'uint64_t', value: streamTesterID }]);
-        streamConnection.invalidate();
+        // Test starts here.
+        try {
+            assert_throws_js(TypeError,
+            () => { streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageEmptyReply.name, defaultTimeout, [  ]) },
+            `failed sync message must throw error`);
+        } finally {
+            IPC.sendSyncMessage(processTarget, 0, IPC.messages.IPCTester_ReleaseStreamTester.name, defaultTimeout, [{ type: 'uint64_t', value: streamTesterID }]);
+            streamConnection.invalidate();
+        }
     }
 
-}, "Sending sync stream message with incorrect parameters to the UI process shouldn't crash when IPCTestingAPI is enabled");
-
-promise_test(async t => {
-    if (!window.IPC)
-        return;
-
-    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
-    streamConnection.open();
-    IPC.sendMessage("GPU", 0, IPC.messages.IPCTester_CreateStreamTester.name, [
-        { type: 'uint64_t', value: streamTesterID },
-        { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
-    ]);
-    const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
-    streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
-
-    // Test starts here.
-    try {
-        assert_throws_js(TypeError,
-        () => { streamConnection.sendSyncMessage(streamTesterID, IPC.messages.IPCStreamTester_SyncMessageEmptyReply.name, defaultTimeout, [  ]) },
-        `failed sync message must throw error`);
-    } finally {
-        IPC.sendSyncMessage("GPU", 0, IPC.messages.IPCTester_ReleaseStreamTester.name, defaultTimeout, [{ type: 'uint64_t', value: streamTesterID }]);
-        streamConnection.invalidate();
-    }
-
-}, "Sending sync stream message with incorrect parameters to the GPU process shouldn't crash when IPCTestingAPI is enabled");
+}, "Sending sync stream message with incorrect parameters shouldn't crash when IPCTestingAPI is enabled");
 
 </script>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -405,10 +405,8 @@ bool NetworkConnectionToWebProcess::didReceiveSyncMessage(IPC::Connection& conne
 #endif
 
 #if ENABLE(IPC_TESTING_API)
-    if (decoder.messageReceiverName() == Messages::IPCTester::messageReceiverName()) {
-        m_ipcTester.didReceiveSyncMessage(connection, decoder, reply);
-        return true;
-    }
+    if (decoder.messageReceiverName() == Messages::IPCTester::messageReceiverName())
+        return m_ipcTester.didReceiveSyncMessage(connection, decoder, reply);
 #endif
 
     // Add new receiver name tests above this.

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -399,6 +399,11 @@ void NetworkProcess::createNetworkConnectionToWebProcess(ProcessIdentifier ident
 
     connection->setOnLineState(NetworkStateNotifier::singleton().onLine());
 
+#if ENABLE(IPC_TESTING_API)
+    if (parameters.ignoreInvalidMessageForTesting)
+        connection->connection().setIgnoreInvalidMessageForTesting();
+#endif
+
     if (auto* session = networkSession(sessionID))
         session->storageManager().startReceivingMessageFromConnection(Ref { connection->connection() });
 }

--- a/Source/WebKit/Shared/NetworkProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/NetworkProcessConnectionParameters.h
@@ -29,6 +29,9 @@ namespace WebKit {
 
 struct NetworkProcessConnectionParameters {
     bool allowTestOnlyIPC { false };
+#if ENABLE(IPC_TESTING_API)
+    bool ignoreInvalidMessageForTesting { false };
+#endif
 };
 
 }; // namespace WebKit

--- a/Source/WebKit/Shared/NetworkProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/NetworkProcessConnectionParameters.serialization.in
@@ -22,4 +22,7 @@
 
 struct WebKit::NetworkProcessConnectionParameters {
     bool allowTestOnlyIPC;
+#if ENABLE(IPC_TESTING_API)
+    bool ignoreInvalidMessageForTesting;
+#endif
 };

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -288,7 +288,12 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
 {
     RELEASE_LOG(ProcessSuspension, "%p - NetworkProcessProxy is taking a background assertion because a web process is requesting a connection", this);
     startResponsivenessTimer(UseLazyStop::No);
-    sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID(), { webProcessProxy.allowTestOnlyIPC() } }, [this, weakThis = WeakPtr { *this }, reply = WTFMove(reply)](auto&& identifier, auto cookieAcceptPolicy) mutable {
+    NetworkProcessConnectionParameters parameters;
+    parameters.allowTestOnlyIPC = webProcessProxy.allowTestOnlyIPC();
+#if ENABLE(IPC_TESTING_API)
+    parameters.ignoreInvalidMessageForTesting = webProcessProxy.ignoreInvalidMessageForTesting();
+#endif
+    sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID(), parameters }, [this, weakThis = WeakPtr { *this }, reply = WTFMove(reply)](auto&& identifier, auto cookieAcceptPolicy) mutable {
         if (!weakThis) {
             RELEASE_LOG_ERROR(Process, "NetworkProcessProxy::getNetworkProcessConnection: NetworkProcessProxy deallocated during connection establishment");
             return reply({ });


### PR DESCRIPTION
#### dd412bf60ee4bee14e5e1cab8ef584f546f245cc
<pre>
Propagate ignoreInvalidMessageForTesting to the NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=264821">https://bugs.webkit.org/show_bug.cgi?id=264821</a>
<a href="https://rdar.apple.com/118404748">rdar://118404748</a>

Reviewed by Alex Christensen.

This change propagates ignoreInvalidMessageForTesting to the
NetworkConnectionToWebProcess.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didReceiveSyncMessage):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::createNetworkConnectionToWebProcess):
* Source/WebKit/Shared/NetworkProcessConnectionParameters.h:
* Source/WebKit/Shared/NetworkProcessConnectionParameters.serialization.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getNetworkProcessConnection):

Canonical link: <a href="https://commits.webkit.org/271305@main">https://commits.webkit.org/271305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3617abdfbf3bef3c050cdb6f77ff5ce11686fbd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25491 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3971 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4613 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31035 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28847 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24768 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6709 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->