### PR TITLE
[UnifiedPDF] PDFPluginBase should send cursor updates to the web page

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -98,7 +98,6 @@ public:
     void notifyDisplayModeChanged(int);
 
     void notifySelectionChanged(PDFSelection *);
-    void notifyCursorChanged(uint64_t /* PDFLayerControllerCursorType */);
 
     // HUD Actions.
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -428,6 +428,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 @end
 
+static WebCore::Cursor::Type toWebCoreCursorType(PDFLayerControllerCursorType cursorType)
+{
+    switch (cursorType) {
+    case kPDFLayerControllerCursorTypePointer: return WebCore::Cursor::Type::Pointer;
+    case kPDFLayerControllerCursorTypeHand: return WebCore::Cursor::Type::Hand;
+    case kPDFLayerControllerCursorTypeIBeam: return WebCore::Cursor::Type::IBeam;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return WebCore::Cursor::Type::Pointer;
+}
+
 @implementation WKPDFLayerControllerDelegate
 
 @synthesize pdfPlugin = _pdfPlugin;
@@ -519,7 +531,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)setMouseCursor:(PDFLayerControllerCursorType)cursorType
 {
-    _pdfPlugin->notifyCursorChanged(cursorType);
+    _pdfPlugin->notifyCursorChanged(toWebCoreCursorType(cursorType));
 }
 
 - (void)didChangeAnnotationState
@@ -2290,27 +2302,6 @@ void PDFPlugin::notifySelectionChanged(PDFSelection *)
     if (!m_frame || !m_frame->page())
         return;
     m_frame->page()->didChangeSelection(*m_frame->coreLocalFrame());
-}
-
-static const WebCore::Cursor& coreCursor(PDFLayerControllerCursorType type)
-{
-    switch (type) {
-    case kPDFLayerControllerCursorTypeHand:
-        return WebCore::handCursor();
-    case kPDFLayerControllerCursorTypeIBeam:
-        return WebCore::iBeamCursor();
-    case kPDFLayerControllerCursorTypePointer:
-    default:
-        return WebCore::pointerCursor();
-    }
-}
-
-void PDFPlugin::notifyCursorChanged(uint64_t type)
-{
-    if (!m_frame || !m_frame->page())
-        return;
-
-    m_frame->page()->send(Messages::WebPageProxy::SetCursor(coreCursor(static_cast<PDFLayerControllerCursorType>(type))));
 }
 
 String PDFPlugin::getSelectionString() const

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -54,6 +54,7 @@ class HTMLPlugInElement;
 class ResourceResponse;
 class Scrollbar;
 class SharedBuffer;
+enum class PlatformCursorType : uint8_t;
 }
 
 namespace WebKit {
@@ -166,6 +167,8 @@ public:
     virtual void save(CompletionHandler<void(const String&, const URL&, const IPC::DataReference&)>&&) = 0;
     virtual void openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, const IPC::DataReference&, const String&)>&&) = 0;
 #endif
+
+    void notifyCursorChanged(WebCore::PlatformCursorType);
 
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -28,14 +28,17 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#import "MessageSenderInlines.h"
 #import "PluginView.h"
 #import "WebEventConversion.h"
 #import "WebFrame.h"
 #import "WebPage.h"
+#import "WebPageProxyMessages.h"
 #import <CoreFoundation/CoreFoundation.h>
 #import <WebCore/AXObjectCache.h>
 #import <WebCore/ArchiveResource.h>
 #import <WebCore/Chrome.h>
+#import <WebCore/Cursor.h>
 #import <WebCore/Document.h>
 #import <WebCore/FocusController.h>
 #import <WebCore/Frame.h>
@@ -557,6 +560,14 @@ bool PDFPluginBase::hudEnabled() const
 }
 
 #endif // ENABLE(PDF_HUD)
+
+void PDFPluginBase::notifyCursorChanged(WebCore::PlatformCursorType cursorType)
+{
+    if (!m_frame || !m_frame->page())
+        return;
+
+    m_frame->protectedPage()->send(Messages::WebPageProxy::SetCursor(WebCore::Cursor::fromType(cursorType)));
+}
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### ce5a85abac3927874650474cd432d10cbd3ca083
<pre>
[UnifiedPDF] PDFPluginBase should send cursor updates to the web page
<a href="https://bugs.webkit.org/show_bug.cgi?id=264913">https://bugs.webkit.org/show_bug.cgi?id=264913</a>
<a href="https://rdar.apple.com/118483364">rdar://118483364</a>

Reviewed by Tim Horton.

In preparation to get cursor updates working for `UnifiedPDFPlugin`, we
should move `PDFPlugin::notifyCursorChanged` up into the `PDFPluginBase`
structure. We should be doing the same (trivial) amount of work for both
PDF plugin types to send cursor updates to the web page.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(toWebCoreCursorType):
(-[WKPDFLayerControllerDelegate setMouseCursor:]):
(WebKit::PDFPlugin::notifySelectionChanged):
(WebKit::coreCursor): Deleted.
(WebKit::PDFPlugin::notifyCursorChanged): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::notifyCursorChanged):

Canonical link: <a href="https://commits.webkit.org/270863@main">https://commits.webkit.org/270863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cd8be781cf3be3499a9aaf7988b1bfe3f94c6d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24323 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24282 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3557 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29869 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27766 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5073 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->