### PR TITLE
2D context get/putImageData cache should be aware of empty contents

### DIFF
--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -38,10 +38,7 @@ namespace WebCore {
 
 static CheckedUint32 computeDataSize(const IntSize& size)
 {
-    CheckedUint32 checkedDataSize = 4;
-    checkedDataSize *= static_cast<unsigned>(size.width());
-    checkedDataSize *= static_cast<unsigned>(size.height());
-    return checkedDataSize;
+    return PixelBuffer::computeBufferSize(PixelFormat::RGBA8, size);
 }
 
 PredefinedColorSpace ImageData::computeColorSpace(std::optional<ImageDataSettings> settings, PredefinedColorSpace defaultColorSpace)
@@ -64,7 +61,7 @@ RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer)
     return create(pixelBuffer.releaseNonNull());
 }
 
-RefPtr<ImageData> ImageData::create(const IntSize& size)
+RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace colorSpace)
 {
     auto dataSize = computeDataSize(size);
     if (dataSize.hasOverflowed())
@@ -72,7 +69,7 @@ RefPtr<ImageData> ImageData::create(const IntSize& size)
     auto byteArray = Uint8ClampedArray::tryCreateUninitialized(dataSize);
     if (!byteArray)
         return nullptr;
-    return adoptRef(*new ImageData(size, byteArray.releaseNonNull(), PredefinedColorSpace::SRGB));
+    return adoptRef(*new ImageData(size, byteArray.releaseNonNull(), colorSpace));
 }
 
 RefPtr<ImageData> ImageData::create(const IntSize& size, Ref<Uint8ClampedArray>&& byteArray, PredefinedColorSpace colorSpace)

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -42,7 +42,7 @@ class ImageData : public RefCounted<ImageData> {
 public:
     WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&);
     WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&);
-    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&);
+    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, Ref<Uint8ClampedArray>&&, PredefinedColorSpace);
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> createUninitialized(unsigned rows, unsigned pixelsPerRow, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> = std::nullopt);
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, std::optional<ImageDataSettings>);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -100,6 +100,7 @@ void CanvasRenderingContext2D::drawFocusIfNeededInternal(const Path& path, Eleme
     if (!element.focused() || !state().hasInvertibleTransform || path.isEmpty() || !element.isDescendantOf(canvas()) || !context)
         return;
     context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(element.document().styleColorOptions(canvas().computedStyle())));
+    didDrawEntireCanvas();
 }
 
 void CanvasRenderingContext2D::setFont(const String& newFont)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -309,39 +309,12 @@ protected:
     State& modifiableState() { ASSERT(!m_unrealizedSaveCount || m_stateStack.size() >= MaxSaveCount); return m_stateStack.last(); }
 
     GraphicsContext* drawingContext() const;
-
-    static String normalizeSpaces(const String&);
-
-    void drawText(const String& text, double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
-    bool canDrawText(double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
-    void drawTextUnchecked(const TextRun&, double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
-
-    Ref<TextMetrics> measureTextInternal(const TextRun&);
-    Ref<TextMetrics> measureTextInternal(const String& text);
-
-    bool usesCSSCompatibilityParseMode() const { return m_usesCSSCompatibilityParseMode; }
-
-    OptionSet<ImageBufferOptions> adjustImageBufferOptionsForTesting(OptionSet<ImageBufferOptions>) final;
-
-private:
-    struct CachedImageData {
-        CachedImageData(CanvasRenderingContext2DBase&, Ref<ByteArrayPixelBuffer>);
-
-        Ref<ByteArrayPixelBuffer> imageData;
-        DeferrableOneShotTimer evictionTimer;
-    };
-
-    void applyLineDash() const;
-    void setShadow(const FloatSize& offset, float blur, const Color&);
-    void applyShadow();
-    bool shouldDrawShadows() const;
-
     enum class DidDrawOption {
         ApplyTransform = 1 << 0,
         ApplyShadow = 1 << 1,
         ApplyClip = 1 << 2,
         ApplyPostProcessing = 1 << 3,
-        PreserveCachedImageData = 1 << 4,
+        PreserveCachedContents = 1 << 4,
     };
 
     static constexpr OptionSet<DidDrawOption> defaultDidDrawOptions()
@@ -362,11 +335,40 @@ private:
             DidDrawOption::ApplyClip,
         };
     }
-
     void didDraw(std::optional<FloatRect>, OptionSet<DidDrawOption> = defaultDidDrawOptions());
     void didDrawEntireCanvas(OptionSet<DidDrawOption> options = defaultDidDrawOptions());
     void didDraw(bool entireCanvas, const FloatRect&, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
     template<typename RectProvider> void didDraw(bool entireCanvas, RectProvider, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
+
+    static String normalizeSpaces(const String&);
+
+    void drawText(const String& text, double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
+    bool canDrawText(double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
+    void drawTextUnchecked(const TextRun&, double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
+
+    Ref<TextMetrics> measureTextInternal(const TextRun&);
+    Ref<TextMetrics> measureTextInternal(const String& text);
+
+    bool usesCSSCompatibilityParseMode() const { return m_usesCSSCompatibilityParseMode; }
+
+    OptionSet<ImageBufferOptions> adjustImageBufferOptionsForTesting(OptionSet<ImageBufferOptions>) final;
+
+private:
+    struct CachedContentsTransparent {
+    };
+    struct CachedContentsUnknown {
+    };
+    struct CachedContentsImageData {
+        CachedContentsImageData(CanvasRenderingContext2DBase&, Ref<ByteArrayPixelBuffer>);
+
+        Ref<ByteArrayPixelBuffer> imageData;
+        DeferrableOneShotTimer evictionTimer;
+    };
+
+    void applyLineDash() const;
+    void setShadow(const FloatSize& offset, float blur, const Color&);
+    void applyShadow();
+    bool shouldDrawShadows() const;
 
     bool is2dBase() const final { return true; }
     bool needsPreparationForDisplay() const final;
@@ -445,7 +447,7 @@ private:
     FloatPoint textOffset(float width, TextDirection);
 
     RefPtr<ByteArrayPixelBuffer> cacheImageDataIfPossible(const ImageData&, const IntRect& sourceRect, const IntPoint& destinationPosition);
-    RefPtr<ImageData> takeCachedImageDataIfPossible(const IntRect& sourceRect, PredefinedColorSpace) const;
+    RefPtr<ImageData> makeImageDataIfContentsCached(const IntRect& sourceRect, PredefinedColorSpace) const;
     void evictCachedImageData();
 
     static constexpr unsigned MaxSaveCount = 1024 * 16;
@@ -453,7 +455,7 @@ private:
     FloatRect m_dirtyRect;
     unsigned m_unrealizedSaveCount { 0 };
     bool m_usesCSSCompatibilityParseMode;
-    mutable std::optional<CachedImageData> m_cachedImageData;
+    mutable std::variant<CachedContentsTransparent, CachedContentsUnknown, CachedContentsImageData> m_cachedContents;
     CanvasRenderingContext2DSettings m_settings;
 };
 

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -43,7 +43,7 @@ std::optional<Ref<ByteArrayPixelBuffer>> ByteArrayPixelBuffer::create(const Pixe
         return std::nullopt;
     }
 
-    auto computedBufferSize = PixelBuffer::computeBufferSize(format, size);
+    auto computedBufferSize = PixelBuffer::computeBufferSize(format.pixelFormat, size);
     if (computedBufferSize.hasOverflowed()) {
         ASSERT_NOT_REACHED();
         return std::nullopt;
@@ -67,10 +67,8 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
 {
     ASSERT(supportedPixelFormat(format.pixelFormat));
 
-    auto bufferSize = computeBufferSize(format, size);
+    auto bufferSize = computeBufferSize(format.pixelFormat, size);
     if (bufferSize.hasOverflowed())
-        return nullptr;
-    if (bufferSize > std::numeric_limits<int32_t>::max())
         return nullptr;
 
     auto data = Uint8ClampedArray::tryCreateUninitialized(bufferSize);
@@ -84,7 +82,7 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
 {
     ASSERT(supportedPixelFormat(format.pixelFormat));
 
-    auto bufferSize = computeBufferSize(format, size);
+    auto bufferSize = computeBufferSize(format.pixelFormat, size);
     if (bufferSize.hasOverflowed())
         return nullptr;
     if (bufferSize != arrayBuffer->byteLength())

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -48,13 +48,15 @@ bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
     return false;
 }
 
-CheckedUint32 PixelBuffer::computeBufferSize(const PixelBufferFormat& format, const IntSize& size)
+CheckedUint32 PixelBuffer::computeBufferSize(PixelFormat pixelFormat, const IntSize& size)
 {
-    ASSERT_UNUSED(format, supportedPixelFormat(format.pixelFormat));
-
+    ASSERT_UNUSED(pixelFormat, supportedPixelFormat(pixelFormat));
     constexpr unsigned bytesPerPixel = 4;
+    auto bufferSize = CheckedUint32 { size.width() } * size.height() * bytesPerPixel;
+    if (!bufferSize.hasOverflowed() && bufferSize.value() > std::numeric_limits<int32_t>::max())
+        bufferSize.overflowed();
+    return bufferSize;
 
-    return size.area<RecordOverflow>() * bytesPerPixel;
 }
 
 PixelBuffer::PixelBuffer(const PixelBufferFormat& format, const IntSize& size, uint8_t* bytes, size_t sizeInBytes)

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -38,6 +38,8 @@ namespace WebCore {
 class PixelBuffer : public RefCounted<PixelBuffer> {
     WTF_MAKE_NONCOPYABLE(PixelBuffer);
 public:
+    WEBCORE_EXPORT static CheckedUint32 computeBufferSize(PixelFormat, const IntSize&);
+
     WEBCORE_EXPORT static bool supportedPixelFormat(PixelFormat);
 
     WEBCORE_EXPORT virtual ~PixelBuffer();
@@ -61,8 +63,6 @@ public:
 protected:
     WEBCORE_EXPORT PixelBuffer(const PixelBufferFormat&, const IntSize&, uint8_t* bytes, size_t sizeInBytes);
     
-    WEBCORE_EXPORT static CheckedUint32 computeBufferSize(const PixelBufferFormat&, const IntSize&);
-
     PixelBufferFormat m_format;
     IntSize m_size;
 

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
@@ -35,12 +35,9 @@ RefPtr<ShareablePixelBuffer> ShareablePixelBuffer::tryCreate(const PixelBufferFo
 {
     ASSERT(supportedPixelFormat(format.pixelFormat));
 
-    auto bufferSize = computeBufferSize(format, size);
+    auto bufferSize = computeBufferSize(format.pixelFormat, size);
     if (bufferSize.hasOverflowed())
         return nullptr;
-    if (bufferSize > std::numeric_limits<int32_t>::max())
-        return nullptr;
-
     RefPtr<SharedMemory> sharedMemory = SharedMemory::allocate(bufferSize);
     if (!sharedMemory)
         return nullptr;


### PR DESCRIPTION
#### abc23583c3fded932dce57b3a4cdfa547d771464
<pre>
2D context get/putImageData cache should be aware of empty contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=264930">https://bugs.webkit.org/show_bug.cgi?id=264930</a>
<a href="https://rdar.apple.com/118499949">rdar://118499949</a>

Reviewed by Cameron McCormack.

Avoid real ImageBuffer::getPixelBuffer when getImageData is called
for a new 2D context. Track the transparent contents state and
just return zero filled ImageData buffer.

Hardens ImageData to ensure the data buffer is not created too big.
The buffer size is limited with PixelBuffer max size.
This would be caught with test
fast/canvas/canvas-getImageData-invalid-result-buffer-crash.html

Fixes a bug where CG path of text drawing would not mark the canvas
as modified. This would be caught with test
fast/canvas/gradient-text-with-shadow.html

Fixes a bug where focus drawing would not mark the canvas as modified.
This would be caught with test
fast/canvas/draw-focus-if-needed-with-path.html
fast/canvas/draw-focus-if-needed.html

* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
* Source/WebCore/html/ImageData.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::reset):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::evictCachedImageData):
(WebCore::CanvasRenderingContext2DBase::CachedContentsImageData::CachedContentsImageData):
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::putImageData):
(WebCore::CanvasRenderingContext2DBase::CachedImageData::CachedImageData): Deleted.
(WebCore::CanvasRenderingContext2DBase::takeCachedImageDataIfPossible const): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:

Canonical link: <a href="https://commits.webkit.org/271462@main">https://commits.webkit.org/271462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2762e2504380bc9dcbf27d8874172e799ed181ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25220 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30943 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28809 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6264 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6820 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5189 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->