### PR TITLE
Stop using EnumTraits in OptionSet

### DIFF
--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -39,59 +39,6 @@ namespace WTF {
 
 template<typename E> class OptionSet;
 
-
-template<typename T, typename E> struct OptionSetValueChecker;
-
-template<typename T, typename E, E e, E... es>
-struct OptionSetValueChecker<T, EnumValues<E, e, es...>> {
-    static constexpr T allValidBits()
-    {
-        return static_cast<T>(e) | OptionSetValueChecker<T, EnumValues<E, es...>>::allValidBits();
-    }
-
-    static constexpr bool isValidOptionSetEnum(T t)
-    {
-        return (static_cast<T>(e) == t) ? true : OptionSetValueChecker<T, EnumValues<E, es...>>::isValidOptionSetEnum(t);
-    }
-};
-
-template<typename T, typename E>
-struct OptionSetValueChecker<T, EnumValues<E>> {
-    static constexpr T allValidBits()
-    {
-        return 0;
-    }
-
-    static constexpr bool isValidOptionSetEnum(T)
-    {
-        return false;
-    }
-};
-
-template<typename E>
-constexpr std::enable_if_t<std::is_enum_v<E>, bool> isValidOptionSetEnum(E e)
-{
-    if constexpr (IsTypeComplete<EnumTraits<E>>)
-        return OptionSetValueChecker<std::underlying_type_t<E>, typename EnumTraits<E>::values>::isValidOptionSetEnum(static_cast<std::underlying_type_t<E>>(e));
-    else {
-        // FIXME: Remove once all OptionSet<> enums have EnumTraits<> defined.
-        return hasOneBitSet(static_cast<typename OptionSet<E>::StorageType>(e));
-    }
-}
-
-template<typename E>
-constexpr std::enable_if_t<std::is_enum_v<E>, typename OptionSet<E>::StorageType> maskRawValue(typename OptionSet<E>::StorageType rawValue)
-{
-    if constexpr (IsTypeComplete<EnumTraits<E>>) {
-        auto allValidBitsValue = OptionSetValueChecker<std::underlying_type_t<E>, typename EnumTraits<E>::values>::allValidBits();
-        return rawValue & allValidBitsValue;
-    } else {
-        // FIXME: Remove once all OptionSet<> enums have EnumTraits<> defined.
-        return rawValue;
-    }
-}
-
-
 // OptionSet is a class that represents a set of enumerators in a space-efficient manner. The enumerators
 // must be powers of two greater than 0. This class is useful as a replacement for passing a bitmask of
 // enumerators around.
@@ -130,12 +77,7 @@ public:
 
     static constexpr OptionSet fromRaw(StorageType rawValue)
     {
-        return OptionSet(static_cast<E>(maskRawValue<E>(rawValue)), FromRawValue);
-    }
-
-    static constexpr OptionSet all()
-    {
-        return fromRaw(std::numeric_limits<StorageType>::max());
+        return OptionSet(static_cast<E>(rawValue), FromRawValue);
     }
 
     constexpr OptionSet() = default;
@@ -143,13 +85,13 @@ public:
     constexpr OptionSet(E e)
         : m_storage(static_cast<StorageType>(e))
     {
-        ASSERT(!m_storage || isValidOptionSetEnum(e));
+        ASSERT(!m_storage || hasOneBitSet(static_cast<StorageType>(e)));
     }
 
     constexpr OptionSet(std::initializer_list<E> initializerList)
     {
         for (auto& option : initializerList) {
-            ASSERT(isValidOptionSetEnum(option));
+            ASSERT(hasOneBitSet(static_cast<StorageType>(option)));
             m_storage |= static_cast<StorageType>(option);
         }
     }
@@ -242,10 +184,23 @@ private:
     StorageType m_storage { 0 };
 };
 
+namespace IsValidOptionSetHelper {
+template<typename T, typename E> struct OptionSetValueChecker;
+template<typename T, typename E, E e, E... es>
+struct OptionSetValueChecker<T, EnumValues<E, e, es...>> {
+    static constexpr T allValidBits() { return static_cast<T>(e) | OptionSetValueChecker<T, EnumValues<E, es...>>::allValidBits(); }
+};
+template<typename T, typename E>
+struct OptionSetValueChecker<T, EnumValues<E>> {
+    static constexpr T allValidBits() { return 0; }
+};
+}
+
 template<typename E>
 WARN_UNUSED_RETURN constexpr bool isValidOptionSet(OptionSet<E> optionSet)
 {
-    auto allValidBitsValue = OptionSetValueChecker<std::make_unsigned_t<std::underlying_type_t<E>>, typename EnumTraits<E>::values>::allValidBits();
+    // FIXME: Remove this when all OptionSet enums are migrated to generated serialization.
+    auto allValidBitsValue = IsValidOptionSetHelper::OptionSetValueChecker<std::make_unsigned_t<std::underlying_type_t<E>>, typename EnumTraits<E>::values>::allValidBits();
     return (optionSet.toRaw() | allValidBitsValue) == allValidBitsValue;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
@@ -116,7 +116,7 @@ using CocoaModifierFlags = UIKeyModifierFlags;
 
 - (void)setModifierFlags:(CocoaModifierFlags)modifierFlags
 {
-    auto optionSet = OptionSet<WebKit::WebExtension::ModifierFlags>::fromRaw(modifierFlags);
+    auto optionSet = OptionSet<WebKit::WebExtension::ModifierFlags>::fromRaw(modifierFlags) & WebKit::WebExtension::allModifierFlags();
     NSAssert(optionSet.toRaw() == modifierFlags, @"Invalid parameter: an unsupported modifier flag was provided");
 
     _webExtensionCommand->setModifierFlags(optionSet);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -720,7 +720,7 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
         return { };
 
     if (properties == _WKWebExtensionTabChangedPropertiesAll)
-        return OptionSet<WebKit::WebExtensionTab::ChangedProperties>::all();
+        return WebKit::WebExtensionTab::allChangedProperties();
 
     OptionSet<WebKit::WebExtensionTab::ChangedProperties> result;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -128,6 +128,16 @@ public:
         Command = 1 << 20
     };
 
+    static constexpr OptionSet<ModifierFlags> allModifierFlags()
+    {
+        return {
+            ModifierFlags::Shift,
+            ModifierFlags::Control,
+            ModifierFlags::Option,
+            ModifierFlags::Command
+        };
+    }
+
     struct CommandData {
         String identifier;
         String description;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -78,6 +78,21 @@ public:
         ZoomFactor = 1 << 9,
     };
 
+    static constexpr OptionSet<ChangedProperties> allChangedProperties()
+    {
+        return {
+            ChangedProperties::Audible,
+            ChangedProperties::Loading,
+            ChangedProperties::Muted,
+            ChangedProperties::Pinned,
+            ChangedProperties::ReaderMode,
+            ChangedProperties::Size,
+            ChangedProperties::Title,
+            ChangedProperties::URL,
+            ChangedProperties::ZoomFactor,
+        };
+    }
+
     using ImageFormat = WebExtensionTabImageFormat;
 
     enum class AssumeWindowMatches : bool { No, Yes };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -50,6 +50,14 @@ enum class WebExtensionWindowTypeFilter : uint8_t {
     Popup  = 1 << 1,
 };
 
+static constexpr OptionSet<WebExtensionWindowTypeFilter> allWebExtensionWindowTypeFilters()
+{
+    return {
+        WebExtensionWindowTypeFilter::Normal,
+        WebExtensionWindowTypeFilter::Popup
+    };
+}
+
 class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow> {
     WTF_MAKE_NONCOPYABLE(WebExtensionWindow);
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -196,7 +196,7 @@ bool WebExtensionAPIWindows::parsePopulateTabs(NSDictionary *options, PopulateTa
 bool WebExtensionAPIWindows::parseWindowTypesFilter(NSDictionary *options, OptionSet<WindowTypeFilter>& windowTypeFilter, NSString *sourceKey, NSString **outExceptionString)
 {
     // All windows match by default.
-    windowTypeFilter = OptionSet<WindowTypeFilter>::all();
+    windowTypeFilter = allWebExtensionWindowTypeFilters();
 
     static NSDictionary<NSString *, id> *types = @{
         windowTypesKey: @[ NSString.class ],
@@ -597,7 +597,7 @@ inline OptionSet<WebExtensionWindowTypeFilter> toWindowTypeFilter(WebExtensionWi
 
 void WebExtensionContextProxy::dispatchWindowsEvent(WebExtensionEventListenerType type, const std::optional<WebExtensionWindowParameters>& windowParameters)
 {
-    auto filter = windowParameters ? toWindowTypeFilter(windowParameters.value().type.value()) : OptionSet<WebExtensionWindowTypeFilter>::all();
+    auto filter = windowParameters ? toWindowTypeFilter(windowParameters.value().type.value()) : allWebExtensionWindowTypeFilters();
 
     enumerateNamespaceObjects([&](auto& namespaceObject) {
         auto& windowsObject = namespaceObject.windows();


### PR DESCRIPTION
#### 57afbafbe26097d0816e24c85b2a9c096bcab60d
<pre>
Stop using EnumTraits in OptionSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=264903">https://bugs.webkit.org/show_bug.cgi?id=264903</a>

Reviewed by Timothy Hatcher.

It was used for only a few things:

1. It was used for isValidOptionSet, which is called when deserializing bytes from IPC.
   These uses are on their way to being entirely generated instead of using EnumTraits,
   and EnumTraits continues to be used for the types that are deserialized from IPC but
   have not yet been generated.
2. It was used in OptionSet::all to generate an OptionSet that contained only the valid
   bits.  The 3 uses of this function have been replaced by manually-written constexpr
   functions that are right next to the enum class definition, making it difficult to
   make errors of omission.  These 3 uses and any similar future uses are not worth
   keeping EnumTraits infrastructure around.
3. It was used to trim unused bits in OptionSet::fromRaw.  A manual inspection of all
   the functions named &quot;decodeForPersistence&quot; indicated that there are 0 places where
   OptionSet::fromRaw was used to &quot;parse&quot; data from disk.  Similarly, searching for
   &quot;&gt;::fromRaw(&quot; shows us the 36 places this is used, and most of them are just
   converting bit fields to OptionSets, but none of them are used to get data from an
   untrusted source and use operations like OptionSet::operator==.  Other operations
   like contains, add, remove, etc. are unaffected by unrecognized bits.
4. It was used for debug assertions in constructors that take enum values directly.  I
   replaced these assertions by stricter assertions using hasOneBitSet instead.

Generated serialization is generating isValidOptionSet functions directly, which keeps
our code from decoding unexpected bits from IPC to prevent untrusted, possibly
compromised web content processes from being able to do unexpected things.

* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::fromRaw):
(WTF::OptionSet::OptionSet):
(WTF::isValidOptionSet):
(WTF::isValidOptionSetEnum): Deleted.
(WTF::maskRawValue): Deleted.
(WTF::OptionSet::all): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(toImpl):
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
(WebKit::WebExtensionTab::allChangedProperties):
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
(WebKit::allWebExtensionWindowTypeFilters):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::parseWindowTypesFilter):
(WebKit::WebExtensionContextProxy::dispatchWindowsEvent):

Canonical link: <a href="https://commits.webkit.org/270838@main">https://commits.webkit.org/270838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ca513422153a803f745c3de4b96c9609278fdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24298 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2591 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3541 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29262 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23152 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24214 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25773 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27748 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5048 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33228 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6372 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4086 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7196 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3940 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->