### PR TITLE
Parse web extension manifest for declarativeNetRequest rulesets

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -469,6 +469,12 @@
 /* Display name for easy reader (i.e. 3rd-grade level) text tracks. */
 "Easy Reader (text track)" = "Easy Reader";
 
+/* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty JSON path */
+"Empty `declarative_net_request` JSON path." = "Empty `declarative_net_request` JSON path.";
+
+/* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for empty ruleset id */
+"Empty `declarative_net_request` ruleset id." = "Empty `declarative_net_request` ruleset id.";
+
 /* WKWebExtensionErrorInvalidManifestEntry description for background */
 "Empty or invalid `background` manifest entry." = "Empty or invalid `background` manifest entry.";
 
@@ -531,6 +537,12 @@
 
 /* Custom protocol synchronous load failure description */
 "Error handling synchronous load with custom protocol" = "Error handling synchronous load with custom protocol";
+
+/* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many rulesets */
+"Exceeded maximum number of `declarative_net_request` rulesets. Ignoring extra rulesets." = "Exceeded maximum number of `declarative_net_request` rulesets. Ignoring extra rulesets.";
+
+/* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many enabled static rulesets */
+"Exceeded maxmimum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored." = "Exceeded maxmimum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.";
 
 /* Button for exiting full screen when in full screen media playback */
 "Exit Full Screen" = "Exit Full Screen";
@@ -781,6 +793,9 @@
 /* WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value */
 "Manifest `content_scripts` entry has unknown `run_at` value." = "Manifest `content_scripts` entry has unknown `run_at` value.";
 
+/* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for missing declarativeNetRequest permission */
+"Manifest has no `declarativeNetRequest` permission." = "Manifest has no `declarativeNetRequest` permission.";
+
 /* Validation message for input form controls requiring a constrained value according to pattern */
 "Match the requested format" = "Match the requested format";
 
@@ -972,6 +987,9 @@
 
 /* Previous Page context menu item */
 "Previous Page" = "Previous Page";
+
+/* Title for the webarea while the accessibility tree is being built. */
+"Processing page" = "Processing page";
 
 /* Undo action name */
 "Raise Baseline (Undo action name)" = "Raise Baseline";
@@ -1444,6 +1462,9 @@
 /* Zoom Out context menu item */
 "Zoom Out" = "Zoom Out";
 
+/* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for duplicate ruleset id */
+"`declarative_net_request` ruleset with id \"%@\" is invalid. Ruleset id must be unique." = "`declarative_net_request` ruleset with id \"%@\" is invalid. Ruleset id must be unique.";
+
 /* Verb stating the action that will occur when a text field is selected, as used by accessibility */
 "activate" = "activate";
 
@@ -1785,9 +1806,6 @@
 
 /* accessibility label for a date field year input. */
 "year" = "year";
-
-/* Accessibility message to indicate that a page is being processed to be accessed. */
-"Processing page" = "Processing page";
 
 /* Message for requesting access to the device motion and orientation */
 "“%@” Would Like to Access Motion and Orientation" = "“%@” Would Like to Access Motion and Orientation";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -246,6 +246,9 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  */
 @property (nonatomic, readonly) BOOL hasCommands;
 
+/*! @abstract A boolean value indicating whether the extension includes rules used for content modification or blocking. */
+@property (nonatomic, readonly) BOOL hasContentModificationRules;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -275,6 +275,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return _webExtension->hasCommands();
 }
 
+- (BOOL)hasContentModificationRules
+{
+    return _webExtension->hasContentModificationRules();
+}
+
 - (BOOL)_backgroundContentIsServiceWorker
 {
     return _webExtension->backgroundContentIsServiceWorker();
@@ -450,6 +455,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 }
 
 - (BOOL)hasCommands
+{
+    return NO;
+}
+
+- (BOOL)hasContentModificationRules
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -160,9 +160,16 @@ public:
         Vector<String> resourcePathPatterns;
     };
 
+    struct DeclarativeNetRequestRulesetData {
+        String rulesetID;
+        bool enabled;
+        String jsonPath;
+    };
+
     using CommandsVector = Vector<CommandData>;
     using InjectedContentVector = Vector<InjectedContentData>;
     using WebAccessibleResourcesVector = Vector<WebAccessibleResourceData>;
+    using DeclarativeNetRequestRulesetVector = Vector<DeclarativeNetRequestRulesetData>;
 
     static const PermissionsSet& supportedPermissions();
 
@@ -235,6 +242,9 @@ public:
     const CommandsVector& commands();
     bool hasCommands();
 
+    const DeclarativeNetRequestRulesetVector& declarativeNetRequestRulesets();
+    bool hasContentModificationRules() { return !declarativeNetRequestRulesets().isEmpty(); }
+
     const InjectedContentVector& staticInjectedContents();
     bool hasStaticInjectedContentForURL(NSURL *);
     bool hasStaticInjectedContent();
@@ -279,10 +289,14 @@ private:
     void populateContentSecurityPolicyStringsIfNeeded();
     void populateWebAccessibleResourcesIfNeeded();
     void populateCommandsIfNeeded();
+    void populateDeclarativeNetRequestPropertiesIfNeeded();
+
+    std::optional<WebExtension::DeclarativeNetRequestRulesetData> parseDeclarativeNetRequestRulesetDictionary(NSDictionary *, NSError **);
 
     InjectedContentVector m_staticInjectedContents;
     WebAccessibleResourcesVector m_webAccessibleResources;
     CommandsVector m_commands;
+    DeclarativeNetRequestRulesetVector m_declarativeNetRequestRulesets;
 
     MatchPatternSet m_permissionMatchPatterns;
     MatchPatternSet m_optionalPermissionMatchPatterns;
@@ -339,6 +353,7 @@ private:
     bool m_parsedManifestPageProperties : 1 { false };
     bool m_parsedManifestWebAccessibleResources : 1 { false };
     bool m_parsedManifestCommands : 1 { false };
+    bool m_parsedManifestDeclarativeNetRequestRulesets : 1 { false };
 };
 
 #ifdef __OBJC__


### PR DESCRIPTION
#### 1093d6012bcfd5c17dbd4710264729b559612699
<pre>
Parse web extension manifest for declarativeNetRequest rulesets
<a href="https://bugs.webkit.org/show_bug.cgi?id=264836">https://bugs.webkit.org/show_bug.cgi?id=264836</a>
<a href="https://rdar.apple.com/118415584">rdar://118415584</a>

Reviewed by Timothy Hatcher.

This patch hooks up basic manifest parsing for declarativeNetRequest rule sets.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension hasDeclarativeNetRequestRules]): Mostly added for testing at this point. Returns if there were any correctly parsed rulesets.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::errors): Call parseDeclarativeNetRequestRulesetDictionary.
(WebKit::WebExtension::declarativeNetRequestRulesets): Call populateDeclarativeNetRequestPropertiesIfNeeded and return the vector of rulesets.
(WebKit::WebExtension::parseDeclarativeNetRequestRulesetDictionary): Takes in a dictionary and returns an optional DeclarativeNetRequestRulesetData. This method
does argument type checking and makes sure the string arguments aren&apos;t nil or empty.
(WebKit::WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded): Read the manifest and turn the JSON into a vector of DeclarativeNetRequestRulesetData. This
PR makes sure the extension doesn&apos;t specify too many rulesets, too many enabled rulesets, or multiple rulesets with the same id.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST): Add some tests for the manifest parsing.

Canonical link: <a href="https://commits.webkit.org/270751@main">https://commits.webkit.org/270751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fe2289c69d4b7a4f308a2ce650e64f9e58a7846

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2325 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3757 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28979 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29646 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4811 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6321 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->