### PR TITLE
[GStreamer][WebCodecs][Debug] ASSERTs in video encoder

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -62,7 +62,7 @@ public:
 private:
     GStreamerInternalAudioEncoder(const String& codecName, AudioEncoder::DescriptionCallback&&, AudioEncoder::OutputCallback&&, AudioEncoder::PostTaskCallback&&, GRefPtr<GstElement>&&);
 
-    const String m_codecName;
+    String m_codecName;
     AudioEncoder::DescriptionCallback m_descriptionCallback;
     AudioEncoder::OutputCallback m_outputCallback;
     AudioEncoder::PostTaskCallback m_postTaskCallback;
@@ -88,8 +88,9 @@ void GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::
     if (codecName.startsWith("pcm-"_s)) {
         auto components = codecName.split('-');
         if (components.size() != 2) {
-            postTaskCallback([callback = WTFMove(callback), codecName]() mutable {
-                callback(makeUnexpected(makeString("Invalid LPCM codec string: "_s, codecName)));
+            auto errorMessage = makeString("Invalid LPCM codec string: "_s, codecName);
+            postTaskCallback([callback = WTFMove(callback), errorMessage = WTFMove(errorMessage)]() mutable {
+                callback(makeUnexpected(WTFMove(errorMessage)));
             });
             return;
         }
@@ -98,8 +99,9 @@ void GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::
         auto& scanner = GStreamerRegistryScanner::singleton();
         auto lookupResult = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Encoding, codecName);
         if (!lookupResult) {
-            postTaskCallback([callback = WTFMove(callback), codecName]() mutable {
-                callback(makeUnexpected(makeString("No GStreamer encoder found for codec ", codecName)));
+            auto errorMessage = makeString("No GStreamer encoder found for codec "_s, codecName);
+            postTaskCallback([callback = WTFMove(callback), errorMessage = WTFMove(errorMessage)]() mutable {
+                callback(makeUnexpected(WTFMove(errorMessage)));
             });
             return;
         }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -67,7 +67,7 @@ public:
 private:
     GStreamerInternalVideoEncoder(const String& codecName, VideoEncoder::DescriptionCallback&&, VideoEncoder::OutputCallback&&, VideoEncoder::PostTaskCallback&&);
 
-    const String m_codecName;
+    String m_codecName;
     VideoEncoder::DescriptionCallback m_descriptionCallback;
     VideoEncoder::OutputCallback m_outputCallback;
     VideoEncoder::PostTaskCallback m_postTaskCallback;
@@ -90,8 +90,9 @@ void GStreamerVideoEncoder::create(const String& codecName, const VideoEncoder::
     registerWebKitGStreamerVideoEncoder();
     auto& scanner = GStreamerRegistryScanner::singleton();
     if (!scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Encoding, codecName)) {
-        postTaskCallback([callback = WTFMove(callback), codecName]() mutable {
-            callback(makeUnexpected(makeString("No GStreamer encoder found for codec "_s, codecName)));
+        auto errorMessage = makeString("No GStreamer encoder found for codec "_s, codecName);
+        postTaskCallback([callback = WTFMove(callback), errorMessage = WTFMove(errorMessage)]() mutable {
+            callback(makeUnexpected(WTFMove(errorMessage)));
         });
         return;
     }


### PR DESCRIPTION
#### 0bb4da6c65e2519ef6c902d2355a99ff88543392
<pre>
[GStreamer][WebCodecs][Debug] ASSERTs in video encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=264935">https://bugs.webkit.org/show_bug.cgi?id=264935</a>

Reviewed by Xabier Rodriguez-Calvar.

Pass owned strings to WorkQueue callbacks and make a copy of the codecName string in the internal
encoders, as attempts to fix flaky crashes that I am unable to reproduce here.

* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::create):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerVideoEncoder::create):

Canonical link: <a href="https://commits.webkit.org/270883@main">https://commits.webkit.org/270883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d670b3babd380a30e16c47a1d2d581a628bfcdee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24222 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3543 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23770 "Found 1 new test failure: platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29222 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29813 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27705 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5009 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6412 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->