### PR TITLE
Regression(267645@main) ~3MB increase in binary size

### DIFF
--- a/Source/JavaScriptCore/b3/B3Effects.cpp
+++ b/Source/JavaScriptCore/b3/B3Effects.cpp
@@ -85,6 +85,20 @@ bool Effects::interferes(const Effects& other) const
         || (fence && other.fence);
 }
 
+bool Effects::operator==(const Effects& other) const
+{
+    return terminal == other.terminal
+        && exitsSideways == other.exitsSideways
+        && controlDependent == other.controlDependent
+        && writesLocalState == other.writesLocalState
+        && readsLocalState == other.readsLocalState
+        && writesPinned == other.writesPinned
+        && readsPinned == other.readsPinned
+        && writes == other.writes
+        && reads == other.reads
+        && fence == other.fence;
+}
+
 void Effects::dump(PrintStream& out) const
 {
     CommaPrinter comma("|");

--- a/Source/JavaScriptCore/b3/B3Effects.h
+++ b/Source/JavaScriptCore/b3/B3Effects.h
@@ -118,7 +118,7 @@ struct Effects {
     // behavior in an observable way.
     bool interferes(const Effects&) const;
     
-    friend bool operator==(const Effects&, const Effects&) = default;
+    JS_EXPORT_PRIVATE bool operator==(const Effects&) const;
 
     JS_EXPORT_PRIVATE void dump(PrintStream& out) const;
 };

--- a/Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp
@@ -86,6 +86,12 @@ void AvailabilityMap::dump(PrintStream& out) const
     out.print("{locals = ", m_locals, "; heap = ", mapDump(m_heap), "}");
 }
 
+bool AvailabilityMap::operator==(const AvailabilityMap& other) const
+{
+    return m_locals == other.m_locals
+        && m_heap == other.m_heap;
+}
+
 void AvailabilityMap::merge(const AvailabilityMap& other)
 {
     for (unsigned i = other.m_locals.size(); i--;)

--- a/Source/JavaScriptCore/dfg/DFGAvailabilityMap.h
+++ b/Source/JavaScriptCore/dfg/DFGAvailabilityMap.h
@@ -39,7 +39,7 @@ struct AvailabilityMap {
     
     void dump(PrintStream& out) const;
     
-    friend bool operator==(const AvailabilityMap&, const AvailabilityMap&) = default;
+    bool operator==(const AvailabilityMap& other) const;
     
     void merge(const AvailabilityMap& other);
     


### PR DESCRIPTION
#### ed83f1ea3c349839cb131e162da9ff4a94c12f01
<pre>
Regression(267645@main) ~3MB increase in binary size
<a href="https://bugs.webkit.org/show_bug.cgi?id=264896">https://bugs.webkit.org/show_bug.cgi?id=264896</a>

Unreviewed, partial revert of 267645@main to move some JSC comparison
operators back out of line. My patch inlined them when I defaulted them
as it doesn&apos;t seem possible at the moment to default a comparison operator
outside the class.

* Source/JavaScriptCore/b3/B3Effects.cpp:
* Source/JavaScriptCore/b3/B3Effects.h:
* Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp:
* Source/JavaScriptCore/dfg/DFGAvailabilityMap.h:

Canonical link: <a href="https://commits.webkit.org/270804@main">https://commits.webkit.org/270804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cd8a16251668fe4f7232bd0420ba8aaa9be4ed0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27715 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28642 "Failed to print configuration") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24206 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6881 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/28642 "Failed to print configuration") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26725 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/28642 "Failed to print configuration") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29157 "Failed to print configuration") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23070 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24104 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29157 "Failed to print configuration") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25676 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3519 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29157 "Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4951 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33124 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3998 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/7171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3419 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->