### PR TITLE
[TextureMapper] BitmapTexurePool doesn't need to be heap allocated

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -23,6 +23,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/nicosia/NicosiaAnimation.h
 
     platform/graphics/texmap/BitmapTexture.h
+    platform/graphics/texmap/BitmapTexturePool.h
     platform/graphics/texmap/ClipStack.h
     platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
     platform/graphics/texmap/GraphicsLayerTextureMapper.h

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -28,7 +28,6 @@
 #include "BitmapTexturePool.h"
 
 #if USE(TEXTURE_MAPPER)
-#include "BitmapTexture.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -37,7 +37,6 @@ class IntSize;
 
 class BitmapTexturePool {
     WTF_MAKE_NONCOPYABLE(BitmapTexturePool);
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     BitmapTexturePool();
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -21,7 +21,7 @@
 
 #if USE(TEXTURE_MAPPER)
 
-#include "BitmapTexture.h"
+#include "BitmapTexturePool.h"
 #include "ClipStack.h"
 #include "Color.h"
 #include "FilterOperation.h"
@@ -38,7 +38,6 @@
 
 namespace WebCore {
 
-class BitmapTexturePool;
 class GraphicsLayer;
 class TextureMapperGLData;
 class TextureMapperShaderProgram;
@@ -97,8 +96,6 @@ public:
 #endif
 
 private:
-    std::unique_ptr<BitmapTexturePool> m_texturePool;
-
     bool isInMaskMode() const { return m_isMaskMode; }
     const TransformationMatrix& patternTransform() const { return m_patternTransform; }
 
@@ -126,6 +123,7 @@ private:
 
     void updateProjectionMatrix();
 
+    BitmapTexturePool m_texturePool;
     bool m_isMaskMode { false };
     TransformationMatrix m_patternTransform;
     WrapMode m_wrapMode { WrapMode::Stretch };


### PR DESCRIPTION
#### db648b65929de84c4fd0575534abb651015efd2d
<pre>
[TextureMapper] BitmapTexurePool doesn&apos;t need to be heap allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=264863">https://bugs.webkit.org/show_bug.cgi?id=264863</a>

Reviewed by Fujii Hironori.

* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::TextureMapper):
(WebCore::TextureMapper::acquireTextureFromPool):
(WebCore::TextureMapper::releaseUnusedTexturesNow):
(WebCore::TextureMapper::drawNumber):
(WebCore::TextureMapper::applyBlurFilter):
(WebCore::TextureMapper::applyDropShadowFilter):
(WebCore::TextureMapper::applySinglePassFilter):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:

Canonical link: <a href="https://commits.webkit.org/270758@main">https://commits.webkit.org/270758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f8171c1b8cbff847f60f113e3d7fe0d292929be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2342 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28992 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29656 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23997 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1602 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4824 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3877 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3390 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->