### PR TITLE
REGRESSION(268639@main): [ macOS wk2 ] fast/frames/iframe-window-focus.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/frames/iframe-window-focus-expected.txt
+++ b/LayoutTests/fast/frames/iframe-window-focus-expected.txt
@@ -1,3 +1,6 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This tests that focusing an editable iframe's window works correctly and allows text and newlines to be entered.
 
 TEST

--- a/LayoutTests/fast/frames/iframe-window-focus.html
+++ b/LayoutTests/fast/frames/iframe-window-focus.html
@@ -1,18 +1,23 @@
 <html>
     <head>
+        <script src="../../resources/js-test.js"></script>
+        <script src="../../resources/ui-helper.js"></script>
         <script>
+            jsTestIsAsync = true;
             if (window.testRunner)
                 testRunner.dumpAsText();
 
-            function moveFocus() {
+            async function moveFocus() {
                 var ifrm = document.getElementById("rte");
                 ifrm.contentWindow.focus();
+                await UIHelper.ensurePresentationUpdate();
             }
             
-            function init() {
+            async function init() {
                 var ifrm = document.getElementById("rte");
                 ifrm.contentDocument.designMode = "on";
                 ifrm.contentWindow.focus();
+                await UIHelper.ensurePresentationUpdate();
                 
                 if (window.testRunner) {
                     eventSender.keyDown('T');
@@ -34,6 +39,7 @@
                     eventSender.keyDown('S');
                 }
                 document.getElementById('res').innerHTML = ifrm.contentDocument.body.innerHTML;
+                finishJSTest();
             }
         </script>
     </head>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1996,6 +1996,4 @@ webkit.org/b/264306 [ Sonoma+ ] fast/scrolling/mac/scrollbars/very-wide-overlay-
 
 webkit.org/b/264362 [ Sonoma+ ] fast/rendering/render-style-null-optgroup-crash.html [ Pass Failure ]
 
-webkit.org/b/264751 fast/frames/iframe-window-focus.html [ Pass Failure ]
-
 webkit.org/b/264783 [ Monterey+ x86_64 ] http/wpt/mediarecorder/record-context-created-late.html [ Failure ]


### PR DESCRIPTION
#### 7326eec8056635e58c1481483280839435fe099c
<pre>
REGRESSION(268639@main): [ macOS wk2 ] fast/frames/iframe-window-focus.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=264751">https://bugs.webkit.org/show_bug.cgi?id=264751</a>
<a href="https://rdar.apple.com/118340493">rdar://118340493</a>

Reviewed by Pascoe.

268639@main made a change to refer to the focused frame stored in the UI process to know which frame a
key event should be sent to. We should wait for a presentation update so the UI process has up to date
information after focusing the iframe.

* LayoutTests/fast/frames/iframe-window-focus-expected.txt:
* LayoutTests/fast/frames/iframe-window-focus.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/270731@main">https://commits.webkit.org/270731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d027b5a57409f35fd872d21440a18912914779c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24015 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24025 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3700 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28905 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29588 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1545 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23280 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3802 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3380 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->