### PR TITLE
Allow named frame navigation in RemoteFrames

### DIFF
--- a/LayoutTests/http/tests/site-isolation/window-open-with-name-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-open-with-name-expected.txt
@@ -3,9 +3,8 @@ Verifies window.open with a target name correctly reuses a main frame
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-FAIL first opened window should have been reused
+PASS event.data is 'second opened window received: sent to first window, which should be reused'
 PASS successfullyParsed is true
-Some tests failed.
 
 TEST COMPLETE
 click to run test manually in a browser

--- a/LayoutTests/http/tests/site-isolation/window-open-with-name.html
+++ b/LayoutTests/http/tests/site-isolation/window-open-with-name.html
@@ -17,7 +17,7 @@ addEventListener("message", (event) => {
     } else if (event.data == 'second ping') {
         firstOpenedWindow.postMessage('sent to first window, which should be reused', '*')
     } else if (event.data.startsWith('opened window received')) {
-        testFailed("first opened window should have been reused"); // FIXME: <rdar://118363128> Reuse the main frame and make this test not fail with site isolation enabled.
+        testFailed("first opened window should have been reused");
         finishJSTest();
     } else if (event.data.startsWith('second opened window received')) {
         shouldBe("event.data", "'second opened window received: sent to first window, which should be reused'");

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -282,7 +282,8 @@ void HTMLFormElement::submitIfPossible(Event* event, HTMLFormControlElement* sub
     if (!targetFrame)
         targetFrame = frame.get();
     auto formState = FormState::create(*this, textFieldValues(), document(), NotSubmittedByJavaScript);
-    targetFrame->loader().client().dispatchWillSendSubmitEvent(WTFMove(formState));
+    if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrame))
+        localTargetFrame->loader().client().dispatchWillSendSubmitEvent(WTFMove(formState));
 
     Ref protectedThis { *this };
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -290,11 +290,11 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
 
     bool created;
     WindowFeatures features;
-    auto frame = WebCore::createWindow(mainFrame, mainFrame, WTFMove(frameLoadRequest), features, created);
+    RefPtr frame = dynamicDowncast<LocalFrame>(WebCore::createWindow(mainFrame, mainFrame, WTFMove(frameLoadRequest), features, created));
     if (!frame)
         return;
 
-    frame->loader().setOpener(mainFrame.copyRef());
+    frame->loader().setOpener(mainFrame.ptr());
     frame->page()->setOpenedByDOM();
 
     // FIXME: Why do we compute the absolute URL with respect to |frame| instead of |mainFrame|?

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -284,7 +284,7 @@ public:
 
     void advanceStatePastInitialEmptyDocument();
 
-    WEBCORE_EXPORT RefPtr<LocalFrame> findFrameForNavigation(const AtomString& name, Document* activeDocument = nullptr);
+    WEBCORE_EXPORT RefPtr<Frame> findFrameForNavigation(const AtomString& name, Document* activeDocument = nullptr);
 
     void applyUserAgentIfNeeded(ResourceRequest&);
 
@@ -533,6 +533,6 @@ private:
 //
 // FIXME: Consider making this function part of an appropriate class (not FrameLoader)
 // and moving it to a more appropriate location.
-RefPtr<LocalFrame> createWindow(LocalFrame& openerFrame, LocalFrame& lookupFrame, FrameLoadRequest&&, WindowFeatures&, bool& created);
+RefPtr<Frame> createWindow(LocalFrame& openerFrame, LocalFrame& lookupFrame, FrameLoadRequest&&, WindowFeatures&, bool& created);
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -86,6 +86,7 @@ public:
 
     virtual FrameView* virtualView() const = 0;
     virtual void disconnectView() = 0;
+    virtual void setOpener(Frame*) = 0;
     virtual const Frame* opener() const = 0;
     virtual Frame* opener() = 0;
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1508,6 +1508,7 @@ void LocalDOMWindow::setStatus(const String& string)
 
 WindowProxy* LocalDOMWindow::opener() const
 {
+    // FIXME: <rdar://118263278> Move LocalDOMWindow::opener and RemoteDOMWindow::opener to DOMWindow.
     RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
@@ -2611,23 +2612,24 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
 
     bool noopener = windowFeatures.wantsNoOpener();
     if (!noopener)
-        newFrame->checkedLoader()->setOpener(&openerFrame);
+        newFrame->setOpener(&openerFrame);
 
     if (created)
         newFrame->checkedPage()->setOpenedByDOM();
 
-    if (newFrame->document()->domWindow()->isInsecureScriptAccess(activeWindow, completedURL.string()))
-        return noopener ? RefPtr<LocalFrame> { nullptr } : newFrame;
+    RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
+    if (localNewFrame && localNewFrame->document()->domWindow()->isInsecureScriptAccess(activeWindow, completedURL.string()))
+        return noopener ? RefPtr<LocalFrame> { nullptr } : localNewFrame;
 
-    if (prepareDialogFunction)
-        prepareDialogFunction(*newFrame->document()->protectedWindow());
+    if (prepareDialogFunction && localNewFrame)
+        prepareDialogFunction(*localNewFrame->document()->protectedWindow());
 
     if (created) {
         ResourceRequest resourceRequest { completedURL, referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
         FrameLoader::addSameSiteInfoToRequestIfNeeded(resourceRequest, openerFrame.protectedDocument().get());
         FrameLoadRequest frameLoadRequest { activeWindow.protectedDocument().releaseNonNull(), activeWindow.document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame };
         frameLoadRequest.setShouldOpenExternalURLsPolicy(activeDocument->shouldOpenExternalURLsPolicyToPropagate());
-        newFrame->checkedLoader()->changeLocation(WTFMove(frameLoadRequest));
+        newFrame->changeLocation(WTFMove(frameLoadRequest));
     } else if (!urlString.isEmpty()) {
         LockHistory lockHistory = UserGestureIndicator::processingUserGesture() ? LockHistory::No : LockHistory::Yes;
         newFrame->checkedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(), completedURL, referrer, lockHistory, LockBackForwardList::No);
@@ -2637,7 +2639,7 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
     if (!newFrame->page())
         return RefPtr<LocalFrame> { nullptr };
 
-    return noopener ? RefPtr<LocalFrame> { nullptr } : newFrame;
+    return noopener ? RefPtr<LocalFrame> { nullptr } : localNewFrame;
 }
 
 ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWindow, LocalDOMWindow& firstWindow, const String& urlStringToOpen, const AtomString& frameName, const String& windowFeaturesString)

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -971,6 +971,11 @@ void LocalFrame::disconnectView()
     setView(nullptr);
 }
 
+void LocalFrame::setOpener(Frame* opener)
+{
+    loader().setOpener(opener);
+}
+
 const Frame* LocalFrame::opener() const
 {
     return loader().opener();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -322,6 +322,7 @@ private:
     FrameView* virtualView() const final;
     void disconnectView() final;
     DOMWindow* virtualWindow() const final;
+    void setOpener(Frame*) final;
     const Frame* opener() const final;
     Frame* opener();
 

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -49,8 +49,7 @@ public:
 
     RemoteDOMWindow& window() const;
 
-    // FIXME: <rdar://118263278> Move this to a pure virtual function on Frame or just a function on Frame, move LocalDOMWindow::opener to DOMWindow.
-    void setOpener(Frame* opener) { m_opener = opener; }
+    void setOpener(Frame* opener) final { m_opener = opener; }
     Frame* opener() final { return m_opener.get(); }
     const Frame* opener() const final { return m_opener.get(); }
 


### PR DESCRIPTION
#### 7068fc99c675daf54db63700834f113d13dcafbd
<pre>
Allow named frame navigation in RemoteFrames
<a href="https://bugs.webkit.org/show_bug.cgi?id=264846">https://bugs.webkit.org/show_bug.cgi?id=264846</a>
<a href="https://rdar.apple.com/118363128">rdar://118363128</a>

Reviewed by Pascoe.

A few places where we made it only work with LocalFrames can be generalized
to work with any type of Frame.  Doing so a little more makes an existing test
start working like it did before site isolation.  We already have a large
task to audit all uses of dynamicDowncast&lt;LocalFrame&gt;, so the parts of this PR
that might not work correctly with site isolation yet will at some point.

No changes affect behavior with site isolation not enabled, and no changes cause
nullptr crashes with site isolation enabled.

* LayoutTests/http/tests/site-isolation/window-open-with-name-expected.txt:
* LayoutTests/http/tests/site-isolation/window-open-with-name.html:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitIfPossible):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::openURLExternally):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::detachFromAllOpenedFrames):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::findFrameForNavigation):
(WebCore::createWindow):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::opener const):
(WebCore::LocalDOMWindow::createWindow):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::setOpener):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/RemoteFrame.h:

Canonical link: <a href="https://commits.webkit.org/270789@main">https://commits.webkit.org/270789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35eebc576327fa8564131155e424e912220925c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24160 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3425 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29094 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27636 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23423 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3951 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3406 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3795 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->