### PR TITLE
Sending multiple `VideoFrame`s per `postMessage()` only sends duplicates of the first

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/audioData-serialization-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/audioData-serialization-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Verify serializing more than one audio data promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
+

--- a/LayoutTests/http/wpt/webcodecs/audioData-serialization.html
+++ b/LayoutTests/http/wpt/webcodecs/audioData-serialization.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+function makeAudioData(timestamp, channels, sampleRate, frames)
+{
+  let data = new Float32Array(frames*channels);
+
+  // This generates samples in a planar format.
+  for (var channel = 0; channel < channels; channel++) {
+    let hz = 100 + channel * 50; // sound frequency
+    let base_index = channel * frames;
+    for (var i = 0; i < frames; i++) {
+      let t = (i / sampleRate) * hz * (Math.PI * 2);
+      data[base_index + i] = Math.sin(t);
+    }
+  }
+
+  return new AudioData({
+    timestamp: timestamp,
+    data: data,
+    numberOfChannels: channels,
+    numberOfFrames: frames,
+    sampleRate: sampleRate,
+    format: "f32-planar",
+  });
+}
+
+var defaultInit = {
+  timestamp: 1234,
+  channels: 2,
+  sampleRate: 8000,
+  frames: 100,
+}
+
+function createDefaultAudioData(timestamp)
+{
+  if (!timestamp)
+    timestamp = defaultInit.timestamp;
+  return makeAudioData(defaultInit.timestamp, defaultInit.channels, defaultInit.sampleRate, defaultInit.frames);
+}
+
+promise_test(async t => {
+  const audioData0 = createDefaultAudioData(1);
+  const audioData1 = createDefaultAudioData(2);
+
+  t.add_cleanup(() => {
+    audioData0.close();
+    audioData1.close();
+  });
+
+  const channel = new MessageChannel;
+  const promise = new Promise(resolve => channel.port2.onmessage = (e) => resolve(e.data));
+  channel.port1.postMessage([audioData0, audioData1]);
+
+  const audioDatas = await promise;
+  t.add_cleanup(() => {
+    audioDatas[0].close();
+    audioDatas[1].close();
+  });
+
+  assert_equals(audioDatas[0].timestamp, audioData0.timestamp);
+  assert_equals(audioDatas[1].timestamp, audioData1.timestamp);
+}, 'Verify serializing more than one audio data');
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-serialization-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-serialization-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Verify closing frames does not propagate accross contexts with Worker.postMessage.
 PASS Verify transferring frames closes them with Worker.postMessage.
+PASS Verify serializing more than one video frame
 

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-serialization.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-serialization.html
@@ -11,13 +11,16 @@ var defaultInit = {
   duration : 33,
 }
 
-function createDefaultVideoFrame() {
+function createDefaultVideoFrame(timestamp) {
+  if (!timestamp)
+    timestamp = defaultInit.timestamp;
+
   const init = {
     format: 'I420',
-    timestamp: 1234,
+    timestamp,
     codedWidth: 4,
     codedHeight: 2,
-    timestamp: defaultInit.timestamp,
+    timestamp,
     duration: defaultInit.duration
   };
   const data = new Uint8Array([
@@ -77,6 +80,29 @@ promise_test(async t => {
   assert_equals(await promise, defaultInit.timestamp);
   localFrame.close();
 }, 'Verify transferring frames closes them with Worker.postMessage.');
+
+promise_test(async t => {
+  const frame0 = createDefaultVideoFrame(1);
+  const frame1 = createDefaultVideoFrame(2);
+
+  t.add_cleanup(() => {
+    frame0.close();
+    frame1.close();
+  });
+
+  const channel = new MessageChannel;
+  const promise = new Promise(resolve => channel.port2.onmessage = (e) => resolve(e.data));
+  channel.port1.postMessage([frame0, frame1]);
+
+  const frames = await promise;
+  t.add_cleanup(() => {
+    frames[0].close();
+    frames[1].close();
+  });
+
+  assert_equals(frames[0].timestamp, frame0.timestamp);
+  assert_equals(frames[1].timestamp, frame1.timestamp);
+}, 'Verify serializing more than one video frame');
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/glib/http/wpt/webcodecs/audioData-serialization-expected.txt
+++ b/LayoutTests/platform/glib/http/wpt/webcodecs/audioData-serialization-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Verify serializing more than one audio data
+

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1430,7 +1430,7 @@ private:
 
         auto index = m_serializedVideoFrames.find(videoFrame.ptr());
         if (index == notFound) {
-            index = m_serializedVideoChunks.size();
+            index = m_serializedVideoFrames.size();
             m_serializedVideoFrames.append(WTFMove(videoFrame));
         }
         write(WebCodecsVideoFrameTag);
@@ -1460,7 +1460,7 @@ private:
 
         auto index = m_serializedAudioData.find(audioData.ptr());
         if (index == notFound) {
-            index = m_serializedVideoChunks.size();
+            index = m_serializedAudioData.size();
             m_serializedAudioData.append(WTFMove(audioData));
         }
         write(WebCodecsAudioDataTag);


### PR DESCRIPTION
#### b55438f2a83cca2884e294de5c9f77cc63b17ed3
<pre>
Sending multiple `VideoFrame`s per `postMessage()` only sends duplicates of the first
<a href="https://bugs.webkit.org/show_bug.cgi?id=264516">https://bugs.webkit.org/show_bug.cgi?id=264516</a>
<a href="https://rdar.apple.com/118445968">rdar://118445968</a>

Reviewed by Eric Carlson.

Update the index computation so that we reuse the right serialized data on deserialization, for both audio data and video frame.

* LayoutTests/http/wpt/webcodecs/audioData-serialization-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/audioData-serialization.html: Added.
* LayoutTests/http/wpt/webcodecs/videoFrame-serialization-expected.txt:
* LayoutTests/http/wpt/webcodecs/videoFrame-serialization.html:
* LayoutTests/platform/glib/http/wpt/webcodecs/audioData-serialization-expected.txt: Added.
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpWebCodecsVideoFrame):
(WebCore::CloneDeserializer::readWebCodecsVideoFrame):

Canonical link: <a href="https://commits.webkit.org/270772@main">https://commits.webkit.org/270772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc2663369344f6cae134ed9c36429f0e032a03e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28444 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24104 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29030 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29684 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1640 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6337 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->