### PR TITLE
Fix some site isolation interaction tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -1271,7 +1271,7 @@ TEST(SiteIsolation, PropagateMouseEventsToSubframe)
     "<iframe src='https://domain2.com/subframe'></iframe>"_s;
 
     auto subframeHTML = "<script>"
-    "    addEventListener('mousemove', window.parent.postMessage('mousemove', '*'));"
+    "    addEventListener('mousemove', (event) => { window.parent.postMessage('mousemove', '*') });"
     "    addEventListener('mousedown', (event) => { window.parent.postMessage('mousedown,' + event.pageX + ',' + event.pageY, '*') });"
     "    addEventListener('mouseup', (event) => { window.parent.postMessage('mouseup,' + event.pageX + ',' + event.pageY, '*') });"
     "</script>"_s;
@@ -1293,6 +1293,7 @@ TEST(SiteIsolation, PropagateMouseEventsToSubframe)
 
     CGPoint eventLocationInWindow = [webView convertPoint:CGPointMake(50, 50) toView:nil];
     [webView mouseEnterAtPoint:eventLocationInWindow];
+    [webView mouseMoveToPoint:eventLocationInWindow withFlags:0];
     [webView mouseDownAtPoint:eventLocationInWindow simulatePressure:NO];
     [webView mouseUpAtPoint:eventLocationInWindow];
     [webView waitForPendingMouseEvents];
@@ -1317,11 +1318,10 @@ TEST(SiteIsolation, DragEvents)
     auto subframeHTML = "<body>"
     "<div id='draggable' draggable='true' style='width: 100px; height: 100px; background-color: blue;'></div>"
     "<script>"
-    "    draggable.addEventListener('dragstart', window.parent.postMessage('dragstart', '*'));"
-    "    draggable.addEventListener('drag', window.parent.postMessage('drag', '*'));"
-    "    draggable.addEventListener('dragend', window.parent.postMessage('dragend', '*'));"
-    "    draggable.addEventListener('dragenter', window.parent.postMessage('dragenter', '*'));"
-    "    draggable.addEventListener('dragleave', window.parent.postMessage('dragleave', '*'));"
+    "    draggable.addEventListener('dragstart', (event) => { window.parent.postMessage('dragstart', '*') });"
+    "    draggable.addEventListener('dragend', (event) => { window.parent.postMessage('dragend', '*') });"
+    "    draggable.addEventListener('dragenter', (event) => { window.parent.postMessage('dragenter', '*') });"
+    "    draggable.addEventListener('dragleave', (event) => { window.parent.postMessage('dragleave', '*') });"
     "</script>"
     "</body>"_s;
 
@@ -1344,12 +1344,11 @@ TEST(SiteIsolation, DragEvents)
     [simulator runFrom:CGPointMake(50, 50) to:CGPointMake(150, 150)];
 
     NSArray<NSString *> *events = [webView objectByEvaluatingJavaScript:@"window.events"];
-    EXPECT_EQ(5U, events.count);
+    EXPECT_EQ(4U, events.count);
     EXPECT_WK_STREQ("dragstart", events[0]);
-    EXPECT_WK_STREQ("drag", events[1]);
-    EXPECT_WK_STREQ("dragend", events[2]);
-    EXPECT_WK_STREQ("dragenter", events[3]);
-    EXPECT_WK_STREQ("dragleave", events[4]);
+    EXPECT_WK_STREQ("dragenter", events[1]);
+    EXPECT_WK_STREQ("dragleave", events[2]);
+    EXPECT_WK_STREQ("dragend", events[3]);
 }
 #endif
 


### PR DESCRIPTION
#### fa7308e615b9c18128d2d5a182cd950e012d2f22
<pre>
Fix some site isolation interaction tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=264860">https://bugs.webkit.org/show_bug.cgi?id=264860</a>
<a href="https://rdar.apple.com/118436235">rdar://118436235</a>

Reviewed by Wenson Hsieh.

Some site isolation interaction tests had postMessage sent on the load of the iframe instead of when the
event was firing.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/270759@main">https://commits.webkit.org/270759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11722ed38c5b21120de5967151ab310e50ad51ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24079 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2330 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28984 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29650 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3869 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3391 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->