### PR TITLE
[Curl] Implements authentication challenge handling when server certificate evaluation fails in the WebSocket

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -938,7 +938,6 @@ http/tests/workers/service/openwindow-from-notification-click.html [ Failure ]
 http/tests/workers/service/service-worker-cache-api.https.html [ Failure ]
 http/tests/workers/service/service-worker-download-body.https.html [ Failure ]
 http/tests/workers/service/service-worker-download-stream.https.html [ Failure ]
-http/tests/workers/service/serviceworker-websocket.https.html [ Failure ]
 http/tests/workers/service/shownotification-denied.html [ Failure ]
 http/wpt/push-api/pushManager.any.html [ Failure ]
 http/wpt/push-api/pushManager.any.serviceworker.html [ Failure ]
@@ -2663,11 +2662,6 @@ webkit.org/b/263953 fast/url/idna2008.html [ Failure ]
 webkit.org/b/263953 fast/url/url-hostname-encoding.html [ Failure ]
 
 webkit.org/b/261308 imported/w3c/web-platform-tests/cookies/path/default.html [ Pass Failure ]
-
-webkit.org/b/264433 http/tests/websocket/tests/hybi/secure-cookie-secure-connection.pl [ Skip ] # Timeout
-webkit.org/b/264433 http/tests/websocket/tests/hybi/simple-wss.html [ Skip ] # Failure
-webkit.org/b/264433 imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html [ Skip ] # Failure
-webkit.org/b/264433 imported/w3c/web-platform-tests/cookies/secure/set-from-wss.https.sub.html [ Skip ] # Failure
 
 imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.worker.html [ Skip ] # Failure
 imported/w3c/web-platform-tests/wasm/serialization/module/serialization-via-notifications-api.any.html [ Skip ] # Failure

--- a/Source/WebCore/platform/network/curl/CurlStream.h
+++ b/Source/WebCore/platform/network/curl/CurlStream.h
@@ -43,20 +43,22 @@ class CurlStream {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(CurlStream);
 public:
+    enum class ServerTrustEvaluation : bool { Disable, Enable };
+
     class Client {
     public:
         virtual void didOpen(CurlStreamID) = 0;
         virtual void didSendData(CurlStreamID, size_t) = 0;
         virtual void didReceiveData(CurlStreamID, const SharedBuffer&) = 0;
-        virtual void didFail(CurlStreamID, CURLcode) = 0;
+        virtual void didFail(CurlStreamID, CURLcode, CertificateInfo&&) = 0;
     };
 
-    static std::unique_ptr<CurlStream> create(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url)
+    static std::unique_ptr<CurlStream> create(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url, ServerTrustEvaluation serverTrustEvaluation)
     {
-        return makeUnique<CurlStream>(scheduler, streamID, WTFMove(url));
+        return makeUnique<CurlStream>(scheduler, streamID, WTFMove(url), serverTrustEvaluation);
     }
 
-    CurlStream(CurlStreamScheduler&, CurlStreamID, URL&&);
+    CurlStream(CurlStreamScheduler&, CurlStreamID, URL&&, ServerTrustEvaluation);
     virtual ~CurlStream();
 
     void send(UniqueArray<uint8_t>&&, size_t);

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
@@ -40,7 +40,7 @@ CurlStreamScheduler::~CurlStreamScheduler()
     ASSERT(isMainThread());
 }
 
-CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Client& client)
+CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Client& client, CurlStream::ServerTrustEvaluation serverTrustEvaluation)
 {
     ASSERT(isMainThread());
 
@@ -51,8 +51,8 @@ CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Clien
     auto streamID = m_currentStreamID;
     m_clientList.add(streamID, &client);
 
-    callOnWorkerThread([this, streamID, url = url.isolatedCopy()]() mutable {
-        m_streamList.add(streamID, CurlStream::create(*this, streamID, WTFMove(url)));
+    callOnWorkerThread([this, streamID, url = url.isolatedCopy(), serverTrustEvaluation]() mutable {
+        m_streamList.add(streamID, CurlStream::create(*this, streamID, WTFMove(url), serverTrustEvaluation));
     });
 
     return streamID;

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
@@ -38,7 +38,7 @@ public:
     CurlStreamScheduler();
     virtual ~CurlStreamScheduler();
 
-    WEBCORE_EXPORT CurlStreamID createStream(const URL&, CurlStream::Client&);
+    WEBCORE_EXPORT CurlStreamID createStream(const URL&, CurlStream::Client&, CurlStream::ServerTrustEvaluation = CurlStream::ServerTrustEvaluation::Enable);
     WEBCORE_EXPORT void destroyStream(CurlStreamID);
     WEBCORE_EXPORT void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
 

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "NetworkSessionCurl.h"
 
+#include "AuthenticationManager.h"
 #include "NetworkProcess.h"
 #include "NetworkSessionCreationParameters.h"
 #include "WebCookieManager.h"
@@ -64,9 +65,14 @@ void NetworkSessionCurl::clearAlternativeServices(WallTime)
     networkStorageSession()->clearAlternativeServices();
 }
 
-std::unique_ptr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdentifier, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::AdvancedPrivacyProtections>, ShouldRelaxThirdPartyCookieBlocking, StoredCredentialsPolicy)
+std::unique_ptr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin& clientOrigin, bool, bool, OptionSet<WebCore::AdvancedPrivacyProtections>, ShouldRelaxThirdPartyCookieBlocking, StoredCredentialsPolicy)
 {
-    return makeUnique<WebSocketTask>(channel, request, protocol);
+    return makeUnique<WebSocketTask>(channel, webPageProxyID, request, protocol, clientOrigin);
+}
+
+void NetworkSessionCurl::didReceiveChallenge(WebSocketTask& webSocketTask, WebCore::AuthenticationChallenge&& challenge, CompletionHandler<void(WebKit::AuthenticationChallengeDisposition, const WebCore::Credential&)>&& challengeCompletionHandler)
+{
+    networkProcess().authenticationManager().didReceiveAuthenticationChallenge(sessionID(), webSocketTask.webProxyPageID(), !webSocketTask.topOrigin().isNull() ? &webSocketTask.topOrigin() : nullptr, challenge, NegotiatedLegacyTLS::No, WTFMove(challengeCompletionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h
@@ -25,11 +25,13 @@
 
 #pragma once
 
+#include "AuthenticationChallengeDisposition.h"
 #include "NetworkSession.h"
 
 namespace WebKit {
 
 struct NetworkSessionCreationParameters;
+class WebSocketTask;
 
 class NetworkSessionCurl final : public NetworkSession {
 public:
@@ -41,6 +43,8 @@ public:
     ~NetworkSessionCurl();
 
     void clearAlternativeServices(WallTime) override;
+
+    void didReceiveChallenge(WebSocketTask&, WebCore::AuthenticationChallenge&&, CompletionHandler<void(WebKit::AuthenticationChallengeDisposition, const WebCore::Credential&)>&&);
 
 private:
     std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy) final;


### PR DESCRIPTION
#### d5bb238e93ae50ca81233a2915e1f141d84b5b2c
<pre>
[Curl] Implements authentication challenge handling when server certificate evaluation fails in the WebSocket
<a href="https://bugs.webkit.org/show_bug.cgi?id=264433">https://bugs.webkit.org/show_bug.cgi?id=264433</a>

Reviewed by Fujii Hironori.

The WebSocket implementation of the Curl port did not implement handling
of authentication challenges when evaluating server certificates fails.
This causes some wss WebSocket tests to fail after 270374@main (bug#264366).
To solve this problem, we implement authentication challenge handling
to WebSocket.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/network/curl/CurlStream.cpp:
(WebCore::CurlStream::CurlStream):
(WebCore::CurlStream::notifyFailure):
* Source/WebCore/platform/network/curl/CurlStream.h:
(WebCore::CurlStream::create):
* Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp:
(WebCore::CurlStreamScheduler::createStream):
* Source/WebCore/platform/network/curl/CurlStreamScheduler.h:
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp:
(WebKit::NetworkSessionCurl::createWebSocketTask):
(WebKit::NetworkSessionCurl::didReceiveChallenge):
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h:
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::networkSession):
(WebKit::WebSocketTask::didFail):
(WebKit::WebSocketTask::tryServerTrustEvaluation):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h:
(WebKit::WebSocketTask::webProxyPageID const):
(WebKit::WebSocketTask::topOrigin const):

Canonical link: <a href="https://commits.webkit.org/270809@main">https://commits.webkit.org/270809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a49e778772800aadc9f360bd93fe44ea0d755161

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2505 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26742 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/3922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3454 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24115 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29770 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4010 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3421 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->