### PR TITLE
Add style invalidity state for animations

### DIFF
--- a/Source/WebCore/animation/ElementAnimationRareData.h
+++ b/Source/WebCore/animation/ElementAnimationRareData.h
@@ -58,9 +58,10 @@ public:
     void cssAnimationsDidUpdate() { m_hasPendingKeyframesUpdate = false; }
     void keyframesRuleDidChange() { m_hasPendingKeyframesUpdate = true; }
     bool hasPendingKeyframesUpdate() const { return m_hasPendingKeyframesUpdate; }
+    bool hasPropertiesOverridenAfterAnimation() const { return m_hasPropertiesOverridenAfterAnimation; }
+    void setHasPropertiesOverridenAfterAnimation(bool value) { m_hasPropertiesOverridenAfterAnimation = value; }
 
 private:
-
     std::unique_ptr<KeyframeEffectStack> m_keyframeEffectStack;
     std::unique_ptr<const RenderStyle> m_lastStyleChangeEventStyle;
     AnimationCollection m_animations;
@@ -69,6 +70,7 @@ private:
     AnimatableCSSPropertyToTransitionMap m_runningTransitionsByProperty;
     PseudoId m_pseudoId;
     bool m_hasPendingKeyframesUpdate { false };
+    bool m_hasPropertiesOverridenAfterAnimation { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2430,6 +2430,11 @@ void Element::invalidateStyleInternal()
     Node::invalidateStyle(Style::Validity::ElementInvalid);
 }
 
+void Element::invalidateStyleForAnimation()
+{
+    Node::invalidateStyle(Style::Validity::AnimationInvalid);
+}
+
 void Element::invalidateStyleForSubtreeInternal()
 {
     Node::invalidateStyle(Style::Validity::SubtreeInvalid);
@@ -4626,6 +4631,23 @@ void Element::setLastStyleChangeEventStyle(PseudoId pseudoId, std::unique_ptr<co
         animationData->setLastStyleChangeEventStyle(WTFMove(style));
     else if (style)
         ensureAnimationRareData(pseudoId).setLastStyleChangeEventStyle(WTFMove(style));
+}
+
+bool Element::hasPropertiesOverridenAfterAnimation(PseudoId pseudoId) const
+{
+    if (auto* animationData = animationRareData(pseudoId))
+        return animationData->hasPropertiesOverridenAfterAnimation();
+    return false;
+}
+
+void Element::setHasPropertiesOverridenAfterAnimation(PseudoId pseudoId, bool value)
+{
+    if (auto* animationData = animationRareData(pseudoId)) {
+        animationData->setHasPropertiesOverridenAfterAnimation(value);
+        return;
+    }
+    if (value)
+        ensureAnimationRareData(pseudoId).setHasPropertiesOverridenAfterAnimation(true);
 }
 
 void Element::cssAnimationsDidUpdate(PseudoId pseudoId)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -583,6 +583,8 @@ public:
 
     const RenderStyle* lastStyleChangeEventStyle(PseudoId) const;
     void setLastStyleChangeEventStyle(PseudoId, std::unique_ptr<const RenderStyle>&&);
+    bool hasPropertiesOverridenAfterAnimation(PseudoId) const;
+    void setHasPropertiesOverridenAfterAnimation(PseudoId, bool);
 
     void cssAnimationsDidUpdate(PseudoId);
     void keyframesRuleDidChange(PseudoId);
@@ -696,6 +698,7 @@ public:
     void invalidateStyleAndRenderersForSubtree();
 
     void invalidateStyleInternal();
+    void invalidateStyleForAnimation();
     void invalidateStyleForSubtreeInternal();
     void invalidateForQueryContainerSizeChange();
     void invalidateForResumingQueryContainerResolution();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -707,8 +707,8 @@ protected:
         void clearDescendantsNeedStyleResolution() { m_flags = (flags() - NodeStyleFlag::DescendantNeedsStyleResolution - NodeStyleFlag::DirectChildNeedsStyleResolution).toRaw(); }
 
     private:
-        uint16_t m_styleValidity : 2;
-        uint16_t m_flags : 14;
+        uint16_t m_styleValidity : 3;
+        uint16_t m_flags : 13;
     };
 
     StyleBitfields styleBitfields() const { return StyleBitfields::fromRaw(m_rendererWithStyleFlags.type()); }

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -159,7 +159,8 @@ Invalidator::CheckDescendants Invalidator::invalidateIfNeeded(Element& element, 
         invalidateAssignedElements(downcast<HTMLSlotElement>(element));
 
     switch (element.styleValidity()) {
-    case Style::Validity::Valid: {
+    case Validity::Valid:
+    case Validity::AnimationInvalid: {
         for (auto& ruleSet : m_ruleSets) {
             ElementRuleCollector ruleCollector(element, *ruleSet, selectorMatchingState);
             ruleCollector.setMode(SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements);
@@ -172,10 +173,10 @@ Invalidator::CheckDescendants Invalidator::invalidateIfNeeded(Element& element, 
 
         return CheckDescendants::Yes;
     }
-    case Style::Validity::ElementInvalid:
+    case Validity::ElementInvalid:
         return CheckDescendants::Yes;
-    case Style::Validity::SubtreeInvalid:
-    case Style::Validity::SubtreeAndRenderersInvalid:
+    case Validity::SubtreeInvalid:
+    case Validity::SubtreeAndRenderersInvalid:
         return CheckDescendants::No;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -60,7 +60,7 @@ public:
     bool hasUnresolvedQueryContainers() const { return m_hasUnresolvedQueryContainers; }
 
 private:
-    enum class ResolutionType : uint8_t { FastPathInherit, Full };
+    enum class ResolutionType : uint8_t { AnimationOnly, FastPathInherit, Full };
     ResolvedStyle styleForStyleable(const Styleable&, ResolutionType, const ResolutionContext&);
 
     void resolveComposedTree();

--- a/Source/WebCore/style/StyleValidity.h
+++ b/Source/WebCore/style/StyleValidity.h
@@ -28,19 +28,20 @@
 namespace WebCore {
 namespace Style {
 
-enum class Validity {
+enum class Validity : uint8_t {
     Valid,
+    AnimationInvalid,
     ElementInvalid,
     SubtreeInvalid,
     SubtreeAndRenderersInvalid
 };
 
-enum class InvalidationMode {
+enum class InvalidationMode : uint8_t {
     Normal,
     RecompositeLayer
 };
 
-enum class InvalidationScope {
+enum class InvalidationScope : uint8_t {
     All,
     SelfChildrenAndSiblings,
     Descendants

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -153,6 +153,16 @@ struct Styleable {
         element.setLastStyleChangeEventStyle(pseudoId, WTFMove(style));
     }
 
+    bool hasPropertiesOverridenAfterAnimation() const
+    {
+        return element.hasPropertiesOverridenAfterAnimation(pseudoId);
+    }
+
+    void setHasPropertiesOverridenAfterAnimation(bool value) const
+    {
+        element.setHasPropertiesOverridenAfterAnimation(pseudoId, value);
+    }
+
     void keyframesRuleDidChange() const
     {
         element.keyframesRuleDidChange(pseudoId);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -826,6 +826,8 @@ static String styleValidityToToString(Style::Validity validity)
     switch (validity) {
     case Style::Validity::Valid:
         return "NoStyleChange"_s;
+    case Style::Validity::AnimationInvalid:
+        return "AnimationInvalid"_s;
     case Style::Validity::ElementInvalid:
         return "InlineStyleChange"_s;
     case Style::Validity::SubtreeInvalid:


### PR DESCRIPTION
#### c5a71dadf89f5816fedaab3d7efaaec4e247fdc6
<pre>
Add style invalidity state for animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=264932">https://bugs.webkit.org/show_bug.cgi?id=264932</a>
<a href="https://rdar.apple.com/118500247">rdar://118500247</a>

Reviewed by Antoine Quint.

We may be able to apply animation effects only without reapplying normal style rules.

* Source/WebCore/animation/ElementAnimationRareData.h:
(WebCore::ElementAnimationRareData::hasPropertiesOverridenAfterAnimation const):
(WebCore::ElementAnimationRareData::setHasPropertiesOverridenAfterAnimation):

If we have rules the override animation effects we can not use this optimization.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::invalidateElement):

Set the animation invalidity state instead of invaliding the element fully.

(WebCore::KeyframeEffect::animationDidChangeTimingProperties):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateStyleForAnimation):
(WebCore::Element::hasPropertiesOverridenAfterAnimation const):
(WebCore::Element::setHasPropertiesOverridenAfterAnimation):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateIfNeeded):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):

Use the base style from the previous frame instead of computing it again if only
the animation is invalid.

(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::determineResolutionType):
(WebCore::Style::shouldResolvePseudoElement): Deleted.
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/StyleValidity.h:
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::hasPropertiesOverridenAfterAnimation const):
(WebCore::Styleable::setHasPropertiesOverridenAfterAnimation const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::styleValidityToToString):

Canonical link: <a href="https://commits.webkit.org/270890@main">https://commits.webkit.org/270890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f31bbd48cdea8dfaf1e0b60a40cf0471ccd3dff3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24444 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2745 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3662 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24345 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27868 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5190 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6421 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->