### PR TITLE
Generate serializers for DDScannerResult and NSValue

### DIFF
--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -57,7 +57,10 @@
 #include "InternalsAdditions.h"
 #endif
 
+#if ENABLE(DATA_DETECTION)
 OBJC_CLASS DDScannerResult;
+#endif
+
 OBJC_CLASS VKCImageAnalysis;
 
 namespace WebCore {

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -197,12 +197,14 @@ $(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCArray.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFType.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCColor.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCData.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDate.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDictionary.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCError.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCFont.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSValue.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCString.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -517,12 +517,14 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCArray.serialization.in \
 	Shared/Cocoa/CoreIPCCFType.serialization.in \
 	Shared/Cocoa/CoreIPCColor.serialization.in \
+	Shared/Cocoa/CoreIPCDDScannerResult.serialization.in \
 	Shared/Cocoa/CoreIPCData.serialization.in \
 	Shared/Cocoa/CoreIPCDate.serialization.in \
 	Shared/Cocoa/CoreIPCDictionary.serialization.in \
 	Shared/Cocoa/CoreIPCError.serialization.in \
 	Shared/Cocoa/CoreIPCFont.serialization.in \
 	Shared/Cocoa/CoreIPCNSCFObject.serialization.in \
+	Shared/Cocoa/CoreIPCNSValue.serialization.in \
 	Shared/Cocoa/CoreIPCSecureCoding.serialization.in \
 	Shared/Cocoa/CoreIPCString.serialization.in \
 	Shared/Cocoa/CoreIPCURL.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -31,6 +31,10 @@
 
 #import <wtf/RetainPtr.h>
 
+#if ENABLE(DATA_DETECTION)
+OBJC_CLASS DDScannerResult;
+#endif
+
 namespace IPC {
 
 #ifdef __OBJC__
@@ -57,6 +61,9 @@ public:
 enum class NSType : uint8_t {
     Array,
     Color,
+#if ENABLE(DATA_DETECTION)
+    DDScannerResult,
+#endif
     Data,
     Date,
     Error,
@@ -66,12 +73,16 @@ enum class NSType : uint8_t {
     SecureCoding,
     String,
     URL,
+    NSValue,
     CF,
     Unknown,
 };
 NSType typeFromObject(id);
 bool isSerializableValue(id);
 
+#if ENABLE(DATA_DETECTION)
+template<> Class getClass<DDScannerResult>();
+#endif
 
 void encodeObjectWithWrapper(Encoder&, id);
 std::optional<RetainPtr<id>> decodeObjectFromWrapper(Decoder&, const HashSet<Class>& allowedClasses);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -261,6 +261,13 @@ using namespace WebCore;
 
 #pragma mark - Helpers
 
+#if ENABLE(DATA_DETECTION)
+template<> Class getClass<DDScannerResult>()
+{
+    return PAL::getDDScannerResultClass();
+}
+#endif
+
 NSType typeFromObject(id object)
 {
     ASSERT(object);
@@ -270,6 +277,10 @@ NSType typeFromObject(id object)
         return NSType::Array;
     if ([object isKindOfClass:[WebCore::CocoaColor class]])
         return NSType::Color;
+#if ENABLE(DATA_DETECTION)
+    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:[PAL::getDDScannerResultClass() class]])
+        return NSType::DDScannerResult;
+#endif
     if ([object isKindOfClass:[NSData class]])
         return NSType::Data;
     if ([object isKindOfClass:[NSDate class]])
@@ -282,6 +293,8 @@ NSType typeFromObject(id object)
         return NSType::Font;
     if ([object isKindOfClass:[NSNumber class]])
         return NSType::Number;
+    if ([object isKindOfClass:[NSValue class]])
+        return NSType::NSValue;
     if ([object isKindOfClass:[NSString class]])
         return NSType::String;
     if ([object isKindOfClass:[NSURL class]])

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h
@@ -25,43 +25,46 @@
 
 #pragma once
 
+#if ENABLE(DATA_DETECTION)
 #if PLATFORM(COCOA)
 
-#include <wtf/ArgumentCoder.h>
-#include <wtf/KeyValuePair.h>
+#include "ArgumentCodersCocoa.h"
+#include "CoreIPCDictionary.h"
+#include "CoreIPCSecureCoding.h"
 #include <wtf/RetainPtr.h>
-#include <wtf/UniqueRef.h>
-#include <wtf/Vector.h>
+
+OBJC_CLASS DDScannerResult;
 
 namespace WebKit {
 
 class CoreIPCNSCFObject;
 
-class CoreIPCDictionary {
-    WTF_MAKE_FAST_ALLOCATED;
+class CoreIPCDDScannerResult {
 public:
-    CoreIPCDictionary(NSDictionary *);
-
-    CoreIPCDictionary(const RetainPtr<NSDictionary>& dictionary)
-        : CoreIPCDictionary(dictionary.get())
+    CoreIPCDDScannerResult(DDScannerResult *);
+    CoreIPCDDScannerResult(const RetainPtr<DDScannerResult>& result)
+        : CoreIPCDDScannerResult(result.get())
     {
     }
 
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCDictionary, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCDDScannerResult, void>;
 
-    using ValueType = Vector<KeyValuePair<UniqueRef<CoreIPCNSCFObject>, UniqueRef<CoreIPCNSCFObject>>>;
+    using Value = std::variant<CoreIPCDictionary, CoreIPCSecureCoding>;
 
-    CoreIPCDictionary(ValueType&& keyValuePairs)
-        : m_keyValuePairs(WTFMove(keyValuePairs))
+    static Value valueFromDDScannerResult(DDScannerResult *);
+
+    CoreIPCDDScannerResult(Value&& value)
+        : m_value(WTFMove(value))
     {
     }
 
-    ValueType m_keyValuePairs;
+    Value m_value;
 };
 
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA)
+#endif // ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCDDScannerResult.h"
+
+#if ENABLE(DATA_DETECTION)
+#if PLATFORM(COCOA)
+
+#import "CoreIPCDictionary.h"
+#import "CoreIPCNSCFObject.h"
+#import <pal/cocoa/DataDetectorsCoreSoftLink.h>
+
+@interface DDScannerResult ()
+- (NSDictionary *)_webKitPropertyListData;
+- (id)_initWithWebKitPropertyListData:(NSDictionary *)plist;
+@end
+
+namespace WebKit {
+
+static bool shouldWrapDDScannerResult()
+{
+    static std::once_flag onceFlag;
+    static bool shouldWrap;
+    std::call_once(onceFlag, [&] {
+        shouldWrap = PAL::getDDScannerResultClass()
+            && [PAL::getDDScannerResultClass() instancesRespondToSelector:@selector(_webKitPropertyListData)]
+            && [PAL::getDDScannerResultClass() instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)];
+    });
+
+    return shouldWrap;
+}
+
+CoreIPCDDScannerResult::Value CoreIPCDDScannerResult::valueFromDDScannerResult(DDScannerResult *result)
+{
+    if (shouldWrapDDScannerResult())
+        return CoreIPCDictionary { [result _webKitPropertyListData] };
+    return CoreIPCSecureCoding { result };
+}
+
+CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *result)
+    : m_value(valueFromDDScannerResult(result))
+{
+}
+
+RetainPtr<id> CoreIPCDDScannerResult::toID() const
+{
+    RetainPtr<id> result;
+
+    WTF::switchOn(m_value,
+        [&](const CoreIPCDictionary& dictionary) {
+            ASSERT(shouldWrapDDScannerResult());
+            result = adoptNS([[PAL::getDDScannerResultClass() alloc] _initWithWebKitPropertyListData:dictionary.toID().get()]);
+        }, [&](const CoreIPCSecureCoding& secureCoding) {
+            result = secureCoding.toID();
+        }
+    );
+
+    return result;
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(COCOA)
+#endif // ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA) && ENABLE(DATA_DETECTION)
+
+webkit_platform_headers: "CoreIPCDDScannerResult.h"
+
+[WebKitPlatform] class WebKit::CoreIPCDDScannerResult {
+    WebKit::CoreIPCDDScannerResult::Value m_value
+}
+
+#endif // PLATFORM(COCOA) && ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -30,11 +30,13 @@
 #include "CoreIPCArray.h"
 #include "CoreIPCCFType.h"
 #include "CoreIPCColor.h"
+#include "CoreIPCDDScannerResult.h"
 #include "CoreIPCData.h"
 #include "CoreIPCDate.h"
 #include "CoreIPCDictionary.h"
 #include "CoreIPCError.h"
 #include "CoreIPCFont.h"
+#include "CoreIPCNSValue.h"
 #include "CoreIPCNumber.h"
 #include "CoreIPCSecureCoding.h"
 #include "CoreIPCString.h"
@@ -51,11 +53,15 @@ public:
         CoreIPCArray,
         CoreIPCCFType,
         CoreIPCColor,
+#if ENABLE(DATA_DETECTION)
+        CoreIPCDDScannerResult,
+#endif
         CoreIPCData,
         CoreIPCDate,
         CoreIPCDictionary,
         CoreIPCError,
         CoreIPCFont,
+        CoreIPCNSValue,
         CoreIPCNumber,
         CoreIPCSecureCoding,
         CoreIPCString,

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -43,6 +43,10 @@ static CoreIPCNSCFObject::ObjectValue valueFromID(id object)
         return CoreIPCArray((NSArray *)object);
     case IPC::NSType::Color:
         return CoreIPCColor((WebCore::CocoaColor *)object);
+#if ENABLE(DATA_DETECTION)
+    case IPC::NSType::DDScannerResult:
+        return CoreIPCDDScannerResult((DDScannerResult *)object);
+#endif
     case IPC::NSType::Data:
         return CoreIPCData((NSData *)object);
     case IPC::NSType::Date:
@@ -53,6 +57,8 @@ static CoreIPCNSCFObject::ObjectValue valueFromID(id object)
         return CoreIPCError((NSError *)object);
     case IPC::NSType::Font:
         return CoreIPCFont((WebCore::CocoaFont *)object);
+    case IPC::NSType::NSValue:
+        return CoreIPCNSValue((NSValue *)object);
     case IPC::NSType::Number:
         return CoreIPCNumber(bridge_cast((NSNumber *)object));
     case IPC::NSType::SecureCoding:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in
@@ -1,0 +1,36 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCNSValue.h" <Foundation/NSRange.h>
+
+[WebKitPlatform] struct _NSRange {
+    NSUInteger location;
+    NSUInteger length;
+}
+
+[WebKitPlatform] class WebKit::CoreIPCNSValue {
+    WebKit::CoreIPCNSValue::Value m_value
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
@@ -33,9 +33,13 @@
 namespace WebKit {
 
 class CoreIPCSecureCoding {
+WTF_MAKE_FAST_ALLOCATED;
 public:
     CoreIPCSecureCoding(NSObject<NSSecureCoding> *);
-    CoreIPCSecureCoding(RetainPtr<NSObject<NSSecureCoding>>&&);
+    CoreIPCSecureCoding(const RetainPtr<NSObject<NSSecureCoding>>& object)
+        : CoreIPCSecureCoding(object.get())
+    {
+    }
 
     RetainPtr<id> toID() const { return m_secureCoding; }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -35,13 +35,7 @@ namespace WebKit {
 CoreIPCSecureCoding::CoreIPCSecureCoding(NSObject<NSSecureCoding> *object)
     : m_secureCoding(object)
 {
-    RELEASE_ASSERT(!m_secureCoding || IPC::typeFromObject(object) == IPC::NSType::SecureCoding);
-}
-
-CoreIPCSecureCoding::CoreIPCSecureCoding(RetainPtr<NSObject<NSSecureCoding>>&& object)
-    : m_secureCoding(WTFMove(object))
-{
-    RELEASE_ASSERT(!m_secureCoding || IPC::typeFromObject(m_secureCoding.get()) == IPC::NSType::SecureCoding);
+    RELEASE_ASSERT(!m_secureCoding || [object conformsToProtocol:@protocol(NSSecureCoding)]);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -621,11 +621,6 @@ bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(De
 
 #if ENABLE(DATA_DETECTION)
 
-template<> Class getClass<DDScannerResult>()
-{
-    return PAL::getDDScannerResultClass();
-}
-
 void ArgumentCoder<WebCore::DataDetectorElementInfo>::encode(Encoder& encoder, const WebCore::DataDetectorElementInfo& info)
 {
     encoder << info.result.get();

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1203,6 +1203,10 @@
 		51A9E10B1315CD18009E7031 /* WKKeyValueStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A9E1091315CD18009E7031 /* WKKeyValueStorageManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51ACBB82127A8BAD00D203B9 /* WebContextMenuProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACBB81127A8BAD00D203B9 /* WebContextMenuProxy.h */; };
 		51ACBBA0127A8F2C00D203B9 /* WebContextMenuProxyMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACBB9E127A8F2C00D203B9 /* WebContextMenuProxyMac.h */; };
+		51ACFFD92B048804001331A2 /* CoreIPCDDScannerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACFFD62B048804001331A2 /* CoreIPCDDScannerResult.h */; };
+		51ACFFDF2B048821001331A2 /* CoreIPCNSValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */; };
+		51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */; };
+		51ACFFE12B048831001331A2 /* CoreIPCDDScannerResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51ACFFD42B048803001331A2 /* CoreIPCDDScannerResult.mm */; };
 		51B15A8513843A3900321AD8 /* EnvironmentUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B15A8313843A3900321AD8 /* EnvironmentUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51BE6C572AA92480001745C1 /* WebPushToolMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F64275A8D7E002DC22D /* WebPushToolMain.mm */; };
 		51BE6C5A2AA9250D001745C1 /* webpushtool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51BE6C582AA92503001745C1 /* webpushtool.cpp */; };
@@ -5275,6 +5279,12 @@
 		51ACBB9F127A8F2C00D203B9 /* WebContextMenuProxyMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContextMenuProxyMac.mm; sourceTree = "<group>"; };
 		51ACC9341628064800342550 /* NetworkProcessMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkProcessMessageReceiver.cpp; sourceTree = "<group>"; };
 		51ACC9351628064800342550 /* NetworkProcessMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcessMessages.h; sourceTree = "<group>"; };
+		51ACFFD42B048803001331A2 /* CoreIPCDDScannerResult.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDScannerResult.mm; sourceTree = "<group>"; };
+		51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCDDScannerResult.serialization.in; sourceTree = "<group>"; };
+		51ACFFD62B048804001331A2 /* CoreIPCDDScannerResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDScannerResult.h; sourceTree = "<group>"; };
+		51ACFFDA2B048820001331A2 /* CoreIPCNSValue.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNSValue.serialization.in; sourceTree = "<group>"; };
+		51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSValue.mm; sourceTree = "<group>"; };
+		51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSValue.h; sourceTree = "<group>"; };
 		51B15A8213843A3900321AD8 /* EnvironmentUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EnvironmentUtilities.cpp; path = unix/EnvironmentUtilities.cpp; sourceTree = "<group>"; };
 		51B15A8313843A3900321AD8 /* EnvironmentUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EnvironmentUtilities.h; path = unix/EnvironmentUtilities.h; sourceTree = "<group>"; };
 		51BE6C552AA92406001745C1 /* WebPushToolMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPushToolMain.h; sourceTree = "<group>"; };
@@ -10769,6 +10779,9 @@
 				F48C81E52AE0E1DF00073850 /* CoreIPCData.serialization.in */,
 				F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */,
 				F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */,
+				51ACFFD62B048804001331A2 /* CoreIPCDDScannerResult.h */,
+				51ACFFD42B048803001331A2 /* CoreIPCDDScannerResult.mm */,
+				51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */,
 				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
 				5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */,
 				5197FADE2AFD33B3009180C5 /* CoreIPCDictionary.serialization.in */,
@@ -10781,6 +10794,9 @@
 				5197FACE2AFD33AF009180C5 /* CoreIPCNSCFObject.h */,
 				5197FADC2AFD33B2009180C5 /* CoreIPCNSCFObject.mm */,
 				5197FAD02AFD33AF009180C5 /* CoreIPCNSCFObject.serialization.in */,
+				51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */,
+				51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */,
+				51ACFFDA2B048820001331A2 /* CoreIPCNSValue.serialization.in */,
 				5197FAD92AFD33B2009180C5 /* CoreIPCSecureCoding.h */,
 				5197FADA2AFD33B2009180C5 /* CoreIPCSecureCoding.mm */,
 				5197FAD12AFD33B0009180C5 /* CoreIPCSecureCoding.serialization.in */,
@@ -14977,10 +14993,12 @@
 				5197FAE82AFD33CF009180C5 /* CoreIPCColor.h in Headers */,
 				F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */,
 				F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */,
+				51ACFFD92B048804001331A2 /* CoreIPCDDScannerResult.h in Headers */,
 				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
 				F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */,
 				5197FAE32AFD33CF009180C5 /* CoreIPCFont.h in Headers */,
 				5197FAE42AFD33CF009180C5 /* CoreIPCNSCFObject.h in Headers */,
+				51ACFFDF2B048821001331A2 /* CoreIPCNSValue.h in Headers */,
 				F4EFF36D2AF0267300479AB8 /* CoreIPCNumber.h in Headers */,
 				5197FAE92AFD33CF009180C5 /* CoreIPCSecureCoding.h in Headers */,
 				5197FAE52AFD33CF009180C5 /* CoreIPCString.h in Headers */,
@@ -17801,10 +17819,12 @@
 				51FFD3092AE9A9FC00B0AB70 /* ArgumentCodersCocoa.mm in Sources */,
 				5131D5442AE9D4370016EF39 /* ArgumentCodersCocoa.mm in Sources */,
 				5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */,
+				51ACFFE12B048831001331A2 /* CoreIPCDDScannerResult.mm in Sources */,
 				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,
 				F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */,
 				5187BDF02B007445008A6EE5 /* CoreIPCFont.mm in Sources */,
 				5197FAF22AFD33FF009180C5 /* CoreIPCNSCFObject.mm in Sources */,
+				51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */,
 				5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */,
 				5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */,
 				7B9FC5D128A53014007570E7 /* PlatformUnifiedSource1-mm.mm in Sources */,


### PR DESCRIPTION
#### 72c2238b339fd7c807bb5f0d7f5534cb9cfc8f4f
<pre>
Generate serializers for DDScannerResult and NSValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=264915">https://bugs.webkit.org/show_bug.cgi?id=264915</a>
<a href="https://rdar.apple.com/118486039">rdar://118486039</a>

Reviewed by Alex Christensen.

This patch starts the process of breaking out specific secure coding types into their own wrappers.

Starting with DDScannerResult, it optionally uses SPI on the object if it exists to grab a directly
serializable NSDictionary, or it falls back to just wrapping the object itself like any secure coding type.

That NSDictionary is known to contain NSValues that wrap an NSRange, so this patch also adds an NSValue wrapper.

Currently, any NSValues that are serialized would go through the secure coding path.
For this one wrapped type we&apos;re known to need (NSRange), we go through a directly serialized code path.

Headed down this road, the goal is to identify all specific types we need to serialize, have a direct wrapper
for each, and reduce our reliance on the secure coding code path to zero.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;DDScannerResult&gt;):
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h.
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm.
(WebKit::shouldWrapDDScannerResult):
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
(WebKit::CoreIPCDDScannerResult::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h.
(WebKit::CoreIPCNSValue::CoreIPCNSValue):
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm.
(WebKit::CoreIPCNSValue::CoreIPCNSValue):
(WebKit::CoreIPCNSValue::toID const):
(WebKit::CoreIPCNSValue::shouldWrapValue):
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h:
(WebKit::CoreIPCSecureCoding::CoreIPCSecureCoding):
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
(WebKit::CoreIPCSecureCoding::CoreIPCSecureCoding):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::getClass&lt;DDScannerResult&gt;): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Since NSNumber is itself an NSValue, refactor these tests to explicitly emplace into the testing variant:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):
(fakeDataDetectorResultForTesting):

Canonical link: <a href="https://commits.webkit.org/270840@main">https://commits.webkit.org/270840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acbd61923934cf9f85b6838189d2c35e125a6082

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28772 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24290 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2582 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3531 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3572 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29840 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27734 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5040 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6377 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->