### PR TITLE
[webkitscmpy] Add commit status to pull-request

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.7.3',
+    version='6.8.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 7, 3)
+version = Version(6, 8, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
 import re
 
 from .commit import Commit
@@ -58,6 +59,37 @@ class PullRequest(object):
                 self.author,
                 datetime.utcfromtimestamp(self.timestamp) if self.timestamp else '-',
                 self.content,
+            )
+
+    class Status(object):
+        class Encoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, dict):
+                    return {key: self.default(value) for key, value in obj.items()}
+                if isinstance(obj, list):
+                    return [self.default(value) for value in obj]
+                if not isinstance(obj, PullRequest.Status):
+                    return super(PullRequest.Status.Encoder, self).default(obj)
+
+                return dict(
+                    name=obj.name,
+                    status=obj.status,
+                    description=obj.description,
+                    url=obj.url,
+                )
+
+        def __init__(self, name=None, status=None, description=None, url=None):
+            self.name = name
+            self.status = status
+            if status not in ('error', 'failure', 'pending', 'success'):
+                raise ValueError('Invalid status, got {!r}'.format(status))
+
+            self.description = description
+            self.url = url
+
+        def __repr__(self):
+            return "Status(name={!r}, status={!r}, url={!r})".format(
+                self.name or '?', self.status, self.url or '?',
             )
 
 
@@ -156,6 +188,7 @@ class PullRequest(object):
         self._blockers = None
         self._metadata = metadata
         self._comments = None
+        self._statuses = None
         self.generator = generator
         self.url = url
 
@@ -214,6 +247,12 @@ class PullRequest(object):
         if not self.generator:
             raise self.Exception('No associated pull-request generator')
         return self.generator.review(self, comment=comment, approve=approve)
+
+    @property
+    def statuses(self):
+        if self._statuses is None and self.generator:
+            self._statuses = list(self.generator.statuses(self))
+        return self._statuses
 
     def __repr__(self):
         return 'PR {}{}'.format(self.number, ' | {}'.format(self.title) if self.title else '')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -356,6 +356,20 @@ class GitHub(Scm):
 
             return pull_request
 
+        def statuses(self, pull_request):
+            statuses = self.repository.request(
+                'commits/{ref}/statuses'.format(
+                    ref=pull_request.hash,
+                )
+            )
+            for status in statuses or []:
+                yield PullRequest.Status(
+                    name=status.get('context'),
+                    url=status.get('target_url'),
+                    status=status.get('state', 'error'),
+                    description=status.get('description'),
+                )
+
 
     @classmethod
     def is_webserver(cls, url):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
@@ -57,6 +57,9 @@ class Scm(ScmBase):
         def review(self, pull_request, comment=None, approve=None):
             raise NotImplementedError()
 
+        def statuses(self, pull_request):
+            raise NotImplementedError()
+
 
     @classmethod
     def from_url(cls, url, contributors=None, classifier=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1998,6 +1998,13 @@ Reviewed by NOBODY (OOPS!).
                 issue=dict(href='https://{}/issues/1'.format(result.api_remote)),
             ), draft=False,
         )]
+
+        result.statuses['95507e3a1a4a'] = PullRequest.Status.Encoder().default([
+            PullRequest.Status(name='test-webkitpy', status='pending', description='Running...'),
+            PullRequest.Status(name='test-webkitcorepy', status='success', description='Finished!'),
+            PullRequest.Status(name='test-webkitscmpy', status='failure', description='Failed webkitscmpy.test.pull_request_unittest.TestNetworkPullRequestGitHub.test_status'),
+        ])
+
         return result
 
     def test_find(self):
@@ -2087,6 +2094,17 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual(pr.comments[-1].content, 'Looks good!')
             self.assertEqual(len(pr.approvers), 2)
 
+    def test_status(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(len(pr.statuses), 3)
+            self.assertEqual(
+                [pr.status for pr in pr.statuses],
+                ['pending', 'success', 'failure'],
+            )
+
+
 
 class TestNetworkPullRequestBitBucket(unittest.TestCase):
     remote = 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit'
@@ -2138,6 +2156,13 @@ Reviewed by NOBODY (OOPS!).
                 ),
             ],
         )]
+
+        result.statuses['95507e3a1a4a'] = PullRequest.Status.Encoder().default([
+            PullRequest.Status(name='test-webkitpy', status='pending', description='Running...'),
+            PullRequest.Status(name='test-webkitcorepy', status='success', description='Finished!'),
+            PullRequest.Status(name='test-webkitscmpy', status='failure', description='Failed webkitscmpy.test.pull_request_unittest.TestNetworkPullRequestGitHub.test_status'),
+        ])
+
         return result
 
     def test_find(self):
@@ -2223,3 +2248,13 @@ Reviewed by NOBODY (OOPS!).
 
             self.assertEqual(pr.comments[-1].content, 'Looks good!')
             self.assertEqual(len(pr.approvers), 2)
+
+    def test_status(self):
+        with self.webserver():
+            repo = remote.BitBucket(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(len(pr.statuses), 3)
+            self.assertEqual(
+                [pr.status for pr in pr.statuses],
+                ['pending', 'success', 'failure'],
+            )


### PR DESCRIPTION
#### fca112b99b353e4785aefd05ec18e2ce5c624290
<pre>
[webkitscmpy] Add commit status to pull-request
<a href="https://bugs.webkit.org/show_bug.cgi?id=264827">https://bugs.webkit.org/show_bug.cgi?id=264827</a>
<a href="https://rdar.apple.com/118406906">rdar://118406906</a>

Reviewed by Elliott Williams.

Add commit status and associated mock support to webkitscmpy for future use.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.__init__): Add &quot;statuses&quot; dictionary.
(BitBucket.request): Respond with mock commit status.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.__init__): Add &quot;statuses&quot; dictionary.
(GitHub._commit_response): Repond with mock commit status.
(GitHub.request): Handle commit URLs with trailing path arguments.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.Status): Added.
(PullRequest.Status.Encoder): Added JSON decoder.
(PullRequest.statuses): Return all commit statuses on the current pull-request object.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.statuses): Populate commit statuses in pull-request object.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.statuses): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
(Scm.PRGenerator.statuses):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/270736@main">https://commits.webkit.org/270736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/352bbfe6bba39093a0e4d073534e2c5ba669f116

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26284 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/4893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27544 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/28379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/24056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26616 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/6676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/28379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26540 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/6676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/28958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/26447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/6676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/28958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/6676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/28958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/26052 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/4791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3383 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->