### PR TITLE
Build fix when SERVICE_WORKER is disabled

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6664,6 +6664,7 @@ enum class WebCore::ExceptionCode : uint8_t {
     ExistingExceptionError,
 }
 
+#if ENABLE(SERVICE_WORKER)
 header: <WebCore/BackgroundFetchFailureReason.h>
 enum class WebCore::BackgroundFetchFailureReason : uint8_t {
     EmptyString,
@@ -6673,13 +6674,16 @@ enum class WebCore::BackgroundFetchFailureReason : uint8_t {
     QuotaExceeded,
     DownloadTotalExceeded
 };
+#endif
 
+#if ENABLE(SERVICE_WORKER)
 header: <WebCore/BackgroundFetchResult.h>
 enum class WebCore::BackgroundFetchResult : uint8_t {
     EmptyString,
     Success,
     Failure
 };
+#endif
 
 enum class WebCore::ResourceErrorBaseType : uint8_t {
      Null,


### PR DESCRIPTION
#### ed1571ff480ce80acff17a25d0d0588d916f0580
<pre>
Build fix when SERVICE_WORKER is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=264902">https://bugs.webkit.org/show_bug.cgi?id=264902</a>

Reviewed by Don Olmstead.

When SERVICE_WORKER is dsabled, building webkit fails.
Functions below in GeneratedSerializers.cpp should be disabled when SERVICE_WORKER is off.

isValidEnum&lt;WebCore::BackgroundFetchFailureReason, void&gt;
isValidEnum&lt;WebCore::BackgroundFetchResult, void&gt;

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270920@main">https://commits.webkit.org/270920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ad9174b90697c9819b84475a534a78a1d5d7521

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24477 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24378 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3740 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30001 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27907 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5224 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6444 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->