### PR TITLE
[webkitpy] make TestResultWriter.{actual,expected}_filename handle variants

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
@@ -82,3 +82,37 @@ class TestResultWriterTest(unittest.TestCase):
         fs = host.filesystem
         writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), 'svg/W3C-SVG-1.1/animate-elem-02-t.svg')
         self.assertEqual(fs.join(port.results_directory(), 'svg/W3C-SVG-1.1/animate-elem-02-t-diff.txt'), writer.output_filename('-diff.txt'))
+
+    def test_expected_filename(self):
+        host = MockHost()
+        port = TestPort(host)
+        fs = host.filesystem
+
+        expected = test_result_writer.TestResultWriter.expected_filename(
+            "fast/dom/foo.html", fs
+        )
+        self.assertEqual("fast/dom/foo-expected.txt", expected)
+
+        expected = test_result_writer.TestResultWriter.expected_filename(
+            "template_test/pbkdf2.https.any.worker.html?1-1000", fs
+        )
+        self.assertEqual(
+            "template_test/pbkdf2.https.any.worker_1-1000-expected.txt", expected
+        )
+
+    def test_actual_filename(self):
+        host = MockHost()
+        port = TestPort(host)
+        fs = host.filesystem
+
+        actual = test_result_writer.TestResultWriter.actual_filename(
+            "fast/dom/foo.html", fs
+        )
+        self.assertEqual("fast/dom/foo-actual.txt", actual)
+
+        actual = test_result_writer.TestResultWriter.actual_filename(
+            "template_test/pbkdf2.https.any.worker.html?1-1000", fs
+        )
+        self.assertEqual(
+            "template_test/pbkdf2.https.any.worker_1-1000-actual.txt", actual
+        )


### PR DESCRIPTION
#### 03a4b1575bc818054d0f81dece03a4ac12728fa7
<pre>
[webkitpy] make TestResultWriter.{actual,expected}_filename handle variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=264816">https://bugs.webkit.org/show_bug.cgi?id=264816</a>

Reviewed by Jonathan Bedard.

While 259006@main made output_filename handle variants correctly, it
didn&apos;t make the other methods handle it correctly. This fixes this by
making all the methods behave correctly.

* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py:
(TestResultWriter):
(TestResultWriter._modified_filename):
(TestResultWriter.expected_filename):
(TestResultWriter.actual_filename):
(TestResultWriter.output_filename):
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py:
(TestResultWriterTest.test_output_svg_filename):
(TestResultWriterTest):
(TestResultWriterTest.test_expected_filename):
(TestResultWriterTest.test_actual_filename):

Canonical link: <a href="https://commits.webkit.org/270773@main">https://commits.webkit.org/270773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13726337b6df7de291b34da01a14d64b0c1c6d9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/26374 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/4987 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/27636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/28490 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/24142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/26711 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/6787 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/28490 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/26634 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/6787 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/27636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/29072 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/26539 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/6787 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/27636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/29072 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/6787 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/27636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/29072 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/4878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/27636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3395 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->