### PR TITLE
[WebGPU] ArrayBuffer detaching on unmap is not implemented

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
@@ -44,8 +44,8 @@ interface GPUBuffer {
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219 The next two lines should be able to say "optional thingy = 0" instead of just "optional thingy".
     Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset, optional GPUSize64 size);
-    undefined unmap();
+    [CallWith=CurrentScriptExecutionContext] undefined unmap();
 
-    undefined destroy();
+    [CallWith=CurrentScriptExecutionContext] undefined destroy();
 };
 GPUBuffer includes GPUObjectBase;

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -93,9 +93,9 @@ public:
 
     Ref<GPUQueue> queue() const;
 
-    void destroy();
+    void destroy(ScriptExecutionContext&);
 
-    Ref<GPUBuffer> createBuffer(const GPUBufferDescriptor&);
+    ExceptionOr<Ref<GPUBuffer>> createBuffer(const GPUBufferDescriptor&);
     Ref<GPUTexture> createTexture(const GPUTextureDescriptor&);
     Ref<GPUSampler> createSampler(const std::optional<GPUSamplerDescriptor>&);
     Ref<GPUExternalTexture> importExternalTexture(const GPUExternalTextureDescriptor&);
@@ -126,6 +126,8 @@ public:
 
     WebGPU::Device& backing() { return m_backing; }
     const WebGPU::Device& backing() const { return m_backing; }
+    void removeBufferToUnmap(GPUBuffer&);
+    void addBufferToUnmap(GPUBuffer&);
 
     using RefCounted::ref;
     using RefCounted::deref;
@@ -148,6 +150,7 @@ private:
     Ref<WebGPU::Device> m_backing;
     Ref<GPUQueue> m_queue;
     Ref<GPUPipelineLayout> m_autoPipelineLayout;
+    HashSet<GPUBuffer*> m_buffersToUnmap;
     bool m_waitingForDeviceLostPromise { false };
 };
 

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -37,7 +37,7 @@ interface GPUDevice : EventTarget {
 
     [SameObject] readonly attribute GPUQueue queue;
 
-    undefined destroy();
+    [CallWith=CurrentScriptExecutionContext] undefined destroy();
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);


### PR DESCRIPTION
#### 1007b7a34ee9ad34c10f8032d13663567e7bdf4e
<pre>
[WebGPU] ArrayBuffer detaching on unmap is not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=264865">https://bugs.webkit.org/show_bug.cgi?id=264865</a>
radar://118439123

Reviewed by Dan Glastonbury.

Per section 5.2 of the WebGPU specification, ArrayBuffer instances
returned via GPUBuffer.getMappedRange should be detached after unmap
is called.

Enabling tests tracked by <a href="https://bugs.webkit.org/show_bug.cgi?id=264552">https://bugs.webkit.org/show_bug.cgi?id=264552</a>
as mapping via postMessage and out of memory mapping tests still fail.

* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::~GPUBuffer):
(WebCore::GPUBuffer::GPUBuffer):
(WebCore::makeArrayBuffer):
(WebCore::GPUBuffer::getMappedRange):
(WebCore::GPUBuffer::unmap):
(WebCore::GPUBuffer::internalUnmap):
(WebCore::GPUBuffer::destroy):
* Source/WebCore/Modules/WebGPU/GPUBuffer.h:
(WebCore::GPUBuffer::create):
* Source/WebCore/Modules/WebGPU/GPUBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::addBufferToUnmap):
(WebCore::GPUDevice::removeBufferToUnmap):
(WebCore::GPUDevice::destroy):
(WebCore::GPUDevice::createBuffer):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/WebGPU/GPUDevice.idl:

Canonical link: <a href="https://commits.webkit.org/270806@main">https://commits.webkit.org/270806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7428a5b953644d1ff8bd5295d008c8b7a786f05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2468 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24175 "Failed to print configuration") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27646 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4921 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6356 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->