### PR TITLE
Cleanup NamedImageGeneratedImage

### DIFF
--- a/Source/WebCore/platform/graphics/NamedImageGeneratedImage.cpp
+++ b/Source/WebCore/platform/graphics/NamedImageGeneratedImage.cpp
@@ -42,7 +42,6 @@ NamedImageGeneratedImage::NamedImageGeneratedImage(String name, const FloatSize&
 
 ImageDrawResult NamedImageGeneratedImage::draw(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-#if USE(NEW_THEME) || PLATFORM(IOS_FAMILY)
     GraphicsContextStateSaver stateSaver(context);
     context.setCompositeOperation(options.compositeOperator(), options.blendMode());
     context.clip(dstRect);
@@ -53,18 +52,10 @@ ImageDrawResult NamedImageGeneratedImage::draw(GraphicsContext& context, const F
 
     Theme::singleton().drawNamedImage(m_name, context, dstRect.size());
     return ImageDrawResult::DidDraw;
-#else
-    UNUSED_PARAM(context);
-    UNUSED_PARAM(dstRect);
-    UNUSED_PARAM(srcRect);
-    UNUSED_PARAM(options);
-    return ImageDrawResult::DidNothing;
-#endif
 }
 
 void NamedImageGeneratedImage::drawPattern(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-#if USE(NEW_THEME)
     auto imageBuffer = context.createAlignedImageBuffer(size());
     if (!imageBuffer)
         return;
@@ -74,15 +65,6 @@ void NamedImageGeneratedImage::drawPattern(GraphicsContext& context, const Float
 
     // Tile the image buffer into the context.
     context.drawPattern(*imageBuffer, dstRect, srcRect, patternTransform, phase, spacing, options);
-#else
-    UNUSED_PARAM(context);
-    UNUSED_PARAM(dstRect);
-    UNUSED_PARAM(srcRect);
-    UNUSED_PARAM(patternTransform);
-    UNUSED_PARAM(phase);
-    UNUSED_PARAM(spacing);
-    UNUSED_PARAM(options);
-#endif
 }
 
 void NamedImageGeneratedImage::dump(TextStream& ts) const


### PR DESCRIPTION
#### 75ca1048e0a16e92ed2a5eaf85fda2b19ddab7c7
<pre>
Cleanup NamedImageGeneratedImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=264874">https://bugs.webkit.org/show_bug.cgi?id=264874</a>

Reviewed by Simon Fraser.

As far as I can tell 176071@main forgot to enable drawPattern() for iOS
platforms. Furthermore, USE(NEW_THEME) || PLATFORM(IOS_FAMILY) is
essentially all platforms and all platforms support Theme, so again, as
far as I can tell, there&apos;s no need for these conditionals.

* Source/WebCore/platform/graphics/NamedImageGeneratedImage.cpp:
(WebCore::NamedImageGeneratedImage::draw):
(WebCore::NamedImageGeneratedImage::drawPattern):

Canonical link: <a href="https://commits.webkit.org/270770@main">https://commits.webkit.org/270770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9f006e360ad5a4fb9394f59a4dc5507c7c53ad5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24103 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29027 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29683 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1641 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4848 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6336 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->