### PR TITLE
REGRESSION (270663@main): safe-merge-queue failing status check step with exception

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2534,10 +2534,10 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
             return defer.returnValue(False if response.status_code // 100 == 4 else None)
 
         # FIXME: safe-merge-queue should obtain skipped status from EWS instead of hardcoding
-        queues_for_safe_merge = EMBEDDED_CHECKS + MACOS_CHECKS
+        queues_for_safe_merge = self.EMBEDDED_CHECKS + self.MACOS_CHECKS
         if self.getProperty('project') == GITHUB_PROJECTS[0]:
-            queues_for_safe_merge += LINUX_CHECKS
-            queues_for_safe_merge += WINDOWS_CHECKS
+            queues_for_safe_merge += self.LINUX_CHECKS
+            queues_for_safe_merge += self.WINDOWS_CHECKS
 
         for queue in queues_for_safe_merge:
             queue_data = response.json().get(queue, None)


### PR DESCRIPTION
#### ec96d3d0f797d1fbd61a66c8ae0b24324ec24483
<pre>
REGRESSION (270663@main): safe-merge-queue failing status check step with exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=264914">https://bugs.webkit.org/show_bug.cgi?id=264914</a>
<a href="https://rdar.apple.com/118485694">rdar://118485694</a>

Reviewed by Mike Wyrzykowski.

* Tools/CISupport/ews-build/steps.py:
(CheckStatusOfPR.getQueueStatusFromList): Add the missing `self` prefix so that we can
access the instance variables.

Canonical link: <a href="https://commits.webkit.org/270802@main">https://commits.webkit.org/270802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e48f926fe7e888f99f26d5229e63c4322fe25f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5075 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/27712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28636 "") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/24203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/26865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/6878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/2490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/28636 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26720 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/6878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/27712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/28636 "") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/6878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/27712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29153 "") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/6878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/27712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29153 "") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/2490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29153 "") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/26230 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4947 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/27712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/3995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3418 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->