### PR TITLE
Stop overriding -[UIResponder _characterInRelationToCaretSelection:] in WKContentView

### DIFF
--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -539,6 +539,7 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 @end
 
 @protocol UITextInputInternal
+- (UTF32Char)_characterInRelationToCaretSelection:(int)amount;
 - (CGRect)_selectionClipRect;
 - (void)moveByOffset:(NSInteger)offset;
 @optional


### PR DESCRIPTION
#### 8284b38b4eb51acd82731c4e97579b3f1bd786a5
<pre>
Stop overriding -[UIResponder _characterInRelationToCaretSelection:] in WKContentView
<a href="https://bugs.webkit.org/show_bug.cgi?id=264918">https://bugs.webkit.org/show_bug.cgi?id=264918</a>
<a href="https://rdar.apple.com/118028374">rdar://118028374</a>

Reviewed by Tim Horton.

Stop overriding `UIResponder`&apos;s default implementation of `-_characterInRelationToCaretSelection:`.
This internal method is consulted to determine what characters exist 1 character after and up to 2
characters before the start of the current selection, and is used to drive various keyboard-related
behaviors such as autocapitalization, autocorrection, dictation and smart spaces.

This is currently broken for WebKit2 unless we override this method with our custom logic, since the
default method in `UIResponder` uses several `UITextInput` methods that are (mostly) empty stubs in
WebKit2:

```
-positionFromPosition:offset:
-textRangeFromPosition:toPosition:
-textInRange:
```

...while a fully-fleshed-out implementation is incompatible with the fact that the real layout
information and DOM positions are inaccessible from the app process, we can still make UIKit return
the right answer using those above methods, by synchronously returning fake `UITextPosition` objects
that represent text positions at offsets relative to the start or end of the selection.

We then implement `-textInRange:`, and have it return cached values for the characters before or
after the start of the selection, using the same post-layout data that we&apos;re currently returning in
our custom implementation of `-_characterInRelationToCaretSelection:`.

Test: KeyboardInputTests.CharactersAroundCaretSelection

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(positionWithOffsetFrom):
(anchorsAndOffset):
(textRelativeToSelectionStart):
(-[WKRelativeTextPosition initWithAnchors:offset:]):
(-[WKRelativeTextPosition isRelativeToStart]):
(-[WKRelativeTextPosition description]):

Add a `UITextPosition` subclass that represents a position located at some character offset,
relative to either the selection start, or end, or both (in the case of a caret selection).

(-[WKRelativeTextRange initWithStart:end:]):
(-[WKRelativeTextRange start]):
(-[WKRelativeTextRange end]):
(-[WKRelativeTextRange isEmpty]):
(-[WKRelativeTextRange description]):

Add a `UITextRange` subclass that represents two visible positions, anchored relative to the start
or end of a text range.

(-[WKContentView textInRange:]):
(-[WKContentView textRangeFromPosition:toPosition:]):
(-[WKContentView positionFromPosition:offset:]):
(+[WKTextRange textRangeWithState:isRange:isEditable:startRect:endRect:selectionRects:selectedTextLength:]):
(-[WKTextRange start]):
(-[WKTextRange end]):
(-[WKContentView _characterInRelationToCaretSelection:]): Deleted.

Stop implementing this internal method.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:

Add an API test to exercise the change by using the previously-overridden method.

Canonical link: <a href="https://commits.webkit.org/270847@main">https://commits.webkit.org/270847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f25e981b331980418e98e7d08472e848cd02a111

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24189 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3464 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29778 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27672 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4979 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6384 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->