### PR TITLE
Add an arg to disable retry for run-jsc-stress-tests and run-javascript-test

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -80,6 +80,8 @@ my $buildbotWorker;
 my $buildJSC = 1;
 my $copyJSC = 1;
 
+my $noRetry;
+
 use constant {
     ENV_VAR_SAYS_DO_RUN => 4,
     ENV_VAR_SAYS_DONT_RUN => 3,
@@ -307,6 +309,7 @@ Usage: $programName [options] [options to pass to build system]
   --builder-name:               The name of the buildbot builder tests were run on.
   --build-number:               The buildbot build number tests are associated with.
   --buildbot-worker:            The buildbot worker tests were run on.
+  --no-retry:                   Disable retry
 
 Environment Variables:
   - set RUN_JAVASCRIPTCORE_TESTS_TESTMASM to "true" or "false" (no quotes) to determine if we run testmasm by default.
@@ -375,6 +378,7 @@ GetOptions(
     'builder-name=s' => \$builderName,
     'build-number=s' => \$buildNumber,
     'buildbot-worker=s' => \$buildbotWorker,
+    'no-retry' => \$noRetry,
 );
 
 my $specificTestsSpecified = 0;
@@ -918,6 +922,10 @@ sub runJSCStressTests
     if ($filter) {
         push(@jscStressDriverCmd, "--filter");
         push(@jscStressDriverCmd, $filter);
+    }
+
+    if ($noRetry) {
+        push(@jscStressDriverCmd, "--no-retry");
     }
 
     push(@jscStressDriverCmd, ("--verbose") x $verbose) if ($verbose > 0);

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -222,6 +222,7 @@ def usage
     puts "                            no-cjit-validate-phases, no-cjit-collect-continuously, dfg-eager"
     puts "                            and for FTL platforms: no-ftl, ftl-eager-no-cjit and"
     puts "                            ftl-no-cjit-small-pool."
+    puts "--no-retry                  Disable auto retry"
     exit 1
 end
 
@@ -260,7 +261,8 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
                ['--debug', GetoptLong::NO_ARGUMENT],
                ['--release', GetoptLong::NO_ARGUMENT],
                ['--quick', '-q', GetoptLong::NO_ARGUMENT],
-               ['--basic', GetoptLong::NO_ARGUMENT]).each {
+               ['--basic', GetoptLong::NO_ARGUMENT],
+               ['--no-retry', GetoptLong::NO_ARGUMENT]).each {
     | opt, arg |
     case opt
     when '--help'
@@ -361,6 +363,9 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
         $buildType = "debug"
     when '--release'
         $buildType = "release"
+    when '--no-retry'
+        ITERATION_LIMITS.infraIterationsFloor = 1
+        ITERATION_LIMITS.iterationsCeiling = 1
     end
 }
 

--- a/Tools/Scripts/webkitruby/jsc-stress-test/executor.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test/executor.rb
@@ -35,7 +35,7 @@ class BaseTestsExecutor
         @treatFailingAsFlaky = treatFailingAsFlaky
         @infraIterationsFloor = iterationLimits.infraIterationsFloor
         @iterationsCeiling = iterationLimits.iterationsCeiling
-        if @iterationsCeiling < @infraIterationsFloor
+        if @infraIterationsFloor != 1 && @iterationsCeiling !=1 && @iterationsCeiling < @infraIterationsFloor
             raise "iterationsCeiling (#{@iterationsCeiling} < @infraIterationsFloor (#{@infraIterationsFloor}"
         end
         @maxIterations = setMaxIterations(initialMaxAllowedIterations(runlist))


### PR DESCRIPTION
#### eb96b31b4de1c6d70b2d3736bfaf22a2ee0c5ed9
<pre>
Add an arg to disable retry for run-jsc-stress-tests and run-javascript-test
<a href="https://bugs.webkit.org/show_bug.cgi?id=264840">https://bugs.webkit.org/show_bug.cgi?id=264840</a>
<a href="https://rdar.apple.com/118418997">rdar://118418997</a>

Reviewed by Ryan Haddad.

Currently, run-jsc-stress-tests will add at least 3 retry, should
provide an arg to disable it.

* Tools/Scripts/run-javascriptcore-tests:
(runJSCStressTests):
* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/webkitruby/jsc-stress-test/executor.rb:

Canonical link: <a href="https://commits.webkit.org/270732@main">https://commits.webkit.org/270732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8501496b0f71c20c26da5994cf43981427c17b06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6652 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26516 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28934 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22886 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/23950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27496 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25473 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32919 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4770 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7121 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6308 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3826 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->