### PR TITLE
Change to use single test results file for jsc tests

### DIFF
--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -74,7 +74,7 @@ raise unless SCRIPTS_PATH.basename.to_s == "Scripts"
 raise unless SCRIPTS_PATH.dirname.basename.to_s == "Tools"
 
 HELPERS_PATH = SCRIPTS_PATH + "jsc-stress-test-helpers"
-STATUS_FILE_PREFIX = "test_status_"
+STATUS_FILE = "test_results"
 STATUS_FILE_PASS = "P"
 STATUS_FILE_FAIL = "F"
 
@@ -2661,7 +2661,7 @@ def cleanRunnerDirectory
     raise unless $bundle
     Dir.foreach($runnerDir) {
         | filename |
-        next unless filename =~ /^#{STATUS_FILE_PREFIX}/
+        next unless filename =~ /^#{STATUS_FILE}/
         FileUtils.rm_f $runnerDir + filename
     }
 end
@@ -2818,6 +2818,21 @@ def copyBundleToRemote(remoteHost)
     mysys(["scp"] + SSH_OPTIONS_DEFAULT + (remoteHost.identity_file_path ? ["-i", remoteHost.identity_file_path] : []) + ["-P", remoteHost.port.to_s, ($outputDir.dirname + $tarFileName).to_s, "#{remoteHost.user}@#{remoteHost.host}:#{remoteHost.remoteDirectory}"])
 end
 
+def getLocalRemoteResultPath(remoteHost)
+    $outputDir.dirname + "#{remoteHost.host}-#{remoteHost.port}"
+end
+
+def copyRemoteResultToHost(remoteHost)
+    hostResultFolder = getLocalRemoteResultPath(remoteHost)
+    Dir.mkdir hostResultFolder unless hostResultFolder.directory?
+    mysys(["scp"] + SSH_OPTIONS_DEFAULT + (remoteHost.identity_file_path ? ["-i", remoteHost.identity_file_path] : []) + ["-P", remoteHost.port.to_s, "#{remoteHost.user}@#{remoteHost.host}:#{remoteHost.remoteDirectory}/#{$outputDir.basename}/.runner/#{STATUS_FILE}", "#{getLocalRemoteResultPath(remoteHost).to_s}/#{STATUS_FILE}" ])
+end
+
+def clearLocalRemoteResults(remoteHost)
+    hostResultFolder = getLocalRemoteResultPath(remoteHost)
+    FileUtils.rm_rf hostResultFolder
+end
+
 def exportBaseEnvironmentVariables(escape)
     if escape
         dyldFrameworkPath = "\\$(cd #{$testingFrameworkPath.dirname}; pwd)"
@@ -2853,7 +2868,7 @@ def runTestRunner(testRunner, remoteHosts, remoteIndex=0)
     end
 end
 
-STATUS_RE = /^[.]\/#{STATUS_FILE_PREFIX}(?<index>\d+)\s(?<runId>\h+)\s(?<exitCode>\d+)\s(?<result>#{STATUS_FILE_PASS}|#{STATUS_FILE_FAIL})$/
+STATUS_RE = /^(?<index>\d+)\s(?<runId>\h+)\s(?<exitCode>\d+)\s(?<result>#{STATUS_FILE_PASS}|#{STATUS_FILE_FAIL})$/
 
 def processStatusLine(map, line)
     md = STATUS_RE.match(line)
@@ -2887,7 +2902,6 @@ def processStatusLine(map, line)
 end
 
 def getStatusMap(map={})
-    find_cmd = "find . -maxdepth 1 -name \"#{STATUS_FILE_PREFIX}*\" -a -size +0c -exec sh -c \"printf \\\"%s \\\" {}; cat {}\" \\;"
     if $remote
         # Note: here we're using $remoteHosts (instead of getting the
         # list of live remoteHosts from the caller, because there may
@@ -2895,22 +2909,16 @@ def getStatusMap(map={})
         # (note, the test results are tagged with a run ID, so we'll
         # ignore any stale results from a previous run).
         forEachRemote($remoteHosts, :dropOnFailure => true, :timeout => 8 * REMOTE_TIMEOUT) { |_, host|
-            runnerDir = "#{host.remoteDirectory}/#{$outputDir.basename}/.runner"
-            output = sshRead("if test -d #{runnerDir}; then cd #{runnerDir}; else false; fi && " + find_cmd, host, :ignoreFailure => true)
-            output.split(/\n/).each {
-                | line |
-                processStatusLine(map, line)
-            }
+            copyRemoteResultToHost(host)
+            File.open(getLocalRemoteResultPath(host) + STATUS_FILE).each do |line|
+                processStatusLine(map, line.strip)
+            end
+            clearLocalRemoteResults(host)
         }
     else
         Dir.chdir($runnerDir) {
-            Dir.glob("#{STATUS_FILE_PREFIX}*").each do |name|
-                if File.size(name) > 0
-                    File.open(name, 'r') { |f|
-                        line = f.first
-                        processStatusLine(map, "./#{name} #{line}")
-                    }
-                end
+            File.open(STATUS_FILE).each do |line|
+                processStatusLine(map, line.strip)
             end
         }
     end

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -252,7 +252,7 @@ class Plan < BasePlan
     end
 
     def statusCommand(status)
-        "echo #{$runUniqueId} $exitCode #{status} > #{statusFile}"
+        "echo #{@index} #{$runUniqueId} $exitCode #{status} >> #{statusFile}"
     end
 
     def failCommand
@@ -272,7 +272,7 @@ class Plan < BasePlan
     end
     
     def statusFile
-        "#{STATUS_FILE_PREFIX}#{@index}"
+        "#{STATUS_FILE}"
     end
     
     def writeRunScript(filename)

--- a/Tools/Scripts/webkitruby/jsc-stress-test/executor.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test/executor.rb
@@ -209,7 +209,7 @@ module ExecutorSelfTests
                     index = @runlist[testIndex].index
                     # Because of infra issues, a test might have multiple results.
                     testResult.results.each { |result|
-                        line = "./#{STATUS_FILE_PREFIX}#{index} #{$runUniqueId} 0 #{result}"
+                        line = "#{index} #{$runUniqueId} 0 #{result}"
                         processStatusLine(statusMap, line)
                     }
                 }


### PR DESCRIPTION
#### bdd01b8335f05aab55cafe0677c2f6df565d2129
<pre>
Change to use single test results file for jsc tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=264908">https://bugs.webkit.org/show_bug.cgi?id=264908</a>
<a href="https://rdar.apple.com/118482056">rdar://118482056</a>

Reviewed by Ryan Haddad.

Currently we generate a test status file for each jsc test we run, and then
we will use a find command for remote devices to get the content of the each
file.

This find command is time consuming, it may take forever for low end embedded
device. This patch will make the test result ouput to a single file, then we copy
the file back the host, open it locally, and process the results line by line.
It will save a lot of time for the script to report the final status.

* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb:
* Tools/Scripts/webkitruby/jsc-stress-test/executor.rb:

Canonical link: <a href="https://commits.webkit.org/272663@main">https://commits.webkit.org/272663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a506c6fb0fb379566319213145c4998140a70fb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36470 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27937 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34570 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32632 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32429 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10252 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39070 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7581 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9189 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8249 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->