### PR TITLE
[WGSL] Add tests for bitwise operators and fix compound assignment

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1860,6 +1860,7 @@ void FunctionDefinitionWriter::visit(AST::CallStatement& statement)
 
 void FunctionDefinitionWriter::visit(AST::CompoundAssignmentStatement& statement)
 {
+    visit(statement.leftExpression());
     m_stringBuilder.append(" = ");
     serializeBinaryExpression(statement.leftExpression(), statement.operation(), statement.rightExpression());
 }

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -291,49 +291,97 @@ fn testComparison() {
 
 // 8.9. Bit Expressions (https://www.w3.org/TR/WGSL/#bit-expr)
 
+// RUN: %metal-compile testBitwise
+@compute @workgroup_size(1)
 fn testBitwise()
 {
-  {
-    _ = ~0;
-    _ = ~0i;
-    _ = ~0u;
-  }
+    {
+        var i = 0i;
+        var u = 0u;
+        const x1: u32 = ~(-1);
+        const x2: i32 = ~1i;
+        const x3: u32 = ~1u;
+        const x4: vec2<u32> = ~vec2(-1);
+        const x5: vec2<i32> = ~vec2(0i);
+        const x6: vec2<u32> = ~vec2(0u);
+        let x7: i32 = ~i;
+        let x8: u32 = ~u;
+    }
 
-  {
-    _ = 0 & 1;
-    _ = 0i & 1i;
-    _ = 0u & 1u;
-  }
+    {
+        var i = 0i;
+        var u = 0u;
+        const x1: u32 = 0 & 1;
+        const x2: i32 = 0i & 1i;
+        const x3: u32 = 0u & 1u;
+        const x4: vec2<u32> = vec2(0) & vec2(1);
+        const x5: vec2<i32> = vec2(0i) & vec2(1i);
+        const x6: vec2<u32> = vec2(0u) & vec2(1u);
+        let x7: i32 = i & 1;
+        let x8: u32 = u & 1;
+        i &= 1;
+        u &= 1;
+    }
 
-  {
-    _ = 0 | 1;
-    _ = 0i | 1i;
-    _ = 0u | 1u;
-  }
+    {
+        var i = 0i;
+        var u = 0u;
+        const x1: u32 = 0 | 1;
+        const x2: i32 = 0i | 1i;
+        const x3: u32 = 0u | 1u;
+        const x4: vec2<u32> = vec2(0) | vec2(1);
+        const x5: vec2<i32> = vec2(0i) | vec2(1);
+        const x6: vec2<u32> = vec2(0u) | vec2(1);
+        let x7: i32 = i | 1;
+        let x8: u32 = u | 1;
+        i |= 1;
+        u |= 1;
+    }
 
-  {
-    _ = 0 ^ 1;
-    _ = 0i ^ 1i;
-    _ = 0u ^ 1u;
-  }
+    {
+        var i = 0i;
+        var u = 0u;
+        const x1: u32 = 0 ^ 1;
+        const x2: i32 = 0i ^ 1i;
+        const x3: u32 = 0u ^ 1u;
+        const x4: vec2<u32> = vec2(0) ^ vec2(1);
+        const x5: vec2<i32> = vec2(0i) ^ vec2(1i);
+        const x6: vec2<u32> = vec2(0u) ^ vec2(1u);
+        let x7: i32 = i ^ 1;
+        let x8: u32 = u ^ 1;
+        i ^= 1;
+        u ^= 1;
+    }
 
-  {
-    const x: u32 = 1 << 2;
-    _ = 1i << 2u;
-    _ = 1u << 2u;
-    _ = vec2(1) << vec2(2);
-    _ = vec2(1i) << vec2(2u);
-    _ = vec2(1u) << vec2(2u);
-  }
+    {
+        var i = 0i;
+        var u = 0u;
+        const x1: u32 = 1 << 2;
+        const x2: i32 = 1i << 2u;
+        const x3: u32 = 1u << 2u;
+        const x4: vec2<u32> = vec2(1) << vec2(2);
+        const x5: vec2<i32> = vec2(1i) << vec2(2u);
+        const x6: vec2<u32> = vec2(1u) << vec2(2u);
+        let x7: i32 = i << 1;
+        let x8: u32 = u << 1;
+        i <<= 1;
+        u <<= 1;
+    }
 
-  {
-    const x: u32 = 1 >> 2;
-    _ = 1i >> 2u;
-    _ = 1u >> 2u;
-    _ = vec2(1) >> vec2(2);
-    _ = vec2(1i) >> vec2(2u);
-    _ = vec2(1u) >> vec2(2u);
-  }
+    {
+        var i = 0i;
+        var u = 0u;
+        const x: u32 = 1 >> 2;
+        const x2: i32 = 1i >> 2u;
+        const x3: u32 = 1u >> 2u;
+        const x4: vec2<u32> = vec2(1) >> vec2(2);
+        const x5: vec2<i32> = vec2(1i) >> vec2(2u);
+        const x6: vec2<u32> = vec2(1u) >> vec2(2u);
+        let x7: i32 = i >> 1;
+        let x8: u32 = u >> 1;
+        i >>= 1;
+        u >>= 1;
+    }
 }
 
 // 8.13. Address-Of Expression (https://www.w3.org/TR/WGSL/#address-of-expr)


### PR DESCRIPTION
#### 8f82a0e1711d3a24faaba6302fd1541cbf52be03
<pre>
[WGSL] Add tests for bitwise operators and fix compound assignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=264832">https://bugs.webkit.org/show_bug.cgi?id=264832</a>
<a href="https://rdar.apple.com/118408447">rdar://118408447</a>

Reviewed by Mike Wyrzykowski.

Modify the existing tests to also be run through the Metal compiler, and expand the
tests to cover both constant and runtime operations. In the process the tests also
showed that I broke compound assignment in 270641@main, so I fixed that.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/270761@main">https://commits.webkit.org/270761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f908835b078db88ddd4acbb3cff0eb6cb213685

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28320 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24010 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24020 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28898 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3292 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29581 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27466 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1540 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4739 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6329 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->