### PR TITLE
SourceBufferPrivateClient/MediaSourcePrivateClient should use NativePromise

### DIFF
--- a/LayoutTests/media/media-source/media-source-restrictions.html
+++ b/LayoutTests/media/media-source/media-source-restrictions.html
@@ -35,7 +35,7 @@
         initSegment = makeAInit(8, [makeATrack(1, 'mock', TRACK_KIND.AUDIO)]);
         run('sourceBuffer.appendBuffer(initSegment)');
 
-        waitForEvent('pause', handlePause);
+        waitFor(video, 'pause', false).then(handlePause);
         video.play().catch(function(error) {
             failTest();
         });
@@ -53,7 +53,7 @@
             makeASample(7, 7, 1, 1, 1, SAMPLE_FLAG.SYNC),
         ]);
 
-        waitForEventOn(sourceBuffer, 'updateend', updateEnd, false, true);
+        waitFor(sourceBuffer, 'updateend', false).then(updateEnd);
         run('sourceBuffer.appendBuffer(samples)');
     }
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -38,9 +38,12 @@
 #include "HTMLMediaElement.h"
 #include "MediaSourcePrivateClient.h"
 #include "URLRegistry.h"
+#include <optional>
 #include <wtf/LoggerHelper.h>
+#include <wtf/NativePromise.h>
 #include <wtf/RefCounted.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -155,8 +158,8 @@ private:
     static bool isTypeSupported(ScriptExecutionContext&, const String& type, Vector<ContentType>&& contentTypesRequiringHardwareSupport);
 
     void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) final;
-    void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
-    void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
+    Ref<MediaTimePromise> waitForTarget(const SeekTarget&) final;
+    Ref<GenericPromise> seekToTime(const MediaTime&) final;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
@@ -185,7 +188,7 @@ private:
     WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     MediaTime m_duration;
     std::optional<SeekTarget> m_pendingSeekTarget;
-    CompletionHandler<void(const MediaTime&)> m_seekCompletedHandler;
+    std::optional<MediaTimePromise::Producer> m_seekTargetPromise;
     ReadyState m_readyState { ReadyState::Closed };
     bool m_openDeferred { false };
     bool m_sourceopenPending { false };

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -105,7 +105,8 @@ public:
 
     void abortIfUpdating();
     void removedFromMediaSource();
-    void computeSeekTime(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&);
+    using ComputeSeekPromise = SourceBufferPrivate::ComputeSeekPromise;
+    Ref<ComputeSeekPromise> computeSeekTime(const SeekTarget&);
     void seekToTime(const MediaTime&);
 
     bool canPlayThroughRange(const PlatformTimeRanges&);
@@ -163,11 +164,11 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // SourceBufferPrivateClient
-    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) final;
+    Ref<ReceiveResultPromise> sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&) final;
     void sourceBufferPrivateAppendComplete(AppendResult) final;
-    void sourceBufferPrivateBufferedChanged(const PlatformTimeRanges&, CompletionHandler<void()>&&) final;
+    Ref<GenericPromise> sourceBufferPrivateBufferedChanged(const PlatformTimeRanges&) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;
-    void sourceBufferPrivateDurationChanged(const MediaTime& duration, CompletionHandler<void()>&&) final;
+    Ref<GenericPromise> sourceBufferPrivateDurationChanged(const MediaTime& duration) final;
     void sourceBufferPrivateDidParseSample(double sampleDuration) final;
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -295,7 +295,7 @@ void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<Audi
         m_audioDecoder = makeUnique<AsyncAudioDecoder>();
 
     auto p = m_audioDecoder->decodeAsync(WTFMove(audioData), sampleRate());
-    p->whenSettled(RunLoop::main(), [this, activity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise)] (DecodingTaskPromise::Result&& result) mutable {
+    p->whenSettled(RunLoop::current(), [this, activity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise)] (DecodingTaskPromise::Result&& result) mutable {
         queueTaskKeepingObjectAlive(*this, TaskSource::InternalAsyncTask, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise), result = WTFMove(result)]() mutable {
             if (!result) {
                 promise->reject(WTFMove(result.error()));

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -76,8 +76,9 @@ public:
     virtual MediaTime currentMediaTime() const = 0;
     virtual MediaTime duration() const = 0;
 
-    virtual void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) = 0;
-    virtual void seekToTime(const MediaTime&, CompletionHandler<void()>&&) = 0;
+    using MediaTimePromise = NativePromise<MediaTime, int>;
+    virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
+    virtual Ref<GenericPromise> seekToTime(const MediaTime&) = 0;
 
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -29,6 +29,7 @@
 
 #include "PlatformTimeRanges.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/Forward.h>
 #include <wtf/Logger.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,8 +44,9 @@ public:
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
     virtual MediaTime duration() const = 0;
     virtual const PlatformTimeRanges& buffered() const = 0;
-    virtual void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) = 0;
-    virtual void seekToTime(const MediaTime&, CompletionHandler<void()>&&) = 0;
+    using MediaTimePromise = NativePromise<MediaTime, int>;
+    virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
+    virtual Ref<GenericPromise> seekToTime(const MediaTime&) = 0;
     virtual void monitorSourceBuffers() = 0;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -74,22 +74,22 @@ public:
         BufferRemoved,
         IPCError,
     };
-    virtual void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) = 0;
+    using ReceiveResultPromise = NativePromise<void, ReceiveResult>;
+    virtual Ref<ReceiveResultPromise> sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&) = 0;
     enum class AppendResult : uint8_t {
         Succeeded,
         ReadStreamFailed,
         ParsingFailed
     };
     virtual void sourceBufferPrivateAppendComplete(AppendResult) = 0;
-    virtual void sourceBufferPrivateBufferedChanged(const PlatformTimeRanges&, CompletionHandler<void()>&&) = 0;
+    virtual Ref<GenericPromise> sourceBufferPrivateBufferedChanged(const PlatformTimeRanges&) = 0;
     virtual void sourceBufferPrivateTrackBuffersChanged(const Vector<PlatformTimeRanges>&) { };
-    virtual void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&) = 0;
+    virtual Ref<GenericPromise> sourceBufferPrivateDurationChanged(const MediaTime&) = 0;
     virtual void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) = 0;
     virtual void sourceBufferPrivateDidParseSample(double frameDuration) = 0;
     virtual void sourceBufferPrivateDidDropSample() = 0;
     virtual void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) = 0;
     virtual void sourceBufferPrivateReportExtraMemoryCost(uint64_t) = 0;
-    virtual bool isAsync() const { return false; }
 };
 
 String convertEnumerationToString(SourceBufferPrivateClient::ReceiveResult);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -71,8 +71,8 @@ public:
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;
 
-    void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
-    void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
+    Ref<MediaSourcePrivate::MediaTimePromise> waitForTarget(const SeekTarget&) final;
+    Ref<GenericPromise> seekToTime(const MediaTime&) final;
 
     MediaTime duration() const final;
     const PlatformTimeRanges& buffered();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -38,6 +38,7 @@
 #import "SourceBufferPrivateAVFObjC.h"
 #import <objc/runtime.h>
 #import <wtf/Algorithms.h>
+#import <wtf/NativePromise.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/text/AtomString.h>
 
@@ -177,22 +178,14 @@ void MediaSourcePrivateAVFObjC::willSeek()
         downcast<SourceBufferPrivateAVFObjC>(sourceBuffer)->willSeek();
 }
 
-void MediaSourcePrivateAVFObjC::waitForTarget(const SeekTarget& target, CompletionHandler<void(const MediaTime&)>&& completionHandler)
+Ref<MediaSourcePrivate::MediaTimePromise> MediaSourcePrivateAVFObjC::waitForTarget(const SeekTarget& target)
 {
-    if (!m_client) {
-        completionHandler(MediaTime::invalidTime());
-        return;
-    }
-    m_client->waitForTarget(target, WTFMove(completionHandler));
+    return m_client ? m_client->waitForTarget(target) : MediaTimePromise::createAndReject(-1);
 }
 
-void MediaSourcePrivateAVFObjC::seekToTime(const MediaTime& time, CompletionHandler<void()>&& completionHandler)
+Ref<GenericPromise> MediaSourcePrivateAVFObjC::seekToTime(const MediaTime& time)
 {
-    if (!m_client) {
-        completionHandler();
-        return;
-    }
-    m_client->seekToTime(time, WTFMove(completionHandler));
+    return m_client ? m_client->seekToTime(time) : GenericPromise::createAndReject(-1);
 }
 
 FloatSize MediaSourcePrivateAVFObjC::naturalSize() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -58,7 +58,7 @@ public:
     AVStreamDataParser* streamDataParser() const { return m_parser.get(); }
 
     Type type() const { return Type::AVFObjC; }
-    void appendData(Segment&&, CompletionHandler<void()>&&, AppendFlags = AppendFlags::None) final;
+    Expected<void, int> appendData(Segment&&, AppendFlags = AppendFlags::None) final;
     void flushPendingMediaData() final;
     void setShouldProvideMediaDataForTrackID(bool, uint64_t) final;
     bool shouldProvideMediadataForTrackID(uint64_t) final;
@@ -87,6 +87,7 @@ private:
     RetainPtr<AVStreamDataParser> m_parser;
     RetainPtr<WebAVStreamDataParserListener> m_delegate;
     bool m_parserStateWasReset { false };
+    std::optional<int> m_lastErrorCode;
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -153,15 +153,12 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 private:
     explicit SourceBufferPrivateAVFObjC(MediaSourcePrivateAVFObjC&, Ref<SourceBufferParser>&&);
 
-    using InitializationSegment = SourceBufferPrivateClient::InitializationSegment;
     void didParseInitializationData(InitializationSegment&&);
-    void didEncounterErrorDuringParsing(int32_t);
     void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, uint64_t trackId, const String& mediaType);
     bool isMediaSampleAllowed(const MediaSample&) const final;
-    void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, uint64_t);
 
     // SourceBufferPrivate overrides
-    void appendInternal(Ref<SharedBuffer>&&) final;
+    Ref<GenericPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void abort() final;
     void resetParserStateInternal() final;
     MediaPlayer::ReadyState readyState() const final;
@@ -176,6 +173,10 @@ private:
     void clearMinimumUpcomingPresentationTime(const AtomString&) override;
     bool canSwitchToType(const ContentType&) final;
     bool isSeeking() const final;
+
+    bool precheckInitialisationSegment(const InitializationSegment&) final;
+    void processInitialisationSegment(std::optional<InitializationSegment>&&) final;
+    void processFormatDescriptionForTrackId(Ref<TrackInfo>&&, uint64_t) final;
 
     void processPendingTrackChangeTasks();
     void enqueueSample(Ref<MediaSampleAVFObjC>&&, uint64_t trackID);
@@ -200,7 +201,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void keyStatusesChanged();
 #endif
 
-    void setTrackChangeCallbacks(const Vector<Ref<TrackPrivateBase>>& tracks, bool initialized);
+    void setTrackChangeCallbacks(const InitializationSegment&, bool initialized);
 
     HashMap<AtomString, RefPtr<VideoTrackPrivate>> m_videoTracks;
     HashMap<AtomString, RefPtr<AudioTrackPrivate>> m_audioTracks;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -208,11 +208,9 @@ private:
 
     using InitializationSegment = SourceBufferParserWebM::InitializationSegment;
     void didParseInitializationData(InitializationSegment&&);
-    void didEncounterErrorDuringParsing(int32_t);
     void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, uint64_t trackId, const String& mediaType);
 
     void append(SharedBuffer&);
-    void abort();
     void resetParserState();
 
     void flush();
@@ -312,7 +310,6 @@ private:
     bool m_visible { false };
     mutable bool m_loadingProgressed { false };
     bool m_loadFinished { false };
-    bool m_parsingSucceeded { true };
     bool m_processingInitializationSegment { false };
 };
 

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -32,7 +32,6 @@
 #include <JavaScriptCore/Forward.h>
 #include <pal/spi/cocoa/MediaToolboxSPI.h>
 #include <variant>
-#include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -97,7 +96,7 @@ public:
 
     // appendData will be called on the SourceBufferPrivateAVFObjC data parser queue.
     // Other methods will be called on the main thread, but only once appendData has returned.
-    virtual void appendData(Segment&&, CompletionHandler<void()>&& = [] { }, AppendFlags = AppendFlags::None) = 0;
+    virtual Expected<void, int> appendData(Segment&&, AppendFlags = AppendFlags::None) = 0;
     virtual void flushPendingMediaData() = 0;
     virtual void setShouldProvideMediaDataForTrackID(bool, uint64_t) = 0;
     virtual bool shouldProvideMediadataForTrackID(uint64_t) = 0;
@@ -114,13 +113,6 @@ public:
     void setDidParseInitializationDataCallback(DidParseInitializationDataCallback&& callback)
     {
         m_didParseInitializationDataCallback = WTFMove(callback);
-    }
-
-    // Will be called on the main thread.
-    using DidEncounterErrorDuringParsingCallback = Function<void(uint64_t errorCode)>;
-    void setDidEncounterErrorDuringParsingCallback(DidEncounterErrorDuringParsingCallback&& callback)
-    {
-        m_didEncounterErrorDuringParsingCallback = WTFMove(callback);
     }
 
     // Will be called on the main thread.
@@ -163,7 +155,6 @@ protected:
 
     CallOnClientThreadCallback m_callOnClientThreadCallback;
     DidParseInitializationDataCallback m_didParseInitializationDataCallback;
-    DidEncounterErrorDuringParsingCallback m_didEncounterErrorDuringParsingCallback;
     DidProvideMediaDataCallback m_didProvideMediaDataCallback;
     WillProvideContentKeyRequestInitializationDataForTrackIDCallback m_willProvideContentKeyRequestInitializationDataForTrackIDCallback;
     DidProvideContentKeyRequestInitializationDataForTrackIDCallback m_didProvideContentKeyRequestInitializationDataForTrackIDCallback;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -329,7 +329,7 @@ public:
     static bool isAvailable();
 
     Type type() const { return Type::WebM; }
-    WEBCORE_EXPORT void appendData(Segment&&, CompletionHandler<void()>&& = [] { }, AppendFlags = AppendFlags::None) final;
+    WEBCORE_EXPORT Expected<void, int> appendData(Segment&&, AppendFlags = AppendFlags::None) final;
     void flushPendingMediaData() final;
     void setShouldProvideMediaDataForTrackID(bool, uint64_t) final;
     bool shouldProvideMediadataForTrackID(uint64_t) final;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -49,7 +49,9 @@
 #include <gst/video/video.h>
 #include <wtf/Condition.h>
 #include <wtf/HashSet.h>
+#include <wtf/NativePromise.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/RunLoop.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/URL.h>
 #include <wtf/text/AtomString.h>
@@ -195,11 +197,11 @@ bool MediaPlayerPrivateGStreamerMSE::doSeek(const SeekTarget& target, float rate
     // Notify MediaSource and have new frames enqueued (when they're available).
     // Seek should only continue once the seekToTarget completionhandler has run.
     // This will also add support for fastSeek once done (see webkit.org/b/260607)
-    m_mediaSource->waitForTarget(target, [this, weakThis = WeakPtr { this }](const MediaTime& time) {
-        if (!weakThis)
+    m_mediaSource->waitForTarget(target)->whenSettled(RunLoop::current(), [this, weakThis = WeakPtr { this }](auto&& result) {
+        if (!weakThis || !result)
             return;
 
-        m_mediaSource->seekToTime(time, [] { });
+        m_mediaSource->seekToTime(*result);
 
         auto player = m_player.get();
         if (player && !player->isVideoPlayer() && m_audioSink) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -46,6 +46,7 @@
 #include "SourceBufferPrivateGStreamer.h"
 #include "TimeRanges.h"
 #include "WebKitMediaSourceGStreamer.h"
+#include <wtf/NativePromise.h>
 #include <wtf/RefPtr.h>
 #include <wtf/glib/GRefPtr.h>
 
@@ -138,20 +139,18 @@ void MediaSourcePrivateGStreamer::setReadyState(MediaPlayer::ReadyState state)
     m_playerPrivate.setReadyState(state);
 }
 
-void MediaSourcePrivateGStreamer::waitForTarget(const SeekTarget& target, CompletionHandler<void(const MediaTime&)>&& completionHandler)
+Ref<MediaSourcePrivate::MediaTimePromise> MediaSourcePrivateGStreamer::waitForTarget(const SeekTarget& target)
 {
     if (m_mediaSource)
-        m_mediaSource->waitForTarget(target, WTFMove(completionHandler));
-    else
-        completionHandler(MediaTime::invalidTime());
+        return m_mediaSource->waitForTarget(target);
+    return MediaTimePromise::createAndReject(-1);
 }
 
-void MediaSourcePrivateGStreamer::seekToTime(const MediaTime& time, CompletionHandler<void()>&& completionHandler)
+Ref<GenericPromise> MediaSourcePrivateGStreamer::seekToTime(const MediaTime& time)
 {
     if (m_mediaSource)
-        m_mediaSource->seekToTime(time, WTFMove(completionHandler));
-    else
-        completionHandler();
+        return m_mediaSource->seekToTime(time);
+    return GenericPromise::createAndReject(-1);
 }
 
 MediaTime MediaSourcePrivateGStreamer::duration() const

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -64,8 +64,8 @@ public:
     MediaPlayer::ReadyState readyState() const override;
     void setReadyState(MediaPlayer::ReadyState) override;
 
-    void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
-    void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
+    Ref<MediaTimePromise> waitForTarget(const SeekTarget&) final;
+    Ref<GenericPromise> seekToTime(const MediaTime&) final;
 
     MediaTime duration() const final;
     MediaTime currentMediaTime() const final;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -43,6 +43,7 @@
 #include "TrackPrivateBaseGStreamer.h"
 #include "WebKitMediaSourceGStreamer.h"
 #include <wtf/LoggerHelper.h>
+#include <wtf/NativePromise.h>
 
 namespace WebCore {
 
@@ -58,7 +59,7 @@ public:
 
     constexpr PlatformType platformType() const final { return PlatformType::GStreamer; }
 
-    void appendInternal(Ref<SharedBuffer>&&) final;
+    Ref<GenericPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void resetParserStateInternal() final;
     void removedFromMediaSource() final;
     MediaPlayer::ReadyState readyState() const final;
@@ -68,6 +69,9 @@ public:
     void enqueueSample(Ref<MediaSample>&&, const AtomString&) final;
     void allSamplesInTrackEnqueued(const AtomString&) final;
     bool isReadyForMoreSamples(const AtomString&) final;
+
+    bool precheckInitialisationSegment(const InitializationSegment&) final;
+    void processInitialisationSegment(std::optional<InitializationSegment>&&) final;
 
     void didReceiveInitializationSegment(InitializationSegment&&);
     void didReceiveSample(Ref<MediaSample>&&);
@@ -101,6 +105,7 @@ private:
     UniqueRef<AppendPipeline> m_appendPipeline;
     AtomString m_trackId;
     HashMap<AtomString, RefPtr<MediaSourceTrackGStreamer>> m_tracks;
+    std::optional<GenericPromise::Producer> m_appendPromise;
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -113,20 +113,18 @@ void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
     m_player.notifyActiveSourceBuffersChanged();
 }
 
-void MockMediaSourcePrivate::waitForTarget(const SeekTarget& target, CompletionHandler<void(const MediaTime&)>&& completionHandler)
+Ref<MediaSourcePrivate::MediaTimePromise> MockMediaSourcePrivate::waitForTarget(const SeekTarget& target)
 {
-    if (m_client)
-        m_client->waitForTarget(target, WTFMove(completionHandler));
-    else
-        completionHandler(MediaTime::invalidTime());
+    if (!m_client)
+        return MediaTimePromise::createAndReject(-1);
+    return m_client->waitForTarget(target);
 }
 
-void MockMediaSourcePrivate::seekToTime(const MediaTime& time, CompletionHandler<void()>&& completionHandler)
+Ref<GenericPromise> MockMediaSourcePrivate::seekToTime(const MediaTime& time)
 {
-    if (m_client)
-        m_client->seekToTime(time, WTFMove(completionHandler));
-    else
-        completionHandler();
+    if (!m_client)
+        return GenericPromise::createAndReject(-1);
+    return m_client->seekToTime(time);
 }
 
 MediaTime MockMediaSourcePrivate::currentMediaTime() const

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -50,8 +50,8 @@ public:
 
     MockMediaPlayerMediaSource& player() const { return m_player; }
 
-    void waitForTarget(const SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
-    void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
+    Ref<MediaTimePromise> waitForTarget(const SeekTarget&) final;
+    Ref<GenericPromise> seekToTime(const MediaTime&) final;
     MediaTime currentMediaTime() const final;
     MediaTime duration() const final;
 

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -50,7 +50,7 @@ private:
     MockMediaSourcePrivate* mediaSourcePrivate() const;
 
     // SourceBufferPrivate overrides
-    void appendInternal(Ref<SharedBuffer>&&) final;
+    Ref<GenericPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void resetParserStateInternal() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -65,8 +65,8 @@ public:
     void setPrivateAndOpen(Ref<WebCore::MediaSourcePrivate>&&) final;
     MediaTime duration() const final;
     const WebCore::PlatformTimeRanges& buffered() const final;
-    void waitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
-    void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
+    Ref<WebCore::MediaSourcePrivate::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
+    Ref<GenericPromise> seekToTime(const MediaTime&) final;
     void monitorSourceBuffers() final;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -71,17 +71,16 @@ private:
     RemoteSourceBufferProxy(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
 
     // SourceBufferPrivateClient
-    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) final;
+    Ref<ReceiveResultPromise> sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&) final;
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult) final;
-    void sourceBufferPrivateBufferedChanged(const WebCore::PlatformTimeRanges&, CompletionHandler<void()>&&) final;
+    Ref<GenericPromise> sourceBufferPrivateBufferedChanged(const WebCore::PlatformTimeRanges&) final;
     void sourceBufferPrivateTrackBuffersChanged(const Vector<WebCore::PlatformTimeRanges>&) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;
-    void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&) final;
+    Ref<GenericPromise> sourceBufferPrivateDurationChanged(const MediaTime&) final;
     void sourceBufferPrivateDidParseSample(double sampleDuration) final;
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
     void sourceBufferPrivateReportExtraMemoryCost(uint64_t extraMemory) final;
-    bool isAsync() const final { return true; }
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -111,7 +110,7 @@ private:
     void setTimestampOffset(const MediaTime&);
     void setAppendWindowStart(const MediaTime&);
     void setAppendWindowEnd(const MediaTime&);
-    void computeSeekTime(const WebCore::SeekTarget&, CompletionHandler<void(const MediaTime&)>&&);
+    void computeSeekTime(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::SourceBufferPrivate::ComputeSeekPromise::Result&&)>&&);
     void seekToTime(const MediaTime&);
     void updateTrackIds(Vector<std::pair<TrackPrivateRemoteIdentifier, TrackPrivateRemoteIdentifier>>&&);
     void bufferedSamplesForTrackId(TrackPrivateRemoteIdentifier, CompletionHandler<void(Vector<String>&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -50,7 +50,7 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     SetTimestampOffset(MediaTime timestampOffset)
     SetAppendWindowStart(MediaTime appendWindowStart)
     SetAppendWindowEnd(MediaTime appendWindowEnd)
-    ComputeSeekTime(struct WebCore::SeekTarget target) -> (MediaTime seekedTime)
+    ComputeSeekTime(struct WebCore::SeekTarget target) -> (WebCore::SourceBufferPrivate::ComputeSeekPromise::Result seekedTime)
     SeekToTime(MediaTime time)
     UpdateTrackIds(Vector<std::pair<WebKit::TrackPrivateRemoteIdentifier, WebKit::TrackPrivateRemoteIdentifier>> identifierPairs)
     BufferedSamplesForTrackId(WebKit::TrackPrivateRemoteIdentifier remoteIdentifier) -> (Vector<String> samples)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -71,8 +71,8 @@ public:
     WebCore::MediaPlayer::ReadyState readyState() const final;
     void setReadyState(WebCore::MediaPlayer::ReadyState) final;
 
-    void waitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
-    void seekToTime(const MediaTime&, CompletionHandler<void()>&&) final;
+    Ref<MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
+    Ref<GenericPromise> seekToTime(const MediaTime&) final;
 
     void setTimeFudgeFactor(const MediaTime&) final;
 
@@ -87,6 +87,10 @@ public:
     const Logger& logger() const final { return m_logger.get(); }
     const void* nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
 #endif
+
+    // IPC Methods
+    void proxyWaitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(MediaTimePromise::Result&&)>&&);
+    void proxySeekToTime(const MediaTime&, CompletionHandler<void(GenericPromise::Result&&)>&&);
 
 private:
     MediaSourcePrivateRemote(GPUProcessConnection&, RemoteMediaSourceIdentifier, RemoteMediaPlayerMIMETypeCache&, const MediaPlayerPrivateRemote&, WebCore::MediaSourcePrivateClient&);

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in
@@ -26,8 +26,8 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 messages -> MediaSourcePrivateRemote NotRefCounted {
-    WaitForTarget(struct WebCore::SeekTarget target) -> (MediaTime seekedTime);
-    SeekToTime(MediaTime time) -> ();
+    ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (WebCore::MediaSourcePrivate::MediaTimePromise::Result seekedTime);
+    ProxySeekToTime(MediaTime time) -> (Expected<void, int> result);
     MediaSourcePrivateShuttingDown() -> ();
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -75,7 +75,7 @@ private:
     // SourceBufferPrivate overrides
     void setActive(bool) final;
     void append(Ref<WebCore::SharedBuffer>&&) final;
-    void appendInternal(Ref<WebCore::SharedBuffer>&&) final;
+    Ref<GenericPromise> appendInternal(Ref<WebCore::SharedBuffer>&&) final;
     void resetParserStateInternal() final;
     void abort() final;
     void resetParserState() final;
@@ -102,7 +102,7 @@ private:
     void setAppendWindowEnd(const MediaTime&) final;
     Vector<WebCore::PlatformTimeRanges> trackBuffersRanges() const final { return m_trackBufferRanges; };
 
-    void computeSeekTime(const WebCore::SeekTarget&, CompletionHandler<void(const MediaTime&)>&&) final;
+    Ref<ComputeSeekPromise> computeSeekTime(const WebCore::SeekTarget&) final;
     void seekToTime(const MediaTime&) final;
 
     void updateTrackIds(Vector<std::pair<AtomString, AtomString>>&&) final;
@@ -115,7 +115,7 @@ private:
     void enqueuedSamplesForTrackID(const AtomString&, CompletionHandler<void(Vector<String>&&)>&&) final;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::SourceBufferPrivateClient::ReceiveResult)>&&);
+    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::SourceBufferPrivateClient::ReceiveResultPromise::Result&&)>&&);
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult, uint64_t totalTrackBufferSizeInBytes, const MediaTime& timestampOffset);
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
     void sourceBufferPrivateBufferedChanged(WebCore::PlatformTimeRanges&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 messages -> SourceBufferPrivateRemote NotRefCounted {
-    SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (WebCore::SourceBufferPrivateClient::ReceiveResult result)
+    SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (WebCore::SourceBufferPrivateClient::ReceiveResultPromise::Result result)
     SourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult appendResult, uint64_t totalTrackBufferSizeInBytes, MediaTime timeStampOffset)
     SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)
     SourceBufferPrivateBufferedChanged(WebCore::PlatformTimeRanges buffered) -> ()


### PR DESCRIPTION
#### f15fc780c0603a566785b95bc37a8c929ca80ebe
<pre>
SourceBufferPrivateClient/MediaSourcePrivateClient should use NativePromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=264847">https://bugs.webkit.org/show_bug.cgi?id=264847</a>
<a href="https://rdar.apple.com/problem/118426574">rdar://problem/118426574</a>

Reviewed by Youenn Fablet.

By using NativePromise, the SourceBufferPrivate and MediaSourcePrivate can be made to run on any threads
as NativePromise let you control on which thread the result of an operation should be delivered.

We make all internal SourceBufferPrivate/MediaSourcePrivate methods communicate via their respective
SourceBufferPrivateClient/MediaSourcePrivateClient using NativePromise instead of CompletionHandler.

It also allows to more explicitly handle errors.

The communication between SourceBuffer and SourceBufferPrivate will also be made to use NativePromise
in a follow-up change.

No change in behaviour in WK2, in WK1 some asynchronicity introduced which makes the behaviour more similar
to WK2

* LayoutTests/media/media-source/media-source-restrictions.html: Update test as we&apos;ve introduced more asynchronicity,
and in WK1 events are fired in a different order (but still per spec). So ensure the events are still fired but
don&apos;t log them.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::waitForTarget):
(WebCore::MediaSource::completeSeek):
(WebCore::MediaSource::seekToTime):
(WebCore::MediaSource::detachFromElement):
(WebCore::MediaSource::stop):
(WebCore::MediaSource::onReadyStateChange):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::computeSeekTime):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::sourceBufferPrivateDurationChanged):
(WebCore::SourceBuffer::sourceBufferPrivateBufferedChanged):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::decodeAudioData):
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::setBufferedRanges):
(WebCore::SourceBufferPrivate::updateBufferedFromTrackBuffers):
(WebCore::SourceBufferPrivate::processAppendCompletedOperation):
(WebCore::SourceBufferPrivate::computeSeekTime):
(WebCore::SourceBufferPrivate::removeCodedFrames):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didUpdateFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::processPendingOperations):
(WebCore::SourceBufferPrivate::abortPendingOperations):
(WebCore::SourceBufferPrivate::processInitOperation):
(WebCore::SourceBufferPrivate::appendCompleted): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::precheckInitialisationSegment):
(WebCore::SourceBufferPrivate::processInitialisationSegment):
(WebCore::SourceBufferPrivate::processFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::updateBufferedFromTrackBuffers): Deleted.
(WebCore::SourceBufferPrivate::setBufferedRanges): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WebCore::SourceBufferPrivateClient::isAsync const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::waitForTarget):
(WebCore::MediaSourcePrivateAVFObjC::seekToTime):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::appendData):
(WebCore::SourceBufferParserAVFObjC::didFailToParseStreamDataWithError):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setTrackChangeCallbacks):
(WebCore::SourceBufferPrivateAVFObjC::didParseInitializationData):
(WebCore::SourceBufferPrivateAVFObjC::precheckInitialisationSegment):
(WebCore::SourceBufferPrivateAVFObjC::processInitialisationSegment):
(WebCore::SourceBufferPrivateAVFObjC::processFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::appendInternal):
(WebCore::SourceBufferPrivateAVFObjC::appendCompleted):
(WebCore::SourceBufferPrivateAVFObjC::didEncounterErrorDuringParsing): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::didUpdateFormatDescriptionForTrackId): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::append):
(WebCore::MediaPlayerPrivateWebM::didEncounterErrorDuringParsing): Deleted.
(WebCore::MediaPlayerPrivateWebM::abort): Deleted.
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::SourceBufferParserWebM::appendData):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::SourceBufferParserWebM::appendData): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::doSeek):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::waitForTarget):
(WebCore::MediaSourcePrivateGStreamer::seekToTime):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::appendInternal):
(WebCore::SourceBufferPrivateGStreamer::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivateGStreamer::precheckInitialisationSegment):
(WebCore::SourceBufferPrivateGStreamer::processInitialisationSegment):
(WebCore::SourceBufferPrivateGStreamer::didReceiveAllPendingSamples):
(WebCore::SourceBufferPrivateGStreamer::appendParsingFailed):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::waitForTarget):
(WebCore::MockMediaSourcePrivate::seekToTime):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::appendInternal):
(WebCore::MockSourceBufferPrivate::didReceiveInitializationSegment):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::waitForTarget):
(WebKit::RemoteMediaSourceProxy::seekToTime):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged):
(WebKit::RemoteSourceBufferProxy::computeSeekTime):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::waitForTarget):
(WebKit::MediaSourcePrivateRemote::proxyWaitForTarget):
(WebKit::MediaSourcePrivateRemote::seekToTime):
(WebKit::MediaSourcePrivateRemote::proxySeekToTime):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::appendInternal):
(WebKit::SourceBufferPrivateRemote::removeCodedFrames):
(WebKit::SourceBufferPrivateRemote::computeSeekTime):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDurationChanged):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateBufferedChanged):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in:

Canonical link: <a href="https://commits.webkit.org/270788@main">https://commits.webkit.org/270788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf4e7771f78541b756ffc51bd32a6cb0e19131e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2377 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29034 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29688 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27581 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1639 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23373 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6344 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->