### PR TITLE
REGRESSION(268278@main): WTFCrash in ~CanMakeCheckedPtrBase of ~EventTarget

### DIFF
--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -224,6 +224,9 @@ private:
     Ref<Document> protectedDocument() const;
     Ref<ContainerNode> protectedAttachmentRoot() const;
 
+    // m_head has to be destroyed after destroying CheckedRef of m_document and m_attachmentRoot
+    HTMLStackItem m_head;
+
     CheckedRef<Document> m_document;
     
     // This is the root ContainerNode to which the parser attaches all newly
@@ -231,7 +234,6 @@ private:
     // and a Document in all other cases.
     CheckedRef<ContainerNode> m_attachmentRoot;
     
-    HTMLStackItem m_head;
     RefPtr<HTMLFormElement> m_form;
     mutable HTMLElementStack m_openElements;
     mutable HTMLFormattingElementList m_activeFormattingElements;


### PR DESCRIPTION
#### b43c0f571e0a944810dd7e721ea2b0dea21ffc2f
<pre>
REGRESSION(268278@main): WTFCrash in ~CanMakeCheckedPtrBase of ~EventTarget
<a href="https://bugs.webkit.org/show_bug.cgi?id=264382">https://bugs.webkit.org/show_bug.cgi?id=264382</a>

Reviewed by Chris Dumez.

Windows port was ocationally observing a CheckedPtr release check
failure in ~EventTarget with the following backtrace.

&gt; WebCore!WTFCrashWithInfo(void)+0x1d
&gt; WebCore!WTF::CanMakeCheckedPtrBase&lt;WTF::SingleThreadIntegralWrapper&lt;unsigned int&gt;,unsigned int&gt;::~CanMakeCheckedPtrBase(void)+0xab
&gt; WebCore!WebCore::EventTarget::~EventTarget(void)+0x11c
&gt; WebCore!WebCore::TextDocument::~TextDocument(int should_call_delete = 0n1)+0x10
&gt; WebCore!WebCore::Document::decrementReferencingNodeCount(void)+0x23
&gt; WebCore!WebCore::Node::~Node(void)+0xcf
&gt; WebCore!WebCore::Element::~Element(void)+0x13f
&gt; WebCore!WebCore::HTMLHeadElement::~HTMLHeadElement(int should_call_delete = 0n1)+0x10
&gt; WebCore!WebCore::Node::deref(void)+0x12
&gt; WebCore!WTF::DefaultRefDerefTraits&lt;WebCore::ContainerNode&gt;::derefIfNotNull(class WebCore::ContainerNode * ptr = &lt;Value unavailable error&gt;)+0x17
&gt; WebCore!WTF::RefPtr&lt;WebCore::ContainerNode,WTF::RawPtrTraits&lt;WebCore::ContainerNode&gt;,WTF::DefaultRefDerefTraits&lt;WebCore::ContainerNode&gt; &gt;::~RefPtr(void)+0x23
&gt; WebCore!WebCore::HTMLStackItem::~HTMLStackItem(void)+0x2c
&gt; WebCore!WebCore::HTMLConstructionSite::~HTMLConstructionSite(void)+0x84
&gt; WebCore!WebCore::HTMLTreeBuilder::~HTMLTreeBuilder(void)+0xce
&gt; [...]

This is under ~HTMLStackItem and ~HTMLConstructionSite. While
destroying m_head of HTMLConstructionSite, something still had a
CheckedPtr to the EventTarget.

268278@main adopted CheckedRef to m_document and m_attachmentRoot of
HTMLConstructionSite. m_document and m_attachmentRoot should be
destroyed before destroying m_head.

* Source/WebCore/html/parser/HTMLConstructionSite.h:
Reodered member variables so that m_head is destroyed after m_document
and m_attachmentRoot.

Canonical link: <a href="https://commits.webkit.org/270813@main">https://commits.webkit.org/270813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc8524d87908873bb64d9cbe1807160d38129761

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27721 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28653 "Failed to print configuration") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2499 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/28653 "Failed to print configuration") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22735 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/28653 "Failed to print configuration") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23711 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29167 "Failed to print configuration") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24110 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29167 "Failed to print configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1733 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29167 "Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4004 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3425 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->