### PR TITLE
Fix PlayStation build after 270770@main

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -56,6 +56,7 @@ list(APPEND WebCore_SOURCES
     platform/playstation/MIMETypeRegistryPlayStation.cpp
     platform/playstation/PlatformScreenPlayStation.cpp
     platform/playstation/ScrollbarThemePlayStation.cpp
+    platform/playstation/ThemePlayStation.cpp
     platform/playstation/UserAgentPlayStation.cpp
 
     platform/text/Hyphenation.cpp

--- a/Source/WebCore/platform/playstation/ThemePlayStation.cpp
+++ b/Source/WebCore/platform/playstation/ThemePlayStation.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2018 Sony Interactive Entertainment Inc.
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,15 +24,15 @@
  */
 
 #include "config.h"
-#include "RenderThemePlayStation.h"
+#include "ThemePlayStation.h"
 
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
-RenderTheme& RenderTheme::singleton()
+Theme& Theme::singleton()
 {
-    static NeverDestroyed<RenderThemePlayStation> theme;
+    static NeverDestroyed<ThemePlayStation> theme;
     return theme;
 }
 

--- a/Source/WebCore/platform/playstation/ThemePlayStation.h
+++ b/Source/WebCore/platform/playstation/ThemePlayStation.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2018 Sony Interactive Entertainment Inc.
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,17 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "RenderThemePlayStation.h"
+#pragma once
 
-#include <wtf/NeverDestroyed.h>
+#include "Theme.h"
 
 namespace WebCore {
 
-RenderTheme& RenderTheme::singleton()
-{
-    static NeverDestroyed<RenderThemePlayStation> theme;
-    return theme;
-}
+class ThemePlayStation final : public Theme {
+private:
+    friend NeverDestroyed<ThemePlayStation>;
+};
 
 } // namespace WebCore


### PR DESCRIPTION
#### 5d3e502dfd43fa419482c258d6b7bb7678668813
<pre>
Fix PlayStation build after 270770@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=264929">https://bugs.webkit.org/show_bug.cgi?id=264929</a>

Reviewed by Don Olmstead.

Add ThemePlayStation and implement Theme::singleton().

* Source/WebCore/PlatformPlayStation.cmake: Add new file.
* Source/WebCore/platform/playstation/ThemePlayStation.cpp: Added.
* Source/WebCore/platform/playstation/ThemePlayStation.h: Added.
* Source/WebCore/rendering/RenderThemePlayStation.cpp: Fix bogus include.

Canonical link: <a href="https://commits.webkit.org/270829@main">https://commits.webkit.org/270829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db2e29d28e7c5506d645c5649b85f168c32152fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24210 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3480 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29204 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29790 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3559 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27686 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4033 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3431 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->