### PR TITLE
Change all enums under WebCore/platform/graphics/filters/ to use serializer

### DIFF
--- a/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
@@ -45,9 +45,9 @@ FEColorMatrixCoreImageApplier::FEColorMatrixCoreImageApplier(const FEColorMatrix
 
 bool FEColorMatrixCoreImageApplier::supportsCoreImageRendering(const FEColorMatrix& effect)
 {
-    return effect.type() == FECOLORMATRIX_TYPE_SATURATE
-        || effect.type() == FECOLORMATRIX_TYPE_HUEROTATE
-        || effect.type() == FECOLORMATRIX_TYPE_MATRIX;
+    return effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE
+        || effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE
+        || effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX;
 }
 
 bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
@@ -63,19 +63,19 @@ bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector
     float components[9];
 
     switch (m_effect.type()) {
-    case FECOLORMATRIX_TYPE_SATURATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
         FEColorMatrix::calculateSaturateComponents(components, values[0]);
         break;
 
-    case FECOLORMATRIX_TYPE_HUEROTATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
         FEColorMatrix::calculateHueRotateComponents(components, values[0]);
         break;
 
-    case FECOLORMATRIX_TYPE_MATRIX:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
         break;
 
-    case FECOLORMATRIX_TYPE_UNKNOWN:
-    case FECOLORMATRIX_TYPE_LUMINANCETOALPHA: // FIXME: Add Luminance to Alpha Implementation
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA: // FIXME: Add Luminance to Alpha Implementation
         return false;
     }
 
@@ -83,8 +83,8 @@ bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector
     [colorMatrixFilter setValue:inputImage.get() forKey:kCIInputImageKey];
 
     switch (m_effect.type()) {
-    case FECOLORMATRIX_TYPE_SATURATE:
-    case FECOLORMATRIX_TYPE_HUEROTATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
         [colorMatrixFilter setValue:[CIVector vectorWithX:components[0] Y:components[1] Z:components[2] W:0] forKey:@"inputRVector"];
         [colorMatrixFilter setValue:[CIVector vectorWithX:components[3] Y:components[4] Z:components[5] W:0] forKey:@"inputGVector"];
         [colorMatrixFilter setValue:[CIVector vectorWithX:components[6] Y:components[7] Z:components[8] W:0] forKey:@"inputBVector"];
@@ -92,7 +92,7 @@ bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector
         [colorMatrixFilter setValue:[CIVector vectorWithX:0             Y:0             Z:0             W:0] forKey:@"inputBiasVector"];
         break;
 
-    case FECOLORMATRIX_TYPE_MATRIX:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
         [colorMatrixFilter setValue:[CIVector vectorWithX:values[0]  Y:values[1]  Z:values[2]  W:values[3]]  forKey:@"inputRVector"];
         [colorMatrixFilter setValue:[CIVector vectorWithX:values[5]  Y:values[6]  Z:values[7]  W:values[8]]  forKey:@"inputGVector"];
         [colorMatrixFilter setValue:[CIVector vectorWithX:values[10] Y:values[11] Z:values[12] W:values[13]] forKey:@"inputBVector"];
@@ -100,8 +100,8 @@ bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector
         [colorMatrixFilter setValue:[CIVector vectorWithX:values[4]  Y:values[9]  Z:values[14] W:values[19]] forKey:@"inputBiasVector"];
         break;
 
-    case FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
-    case FECOLORMATRIX_TYPE_UNKNOWN:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
         return false;
     }
 

--- a/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
@@ -45,8 +45,8 @@ FEComponentTransferCoreImageApplier::FEComponentTransferCoreImageApplier(const F
 bool FEComponentTransferCoreImageApplier::supportsCoreImageRendering(const FEComponentTransfer& effect)
 {
     auto isNullOrLinear = [] (const ComponentTransferFunction& function) {
-        return function.type == FECOMPONENTTRANSFER_TYPE_UNKNOWN
-            || function.type == FECOMPONENTTRANSFER_TYPE_LINEAR;
+        return function.type == ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN
+            || function.type == ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR;
     };
 
     return isNullOrLinear(effect.redFunction())
@@ -68,7 +68,7 @@ bool FEComponentTransferCoreImageApplier::apply(const Filter&, const FilterImage
     [componentTransferFilter setValue:inputImage.get() forKey:kCIInputImageKey];
 
     auto setCoefficients = [&] (NSString *key, const ComponentTransferFunction& function) {
-        if (function.type == FECOMPONENTTRANSFER_TYPE_LINEAR)
+        if (function.type == ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR)
             [componentTransferFilter setValue:[CIVector vectorWithX:function.intercept Y:function.slope Z:0 W:0] forKey:key];
     };
 

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 FECompositeNeonArithmeticApplier::FECompositeNeonArithmeticApplier(const FEComposite& effect)
     : Base(effect)
 {
-    ASSERT(m_effect.operation() == FECOMPOSITE_OPERATOR_ARITHMETIC);
+    ASSERT(m_effect.operation() == CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
 }
 
 template <int b1, int b4>

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.cpp
@@ -41,7 +41,7 @@ Ref<DistantLightSource> DistantLightSource::create(float azimuth, float elevatio
 }
 
 DistantLightSource::DistantLightSource(float azimuth, float elevation)
-    : LightSource(LS_DISTANT)
+    : LightSource(LightType::LS_DISTANT)
     , m_azimuth(azimuth)
     , m_elevation(elevation)
 {

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.h
@@ -59,4 +59,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_LIGHTSOURCE(DistantLightSource, LS_DISTANT)
+SPECIALIZE_TYPE_TRAITS_LIGHTSOURCE(DistantLightSource, LightType::LS_DISTANT)

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -114,7 +114,7 @@ Vector<float> FEColorMatrix::normalizedFloats(const Vector<float>& values)
 
 bool FEColorMatrix::resultIsAlphaImage(const FilterImageVector&) const
 {
-    return m_type == FECOLORMATRIX_TYPE_LUMINANCETOALPHA;
+    return m_type == ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA;
 }
 
 OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes() const
@@ -125,7 +125,7 @@ OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes() co
         modes.add(FilterRenderingMode::Accelerated);
 #endif
 #if HAVE(CGSTYLE_COLORMATRIX_BLUR)
-    if (m_type == FECOLORMATRIX_TYPE_MATRIX)
+    if (m_type == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX)
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif
     return modes;
@@ -155,19 +155,19 @@ std::optional<GraphicsStyle> FEColorMatrix::createGraphicsStyle(const Filter&) c
 static TextStream& operator<<(TextStream& ts, const ColorMatrixType& type)
 {
     switch (type) {
-    case FECOLORMATRIX_TYPE_UNKNOWN:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
         ts << "UNKNOWN";
         break;
-    case FECOLORMATRIX_TYPE_MATRIX:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
         ts << "MATRIX";
         break;
-    case FECOLORMATRIX_TYPE_SATURATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
         ts << "SATURATE";
         break;
-    case FECOLORMATRIX_TYPE_HUEROTATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
         ts << "HUEROTATE";
         break;
-    case FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
         ts << "LUMINANCETOALPHA";
         break;
     }

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -27,7 +27,7 @@
 
 namespace WebCore {
 
-enum ColorMatrixType {
+enum class ColorMatrixType : uint8_t {
     FECOLORMATRIX_TYPE_UNKNOWN          = 0,
     FECOLORMATRIX_TYPE_MATRIX           = 1,
     FECOLORMATRIX_TYPE_SATURATE         = 2,
@@ -71,21 +71,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ColorMatrixType> {
-    using values = EnumValues<
-        WebCore::ColorMatrixType,
-
-        WebCore::FECOLORMATRIX_TYPE_UNKNOWN,
-        WebCore::FECOLORMATRIX_TYPE_MATRIX,
-        WebCore::FECOLORMATRIX_TYPE_SATURATE,
-        WebCore::FECOLORMATRIX_TYPE_HUEROTATE,
-        WebCore::FECOLORMATRIX_TYPE_LUMINANCETOALPHA
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(FEColorMatrix)

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -152,22 +152,22 @@ bool FEComponentTransfer::setTableValues(ComponentTransferChannel channel, Vecto
 static TextStream& operator<<(TextStream& ts, ComponentTransferType type)
 {
     switch (type) {
-    case FECOMPONENTTRANSFER_TYPE_UNKNOWN:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN:
         ts << "UNKNOWN";
         break;
-    case FECOMPONENTTRANSFER_TYPE_IDENTITY:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY:
         ts << "IDENTITY";
         break;
-    case FECOMPONENTTRANSFER_TYPE_TABLE:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_TABLE:
         ts << "TABLE";
         break;
-    case FECOMPONENTTRANSFER_TYPE_DISCRETE:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_DISCRETE:
         ts << "DISCRETE";
         break;
-    case FECOMPONENTTRANSFER_TYPE_LINEAR:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR:
         ts << "LINEAR";
         break;
-    case FECOMPONENTTRANSFER_TYPE_GAMMA:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_GAMMA:
         ts << "GAMMA";
         break;
     }
@@ -179,20 +179,20 @@ static TextStream& operator<<(TextStream& ts, const ComponentTransferFunction& f
     ts << "type=\"" << function.type;
 
     switch (function.type) {
-    case FECOMPONENTTRANSFER_TYPE_UNKNOWN:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN:
         break;
-    case FECOMPONENTTRANSFER_TYPE_IDENTITY:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY:
         break;
-    case FECOMPONENTTRANSFER_TYPE_TABLE:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_TABLE:
         ts << " " << function.tableValues;
         break;
-    case FECOMPONENTTRANSFER_TYPE_DISCRETE:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_DISCRETE:
         ts << " " << function.tableValues;
         break;
-    case FECOMPONENTTRANSFER_TYPE_LINEAR:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR:
         ts << "\" slope=\"" << function.slope << "\" intercept=\"" << function.intercept << "\"";
         break;
-    case FECOMPONENTTRANSFER_TYPE_GAMMA:
+    case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_GAMMA:
         ts << "\" amplitude=\"" << function.amplitude << "\" exponent=\"" << function.exponent << "\" offset=\"" << function.offset << "\"";
         break;
     }

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-enum ComponentTransferType {
+enum class ComponentTransferType : uint8_t {
     FECOMPONENTTRANSFER_TYPE_UNKNOWN  = 0,
     FECOMPONENTTRANSFER_TYPE_IDENTITY = 1,
     FECOMPONENTTRANSFER_TYPE_TABLE    = 2,
@@ -38,7 +38,7 @@ enum ComponentTransferType {
 };
 
 struct ComponentTransferFunction {
-    ComponentTransferType type { FECOMPONENTTRANSFER_TYPE_UNKNOWN };
+    ComponentTransferType type { ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN };
 
     float slope { 0 };
     float intercept { 0 };
@@ -55,19 +55,9 @@ enum class ComponentTransferChannel : uint8_t { Red, Green, Blue, Alpha };
 
 } // namespace WebCore
 
-namespace WTF {
-template<> struct EnumTraits<WebCore::ComponentTransferChannel> {
-    using values = EnumValues<WebCore::ComponentTransferChannel,
-        WebCore::ComponentTransferChannel::Red,
-        WebCore::ComponentTransferChannel::Green,
-        WebCore::ComponentTransferChannel::Blue,
-        WebCore::ComponentTransferChannel::Alpha>;
-};
-}
-
 namespace WebCore {
 
-using ComponentTransferFunctions = EnumeratedArray<ComponentTransferChannel, ComponentTransferFunction>;
+using ComponentTransferFunctions = EnumeratedArray<ComponentTransferChannel, ComponentTransferFunction, ComponentTransferChannel::Alpha>;
 
 class FEComponentTransfer : public FilterEffect {
 public:
@@ -105,22 +95,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ComponentTransferType> {
-    using values = EnumValues<
-        WebCore::ComponentTransferType,
-
-        WebCore::FECOMPONENTTRANSFER_TYPE_UNKNOWN,
-        WebCore::FECOMPONENTTRANSFER_TYPE_IDENTITY,
-        WebCore::FECOMPONENTTRANSFER_TYPE_TABLE,
-        WebCore::FECOMPONENTTRANSFER_TYPE_DISCRETE,
-        WebCore::FECOMPONENTTRANSFER_TYPE_LINEAR,
-        WebCore::FECOMPONENTTRANSFER_TYPE_GAMMA
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(FEComponentTransfer)

--- a/Source/WebCore/platform/graphics/filters/FEComposite.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.cpp
@@ -101,13 +101,13 @@ bool FEComposite::setK4(float k4)
 FloatRect FEComposite::calculateImageRect(const Filter& filter, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const
 {
     switch (m_type) {
-    case FECOMPOSITE_OPERATOR_IN:
-    case FECOMPOSITE_OPERATOR_ATOP:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_IN:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ATOP:
         // For In and Atop the first FilterImage just influences the result of the
         // second FilterImage. So just use the rect of the second FilterImage here.
         return filter.clipToMaxEffectRect(inputImageRects[1], primitiveSubregion);
 
-    case FECOMPOSITE_OPERATOR_ARITHMETIC:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC:
         // Arithmetic may influnce the entire filter primitive region. So we can't
         // optimize the paint region here.
         return filter.maxEffectRect(primitiveSubregion);
@@ -120,7 +120,7 @@ FloatRect FEComposite::calculateImageRect(const Filter& filter, std::span<const 
 
 std::unique_ptr<FilterEffectApplier> FEComposite::createSoftwareApplier() const
 {
-    if (m_type != FECOMPOSITE_OPERATOR_ARITHMETIC)
+    if (m_type != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC)
         return FilterEffectApplier::create<FECompositeSoftwareApplier>(*this);
 #if HAVE(ARM_NEON_INTRINSICS)
     return FilterEffectApplier::create<FECompositeNeonArithmeticApplier>(*this);
@@ -132,28 +132,28 @@ std::unique_ptr<FilterEffectApplier> FEComposite::createSoftwareApplier() const
 static TextStream& operator<<(TextStream& ts, const CompositeOperationType& type)
 {
     switch (type) {
-    case FECOMPOSITE_OPERATOR_UNKNOWN:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
         ts << "UNKNOWN";
         break;
-    case FECOMPOSITE_OPERATOR_OVER:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_OVER:
         ts << "OVER";
         break;
-    case FECOMPOSITE_OPERATOR_IN:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_IN:
         ts << "IN";
         break;
-    case FECOMPOSITE_OPERATOR_OUT:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_OUT:
         ts << "OUT";
         break;
-    case FECOMPOSITE_OPERATOR_ATOP:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ATOP:
         ts << "ATOP";
         break;
-    case FECOMPOSITE_OPERATOR_XOR:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_XOR:
         ts << "XOR";
         break;
-    case FECOMPOSITE_OPERATOR_ARITHMETIC:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC:
         ts << "ARITHMETIC";
         break;
-    case FECOMPOSITE_OPERATOR_LIGHTER:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_LIGHTER:
         ts << "LIGHTER";
         break;
     }
@@ -166,7 +166,7 @@ TextStream& FEComposite::externalRepresentation(TextStream& ts, FilterRepresenta
     FilterEffect::externalRepresentation(ts, representation);
 
     ts << " operation=\"" << m_type << "\"";
-    if (m_type == FECOMPOSITE_OPERATOR_ARITHMETIC)
+    if (m_type == CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC)
         ts << " k1=\"" << m_k1 << "\" k2=\"" << m_k2 << "\" k3=\"" << m_k3 << "\" k4=\"" << m_k4 << "\"";
 
     ts << "]\n";

--- a/Source/WebCore/platform/graphics/filters/FEComposite.h
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.h
@@ -27,8 +27,8 @@
 
 namespace WebCore {
 
-enum CompositeOperationType {
-    FECOMPOSITE_OPERATOR_UNKNOWN    = 0, 
+enum class CompositeOperationType : uint8_t {
+    FECOMPOSITE_OPERATOR_UNKNOWN    = 0,
     FECOMPOSITE_OPERATOR_OVER       = 1,
     FECOMPOSITE_OPERATOR_IN         = 2,
     FECOMPOSITE_OPERATOR_OUT        = 3,
@@ -68,7 +68,7 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
-    bool resultIsValidPremultiplied() const override { return m_type != FECOMPOSITE_OPERATOR_ARITHMETIC; }
+    bool resultIsValidPremultiplied() const override { return m_type != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC; }
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
@@ -89,24 +89,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CompositeOperationType> {
-    using values = EnumValues<
-        WebCore::CompositeOperationType,
-
-        WebCore::FECOMPOSITE_OPERATOR_UNKNOWN,
-        WebCore::FECOMPOSITE_OPERATOR_OVER,
-        WebCore::FECOMPOSITE_OPERATOR_IN,
-        WebCore::FECOMPOSITE_OPERATOR_OUT,
-        WebCore::FECOMPOSITE_OPERATOR_ATOP,
-        WebCore::FECOMPOSITE_OPERATOR_XOR,
-        WebCore::FECOMPOSITE_OPERATOR_ARITHMETIC,
-        WebCore::FECOMPOSITE_OPERATOR_LIGHTER
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(FEComposite)

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class EdgeModeType {
+enum class EdgeModeType : uint8_t {
     Unknown,
     Duplicate,
     Wrap,
@@ -88,20 +88,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::EdgeModeType> {
-    using values = EnumValues<
-        WebCore::EdgeModeType,
-
-        WebCore::EdgeModeType::Unknown,
-        WebCore::EdgeModeType::Duplicate,
-        WebCore::EdgeModeType::Wrap,
-        WebCore::EdgeModeType::None
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(FEConvolveMatrix)

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
@@ -105,19 +105,19 @@ std::unique_ptr<FilterEffectApplier> FEDisplacementMap::createSoftwareApplier() 
 static TextStream& operator<<(TextStream& ts, const ChannelSelectorType& type)
 {
     switch (type) {
-    case CHANNEL_UNKNOWN:
+    case ChannelSelectorType::CHANNEL_UNKNOWN:
         ts << "UNKNOWN";
         break;
-    case CHANNEL_R:
+    case ChannelSelectorType::CHANNEL_R:
         ts << "RED";
         break;
-    case CHANNEL_G:
+    case ChannelSelectorType::CHANNEL_G:
         ts << "GREEN";
         break;
-    case CHANNEL_B:
+    case ChannelSelectorType::CHANNEL_B:
         ts << "BLUE";
         break;
-    case CHANNEL_A:
+    case ChannelSelectorType::CHANNEL_A:
         ts << "ALPHA";
         break;
     }

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
@@ -27,7 +27,7 @@
 
 namespace WebCore {
 
-enum ChannelSelectorType {
+enum class ChannelSelectorType : uint8_t {
     CHANNEL_UNKNOWN = 0,
     CHANNEL_R = 1,
     CHANNEL_G = 2,
@@ -72,21 +72,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ChannelSelectorType> {
-    using values = EnumValues<
-        WebCore::ChannelSelectorType,
-
-        WebCore::CHANNEL_UNKNOWN,
-        WebCore::CHANNEL_R,
-        WebCore::CHANNEL_G,
-        WebCore::CHANNEL_B,
-        WebCore::CHANNEL_A
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(FEDisplacementMap)

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.h
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.h
@@ -26,7 +26,7 @@
 
 namespace WebCore {
 
-enum class MorphologyOperatorType {
+enum class MorphologyOperatorType : uint8_t {
     Unknown,
     Erode,
     Dilate
@@ -66,19 +66,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::MorphologyOperatorType> {
-    using values = EnumValues<
-        WebCore::MorphologyOperatorType,
-
-        WebCore::MorphologyOperatorType::Unknown,
-        WebCore::MorphologyOperatorType::Erode,
-        WebCore::MorphologyOperatorType::Dilate
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(FEMorphology)

--- a/Source/WebCore/platform/graphics/filters/FETurbulence.h
+++ b/Source/WebCore/platform/graphics/filters/FETurbulence.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class TurbulenceType {
+enum class TurbulenceType : uint8_t {
     Unknown,
     FractalNoise,
     Turbulence
@@ -81,19 +81,5 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::TurbulenceType> {
-    using values = EnumValues<
-        WebCore::TurbulenceType,
-
-        WebCore::TurbulenceType::Unknown,
-        WebCore::TurbulenceType::FractalNoise,
-        WebCore::TurbulenceType::Turbulence
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(FETurbulence)

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -55,9 +55,8 @@ public:
         CSSFilter,
         SVGFilter,
 
-        FEFirst,
-
-        FEBlend = FEFirst,
+        // These are filter effects
+        FEBlend,
         FEColorMatrix,
         FEComponentTransfer,
         FEComposite,
@@ -75,9 +74,7 @@ public:
         FETile,
         FETurbulence,
         SourceAlpha,
-        SourceGraphic,
-
-        FELast = SourceGraphic
+        SourceGraphic
     };
 
     FilterFunction(Type, std::optional<RenderingResourceIdentifier> = std::nullopt);
@@ -88,7 +85,7 @@ public:
     bool isCSSFilter() const { return m_filterType == Type::CSSFilter; }
     bool isSVGFilter() const { return m_filterType == Type::SVGFilter; }
     bool isFilter() const override { return m_filterType == Type::CSSFilter || m_filterType == Type::SVGFilter; }
-    bool isFilterEffect() const { return m_filterType >= Type::FEFirst && m_filterType <= Type::FELast; }
+    bool isFilterEffect() const { return m_filterType >= Type::FEBlend && m_filterType <= Type::SourceGraphic; }
 
     static AtomString filterName(Type);
     static AtomString sourceAlphaName() { return filterName(Type::SourceAlpha); }
@@ -108,39 +105,6 @@ private:
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, const FilterFunction&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::FilterFunction::Type> {
-    using values = EnumValues<
-        WebCore::FilterFunction::Type,
-
-        WebCore::FilterFunction::Type::CSSFilter,
-        WebCore::FilterFunction::Type::SVGFilter,
-
-        WebCore::FilterFunction::Type::FEBlend,
-        WebCore::FilterFunction::Type::FEColorMatrix,
-        WebCore::FilterFunction::Type::FEComponentTransfer,
-        WebCore::FilterFunction::Type::FEComposite,
-        WebCore::FilterFunction::Type::FEConvolveMatrix,
-        WebCore::FilterFunction::Type::FEDiffuseLighting,
-        WebCore::FilterFunction::Type::FEDisplacementMap,
-        WebCore::FilterFunction::Type::FEDropShadow,
-        WebCore::FilterFunction::Type::FEFlood,
-        WebCore::FilterFunction::Type::FEGaussianBlur,
-        WebCore::FilterFunction::Type::FEImage,
-        WebCore::FilterFunction::Type::FEMerge,
-        WebCore::FilterFunction::Type::FEMorphology,
-        WebCore::FilterFunction::Type::FEOffset,
-        WebCore::FilterFunction::Type::FESpecularLighting,
-        WebCore::FilterFunction::Type::FETile,
-        WebCore::FilterFunction::Type::FETurbulence,
-        WebCore::FilterFunction::Type::SourceAlpha,
-        WebCore::FilterFunction::Type::SourceGraphic
-    >;
-};
-
-} // namespace WTF
 
 #define SPECIALIZE_TYPE_TRAITS_FILTER_FUNCTION(ClassName) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ClassName) \

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.h
@@ -403,28 +403,3 @@ SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(BasicComponentTransferFilterOperation, is
 SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(InvertLightnessFilterOperation, type() == WebCore::FilterOperation::Type::AppleInvertLightness)
 SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(BlurFilterOperation, type() == WebCore::FilterOperation::Type::Blur)
 SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(DropShadowFilterOperation, type() == WebCore::FilterOperation::Type::DropShadow)
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::FilterOperation::Type> {
-    using values = EnumValues<
-        WebCore::FilterOperation::Type,
-        WebCore::FilterOperation::Type::Reference,
-        WebCore::FilterOperation::Type::Grayscale,
-        WebCore::FilterOperation::Type::Sepia,
-        WebCore::FilterOperation::Type::Saturate,
-        WebCore::FilterOperation::Type::HueRotate,
-        WebCore::FilterOperation::Type::Invert,
-        WebCore::FilterOperation::Type::AppleInvertLightness,
-        WebCore::FilterOperation::Type::Opacity,
-        WebCore::FilterOperation::Type::Brightness,
-        WebCore::FilterOperation::Type::Contrast,
-        WebCore::FilterOperation::Type::Blur,
-        WebCore::FilterOperation::Type::DropShadow,
-        WebCore::FilterOperation::Type::Passthrough,
-        WebCore::FilterOperation::Type::Default,
-        WebCore::FilterOperation::Type::None
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/filters/FilterRenderingMode.h
+++ b/Source/WebCore/platform/graphics/filters/FilterRenderingMode.h
@@ -42,17 +42,3 @@ constexpr OptionSet<FilterRenderingMode> allFilterRenderingModes = {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::FilterRenderingMode> {
-    using values = EnumValues<
-        WebCore::FilterRenderingMode,
-
-        WebCore::FilterRenderingMode::Software,
-        WebCore::FilterRenderingMode::Accelerated,
-        WebCore::FilterRenderingMode::GraphicsContext
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/filters/LightSource.h
+++ b/Source/WebCore/platform/graphics/filters/LightSource.h
@@ -34,7 +34,7 @@ class TextStream;
 
 namespace WebCore {
 
-enum LightType {
+enum class LightType : uint8_t {
     LS_DISTANT,
     LS_POINT,
     LS_SPOT
@@ -106,20 +106,6 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::LightType> {
-    using values = EnumValues<
-        WebCore::LightType,
-
-        WebCore::LS_DISTANT,
-        WebCore::LS_POINT,
-        WebCore::LS_SPOT
-    >;
-};
-
-} // namespace WTF
 
 #define SPECIALIZE_TYPE_TRAITS_LIGHTSOURCE(ClassName, Type) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ClassName) \

--- a/Source/WebCore/platform/graphics/filters/PointLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/PointLightSource.cpp
@@ -44,7 +44,7 @@ Ref<PointLightSource> PointLightSource::create(const FloatPoint3D& position)
 }
 
 PointLightSource::PointLightSource(const FloatPoint3D& position)
-    : LightSource(LS_POINT)
+    : LightSource(LightType::LS_POINT)
     , m_position(position)
 {
 }

--- a/Source/WebCore/platform/graphics/filters/PointLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/PointLightSource.h
@@ -55,4 +55,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_LIGHTSOURCE(PointLightSource, LS_POINT)
+SPECIALIZE_TYPE_TRAITS_LIGHTSOURCE(PointLightSource, LightType::LS_POINT)

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
@@ -50,7 +50,7 @@ Ref<SpotLightSource> SpotLightSource::create(const FloatPoint3D& position, const
 }
 
 SpotLightSource::SpotLightSource(const FloatPoint3D& position, const FloatPoint3D& pointsAt, float specularExponent, float limitingConeAngle)
-    : LightSource(LS_SPOT)
+    : LightSource(LightType::LS_SPOT)
     , m_position(position)
     , m_pointsAt(pointsAt)
     , m_specularExponent(clampTo<float>(specularExponent, 1.0f, 128.0f))

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.h
@@ -70,4 +70,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_LIGHTSOURCE(SpotLightSource, LS_SPOT)
+SPECIALIZE_TYPE_TRAITS_LIGHTSOURCE(SpotLightSource, LightType::LS_SPOT)

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -39,9 +39,9 @@ namespace WebCore {
 FEColorMatrixSoftwareApplier::FEColorMatrixSoftwareApplier(const FEColorMatrix& effect)
     : Base(effect)
 {
-    if (m_effect.type() == FECOLORMATRIX_TYPE_SATURATE)
+    if (m_effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE)
         FEColorMatrix::calculateSaturateComponents(m_components, m_effect.values()[0]);
-    else if (m_effect.type() == FECOLORMATRIX_TYPE_HUEROTATE)
+    else if (m_effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE)
         FEColorMatrix::calculateHueRotateComponents(m_components, m_effect.values()[0]);
 }
 
@@ -100,10 +100,10 @@ void FEColorMatrixSoftwareApplier::applyPlatformAccelerated(PixelBuffer& pixelBu
     dest.data = pixelBytes;
 
     switch (m_effect.type()) {
-    case FECOLORMATRIX_TYPE_UNKNOWN:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
         break;
 
-    case FECOLORMATRIX_TYPE_MATRIX: {
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX: {
         const auto& values = m_effect.values();
 
         const int16_t matrix[4 * 4] = {
@@ -131,8 +131,8 @@ void FEColorMatrixSoftwareApplier::applyPlatformAccelerated(PixelBuffer& pixelBu
         break;
     }
 
-    case FECOLORMATRIX_TYPE_SATURATE:
-    case FECOLORMATRIX_TYPE_HUEROTATE: {
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE: {
         const int16_t matrix[4 * 4] = {
             static_cast<int16_t>(roundf(m_components[0] * divisor)),
             static_cast<int16_t>(roundf(m_components[3] * divisor)),
@@ -157,7 +157,7 @@ void FEColorMatrixSoftwareApplier::applyPlatformAccelerated(PixelBuffer& pixelBu
         vImageMatrixMultiply_ARGB8888(&src, &dest, matrix, divisor, nullptr, nullptr, kvImageNoFlags);
         break;
     }
-    case FECOLORMATRIX_TYPE_LUMINANCETOALPHA: {
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA: {
         const int16_t matrix[4 * 4] = {
             0,
             0,
@@ -191,10 +191,10 @@ void FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated(PixelBuffer& pixel
     auto pixelByteLength = pixelBuffer.sizeInBytes();
 
     switch (m_effect.type()) {
-    case FECOLORMATRIX_TYPE_UNKNOWN:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
         break;
 
-    case FECOLORMATRIX_TYPE_MATRIX:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
         for (unsigned pixelByteOffset = 0; pixelByteOffset < pixelByteLength; pixelByteOffset += 4) {
             float red = pixelBuffer.item(pixelByteOffset);
             float green = pixelBuffer.item(pixelByteOffset + 1);
@@ -208,8 +208,8 @@ void FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated(PixelBuffer& pixel
         }
         break;
 
-    case FECOLORMATRIX_TYPE_SATURATE:
-    case FECOLORMATRIX_TYPE_HUEROTATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
         for (unsigned pixelByteOffset = 0; pixelByteOffset < pixelByteLength; pixelByteOffset += 4) {
             float red = pixelBuffer.item(pixelByteOffset);
             float green = pixelBuffer.item(pixelByteOffset + 1);
@@ -223,7 +223,7 @@ void FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated(PixelBuffer& pixel
         }
         break;
 
-    case FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
         for (unsigned pixelByteOffset = 0; pixelByteOffset < pixelByteLength; pixelByteOffset += 4) {
             float red = pixelBuffer.item(pixelByteOffset);
             float green = pixelBuffer.item(pixelByteOffset + 1);
@@ -246,7 +246,7 @@ void FEColorMatrixSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
 
     // vImageMatrixMultiply_ARGB8888 takes a 4x4 matrix, if any value in the last column of the FEColorMatrix 5x4 matrix
     // is not zero, fall back to non-vImage code.
-    if (m_effect.type() != FECOLORMATRIX_TYPE_MATRIX || (!values[4] && !values[9] && !values[14] && !values[19])) {
+    if (m_effect.type() != ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX || (!values[4] && !values[9] && !values[14] && !values[19])) {
         applyPlatformAccelerated(pixelBuffer);
         return;
     }

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -107,7 +107,7 @@ FEComponentTransferSoftwareApplier::LookupTable FEComponentTransferSoftwareAppli
     };
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(static_cast<size_t>(function.type) < std::size(callEffect));
-    callEffect[function.type](table, function);
+    callEffect[static_cast<size_t>(function.type)](table, function);
 
     return table;
 }

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 FECompositeSoftwareApplier::FECompositeSoftwareApplier(const FEComposite& effect)
     : Base(effect)
 {
-    ASSERT(m_effect.operation() != FECOMPOSITE_OPERATOR_ARITHMETIC);
+    ASSERT(m_effect.operation() != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
 }
 
 bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
@@ -58,15 +58,15 @@ bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& i
     auto inputImageRect2 = input2.absoluteImageRectRelativeTo(result);
 
     switch (m_effect.operation()) {
-    case FECOMPOSITE_OPERATOR_UNKNOWN:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
         return false;
 
-    case FECOMPOSITE_OPERATOR_OVER:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_OVER:
         filterContext.drawImageBuffer(*inputImage2, inputImageRect2);
         filterContext.drawImageBuffer(*inputImage, inputImageRect);
         break;
 
-    case FECOMPOSITE_OPERATOR_IN: {
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_IN: {
         // Applies only to the intersected region.
         IntRect destinationRect = input.absoluteImageRect();
         destinationRect.intersect(input2.absoluteImageRect());
@@ -81,27 +81,26 @@ bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& i
         break;
     }
 
-    case FECOMPOSITE_OPERATOR_OUT:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_OUT:
         filterContext.drawImageBuffer(*inputImage, inputImageRect);
         filterContext.drawImageBuffer(*inputImage2, inputImageRect2, { { }, inputImage2->logicalSize() }, { CompositeOperator::DestinationOut });
         break;
 
-    case FECOMPOSITE_OPERATOR_ATOP:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ATOP:
         filterContext.drawImageBuffer(*inputImage2, inputImageRect2);
         filterContext.drawImageBuffer(*inputImage, inputImageRect, { { }, inputImage->logicalSize() }, { CompositeOperator::SourceAtop });
         break;
 
-    case FECOMPOSITE_OPERATOR_XOR:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_XOR:
         filterContext.drawImageBuffer(*inputImage2, inputImageRect2);
         filterContext.drawImageBuffer(*inputImage, inputImageRect, { { }, inputImage->logicalSize() }, { CompositeOperator::XOR });
         break;
 
-    case FECOMPOSITE_OPERATOR_ARITHMETIC:
-        // Should be handled by FECompositeSoftwareArithmeticApplier.
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC:
         ASSERT_NOT_REACHED();
         return false;
 
-    case FECOMPOSITE_OPERATOR_LIGHTER:
+    case CompositeOperationType::FECOMPOSITE_OPERATOR_LIGHTER:
         filterContext.drawImageBuffer(*inputImage2, inputImageRect2);
         filterContext.drawImageBuffer(*inputImage, inputImageRect, { { }, inputImage->logicalSize() }, { CompositeOperator::PlusLighter });
         break;

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 FECompositeSoftwareArithmeticApplier::FECompositeSoftwareArithmeticApplier(const FEComposite& effect)
     : Base(effect)
 {
-    ASSERT(m_effect.operation() == FECOMPOSITE_OPERATOR_ARITHMETIC);
+    ASSERT(m_effect.operation() == CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
 }
 
 uint8_t FECompositeSoftwareArithmeticApplier::clampByte(int c)

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 class FEConvolveMatrix;
-enum class EdgeModeType;
+enum class EdgeModeType : uint8_t;
 
 class FEConvolveMatrixSoftwareApplier final : public FilterEffectConcreteApplier<FEConvolveMatrix> {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
@@ -35,18 +35,18 @@ namespace WebCore {
 FEDisplacementMapSoftwareApplier::FEDisplacementMapSoftwareApplier(const FEDisplacementMap& effect)
     : Base(effect)
 {
-    ASSERT(m_effect.xChannelSelector() != CHANNEL_UNKNOWN);
-    ASSERT(m_effect.yChannelSelector() != CHANNEL_UNKNOWN);
+    ASSERT(m_effect.xChannelSelector() != ChannelSelectorType::CHANNEL_UNKNOWN);
+    ASSERT(m_effect.yChannelSelector() != ChannelSelectorType::CHANNEL_UNKNOWN);
 }
 
 int FEDisplacementMapSoftwareApplier::xChannelIndex() const
 {
-    return m_effect.xChannelSelector() - 1;
+    return static_cast<int>(m_effect.xChannelSelector()) - 1;
 }
 
 int FEDisplacementMapSoftwareApplier::yChannelIndex() const
 {
-    return m_effect.yChannelSelector() - 1;
+    return static_cast<int>(m_effect.yChannelSelector()) - 1;
 }
 
 bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 class FEGaussianBlur;
-enum class EdgeModeType;
+enum class EdgeModeType : uint8_t;
 
 class FEGaussianBlurSoftwareApplier final : public FilterEffectConcreteApplier<FEGaussianBlur> {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 class FEMorphology;
-enum class MorphologyOperatorType;
+enum class MorphologyOperatorType : uint8_t;
 
 class FEMorphologySoftwareApplier final : public FilterEffectConcreteApplier<FEMorphology> {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
@@ -34,7 +34,7 @@
 namespace WebCore {
 
 class FETurbulence;
-enum class TurbulenceType;
+enum class TurbulenceType : uint8_t;
 
 class FETurbulenceSoftwareApplier final : public FilterEffectConcreteApplier<FETurbulence> {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -103,7 +103,7 @@ static RefPtr<FilterEffect> createBlurEffect(const BlurFilterOperation& blurOper
 static RefPtr<FilterEffect> createBrightnessEffect(const BasicComponentTransferFilterOperation& componentTransferOperation)
 {
     ComponentTransferFunction transferFunction;
-    transferFunction.type = FECOMPONENTTRANSFER_TYPE_LINEAR;
+    transferFunction.type = ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR;
     transferFunction.slope = narrowPrecisionToFloat(componentTransferOperation.amount());
     transferFunction.intercept = 0;
 
@@ -114,7 +114,7 @@ static RefPtr<FilterEffect> createBrightnessEffect(const BasicComponentTransferF
 static RefPtr<FilterEffect> createContrastEffect(const BasicComponentTransferFilterOperation& componentTransferOperation)
 {
     ComponentTransferFunction transferFunction;
-    transferFunction.type = FECOMPONENTTRANSFER_TYPE_LINEAR;
+    transferFunction.type = ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR;
     float amount = narrowPrecisionToFloat(componentTransferOperation.amount());
     transferFunction.slope = amount;
     transferFunction.intercept = -0.5 * amount + 0.5;
@@ -139,19 +139,19 @@ static RefPtr<FilterEffect> createGrayScaleEffect(const BasicColorMatrixFilterOp
         0, 0, 0, 1, 0,
     };
 
-    return FEColorMatrix::create(FECOLORMATRIX_TYPE_MATRIX, WTFMove(inputParameters));
+    return FEColorMatrix::create(ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX, WTFMove(inputParameters));
 }
 
 static RefPtr<FilterEffect> createHueRotateEffect(const BasicColorMatrixFilterOperation& colorMatrixOperation)
 {
     Vector<float> inputParameters { narrowPrecisionToFloat(colorMatrixOperation.amount()) };
-    return FEColorMatrix::create(FECOLORMATRIX_TYPE_HUEROTATE, WTFMove(inputParameters));
+    return FEColorMatrix::create(ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE, WTFMove(inputParameters));
 }
 
 static RefPtr<FilterEffect> createInvertEffect(const BasicComponentTransferFilterOperation& componentTransferOperation)
 {
     ComponentTransferFunction transferFunction;
-    transferFunction.type = FECOMPONENTTRANSFER_TYPE_LINEAR;
+    transferFunction.type = ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR;
     float amount = narrowPrecisionToFloat(componentTransferOperation.amount());
     transferFunction.slope = 1 - 2 * amount;
     transferFunction.intercept = amount;
@@ -163,7 +163,7 @@ static RefPtr<FilterEffect> createInvertEffect(const BasicComponentTransferFilte
 static RefPtr<FilterEffect> createOpacityEffect(const BasicComponentTransferFilterOperation& componentTransferOperation)
 {
     ComponentTransferFunction transferFunction;
-    transferFunction.type = FECOMPONENTTRANSFER_TYPE_LINEAR;
+    transferFunction.type = ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR;
     float amount = narrowPrecisionToFloat(componentTransferOperation.amount());
     transferFunction.slope = amount;
     transferFunction.intercept = 0;
@@ -175,7 +175,7 @@ static RefPtr<FilterEffect> createOpacityEffect(const BasicComponentTransferFilt
 static RefPtr<FilterEffect> createSaturateEffect(const BasicColorMatrixFilterOperation& colorMatrixOperation)
 {
     Vector<float> inputParameters { narrowPrecisionToFloat(colorMatrixOperation.amount()) };
-    return FEColorMatrix::create(FECOLORMATRIX_TYPE_SATURATE, WTFMove(inputParameters));
+    return FEColorMatrix::create(ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE, WTFMove(inputParameters));
 }
 
 static RefPtr<FilterEffect> createSepiaEffect(const BasicColorMatrixFilterOperation& colorMatrixOperation)
@@ -188,7 +188,7 @@ static RefPtr<FilterEffect> createSepiaEffect(const BasicColorMatrixFilterOperat
         0, 0, 0, 1, 0,
     };
 
-    return FEColorMatrix::create(FECOLORMATRIX_TYPE_MATRIX, WTFMove(inputParameters));
+    return FEColorMatrix::create(ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX, WTFMove(inputParameters));
 }
 
 static RefPtr<SVGFilterElement> referenceFilterElement(const ReferenceFilterOperation& filterOperation, RenderElement& renderer)

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -53,7 +53,7 @@ void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& 
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
         ComponentTransferType propertyValue = SVGPropertyTraits<ComponentTransferType>::fromString(newValue);
-        if (propertyValue > 0)
+        if (enumToUnderlyingType(propertyValue))
             m_type->setBaseValInternal<ComponentTransferType>(propertyValue);
         break;
     }

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -30,22 +30,22 @@ namespace WebCore {
 
 template<>
 struct SVGPropertyTraits<ComponentTransferType> {
-    static unsigned highestEnumValue() { return FECOMPONENTTRANSFER_TYPE_GAMMA; }
+    static unsigned highestEnumValue() { return enumToUnderlyingType(ComponentTransferType::FECOMPONENTTRANSFER_TYPE_GAMMA); }
 
     static String toString(ComponentTransferType type)
     {
         switch (type) {
-        case FECOMPONENTTRANSFER_TYPE_UNKNOWN:
+        case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN:
             return emptyString();
-        case FECOMPONENTTRANSFER_TYPE_IDENTITY:
+        case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY:
             return "identity"_s;
-        case FECOMPONENTTRANSFER_TYPE_TABLE:
+        case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_TABLE:
             return "table"_s;
-        case FECOMPONENTTRANSFER_TYPE_DISCRETE:
+        case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_DISCRETE:
             return "discrete"_s;
-        case FECOMPONENTTRANSFER_TYPE_LINEAR:
+        case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR:
             return "linear"_s;
-        case FECOMPONENTTRANSFER_TYPE_GAMMA:
+        case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_GAMMA:
             return "gamma"_s;
         }
 
@@ -56,14 +56,14 @@ struct SVGPropertyTraits<ComponentTransferType> {
     static ComponentTransferType fromString(const String& value)
     {
         static constexpr std::pair<PackedASCIILiteral<uint64_t>, ComponentTransferType> mappings[] = {
-            { "discrete", FECOMPONENTTRANSFER_TYPE_DISCRETE },
-            { "gamma", FECOMPONENTTRANSFER_TYPE_GAMMA },
-            { "identity", FECOMPONENTTRANSFER_TYPE_IDENTITY },
-            { "linear", FECOMPONENTTRANSFER_TYPE_LINEAR },
-            { "table", FECOMPONENTTRANSFER_TYPE_TABLE }
+            { "discrete", ComponentTransferType::FECOMPONENTTRANSFER_TYPE_DISCRETE },
+            { "gamma", ComponentTransferType::FECOMPONENTTRANSFER_TYPE_GAMMA },
+            { "identity", ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY },
+            { "linear", ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR },
+            { "table", ComponentTransferType::FECOMPONENTTRANSFER_TYPE_TABLE }
         };
         static constexpr SortedArrayMap map { mappings };
-        return  map.get(value, FECOMPONENTTRANSFER_TYPE_UNKNOWN);
+        return map.get(value, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN);
     }
 };
 
@@ -100,7 +100,7 @@ protected:
     bool rendererIsNeeded(const RenderStyle&) override { return false; }
     
 private:
-    Ref<SVGAnimatedEnumeration> m_type { SVGAnimatedEnumeration::create(this, FECOMPONENTTRANSFER_TYPE_IDENTITY) };
+    Ref<SVGAnimatedEnumeration> m_type { SVGAnimatedEnumeration::create(this, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY) };
     Ref<SVGAnimatedNumberList> m_tableValues { SVGAnimatedNumberList::create(this) };
     Ref<SVGAnimatedNumber> m_slope { SVGAnimatedNumber::create(this, 1) };
     Ref<SVGAnimatedNumber> m_intercept { SVGAnimatedNumber::create(this) };

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -54,9 +54,9 @@ bool SVGFEColorMatrixElement::isInvalidValuesLength() const
     auto filterType = type();
     auto size = values().size();
 
-    return (filterType == FECOLORMATRIX_TYPE_MATRIX    && size != 20)
-        || (filterType == FECOLORMATRIX_TYPE_HUEROTATE && size != 1)
-        || (filterType == FECOLORMATRIX_TYPE_SATURATE  && size != 1);
+    return (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX    && size != 20)
+        || (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE && size != 1)
+        || (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE  && size != 1);
 }
 
 void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -64,7 +64,7 @@ void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const 
     switch (name.nodeName()) {
     case AttributeNames::typeAttr: {
         auto propertyValue = SVGPropertyTraits<ColorMatrixType>::fromString(newValue);
-        if (propertyValue > 0)
+        if (enumToUnderlyingType(propertyValue))
             m_type->setBaseValInternal<ColorMatrixType>(propertyValue);
         break;
     }
@@ -125,17 +125,17 @@ RefPtr<FilterEffect> SVGFEColorMatrixElement::createFilterEffect(const FilterEff
     // Use defaults if values is empty (SVG 1.1 15.10).
     if (!hasAttribute(SVGNames::valuesAttr)) {
         switch (filterType) {
-        case FECOLORMATRIX_TYPE_MATRIX: {
+        case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX: {
             static constexpr unsigned matrixValueCount = 20;
             filterValues = Vector<float>(matrixValueCount, [](size_t i) {
                 return (i % 6) ? 0.0 : 1.0;
             });
             break;
         }
-        case FECOLORMATRIX_TYPE_HUEROTATE:
+        case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
             filterValues = { 0 };
             break;
-        case FECOLORMATRIX_TYPE_SATURATE:
+        case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
             filterValues = { 1 };
             break;
         default:

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -28,20 +28,20 @@ namespace WebCore {
 
 template<>
 struct SVGPropertyTraits<ColorMatrixType> {
-    static unsigned highestEnumValue() { return FECOLORMATRIX_TYPE_LUMINANCETOALPHA; }
+    static unsigned highestEnumValue() { return enumToUnderlyingType(ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA); }
 
     static String toString(ColorMatrixType type)
     {
         switch (type) {
-        case FECOLORMATRIX_TYPE_UNKNOWN:
+        case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
             return emptyString();
-        case FECOLORMATRIX_TYPE_MATRIX:
+        case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
             return "matrix"_s;
-        case FECOLORMATRIX_TYPE_SATURATE:
+        case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
             return "saturate"_s;
-        case FECOLORMATRIX_TYPE_HUEROTATE:
+        case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
             return "hueRotate"_s;
-        case FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
+        case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
             return "luminanceToAlpha"_s;
         }
 
@@ -52,14 +52,14 @@ struct SVGPropertyTraits<ColorMatrixType> {
     static ColorMatrixType fromString(const String& value)
     {
         if (value == "matrix"_s)
-            return FECOLORMATRIX_TYPE_MATRIX;
+            return ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX;
         if (value == "saturate"_s)
-            return FECOLORMATRIX_TYPE_SATURATE;
+            return ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE;
         if (value == "hueRotate"_s)
-            return FECOLORMATRIX_TYPE_HUEROTATE;
+            return ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE;
         if (value == "luminanceToAlpha"_s)
-            return FECOLORMATRIX_TYPE_LUMINANCETOALPHA;
-        return FECOLORMATRIX_TYPE_UNKNOWN;
+            return ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA;
+        return ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN;
     }
 };
 
@@ -91,7 +91,7 @@ private:
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
-    Ref<SVGAnimatedEnumeration> m_type { SVGAnimatedEnumeration::create(this, FECOLORMATRIX_TYPE_MATRIX) };
+    Ref<SVGAnimatedEnumeration> m_type { SVGAnimatedEnumeration::create(this, ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX) };
     Ref<SVGAnimatedNumberList> m_values { SVGAnimatedNumberList::create(this) };
 };
 

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -58,7 +58,7 @@ void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const At
     switch (name.nodeName()) {
     case AttributeNames::operatorAttr: {
         CompositeOperationType propertyValue = SVGPropertyTraits<CompositeOperationType>::fromString(newValue);
-        if (propertyValue > 0)
+        if (enumToUnderlyingType(propertyValue))
             m_svgOperator->setBaseValInternal<CompositeOperationType>(propertyValue);
         break;
     }

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -28,30 +28,30 @@
 namespace WebCore {
 
 template<>
-inline unsigned SVGIDLEnumLimits<CompositeOperationType>::highestExposedEnumValue() { return FECOMPOSITE_OPERATOR_ARITHMETIC; }
+inline unsigned SVGIDLEnumLimits<CompositeOperationType>::highestExposedEnumValue() { return enumToUnderlyingType(CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC); }
 
 template<>
 struct SVGPropertyTraits<CompositeOperationType> {
-    static unsigned highestEnumValue() { return FECOMPOSITE_OPERATOR_LIGHTER; }
+    static unsigned highestEnumValue() { return enumToUnderlyingType(CompositeOperationType::FECOMPOSITE_OPERATOR_LIGHTER); }
 
     static String toString(CompositeOperationType type)
     {
         switch (type) {
-        case FECOMPOSITE_OPERATOR_UNKNOWN:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
             return emptyString();
-        case FECOMPOSITE_OPERATOR_OVER:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_OVER:
             return "over"_s;
-        case FECOMPOSITE_OPERATOR_IN:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_IN:
             return "in"_s;
-        case FECOMPOSITE_OPERATOR_OUT:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_OUT:
             return "out"_s;
-        case FECOMPOSITE_OPERATOR_ATOP:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_ATOP:
             return "atop"_s;
-        case FECOMPOSITE_OPERATOR_XOR:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_XOR:
             return "xor"_s;
-        case FECOMPOSITE_OPERATOR_ARITHMETIC:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC:
             return "arithmetic"_s;
-        case FECOMPOSITE_OPERATOR_LIGHTER:
+        case CompositeOperationType::FECOMPOSITE_OPERATOR_LIGHTER:
             return "lighter"_s;
         }
 
@@ -62,16 +62,16 @@ struct SVGPropertyTraits<CompositeOperationType> {
     static CompositeOperationType fromString(const String& value)
     {
         static constexpr std::pair<ComparableASCIILiteral, CompositeOperationType> mappings[] = {
-            { "arithmetic", FECOMPOSITE_OPERATOR_ARITHMETIC },
-            { "atop", FECOMPOSITE_OPERATOR_ATOP },
-            { "in", FECOMPOSITE_OPERATOR_IN },
-            { "lighter", FECOMPOSITE_OPERATOR_LIGHTER },
-            { "out", FECOMPOSITE_OPERATOR_OUT },
-            { "over", FECOMPOSITE_OPERATOR_OVER },
-            { "xor", FECOMPOSITE_OPERATOR_XOR },
+            { "arithmetic", CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC },
+            { "atop", CompositeOperationType::FECOMPOSITE_OPERATOR_ATOP },
+            { "in", CompositeOperationType::FECOMPOSITE_OPERATOR_IN },
+            { "lighter", CompositeOperationType::FECOMPOSITE_OPERATOR_LIGHTER },
+            { "out", CompositeOperationType::FECOMPOSITE_OPERATOR_OUT },
+            { "over", CompositeOperationType::FECOMPOSITE_OPERATOR_OVER },
+            { "xor", CompositeOperationType::FECOMPOSITE_OPERATOR_XOR },
         };
         static constexpr SortedArrayMap map { mappings };
-        return map.get(value, FECOMPOSITE_OPERATOR_UNKNOWN);
+        return map.get(value, CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN);
     }
 };
 
@@ -110,7 +110,7 @@ private:
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
     Ref<SVGAnimatedString> m_in2 { SVGAnimatedString::create(this) };
-    Ref<SVGAnimatedEnumeration> m_svgOperator { SVGAnimatedEnumeration::create(this, FECOMPOSITE_OPERATOR_OVER) };
+    Ref<SVGAnimatedEnumeration> m_svgOperator { SVGAnimatedEnumeration::create(this, CompositeOperationType::FECOMPOSITE_OPERATOR_OVER) };
     Ref<SVGAnimatedNumber> m_k1 { SVGAnimatedNumber::create(this) };
     Ref<SVGAnimatedNumber> m_k2 { SVGAnimatedNumber::create(this) };
     Ref<SVGAnimatedNumber> m_k3 { SVGAnimatedNumber::create(this) };

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -55,13 +55,13 @@ void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, co
     switch (name.nodeName()) {
     case AttributeNames::xChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
-        if (propertyValue > 0)
+        if (enumToUnderlyingType(propertyValue))
             m_xChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
         break;
     }
     case AttributeNames::yChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
-        if (propertyValue > 0)
+        if (enumToUnderlyingType(propertyValue))
             m_yChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
         break;
     }

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -27,20 +27,20 @@ namespace WebCore {
  
 template<>
 struct SVGPropertyTraits<ChannelSelectorType> {
-    static unsigned highestEnumValue() { return CHANNEL_A; }
+    static unsigned highestEnumValue() { return enumToUnderlyingType(ChannelSelectorType::CHANNEL_A); }
 
     static String toString(ChannelSelectorType type)
     {
         switch (type) {
-        case CHANNEL_UNKNOWN:
+        case ChannelSelectorType::CHANNEL_UNKNOWN:
             return emptyString();
-        case CHANNEL_R:
+        case ChannelSelectorType::CHANNEL_R:
             return "R"_s;
-        case CHANNEL_G:
+        case ChannelSelectorType::CHANNEL_G:
             return "G"_s;
-        case CHANNEL_B:
+        case ChannelSelectorType::CHANNEL_B:
             return "B"_s;
-        case CHANNEL_A:
+        case ChannelSelectorType::CHANNEL_A:
             return "A"_s;
         }
 
@@ -51,14 +51,14 @@ struct SVGPropertyTraits<ChannelSelectorType> {
     static ChannelSelectorType fromString(const String& value)
     {
         if (value == "R"_s)
-            return CHANNEL_R;
+            return ChannelSelectorType::CHANNEL_R;
         if (value == "G"_s)
-            return CHANNEL_G;
+            return ChannelSelectorType::CHANNEL_G;
         if (value == "B"_s)
-            return CHANNEL_B;
+            return ChannelSelectorType::CHANNEL_B;
         if (value == "A"_s)
-            return CHANNEL_A;
-        return CHANNEL_UNKNOWN;
+            return ChannelSelectorType::CHANNEL_A;
+        return ChannelSelectorType::CHANNEL_UNKNOWN;
     }
 };
 
@@ -95,8 +95,8 @@ private:
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
     Ref<SVGAnimatedString> m_in2 { SVGAnimatedString::create(this) };
-    Ref<SVGAnimatedEnumeration> m_xChannelSelector { SVGAnimatedEnumeration::create(this, CHANNEL_A) };
-    Ref<SVGAnimatedEnumeration> m_yChannelSelector { SVGAnimatedEnumeration::create(this, CHANNEL_A) };
+    Ref<SVGAnimatedEnumeration> m_xChannelSelector { SVGAnimatedEnumeration::create(this, ChannelSelectorType::CHANNEL_A) };
+    Ref<SVGAnimatedEnumeration> m_yChannelSelector { SVGAnimatedEnumeration::create(this, ChannelSelectorType::CHANNEL_A) };
     Ref<SVGAnimatedNumber> m_scale { SVGAnimatedNumber::create(this) };
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7305,3 +7305,129 @@ header: <WebCore/VideoTrackPrivate.h>
 };
 
 #endif
+header: <WebCore/FEComposite.h>
+enum class WebCore::CompositeOperationType : uint8_t {
+    FECOMPOSITE_OPERATOR_UNKNOWN,
+    FECOMPOSITE_OPERATOR_OVER,
+    FECOMPOSITE_OPERATOR_IN,
+    FECOMPOSITE_OPERATOR_OUT,
+    FECOMPOSITE_OPERATOR_ATOP,
+    FECOMPOSITE_OPERATOR_XOR,
+    FECOMPOSITE_OPERATOR_ARITHMETIC,
+    FECOMPOSITE_OPERATOR_LIGHTER
+};
+
+header: <WebCore/FEColorMatrix.h>
+enum class WebCore::ColorMatrixType : uint8_t {
+    FECOLORMATRIX_TYPE_UNKNOWN,
+    FECOLORMATRIX_TYPE_MATRIX,
+    FECOLORMATRIX_TYPE_SATURATE,
+    FECOLORMATRIX_TYPE_HUEROTATE,
+    FECOLORMATRIX_TYPE_LUMINANCETOALPHA
+};
+
+header: <WebCore/FETurbulence.h>
+enum class WebCore::TurbulenceType : uint8_t {
+    Unknown,
+    FractalNoise,
+    Turbulence
+};
+
+header: <WebCore/FilterRenderingMode.h>
+[OptionSet] enum class WebCore::FilterRenderingMode : uint8_t {
+    Software,
+    Accelerated,
+    GraphicsContext
+};
+
+header: <WebCore/LightSource.h>
+enum class WebCore::LightType : uint8_t {
+    LS_DISTANT,
+    LS_POINT,
+    LS_SPOT
+};
+
+header: <WebCore/FEComponentTransfer.h>
+enum class WebCore::ComponentTransferType : uint8_t {
+    FECOMPONENTTRANSFER_TYPE_UNKNOWN,
+    FECOMPONENTTRANSFER_TYPE_IDENTITY,
+    FECOMPONENTTRANSFER_TYPE_TABLE,
+    FECOMPONENTTRANSFER_TYPE_DISCRETE,
+    FECOMPONENTTRANSFER_TYPE_LINEAR,
+    FECOMPONENTTRANSFER_TYPE_GAMMA
+};
+
+enum class WebCore::ComponentTransferChannel : uint8_t {
+    Red,
+    Green,
+    Blue,
+    Alpha
+};
+
+header: <WebCore/FEMorphology.h>
+enum class WebCore::MorphologyOperatorType : uint8_t {
+    Unknown,
+    Erode,
+    Dilate
+};
+
+header: <WebCore/FEDisplacementMap.h>
+enum class WebCore::ChannelSelectorType : uint8_t {
+    CHANNEL_UNKNOWN,
+    CHANNEL_R,
+    CHANNEL_G,
+    CHANNEL_B,
+    CHANNEL_A
+};
+
+header: <WebCore/FEConvolveMatrix.h>
+enum class WebCore::EdgeModeType : uint8_t {
+    Unknown,
+    Duplicate,
+    Wrap,
+    None
+};
+
+header: <WebCore/FilterOperation.h>
+[Nested] enum class WebCore::FilterOperation::Type : uint8_t {
+    Reference,
+    Grayscale,
+    Sepia,
+    Saturate,
+    HueRotate,
+    Invert,
+    AppleInvertLightness,
+    Opacity,
+    Brightness,
+    Contrast,
+    Blur,
+    DropShadow,
+    Passthrough,
+    Default,
+    None
+};
+
+header: <WebCore/FilterFunction.h>
+[Nested] enum class WebCore::FilterFunction::Type : uint8_t {
+    CSSFilter,
+    SVGFilter,
+    FEBlend,
+    FEColorMatrix,
+    FEComponentTransfer,
+    FEComposite,
+    FEConvolveMatrix,
+    FEDiffuseLighting,
+    FEDisplacementMap,
+    FEDropShadow,
+    FEFlood,
+    FEGaussianBlur,
+    FEImage,
+    FEMerge,
+    FEMorphology,
+    FEOffset,
+    FESpecularLighting,
+    FETile,
+    FETurbulence,
+    SourceAlpha,
+    SourceGraphic
+};


### PR DESCRIPTION
#### 99370f48350dfae138b30520042652145a85eff8
<pre>
Change all enums under WebCore/platform/graphics/filters/ to use serializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=264834">https://bugs.webkit.org/show_bug.cgi?id=264834</a>

Reviewed by Chris Dumez.

This patch changes all enums so they don&apos;t use the EnumTraits template
anymore.

Most of the patch is straightforward: it turns the enum into enum classes,
adds an uint8_t type specifier to the enum classes, and adds the enum scope
in the call sites. The only change that doesn&apos;t follow this is the
removal of FEFirst and FELast from FilterFunction::Type, default values
for the start and end of a subset of values in the enum; they are only
ever used in the isFilterEffect() function, so I just replaced them with
the actual values.

* Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm:
(WebCore::FEColorMatrixCoreImageApplier::supportsCoreImageRendering):
(WebCore::FEColorMatrixCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm:
(WebCore::FEComponentTransferCoreImageApplier::supportsCoreImageRendering):
(WebCore::FEComponentTransferCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp:
(WebCore::FECompositeNeonArithmeticApplier::FECompositeNeonArithmeticApplier):
* Source/WebCore/platform/graphics/filters/DistantLightSource.cpp:
(WebCore::DistantLightSource::DistantLightSource):
* Source/WebCore/platform/graphics/filters/DistantLightSource.h:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::resultIsAlphaImage const):
(WebCore::FEColorMatrix::supportedFilterRenderingModes const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/platform/graphics/filters/FEComposite.cpp:
(WebCore::FEComposite::calculateImageRect const):
(WebCore::FEComposite::createSoftwareApplier const):
(WebCore::operator&lt;&lt;):
(WebCore::FEComposite::externalRepresentation const):
* Source/WebCore/platform/graphics/filters/FEComposite.h:
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h:
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.h:
* Source/WebCore/platform/graphics/filters/FEMorphology.h:
* Source/WebCore/platform/graphics/filters/FETurbulence.h:
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
(WebCore::FilterFunction::isFilterEffect const):
* Source/WebCore/platform/graphics/filters/FilterOperation.h:
* Source/WebCore/platform/graphics/filters/FilterRenderingMode.h:
* Source/WebCore/platform/graphics/filters/LightSource.h:
(): Deleted.
* Source/WebCore/platform/graphics/filters/PointLightSource.cpp:
(WebCore::PointLightSource::PointLightSource):
* Source/WebCore/platform/graphics/filters/PointLightSource.h:
* Source/WebCore/platform/graphics/filters/SpotLightSource.cpp:
(WebCore::SpotLightSource::SpotLightSource):
* Source/WebCore/platform/graphics/filters/SpotLightSource.h:
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp:
(WebCore::FEColorMatrixSoftwareApplier::FEColorMatrixSoftwareApplier):
(WebCore::FEColorMatrixSoftwareApplier::applyPlatformAccelerated const):
(WebCore::FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated const):
(WebCore::FEColorMatrixSoftwareApplier::applyPlatform const):
* Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp:
(WebCore::FEComponentTransferSoftwareApplier::computeLookupTable):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp:
(WebCore::FECompositeSoftwareApplier::FECompositeSoftwareApplier):
(WebCore::FECompositeSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp:
(WebCore::FECompositeSoftwareArithmeticApplier::FECompositeSoftwareArithmeticApplier):
* Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h:
* Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp:
(WebCore::FEDisplacementMapSoftwareApplier::FEDisplacementMapSoftwareApplier):
(WebCore::FEDisplacementMapSoftwareApplier::xChannelIndex const):
(WebCore::FEDisplacementMapSoftwareApplier::yChannelIndex const):
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.h:
* Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h:
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::createBrightnessEffect):
(WebCore::createContrastEffect):
(WebCore::createGrayScaleEffect):
(WebCore::createHueRotateEffect):
(WebCore::createInvertEffect):
(WebCore::createOpacityEffect):
(WebCore::createSaturateEffect):
(WebCore::createSepiaEffect):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::attributeChanged):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
(WebCore::SVGPropertyTraits&lt;ComponentTransferType&gt;::highestEnumValue):
(WebCore::SVGPropertyTraits&lt;ComponentTransferType&gt;::toString):
(WebCore::SVGPropertyTraits&lt;ComponentTransferType&gt;::fromString):
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::isInvalidValuesLength const):
(WebCore::SVGFEColorMatrixElement::attributeChanged):
(WebCore::SVGFEColorMatrixElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEColorMatrixElement.h:
(WebCore::SVGPropertyTraits&lt;ColorMatrixType&gt;::highestEnumValue):
(WebCore::SVGPropertyTraits&lt;ColorMatrixType&gt;::toString):
(WebCore::SVGPropertyTraits&lt;ColorMatrixType&gt;::fromString):
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(WebCore::SVGFECompositeElement::attributeChanged):
* Source/WebCore/svg/SVGFECompositeElement.h:
(WebCore::SVGIDLEnumLimits&lt;CompositeOperationType&gt;::highestExposedEnumValue):
(WebCore::SVGPropertyTraits&lt;CompositeOperationType&gt;::highestEnumValue):
(WebCore::SVGPropertyTraits&lt;CompositeOperationType&gt;::toString):
(WebCore::SVGPropertyTraits&lt;CompositeOperationType&gt;::fromString):
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::attributeChanged):
* Source/WebCore/svg/SVGFEDisplacementMapElement.h:
(WebCore::SVGPropertyTraits&lt;ChannelSelectorType&gt;::highestEnumValue):
(WebCore::SVGPropertyTraits&lt;ChannelSelectorType&gt;::toString):
(WebCore::SVGPropertyTraits&lt;ChannelSelectorType&gt;::fromString):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273147@main">https://commits.webkit.org/273147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad738d3c579381aa1c31835be62b8ee31ba90eb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34414 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30126 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35943 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33887 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11799 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7917 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->