### PR TITLE
[JSC] Array.from fast path should handle array with holes

### DIFF
--- a/JSTests/stress/array-from-empty.js
+++ b/JSTests/stress/array-from-empty.js
@@ -1,0 +1,100 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let source = new Array(0);
+    let result = Array.from(source);
+    shouldBe(result.length, 0);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42;
+    source[1] = 43;
+    let result = Array.from(source);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 42);
+    shouldBe(result[1], 43);
+}
+
+{
+    let source = new Array(2);
+    source[0] = 42.195;
+    source[1] = 43.195;
+    let result = Array.from(source);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], 42.195);
+    shouldBe(result[1], 43.195);
+}
+
+{
+    let source = new Array(6);
+    let result = Array.from(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42;
+    let result = Array.from(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], 42);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42.195;
+    let result = Array.from(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], 42.195);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    let result = Array.from(source);
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], "string");
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    $vm.ensureArrayStorage(source);
+    source[1000] = "Hello";
+    let result = Array.from(source);
+    shouldBe(result.length, 1001);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], "string");
+        else if (i === 1000)
+            shouldBe(result[i], "Hello");
+        else
+            shouldBe(result[i], undefined);
+    }
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1286,6 +1286,12 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncLastIndexOf, (JSGlobalObject* globalObjec
     return JSValue::encode(jsNumber(-1));
 }
 
+enum class FillMode {
+    Undefined,
+    Empty,
+};
+
+template<FillMode fillMode>
 static bool moveElements(JSGlobalObject* globalObject, VM& vm, JSArray* target, unsigned targetOffset, JSArray* source, unsigned sourceLength)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1293,19 +1299,29 @@ static bool moveElements(JSGlobalObject* globalObject, VM& vm, JSArray* target, 
     if (LIKELY(!hasAnyArrayStorage(source->indexingType()) && !source->holesMustForwardToPrototype())) {
         for (unsigned i = 0; i < sourceLength; ++i) {
             JSValue value = source->tryGetIndexQuickly(i);
-            if (value) {
-                target->putDirectIndex(globalObject, targetOffset + i, value, 0, PutDirectIndexShouldThrow);
-                RETURN_IF_EXCEPTION(scope, false);
+            if constexpr (fillMode == FillMode::Empty) {
+                if (!value)
+                    continue;
+            } else {
+                if (!value)
+                    value = jsUndefined();
             }
+            target->putDirectIndex(globalObject, targetOffset + i, value, 0, PutDirectIndexShouldThrow);
+            RETURN_IF_EXCEPTION(scope, false);
         }
     } else {
         for (unsigned i = 0; i < sourceLength; ++i) {
             JSValue value = getProperty(globalObject, source, i);
             RETURN_IF_EXCEPTION(scope, false);
-            if (value) {
-                target->putDirectIndex(globalObject, targetOffset + i, value, 0, PutDirectIndexShouldThrow);
-                RETURN_IF_EXCEPTION(scope, false);
+            if constexpr (fillMode == FillMode::Empty) {
+                if (!value)
+                    continue;
+            } else {
+                if (!value)
+                    value = jsUndefined();
             }
+            target->putDirectIndex(globalObject, targetOffset + i, value, 0, PutDirectIndexShouldThrow);
+            RETURN_IF_EXCEPTION(scope, false);
         }
     }
     return true;
@@ -1354,7 +1370,7 @@ static JSValue concatAppendOne(JSGlobalObject* globalObject, VM& vm, JSArray* fi
     if (!success) {
         RETURN_IF_EXCEPTION(scope, { });
 
-        bool success = moveElements(globalObject, vm, result, 0, first, firstArraySize);
+        bool success = moveElements<FillMode::Empty>(globalObject, vm, result, 0, first, firstArraySize);
         EXCEPTION_ASSERT(!scope.exception() == success);
         if (UNLIKELY(!success))
             return { };
@@ -1377,19 +1393,35 @@ void clearElement(double& element)
     element = PNaN;
 }
 
-template<typename T, typename U>
+template<FillMode fillMode, typename T, typename U>
 ALWAYS_INLINE void copyElements(T* buffer, unsigned offset, U* source, unsigned sourceSize, IndexingType sourceType)
 {
     if (sourceType == ArrayWithUndecided) {
-        for (unsigned i = 0; i < sourceSize; ++i)
-            clearElement<T>(buffer[i + offset]);
+        if constexpr (fillMode == FillMode::Empty) {
+            for (unsigned i = 0; i < sourceSize; ++i)
+                clearElement<T>(buffer[i + offset]);
+        } else {
+            for (unsigned i = 0; i < sourceSize; ++i)
+                buffer[i + offset].setWithoutWriteBarrier(jsUndefined());
+        }
         return;
     }
 
-    if constexpr (std::is_same_v<T, U>)
-        gcSafeMemcpy(buffer + offset, source, sizeof(JSValue) * sourceSize);
-    else if constexpr (std::is_same_v<T, double>) {
+    if constexpr (std::is_same_v<T, U>) {
+        if constexpr (fillMode == FillMode::Empty) {
+            gcSafeMemcpy(buffer + offset, source, sizeof(JSValue) * sourceSize);
+            return;
+        } else {
+            for (unsigned i = 0; i < sourceSize; ++i) {
+                JSValue value = source[i].get();
+                if (!value)
+                    value = jsUndefined();
+                buffer[i + offset].setWithoutWriteBarrier(value);
+            }
+        }
+    } else if constexpr (std::is_same_v<T, double>) {
         ASSERT(sourceType == ArrayWithInt32);
+        static_assert(fillMode == FillMode::Empty);
         for (unsigned i = 0; i < sourceSize; ++i) {
             JSValue value = source[i].get();
             if (value)
@@ -1398,13 +1430,17 @@ ALWAYS_INLINE void copyElements(T* buffer, unsigned offset, U* source, unsigned 
                 buffer[i + offset] = PNaN;
         }
     } else {
-        ASSERT((std::is_same_v<U, double>));
+        static_assert(std::is_same_v<U, double>);
         for (unsigned i = 0; i < sourceSize; ++i) {
             double value = source[i];
             if (value == value)
                 buffer[i + offset].setWithoutWriteBarrier(JSValue(JSValue::EncodeAsDouble, value));
-            else
-                buffer[i + offset].clear();
+            else {
+                if constexpr (fillMode == FillMode::Undefined)
+                    buffer[i + offset].setWithoutWriteBarrier(jsUndefined());
+                else
+                    buffer[i + offset].clear();
+            }
         }
     }
 };
@@ -1458,11 +1494,11 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncConcatMemcpy, (JSGlobalObject* glo
         JSArray* result = constructEmptyArray(globalObject, nullptr, resultSize);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-        bool success = moveElements(globalObject, vm, result, 0, firstArray, firstArraySize);
+        bool success = moveElements<FillMode::Empty>(globalObject, vm, result, 0, firstArray, firstArraySize);
         EXCEPTION_ASSERT(!scope.exception() == success);
         if (UNLIKELY(!success))
             return encodedJSValue();
-        success = moveElements(globalObject, vm, result, firstArraySize, secondArray, secondArraySize);
+        success = moveElements<FillMode::Empty>(globalObject, vm, result, firstArraySize, secondArray, secondArraySize);
         EXCEPTION_ASSERT(!scope.exception() == success);
         if (UNLIKELY(!success))
             return encodedJSValue();
@@ -1485,17 +1521,17 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncConcatMemcpy, (JSGlobalObject* glo
     if (type == ArrayWithDouble) {
         double* buffer = result->butterfly()->contiguousDouble().data();
         if (firstType == ArrayWithDouble)
-            copyElements(buffer, 0, firstButterfly->contiguousDouble().data(), firstArraySize, firstType);
+            copyElements<FillMode::Empty>(buffer, 0, firstButterfly->contiguousDouble().data(), firstArraySize, firstType);
         else
-            copyElements(buffer, 0, firstButterfly->contiguous().data(), firstArraySize, firstType);
+            copyElements<FillMode::Empty>(buffer, 0, firstButterfly->contiguous().data(), firstArraySize, firstType);
         if (secondType == ArrayWithDouble)
-            copyElements(buffer, firstArraySize, secondButterfly->contiguousDouble().data(), secondArraySize, secondType);
+            copyElements<FillMode::Empty>(buffer, firstArraySize, secondButterfly->contiguousDouble().data(), secondArraySize, secondType);
         else
-            copyElements(buffer, firstArraySize, secondButterfly->contiguous().data(), secondArraySize, secondType);
+            copyElements<FillMode::Empty>(buffer, firstArraySize, secondButterfly->contiguous().data(), secondArraySize, secondType);
     } else if (type != ArrayWithUndecided) {
         WriteBarrier<Unknown>* buffer = result->butterfly()->contiguous().data();
-        copyElements(buffer, 0, firstButterfly->contiguous().data(), firstArraySize, firstType);
-        copyElements(buffer, firstArraySize, secondButterfly->contiguous().data(), secondArraySize, secondType);
+        copyElements<FillMode::Empty>(buffer, 0, firstButterfly->contiguous().data(), firstArraySize, firstType);
+        copyElements<FillMode::Empty>(buffer, firstArraySize, secondButterfly->contiguous().data(), secondArraySize, secondType);
     }
 
     ASSERT(result->butterfly()->publicLength() == resultSize);
@@ -1519,7 +1555,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncAppendMemcpy, (JSGlobalObject* glo
         return JSValue::encode(jsUndefined());
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     scope.release();
-    moveElements(globalObject, vm, resultArray, startIndex, otherArray, otherArray->length());
+    moveElements<FillMode::Empty>(globalObject, vm, resultArray, startIndex, otherArray, otherArray->length());
     return JSValue::encode(jsUndefined());
 }
 
@@ -1539,22 +1575,40 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFast, (JSGlobalObject* globalO
     if (UNLIKELY(!array->isIteratorProtocolFastAndNonObservable()))
         return JSValue::encode(jsUndefined());
 
-    IndexingType type = array->indexingType();
-    if (UNLIKELY(shouldUseSlowPut(type)))
+    IndexingType sourceType = array->indexingType();
+    if (UNLIKELY(shouldUseSlowPut(sourceType)))
         return JSValue::encode(jsUndefined());
 
     Butterfly* butterfly= array->butterfly();
     unsigned resultSize = butterfly->publicLength();
-    if (hasAnyArrayStorage(type) || resultSize >= MIN_SPARSE_ARRAY_INDEX) {
+    if (hasAnyArrayStorage(sourceType) || resultSize >= MIN_SPARSE_ARRAY_INDEX) {
         JSArray* result = constructEmptyArray(globalObject, nullptr, resultSize);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
-        moveElements(globalObject, vm, result, 0, array, resultSize);
+        moveElements<FillMode::Undefined>(globalObject, vm, result, 0, array, resultSize);
         return JSValue::encode(result);
     }
 
-    Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(type);
+    ASSERT(sourceType == ArrayWithDouble || sourceType == ArrayWithInt32 || sourceType == ArrayWithContiguous || sourceType == ArrayWithUndecided);
+    IndexingType resultType = sourceType;
+    if (sourceType == ArrayWithDouble) {
+        double* buffer = butterfly->contiguousDouble().data();
+        for (unsigned i = 0; i < resultSize; ++i) {
+            double value = buffer[i];
+            if (std::isnan(value)) {
+                resultType = ArrayWithContiguous;
+                break;
+            }
+        }
+    } else if (sourceType == ArrayWithInt32) {
+        auto* buffer = butterfly->contiguous().data();
+        if (UNLIKELY(WTF::find64(bitwise_cast<const uint64_t*>(buffer), JSValue::encode(JSValue()), resultSize)))
+            resultType = ArrayWithContiguous;
+    } else if (sourceType == ArrayWithUndecided && resultSize)
+        resultType = ArrayWithContiguous;
+
+    Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(resultType);
     if (UNLIKELY(hasAnyArrayStorage(resultStructure->indexingType())))
         return JSValue::encode(jsUndefined());
 
@@ -1565,16 +1619,33 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFast, (JSGlobalObject* globalO
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
+    ASSERT(result->butterfly()->publicLength() == resultSize);
 
-    if (type == ArrayWithDouble) {
-        double* buffer = result->butterfly()->contiguousDouble().data();
-        copyElements(buffer, 0, butterfly->contiguousDouble().data(), resultSize, ArrayWithDouble);
-    } else if (type != ArrayWithUndecided) {
-        WriteBarrier<Unknown>* buffer = result->butterfly()->contiguous().data();
-        copyElements(buffer, 0, butterfly->contiguous().data(), resultSize, type);
+    if (resultType == ArrayWithUndecided) {
+        ASSERT(!resultSize);
+        return JSValue::encode(result);
     }
 
-    ASSERT(result->butterfly()->publicLength() == resultSize);
+    if (resultType == ArrayWithDouble) {
+        ASSERT(sourceType == ArrayWithDouble);
+        double* buffer = result->butterfly()->contiguousDouble().data();
+        copyElements<FillMode::Empty>(buffer, 0, butterfly->contiguousDouble().data(), resultSize, ArrayWithDouble);
+        return JSValue::encode(result);
+    }
+
+    if (resultType == ArrayWithInt32) {
+        ASSERT(sourceType == ArrayWithInt32);
+        auto* buffer = result->butterfly()->contiguous().data();
+        copyElements<FillMode::Empty>(buffer, 0, butterfly->contiguous().data(), resultSize, ArrayWithInt32);
+        return JSValue::encode(result);
+    }
+
+    ASSERT(resultType == ArrayWithContiguous);
+    auto* buffer = result->butterfly()->contiguous().data();
+    if (sourceType == ArrayWithDouble)
+        copyElements<FillMode::Undefined>(buffer, 0, butterfly->contiguousDouble().data(), resultSize, ArrayWithDouble);
+    else
+        copyElements<FillMode::Undefined>(buffer, 0, butterfly->contiguous().data(), resultSize, sourceType);
     return JSValue::encode(result);
 }
 


### PR DESCRIPTION
#### c68cf48dd75cff6ed634b66127a0bbf13ef913bb
<pre>
[JSC] Array.from fast path should handle array with holes
<a href="https://bugs.webkit.org/show_bug.cgi?id=264853">https://bugs.webkit.org/show_bug.cgi?id=264853</a>
<a href="https://rdar.apple.com/118417483">rdar://118417483</a>

Reviewed by Michael Saboff.

Array.from fills the result with undefined when it detects a hole.
So the fast path needs to handle this properly: we should fill undefined when
we found a hole in the source array. This patch fixes the fast path implementation
correctly filling undefined for source&apos;s holes. Since they are undefined,

1. When ArrayWithUndecided has some length, it should create ArrayWithContiguous with undefineds.
2. When ArrayWithInt32 has some holes, it should create ArrayWithContiguous with undefineds.
3. When ArrayWithDouble has some holes, it should create ArrayWithContiguous with undefineds.
4. When ArrayWithArrayStorage has some holes, it should fill undefined for holes.
5. Otherwise, we can just copy the underlying content.

* JSTests/stress/array-from-empty.js: Added.
(shouldBe):
(throw.new.Error):
(else.shouldBe):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::moveElements):
(JSC::concatAppendOne):
(JSC::copyElements):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/270748@main">https://commits.webkit.org/270748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e687202a2af9ad31b84ff96d638dd7cf7a14161

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24062 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24057 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3743 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28967 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29634 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22916 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/23958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27524 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25506 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1581 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32952 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4799 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7126 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3852 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3386 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->