### PR TITLE
[PlayStation] Fix build break after 270770@main

### DIFF
--- a/Source/WebCore/platform/graphics/NamedImageGeneratedImage.cpp
+++ b/Source/WebCore/platform/graphics/NamedImageGeneratedImage.cpp
@@ -42,6 +42,7 @@ NamedImageGeneratedImage::NamedImageGeneratedImage(String name, const FloatSize&
 
 ImageDrawResult NamedImageGeneratedImage::draw(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
+#if USE(NEW_THEME) || PLATFORM(IOS_FAMILY)
     GraphicsContextStateSaver stateSaver(context);
     context.setCompositeOperation(options.compositeOperator(), options.blendMode());
     context.clip(dstRect);
@@ -52,10 +53,18 @@ ImageDrawResult NamedImageGeneratedImage::draw(GraphicsContext& context, const F
 
     Theme::singleton().drawNamedImage(m_name, context, dstRect.size());
     return ImageDrawResult::DidDraw;
+#else
+    UNUSED_PARAM(context);
+    UNUSED_PARAM(dstRect);
+    UNUSED_PARAM(srcRect);
+    UNUSED_PARAM(options);
+    return ImageDrawResult::DidNothing;
+#endif
 }
 
 void NamedImageGeneratedImage::drawPattern(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
+#if USE(NEW_THEME) || PLATFORM(IOS_FAMILY)
     auto imageBuffer = context.createAlignedImageBuffer(size());
     if (!imageBuffer)
         return;
@@ -65,6 +74,15 @@ void NamedImageGeneratedImage::drawPattern(GraphicsContext& context, const Float
 
     // Tile the image buffer into the context.
     context.drawPattern(*imageBuffer, dstRect, srcRect, patternTransform, phase, spacing, options);
+#else
+    UNUSED_PARAM(context);
+    UNUSED_PARAM(dstRect);
+    UNUSED_PARAM(srcRect);
+    UNUSED_PARAM(patternTransform);
+    UNUSED_PARAM(phase);
+    UNUSED_PARAM(spacing);
+    UNUSED_PARAM(options);
+#endif
 }
 
 void NamedImageGeneratedImage::dump(TextStream& ts) const


### PR DESCRIPTION
#### 8c7ab92549f74f91d2020dfefad1e83273cdae16
<pre>
[PlayStation] Fix build break after 270770@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=264888">https://bugs.webkit.org/show_bug.cgi?id=264888</a>

Reviewed by NOBODY (OOPS!).

This partially reverts commit 75ca1048e0a16e92ed2a5eaf85fda2b19ddab7c7.
That commit assumed `USE(NEW_THEME) || PLATFORM(IOS_FAMILY)` is true for
all platforms, but it is not true for PlayStation.

To ensure `NamedImageGeneratedImage::drawPattern` on iOS it is included
in the guard.

* Source/WebCore/platform/graphics/NamedImageGeneratedImage.cpp:
(WebCore::NamedImageGeneratedImage::draw):
(WebCore::NamedImageGeneratedImage::drawPattern):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c7ab92549f74f91d2020dfefad1e83273cdae16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28581 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2465 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24164 "Failed to print configuration") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3440 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29117 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29753 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27647 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->