### PR TITLE
Cleanup RenderTheme a bit

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -341,8 +341,6 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
     case StyleAppearance::DefaultButton:
     case StyleAppearance::Button:
         return adjustButtonStyle(style, element);
-    case StyleAppearance::InnerSpinButton:
-        return adjustInnerSpinButtonStyle(style, element);
 #endif
     case StyleAppearance::TextField:
         return adjustTextFieldStyle(style, element);
@@ -896,8 +894,6 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
     case StyleAppearance::DefaultButton:
     case StyleAppearance::Button:
         return paintButton(box, paintInfo, integralSnappedRect);
-    case StyleAppearance::InnerSpinButton:
-        return paintInnerSpinButton(box, paintInfo, integralSnappedRect);
 #endif
     case StyleAppearance::Menulist:
         return paintMenuList(box, paintInfo, devicePixelSnappedRect);
@@ -1426,44 +1422,16 @@ bool RenderTheme::hasListButtonPressed(const RenderObject& renderer) const
 
 void RenderTheme::adjustCheckboxStyle(RenderStyle& style, const Element*) const
 {
-    // A summary of the rules for checkbox designed to match WinIE:
-    // width/height - honored (WinIE actually scales its control for small widths, but lets it overflow for small heights.)
-    // font-size - not honored (control has no text), but we use it to decide which control size to use.
-    setCheckboxSize(style);
-
-    // padding - not honored by WinIE, needs to be removed.
     style.resetPadding();
-
-    // border - honored by WinIE, but looks terrible (just paints in the control box and turns off the Windows XP theme)
-    // for now, we will not honor it.
     style.resetBorder();
-
     style.setBoxShadow(nullptr);
 }
 
 void RenderTheme::adjustRadioStyle(RenderStyle& style, const Element*) const
 {
-    // A summary of the rules for checkbox designed to match WinIE:
-    // width/height - honored (WinIE actually scales its control for small widths, but lets it overflow for small heights.)
-    // font-size - not honored (control has no text), but we use it to decide which control size to use.
-    setRadioSize(style);
-
-    // padding - not honored by WinIE, needs to be removed.
     style.resetPadding();
-
-    // border - honored by WinIE, but looks terrible (just paints in the control box and turns off the Windows XP theme)
-    // for now, we will not honor it.
     style.resetBorder();
-
     style.setBoxShadow(nullptr);
-}
-
-void RenderTheme::adjustButtonStyle(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustInnerSpinButtonStyle(RenderStyle&, const Element*) const
-{
 }
 
 #if ENABLE(INPUT_TYPE_COLOR)
@@ -1478,17 +1446,9 @@ bool RenderTheme::paintColorWell(const RenderObject& box, const PaintInfo& paint
     return paintButton(box, paintInfo, rect);
 }
 
-#endif
+#endif // ENABLE(INPUT_TYPE_COLOR)
 
-#endif
-
-void RenderTheme::adjustTextFieldStyle(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustTextAreaStyle(RenderStyle&, const Element*) const
-{
-}
+#endif // !USE(NEW_THEME)
 
 void RenderTheme::adjustMenuListStyle(RenderStyle& style, const Element*) const
 {
@@ -1506,31 +1466,12 @@ FloatSize RenderTheme::meterSizeForBounds(const RenderMeter&, const FloatRect& b
     return bounds.size();
 }
 
-bool RenderTheme::supportsMeter(StyleAppearance, const HTMLMeterElement&) const
-{
-    return false;
-}
-
-bool RenderTheme::paintMeter(const RenderObject&, const PaintInfo&, const IntRect&)
-{
-    return true;
-}
-
 #if ENABLE(INPUT_TYPE_COLOR)
 void RenderTheme::paintColorWellDecorations(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
     paintButtonDecorations(box, paintInfo, snappedIntRect(LayoutRect(rect)));
 }
-#endif
-
-void RenderTheme::adjustCapsLockIndicatorStyle(RenderStyle&, const Element*) const
-{
-}
-
-bool RenderTheme::paintCapsLockIndicator(const RenderObject&, const PaintInfo&, const IntRect&)
-{
-    return false;
-}
+#endif // ENABLE(INPUT_TYPE_COLOR)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
@@ -1540,12 +1481,7 @@ String RenderTheme::attachmentStyleSheet() const
     return "attachment { appearance: auto; }"_s;
 }
 
-bool RenderTheme::paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&)
-{
-    return false;
-}
-
-#endif
+#endif // ENABLE(ATTACHMENT_ELEMENT)
 
 #if ENABLE(INPUT_TYPE_COLOR)
 
@@ -1561,15 +1497,6 @@ String RenderTheme::colorInputStyleSheet(const Settings&) const
 String RenderTheme::dataListStyleSheet() const
 {
     return "datalist { display: none; }"_s;
-}
-
-void RenderTheme::adjustListButtonStyle(RenderStyle&, const Element*) const
-{
-}
-
-LayoutUnit RenderTheme::sliderTickSnappingThreshold() const
-{
-    return 0;
 }
 
 void RenderTheme::paintSliderTicks(const RenderObject& o, const PaintInfo& paintInfo, const FloatRect& rect)
@@ -1649,13 +1576,7 @@ void RenderTheme::paintSliderTicks(const RenderObject& o, const PaintInfo& paint
     }
 }
 
-#endif
-
-#if ENABLE(SERVICE_CONTROLS)
-void RenderTheme::adjustImageControlsButtonStyle(RenderStyle&, const Element*) const
-{
-}
-#endif
+#endif // ENABLE(DATALIST_ELEMENT)
 
 Seconds RenderTheme::animationRepeatIntervalForProgressBar(const RenderProgress&) const
 {
@@ -1665,10 +1586,6 @@ Seconds RenderTheme::animationRepeatIntervalForProgressBar(const RenderProgress&
 Seconds RenderTheme::animationDurationForProgressBar(const RenderProgress&) const
 {
     return 0_s;
-}
-
-void RenderTheme::adjustProgressBarStyle(RenderStyle&, const Element*) const
-{
 }
 
 IntRect RenderTheme::progressBarRectForBounds(const RenderProgress&, const IntRect& bounds) const
@@ -1681,46 +1598,9 @@ bool RenderTheme::shouldHaveSpinButton(const HTMLInputElement& inputElement) con
     return inputElement.isSteppable() && !inputElement.isRangeControl();
 }
 
-bool RenderTheme::shouldHaveCapsLockIndicator(const HTMLInputElement&) const
-{
-    return false;
-}
-
-void RenderTheme::adjustMenuListButtonStyle(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustSliderTrackStyle(RenderStyle&, const Element*) const
-{
-}
-
 void RenderTheme::adjustSliderThumbStyle(RenderStyle& style, const Element* element) const
 {
     adjustSliderThumbSize(style, element);
-}
-
-void RenderTheme::adjustSliderThumbSize(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustSearchFieldStyle(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const
-{
-}
-
-void RenderTheme::adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const
-{
 }
 
 void RenderTheme::purgeCaches()

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -207,7 +207,7 @@ public:
 
     virtual int minimumMenuListSize(const RenderStyle&) const { return 0; }
 
-    virtual void adjustSliderThumbSize(RenderStyle&, const Element*) const;
+    virtual void adjustSliderThumbSize(RenderStyle&, const Element*) const { }
 
     virtual LengthBox popupInternalPaddingBox(const RenderStyle&, const Settings&) const { return { 0, 0, 0, 0 }; }
     virtual bool popupOptionSupportsTextIndent() const { return false; }
@@ -222,11 +222,11 @@ public:
     virtual IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const;
 
     virtual FloatSize meterSizeForBounds(const RenderMeter&, const FloatRect&) const;
-    virtual bool supportsMeter(StyleAppearance, const HTMLMeterElement&) const;
+    virtual bool supportsMeter(StyleAppearance, const HTMLMeterElement&) const { return false; }
 
 #if ENABLE(DATALIST_ELEMENT)
     // Returns the threshold distance for snapping to a slider tick mark.
-    virtual LayoutUnit sliderTickSnappingThreshold() const;
+    virtual LayoutUnit sliderTickSnappingThreshold() const { return 0; }
     // Returns size of one slider tick mark for a horizontal track.
     // For vertical tracks we rotate it and use it. i.e. Width is always length along the track.
     virtual IntSize sliderTickSize() const = 0;
@@ -236,7 +236,7 @@ public:
 #endif
 
     virtual bool shouldHaveSpinButton(const HTMLInputElement&) const;
-    virtual bool shouldHaveCapsLockIndicator(const HTMLInputElement&) const;
+    virtual bool shouldHaveCapsLockIndicator(const HTMLInputElement&) const { return false; }
 
     // Functions for <select> elements.
     virtual bool delegatesMenuListRendering() const { return false; }
@@ -297,23 +297,18 @@ protected:
     // Methods for each appearance value.
     virtual void adjustCheckboxStyle(RenderStyle&, const Element*) const;
     virtual bool paintCheckbox(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
-    virtual void setCheckboxSize(RenderStyle&) const { }
 
     virtual void adjustRadioStyle(RenderStyle&, const Element*) const;
     virtual bool paintRadio(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
-    virtual void setRadioSize(RenderStyle&) const { }
 
-    virtual void adjustButtonStyle(RenderStyle&, const Element*) const;
+    virtual void adjustButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintButton(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
-
-    virtual void adjustInnerSpinButtonStyle(RenderStyle&, const Element*) const;
-    virtual bool paintInnerSpinButton(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
 
 #if ENABLE(INPUT_TYPE_COLOR)
     virtual void adjustColorWellStyle(RenderStyle&, const Element*) const;
     virtual bool paintColorWell(const RenderObject&, const PaintInfo&, const IntRect&);
 #endif
-#endif
+#endif // !USE(NEW_THEME)
 
     virtual void paintCheckboxDecorations(const RenderObject&, const PaintInfo&, const IntRect&) { }
     virtual void paintRadioDecorations(const RenderObject&, const PaintInfo&, const IntRect&) { }
@@ -322,11 +317,11 @@ protected:
     virtual void paintColorWellDecorations(const RenderObject&, const PaintInfo&, const FloatRect&);
 #endif
 
-    virtual void adjustTextFieldStyle(RenderStyle&, const Element*) const;
+    virtual void adjustTextFieldStyle(RenderStyle&, const Element*) const { }
     virtual bool paintTextField(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
     virtual void paintTextFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) { }
 
-    virtual void adjustTextAreaStyle(RenderStyle&, const Element*) const;
+    virtual void adjustTextAreaStyle(RenderStyle&, const Element*) const { }
     virtual bool paintTextArea(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
     virtual void paintTextAreaDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) { }
 
@@ -334,62 +329,62 @@ protected:
     virtual bool paintMenuList(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
     virtual void paintMenuListDecorations(const RenderObject&, const PaintInfo&, const IntRect&) { }
 
-    virtual void adjustMenuListButtonStyle(RenderStyle&, const Element*) const;
+    virtual void adjustMenuListButtonStyle(RenderStyle&, const Element*) const { }
     virtual void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) { }
 
     virtual void paintPushButtonDecorations(const RenderObject&, const PaintInfo&, const IntRect&) { }
     virtual void paintSquareButtonDecorations(const RenderObject&, const PaintInfo&, const IntRect&) { }
 
     virtual void adjustMeterStyle(RenderStyle&, const Element*) const;
-    virtual bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&);
+    virtual bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
 
-    virtual void adjustCapsLockIndicatorStyle(RenderStyle&, const Element*) const;
-    virtual bool paintCapsLockIndicator(const RenderObject&, const PaintInfo&, const IntRect&);
+    virtual void adjustCapsLockIndicatorStyle(RenderStyle&, const Element*) const { }
+    virtual bool paintCapsLockIndicator(const RenderObject&, const PaintInfo&, const IntRect&) { return false; }
 
 #if ENABLE(APPLE_PAY)
     virtual void adjustApplePayButtonStyle(RenderStyle&, const Element*) const { }
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    virtual bool paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&);
+    virtual bool paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&) { return false; }
     virtual void paintAttachmentText(GraphicsContext&, AttachmentLayout*) { }
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)
-    virtual void adjustListButtonStyle(RenderStyle&, const Element*) const;
+    virtual void adjustListButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintListButton(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 #endif
     
 #if ENABLE(SERVICE_CONTROLS)
-    virtual void adjustImageControlsButtonStyle(RenderStyle&, const Element*) const;
+    virtual void adjustImageControlsButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintImageControlsButton(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
     virtual bool isImageControlsButton(const Element&) const { return false; }
 #endif
 
-    virtual void adjustProgressBarStyle(RenderStyle&, const Element*) const;
+    virtual void adjustProgressBarStyle(RenderStyle&, const Element*) const { }
     virtual bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
 
-    virtual void adjustSliderTrackStyle(RenderStyle&, const Element*) const;
+    virtual void adjustSliderTrackStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
 
     virtual void adjustSliderThumbStyle(RenderStyle&, const Element*) const;
     virtual bool paintSliderThumb(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
     virtual void paintSliderThumbDecorations(const RenderObject&, const PaintInfo&, const IntRect&) { }
 
-    virtual void adjustSearchFieldStyle(RenderStyle&, const Element*) const;
+    virtual void adjustSearchFieldStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchField(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
     virtual void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const IntRect&) { }
 
-    virtual void adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const;
+    virtual void adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchFieldCancelButton(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
 
-    virtual void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const;
+    virtual void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
 
-    virtual void adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const;
+    virtual void adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
 
-    virtual void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const;
+    virtual void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
 
 public:


### PR DESCRIPTION
#### 4fb442b35993f278b3aed472c79779f35e6da174
<pre>
Cleanup RenderTheme a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=264866">https://bugs.webkit.org/show_bug.cgi?id=264866</a>

Reviewed by Tim Horton.

This makes the following changes:

- Inline (near-)empty methods into the header to reduce clutter.
- Remove setCheckboxSize, setRadioSize, adjustInnerSpinButtonStyle, and
  paintInnerSpinButton as no theme customizes them.
- Remove some comments referring to a browser we no longer compare
  against.
- Add some #endif comments for clarity.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::adjustCheckboxStyle const):
(WebCore::RenderTheme::adjustRadioStyle const):
(WebCore::RenderTheme::adjustButtonStyle const): Deleted.
(WebCore::RenderTheme::adjustInnerSpinButtonStyle const): Deleted.
(WebCore::RenderTheme::adjustTextFieldStyle const): Deleted.
(WebCore::RenderTheme::adjustTextAreaStyle const): Deleted.
(WebCore::RenderTheme::supportsMeter const): Deleted.
(WebCore::RenderTheme::paintMeter): Deleted.
(WebCore::RenderTheme::adjustCapsLockIndicatorStyle const): Deleted.
(WebCore::RenderTheme::paintCapsLockIndicator): Deleted.
(WebCore::RenderTheme::paintAttachment): Deleted.
(WebCore::RenderTheme::adjustListButtonStyle const): Deleted.
(WebCore::RenderTheme::sliderTickSnappingThreshold const): Deleted.
(WebCore::RenderTheme::adjustImageControlsButtonStyle const): Deleted.
(WebCore::RenderTheme::adjustProgressBarStyle const): Deleted.
(WebCore::RenderTheme::shouldHaveCapsLockIndicator const): Deleted.
(WebCore::RenderTheme::adjustMenuListButtonStyle const): Deleted.
(WebCore::RenderTheme::adjustSliderTrackStyle const): Deleted.
(WebCore::RenderTheme::adjustSliderThumbSize const): Deleted.
(WebCore::RenderTheme::adjustSearchFieldStyle const): Deleted.
(WebCore::RenderTheme::adjustSearchFieldCancelButtonStyle const): Deleted.
(WebCore::RenderTheme::adjustSearchFieldDecorationPartStyle const): Deleted.
(WebCore::RenderTheme::adjustSearchFieldResultsDecorationPartStyle const): Deleted.
(WebCore::RenderTheme::adjustSearchFieldResultsButtonStyle const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::adjustSliderThumbSize const):
(WebCore::RenderTheme::supportsMeter const):
(WebCore::RenderTheme::sliderTickSnappingThreshold const):
(WebCore::RenderTheme::shouldHaveCapsLockIndicator const):
(WebCore::RenderTheme::paintCheckbox):
(WebCore::RenderTheme::paintRadio):
(WebCore::RenderTheme::adjustButtonStyle const):
(WebCore::RenderTheme::adjustTextFieldStyle const):
(WebCore::RenderTheme::adjustTextAreaStyle const):
(WebCore::RenderTheme::adjustMenuListButtonStyle const):
(WebCore::RenderTheme::paintMeter):
(WebCore::RenderTheme::adjustCapsLockIndicatorStyle const):
(WebCore::RenderTheme::paintCapsLockIndicator):
(WebCore::RenderTheme::paintAttachment):
(WebCore::RenderTheme::adjustListButtonStyle const):
(WebCore::RenderTheme::adjustImageControlsButtonStyle const):
(WebCore::RenderTheme::adjustProgressBarStyle const):
(WebCore::RenderTheme::adjustSliderTrackStyle const):
(WebCore::RenderTheme::adjustSearchFieldStyle const):
(WebCore::RenderTheme::adjustSearchFieldCancelButtonStyle const):
(WebCore::RenderTheme::adjustSearchFieldDecorationPartStyle const):
(WebCore::RenderTheme::adjustSearchFieldResultsDecorationPartStyle const):
(WebCore::RenderTheme::adjustSearchFieldResultsButtonStyle const):
(WebCore::RenderTheme::setCheckboxSize const): Deleted.
(WebCore::RenderTheme::setRadioSize const): Deleted.
(WebCore::RenderTheme::paintInnerSpinButton): Deleted.

Canonical link: <a href="https://commits.webkit.org/270871@main">https://commits.webkit.org/270871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0278ea2dc1689a2bc55293a6c75dbc9c293d2e25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24089 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29668 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27561 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4832 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6404 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->