### PR TITLE
Remove USE(NEW_THEME) usage in InspectorPageAgent

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -985,11 +985,7 @@ void InspectorPageAgent::defaultUserPreferencesDidChange()
 {
     auto defaultUserPreferences = JSON::ArrayOf<Protocol::Page::UserPreference>::create();
 
-#if USE(NEW_THEME)
     bool prefersReducedMotion = Theme::singleton().userPrefersReducedMotion();
-#else
-    bool prefersReducedMotion = false;
-#endif
 
     auto prefersReducedMotionUserPreference = Protocol::Page::UserPreference::create()
         .setName(Protocol::Page::UserPreferenceName::PrefersReducedMotion)
@@ -998,11 +994,7 @@ void InspectorPageAgent::defaultUserPreferencesDidChange()
 
     defaultUserPreferences->addItem(WTFMove(prefersReducedMotionUserPreference));
 
-#if USE(NEW_THEME)
     bool prefersContrast = Theme::singleton().userPrefersContrast();
-#else
-    bool prefersContrast = false;
-#endif
 
     auto prefersContrastUserPreference = Protocol::Page::UserPreference::create()
         .setName(Protocol::Page::UserPreferenceName::PrefersContrast)


### PR DESCRIPTION
#### 0ec1dd3955b1d77b5d955fc1b4fc11ce14717a4b
<pre>
Remove USE(NEW_THEME) usage in InspectorPageAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=264871">https://bugs.webkit.org/show_bug.cgi?id=264871</a>

Reviewed by Darin Adler.

Theme is included by all platforms and these methods already default to
false. This change has the upside that we&apos;ll get the correct
information on iOS and have more maintainable code.

* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::defaultUserPreferencesDidChange):

Canonical link: <a href="https://commits.webkit.org/270835@main">https://commits.webkit.org/270835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb545ae09b367e3da034f5b7ce7fc92570b6cdea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24103 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24096 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29674 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27567 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4840 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6374 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->