### PR TITLE
[webkitpy] Move WebKitFinder.{layout,perf}_tests_dir to Port

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
@@ -79,15 +79,15 @@ def argument_parser():
 
 class TestExpectationUpdater(object):
 
-    def __init__(self, host, bugzilla_id, is_bug_id=True, bot_filter_name=None, attachment_fetcher=None):
+    def __init__(self, port, bugzilla_id, is_bug_id=True, bot_filter_name=None, attachment_fetcher=None):
         self.attachment_fetcher = bugzilla.Bugzilla() if attachment_fetcher is None else attachment_fetcher
 
-        self.filesystem = host.filesystem
+        self.filesystem = port.host.filesystem
         self.bot_filter_name = bot_filter_name
         self.bugzilla_id = bugzilla_id
         self.is_bug_id = is_bug_id
 
-        self.layout_test_repository = WebKitFinder(self.filesystem).path_from_webkit_base("LayoutTests")
+        self.layout_test_repository = port.path_from_webkit_base("LayoutTests")
 
         self.ews_results = None
 
@@ -173,5 +173,8 @@ def main(_argv, _stdout, _stderr):
 
     configure_logging(options.debug)
 
-    updater = TestExpectationUpdater(Host(), options.bugzilla_id, options.is_bug_id, options.bot_filter_name)
+    host = Host()
+    port = host.port_factory.get()
+
+    updater = TestExpectationUpdater(port, options.bugzilla_id, options.is_bug_id, options.bot_filter_name)
     updater.do_update()

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
@@ -581,6 +581,7 @@ class TestExpectationUpdaterTest(unittest.TestCase):
 
     def test_update_test_expectations(self):
         host = MockHost()
+        port = host.port_factory.get()
         host.executive = MockExecutive2(exception=OSError())
         host.filesystem = MockFileSystem(files={
             '/mock-checkout/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-expected.txt': 'e-wk1',
@@ -600,7 +601,7 @@ class TestExpectationUpdaterTest(unittest.TestCase):
         }
 
         with mock.patch('webkitpy.common.net.bugzilla.test_expectation_updater.lookup_ews_results_from_bugzilla', mock.Mock(return_value=ews_results)), mock.patch('requests.get', MockRequestsGet):
-            updater = TestExpectationUpdater(host, "123456", True, False, None)
+            updater = TestExpectationUpdater(port, "123456", True, False, None)
             updater.do_update()
             # mac-wk2 expectation
             self.assertTrue(self._is_matching(host, "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-expected.txt", "a"))

--- a/Tools/Scripts/webkitpy/common/webkit_finder.py
+++ b/Tools/Scripts/webkitpy/common/webkit_finder.py
@@ -51,6 +51,14 @@ class WebKitFinder(object):
         return self._webkit_base
 
     def path_from_webkit_base(self, *comps):
+        if len(comps) > 0:
+            if comps[0] == "LayoutTests":
+                msg = "Cannot construct a path beginning with LayoutTests, use port.layout_tests_dir()"
+                raise ValueError(msg)
+            if comps[0] == "PerformanceTests":
+                msg = "Cannot construct a path beginning with LayoutTests, use port.perf_tests_dir()"
+                raise ValueError(msg)
+
         return self._filesystem.join(self.webkit_base(), *comps)
 
     def path_from_webkit_outputdir(self, *comps):
@@ -62,9 +70,3 @@ class WebKitFinder(object):
         # This is intentionally relative in order to force callers to consider what
         # their current working directory is (and change to the top of the tree if necessary).
         return self._filesystem.join("Tools", "Scripts", script_name)
-
-    def layout_tests_dir(self):
-        return self.path_from_webkit_base('LayoutTests')
-
-    def perf_tests_dir(self):
-        return self.path_from_webkit_base('PerformanceTests')

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -682,6 +682,13 @@ class Port(object):
         return self._webkit_finder.webkit_base()
 
     def path_from_webkit_base(self, *comps):
+        # Ports can override the LayoutTests/PerformanceTests paths from the base, so adjust here.
+        if len(comps) > 0:
+            if comps[0] == "LayoutTests":
+                return self._filesystem.join(self.layout_tests_dir(), *comps[1:])
+            if comps[0] == "PerformanceTests":
+                return self._filesystem.join(self.perf_tests_dir(), *comps[1:])
+
         return self._webkit_finder.path_from_webkit_base(*comps)
 
     def path_to_script(self, script_name):
@@ -690,10 +697,10 @@ class Port(object):
     def layout_tests_dir(self):
         if self._layout_tests_dir:
             return self._layout_tests_dir
-        return self._webkit_finder.layout_tests_dir()
+        return self._filesystem.join(self.webkit_base(), "LayoutTests")
 
     def perf_tests_dir(self):
-        return self._webkit_finder.perf_tests_dir()
+        return self._filesystem.join(self.webkit_base(), "PerformanceTests")
 
     def skipped_layout_tests(self, device_type=None):
         """Returns tests skipped outside of the TestExpectations files."""

--- a/Tools/Scripts/webkitpy/w3c/test_downloader.py
+++ b/Tools/Scripts/webkitpy/w3c/test_downloader.py
@@ -73,10 +73,11 @@ class TestDownloader(object):
             }
         ]
 
-    def __init__(self, repository_directory, host, options):
+    def __init__(self, repository_directory, port, options):
         self._options = options
-        self._host = host
-        self._filesystem = host.filesystem
+        self._port = port
+        self._host = port.host
+        self._filesystem = port.host.filesystem
         self._test_suites = []
 
         self.repository_directory = repository_directory
@@ -91,7 +92,7 @@ class TestDownloader(object):
             self.paths_to_import.extend([self._filesystem.join(test_repository['name'], path) for path in test_repository['paths_to_import']])
 
         webkit_finder = WebKitFinder(self._filesystem)
-        self.import_expectations_path = webkit_finder.path_from_webkit_base('LayoutTests', 'imported', 'w3c', 'resources', 'import-expectations.json')
+        self.import_expectations_path = port.path_from_webkit_base('LayoutTests', 'imported', 'w3c', 'resources', 'import-expectations.json')
         if not self._filesystem.isfile(self.import_expectations_path):
             _log.warning('Unable to read import expectation file: %s' % self.import_expectations_path)
         if not self._options.import_all:

--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -97,7 +97,10 @@ def main(_argv, _stdout, _stderr):
 
     configure_logging()
 
-    test_importer = TestImporter(Host(), test_paths, options)
+    host = Host()
+    port = host.port_factory.get()
+
+    test_importer = TestImporter(port, test_paths, options)
     test_importer.do_import()
 
 
@@ -158,21 +161,21 @@ To import a web-platform-tests suite from a specific folder, use 'import-w3c-tes
 
 class TestImporter(object):
 
-    def __init__(self, host, test_paths, options):
-        self.host = host
+    def __init__(self, port, test_paths, options):
+        self.host = port.host
+        self.port = port
         self.source_directory = options.source
         self.options = options
         self.test_paths = test_paths if test_paths else []
 
-        self.port = PortFactory(host).get()
         self.filesystem = self.host.filesystem
 
         webkit_finder = WebKitFinder(self.filesystem)
         self._webkit_root = webkit_finder.webkit_base()
 
-        self.destination_directory = webkit_finder.path_from_webkit_base("LayoutTests", options.destination)
+        self.destination_directory = self.port.path_from_webkit_base("LayoutTests", options.destination)
         self.tests_w3c_relative_path = self.filesystem.join('imported', 'w3c')
-        self.layout_tests_path = webkit_finder.path_from_webkit_base('LayoutTests')
+        self.layout_tests_path = self.port.path_from_webkit_base('LayoutTests')
         self.layout_tests_w3c_path = self.filesystem.join(self.layout_tests_path, self.tests_w3c_relative_path)
         self.tests_download_path = WPTPaths.checkout_directory(webkit_finder)
 
@@ -261,7 +264,7 @@ class TestImporter(object):
             download_options.fetch = self.options.fetch
             download_options.verbose = self.options.verbose
             download_options.import_all = self.options.import_all
-            self._test_downloader = TestDownloader(self.tests_download_path, self.host, download_options)
+            self._test_downloader = TestDownloader(self.tests_download_path, self.port, download_options)
         return self._test_downloader
 
     def should_skip_path(self, path):


### PR DESCRIPTION
#### cb302cd1f44f09c8b330f4c25efb99347b3b8878
<pre>
[webkitpy] Move WebKitFinder.{layout,perf}_tests_dir to Port
<a href="https://bugs.webkit.org/show_bug.cgi?id=264750">https://bugs.webkit.org/show_bug.cgi?id=264750</a>

Reviewed by Jonathan Bedard.

We currently have two copies of these methods: one on the WebKitFinder
and one on the Port. The version on the Port allow the layout test
directory to be overriden by --layout-tests-dir (which is used for
certain non-public tests, for example).

We don&apos;t want to ever end up calling a code path that doesn&apos;t obey that
option if it has been passed, so it makes sense to unify all calls onto
the variants on Port.

To achieve this, we have to adjust a number of call sites to actually
have a Port, but this is a surprisingly small number.

* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py:
(TestExpectationUpdater.__init__):
(main):
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py:
(TestExpectationUpdaterTest.test_update_test_expectations):
* Tools/Scripts/webkitpy/common/webkit_finder.py:
(WebKitFinder.path_from_webkit_base):
(WebKitFinder.path_to_script):
(WebKitFinder.layout_tests_dir): Deleted.
(WebKitFinder.perf_tests_dir): Deleted.
* Tools/Scripts/webkitpy/port/base.py:
(Port.path_from_webkit_base):
(Port.layout_tests_dir):
(Port.perf_tests_dir):
* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader.__init__):
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(main):
(TestImporter.__init__):
(TestImporter.test_downloader):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
(TestImporterTest.test_import_dir_with_no_tests_and_no_hg):
(TestImporterTest.test_import_dir_with_no_tests):
(TestImporterTest.test_import_dir_with_empty_init_py):
(TestImporterTest.import_directory):
(TestImporterTest.import_downloaded_tests.TestDownloaderMock.__init__):
(TestImporterTest.import_downloaded_tests):

Canonical link: <a href="https://commits.webkit.org/270880@main">https://commits.webkit.org/270880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e786a8ec2658dea721d92fd2a8402c54c13f14f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24147 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3413 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/26553 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29728 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27622 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3945 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3451 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->