### PR TITLE
[LBSE] Root 'opacity' should be extended to 'RenderSVGRoot'

### DIFF
--- a/LayoutTests/svg/custom/composited-svg-with-opacity-zoomed-out-expected.html
+++ b/LayoutTests/svg/custom/composited-svg-with-opacity-zoomed-out-expected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<style>
+div {
+  display: inline-block;
+}
+
+svg {
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+  zoom: 0.3;
+}
+rect {
+  opacity: 0.5;
+}
+</style>
+<body>
+  <div>
+    <svg>
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+
+  <div>
+    <svg>
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+
+  <div>
+    <svg>
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+
+  <div>
+    <svg>
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+</body>
+</html>

--- a/LayoutTests/svg/custom/composited-svg-with-opacity-zoomed-out.html
+++ b/LayoutTests/svg/custom/composited-svg-with-opacity-zoomed-out.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<style>
+div {
+  display: inline-block;
+}
+
+svg {
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+  zoom: 0.3;
+}
+</style>
+<body>
+  <div style="opacity: 0.5;">
+    <svg>
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+
+  <div style="opacity: 0.5; transform: translateZ(0);">
+    <svg>
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+
+  <div>
+    <svg style="opacity: 0.5;">
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+
+  <div>
+    <svg style="opacity: 0.5; transform: translateZ(0);">
+      <rect width="100" height="100"></rect>
+    </svg>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -96,7 +96,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
     // Setup transparency layers before setting up SVG resources!
     bool isRenderingMask = isRenderingMaskImage(*m_renderer);
     // RenderLayer takes care of root opacity.
-    float opacity = (renderer.isLegacyRenderSVGRoot() || isRenderingMask) ? 1 : style.opacity();
+    float opacity = (renderer.isRenderOrLegacyRenderSVGRoot() || isRenderingMask) ? 1 : style.opacity();
     bool hasBlendMode = style.hasBlendMode();
     bool hasIsolation = style.hasIsolation();
     bool isolateMaskForBlending = false;


### PR DESCRIPTION
<pre>
[LBSE] Root 'opacity' should be extended to 'RenderSVGRoot'
<a href="https://bugs.webkit.org/show_bug.cgi?id=264889">https://bugs.webkit.org/show_bug.cgi?id=264889</a>

Reviewed by NOBODY (OOPS!).

This patch is to extend root opacity to 'RenderSVGRoot' as well similar to Legacy SVG engine to fix issue noted
while zooming out on existing test from bug 116856.

* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(SVGRenderingContext::prepareToRenderSVGConten):
* LayoutTests/svg/custom/composited-svg-with-opacity-zoomed-out.html: Add Test Case
* LayoutTests/svg/custom/composited-svg-with-opacity-zoomed-out-expected.html: Add Test Case Expectation
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6102f07bbc454c3a112dd4cf4fc2d0d85244447

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24246 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26815 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4040 "Found 1 new test failure: svg/custom/composited-svg-with-opacity-zoomed-out.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3521 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3598 "layout-tests (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23793 "Found 1 new test failure: platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29249 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29834 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3599 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1801 "Found 1 new test failure: svg/custom/composited-svg-with-opacity-zoomed-out.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27727 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23532 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->