### PR TITLE
Web Inspector: only `awaitPromise` for builtin `@Promise`

### DIFF
--- a/LayoutTests/inspector/runtime/awaitPromise-expected.txt
+++ b/LayoutTests/inspector/runtime/awaitPromise-expected.txt
@@ -50,6 +50,14 @@ PASS: The rejected value should be {"a":1,"b":2}
 -- Running test case: Runtime.awaitPromise.Reject.Chain
 PASS: The rejected value should be 3.
 
+-- Running test case: Runtime.awaitPromise.CustomPromise
+PASS: Should produce an error.
+Error: Error: Object with given id is not a Promise
+
+-- Running test case: Runtime.awaitPromise.Thenable
+PASS: Should produce an error.
+Error: Error: Object with given id is not a Promise
+
 -- Running test case: Runtime.awaitPromise.Error.NonPromiseObjectId
 PASS: Should produce an error.
 Error: Error: Object with given id is not a Promise

--- a/LayoutTests/inspector/runtime/awaitPromise.html
+++ b/LayoutTests/inspector/runtime/awaitPromise.html
@@ -7,6 +7,24 @@
 if (window.internals)
     window.internals.settings.setUnhandledPromiseRejectionToConsoleEnabled(false);
 
+function createThenable() {
+    class Thenable {
+        then() { TestPage.log("FAIL: Should not invoke thenable then."); }
+        catch() { TestPage.log("FAIL: Should not invoke thenable catch."); }
+    }
+    return new Thenable;
+}
+
+function createCustomPromise() {
+    class Promise {
+        then() { TestPage.log("FAIL: Should not invoke custom promise then."); }
+        catch() { TestPage.log("FAIL: Should not invoke custom promise catch."); }
+    }
+    if (Promise === globalThis.Promise)
+        TestPage.log("FAIL: Using the wrong promise.");
+    return new Promise;
+}
+
 function test()
 {
     let savedResultCount = 0;
@@ -87,6 +105,34 @@ function test()
     addTest("Runtime.awaitPromise.Reject.Chain", `Promise.reject(1).catch(() => Promise.reject(2)).catch(() => Promise.reject(3))`, {}, async (remoteObject, wasThrown) => {
         InspectorTest.assert(wasThrown, "There should be an error.");
         InspectorTest.expectEqual(remoteObject.value, 3, "The rejected value should be 3.");
+    });
+
+    suite.addTestCase({
+        name: "Runtime.awaitPromise.CustomPromise",
+        async test() {
+            let evaluation = await RuntimeAgent.evaluate(`createCustomPromise()`);
+            try {
+                await RuntimeAgent.awaitPromise(evaluation.result.objectId);
+                InspectorTest.fail("Should not be able to call awaitPromise for a non-Promise object.");
+            } catch (error) {
+                InspectorTest.expectThat(error, "Should produce an error.");
+                InspectorTest.log("Error: " + error);
+            }
+        },
+    });
+
+    suite.addTestCase({
+        name: "Runtime.awaitPromise.Thenable",
+        async test() {
+            let evaluation = await RuntimeAgent.evaluate(`createThenable()`);
+            try {
+                await RuntimeAgent.awaitPromise(evaluation.result.objectId);
+                InspectorTest.fail("Should not be able to call awaitPromise for a non-Promise object.");
+            } catch (error) {
+                InspectorTest.expectThat(error, "Should produce an error.");
+                InspectorTest.log("Error: " + error);
+            }
+        },
     });
 
     suite.addTestCase({

--- a/LayoutTests/inspector/runtime/callFunctionOn-awaitPromise-expected.txt
+++ b/LayoutTests/inspector/runtime/callFunctionOn-awaitPromise-expected.txt
@@ -48,3 +48,11 @@ PASS: Should throw the JSON object.
 PASS: Should throw an error.
 {"preview":{"type":"object","description":"Object","lossless":true,"properties":[{"name":"a","type":"number","value":"2023"}]}}
 
+-- Running test case: AwaitCustomPromise
+PASS: Should not throw an error.
+{"preview":{"type":"object","description":"Promise","lossless":false,"properties":[]}}
+
+-- Running test case: AwaitThenable
+PASS: Should not throw an error.
+{"preview":{"type":"object","description":"Thenable","lossless":false,"properties":[]}}
+

--- a/LayoutTests/inspector/runtime/callFunctionOn-awaitPromise.html
+++ b/LayoutTests/inspector/runtime/callFunctionOn-awaitPromise.html
@@ -236,6 +236,53 @@ function test()
         },
     });
 
+
+    suite.addTestCase({
+        name: "AwaitCustomPromise",
+        async test() {
+            let thisObject = await RuntimeAgent.evaluate.invoke({expression: "myObject"});
+            let result = await RuntimeAgent.callFunctionOn.invoke({
+                functionDeclaration: `function() {
+    class Promise {
+        then() { TestPage.log("FAIL: Should not invoke custom promise then."); }
+        catch() { TestPage.log("FAIL: Should not invoke custom promise catch."); }
+    }
+    if (Promise === globalThis.Promise)
+        TestPage.log("FAIL: Using the wrong promise.");
+    return new Promise;
+}`,
+                awaitPromise: true,
+                returnByValue: false,
+                objectId: thisObject.result.objectId,
+            });
+            InspectorTest.expectFalse(result.wasThrown, "Should not throw an error.");
+            let preview = await RuntimeAgent.getPreview.invoke({objectId: result.result.objectId});
+            InspectorTest.log(preview);
+        },
+    });
+
+    suite.addTestCase({
+        name: "AwaitThenable",
+        async test() {
+            let thisObject = await RuntimeAgent.evaluate.invoke({expression: "myObject"});
+            let result = await RuntimeAgent.callFunctionOn.invoke({
+                functionDeclaration: `function() {
+    class Thenable {
+        then() { TestPage.log("FAIL: Should not invoke thenable then."); }
+        catch() { TestPage.log("FAIL: Should not invoke thenable catch."); }
+    }
+    return new Thenable;
+}`,
+                awaitPromise: true,
+                returnByValue: false,
+                objectId: thisObject.result.objectId,
+            });
+            InspectorTest.expectFalse(result.wasThrown, "Should not throw an error.");
+            let preview = await RuntimeAgent.getPreview.invoke({objectId: result.result.objectId});
+            InspectorTest.log(preview);
+        },
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -172,7 +172,7 @@ let InjectedScript = class InjectedScript extends PrototypelessObjectBase
             return;
         }
 
-        if (!(InjectedScriptHost.internalConstructorName(promiseObject) === "Promise")) {
+        if (!@isPromise(promiseObject)) {
             callback("Object with given id is not a Promise");
             return;
         }
@@ -238,7 +238,7 @@ let InjectedScript = class InjectedScript extends PrototypelessObjectBase
                 return;
             }
             let result = func.@apply(object, resolvedArgs);
-            if (awaitPromise && isDefined(result) && InjectedScriptHost.internalConstructorName(result) === "Promise") {
+            if (awaitPromise && isDefined(result) && @isPromise(result)) {
                 result.then((value) => {
                     callback(@createObjectWithoutPrototype(
                         "wasThrown", false,
@@ -752,7 +752,7 @@ let InjectedScript = class InjectedScript extends PrototypelessObjectBase
                 if (symbol)
                     fakeDescriptor.symbol = symbol;
                 // Silence any possible unhandledrejection exceptions created from accessing a native accessor with a wrong this object.
-                if (InjectedScriptHost.internalConstructorName(fakeDescriptor.value) === "Promise" && InjectedScriptHost.isPromiseRejectedWithNativeGetterTypeError(fakeDescriptor.value))
+                if (@isPromise(fakeDescriptor.value) && InjectedScriptHost.isPromiseRejectedWithNativeGetterTypeError(fakeDescriptor.value))
                     fakeDescriptor.value.@catch(function(){});
                 return fakeDescriptor;
             } catch (e) {


### PR DESCRIPTION
#### a7d66e60ea7f24d6d2ec35a47bb156c050d107ff
<pre>
Web Inspector: only `awaitPromise` for builtin `@Promise`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264920">https://bugs.webkit.org/show_bug.cgi?id=264920</a>

Reviewed by Patrick Angle.

Otherwise our (unchecked) attempts to `.@then()`/`.@catch()` could result in problems. We also don&apos;t really want to support nonstandard behavior (i.e. there&apos;s no guarantee that a custom &quot;thenable&quot; will actually have similar/matching behavior to `Promise.prototype.then`).

* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(InjectedScript.prototype.awaitPromise):
(InjectedScript.prototype.callFunctionOn):
(InjectedScript.prototype._forEachPropertyDescriptor.createFakeValueDescriptor):

* LayoutTests/inspector/runtime/awaitPromise.html:
* LayoutTests/inspector/runtime/awaitPromise-expected.txt:
* LayoutTests/inspector/runtime/callFunctionOn-awaitPromise.html:
* LayoutTests/inspector/runtime/callFunctionOn-awaitPromise-expected.txt:

Canonical link: <a href="https://commits.webkit.org/271249@main">https://commits.webkit.org/271249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00017ab519b70b255b838e4162dc54a3a313e40c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28679 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24228 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24187 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29186 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23087 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29779 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25702 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27673 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23477 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33151 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6675 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4019 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7185 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->