### PR TITLE
Regression(270725@main) Many Web extensions API tests are crashing

### DIFF
--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -125,11 +125,17 @@ public:
 
         StorageType m_value;
     };
+
     using iterator = Iterator<StorageType>;
 
     static constexpr OptionSet fromRaw(StorageType rawValue)
     {
         return OptionSet(static_cast<E>(maskRawValue<E>(rawValue)), FromRawValue);
+    }
+
+    static constexpr OptionSet all()
+    {
+        return fromRaw(std::numeric_limits<StorageType>::max());
     }
 
     constexpr OptionSet() = default;

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
@@ -46,10 +46,8 @@ struct WebKit::WebExtensionWindowParameters {
 };
 
 [OptionSet] enum class WebKit::WebExtensionWindowTypeFilter : uint8_t {
-    None,
     Normal,
     Popup,
-    All,
 };
 
 [Nested] enum class WebKit::WebExtensionWindow::State : uint8_t {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -716,15 +716,13 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSSet<id<_WKWebExtensio
 
 static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWebExtensionTabChangedProperties properties)
 {
-    OptionSet<WebKit::WebExtensionTab::ChangedProperties> result;
-
     if (properties == _WKWebExtensionTabChangedPropertiesNone)
-        return result;
+        return { };
 
-    if (properties == _WKWebExtensionTabChangedPropertiesAll) {
-        result.add(WebKit::WebExtensionTab::ChangedProperties::All);
-        return result;
-    }
+    if (properties == _WKWebExtensionTabChangedPropertiesAll)
+        return OptionSet<WebKit::WebExtensionTab::ChangedProperties>::all();
+
+    OptionSet<WebKit::WebExtensionTab::ChangedProperties> result;
 
     if (properties & _WKWebExtensionTabChangedPropertiesAudible)
         result.add(WebKit::WebExtensionTab::ChangedProperties::Audible);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -67,7 +67,6 @@ public:
     explicit WebExtensionTab(const WebExtensionContext&, _WKWebExtensionTab *);
 
     enum class ChangedProperties : uint16_t {
-        None       = 0,
         Audible    = 1 << 1,
         Loading    = 1 << 2,
         Muted      = 1 << 3,
@@ -77,7 +76,6 @@ public:
         Title      = 1 << 7,
         URL        = 1 << 8,
         ZoomFactor = 1 << 9,
-        All        = Audible | Loading | Muted | Pinned | ReaderMode | Size | Title | URL | ZoomFactor,
     };
 
     using ImageFormat = WebExtensionTabImageFormat;
@@ -227,5 +225,24 @@ private:
 };
 
 } // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraits<WebKit::WebExtensionTab::ChangedProperties> {
+    using values = EnumValues<
+        WebKit::WebExtensionTab::ChangedProperties,
+        WebKit::WebExtensionTab::ChangedProperties::Audible,
+        WebKit::WebExtensionTab::ChangedProperties::Loading,
+        WebKit::WebExtensionTab::ChangedProperties::Muted,
+        WebKit::WebExtensionTab::ChangedProperties::Pinned,
+        WebKit::WebExtensionTab::ChangedProperties::ReaderMode,
+        WebKit::WebExtensionTab::ChangedProperties::Size,
+        WebKit::WebExtensionTab::ChangedProperties::Title,
+        WebKit::WebExtensionTab::ChangedProperties::URL,
+        WebKit::WebExtensionTab::ChangedProperties::ZoomFactor
+    >;
+};
+
+} // namespace WTF
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -46,10 +46,8 @@ struct WebExtensionTabQueryParameters;
 struct WebExtensionWindowParameters;
 
 enum class WebExtensionWindowTypeFilter : uint8_t {
-    None   = 0,
     Normal = 1 << 0,
     Popup  = 1 << 1,
-    All    = Normal | Popup,
 };
 
 class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow> {
@@ -153,5 +151,17 @@ _WKWebExtensionWindowState toAPI(WebExtensionWindow::State);
 #endif
 
 } // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraits<WebKit::WebExtensionWindowTypeFilter> {
+    using values = EnumValues<
+        WebKit::WebExtensionWindowTypeFilter,
+        WebKit::WebExtensionWindowTypeFilter::Normal,
+        WebKit::WebExtensionWindowTypeFilter::Popup
+    >;
+};
+
+} // namespace WTF
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -196,7 +196,7 @@ bool WebExtensionAPIWindows::parsePopulateTabs(NSDictionary *options, PopulateTa
 bool WebExtensionAPIWindows::parseWindowTypesFilter(NSDictionary *options, OptionSet<WindowTypeFilter>& windowTypeFilter, NSString *sourceKey, NSString **outExceptionString)
 {
     // All windows match by default.
-    windowTypeFilter = WindowTypeFilter::All;
+    windowTypeFilter = OptionSet<WindowTypeFilter>::all();
 
     static NSDictionary<NSString *, id> *types = @{
         windowTypesKey: @[ NSString.class ],
@@ -584,20 +584,20 @@ WebExtensionAPIWindowsEvent& WebExtensionAPIWindows::onFocusChanged()
     return *m_onFocusChanged;
 }
 
-inline WebExtensionAPIWindows::WindowTypeFilter toWindowTypeFilter(WebExtensionWindow::Type type)
+inline OptionSet<WebExtensionWindowTypeFilter> toWindowTypeFilter(WebExtensionWindow::Type type)
 {
     switch (type) {
     case WebExtensionWindow::Type::Normal:
-        return WebExtensionAPIWindows::WindowTypeFilter::Normal;
+        return WebExtensionWindowTypeFilter::Normal;
 
     case WebExtensionWindow::Type::Popup:
-        return WebExtensionAPIWindows::WindowTypeFilter::Popup;
+        return WebExtensionWindowTypeFilter::Popup;
     }
 }
 
 void WebExtensionContextProxy::dispatchWindowsEvent(WebExtensionEventListenerType type, const std::optional<WebExtensionWindowParameters>& windowParameters)
 {
-    auto filter = windowParameters ? toWindowTypeFilter(windowParameters.value().type.value()) : WebExtensionAPIWindows::WindowTypeFilter::All;
+    auto filter = windowParameters ? toWindowTypeFilter(windowParameters.value().type.value()) : OptionSet<WebExtensionWindowTypeFilter>::all();
 
     enumerateNamespaceObjects([&](auto& namespaceObject) {
         auto& windowsObject = namespaceObject.windows();

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
@@ -42,13 +42,13 @@
 
 namespace WebKit {
 
-void WebExtensionAPIWindowsEvent::invokeListenersWithArgument(id argument, WindowTypeFilter windowType)
+void WebExtensionAPIWindowsEvent::invokeListenersWithArgument(id argument, OptionSet<WindowTypeFilter> windowTypeFilter)
 {
     if (m_listeners.isEmpty())
         return;
 
     for (auto& listener : m_listeners) {
-        if (!listener.second.contains(windowType))
+        if (!listener.second.containsAny(windowTypeFilter))
             continue;
 
         listener.first->call(argument);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -45,7 +45,7 @@ public:
     using FilterAndCallbackPair = std::pair<RefPtr<WebExtensionCallbackHandler>, OptionSet<WindowTypeFilter>>;
     using ListenerVector = Vector<FilterAndCallbackPair>;
 
-    void invokeListenersWithArgument(id argument, WindowTypeFilter);
+    void invokeListenersWithArgument(id argument, OptionSet<WindowTypeFilter>);
 
     const ListenerVector& listeners() const { return m_listeners; }
 


### PR DESCRIPTION
#### 5effaab5ea008dfd322164523a2253d463911715
<pre>
Regression(270725@main) Many Web extensions API tests are crashing
<a href="https://webkit.org/b/264885">https://webkit.org/b/264885</a>
<a href="https://rdar.apple.com/problem/118464397">rdar://problem/118464397</a>

Reviewed by Chris Dumez.

Remove the None and All values from Web Extension OptionSet enums, and use new OptionSet::all()
instead to get a valid OptionSet for the given enum.

Add back the EnumTraits for the OptionSets, since GeneratedSerializers does not generate them,
and they are needed by OptionSet to check valid values.

* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::all): Added.
* Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(toImpl):
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::parseWindowTypesFilter):
(WebKit::toWindowTypeFilter):
(WebKit::WebExtensionContextProxy::dispatchWindowsEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm:
(WebKit::WebExtensionAPIWindowsEvent::invokeListenersWithArgument):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:

Canonical link: <a href="https://commits.webkit.org/270782@main">https://commits.webkit.org/270782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd4eb2d6313ef5177575141fa9477146e522fad8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26401 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/5014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/27661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/28547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/24164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/6818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/28547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26661 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/6818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/27661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/29098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/6818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/27661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/29098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/6818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/27661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/29098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/25615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/33062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/4900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/27661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/33062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3404 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->