### PR TITLE
[WebXR] Helpers for working with simd types

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -681,6 +681,7 @@ platform/text/cocoa/LocalizedDateCache.mm
 platform/text/mac/TextBoundaries.mm
 platform/text/mac/TextCheckingMac.mm
 platform/xr/cocoa/PlatformXRCocoa.mm
+platform/xr/cocoa/PlatformXRPose.cpp
 platform/text/mac/CoreTextChineseCompositionEngine.cpp
 platform/text/mac/CoreTextCompositionEngine.cpp
 rendering/AttachmentLayout.mm

--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ */
+
+#include "config.h"
+#include "PlatformXRPose.h"
+
+#if ENABLE(WEBXR) && PLATFORM(COCOA)
+
+WebCore::FloatPoint3D PlatformXRPose::position() const
+{
+    simd_float3 simdPosition = this->simdPosition();
+    return { static_cast<float>(simdPosition.x), static_cast<float>(simdPosition.y), static_cast<float>(simdPosition.z) };
+}
+
+PlatformXR::Device::FrameData::FloatQuaternion PlatformXRPose::orientation() const
+{
+    simd_quatf simdOrientation = this->simdOrientation();
+    return { simdOrientation.vector.x, simdOrientation.vector.y, simdOrientation.vector.z, simdOrientation.vector.w };
+}
+
+PlatformXR::Device::FrameData::Pose PlatformXRPose::pose() const
+{
+    PlatformXR::Device::FrameData::Pose pose;
+    pose.position = position();
+    pose.orientation = orientation();
+    return pose;
+}
+
+float PlatformXRPose::distanceToPose(const PlatformXRPose& otherPose) const
+{
+    simd_float3 position = simdPosition();
+    simd_float3 otherPosition = otherPose.simdPosition();
+    return simd_distance(position, otherPosition);
+}
+
+PlatformXRPose PlatformXRPose::verticalTransformPose() const
+{
+    simd_float3 position = simdPosition();
+    simd_float4x4 transform = matrix_identity_float4x4;
+    transform.columns[3].y  = position.y;
+    return PlatformXRPose(transform);
+}
+
+PlatformXRPose::PlatformXRPose(const simd_float4x4& transform)
+    : m_simdTransform(transform)
+{
+}
+
+PlatformXRPose::PlatformXRPose(const simd_float4x4& transform, const simd_float4x4& parentTransform)
+{
+    m_simdTransform = simd_mul(parentTransform, transform);
+}
+
+#endif // ENABLE(WEBXR) && PLATFORM(COCOA)

--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && PLATFORM(COCOA)
+
+#include <WebCore/PlatformXR.h>
+#include <simd/simd.h>
+
+class PlatformXRPose {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    simd_float4x4 simdTransform() const { return m_simdTransform; }
+    simd_float3 simdPosition() const { return m_simdTransform.columns[3].xyz; }
+    simd_quatf simdOrientation() const { return simd_quaternion(m_simdTransform); }
+    WEBCORE_EXPORT WebCore::FloatPoint3D position() const;
+    WEBCORE_EXPORT PlatformXR::Device::FrameData::FloatQuaternion orientation() const;
+    WEBCORE_EXPORT PlatformXR::Device::FrameData::Pose pose() const;
+
+    WEBCORE_EXPORT float distanceToPose(const PlatformXRPose&) const;
+    WEBCORE_EXPORT PlatformXRPose verticalTransformPose() const;
+
+    WEBCORE_EXPORT PlatformXRPose(const simd_float4x4&);
+    WEBCORE_EXPORT PlatformXRPose(const simd_float4x4&, const simd_float4x4& parentTransform);
+
+private:
+    simd_float4x4 m_simdTransform;
+};
+
+#endif // ENABLE(WEBXR) && PLATFORM(COCOA)


### PR DESCRIPTION
#### 44e258dc653d66642a736bab26b8df7f209d12ff
<pre>
[WebXR] Helpers for working with simd types
<a href="https://bugs.webkit.org/show_bug.cgi?id=264910">https://bugs.webkit.org/show_bug.cgi?id=264910</a>
<a href="https://rdar.apple.com/118482297">rdar://118482297</a>

Reviewed by Tim Horton.

PlatformXRPose is a helper for working with transforms as simd4_float4x4.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp: Added.
(PlatformXRPose::position const):
(PlatformXRPose::orientation const):
(PlatformXRPose::pose const):
(PlatformXRPose::distanceToPose const):
(PlatformXRPose::verticalTransformPose const):
(PlatformXRPose::PlatformXRPose):
* Source/WebCore/platform/xr/cocoa/PlatformXRPose.h: Added.

Canonical link: <a href="https://commits.webkit.org/270803@main">https://commits.webkit.org/270803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8d0373ff3a8b5148a9572a1189ad1e7aa8c9147

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27717 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28646 "") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/24208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6884 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/28646 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3907 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/28646 "") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29161 "Failed to print configuration") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24121 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29161 "Failed to print configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3521 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29161 "Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4954 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6353 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->