### PR TITLE
[WebXR] Correct WebGL content over camera feed

### DIFF
--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
@@ -27,6 +27,17 @@ PlatformXR::Device::FrameData::Pose PlatformXRPose::pose() const
     return pose;
 }
 
+PlatformXRPose::FloatMatrix4 PlatformXRPose::toColumnMajorFloatArray() const
+{
+    const simd_float4 (&columns)[4] = m_simdTransform.columns;
+    return { {
+        columns[0][0], columns[0][1], columns[0][2], columns[0][3],
+        columns[1][0], columns[1][1], columns[1][2], columns[1][3],
+        columns[2][0], columns[2][1], columns[2][2], columns[2][3],
+        columns[3][0], columns[3][1], columns[3][2], columns[3][3],
+    } };
+}
+
 float PlatformXRPose::distanceToPose(const PlatformXRPose& otherPose) const
 {
     simd_float3 position = simdPosition();

--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
@@ -20,6 +20,9 @@ public:
     WEBCORE_EXPORT PlatformXR::Device::FrameData::FloatQuaternion orientation() const;
     WEBCORE_EXPORT PlatformXR::Device::FrameData::Pose pose() const;
 
+    using FloatMatrix4 = std::array<float, 16>;
+    WEBCORE_EXPORT FloatMatrix4 toColumnMajorFloatArray() const;
+
     WEBCORE_EXPORT float distanceToPose(const PlatformXRPose&) const;
     WEBCORE_EXPORT PlatformXRPose verticalTransformPose() const;
 

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -31,6 +31,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ARFrame;
 @class ARSession;
 
 @interface WKARPresentationSessionDescriptor : NSObject <NSCopying>
@@ -41,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @protocol WKARPresentationSession <NSObject>
+@property (nonatomic, retain, readonly) ARFrame *currentFrame;
 @property (nonatomic, retain, readonly) ARSession *session;
 @property (nonatomic, nonnull, retain, readonly) id<MTLSharedEvent> completionEvent;
 @property (nonatomic, nullable, retain, readonly) id<MTLTexture> colorTexture;


### PR DESCRIPTION
#### 88d7c41f6d42a67e5236ea7f8c358c1934ee8ee3
<pre>
[WebXR] Correct WebGL content over camera feed
<a href="https://bugs.webkit.org/show_bug.cgi?id=264925">https://bugs.webkit.org/show_bug.cgi?id=264925</a>
<a href="https://rdar.apple.com/118494318">rdar://118494318</a>

Reviewed by Dean Jackson.

Bug 262774 introduced rendering for WebGL content over ARKit provided camera
feed using a CAMetalLayer hosted swap chain. It was intended that the
MTLSharedEvent active.completionEvent would be used to pace the frames and delay
the present until the frame has been rendered in the GPUP. This didn&apos;t work and
would lead to Metal preventing from processing our content for misbehaving.

This patch removes blocking on completionEvent and replaces it with blocking on
a semaphore. This is the same approach present in the visionOS WebXR
system. While this means that we could be racing the rendering, resulting in
glitches, we no long lock up.

In addition, set frame views and origin correctly to make the device behave as
an &quot;interactive camera&quot; in the WebXR scene.

* Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp:
(PlatformXRPose::toColumnMajorFloatArray const):
* Source/WebCore/platform/xr/cocoa/PlatformXRPose.h:
helper toColumnMajorFloatArray() converts simd_float4x4 into a flat float[16]
for serialization.

* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
(WebKit::ARKitCoordinator::submitFrame):
(WebKit::ARKitCoordinator::renderLoop):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[_WKARPresentationSession currentFrame]):
(-[_WKARPresentationSession startFrame]):
(-[_WKARPresentationSession viewDidLoad]):
Vertically flip the CAMetalLayer so the WebGL is displayed the correct way up.

(-[_WKARPresentationSession present]):
(-[_WKARPresentationSession _loadMetal]):
Remote Metal command queue and command buffer.

Canonical link: <a href="https://commits.webkit.org/270848@main">https://commits.webkit.org/270848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c82c1cc33b89957dd438a4bde1a1e9e02a80c90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24193 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3515 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23736 "Found 1 new test failure: platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29782 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27676 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4983 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6387 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->