### PR TITLE
Web Inspector: update test to actually evaluate promise from iframe

### DIFF
--- a/LayoutTests/inspector/runtime/callFunctionOn-awaitPromise.html
+++ b/LayoutTests/inspector/runtime/callFunctionOn-awaitPromise.html
@@ -188,7 +188,7 @@ function test()
         async test() {
             let thisObject = await RuntimeAgent.evaluate.invoke({expression: "myObject"});
             let result = await RuntimeAgent.callFunctionOn.invoke({
-                functionDeclaration: "async function() { return frames[0].iframePromise; }",
+                functionDeclaration: "function() { return frames[0].iframePromise; }",
                 awaitPromise: true,
                 returnByValue: true,
                 objectId: thisObject.result.objectId,


### PR DESCRIPTION
#### b6955d53f2d33b7238ebdfa982c6bf056f20eb9d
<pre>
Web Inspector: update test to actually evaluate promise from iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=264917">https://bugs.webkit.org/show_bug.cgi?id=264917</a>

Reviewed by Devin Rousso.

Updated the test to evaluate a promise that is actually created
in the iframe.

* LayoutTests/inspector/runtime/callFunctionOn-awaitPromise.html:

Canonical link: <a href="https://commits.webkit.org/270830@main">https://commits.webkit.org/270830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78e46f7a7ac63fb4fd81a057c9ea817c5d78b2e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27714 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28641 "Failed to print configuration") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24205 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2492 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/28641 "Failed to print configuration") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22723 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/28641 "Failed to print configuration") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23699 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29156 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24098 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29156 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1728 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29156 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23445 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6369 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->