### PR TITLE
Replace strongThis by protectedThis

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
@@ -164,7 +164,7 @@ bool RemoteConnectionToTarget::setup(bool isAutomaticInspection, bool automatica
 
     auto targetIdentifier = this->targetIdentifier().value_or(0);
 
-    dispatchAsyncOnTarget([this, targetIdentifier, isAutomaticInspection, automaticallyPause, strongThis = Ref { *this }]() {
+    dispatchAsyncOnTarget([this, targetIdentifier, isAutomaticInspection, automaticallyPause, protectedThis = Ref { *this }]() {
         Locker locker { m_targetMutex };
 
         if (!m_target || !m_target->remoteControlAllowed()) {
@@ -202,7 +202,7 @@ void RemoteConnectionToTarget::close()
     if (auto* automationTarget = dynamicDowncast<RemoteAutomationTarget>(m_target))
         automationTarget->setIsPendingTermination();
     
-    dispatchAsyncOnTarget([this, targetIdentifier, strongThis = Ref { *this }]() {
+    dispatchAsyncOnTarget([this, targetIdentifier, protectedThis = Ref { *this }]() {
         Locker locker { m_targetMutex };
         if (m_target) {
             if (m_connected)
@@ -217,7 +217,7 @@ void RemoteConnectionToTarget::close()
 
 void RemoteConnectionToTarget::sendMessageToTarget(NSString *message)
 {
-    dispatchAsyncOnTarget([this, strongMessage = retainPtr(message), strongThis = Ref { *this }]() {
+    dispatchAsyncOnTarget([this, strongMessage = retainPtr(message), protectedThis = Ref { *this }]() {
         RemoteControllableTarget* target = nullptr;
         {
             Locker locker { m_targetMutex };

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -690,7 +690,7 @@ private:
                 }
                 return;
             }
-            m_targetQueue->dispatch([this, strongThis = Ref { *this }, promise = Ref { promise }, operation = *promise.m_result ? "Resolving" : "Rejecting"] () mutable {
+            m_targetQueue->dispatch([this, protectedThis = Ref { *this }, promise = Ref { promise }, operation = *promise.m_result ? "Resolving" : "Rejecting"] () mutable {
                 PROMISE_LOG(operation, " then() call made from ", m_logSiteIdentifier, "[", promise.get(), " callback:", (const void*)this, "]");
                 if (m_disconnected) {
                     PROMISE_LOG("ThenCallback disconnected aborting [callback:", (const void*)this, " callSite:", m_logSiteIdentifier, "]");

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
@@ -58,8 +58,8 @@ void FileSystemDirectoryHandle::getFileHandle(const String& name, const FileSyst
         if (result.hasException())
             return promise.reject(result.releaseException());
 
-        auto strongThis = weakThis.get();
-        RefPtr context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
+        auto protectedThis = weakThis.get();
+        RefPtr context = protectedThis ? protectedThis->scriptExecutionContext() : nullptr;
         if (!context)
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
 
@@ -78,8 +78,8 @@ void FileSystemDirectoryHandle::getDirectoryHandle(const String& name, const Fil
         if (result.hasException())
             return promise.reject(result.releaseException());
 
-        auto strongThis = weakThis.get();
-        RefPtr context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
+        auto protectedThis = weakThis.get();
+        RefPtr context = protectedThis ? protectedThis->scriptExecutionContext() : nullptr;
         if (!context)
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
 
@@ -127,8 +127,8 @@ void FileSystemDirectoryHandle::getHandle(const String& name, CompletionHandler<
             return completionHandler(result.releaseException());
 
         auto [identifier, isDirectory] = result.returnValue()->release();
-        auto strongThis = weakThis.get();
-        RefPtr context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
+        auto protectedThis = weakThis.get();
+        RefPtr context = protectedThis ? protectedThis->scriptExecutionContext() : nullptr;
         if (!context)
             return completionHandler(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -666,19 +666,19 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
     auto handleItemSelected = [weakThis = WeakPtr { *this }, idMap = WTFMove(idMap)] (MenuItemIdentifier selectedItemID) {
         if (!weakThis)
             return;
-        Ref strongThis = *weakThis;
+        Ref protectedThis = *weakThis;
 
-        auto invokeCallbackAtScopeExit = makeScopeExit([strongThis] {
-            if (auto showMediaControlsContextMenuCallback = std::exchange(strongThis->m_showMediaControlsContextMenuCallback, nullptr))
+        auto invokeCallbackAtScopeExit = makeScopeExit([protectedThis] {
+            if (auto showMediaControlsContextMenuCallback = std::exchange(protectedThis->m_showMediaControlsContextMenuCallback, nullptr))
                 showMediaControlsContextMenuCallback->handleEvent();
         });
 
         if (selectedItemID == invalidMenuItemIdentifier)
             return;
 
-        if (!strongThis->m_mediaElement)
+        if (!protectedThis->m_mediaElement)
             return;
-        auto& mediaElement = *strongThis->m_mediaElement;
+        auto& mediaElement = *protectedThis->m_mediaElement;
 
         UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, &mediaElement.document());
 

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
@@ -199,14 +199,14 @@ void InspectorFrontendAPIDispatcher::evaluateOrQueueExpression(const String& exp
         if (!weakThis)
             return;
 
-        Ref strongThis = { *weakThis };
-        if (!strongThis->m_pendingResponses.size())
+        Ref protectedThis = { *weakThis };
+        if (!protectedThis->m_pendingResponses.size())
             return;
 
-        EvaluationResultHandler resultHandler = strongThis->m_pendingResponses.take(promise);
+        EvaluationResultHandler resultHandler = protectedThis->m_pendingResponses.take(promise);
         ASSERT(resultHandler);
         
-        JSDOMGlobalObject* globalObject = strongThis->frontendGlobalObject();
+        JSDOMGlobalObject* globalObject = protectedThis->frontendGlobalObject();
         if (!globalObject) {
             resultHandler(makeUnexpected(EvaluationError::ContextDestroyed));
             return;

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -173,13 +173,13 @@ DOMTimer::DOMTimer(ScriptExecutionContext& context, Function<void(ScriptExecutio
     m_hasReachedMaxNestingLevel = m_nestingLevel >= (m_oneShot ? maxTimerNestingLevelForOneShotTimers : maxTimerNestingLevelForRepeatingTimers);
     if (m_oneShot) {
         m_timer = eventLoop.scheduleTask(m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
-            if (RefPtr strongThis = weakThis.get())
-                strongThis->fired();
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->fired();
         });
     } else {
         m_timer = eventLoop.scheduleRepeatingTask(m_originalInterval, m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
-            if (RefPtr strongThis = weakThis.get())
-                strongThis->fired();
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->fired();
         });
     }
 }
@@ -311,8 +311,8 @@ void DOMTimer::fired()
     if (RefPtr document = dynamicDowncast<Document>(context); document && m_oneShot) {
         if (auto* holdingTank = document->domTimerHoldingTankIfExists(); holdingTank && holdingTank->contains(*this)) {
             m_timer = document->eventLoop().scheduleTask(0_s, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
-                if (RefPtr strongThis = weakThis.get())
-                    strongThis->fired();
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->fired();
             });
             return;
         }

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -136,8 +136,8 @@ void EventSource::scheduleInitialConnect()
 
     auto* context = scriptExecutionContext();
     m_connectTimer = context->eventLoop().scheduleTask(0_s, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
-        if (RefPtr strongThis = weakThis.get())
-            strongThis->connect();
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->connect();
     });
 }
 
@@ -147,8 +147,8 @@ void EventSource::scheduleReconnect()
     m_state = CONNECTING;
     auto* context = scriptExecutionContext();
     m_connectTimer = context->eventLoop().scheduleTask(1_ms * m_reconnectDelay, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
-        if (RefPtr strongThis = weakThis.get())
-            strongThis->connect();
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->connect();
     });
     dispatchErrorEvent();
 }

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -34,8 +34,8 @@ namespace WebCore {
 OpportunisticTaskScheduler::OpportunisticTaskScheduler(Page& page)
     : m_page(&page)
     , m_runLoopObserver(makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [weakThis = WeakPtr { this }] {
-        if (auto strongThis = weakThis.get())
-            strongThis->runLoopObserverFired();
+        if (auto protectedThis = weakThis.get())
+            protectedThis->runLoopObserverFired();
     }, RunLoopObserver::Type::OneShot))
 {
 }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4086,14 +4086,14 @@ bool Page::startApplePayAMSUISession(const URL& originatingURL, ApplePayAMSUIPay
     m_activeApplePayAMSUIPaymentHandler = &paymentHandler;
 
     chrome().client().startApplePayAMSUISession(originatingURL, request, [weakThis = WeakPtr { *this }, paymentHandlerPtr = &paymentHandler] (std::optional<bool>&& result) {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
-        if (paymentHandlerPtr != strongThis->m_activeApplePayAMSUIPaymentHandler)
+        if (paymentHandlerPtr != protectedThis->m_activeApplePayAMSUIPaymentHandler)
             return;
 
-        if (auto activePaymentHandler = std::exchange(strongThis->m_activeApplePayAMSUIPaymentHandler, nullptr))
+        if (auto activePaymentHandler = std::exchange(protectedThis->m_activeApplePayAMSUIPaymentHandler, nullptr))
             activePaymentHandler->finishSession(WTFMove(result));
     });
     return true;

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -266,8 +266,8 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
     addPendingScrollUpdate(WTFMove(scrollUpdate));
 
     auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *this, node.scrollingNodeID(), WheelEventTestMonitor::DeferReason::ScrollingThreadSyncNeeded };
-    RunLoop::main().dispatch([strongThis = Ref { *this }, deferrer = WTFMove(deferrer)] {
-        if (auto* scrollingCoordinator = strongThis->m_scrollingCoordinator.get())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, deferrer = WTFMove(deferrer)] {
+        if (auto* scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
             scrollingCoordinator->scrollingThreadAddedPendingUpdate();
     });
 }
@@ -288,8 +288,8 @@ void ThreadedScrollingTree::scrollingTreeNodeScrollUpdated(ScrollingTreeScrollin
 
     addPendingScrollUpdate(WTFMove(scrollUpdate));
 
-    RunLoop::main().dispatch([strongThis = Ref { *this }] {
-        if (auto* scrollingCoordinator = strongThis->m_scrollingCoordinator.get())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }] {
+        if (auto* scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
             scrollingCoordinator->scrollingThreadAddedPendingUpdate();
     });
 }

--- a/Source/WebCore/platform/graphics/ImageSource.cpp
+++ b/Source/WebCore/platform/graphics/ImageSource.cpp
@@ -77,8 +77,8 @@ bool ImageSource::ensureDecoderAvailable(FragmentedSharedBuffer* data)
         return false;
 
     m_decoder->setEncodedDataStatusChangeCallback([weakThis = ThreadSafeWeakPtr { *this }] (auto status) {
-        if (RefPtr strongThis = weakThis.get())
-            strongThis->encodedDataStatusChanged(status);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->encodedDataStatusChanged(status);
     });
 
     if (auto expectedContentSize = expectedContentLength())

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -304,7 +304,7 @@ void SourceBufferParserAVFObjC::setLogger(const Logger& newLogger, const void* n
 void SourceBufferParserAVFObjC::didParseStreamDataAsAsset(AVAsset* asset)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, asset);
-    m_callOnClientThreadCallback([this, strongThis = Ref { *this }, asset = retainPtr(asset)] {
+    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, asset = retainPtr(asset)] {
         if (!m_didParseInitializationDataCallback)
             return;
 
@@ -344,7 +344,7 @@ void SourceBufferParserAVFObjC::didParseStreamDataAsAsset(AVAsset* asset)
 void SourceBufferParserAVFObjC::didFailToParseStreamDataWithError(NSError* error)
 {
     ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, error);
-    m_callOnClientThreadCallback([this, strongThis = Ref { *this }, error = retainPtr(error)] {
+    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, error = retainPtr(error)] {
         if (m_didEncounterErrorDuringParsingCallback)
             m_didEncounterErrorDuringParsingCallback(error.get().code);
     });
@@ -354,7 +354,7 @@ void SourceBufferParserAVFObjC::didProvideMediaDataForTrackID(uint64_t trackID, 
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "trackID = ", trackID, ", mediaType = ", mediaType);
     UNUSED_PARAM(flags);
-    m_callOnClientThreadCallback([this, strongThis = Ref { *this }, sampleBuffer = retainPtr(sampleBuffer), trackID, mediaType = mediaType] {
+    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, sampleBuffer = retainPtr(sampleBuffer), trackID, mediaType = mediaType] {
         if (!m_didProvideMediaDataCallback)
             return;
 
@@ -385,7 +385,7 @@ void SourceBufferParserAVFObjC::didProvideContentKeyRequestInitializationDataFor
 void SourceBufferParserAVFObjC::didProvideContentKeyRequestSpecifierForTrackID(NSData* nsInitData, uint64_t trackID)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "trackID = ", trackID);
-    m_callOnClientThreadCallback([this, strongThis = Ref { *this }, nsInitData = retainPtr(nsInitData), trackID] {
+    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, nsInitData = retainPtr(nsInitData), trackID] {
         m_didProvideContentKeyRequestIdentifierForTrackIDCallback(SharedBuffer::create(nsInitData.get()), trackID);
     });
 }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -153,8 +153,8 @@ void MediaRecorderPrivateBackend::stopRecording(CompletionHandler<void()>&& comp
     while (!isEOS) {
         LockHolder lock(m_eosLock);
         m_eosCondition.waitFor(m_eosLock, 200_ms, [weakThis = ThreadSafeWeakPtr { *this }]() -> bool {
-            if (auto strongThis = weakThis.get())
-                return strongThis->m_eos;
+            if (auto protectedThis = weakThis.get())
+                return protectedThis->m_eos;
             return true;
         });
         isEOS = m_eos;
@@ -164,8 +164,8 @@ void MediaRecorderPrivateBackend::stopRecording(CompletionHandler<void()>&& comp
 void MediaRecorderPrivateBackend::fetchData(MediaRecorderPrivate::FetchDataCallback&& completionHandler)
 {
     callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis) {
+        auto protectedThis = weakThis.get();
+        if (!protectedThis) {
             completionHandler(nullptr, mimeType(), 0);
             return;
         }

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
@@ -360,8 +360,8 @@ void MediaRecorderPrivateWriter::flushCompressedSampleBuffers(Function<void()>&&
     ASSERT(!m_isFlushingSamples);
     m_isFlushingSamples = true;
     auto block = makeBlockPtr([this, weakThis = ThreadSafeWeakPtr { *this }, hasPendingAudioSamples, hasPendingVideoSamples, audioSampleQueue = WTFMove(m_pendingAudioSampleQueue), videoSampleQueue = WTFMove(m_pendingVideoFrameQueue), callback = WTFMove(callback)]() mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis) {
+        auto protectedThis = weakThis.get();
+        if (!protectedThis) {
             callback();
             return;
         }
@@ -443,13 +443,13 @@ void MediaRecorderPrivateWriter::stopRecording()
     m_isStopping = true;
     // We hop to the main thread since finishing the video compressor might trigger starting the writer asynchronously.
     callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
         auto whenFinished = [this, weakThis] {
-            auto strongThis = weakThis.get();
-            if (!strongThis)
+            auto protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             m_isStopping = false;
@@ -472,8 +472,8 @@ void MediaRecorderPrivateWriter::stopRecording()
 
         ASSERT([m_writer status] == AVAssetWriterStatusWriting);
         flushCompressedSampleBuffers([this, weakThis = WTFMove(weakThis), whenFinished = WTFMove(whenFinished)]() mutable {
-            auto strongThis = weakThis.get();
-            if (!strongThis)
+            auto protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -507,17 +507,17 @@ void MediaRecorderPrivateWriter::fetchData(CompletionHandler<void(RefPtr<Fragmen
     // We hop to the main thread since flushing the video compressor might trigger starting the writer asynchronously.
     callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() mutable {
         flushCompressedSampleBuffers([weakThis = WTFMove(weakThis)]() mutable {
-            auto strongThis = weakThis.get();
-            if (!strongThis)
+            auto protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            [strongThis->m_writer flush];
+            [protectedThis->m_writer flush];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
             callOnMainThread([weakThis = WTFMove(weakThis)] {
-                if (auto strongThis = weakThis.get())
-                    strongThis->completeFetchData();
+                if (auto protectedThis = weakThis.get())
+                    protectedThis->completeFetchData();
             });
         });
     });

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
@@ -499,8 +499,8 @@ void OpenXRDevice::endSession()
 
     // Notify did end event
     callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
         if (m_trackingAndRenderingClient)
             m_trackingAndRenderingClient->sessionDidEnd();
@@ -589,8 +589,8 @@ void OpenXRDevice::updateInteractionProfile()
     didNotifyInputInitialization = true;
     auto inputSources = m_input->collectInputSources(m_frameState);
     callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }, inputSources = WTFMove(inputSources)]() mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
         if (m_trackingAndRenderingClient)
             m_trackingAndRenderingClient->sessionDidInitializeInputSources(WTFMove(inputSources));

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -120,8 +120,8 @@ void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOr
         // so notify the input sources have been initialized with an empty list. This is not a problem because
         // WPT tests rely on requestAnimationFrame updates to test the input sources.
         callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() {
-            auto strongThis = weakThis.get();
-            if (!strongThis)
+            auto protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
             if (m_trackingAndRenderingClient)
                 m_trackingAndRenderingClient->sessionDidInitializeInputSources({ });

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -151,13 +151,14 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
 {
 #if PLATFORM(MAC)
     auto devices = MTLCopyAllDevicesWithObserver(&m_deviceObserver, [weakThis = ThreadSafeWeakPtr { *this }](id<MTLDevice> device, MTLDeviceNotificationName) {
-        RefPtr<Device> strongThis = weakThis.get();
-        if (!strongThis)
+        RefPtr<Device> protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
-        strongThis->instance().scheduleWork([strongThis = WTFMove(strongThis), device = device]() {
-            if (![strongThis->m_device isEqual:device])
+        auto& instance = protectedThis->instance();
+        instance.scheduleWork([protectedThis = WTFMove(protectedThis), device = device]() {
+            if (![protectedThis->m_device isEqual:device])
                 return;
-            strongThis->loseTheDevice(WGPUDeviceLostReason_Undefined);
+            protectedThis->loseTheDevice(WGPUDeviceLostReason_Undefined);
         });
     });
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -694,7 +694,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
 void Device::createRenderPipelineAsync(const WGPURenderPipelineDescriptor& descriptor, CompletionHandler<void(WGPUCreatePipelineAsyncStatus, Ref<RenderPipeline>&&, String&& message)>&& callback)
 {
     auto pipeline = createRenderPipeline(descriptor);
-    instance().scheduleWork([strongThis = Ref { *this }, pipeline, callback = WTFMove(callback)]() mutable {
+    instance().scheduleWork([protectedThis = Ref { *this }, pipeline, callback = WTFMove(callback)]() mutable {
         callback(WGPUCreatePipelineAsyncStatus_Success, WTFMove(pipeline), { });
     });
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -120,8 +120,8 @@ void NetworkDataTask::scheduleFailure(FailureType type)
 {
     m_failureScheduled = true;
     RunLoop::main().dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, type] {
-        auto strongThis = weakThis.get();
-        if (!strongThis || !m_client)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis || !m_client)
             return;
 
         switch (type) {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -460,14 +460,14 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
         request.setFirstPartyForCookies(request.url());
 
     NetworkTaskCocoa::willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis = ThreadSafeWeakPtr { *this }, redirectResponse] (WebCore::ResourceRequest&& request) mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return completionHandler({ });
         if (!m_client)
             return completionHandler({ });
         m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis] (WebCore::ResourceRequest&& request) mutable {
-            auto strongThis = weakThis.get();
-            if (!strongThis || !m_session)
+            auto protectedThis = weakThis.get();
+            if (!protectedThis || !m_session)
                 return completionHandler({ });
             if (!request.isNull())
                 restrictRequestReferrerToOriginIfNeeded(request);

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -80,8 +80,8 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
     // ends up calling queueTaskKeepingObjectAlive() which refs the WebXRSession object, we
     // should delay this call after the WebXRSession has finished construction.
     callOnMainRunLoop([this, weakThis = ThreadSafeWeakPtr { *this }]() {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
         if (trackingAndRenderingClient())

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -468,8 +468,8 @@ void ProcessAssertion::acquireSync()
     if (![m_rbsAssertion acquireWithError:&acquisitionError]) {
         RELEASE_LOG_ERROR(ProcessSuspension, "%p - ProcessAssertion::acquireSync Failed to acquire RBS assertion '%{public}s' for process with PID=%d, error: %{public}@", this, m_reason.utf8().data(), m_pid, acquisitionError);
         RunLoop::main().dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
-            if (auto strongThis = weakThis.get())
-                strongThis->processAssertionWasInvalidated();
+            if (auto protectedThis = weakThis.get())
+                protectedThis->processAssertionWasInvalidated();
         });
     } else
         RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion::acquireSync Successfully took RBS assertion '%{public}s' for process with PID=%d", this, m_reason.utf8().data(), m_pid);
@@ -568,7 +568,7 @@ void ProcessAndUIAssertion::processAssertionWasInvalidated()
     ProcessAssertion::processAssertionWasInvalidated();
 
     // Calling ProcessAssertion::processAssertionWasInvalidated() may have destroyed |this|.
-    if (auto strongThis = weakThis.get())
+    if (auto protectedThis = weakThis.get())
         updateRunInBackgroundCount();
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -179,8 +179,8 @@ void SOAuthorizationSession::start()
     [m_soAuthorization getAuthorizationHintsWithURL:m_navigationAction->request().url() responseCode:0 completion:makeBlockPtr([this, weakThis = ThreadSafeWeakPtr { *this }] (SOAuthorizationHints *authorizationHints, NSError *error) {
         AUTHORIZATIONSESSION_RELEASE_LOG("start: Receive SOAuthorizationHints (error=%ld)", error ? error.code : 0);
 
-        auto strongThis = weakThis.get();
-        if (!strongThis) {
+        auto protectedThis = weakThis.get();
+        if (!protectedThis) {
             RELEASE_LOG_ERROR(AppSSO, "SOAuthorizationSession::start (getAuthorizationHintsWithURL completion handler): Returning early because weakThis is now null.");
             return;
         }
@@ -207,8 +207,8 @@ void SOAuthorizationSession::continueStartAfterGetAuthorizationHints(const Strin
 
     AUTHORIZATIONSESSION_RELEASE_LOG("continueStartAfterGetAuthorizationHints: Checking page for policy choice.");
     m_page->decidePolicyForSOAuthorizationLoad(hints, [weakThis = ThreadSafeWeakPtr { *this }] (SOAuthorizationLoadPolicy policy) {
-        if (auto strongThis = weakThis.get())
-            strongThis->continueStartAfterDecidePolicy(policy);
+        if (auto protectedThis = weakThis.get())
+            protectedThis->continueStartAfterDecidePolicy(policy);
     });
 }
 
@@ -339,8 +339,8 @@ void SOAuthorizationSession::complete(NSHTTPURLResponse *httpResponse, NSData *d
     }
 
     m_page->websiteDataStore().cookieStore().setCookies(WTFMove(cookies), [this, weakThis = ThreadSafeWeakPtr { *this }, response = WTFMove(response), data = adoptNS([[NSData alloc] initWithData:data])] () mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
         AUTHORIZATIONSESSION_RELEASE_LOG("complete: Cookies are set.");
@@ -374,11 +374,11 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
     m_sheetWindow = [NSWindow windowWithContentViewController:m_viewController.get()];
 
     m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification object:m_sheetWindow.get() queue:nil usingBlock:[weakThis = ThreadSafeWeakPtr { *this }] (NSNotification *) {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
         RELEASE_LOG(AppSSO, "presentViewController: Received NSWindowWillCloseNotification. Dismissing the view controller.");
-        strongThis->dismissViewController();
+        protectedThis->dismissViewController();
     }];
     AUTHORIZATIONSESSION_RELEASE_LOG("presentViewController: Added m_sheetWindowWillCloseObserver (%p)", m_sheetWindowWillCloseObserver.get());
 

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -390,12 +390,12 @@ void SystemPreviewController::begin(const URL& url, const SecurityOriginData& to
         if (!weakThis)
             return completionHandler();
 
-        auto strongThis = weakThis.get();
+        auto protectedThis = weakThis.get();
 
         _WKDataTask *dataTask = wrapper(task);
-        strongThis->m_wkSystemPreviewDataTaskDelegate = adoptNS([[_WKSystemPreviewDataTaskDelegate alloc] initWithSystemPreviewController:strongThis]);
-        [dataTask setDelegate:strongThis->m_wkSystemPreviewDataTaskDelegate.get()];
-        strongThis->takeActivityToken();
+        protectedThis->m_wkSystemPreviewDataTaskDelegate = adoptNS([[_WKSystemPreviewDataTaskDelegate alloc] initWithSystemPreviewController:protectedThis]);
+        [dataTask setDelegate:protectedThis->m_wkSystemPreviewDataTaskDelegate.get()];
+        protectedThis->takeActivityToken();
         completionHandler();
     });
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -102,19 +102,19 @@ void WebInspectorUIExtensionControllerProxy::registerExtension(const Inspector::
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [strongThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::RegistrationFailed));
                 return;
             }
 
-            if (!strongThis->m_inspectorPage) {
+            if (!protectedThis->m_inspectorPage) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));
                 return;
             }
 
-            RefPtr<API::InspectorExtension> extensionAPIObject = API::InspectorExtension::create(extensionID, strongThis.get());
-            strongThis->m_extensionAPIObjectMap.set(extensionID, extensionAPIObject.copyRef());
+            RefPtr<API::InspectorExtension> extensionAPIObject = API::InspectorExtension::create(extensionID, protectedThis.get());
+            protectedThis->m_extensionAPIObjectMap.set(extensionID, extensionAPIObject.copyRef());
 
             completionHandler(WTFMove(extensionAPIObject));
         });
@@ -129,18 +129,18 @@ void WebInspectorUIExtensionControllerProxy::unregisterExtension(const Inspector
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [strongThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::InvalidRequest));
                 return;
             }
 
-            if (!strongThis->m_inspectorPage) {
+            if (!protectedThis->m_inspectorPage) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));
                 return;
             }
 
-            strongThis->m_extensionAPIObjectMap.take(extensionID);
+            protectedThis->m_extensionAPIObjectMap.take(extensionID);
 
             completionHandler(WTFMove(result));
         });

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -194,8 +194,8 @@ void RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAn
 {
     ASSERT(ScrollingThread::isCurrentThread());
 
-    RunLoop::main().dispatch([strongThis = Ref { *this }, hasNodeWithAnimatedScroll] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, hasNodeWithAnimatedScroll] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->hasNodeWithAnimatedScrollChanged(hasNodeWithAnimatedScroll);
     });
 }
@@ -204,8 +204,8 @@ void RemoteScrollingTreeMac::setRubberBandingInProgressForNode(ScrollingNodeID n
 {
     ScrollingTree::setRubberBandingInProgressForNode(nodeID, isRubberBanding);
 
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, isRubberBanding] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID, isRubberBanding] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->setRubberBandingInProgressForNode(nodeID, isRubberBanding);
     });
 }
@@ -228,8 +228,8 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNo
         return;
     }
 
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, scrollPosition, layoutViewportOrigin, action] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID, scrollPosition, layoutViewportOrigin, action] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->scrollingTreeNodeDidScroll(nodeID, scrollPosition, layoutViewportOrigin, action);
     });
 }
@@ -245,8 +245,8 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTre
 
     ASSERT(ScrollingThread::isCurrentThread());
 
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID = node.scrollingNodeID()] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID = node.scrollingNodeID()] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->scrollingTreeNodeDidStopAnimatedScroll(nodeID);
     });
 }
@@ -270,32 +270,32 @@ bool RemoteScrollingTreeMac::scrollingTreeNodeRequestsKeyboardScroll(ScrollingNo
 
 void RemoteScrollingTreeMac::currentSnapPointIndicesDidChange(ScrollingNodeID nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical)
 {
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, horizontal, vertical] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID, horizontal, vertical] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->currentSnapPointIndicesDidChange(nodeID, horizontal, vertical);
     });
 }
 
 void RemoteScrollingTreeMac::reportExposedUnfilledArea(MonotonicTime time, unsigned unfilledArea)
 {
-    RunLoop::main().dispatch([strongThis = Ref { *this }, time, unfilledArea] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, time, unfilledArea] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->reportExposedUnfilledArea(time, unfilledArea);
     });
 }
 
 void RemoteScrollingTreeMac::reportSynchronousScrollingReasonsChanged(MonotonicTime timestamp, OptionSet<SynchronousScrollingReason> reasons)
 {
-    RunLoop::main().dispatch([strongThis = Ref { *this }, timestamp, reasons] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, timestamp, reasons] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->reportSynchronousScrollingReasonsChanged(timestamp, reasons);
     });
 }
 
 void RemoteScrollingTreeMac::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
-    RunLoop::main().dispatch([strongThis = Ref { *this }, phase, momentumPhase] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, phase, momentumPhase] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->receivedWheelEventWithPhases(phase, momentumPhase);
     });
 }
@@ -381,8 +381,8 @@ void RemoteScrollingTreeMac::deferWheelEventTestCompletionForReason(ScrollingNod
     if (!isMonitoringWheelEvents())
         return;
 
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, reason] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID, reason] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->deferWheelEventTestCompletionForReason(nodeID, reason);
     });
 }
@@ -392,8 +392,8 @@ void RemoteScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason(Scr
     if (!isMonitoringWheelEvents())
         return;
 
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, reason] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID, reason] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->removeWheelEventTestCompletionDeferralForReason(nodeID, reason);
     });
 }
@@ -555,16 +555,16 @@ OptionSet<EventListenerRegionType> RemoteScrollingTreeMac::eventListenerRegionTy
 
 void RemoteScrollingTreeMac::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
 {
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, orientation, isVisible] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID, orientation, isVisible] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->scrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible);
     });
 }
 
 void RemoteScrollingTreeMac::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, int minimumThumbLength)
 {
-    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, orientation, minimumThumbLength] {
-        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, nodeID, orientation, minimumThumbLength] {
+        if (auto* scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(nodeID, orientation, minimumThumbLength);
     });
 }

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -126,23 +126,23 @@ void PlatformXRSystem::submitFrame()
 void PlatformXRSystem::sessionDidEnd(XRDeviceIdentifier deviceIdentifier)
 {
     ensureOnMainRunLoop([weakThis = WeakPtr { *this }, deviceIdentifier]() mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
-        strongThis->m_page.send(Messages::PlatformXRSystemProxy::SessionDidEnd(deviceIdentifier));
-        strongThis->m_immersiveSessionActivity = nullptr;
+        protectedThis->m_page.send(Messages::PlatformXRSystemProxy::SessionDidEnd(deviceIdentifier));
+        protectedThis->m_immersiveSessionActivity = nullptr;
     });
 }
 
 void PlatformXRSystem::sessionDidUpdateVisibilityState(XRDeviceIdentifier deviceIdentifier, PlatformXR::VisibilityState visibilityState)
 {
     ensureOnMainRunLoop([weakThis = WeakPtr { *this }, deviceIdentifier, visibilityState]() mutable {
-        auto strongThis = weakThis.get();
-        if (!strongThis)
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
-        strongThis->m_page.send(Messages::PlatformXRSystemProxy::SessionDidUpdateVisibilityState(deviceIdentifier, visibilityState));
+        protectedThis->m_page.send(Messages::PlatformXRSystemProxy::SessionDidUpdateVisibilityState(deviceIdentifier, visibilityState));
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -271,13 +271,13 @@ void RemoteDeviceProxy::createComputePipelineAsync(const WebCore::WebGPU::Comput
     }
 
     auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateComputePipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), strongThis = Ref { *this }, label = WTFMove(convertedDescriptor->label)](auto result) mutable {
+    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateComputePipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), protectedThis = Ref { *this }, label = WTFMove(convertedDescriptor->label)](auto result) mutable {
         if (!result) {
             callback(nullptr);
             return;
         }
 
-        auto computePipelineResult = RemoteComputePipelineProxy::create(strongThis, strongThis->m_convertToBackingContext, identifier);
+        auto computePipelineResult = RemoteComputePipelineProxy::create(protectedThis, protectedThis->m_convertToBackingContext, identifier);
         computePipelineResult->setLabel(WTFMove(label));
         callback(WTFMove(computePipelineResult));
     });
@@ -292,13 +292,13 @@ void RemoteDeviceProxy::createRenderPipelineAsync(const WebCore::WebGPU::RenderP
         return;
 
     auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateRenderPipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), strongThis = Ref { *this }, label = WTFMove(convertedDescriptor->label)](auto result) mutable {
+    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateRenderPipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), protectedThis = Ref { *this }, label = WTFMove(convertedDescriptor->label)](auto result) mutable {
         if (!result) {
             callback(nullptr);
             return;
         }
 
-        auto renderPipelineResult = RemoteRenderPipelineProxy::create(strongThis, strongThis->m_convertToBackingContext, identifier);
+        auto renderPipelineResult = RemoteRenderPipelineProxy::create(protectedThis, protectedThis->m_convertToBackingContext, identifier);
         renderPipelineResult->setLabel(WTFMove(label));
         callback(WTFMove(renderPipelineResult));
     });

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3261,8 +3261,8 @@ void WebPage::markLayersVolatile(CompletionHandler<void(bool)>&& completionHandl
 
 void WebPage::markLayersVolatileOrRetry(MarkLayersVolatileDontRetryReason dontRetryReason)
 {
-    tryMarkLayersVolatile([dontRetryReason, strongThis = Ref { *this }](bool didSucceed) {
-        strongThis->tryMarkLayersVolatileCompletionHandler(dontRetryReason, didSucceed);
+    tryMarkLayersVolatile([dontRetryReason, protectedThis = Ref { *this }](bool didSucceed) {
+        protectedThis->tryMarkLayersVolatileCompletionHandler(dontRetryReason, didSucceed);
     });
 }
 

--- a/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
+++ b/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
@@ -62,7 +62,7 @@ void UIScriptControllerIOS::zoomToScale(double scale, JSValueRef callback)
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, scale, callbackID] {
-        [gWebScrollView zoomToScale:scale animated:YES completionHandler:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+        [gWebScrollView zoomToScale:scale animated:YES completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
             if (!m_context)
                 return;
             m_context->asyncTaskComplete(callbackID);

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -306,7 +306,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
         currentTime += nanosecondsEventInterval;
     }
 
-    WorkQueue::main().dispatch([this, strongThis = Ref { *this }, callbackID] {
+    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -113,8 +113,8 @@ public:
 
     void dispatch()
     {
-        m_workQueue->dispatch([strongThis = RefPtr { this }] {
-            strongThis->run();
+        m_workQueue->dispatch([protectedThis = RefPtr { this }] {
+            protectedThis->run();
         });
     }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -83,7 +83,7 @@ void UIScriptControllerCocoa::doAsyncTask(JSValueRef callback)
 void UIScriptControllerCocoa::doAfterPresentationUpdate(JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    [webView() _doAfterNextPresentationUpdate:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView() _doAfterNextPresentationUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -192,7 +192,7 @@ NSUndoManager *UIScriptControllerCocoa::platformUndoManager() const
 void UIScriptControllerCocoa::setDidShowContextMenuCallback(JSValueRef callback)
 {
     UIScriptController::setDidShowContextMenuCallback(callback);
-    webView().didShowContextMenuCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didShowContextMenuCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidShowContextMenu);
@@ -202,7 +202,7 @@ void UIScriptControllerCocoa::setDidShowContextMenuCallback(JSValueRef callback)
 void UIScriptControllerCocoa::setDidDismissContextMenuCallback(JSValueRef callback)
 {
     UIScriptController::setDidDismissContextMenuCallback(callback);
-    webView().didDismissContextMenuCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didDismissContextMenuCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidDismissContextMenu);

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -193,7 +193,7 @@ void UIScriptControllerIOS::waitForOutstandingCallbacks()
 void UIScriptControllerIOS::doAfterNextStablePresentationUpdate(JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    [webView() _doAfterNextStablePresentationUpdate:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView() _doAfterNextStablePresentationUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -203,7 +203,7 @@ void UIScriptControllerIOS::doAfterNextStablePresentationUpdate(JSValueRef callb
 void UIScriptControllerIOS::ensurePositionInformationIsUpToDateAt(long x, long y, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    [webView() _requestActivatedElementAtPosition:CGPointMake(x, y) completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] (_WKActivatedElementInfo *) {
+    [webView() _requestActivatedElementAtPosition:CGPointMake(x, y) completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] (_WKActivatedElementInfo *) {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -213,7 +213,7 @@ void UIScriptControllerIOS::ensurePositionInformationIsUpToDateAt(long x, long y
 void UIScriptControllerIOS::doAfterVisibleContentRectUpdate(JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    [webView() _doAfterNextVisibleContentRectUpdate:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView() _doAfterNextVisibleContentRectUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -224,7 +224,7 @@ void UIScriptControllerIOS::zoomToScale(double scale, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
-    [webView() zoomToScale:scale animated:YES completionHandler:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView() zoomToScale:scale animated:YES completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -235,7 +235,7 @@ void UIScriptControllerIOS::retrieveSpeakSelectionContent(JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
     
-    [webView() accessibilityRetrieveSpeakSelectionContentWithCompletionHandler:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView() accessibilityRetrieveSpeakSelectionContentWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -255,7 +255,7 @@ void UIScriptControllerIOS::simulateAccessibilitySettingsChangeNotification(JSVa
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center postNotificationName:UIAccessibilityInvertColorsStatusDidChangeNotification object:webView];
 
-    [webView _doAfterNextPresentationUpdate:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView _doAfterNextPresentationUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -286,7 +286,7 @@ void UIScriptControllerIOS::touchDownAtPoint(long x, long y, long touchCount, JS
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] touchDown:location touchCount:touchCount completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] touchDown:location touchCount:touchCount completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -298,7 +298,7 @@ void UIScriptControllerIOS::liftUpAtPoint(long x, long y, long touchCount, JSVal
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
     
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] liftUp:location touchCount:touchCount completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] liftUp:location touchCount:touchCount completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -350,7 +350,7 @@ void UIScriptControllerIOS::twoFingerSingleTapAtPoint(long x, long y, JSValueRef
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] twoFingerTap:location completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] twoFingerTap:location completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -396,7 +396,7 @@ void UIScriptControllerIOS::doubleTapAtPoint(long x, long y, float delay, JSValu
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
-    [[HIDEventGenerator sharedHIDEventGenerator] doubleTap:globalToContentCoordinates(webView(), x, y) delay:delay completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] doubleTap:globalToContentCoordinates(webView(), x, y) delay:delay completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -408,7 +408,7 @@ void UIScriptControllerIOS::stylusDownAtPoint(long x, long y, float azimuthAngle
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] stylusDownAtPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] stylusDownAtPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -420,7 +420,7 @@ void UIScriptControllerIOS::stylusMoveToPoint(long x, long y, float azimuthAngle
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] stylusMoveToPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] stylusMoveToPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -432,7 +432,7 @@ void UIScriptControllerIOS::stylusUpAtPoint(long x, long y, JSValueRef callback)
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] stylusUpAtPoint:location completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] stylusUpAtPoint:location completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -455,14 +455,14 @@ void UIScriptControllerIOS::stylusTapAtPointWithModifiers(long x, long y, float 
         [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag];
 
     auto location = globalToContentCoordinates(webView(), x, y);
-    [[HIDEventGenerator sharedHIDEventGenerator] stylusTapAtPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID, modifierFlags = WTFMove(modifierFlags)] {
+    [[HIDEventGenerator sharedHIDEventGenerator] stylusTapAtPoint:location azimuthAngle:azimuthAngle altitudeAngle:altitudeAngle pressure:pressure completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID, modifierFlags = WTFMove(modifierFlags)] {
         if (!m_context)
             return;
         for (size_t i = modifierFlags.size(); i; ) {
             --i;
             [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i]];
         }
-        [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+        [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
             if (!m_context)
                 return;
             m_context->asyncTaskComplete(callbackID);
@@ -577,7 +577,7 @@ void UIScriptControllerIOS::longPressAtPoint(long x, long y, JSValueRef callback
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
     
-    [[HIDEventGenerator sharedHIDEventGenerator] longPress:globalToContentCoordinates(webView(), x, y) completionBlock:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [[HIDEventGenerator sharedHIDEventGenerator] longPress:globalToContentCoordinates(webView(), x, y) completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -595,9 +595,9 @@ void UIScriptControllerIOS::typeCharacterUsingHardwareKeyboard(JSStringRef chara
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     // Assumes that the keyboard is already shown.
-    [[HIDEventGenerator sharedHIDEventGenerator] keyPress:toWTFString(character) completionBlock:makeBlockPtr([strongThis = Ref { *this }, callbackID] {
-        if (strongThis->m_context)
-            strongThis->m_context->asyncTaskComplete(callbackID);
+    [[HIDEventGenerator sharedHIDEventGenerator] keyPress:toWTFString(character) completionBlock:makeBlockPtr([protectedThis = Ref { *this }, callbackID] {
+        if (protectedThis->m_context)
+            protectedThis->m_context->asyncTaskComplete(callbackID);
     }).get()];
 }
 
@@ -676,7 +676,7 @@ void UIScriptControllerIOS::dismissFilePicker(JSValueRef callback)
 
     // Round-trip with the WebProcess to make sure it has been notified of the dismissal.
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    [webView evaluateJavaScript:@"" completionHandler:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] (id result, NSError *error) {
+    [webView evaluateJavaScript:@"" completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] (id result, NSError *error) {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -836,8 +836,8 @@ void UIScriptControllerIOS::applyAutocorrection(JSStringRef newString, JSStringR
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto contentView = static_cast<id<UIWKInteractionViewProtocol>>(platformContentView());
-    [contentView applyAutocorrection:toWTFString(newString) toString:toWTFString(oldString) shouldUnderline:NO withCompletionHandler:makeBlockPtr([this, strongThis = Ref { *this }, callbackID](UIWKAutocorrectionRects *) {
-        dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [contentView applyAutocorrection:toWTFString(newString) toString:toWTFString(oldString) shouldUnderline:NO withCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID](UIWKAutocorrectionRects *) {
+        dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
             // applyAutocorrection can call its completion handler synchronously,
             // which makes UIScriptController unhappy (see bug 172884).
             if (!m_context)
@@ -1094,7 +1094,7 @@ static UIDeviceOrientation toUIDeviceOrientation(DeviceOrientation orientation)
 void UIScriptControllerIOS::simulateRotation(DeviceOrientation orientation, JSValueRef callback)
 {
     auto callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    webView().rotationDidEndCallback = makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    webView().rotationDidEndCallback = makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -1112,7 +1112,7 @@ void UIScriptControllerIOS::simulateRotation(DeviceOrientation orientation, JSVa
 void UIScriptControllerIOS::setDidStartFormControlInteractionCallback(JSValueRef callback)
 {
     UIScriptController::setDidStartFormControlInteractionCallback(callback);
-    webView().didStartFormControlInteractionCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didStartFormControlInteractionCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidStartFormControlInteraction);
@@ -1122,7 +1122,7 @@ void UIScriptControllerIOS::setDidStartFormControlInteractionCallback(JSValueRef
 void UIScriptControllerIOS::setDidEndFormControlInteractionCallback(JSValueRef callback)
 {
     UIScriptController::setDidEndFormControlInteractionCallback(callback);
-    webView().didEndFormControlInteractionCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didEndFormControlInteractionCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidEndFormControlInteraction);
@@ -1132,7 +1132,7 @@ void UIScriptControllerIOS::setDidEndFormControlInteractionCallback(JSValueRef c
 void UIScriptControllerIOS::setWillBeginZoomingCallback(JSValueRef callback)
 {
     UIScriptController::setWillBeginZoomingCallback(callback);
-    webView().willBeginZoomingCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().willBeginZoomingCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeWillBeginZooming);
@@ -1142,7 +1142,7 @@ void UIScriptControllerIOS::setWillBeginZoomingCallback(JSValueRef callback)
 void UIScriptControllerIOS::setDidEndZoomingCallback(JSValueRef callback)
 {
     UIScriptController::setDidEndZoomingCallback(callback);
-    webView().didEndZoomingCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didEndZoomingCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidEndZooming);
@@ -1152,7 +1152,7 @@ void UIScriptControllerIOS::setDidEndZoomingCallback(JSValueRef callback)
 void UIScriptControllerIOS::setDidShowKeyboardCallback(JSValueRef callback)
 {
     UIScriptController::setDidShowKeyboardCallback(callback);
-    webView().didShowKeyboardCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didShowKeyboardCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidShowKeyboard);
@@ -1162,7 +1162,7 @@ void UIScriptControllerIOS::setDidShowKeyboardCallback(JSValueRef callback)
 void UIScriptControllerIOS::setDidHideKeyboardCallback(JSValueRef callback)
 {
     UIScriptController::setDidHideKeyboardCallback(callback);
-    webView().didHideKeyboardCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didHideKeyboardCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidHideKeyboard);
@@ -1172,7 +1172,7 @@ void UIScriptControllerIOS::setDidHideKeyboardCallback(JSValueRef callback)
 void UIScriptControllerIOS::setWillStartInputSessionCallback(JSValueRef callback)
 {
     UIScriptController::setWillStartInputSessionCallback(callback);
-    webView().willStartInputSessionCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().willStartInputSessionCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeWillStartInputSession);
@@ -1206,7 +1206,7 @@ bool UIScriptControllerIOS::isShowingFormValidationBubble() const
 void UIScriptControllerIOS::setWillPresentPopoverCallback(JSValueRef callback)
 {
     UIScriptController::setWillPresentPopoverCallback(callback);
-    webView().willPresentPopoverCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().willPresentPopoverCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeWillPresentPopover);
@@ -1216,7 +1216,7 @@ void UIScriptControllerIOS::setWillPresentPopoverCallback(JSValueRef callback)
 void UIScriptControllerIOS::setDidDismissPopoverCallback(JSValueRef callback)
 {
     UIScriptController::setDidDismissPopoverCallback(callback);
-    webView().didDismissPopoverCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didDismissPopoverCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidDismissPopover);
@@ -1284,7 +1284,7 @@ bool UIScriptControllerIOS::isDismissingMenu() const
 void UIScriptControllerIOS::setDidEndScrollingCallback(JSValueRef callback)
 {
     UIScriptController::setDidEndScrollingCallback(callback);
-    webView().didEndScrollingCallback = makeBlockPtr([this, strongThis = Ref { *this }] {
+    webView().didEndScrollingCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
         if (!m_context)
             return;
         m_context->fireCallback(CallbackTypeDidEndScrolling);
@@ -1317,7 +1317,7 @@ void UIScriptControllerIOS::activateDataListSuggestion(unsigned index, JSValueRe
     [webView() _selectDataListOption:index];
 
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -1486,7 +1486,7 @@ void UIScriptControllerIOS::doAfterDoubleTapDelay(JSValueRef callback)
         maximumIntervalBetweenSuccessiveTaps += additionalDelayBetweenSuccessiveTaps;
     }
 
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(maximumIntervalBetweenSuccessiveTaps * NSEC_PER_SEC)), dispatch_get_main_queue(), makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(maximumIntervalBetweenSuccessiveTaps * NSEC_PER_SEC)), dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -73,7 +73,7 @@ void UIScriptControllerMac::zoomToScale(double scale, JSValueRef callback)
     auto* webView = this->webView();
     [webView _setPageScale:scale withOrigin:CGPointZero];
 
-    [webView _doAfterNextPresentationUpdate:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView _doAfterNextPresentationUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -93,7 +93,7 @@ void UIScriptControllerMac::simulateAccessibilitySettingsChangeNotification(JSVa
     NSNotificationCenter *center = [[NSWorkspace sharedWorkspace] notificationCenter];
     [center postNotificationName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:webView];
 
-    [webView _doAfterNextPresentationUpdate:makeBlockPtr([this, strongThis = Ref { *this }, callbackID] {
+    [webView _doAfterNextPresentationUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -213,7 +213,7 @@ void UIScriptControllerMac::chooseMenuAction(JSStringRef jsAction, JSValueRef ca
         [activeMenu cancelTracking];
     }
 
-    WorkQueue::main().dispatch([this, strongThis = Ref { *this }, callbackID] {
+    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -307,7 +307,7 @@ void UIScriptControllerMac::activateAtPoint(long x, long y, JSValueRef callback)
     eventSender->mouseDown(0, 0);
     eventSender->mouseUp(0, 0);
 
-    WorkQueue::main().dispatch([this, strongThis = Ref { *this }, callbackID] {
+    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -427,7 +427,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
         currentTime += nanosecondsEventInterval;
     }
 
-    WorkQueue::main().dispatch([this, strongThis = Ref { *this }, callbackID] {
+    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);


### PR DESCRIPTION
#### c72b2982933d07505ecece6854f989828981e367
<pre>
Replace strongThis by protectedThis
<a href="https://bugs.webkit.org/show_bug.cgi?id=264859">https://bugs.webkit.org/show_bug.cgi?id=264859</a>
<a href="https://rdar.apple.com/118434279">rdar://118434279</a>

Reviewed by Chris Dumez and Mike Wyrzykowski.

Mechanical change using find/replace. No change in behaviour.

* Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm:
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::close):
(Inspector::RemoteConnectionToTarget::sendMessageToTarget):
* Source/WTF/wtf/NativePromise.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp:
(WebCore::FileSystemDirectoryHandle::getFileHandle):
(WebCore::FileSystemDirectoryHandle::getDirectoryHandle):
(WebCore::FileSystemDirectoryHandle::getHandle):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp:
(WebCore::InspectorFrontendAPIDispatcher::evaluateOrQueueExpression):
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::DOMTimer):
(WebCore::DOMTimer::fired):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::scheduleInitialConnect):
(WebCore::EventSource::scheduleReconnect):
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::startApplePayAMSUISession):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeScrollUpdated):
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::ensureDecoderAvailable):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::didParseStreamDataAsAsset):
(WebCore::SourceBufferParserAVFObjC::didFailToParseStreamDataWithError):
(WebCore::SourceBufferParserAVFObjC::didProvideMediaDataForTrackID):
(WebCore::SourceBufferParserAVFObjC::didProvideContentKeyRequestSpecifierForTrackID):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::stopRecording):
(WebCore::MediaRecorderPrivateBackend::fetchData):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm:
(WebCore::MediaRecorderPrivateWriter::flushCompressedSampleBuffers):
(WebCore::MediaRecorderPrivateWriter::stopRecording):
(WebCore::MediaRecorderPrivateWriter::fetchData):
* Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp:
(PlatformXR::OpenXRDevice::endSession):
(PlatformXR::OpenXRDevice::updateInteractionProfile):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::initializeTrackingAndRendering):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device): Fly-by fix. protectedThis was moved in lambda&apos;s capture prior being used.
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipelineAsync):
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::scheduleFailure):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::prepareForEviction):
(WebKit::NetworkStorageManager::originQuotaManagerParameters):
(WebKit::NetworkStorageManager::fetchRegistrableDomainsForPersist):
(WebKit::NetworkStorageManager::didFetchRegistrableDomainsForPersist):
(WebKit::NetworkStorageManager::persist):
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::acquireSync):
(WebKit::ProcessAndUIAssertion::processAssertionWasInvalidated):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::start):
(WebKit::SOAuthorizationSession::continueStartAfterGetAuthorizationHints):
(WebKit::SOAuthorizationSession::complete):
(WebKit::SOAuthorizationSession::presentViewController):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::registerExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::unregisterExtension):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged):
(WebKit::RemoteScrollingTreeMac::setRubberBandingInProgressForNode):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingTreeMac::currentSnapPointIndicesDidChange):
(WebKit::RemoteScrollingTreeMac::reportExposedUnfilledArea):
(WebKit::RemoteScrollingTreeMac::reportSynchronousScrollingReasonsChanged):
(WebKit::RemoteScrollingTreeMac::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingTreeMac::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeScrollbarVisibilityDidChange):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::sessionDidEnd):
(WebKit::PlatformXRSystem::sessionDidUpdateVisibilityState):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createComputePipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderPipelineAsync):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::markLayersVolatileOrRetry):
* Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::zoomToScale):
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::sendEventStream):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::doAfterPresentationUpdate):
(WTR::UIScriptControllerCocoa::setDidShowContextMenuCallback):
(WTR::UIScriptControllerCocoa::setDidDismissContextMenuCallback):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::doAfterNextStablePresentationUpdate):
(WTR::UIScriptControllerIOS::ensurePositionInformationIsUpToDateAt):
(WTR::UIScriptControllerIOS::doAfterVisibleContentRectUpdate):
(WTR::UIScriptControllerIOS::zoomToScale):
(WTR::UIScriptControllerIOS::retrieveSpeakSelectionContent):
(WTR::UIScriptControllerIOS::simulateAccessibilitySettingsChangeNotification):
(WTR::UIScriptControllerIOS::touchDownAtPoint):
(WTR::UIScriptControllerIOS::liftUpAtPoint):
(WTR::UIScriptControllerIOS::twoFingerSingleTapAtPoint):
(WTR::UIScriptControllerIOS::doubleTapAtPoint):
(WTR::UIScriptControllerIOS::stylusDownAtPoint):
(WTR::UIScriptControllerIOS::stylusMoveToPoint):
(WTR::UIScriptControllerIOS::stylusUpAtPoint):
(WTR::UIScriptControllerIOS::stylusTapAtPointWithModifiers):
(WTR::UIScriptControllerIOS::longPressAtPoint):
(WTR::UIScriptControllerIOS::typeCharacterUsingHardwareKeyboard):
(WTR::UIScriptControllerIOS::dismissFilePicker):
(WTR::UIScriptControllerIOS::applyAutocorrection):
(WTR::UIScriptControllerIOS::simulateRotation):
(WTR::UIScriptControllerIOS::setDidStartFormControlInteractionCallback):
(WTR::UIScriptControllerIOS::setDidEndFormControlInteractionCallback):
(WTR::UIScriptControllerIOS::setWillBeginZoomingCallback):
(WTR::UIScriptControllerIOS::setDidEndZoomingCallback):
(WTR::UIScriptControllerIOS::setDidShowKeyboardCallback):
(WTR::UIScriptControllerIOS::setDidHideKeyboardCallback):
(WTR::UIScriptControllerIOS::setWillStartInputSessionCallback):
(WTR::UIScriptControllerIOS::setWillPresentPopoverCallback):
(WTR::UIScriptControllerIOS::setDidDismissPopoverCallback):
(WTR::UIScriptControllerIOS::setDidEndScrollingCallback):
(WTR::UIScriptControllerIOS::activateDataListSuggestion):
(WTR::UIScriptControllerIOS::doAfterDoubleTapDelay):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::zoomToScale):
(WTR::UIScriptControllerMac::simulateAccessibilitySettingsChangeNotification):
(WTR::UIScriptControllerMac::chooseMenuAction):
(WTR::UIScriptControllerMac::activateAtPoint):
(WTR::UIScriptControllerMac::sendEventStream):

Canonical link: <a href="https://commits.webkit.org/270757@main">https://commits.webkit.org/270757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13ce3fbaba2bcf23ba998661b9eaac063f0036e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26308 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24072 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28982 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23587 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27545 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1593 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32967 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4814 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7129 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6326 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->