### PR TITLE
Use NativePromise chaining in place of operations queue in SourceBufferPrivate

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -153,7 +153,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 private:
     explicit SourceBufferPrivateAVFObjC(MediaSourcePrivateAVFObjC&, Ref<SourceBufferParser>&&);
 
-    void didParseInitializationData(InitializationSegment&&);
     void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, uint64_t trackId, const String& mediaType);
     bool isMediaSampleAllowed(const MediaSample&) const final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -434,13 +434,6 @@ void SourceBufferPrivateAVFObjC::setTrackChangeCallbacks(const InitializationSeg
     }
 }
 
-void SourceBufferPrivateAVFObjC::didParseInitializationData(InitializationSegment&& segment)
-{
-    ALWAYS_LOG(LOGIDENTIFIER);
-
-    didReceiveInitializationSegment(WTFMove(segment));
-}
-
 bool SourceBufferPrivateAVFObjC::precheckInitialisationSegment(const InitializationSegment& segment)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
@@ -622,7 +615,7 @@ Ref<GenericPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>
         ASSERT(isMainThread());
         if (!weakThis)
             return;
-        weakThis->didParseInitializationData(WTFMove(segment));
+        weakThis->didReceiveInitializationSegment(WTFMove(segment));
     });
 
     m_parser->setDidProvideMediaDataCallback([weakThis = WeakPtr { *this }] (Ref<MediaSampleAVFObjC>&& sample, uint64_t trackId, const String& mediaType) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -196,12 +196,6 @@ void SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued(const AtomString& t
     track->enqueueObject(adoptGRef(GST_MINI_OBJECT(gst_event_new_eos())));
 }
 
-void SourceBufferPrivateGStreamer::didReceiveInitializationSegment(InitializationSegment&& initializationSegment)
-{
-    SourceBufferPrivate::didReceiveInitializationSegment(WTFMove(initializationSegment));
-}
-
-
 bool SourceBufferPrivateGStreamer::precheckInitialisationSegment(const InitializationSegment& segment)
 {
     for (auto& trackInfo : segment.videoTracks) {
@@ -232,21 +226,21 @@ void SourceBufferPrivateGStreamer::processInitialisationSegment(std::optional<In
         static_cast<MediaSourcePrivateGStreamer*>(m_mediaSource.get())->startPlaybackIfHasAllTracks();
 }
 
-void SourceBufferPrivateGStreamer::didReceiveSample(Ref<MediaSample>&& sample)
-{
-    SourceBufferPrivate::didReceiveSample(WTFMove(sample));
-}
-
 void SourceBufferPrivateGStreamer::didReceiveAllPendingSamples()
 {
-    m_appendPromise->resolve();
-    m_appendPromise.reset();
+    // TODO: didReceiveAllPendingSamples is called even when an error occurred.
+    if (m_appendPromise) {
+        m_appendPromise->resolve();
+        m_appendPromise.reset();
+    }
 }
 
 void SourceBufferPrivateGStreamer::appendParsingFailed()
 {
-    m_appendPromise->reject(1);
-    m_appendPromise.reset();
+    if (m_appendPromise) {
+        m_appendPromise->reject(1);
+        m_appendPromise.reset();
+    }
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -42,8 +42,8 @@
 #include "SourceBufferPrivateClient.h"
 #include "TrackPrivateBaseGStreamer.h"
 #include "WebKitMediaSourceGStreamer.h"
+#include <optional>
 #include <wtf/LoggerHelper.h>
-#include <wtf/NativePromise.h>
 
 namespace WebCore {
 
@@ -73,8 +73,6 @@ public:
     bool precheckInitialisationSegment(const InitializationSegment&) final;
     void processInitialisationSegment(std::optional<InitializationSegment>&&) final;
 
-    void didReceiveInitializationSegment(InitializationSegment&&);
-    void didReceiveSample(Ref<MediaSample>&&);
     void didReceiveAllPendingSamples();
     void appendParsingFailed();
 
@@ -95,6 +93,8 @@ public:
     size_t platformEvictionThreshold() const final;
 
 private:
+    friend class AppendPipeline;
+
     SourceBufferPrivateGStreamer(MediaSourcePrivateGStreamer&, const ContentType&, MediaPlayerPrivateGStreamerMSE&);
 
     void notifyClientWhenReadyForMoreSamples(const AtomString&) override;


### PR DESCRIPTION
#### 19836c74aa9f0c3783d5c3f3e9b8b9e3b415afd6
<pre>
Use NativePromise chaining in place of operations queue in SourceBufferPrivate
<a href="https://bugs.webkit.org/show_bug.cgi?id=264854">https://bugs.webkit.org/show_bug.cgi?id=264854</a>
<a href="https://rdar.apple.com/118429088">rdar://118429088</a>

Reviewed by Jer Noble.

By using promise chaining we can remove the need for an operations queue to serialise the tasks.
It also makes the code easier to read/follow as the entire appendBuffer operation is now available at a
glance.
This will simplify making SourceBufferPrivate::append/removeCodedFrames be made asynchronous and use
NativePromise.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didUpdateFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::didReceiveSample):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::processPendingMediaSamples):
(WebCore::SourceBufferPrivate::processMediaSample):
(WebCore::SourceBufferPrivate::resetParserState):
(WebCore::SourceBufferPrivate::memoryPressure):
(WebCore::SourceBufferPrivate::~SourceBufferPrivate): Deleted.
(WebCore::SourceBufferPrivate::advanceOperationState): Deleted.
(WebCore::SourceBufferPrivate::rewindOperationState): Deleted.
(WebCore::SourceBufferPrivate::processAppendCompletedOperation): Deleted.
(WebCore::SourceBufferPrivate::queueOperation): Deleted.
(WebCore::SourceBufferPrivate::processPendingOperations): Deleted.
(WebCore::SourceBufferPrivate::abortPendingOperations): Deleted.
(WebCore::SourceBufferPrivate::processError): Deleted.
(WebCore::SourceBufferPrivate::processInitOperation): Deleted.
(WebCore::SourceBufferPrivate::processMediaSamplesOperation): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::didReceiveAllPendingSamples): Test that the promise wasn&apos;t previously resolved.
fallout from bug 264847.
(WebCore::SourceBufferPrivateGStreamer::appendParsingFailed):

Canonical link: <a href="https://commits.webkit.org/270808@main">https://commits.webkit.org/270808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96a3f81fddd28e9c097fb88b6c56803d539f2ee9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27716 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28655 "") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24207 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2494 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/28655 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22732 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/28655 "") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23708 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29170 "Failed to print configuration") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24107 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29170 "Failed to print configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3520 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29170 "Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4953 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6354 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->