### PR TITLE
[scroll-anchoring] A scroll anchoring adjustment during a momentum scroll stops the scroll

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll-expected.txt
@@ -1,0 +1,11 @@
+Verifies that a scroll anchoring adjustment does not cancel a momentum scroll.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.scrollingElement.scrollTop is > 900
+PASS successfullyParsed is true
+
+TEST COMPLETE
+abc
+def

--- a/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body { height: 4000px; }
+
+#block1 {
+    height: 100px;
+    background-color: green;
+}
+
+#block2 {
+    height: 600px;
+    background-color: blue;
+}
+</style>
+
+<body onload="runTest()">
+    <div id="block1">abc</div>
+    <div id="block2">def</div>
+</body>
+
+<script>
+jsTestIsAsync = true;
+
+async function runTest()
+{
+    description("Verifies that a scroll anchoring adjustment does not cancel a momentum scroll.");
+
+    if (!window.testRunner)
+        return;
+    
+    document.scrollingElement.scrollTop = 350;
+
+    await UIHelper.dragFromPointToPoint(150, 420, 150, 400, 0.01);
+    document.querySelector("#block1").style.height = "200px";
+    await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+    shouldBeGreaterThan("document.scrollingElement.scrollTop", "900");
+   finishJSTest();
+}
+</script>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -322,6 +322,13 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 
     FloatSize adjustment = computeOffsetFromOwningScroller(*renderer) - m_lastOffsetForAnchorElement;
     if (!adjustment.isZero()) {
+#if PLATFORM(IOS_FAMILY)
+        if (m_owningScrollableArea.isUserScrollInProgress()) {
+            invalidateAnchorElement();
+            updateAnchorElement();
+            return;
+        }
+#endif
         auto newScrollPosition = m_owningScrollableArea.scrollPosition() + IntPoint(adjustment.width(), adjustment.height());
         LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() for frame: " << frameView() << " for scroller: " << m_owningScrollableArea << " adjusting from: " << m_owningScrollableArea.scrollPosition() << " to: " << newScrollPosition);
         auto options = ScrollPositionChangeOptions::createProgrammatic();


### PR DESCRIPTION
#### bdce1d6d1b68d8c04c45c4128a257a5778f6fcbd
<pre>
[scroll-anchoring] A scroll anchoring adjustment during a momentum scroll stops the scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=264898">https://bugs.webkit.org/show_bug.cgi?id=264898</a>
<a href="https://rdar.apple.com/118476758">rdar://118476758</a>

Reviewed by Simon Fraser.

On iOS, _scrollToContentScrollPosition calls [_scrollView _wk_stopScrollingAndZooming], which
means when we issue a programmatic scroll, it would stop a current user scroll (<a href="https://rdar.apple.com/115703492">rdar://115703492</a>).
For scroll anchoring, this isn&apos;t great as a scroll anchoring adjustment could kill a user scroll.
To mitigate this, ignore scroll anchoring adjustments on scrollable areas that have an ongoing
user scroll. Ideally, we would add the delta to the ongoing momentum scroll to compensate for layout
changes during user scrolls, which requires a fix for <a href="https://rdar.apple.com/115703492">rdar://115703492</a>.

* LayoutTests/resources/js-test.js:
(getOrCreate):
(description):
(debug):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::handleWheelEvent):

Canonical link: <a href="https://commits.webkit.org/271517@main">https://commits.webkit.org/271517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11ec38a87896d8b55ffb7f2086ae98bf6d5f99d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4622 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25601 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26046 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31608 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5326 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3500 "Found 1 new test failure: imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29385 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25395 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5790 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3698 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->