### PR TITLE
Stop using Vector::unsafeAppendWithoutCapacityCheck() in MarkedSpaceInlines.h

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
@@ -89,18 +89,19 @@ inline Ref<SharedTask<void(Visitor&)>> MarkedSpace::forEachWeakInParallel()
         {
         }
 
-        void drain(Vector<WeakBlock*, batchSize>& results)
+        std::span<WeakBlock*> drain(std::array<WeakBlock*, batchSize>& results)
         {
             Locker locker { m_lock };
+            size_t resultsSize = 0;
             while (true) {
                 if (m_current) {
                     auto* block = m_current;
                     m_current = m_current->next();
                     if (block->isEmpty())
                         continue;
-                    results.unsafeAppendWithoutCapacityCheck(block);
-                    if (results.size() == batchSize)
-                        return;
+                    results[resultsSize++] = block;
+                    if (resultsSize == batchSize)
+                        return std::span { results.begin(), resultsSize };
                     continue;
                 }
 
@@ -115,20 +116,19 @@ inline Ref<SharedTask<void(Visitor&)>> MarkedSpace::forEachWeakInParallel()
                     ++m_activeCursor;
                     continue;
                 }
-                return;
+                return std::span { results.begin(), resultsSize };
             }
         }
 
         void run(Visitor& visitor) final
         {
-            Vector<WeakBlock*, batchSize> results;
+            std::array<WeakBlock*, batchSize> resultsStorage;
             while (true) {
-                drain(results);
-                if (results.isEmpty())
+                auto results = drain(resultsStorage);
+                if (!results.size())
                     return;
-                for (WeakBlock* block : results)
-                    block->visit(visitor);
-                results.clear();
+                for (auto* result : results)
+                    result->visit(visitor);
             }
         }
 


### PR DESCRIPTION
#### 4b9b56921199bcc194e00f474c3608f5124aeb78
<pre>
Stop using Vector::unsafeAppendWithoutCapacityCheck() in MarkedSpaceInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=264922">https://bugs.webkit.org/show_bug.cgi?id=264922</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/heap/MarkedSpaceInlines.h:
(JSC::MarkedSpace::forEachWeakInParallel):

Canonical link: <a href="https://commits.webkit.org/270852@main">https://commits.webkit.org/270852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63ccbda1bac095d28e08da1a2495061fe5af3c70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2633 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26873 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/4070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3570 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29309 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23195 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29876 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25817 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27774 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5088 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33272 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6389 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4120 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7199 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->