### PR TITLE
2D Context get/putImageData cache copies cached image data twice

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1039,16 +1039,16 @@ void CanvasRenderingContext2DBase::clip(Path2D& path, CanvasFillRule windingRule
     clipInternal(path.path(), windingRule);
 }
 
-static inline IntRect computeImageDataRect(const ImageBuffer& buffer, int width, int height, IntRect& destRect, const IntSize& destOffset)
+static inline IntRect computeImageDataRect(const ImageBuffer& buffer, IntSize sourceSize, IntRect& destRect, IntPoint destOffset)
 {
-    destRect.intersect(IntRect { 0, 0, width, height });
-    destRect.move(destOffset);
+    destRect.intersect(IntRect { { }, sourceSize });
+    destRect.moveBy(destOffset);
     destRect.intersect(IntRect { { }, buffer.truncatedLogicalSize() });
     if (destRect.isEmpty())
         return destRect;
     IntRect sourceRect { destRect };
-    sourceRect.move(-destOffset);
-    sourceRect.intersect(IntRect { 0, 0, width, height });
+    sourceRect.moveBy(-destOffset);
+    sourceRect.intersect(IntRect { { }, sourceSize });
     return sourceRect;
 }
 
@@ -2308,72 +2308,65 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::createImageData(int sw
     return imageData;
 }
 
-static void roundTripThroughPremultipliedRepresentationForQuantization(unsigned bytesPerRow, uint8_t* data, const IntSize& size)
-{
-    ConstPixelBufferConversionView source {
-        .format = {
-            .alphaFormat = AlphaPremultiplication::Unpremultiplied,
-            .pixelFormat = PixelFormat::RGBA8,
-            .colorSpace = DestinationColorSpace::SRGB(),
-        },
-        .bytesPerRow = bytesPerRow,
-        .rows = data,
-    };
-    PixelBufferConversionView destination {
-        .format = {
-            .alphaFormat = AlphaPremultiplication::Premultiplied,
-            .pixelFormat = PixelFormat::RGBA8,
-            .colorSpace = DestinationColorSpace::SRGB(),
-        },
-        .bytesPerRow = bytesPerRow,
-        .rows = data,
-    };
-    convertImagePixels(source, destination, size);
-
-    source.format.alphaFormat = AlphaPremultiplication::Premultiplied;
-    destination.format.alphaFormat = AlphaPremultiplication::Unpremultiplied;
-    convertImagePixels(source, destination, size);
-}
-
 void CanvasRenderingContext2DBase::evictCachedImageData()
 {
     if (m_cachedImageData)
-        m_cachedImageData->imageData = nullptr;
+        m_cachedImageData = std::nullopt;
 }
 
-CanvasRenderingContext2DBase::CachedImageData::CachedImageData(CanvasRenderingContext2DBase& context)
-    : evictionTimer(context, &CanvasRenderingContext2DBase::evictCachedImageData, 5_s)
+CanvasRenderingContext2DBase::CachedImageData::CachedImageData(CanvasRenderingContext2DBase& context, Ref<ByteArrayPixelBuffer> imageData)
+    : imageData(WTFMove(imageData))
+    , evictionTimer(context, &CanvasRenderingContext2DBase::evictCachedImageData, 5_s)
 {
 }
 
-static constexpr unsigned minimumConsecutiveCachedImageDataRequestsBeforeCaching = 2;
 static constexpr unsigned imageDataSizeThresholdForCaching = 60 * 60;
 
-bool CanvasRenderingContext2DBase::cacheImageDataIfPossible(ImageData& data, const IntPoint& destinationPosition, const IntRect& sourceRect)
+RefPtr<ByteArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossible(const ImageData& imageData, const IntRect& sourceRect, const IntPoint& destinationPosition)
 {
-    if (!destinationPosition.isZero() || !sourceRect.location().isZero() || sourceRect.size() != data.size() || sourceRect.size() != canvasBase().size())
-        return false;
+    if (!destinationPosition.isZero() || !sourceRect.location().isZero() || sourceRect.size() != imageData.size() || sourceRect.size() != canvasBase().size())
+        return nullptr;
 
-    if (data.colorSpace() != m_settings.colorSpace)
-        return false;
+    auto size = imageData.size();
+    if (size.area() > imageDataSizeThresholdForCaching)
+        return nullptr;
 
-    if (data.size().area() > imageDataSizeThresholdForCaching)
-        return false;
+    if (imageData.colorSpace() != m_settings.colorSpace)
+        return nullptr;
 
-    if (m_cachedImageData) {
-        if (++m_cachedImageData->requestCount >= minimumConsecutiveCachedImageDataRequestsBeforeCaching) {
-            m_cachedImageData->imageData = data.clone();
-            m_cachedImageData->evictionTimer.restart();
-        }
-    } else
-        m_cachedImageData.emplace(*this);
+    // Consider:
+    //   * Real putImageData needs premultiply step.
+    //   * Retrieve from cache needs to ensure premultiply + unpremultiply was made to simulate the real putImageData.
+    //   * Caching needs at least a memcpy here.
+    // Instead of doing the plain memcpy, copy by doing premultiply here.
+    // This computation can be used for cache retrieval as well as the real putImageData.
+    // We're not doing RGBA -> BGRA swizzle here, as that is not needed for cache retrieval and
+    // the swizzle copy can be made at the putImageData copy site.
+    auto colorSpace = toDestinationColorSpace(imageData.colorSpace());
+    unsigned bytesPerRow = static_cast<unsigned>(size.width()) * 4u;
+    PixelBufferFormat cachedFormat { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, colorSpace };
+    auto cachedBuffer = ByteArrayPixelBuffer::tryCreate(cachedFormat, size);
+    if (!cachedBuffer)
+        return nullptr;
+    ConstPixelBufferConversionView source {
+        .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace },
+        .bytesPerRow = bytesPerRow,
+        .rows = imageData.data().data(),
+    };
+    PixelBufferConversionView destination {
+        .format = cachedFormat,
+        .bytesPerRow = bytesPerRow,
+        .rows = cachedBuffer->data().data(),
+    };
+    convertImagePixels(source, destination, size);
 
-    return true;
+    m_cachedImageData.emplace(*this, *cachedBuffer);
+    return cachedBuffer;
 }
 
 RefPtr<ImageData> CanvasRenderingContext2DBase::takeCachedImageDataIfPossible(const IntRect& sourceRect, PredefinedColorSpace colorSpace) const
 {
-    if (!m_cachedImageData || !m_cachedImageData->imageData)
+    if (!m_cachedImageData)
         return nullptr;
 
     if (sourceRect != IntRect { { }, canvasBase().size() })
@@ -2385,14 +2378,23 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::takeCachedImageDataIfPossible(co
     if (colorSpace != m_settings.colorSpace)
         return nullptr;
 
-    ++m_cachedImageData->requestCount;
-
-    RefPtr result = m_cachedImageData->imageData.releaseNonNull();
-
-    if (result)
-        roundTripThroughPremultipliedRepresentationForQuantization(static_cast<unsigned>(result->size().width() * 4), result->data().data(), result->size());
-
-    return result;
+    Ref pixelBuffer = WTFMove(m_cachedImageData->imageData);
+    m_cachedImageData = std::nullopt;
+    auto size = pixelBuffer->size();
+    auto data = pixelBuffer->takeData();
+    unsigned bytesPerRow = static_cast<unsigned>(size.width()) * 4u;
+    ConstPixelBufferConversionView source {
+        .format = pixelBuffer->format(),
+        .bytesPerRow = bytesPerRow,
+        .rows = data->data(),
+    };
+    PixelBufferConversionView destination {
+        .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, pixelBuffer->format().colorSpace },
+        .bytesPerRow = bytesPerRow,
+        .rows = data->data(),
+    };
+    convertImagePixels(source, destination, size);
+    return ImageData::create(size, WTFMove(data), m_settings.colorSpace);
 }
 
 ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, int sy, int sw, int sh, std::optional<ImageDataSettings> settings) const
@@ -2422,7 +2424,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     if (auto imageData = takeCachedImageDataIfPossible({ sx, sy, sw, sh }, computedColorSpace))
         return imageData.releaseNonNull();
     if (m_cachedImageData)
-        m_cachedImageData->imageData = nullptr;
+        m_cachedImageData = std::nullopt;
 
     canvasBase().makeRenderingResultsAvailable();
     RefPtr buffer = canvasBase().buffer();
@@ -2470,20 +2472,19 @@ void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy,
         dirtyHeight = -dirtyHeight;
     }
 
-    IntSize destOffset { dx, dy };
+    IntPoint destOffset { dx, dy };
     IntRect destRect { dirtyX, dirtyY, dirtyWidth, dirtyHeight };
-    // FIXME: computeImageDataRect also updates destRect. Maybe return a tuple? Or move
-    // the calculation of the real destRect to here.
-    IntRect sourceRect = computeImageDataRect(*buffer, data.width(), data.height(), destRect, destOffset);
-
-    if (!sourceRect.isEmpty())
-        buffer->putPixelBuffer(data.pixelBuffer(), sourceRect, IntPoint { destOffset });
+    IntRect sourceRect = computeImageDataRect(*buffer, data.size(), destRect, destOffset);
 
     OptionSet<DidDrawOption> options; // ignore transform, shadow, clip, and post-processing
-
-    if (cacheImageDataIfPossible(data, { dx, dy }, sourceRect))
-        options.add(DidDrawOption::PreserveCachedImageData);
-
+    if (!sourceRect.isEmpty()) {
+        auto pixelBuffer = cacheImageDataIfPossible(data, sourceRect, destOffset);
+        if (pixelBuffer)
+            options.add(DidDrawOption::PreserveCachedImageData);
+        else
+            pixelBuffer = data.pixelBuffer();
+        buffer->putPixelBuffer(*pixelBuffer, sourceRect, destOffset);
+    }
     didDraw(FloatRect { destRect }, options);
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -53,6 +53,7 @@
 
 namespace WebCore {
 
+class ByteArrayPixelBuffer;
 class CachedImage;
 class CanvasGradient;
 class DOMMatrix;
@@ -324,11 +325,10 @@ protected:
 
 private:
     struct CachedImageData {
-        CachedImageData(CanvasRenderingContext2DBase&);
+        CachedImageData(CanvasRenderingContext2DBase&, Ref<ByteArrayPixelBuffer>);
 
-        RefPtr<ImageData> imageData;
+        Ref<ByteArrayPixelBuffer> imageData;
         DeferrableOneShotTimer evictionTimer;
-        unsigned requestCount = 0;
     };
 
     void applyLineDash() const;
@@ -444,7 +444,7 @@ private:
 
     FloatPoint textOffset(float width, TextDirection);
 
-    bool cacheImageDataIfPossible(ImageData&, const IntPoint& destinationPosition, const IntRect& sourceRect);
+    RefPtr<ByteArrayPixelBuffer> cacheImageDataIfPossible(const ImageData&, const IntRect& sourceRect, const IntPoint& destinationPosition);
     RefPtr<ImageData> takeCachedImageDataIfPossible(const IntRect& sourceRect, PredefinedColorSpace) const;
     void evictCachedImageData();
 


### PR DESCRIPTION
#### 83d967c4920fe7d5eaeb957ddc5e2e236abce6a2
<pre>
2D Context get/putImageData cache copies cached image data twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=264927">https://bugs.webkit.org/show_bug.cgi?id=264927</a>
<a href="https://rdar.apple.com/118497211">rdar://118497211</a>

Reviewed by Cameron McCormack.

Store the PixelBuffer that was used for putImageData,
avoid copying the the ImageData redundantly.

Instead of copying during caching, copy with premultiply.
This way we omit one memcpy for caching and one premultiply for the real
putImageData.

To simplify the implementation, removes the conservative approach
where the caching would kick in at 3rd putImageData. Just cache
the first.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::takeCachedImageDataIfPossible const):
(WebCore::CanvasRenderingContext2DBase::putImageData):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:

Canonical link: <a href="https://commits.webkit.org/270975@main">https://commits.webkit.org/270975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19ba692a9ce38d4fea8b35cbbbebe30edac24f12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24228 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3548 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23777 "Found 1 new test failure: platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29229 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24175 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29229 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1784 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29229 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5016 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6477 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->