### PR TITLE
Port IPC::Semaphore to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -375,6 +375,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     NetworkProcess/storage/FileSystemStorageError.serialization.in
 
     Platform/IPC/FormDataReference.serialization.in
+    Platform/IPC/IPCSemaphore.serialization.in
     Platform/IPC/StreamServerConnection.serialization.in
 
     Platform/SharedMemory.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -146,6 +146,7 @@ $(PROJECT_DIR)/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
 $(PROJECT_DIR)/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
 $(PROJECT_DIR)/NetworkProcess/webtransport/NetworkTransportSession.messages.in
 $(PROJECT_DIR)/Platform/IPC/FormDataReference.serialization.in
+$(PROJECT_DIR)/Platform/IPC/IPCSemaphore.serialization.in
 $(PROJECT_DIR)/Platform/IPC/StreamServerConnection.serialization.in
 $(PROJECT_DIR)/Platform/SharedMemory.serialization.in
 $(PROJECT_DIR)/PluginProcess/PluginControllerProxy.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -499,6 +499,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in \
 	NetworkProcess/storage/FileSystemStorageError.serialization.in \
 	Platform/IPC/FormDataReference.serialization.in \
+	Platform/IPC/IPCSemaphore.serialization.in \
 	Platform/IPC/StreamServerConnection.serialization.in \
 	Platform/SharedMemory.serialization.in \
 	Shared/AuxiliaryProcessCreationParameters.serialization.in \

--- a/Source/WebKit/Platform/IPC/IPCEvent.h
+++ b/Source/WebKit/Platform/IPC/IPCEvent.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "Decoder.h"
+#include "Encoder.h"
 #include "IPCSemaphore.h"
 
 namespace IPC {
@@ -57,12 +59,12 @@ public:
 
     void encode(Encoder& encoder) &&
     {
-        m_semaphore.encode(encoder);
+        encoder << m_semaphore;
     }
 
     static std::optional<Signal> decode(Decoder& decoder)
     {
-        std::optional<Semaphore> semaphore = Semaphore::decode(decoder);
+        std::optional<Semaphore> semaphore = decoder.decode<Semaphore>();
         if (!semaphore)
             return std::nullopt;
 

--- a/Source/WebKit/Platform/IPC/IPCSemaphore.h
+++ b/Source/WebKit/Platform/IPC/IPCSemaphore.h
@@ -62,9 +62,6 @@ public:
     ~Semaphore();
     Semaphore& operator=(Semaphore&&);
 
-    void encode(Encoder&) const;
-    static std::optional<Semaphore> decode(Decoder&);
-
     void signal();
     bool wait();
     bool waitFor(Timeout);
@@ -76,8 +73,11 @@ public:
     explicit operator bool() const { return m_sendRight || m_semaphore != SEMAPHORE_NULL; }
 #elif OS(WINDOWS)
     explicit Semaphore(Win32Handle&&);
+    Win32Handle win32Handle() const { return Win32Handle { m_semaphoreHandle }; }
+
 #elif USE(UNIX_DOMAIN_SOCKETS)
     explicit Semaphore(UnixFileDescriptor&&);
+    UnixFileDescriptor duplicateDescriptor() const;
     explicit operator bool() const { return !!m_fd; }
 #else
     explicit operator bool() const { return true; }

--- a/Source/WebKit/Platform/IPC/IPCSemaphore.serialization.in
+++ b/Source/WebKit/Platform/IPC/IPCSemaphore.serialization.in
@@ -1,0 +1,35 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+webkit_platform_header: "IPCSemaphore.h"
+
+[CustomHeader, WebKitPlatform] class IPC::Semaphore {
+#if PLATFORM(COCOA)
+    MachSendRight createSendRight();
+#endif
+#if OS(WINDOWS)
+    Win32Handle win32Handle();
+#endif
+#if USE(UNIX_DOMAIN_SOCKETS)
+    UnixFileDescriptor duplicateDescriptor();
+#endif
+};

--- a/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
@@ -93,19 +93,6 @@ MachSendRight Semaphore::createSendRight() const
     return MachSendRight::create(m_semaphore);
 }
 
-void Semaphore::encode(Encoder& encoder) const
-{
-    encoder << createSendRight();
-}
-
-std::optional<Semaphore> Semaphore::decode(Decoder& decoder)
-{
-    MachSendRight sendRight;
-    if (!decoder.decode(sendRight))
-        return std::nullopt;
-    return std::optional<Semaphore> { std::in_place, WTFMove(sendRight) };
-}
-
 void Semaphore::destroy()
 {
     if (m_sendRight) {

--- a/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp
@@ -124,18 +124,9 @@ bool Semaphore::waitFor(Timeout timeout)
 #endif
 }
 
-void Semaphore::encode(Encoder& encoder) const
+UnixFileDescriptor Semaphore::duplicateDescriptor() const
 {
-    encoder << m_fd.duplicate();
-}
-
-std::optional<Semaphore> Semaphore::decode(Decoder& decoder)
-{
-    std::optional<UnixFileDescriptor> fd;
-    decoder >> fd;
-    if (!fd)
-        return std::nullopt;
-    return std::optional<Semaphore> { std::in_place, WTFMove(*fd) };
+    return m_fd.duplicate();
 }
 
 void Semaphore::destroy()

--- a/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
@@ -77,19 +77,6 @@ bool Semaphore::waitFor(Timeout timeout)
     return WAIT_OBJECT_0 == WaitForSingleObject(m_semaphoreHandle.get(), milliseconds);
 }
 
-void Semaphore::encode(Encoder& encoder) const
-{
-    encoder << Win32Handle { m_semaphoreHandle };
-}
-
-std::optional<Semaphore> Semaphore::decode(Decoder& decoder)
-{
-    auto semaphoreHandle = decoder.decode<Win32Handle>();
-    if (UNLIKELY(!decoder.isValid()))
-        return std::nullopt;
-    return Semaphore { WTFMove(*semaphoreHandle) };
-}
-
 void Semaphore::destroy()
 {
     m_semaphoreHandle = { };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4999,6 +4999,7 @@
 		46C71AC82A942E1800E459AF /* GoToBackForwardItemParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GoToBackForwardItemParameters.serialization.in; sourceTree = "<group>"; };
 		46C916A82799D09D001A4E7C /* WebSharedWorkerServer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSharedWorkerServer.cpp; sourceTree = "<group>"; };
 		46C916A92799D09D001A4E7C /* WebSharedWorkerServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSharedWorkerServer.h; sourceTree = "<group>"; };
+		46CD8C442B059FF500360248 /* IPCSemaphore.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IPCSemaphore.serialization.in; sourceTree = "<group>"; };
 		46CE3B1023D8C83D0016A96A /* WebBackForwardListCounts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackForwardListCounts.h; sourceTree = "<group>"; };
 		46D246242AFE954F00F24C94 /* PlatformCAAnimationRemoteProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformCAAnimationRemoteProperties.h; sourceTree = "<group>"; };
 		46D246252AFE954F00F24C94 /* PlatformCAAnimationRemoteProperties.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PlatformCAAnimationRemoteProperties.serialization.in; sourceTree = "<group>"; };
@@ -8901,6 +8902,7 @@
 				C0CE72AC1247E78D00BC0EC4 /* HandleMessage.h */,
 				A73E66BC2AB107BB005FC327 /* IPCEvent.h */,
 				A31F60A225CC7DB800AF14F4 /* IPCSemaphore.h */,
+				46CD8C442B059FF500360248 /* IPCSemaphore.serialization.in */,
 				7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */,
 				7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */,
 				9BF5EC6325410E9900984E77 /* JSIPCBinding.cpp */,

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -91,7 +91,7 @@ public:
     JSObjectRef createJSWrapper(JSContextRef);
     static JSIPCSemaphore* toWrapped(JSContextRef, JSValueRef);
 
-    void encode(IPC::Encoder& encoder) const { m_semaphore.encode(encoder); }
+    void encode(IPC::Encoder& encoder) const { encoder << m_semaphore; }
     IPC::Semaphore exchange(IPC::Semaphore&& semaphore = { })
     {
         return std::exchange(m_semaphore, WTFMove(semaphore));


### PR DESCRIPTION
#### bdc2cb3920a7260e347d3a7b01fd116959761bbc
<pre>
Port IPC::Semaphore to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264911">https://bugs.webkit.org/show_bug.cgi?id=264911</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/IPCSemaphore.h:
* Source/WebKit/Platform/IPC/IPCSemaphore.serialization.in: Added.
* Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp:
(IPC::Semaphore::encode const): Deleted.
(IPC::Semaphore::decode): Deleted.
* Source/WebKit/Platform/IPC/unix/IPCSemaphoreUnix.cpp:
(IPC::Semaphore::duplicateDescriptor const):
(IPC::Semaphore::encode const): Deleted.
(IPC::Semaphore::decode): Deleted.
* Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp:
(IPC::Semaphore::toWin32Handle const):
(IPC::Semaphore::encode const): Deleted.
(IPC::Semaphore::decode): Deleted.
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCSemaphore::encode const):

Canonical link: <a href="https://commits.webkit.org/270845@main">https://commits.webkit.org/270845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7180cee2f03fcf641a1f178f05abedcf39d6555

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24320 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2615 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3555 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29864 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27761 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5070 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6385 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->