### PR TITLE
Stop using various SPI methods on UIKeyboard and UIKeyboardImpl

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -357,7 +357,6 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 
 @interface UIKeyboard ()
 + (instancetype)activeKeyboard;
-+ (CGSize)defaultSizeForInterfaceOrientation:(UIInterfaceOrientation)orientation;
 + (BOOL)isInHardwareKeyboardMode;
 + (BOOL)isOnScreen;
 + (BOOL)usesInputSystemUI;
@@ -371,16 +370,12 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 @interface UIKeyboardImpl ()
 + (UIKeyboardImpl *)activeInstance;
 + (UIKeyboardImpl *)sharedInstance;
-+ (CGSize)defaultSizeForInterfaceOrientation:(UIInterfaceOrientation)orientation;
 - (BOOL)handleKeyTextCommandForCurrentEvent;
 - (BOOL)handleKeyAppCommandForCurrentEvent;
 - (BOOL)handleKeyInputMethodCommandForCurrentEvent;
-- (BOOL)isCallingInputDelegate;
-- (void)addInputString:(NSString *)string withFlags:(NSUInteger)flags;
 - (void)addInputString:(NSString *)string withFlags:(NSUInteger)flags withInputManagerHint:(NSString *)hint;
 - (BOOL)autocorrectSpellingEnabled;
 - (void)clearShiftState;
-- (void)deleteFromInput;
 - (void)deleteFromInputWithFlags:(NSUInteger)flags;
 - (void)replaceText:(id)replacement;
 @property (nonatomic, readwrite, retain) UIResponder <UIKeyInput> *delegate;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -488,6 +488,8 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isHidingKeyboard;
     BOOL _isInterpretingKeyEvent;
     BOOL _isPresentingEditMenu;
+    BOOL _isHandlingActiveKeyEvent;
+    BOOL _isHandlingActivePressesEvent;
 
     BOOL _focusRequiresStrongPasswordAssistance;
     BOOL _waitingForEditDragSnapshot;
@@ -620,6 +622,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly, getter=isKeyboardScrollingAnimationRunning) BOOL keyboardScrollingAnimationRunning;
 @property (nonatomic, readonly) UIView *unscaledView;
 @property (nonatomic, readonly) BOOL isPresentingEditMenu;
+@property (nonatomic, readonly) CGSize sizeForLegacyFormControlPickerViews;
 
 #if ENABLE(DATALIST_ELEMENT)
 @property (nonatomic, strong) UIView <WKFormControl> *dataListTextSuggestionsInputView;

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -233,7 +233,7 @@ void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOp
     [_pickerView setControl:self];
 
     CGRect frame = [_pickerView frame];
-    frame.size = [UIKeyboard defaultSizeForInterfaceOrientation:view.interfaceOrientation];
+    frame.size = view.sizeForLegacyFormControlPickerViews;
     [_pickerView setFrame:frame];
 
     return self;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -168,7 +168,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self setAllowsMultipleSelection:_allowsMultipleSelection];
 
     CGRect frame = self.frame;
-    frame.size = [UIKeyboard defaultSizeForInterfaceOrientation:view.interfaceOrientation];
+    frame.size = view.sizeForLegacyFormControlPickerViews;
     [self setFrame:frame];
 
     [self reloadAllComponents];


### PR DESCRIPTION
#### 7a57a9b53df0d39626b5aa7f2b2213cfc21c503c
<pre>
Stop using various SPI methods on UIKeyboard and UIKeyboardImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=264820">https://bugs.webkit.org/show_bug.cgi?id=264820</a>
<a href="https://rdar.apple.com/118404384">rdar://118404384</a>

Reviewed by Megan Gardner.

Remove uses of the following keyboard SPI methods:

```
+[UIKeyboard defaultSizeForInterfaceOrientation:]
-[UIKeyboardImpl isCallingInputDelegate]
```

...as well as several unused declarations on these two classes. See below for more details.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView resignFirstResponderForWebView]):
(-[WKContentView insertText:]):

Instead of using `-isCallingInputDelegate` to determine whether or not we&apos;re currently inserting
text due to the user pressing a key, keep track of this state ourselves by tracking of `keydown`/
`keyup` and `pressesBegan`/`pressesEnded`. While this isn&apos;t perfect (i.e. there is a narrow case
where it&apos;s possible for the keyboard to produce text insertion commands right after a keyup), it&apos;s
sufficient to address the original use case this was intended to fix: <a href="https://rdar.apple.com/47902054">rdar://47902054</a>, wherein we
need to ensure a user gesture token when hitting Return to submit a search query.

(-[WKContentView pressesBegan:withEvent:]):
(-[WKContentView pressesEnded:withEvent:]):
(-[WKContentView pressesCancelled:withEvent:]):

Keep track of a `_isHandlingActivePressesEvent` flag.

(-[WKContentView _internalHandleKeyWebEvent:withCompletionHandler:]):

Keep track of a `_isHandlingActiveKeyEvent` flag.

(-[WKContentView _didHandleKeyEvent:eventWasHandled:]):
(-[WKContentView sizeForLegacyFormControlPickerViews]):

Stop using `+defaultSizeForInterfaceOrientation:`; this was only used to try and make the default
size of the picker views used for multiple select elements and datalists consistent with the default
keyboard size, on apps linked against iOS 14 or older.

However, this is unnecessary in any recent version of iOS, where the keyboard will automatically
override the intrinsic height of the input views anyways, so we can just set 0 for the picker view
height to get the default keyboard height.

I manually tested this by forcing `-_shouldUseContextMenusForFormControls` to return NO on iOS 17.

* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsPicker initWithInformation:inView:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKMultipleSelectPicker initWithView:]):

Canonical link: <a href="https://commits.webkit.org/270742@main">https://commits.webkit.org/270742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/958e958d6ef24a03cee913890e2569f816c43de4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28330 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24028 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26490 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28908 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29587 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27472 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1543 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4746 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6315 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3659 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->