### PR TITLE
Generate serialization for NSLocale

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -206,6 +206,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDate.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDictionary.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCError.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCFont.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCLocale.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSValue.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCSecureCoding.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -525,6 +525,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCDictionary.serialization.in \
 	Shared/Cocoa/CoreIPCError.serialization.in \
 	Shared/Cocoa/CoreIPCFont.serialization.in \
+	Shared/Cocoa/CoreIPCLocale.serialization.in \
 	Shared/Cocoa/CoreIPCNSCFObject.serialization.in \
 	Shared/Cocoa/CoreIPCNSValue.serialization.in \
 	Shared/Cocoa/CoreIPCSecureCoding.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -69,6 +69,7 @@ enum class NSType : uint8_t {
     Error,
     Dictionary,
     Font,
+    Locale,
     Number,
     SecureCoding,
     String,

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -289,6 +289,8 @@ NSType typeFromObject(id object)
         return NSType::Dictionary;
     if ([object isKindOfClass:[CocoaFont class]])
         return NSType::Font;
+    if ([object isKindOfClass:[NSLocale class]])
+        return NSType::Locale;
     if ([object isKindOfClass:[NSNumber class]])
         return NSType::Number;
     if ([object isKindOfClass:[NSValue class]])

--- a/Source/WebKit/Shared/Cocoa/CoreIPCLocale.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCLocale.h
@@ -25,18 +25,35 @@
 
 #pragma once
 
-#import "CoreIPCArray.h"
-#import "CoreIPCCFType.h"
-#import "CoreIPCColor.h"
-#import "CoreIPCDDScannerResult.h"
-#import "CoreIPCData.h"
-#import "CoreIPCDate.h"
-#import "CoreIPCDictionary.h"
-#import "CoreIPCError.h"
-#import "CoreIPCFont.h"
-#import "CoreIPCLocale.h"
-#import "CoreIPCNSValue.h"
-#import "CoreIPCNumber.h"
-#import "CoreIPCSecureCoding.h"
-#import "CoreIPCString.h"
-#import "CoreIPCURL.h"
+#if PLATFORM(COCOA)
+
+#import <Foundation/Foundation.h>
+#import <wtf/text/WTFString.h>
+
+OBJC_CLASS NSLocale;
+
+namespace WebKit {
+
+class CoreIPCLocale {
+public:
+    static bool isValidIdentifier(const String&);
+
+    CoreIPCLocale(NSLocale *);
+    CoreIPCLocale(String&&);
+
+    RetainPtr<id> toID() const;
+
+    String identfier() const
+    {
+        return m_identifier;
+    }
+
+private:
+    static std::optional<String> canonicalLocaleStringReplacement(const String& identifier);
+
+    String m_identifier;
+};
+
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCLocale.h"
+
+#import <wtf/HashMap.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/text/StringHash.h>
+
+namespace WebKit {
+
+bool CoreIPCLocale::isValidIdentifier(const String& identifier)
+{
+    if ([[NSLocale availableLocaleIdentifiers] containsObject:identifier])
+        return true;
+    if (canonicalLocaleStringReplacement(identifier))
+        return true;
+    return false;
+}
+
+CoreIPCLocale::CoreIPCLocale(NSLocale *locale)
+    : m_identifier([locale localeIdentifier])
+{
+}
+
+CoreIPCLocale::CoreIPCLocale(String&& identifier)
+    : m_identifier([[NSLocale currentLocale] localeIdentifier])
+{
+    if ([[NSLocale availableLocaleIdentifiers] containsObject:identifier])
+        m_identifier = identifier;
+    else if (auto fixedLocale = canonicalLocaleStringReplacement(identifier))
+        m_identifier = *fixedLocale;
+}
+
+RetainPtr<id> CoreIPCLocale::toID() const
+{
+    return [[NSLocale alloc] initWithLocaleIdentifier:(NSString *)m_identifier];
+}
+
+std::optional<String> CoreIPCLocale::canonicalLocaleStringReplacement(const String& identifier)
+{
+    /*
+        To ensure that all possible valid locale strings are handled, this list provides
+        a lookup from what was returned from -localeIdentifier to what needs to go into
+        -initWithLocaleIdentifier to ensure what was encoded can be decoded on the other side.
+
+        See rdar://118571809.
+
+        The test in IPCSerialization.mm will fail if something changes with the desired behavior.
+
+        This lookup was generated with the following code and then sorted:
+            for (NSString* input in [NSLocale availableLocaleIdentifiers]) {
+                NSString* output = [[NSLocale localeWithLocaleIdentifier: input ] localeIdentifier];
+                if(![output isEqualToString:input])
+                    NSLog(@"{ \"%@\"_s, \"%@\"_s },", output, input);
+            }
+     */
+    static NeverDestroyed<HashMap<String, String>> replacements = HashMap<String, String> {
+        { "az"_s, "az_Latn"_s },
+        { "az-Cyrl"_s, "az_Cyrl"_s },
+        { "az-Cyrl_AZ"_s, "az_Cyrl_AZ"_s },
+        { "az_AZ"_s, "az_Latn_AZ"_s },
+        { "ber-Latn"_s, "ber_Latn"_s },
+        { "ber-Latn_MA"_s, "ber_Latn_MA"_s },
+        { "ber-Tfng"_s, "ber_Tfng"_s },
+        { "ber-Tfng_MA"_s, "ber_Tfng_MA"_s },
+        { "bs"_s, "bs_Latn"_s },
+        { "bs-Cyrl"_s, "bs_Cyrl"_s },
+        { "bs-Cyrl_BA"_s, "bs_Cyrl_BA"_s },
+        { "bs_BA"_s, "bs_Latn_BA"_s },
+        { "ff"_s, "ff_Latn"_s },
+        { "ff-Adlm"_s, "ff_Adlm"_s },
+        { "ff-Adlm_BF"_s, "ff_Adlm_BF"_s },
+        { "ff-Adlm_CM"_s, "ff_Adlm_CM"_s },
+        { "ff-Adlm_GH"_s, "ff_Adlm_GH"_s },
+        { "ff-Adlm_GM"_s, "ff_Adlm_GM"_s },
+        { "ff-Adlm_GN"_s, "ff_Adlm_GN"_s },
+        { "ff-Adlm_GW"_s, "ff_Adlm_GW"_s },
+        { "ff-Adlm_LR"_s, "ff_Adlm_LR"_s },
+        { "ff-Adlm_MR"_s, "ff_Adlm_MR"_s },
+        { "ff-Adlm_NE"_s, "ff_Adlm_NE"_s },
+        { "ff-Adlm_NG"_s, "ff_Adlm_NG"_s },
+        { "ff-Adlm_SL"_s, "ff_Adlm_SL"_s },
+        { "ff-Adlm_SN"_s, "ff_Adlm_SN"_s },
+        { "ff_BF"_s, "ff_Latn_BF"_s },
+        { "ff_CM"_s, "ff_Latn_CM"_s },
+        { "ff_GH"_s, "ff_Latn_GH"_s },
+        { "ff_GM"_s, "ff_Latn_GM"_s },
+        { "ff_GN"_s, "ff_Latn_GN"_s },
+        { "ff_GW"_s, "ff_Latn_GW"_s },
+        { "ff_LR"_s, "ff_Latn_LR"_s },
+        { "ff_MR"_s, "ff_Latn_MR"_s },
+        { "ff_NE"_s, "ff_Latn_NE"_s },
+        { "ff_NG"_s, "ff_Latn_NG"_s },
+        { "ff_SL"_s, "ff_Latn_SL"_s },
+        { "ff_SN"_s, "ff_Latn_SN"_s },
+        { "hi-Latn"_s, "hi_Latn"_s },
+        { "hi-Latn_IN"_s, "hi_Latn_IN"_s },
+        { "ks-Arab"_s, "ks_Arab"_s },
+        { "ks-Arab_IN"_s, "ks_Arab_IN"_s },
+        { "ks-Deva"_s, "ks_Deva"_s },
+        { "ks-Deva_IN"_s, "ks_Deva_IN"_s },
+        { "ks_IN"_s, "ks_Aran_IN"_s },
+        { "mni-Beng"_s, "mni_Beng"_s },
+        { "mni-Beng_IN"_s, "mni_Beng_IN"_s },
+        { "mni-Mtei"_s, "mni_Mtei"_s },
+        { "mni-Mtei_IN"_s, "mni_Mtei_IN"_s },
+        { "ms-Arab"_s, "ms_Arab"_s },
+        { "ms-Arab_BN"_s, "ms_Arab_BN"_s },
+        { "ms-Arab_MY"_s, "ms_Arab_MY"_s },
+        { "nb"_s, "no"_s },
+        { "pa"_s, "pa_Guru"_s },
+        { "pa-Arab"_s, "pa_Arab"_s },
+        { "pa-Arab_PK"_s, "pa_Arab_PK"_s },
+        { "pa-Aran_PK"_s, "pa_Aran_PK"_s },
+        { "pa_IN"_s, "pa_Guru_IN"_s },
+        { "rej-Rjng"_s, "rej_Rjng"_s },
+        { "rej-Rjng_ID"_s, "rej_Rjng_ID"_s },
+        { "rhg-Rohg"_s, "rhg_Rohg"_s },
+        { "rhg-Rohg_BD"_s, "rhg_Rohg_BD"_s },
+        { "rhg-Rohg_MM"_s, "rhg_Rohg_MM"_s },
+        { "sat-Deva"_s, "sat_Deva"_s },
+        { "sat-Deva_IN"_s, "sat_Deva_IN"_s },
+        { "sat-Olck"_s, "sat_Olck"_s },
+        { "sat-Olck_IN"_s, "sat_Olck_IN"_s },
+        { "sd-Arab"_s, "sd_Arab"_s },
+        { "sd-Arab_PK"_s, "sd_Arab_PK"_s },
+        { "sd-Deva"_s, "sd_Deva"_s },
+        { "sd-Deva_IN"_s, "sd_Deva_IN"_s },
+        { "shi"_s, "shi_Latn"_s },
+        { "shi-Tfng"_s, "shi_Tfng"_s },
+        { "shi-Tfng_MA"_s, "shi_Tfng_MA"_s },
+        { "shi_MA"_s, "shi_Latn_MA"_s },
+        { "sr"_s, "sr_Cyrl"_s },
+        { "sr-Latn"_s, "sr_Latn"_s },
+        { "sr-Latn_BA"_s, "sr_Latn_BA"_s },
+        { "sr-Latn_ME"_s, "sr_Latn_ME"_s },
+        { "sr-Latn_RS"_s, "sr_Latn_RS"_s },
+        { "sr-Latn_XK"_s, "sr_Latn_XK"_s },
+        { "sr_BA"_s, "sr_Cyrl_BA"_s },
+        { "sr_ME"_s, "sr_Cyrl_ME"_s },
+        { "sr_RS"_s, "sr_Cyrl_RS"_s },
+        { "sr_XK"_s, "sr_Cyrl_XK"_s },
+        { "su-Latn"_s, "su_Latn"_s },
+        { "su-Latn_ID"_s, "su_Latn_ID"_s },
+        { "ur-Arab"_s, "ur_Arab"_s },
+        { "ur-Arab_IN"_s, "ur_Arab_IN"_s },
+        { "ur-Arab_PK"_s, "ur_Arab_PK"_s },
+        { "ur_IN"_s, "ur_Aran_IN"_s },
+        { "ur_PK"_s, "ur_Aran_PK"_s },
+        { "uz"_s, "uz_Latn"_s },
+        { "uz-Arab"_s, "uz_Arab"_s },
+        { "uz-Arab_AF"_s, "uz_Arab_AF"_s },
+        { "uz-Cyrl"_s, "uz_Cyrl"_s },
+        { "uz-Cyrl_UZ"_s, "uz_Cyrl_UZ"_s },
+        { "uz_UZ"_s, "uz_Latn_UZ"_s },
+        { "vai"_s, "vai_Vaii"_s },
+        { "vai-Latn"_s, "vai_Latn"_s },
+        { "vai-Latn_LR"_s, "vai_Latn_LR"_s },
+        { "vai_LR"_s, "vai_Vaii_LR"_s },
+        { "yue-Hans"_s, "yue_Hans"_s },
+        { "yue-Hant"_s, "yue_Hant"_s },
+        { "yue_CN"_s, "yue_Hans_CN"_s },
+        { "yue_HK"_s, "yue_Hant_HK"_s },
+        { "zh-Hans"_s, "zh_Hans"_s },
+        { "zh-Hans_HK"_s, "zh_Hans_HK"_s },
+        { "zh-Hans_JP"_s, "zh_Hans_JP"_s },
+        { "zh-Hans_MO"_s, "zh_Hans_MO"_s },
+        { "zh-Hant"_s, "zh_Hant"_s },
+        { "zh-Hant_CN"_s, "zh_Hant_CN"_s },
+        { "zh-Hant_JP"_s, "zh_Hant_JP"_s },
+        { "zh_CN"_s, "zh_Hans_CN"_s },
+        { "zh_HK"_s, "zh_Hant_HK"_s },
+        { "zh_MO"_s, "zh_Hant_MO"_s },
+        { "zh_SG"_s, "zh_Hans_SG"_s },
+        { "zh_TW"_s, "zh_Hant_TW"_s }
+    };
+
+    auto entry = replacements.get().find(identifier);
+    if (entry == replacements.get().end())
+        return std::nullopt;
+    return entry->value;
+}
+
+}

--- a/Source/WebKit/Shared/Cocoa/CoreIPCLocale.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCLocale.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCLocale.h"
+
+[WebKitPlatform] class WebKit::CoreIPCLocale {
+    [Validator='WebKit::CoreIPCLocale::isValidIdentifier(*identfier)'] WTF::String identfier()
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -44,6 +44,7 @@ class CoreIPCDate;
 class CoreIPCDictionary;
 class CoreIPCError;
 class CoreIPCFont;
+class CoreIPCLocale;
 class CoreIPCNSValue;
 class CoreIPCNumber;
 class CoreIPCSecureCoding;
@@ -63,6 +64,7 @@ using ObjectValue = std::variant<
     CoreIPCDictionary,
     CoreIPCError,
     CoreIPCFont,
+    CoreIPCLocale,
     CoreIPCNSValue,
     CoreIPCNumber,
     CoreIPCSecureCoding,

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -56,6 +56,8 @@ static ObjectValue valueFromID(id object)
         return CoreIPCDictionary((NSDictionary *)object);
     case IPC::NSType::Error:
         return CoreIPCError((NSError *)object);
+    case IPC::NSType::Locale:
+        return CoreIPCLocale((NSLocale *)object);
     case IPC::NSType::Font:
         return CoreIPCFont((WebCore::CocoaFont *)object);
     case IPC::NSType::NSValue:

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -34,6 +34,7 @@
 #import <WebCore/EventRegion.h>
 #import <WebCore/LengthFunctions.h>
 #import <WebCore/Model.h>
+#import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/TimingFunction.h>
 #import <wtf/text/CString.h>
 #import <wtf/text/TextStream.h>
@@ -343,13 +344,13 @@ HashSet<Ref<PlatformCALayerRemote>>& RemoteLayerTreeTransaction::changedLayers()
 
 const LayerPropertiesMap& RemoteLayerTreeTransaction::changedLayerProperties() const
 {
-    ASSERT(!isInAuxiliaryProcess());
+    ASSERT(!WebCore::isInAuxiliaryProcess());
     return m_changedLayers.changedLayerProperties;
 }
 
 LayerPropertiesMap& RemoteLayerTreeTransaction::changedLayerProperties()
 {
-    ASSERT(!isInAuxiliaryProcess());
+    ASSERT(!WebCore::isInAuxiliaryProcess());
     return m_changedLayers.changedLayerProperties;
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
@@ -104,7 +104,7 @@ void RemoteLayerWithRemoteRenderingBackingStoreCollection::prepareBackingStoresF
 
 RefPtr<WebCore::ImageBuffer> RemoteLayerWithRemoteRenderingBackingStoreCollection::allocateBufferForBackingStore(const RemoteLayerBackingStore& backingStore)
 {
-    OptionSet<ImageBufferOptions> options;
+    OptionSet<WebCore::ImageBufferOptions> options;
     if (backingStore.type() == RemoteLayerBackingStore::Type::IOSurface)
         options.add(WebCore::ImageBufferOptions::Accelerated);
     return remoteRenderingBackendProxy().createImageBuffer(backingStore.size(), WebCore::RenderingPurpose::LayerBacking, backingStore.scale(), backingStore.colorSpace(), backingStore.pixelFormat(), options);

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -155,6 +155,7 @@ Shared/Cocoa/AuxiliaryProcessCocoa.mm
 Shared/Cocoa/CodeSigning.mm
 Shared/Cocoa/CompletionHandlerCallChecker.mm
 Shared/Cocoa/CoreIPCError.mm
+Shared/Cocoa/CoreIPCLocale.mm
 Shared/Cocoa/CoreTextHelpers.mm
 Shared/Cocoa/DefaultWebBrowserChecks.mm
 Shared/Cocoa/ExtensionKitSoftLink.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2358,9 +2358,11 @@
 		F4975CF22624B80A003C626E /* WKQuickLookPreviewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */; };
 		F499BAA32947C1A4001241D6 /* RevealFocusedElementDeferrer.h in Headers */ = {isa = PBXBuildFile; fileRef = F499BAA12947C1A4001241D6 /* RevealFocusedElementDeferrer.h */; };
 		F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */ = {isa = PBXBuildFile; fileRef = F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */; };
+		F4A30A6D2B08255B004E1F24 /* CoreIPCLocale.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A30A6C2B08254C004E1F24 /* CoreIPCLocale.mm */; };
 		F4A7B1C128E4DDC30042C75A /* ShareableBitmapHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = F4A7B1C028E4DDC30042C75A /* ShareableBitmapHandle.h */; };
 		F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ABDB602B018C1A00C5471A /* CoreIPCError.h */; };
 		F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4ABDB622B018C1B00C5471A /* CoreIPCError.mm */; };
+		F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ABDB722B0417AD00C5471A /* CoreIPCLocale.h */; };
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
 		F4BCBBEC2AC332AA00C1858D /* WKFormAccessoryView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
@@ -7653,6 +7655,7 @@
 		F499BAA22947C1A4001241D6 /* RevealFocusedElementDeferrer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = RevealFocusedElementDeferrer.mm; path = ios/RevealFocusedElementDeferrer.mm; sourceTree = "<group>"; };
 		F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCDate.serialization.in; sourceTree = "<group>"; };
 		F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDate.h; sourceTree = "<group>"; };
+		F4A30A6C2B08254C004E1F24 /* CoreIPCLocale.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCLocale.mm; sourceTree = "<group>"; };
 		F4A318A7291EFCF600F7A903 /* RemoteMediaPlayerState.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RemoteMediaPlayerState.serialization.in; sourceTree = "<group>"; };
 		F4A7B1C028E4DDC30042C75A /* ShareableBitmapHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShareableBitmapHandle.h; sourceTree = "<group>"; };
 		F4A7B1C228E4FB050042C75A /* ShareableBitmapHandle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShareableBitmapHandle.cpp; sourceTree = "<group>"; };
@@ -7660,6 +7663,8 @@
 		F4ABDB602B018C1A00C5471A /* CoreIPCError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCError.h; sourceTree = "<group>"; };
 		F4ABDB612B018C1B00C5471A /* CoreIPCError.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCError.serialization.in; sourceTree = "<group>"; };
 		F4ABDB622B018C1B00C5471A /* CoreIPCError.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCError.mm; sourceTree = "<group>"; };
+		F4ABDB722B0417AD00C5471A /* CoreIPCLocale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCLocale.h; sourceTree = "<group>"; };
+		F4ABDB742B041FE900C5471A /* CoreIPCLocale.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCLocale.serialization.in; sourceTree = "<group>"; };
 		F4AC655E22A3140E00A05607 /* WebPreferencesDefaultValuesIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebPreferencesDefaultValuesIOS.mm; path = ios/WebPreferencesDefaultValuesIOS.mm; sourceTree = "<group>"; };
 		F4B378D021DDBBAB0095A378 /* WebUndoStepID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebUndoStepID.h; sourceTree = "<group>"; };
 		F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKImageAnalysisGestureRecognizer.h; path = ios/WKImageAnalysisGestureRecognizer.h; sourceTree = "<group>"; };
@@ -10890,6 +10895,9 @@
 				5197FAD72AFD33B1009180C5 /* CoreIPCFont.h */,
 				5187BDEF2B007445008A6EE5 /* CoreIPCFont.mm */,
 				5197FACA2AFD33AE009180C5 /* CoreIPCFont.serialization.in */,
+				F4ABDB722B0417AD00C5471A /* CoreIPCLocale.h */,
+				F4A30A6C2B08254C004E1F24 /* CoreIPCLocale.mm */,
+				F4ABDB742B041FE900C5471A /* CoreIPCLocale.serialization.in */,
 				5197FACE2AFD33AF009180C5 /* CoreIPCNSCFObject.h */,
 				5197FADC2AFD33B2009180C5 /* CoreIPCNSCFObject.mm */,
 				5197FAD02AFD33AF009180C5 /* CoreIPCNSCFObject.serialization.in */,
@@ -15117,6 +15125,7 @@
 				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
 				F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */,
 				5197FAE32AFD33CF009180C5 /* CoreIPCFont.h in Headers */,
+				F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */,
 				5197FAE42AFD33CF009180C5 /* CoreIPCNSCFObject.h in Headers */,
 				51ACFFDF2B048821001331A2 /* CoreIPCNSValue.h in Headers */,
 				F4EFF36D2AF0267300479AB8 /* CoreIPCNumber.h in Headers */,
@@ -17964,6 +17973,7 @@
 				7B9FC5D128A53014007570E7 /* PlatformUnifiedSource1-mm.mm in Sources */,
 				7B9FC5A828A38D1E007570E7 /* PlatformUnifiedSource1.cpp in Sources */,
 				7B9FC5D028A5300D007570E7 /* PlatformUnifiedSource2-mm.mm in Sources */,
+				F4A30A6D2B08255B004E1F24 /* CoreIPCLocale.mm in Sources */,
 				7B9FC5D428A53023007570E7 /* PlatformUnifiedSource2.cpp in Sources */,
 				7B9FC5DE28A53CCD007570E7 /* PlatformUnifiedSource3-mm.mm in Sources */,
 				7B9FC5D328A5301D007570E7 /* PlatformUnifiedSource3.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -148,6 +148,7 @@ struct ObjCHolderForTesting {
         RetainPtr<NSDictionary>,
         RetainPtr<WebCore::CocoaFont>,
         RetainPtr<NSError>,
+        RetainPtr<NSLocale>,
 #if ENABLE(DATA_DETECTION)
         RetainPtr<DDScannerResult>,
 #endif
@@ -516,6 +517,10 @@ TEST(IPCSerialization, Basic)
     RetainPtr<id> error12 = filteredError11.toID();
     EXPECT_EQ([[[error12.get() userInfo] objectForKey:@"NSErrorPeerCertificateChainKey"] count], (NSUInteger)1);
     runTestNS({ (NSError *)error12.get() });
+
+    // NSLocale
+    for (NSString* identifier : [NSLocale availableLocaleIdentifiers])
+        runTestNS({ [NSLocale localeWithLocaleIdentifier: identifier] });
 
     auto runValueTest = [&](NSValue *value) {
         ObjCHolderForTesting::ValueType valueVariant;


### PR DESCRIPTION
#### ef1d1f5915d3e23a3a67d6174e47169cb7993009
<pre>
Generate serialization for NSLocale
<a href="https://bugs.webkit.org/show_bug.cgi?id=264886">https://bugs.webkit.org/show_bug.cgi?id=264886</a>
<a href="https://rdar.apple.com/118464614">rdar://118464614</a>

Reviewed by Brady Eidson.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCLocale.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCTypes.h.
(WebKit::CoreIPCLocale::identfier const):
* Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm: Added.
(WebKit::CoreIPCLocale::isValidIdentifier):
(WebKit::CoreIPCLocale::CoreIPCLocale):
(WebKit::CoreIPCLocale::toID const):
(WebKit::CoreIPCLocale::canonicalLocaleStringReplacement):
* Source/WebKit/Shared/Cocoa/CoreIPCLocale.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCTypes.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::changedLayerProperties const):
(WebKit::RemoteLayerTreeTransaction::changedLayerProperties):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::allocateBufferForBackingStore):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/271308@main">https://commits.webkit.org/271308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e6121a54989550283e61dbd078f95762c771861

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25242 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31017 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28828 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6233 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6710 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->