### PR TITLE
Port ByteArrayPixelBuffer to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -35,6 +35,34 @@ Ref<ByteArrayPixelBuffer> ByteArrayPixelBuffer::create(const PixelBufferFormat& 
     return adoptRef(*new ByteArrayPixelBuffer(format, size, { data }));
 }
 
+std::optional<Ref<ByteArrayPixelBuffer>> ByteArrayPixelBuffer::create(const PixelBufferFormat& format, const IntSize& size, std::span<const uint8_t> data)
+{
+    // FIXME: Support non-8 bit formats.
+    if (!(format.pixelFormat == PixelFormat::RGBA8 || format.pixelFormat == PixelFormat::BGRA8)) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    auto computedBufferSize = PixelBuffer::computeBufferSize(format, size);
+    if (computedBufferSize.hasOverflowed()) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    if (data.size_bytes() != computedBufferSize.value()) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    auto buffer = Uint8ClampedArray::tryCreate(data.data(), data.size_bytes());
+    if (!buffer) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    return ByteArrayPixelBuffer::create(format, size, buffer.releaseNonNull());
+}
+
 RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size)
 {
     ASSERT(supportedPixelFormat(format.pixelFormat));
@@ -78,6 +106,12 @@ ByteArrayPixelBuffer::ByteArrayPixelBuffer(const PixelBufferFormat& format, cons
 RefPtr<PixelBuffer> ByteArrayPixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
     return ByteArrayPixelBuffer::tryCreate(m_format, size);
+}
+
+std::span<const uint8_t> ByteArrayPixelBuffer::dataSpan() const
+{
+    ASSERT(m_data->byteLength() == (m_size.area() * 4));
+    return { m_data->data(), m_data->byteLength() };
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1976,7 +1976,7 @@ template<class Encoder>
 void ArgumentCoder<PixelBuffer>::encode(Encoder& encoder, const PixelBuffer& pixelBuffer)
 {
     if (LIKELY(is<const ByteArrayPixelBuffer>(pixelBuffer))) {
-        downcast<const ByteArrayPixelBuffer>(pixelBuffer).encode(encoder);
+        encoder << downcast<ByteArrayPixelBuffer>(pixelBuffer);
         return;
     }
     ASSERT_NOT_REACHED();
@@ -1984,7 +1984,7 @@ void ArgumentCoder<PixelBuffer>::encode(Encoder& encoder, const PixelBuffer& pix
 
 std::optional<Ref<PixelBuffer>> ArgumentCoder<PixelBuffer>::decode(Decoder& decoder)
 {
-    return ByteArrayPixelBuffer::decode(decoder);
+    return decoder.decode<Ref<ByteArrayPixelBuffer>>();
 }
 
 template

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6716,6 +6716,12 @@ enum class WebCore::RepaintRectCalculation : bool;
     Rec2020,
 };
 
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ByteArrayPixelBuffer {
+    WebCore:: PixelBufferFormat format();
+    WebCore::IntSize size();
+    std::span<const uint8_t> dataSpan();
+}
+
 #if ENABLE(WEB_AUTHN)
 header: <WebCore/CredentialRequestOptions.h>
 enum class WebCore::MediationRequirement : uint8_t {


### PR DESCRIPTION
#### 82d979dfc5591be1330fe625ede8cfdfb78c7d6b
<pre>
Port ByteArrayPixelBuffer to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264882">https://bugs.webkit.org/show_bug.cgi?id=264882</a>

Reviewed by Alex Christensen.

* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::create):
(WebCore::ByteArrayPixelBuffer::dataSpan const):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(WebCore::ByteArrayPixelBuffer::encode const): Deleted.
(WebCore::ByteArrayPixelBuffer::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;PixelBuffer&gt;::encode):
(IPC::ArgumentCoder&lt;PixelBuffer&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270792@main">https://commits.webkit.org/270792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a88d0519b1d3fe094c7ea8fa39aceef1fa228b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2439 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3420 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29095 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24078 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29733 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27627 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4897 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6345 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->