### PR TITLE
Sync 'VideoTrack+MediaSource.idl', 'AudioTrack+MediaSource.idl' and 'TextTrack+MediaSource.idl' with WebIDL Specification

### DIFF
--- a/Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl
@@ -27,7 +27,8 @@
 [
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled,
-    ImplementedBy=AudioTrackMediaSource
+    ImplementedBy=AudioTrackMediaSource,
+    Exposed=(Window,DedicatedWorker)
 ] partial interface AudioTrack {
     readonly attribute SourceBuffer? sourceBuffer;
 };

--- a/Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl
@@ -27,7 +27,8 @@
 [
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled,
-    ImplementedBy=TextTrackMediaSource
+    ImplementedBy=TextTrackMediaSource,
+    Exposed=(Window,DedicatedWorker)
 ] partial interface TextTrack {
     readonly attribute SourceBuffer? sourceBuffer;
 };

--- a/Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl
@@ -23,10 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://w3c.github.io/media-source/#video-track-extensions
+
 [
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled ,
-    ImplementedBy=VideoTrackMediaSource
+    ImplementedBy=VideoTrackMediaSource,
+    Exposed=(Window,DedicatedWorker)
 ] partial interface VideoTrack {
     readonly attribute SourceBuffer? sourceBuffer;
 };


### PR DESCRIPTION
<pre>
Sync 'VideoTrack+MediaSource.idl', 'AudioTrack+MediaSource.idl' and 'TextTrack+MediaSource.idl' with WebIDL Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=264939">https://bugs.webkit.org/show_bug.cgi?id=264939</a>

Reviewed by NOBODY (OOPS!).

This PR is to sync WebKit with Web-Specifications [1], [2] and [3] by
adding missing 'Exposed=(Window,DedicatedWorker)'.

[1] <a href="https://w3c.github.io/media-source/#audio-track-extensions">https://w3c.github.io/media-source/#audio-track-extensions</a>
[2] <a href="https://w3c.github.io/media-source/#text-track-extensions">https://w3c.github.io/media-source/#text-track-extensions</a>
[3] <a href="https://w3c.github.io/media-source/#video-track-extensions">https://w3c.github.io/media-source/#video-track-extensions</a>

* Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl:
* Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl:
* Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7efce8b9ee065d2014f15c426f2639b6fb9d9c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29814 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27711 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->