### PR TITLE
Fix Debug build on Monterey (Missing SoftLinked classes)

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -380,6 +380,7 @@ static bool shouldEnableStrictMode(Decoder& decoder, const HashSet<Class>& allow
 #if ENABLE(IMAGE_ANALYSIS) && HAVE(VK_IMAGE_ANALYSIS)
     // blocked by rdar://108673895
     if (PAL::isVisionKitCoreFrameworkAvailable()
+        && PAL::getVKCImageAnalysisClass()
         && allowedClasses.contains(PAL::getVKCImageAnalysisClass())
         && isDecodingKnownVKCImageAnalysisMessageFromUIProcess(decoder)
         && isInWebProcess())
@@ -420,17 +421,23 @@ static constexpr bool haveSecureActionContext = false;
 
 #if ENABLE(DATA_DETECTION)
     // rdar://107553330 - don't re-introduce rdar://107676726
-    if (PAL::isDataDetectorsCoreFrameworkAvailable() && allowedClasses.contains(PAL::getDDScannerResultClass()))
+    if (PAL::isDataDetectorsCoreFrameworkAvailable()
+        && PAL::getDDScannerResultClass()
+        && allowedClasses.contains(PAL::getDDScannerResultClass()))
         return haveSecureActionContext;
 #if PLATFORM(MAC)
     // rdar://107553348 - don't re-introduce rdar://107676726
-    if (PAL::isDataDetectorsFrameworkAvailable() && allowedClasses.contains(PAL::getWKDDActionContextClass()))
+    if (PAL::isDataDetectorsFrameworkAvailable()
+        && PAL::getWKDDActionContextClass()
+        && allowedClasses.contains(PAL::getWKDDActionContextClass()))
         return haveSecureActionContext;
 #endif // PLATFORM(MAC)
 #endif // ENABLE(DATA_DETECTION)
 #if ENABLE(REVEAL)
     // rdar://107553310 - don't re-introduce rdar://107673064
-    if (PAL::isRevealCoreFrameworkAvailable() && allowedClasses.contains(PAL::getRVItemClass()))
+    if (PAL::isRevealCoreFrameworkAvailable()
+        && PAL::getRVItemClass()
+        && allowedClasses.contains(PAL::getRVItemClass()))
         return haveSecureActionContext;
 #endif // ENABLE(REVEAL)
 
@@ -441,7 +448,9 @@ static constexpr bool haveSecureActionContext = false;
 #else
     static constexpr bool haveStrictDecodableCNContact = false;
 #endif
-    if (PAL::isPassKitCoreFrameworkAvailable() && allowedClasses.contains(PAL::getPKPaymentMethodClass()))
+    if (PAL::isPassKitCoreFrameworkAvailable()
+        && PAL::getPKPaymentMethodClass()
+        && allowedClasses.contains(PAL::getPKPaymentMethodClass()))
         return haveStrictDecodableCNContact;
 
     // Don't reintroduce rdar://108660074
@@ -450,7 +459,9 @@ static constexpr bool haveSecureActionContext = false;
 #else
     static constexpr bool haveStrictDecodablePKContact = false;
 #endif
-    if (PAL::isPassKitCoreFrameworkAvailable() && allowedClasses.contains(PAL::getPKContactClass()))
+    if (PAL::isPassKitCoreFrameworkAvailable()
+        && PAL::getPKContactClass()
+        && allowedClasses.contains(PAL::getPKContactClass()))
         return haveStrictDecodablePKContact;
 #endif
 
@@ -478,9 +489,9 @@ static constexpr bool haveSecureActionContext = false;
     if (allowedClasses.contains(NSShadow.class) // rdar://107553244
         || allowedClasses.contains(NSTextAttachment.class) // rdar://107553273
 #if ENABLE(APPLE_PAY)
-        || (PAL::isPassKitCoreFrameworkAvailable() && allowedClasses.contains(PAL::getPKPaymentSetupFeatureClass())) // rdar://107553409
-        || (PAL::isPassKitCoreFrameworkAvailable() && allowedClasses.contains(PAL::getPKPaymentMerchantSessionClass())) // rdar://107553452
-        || (PAL::isPassKitCoreFrameworkAvailable() && allowedClasses.contains(PAL::getPKPaymentClass()) && isInWebProcess())
+        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentSetupFeatureClass() && allowedClasses.contains(PAL::getPKPaymentSetupFeatureClass())) // rdar://107553409
+        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentMerchantSessionClass() && allowedClasses.contains(PAL::getPKPaymentMerchantSessionClass())) // rdar://107553452
+        || (PAL::isPassKitCoreFrameworkAvailable() && PAL::getPKPaymentClass() && allowedClasses.contains(PAL::getPKPaymentClass()) && isInWebProcess())
 #endif // ENABLE(APPLE_PAY)
         || (allowedClasses.contains(NSURLCredential.class) && isDecodingKnownNSURLCredentialMessage(decoder))) // rdar://107553367
         return true;


### PR DESCRIPTION
#### 2640f7f95ff4b0d041e4fbed383cf42de591b647
<pre>
Fix Debug build on Monterey (Missing SoftLinked classes)
<a href="https://bugs.webkit.org/show_bug.cgi?id=264858">https://bugs.webkit.org/show_bug.cgi?id=264858</a>
<a href="https://rdar.apple.com/118433817">rdar://118433817</a>

Reviewed by Alex Christensen.

Monterey has at least one softlinked framework in place, but with a class that is missing.
The build was fine, but oh boy was using it in a Debug configuration very unhappy.

This situation used to be fine when we looked up allowed classes in a Vector (search for null is fine)
After we moved to looking up allowed classes in a HashSet...  Search for null is no longer fine.

This change simply null checks any softlinked class being looked up in the set.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):

Canonical link: <a href="https://commits.webkit.org/270754@main">https://commits.webkit.org/270754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f93896fc0b016638532b44bfa9971537e1cc7e26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24073 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2324 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28978 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29644 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27535 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1589 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4810 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6324 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->