### PR TITLE
SECore build fix 3

### DIFF
--- a/Source/JavaScriptCore/Configurations/Base.xcconfig
+++ b/Source/JavaScriptCore/Configurations/Base.xcconfig
@@ -160,11 +160,15 @@ WK_USE_RESTRICTED_ENTITLEMENTS = $(USE_INTERNAL_SDK);
 // Shared variables used for dynamic or static linking of JavaScriptCore and jsc.
 
 // Tomorrow me will be smart enough to figure out how to do this properly.
-JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework ServiceExtensionsCore
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.0*][arch=*] =
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.1*][arch=*] =
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.2*][arch=*] =
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*][arch=*] =
+JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework ServiceExtensionsCore;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.0*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.1*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.2*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
+JSC_SEC_LD_FLAGS[sdk=appletv*] = ;
+JSC_SEC_LD_FLAGS[sdk=watch*] = ;
+JSC_SEC_LD_FLAGS[sdk=xr*] = ;
 
 OTHER_LDFLAGS_JAVASCRIPTCORE_DEPS = $(JSC_SEC_LD_FLAGS) -fobjc-link-runtime -licucore -framework Security;
 

--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -163,11 +163,15 @@ WK_APPLEJPEGXL_LDFLAGS = $(WK_APPLEJPEGXL_LDFLAGS_$(WK_USE_APPLEJPEGXL));
 WK_APPLEJPEGXL_LDFLAGS_YES = -weak_framework AppleJPEGXL;
 
 // Tomorrow me will be smart enough to figure out how to do this properly.
-JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework ServiceExtensionsCore
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.0*][arch=*] =
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.1*][arch=*] =
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.2*][arch=*] =
-JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*][arch=*] =
+JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework ServiceExtensionsCore;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.0*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.1*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.2*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
+JSC_SEC_LD_FLAGS[sdk=appletv*] = ;
+JSC_SEC_LD_FLAGS[sdk=watch*] = ;
+JSC_SEC_LD_FLAGS[sdk=xr*] = ;
 
 // FIXME: Reduce the number of allowable_clients <rdar://problem/31823969>
 OTHER_LDFLAGS = $(inherited) $(WK_RELOCATABLE_FRAMEWORK_LDFLAGS) $(JSC_SEC_LD_FLAGS) -weak-lxslt -lsqlite3 -lobjc -allowable_client WebCoreTestSupport -allowable_client WebKitLegacy -allowable_client WebKit -allowable_client TestIPC -allowable_client TestWebKitAPI -allowable_client DumpRenderTree -allowable_client WebKitTestRunner -force_load $(BUILT_PRODUCTS_DIR)/libPAL.a -framework CFNetwork -framework CoreAudio -framework CoreGraphics -framework CoreText -framework Foundation -framework IOSurface -framework ImageIO -framework Metal -framework Network -lFontParser $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH)) $(OTHER_LDFLAGS_PLATFORM_$(WK_PLATFORM_NAME)) $(WK_ANGLE_LDFLAGS) $(WK_WEBGPU_LDFLAGS) $(WK_APPKIT_LDFLAGS) $(WK_APPSUPPORT_LDFLAGS) $(WK_AUDIO_UNIT_LDFLAGS) $(WK_CARBON_LDFLAGS) $(WK_CORE_UI_LDFLAGS) $(WK_DATA_DETECTORS_CORE_LDFLAGS) $(WK_GRAPHICS_SERVICES_LDFLAGS) $(WK_IOSURFACE_ACCELERATOR_LDFLAGS) $(WK_LIBWEBRTC_LDFLAGS) $(WK_MOBILE_CORE_SERVICES_LDFLAGS) $(WK_MOBILE_GESTALT_LDFLAGS) $(WK_NETWORK_EXTENSION_LDFLAGS) $(WK_SYSTEM_CONFIGURATION_LDFLAGS) $(WK_CORE_IMAGE_LDFLAGS) $(WK_URL_FORMATTING_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_XR_RUNTIME_SUPPORT_LDFLAGS) $(WK_SCENEKIT_LDFLAGS) $(SOURCE_VERSION_LDFLAGS) $(PROFILE_GENERATE_OR_USE_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS) $(WK_APPLEJPEGXL_LDFLAGS) $(WK_DEBUG_LDFLAGS);


### PR DESCRIPTION
#### 16f475eac293efd139c5da6a7f8e461ff28dd32c
<pre>
SECore build fix 3
<a href="https://bugs.webkit.org/show_bug.cgi?id=264890">https://bugs.webkit.org/show_bug.cgi?id=264890</a>
<a href="https://rdar.apple.com/118467465">rdar://118467465</a>

Unreviewed build fix.

BUILD_SETTING[sdk=iphoneos*] lines in xcconfig also apply to tvos.

* Source/JavaScriptCore/Configurations/Base.xcconfig:
* Source/WebCore/Configurations/WebCore.xcconfig:

Canonical link: <a href="https://commits.webkit.org/270780@main">https://commits.webkit.org/270780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87003024508546e8aca77e2e8fc194a0310b28da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28530 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/24157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2435 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29091 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/25608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33054 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/4893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7145 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3403 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/3792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->