### PR TITLE
MediaPlayerPrivateMediaSourceAVFObjC is not handling aspect ratio preservation signal from HTMLMediaElement

### DIFF
--- a/LayoutTests/http/tests/media/media-source/media-source-video-fit-fill-expected.txt
+++ b/LayoutTests/http/tests/media/media-source/media-source-video-fit-fill-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Validate video element is not object-fit fill
+PASS Validate video element is object-fit fill
+

--- a/LayoutTests/http/tests/media/media-source/media-source-video-fit-fill.html
+++ b/LayoutTests/http/tests/media/media-source/media-source-video-fit-fill.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useRemoteLayerTree=true ] -->
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div>
+<video muted id="video" width=300 height=30 autoplay playsinline></video>
+<br>
+<image id='image'></image>
+<script>
+function getPixel(x, y, canvas, data)
+{
+    const position = 4 * (x * canvas.width + y);
+    return {r: data[position], g: data[position+1], b: data[position+2]};
+}
+
+function isPixelRed(x, y, canvas, data)
+{
+   const pixel = getPixel(x, y, canvas, data);
+   return pixel.r === 255 && pixel.g === 0 && pixel.b === 0;
+}
+
+function computeWidth(canvas, data)
+{
+    // We inspect the horizontal line at pixel 20. We should get red, then green, then red.
+    const horizontalLine = 20;
+    let j = 0;
+
+    if (!isPixelRed(horizontalLine, j, canvas, data))
+        return -1;
+    while (isPixelRed(horizontalLine, ++j, canvas, data) && j < canvas.height) { };
+
+    const startGreen = j;
+    while (!isPixelRed(horizontalLine, ++j, canvas, data) && j < canvas.height) { };
+    const endGreen = j;
+
+    return endGreen - startGreen;
+}
+
+function computeHeight(canvas, data)
+{
+    // We inspect the vertical line at pixel 50. We should get red, then green, then red.
+    const verticalLine = 50;
+    let i = 0;
+
+    if (!isPixelRed(i, verticalLine, canvas, data))
+        return -1;
+    while (isPixelRed(++i, verticalLine, canvas, data) && i < canvas.width) { };
+
+    const startGreen = i;
+    while (!isPixelRed(++i, verticalLine, canvas, data) && i < canvas.width) { };
+    const endGreen = i;
+
+    return endGreen - startGreen;
+}
+
+async function testAspectRatio(aspectRatioCallback)
+{
+    if (!window.testRunner || !testRunner.takeViewPortSnapshot)
+        return true;
+
+    const dataURL = await new Promise((resolve, reject) => {
+        testRunner.takeViewPortSnapshot(resolve);
+        setTimeout(() => reject("testRunner.takeViewPortSnapshot timed out"), 5000);
+    });
+
+    const loadPromise = new Promise((resolve, reject) => {
+        image.onload = resolve;
+        image.onerror = reject;
+        setTimeout(() => reject("image load timed out"), 2000);
+    });
+    image.src = dataURL;
+    await loadPromise;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    canvas.getContext('2d').drawImage(image, 0, 0);
+    const data = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height).data;
+
+    const width = computeWidth(canvas, data);
+    const height = computeHeight(canvas, data);
+
+    return aspectRatioCallback(width / height);
+}
+
+var mediaSource = new MediaSource();
+function startMSE(mediaURL)
+{
+    video.src = URL.createObjectURL(mediaSource);
+    mediaSource.addEventListener('sourceopen', () => sourceOpen(mediaURL));
+}
+
+async function sourceOpen(mediaURL)
+{
+  const response = await fetch(mediaURL);
+  const buffer = await response.arrayBuffer();
+  const mimeCodec = 'video/mp4; codecs="avc1.4d401f"';
+  const sourceBuffer = mediaSource.addSourceBuffer(mimeCodec);
+  sourceBuffer.addEventListener('updateend', () => {
+    mediaSource.endOfStream();
+    video.play();
+  });
+  sourceBuffer.appendBuffer(buffer);
+}
+
+promise_test(async (t) => {
+    document.body.style.backgroundColor = "red";
+    t.add_cleanup(async () => document.body.style.backgroundColor = "");
+
+    video.style.objectFit = "";
+    startMSE("/media-resources/media-source/content/test-green-6s-320x240.mp4");
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    let counter = 0;
+    let aspectRatioResult = false;
+    while (counter++ < 50 && !aspectRatioResult) {
+        await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+        try {
+            // aspect ratio should be 10 with object-fit fill and 4/3 without.
+            aspectRatioResult = await testAspectRatio((aspectRatio) => aspectRatio < 3);
+        } catch (e) {
+            console.log(e);
+            break;
+        }
+    }
+    assert_true(aspectRatioResult);
+}, "Validate video element is not object-fit fill")
+
+promise_test(async (t) => {
+    document.body.style.backgroundColor = "red";
+    t.add_cleanup(async () => document.body.style.backgroundColor = "");
+
+    video.style.objectFit = "fill";
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    let counter = 0;
+    let aspectRatioResult = false;
+    while (counter++ < 50 && !aspectRatioResult) {
+        await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+        try {
+            // aspect ratio should be 10 with object-fit fill and 1.5 without.
+            aspectRatioResult = await testAspectRatio((aspectRatio) => aspectRatio > 5);
+        } catch (e) {
+            console.log(e);
+            break;
+        }
+    }
+    assert_true(aspectRatioResult);
+    image.parentNode.removeChild(image);
+}, "Validate video element is object-fit fill")
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1542,6 +1542,9 @@ webkit.org/b/236328 [ Monterey ] webaudio/decode-audio-data-webm-vorbis.html [ F
 
 webkit.org/b/232497 [ BigSur Debug ] media/media-source/media-source-istypesupported-case-sensitive.html [ Pass Crash ]
 
+# Need to handle object fit MSE for non UI-side compositing
+webkit.org/b/264944 [ Monterey Ventura ] http/tests/media/media-source/media-source-video-fit-fill.html [ Failure ]
+
 fast/text/install-font-style-recalc.html [ Pass ]
 
 webkit.org/b/238880 [ Monterey+ Release ] imported/w3c/web-platform-tests/css/css-text/white-space/pre-wrap-012.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -296,6 +296,7 @@ private:
 
     void setShouldDisableHDR(bool) final;
     void playerContentBoxRectChanged(const LayoutRect&) final;
+    void setShouldMaintainAspectRatio(bool) final;
 
     friend class MediaSourcePrivateAVFObjC;
 
@@ -361,6 +362,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     std::optional<VideoFrameMetadata> m_videoFrameMetadata;
     uint64_t m_lastConvertedSampleCount { 0 };
     ProcessIdentity m_resourceOwner;
+    bool m_shouldMaintainAspectRatio { true };
 };
 
 String convertEnumerationToString(MediaPlayerPrivateMediaSourceAVFObjC::SeekState);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -922,6 +922,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer()
 #ifndef NDEBUG
     [m_sampleBufferDisplayLayer setName:@"MediaPlayerPrivateMediaSource AVSampleBufferDisplayLayer"];
 #endif
+    [m_sampleBufferDisplayLayer setVideoGravity: (m_shouldMaintainAspectRatio ? AVLayerVideoGravityResizeAspect : AVLayerVideoGravityResize)];
 
     if (!m_sampleBufferDisplayLayer) {
         ERROR_LOG(LOGIDENTIFIER, "Failed to create AVSampleBufferDisplayLayer");
@@ -1557,6 +1558,24 @@ void MediaPlayerPrivateMediaSourceAVFObjC::playerContentBoxRectChanged(const Lay
 WTFLogChannel& MediaPlayerPrivateMediaSourceAVFObjC::logChannel() const
 {
     return LogMediaSource;
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)
+{
+    if (m_shouldMaintainAspectRatio == shouldMaintainAspectRatio)
+        return;
+
+    m_shouldMaintainAspectRatio = shouldMaintainAspectRatio;
+    if (!m_sampleBufferDisplayLayer)
+        return;
+
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:0];
+    [CATransaction setDisableActions:YES];
+
+    [m_sampleBufferDisplayLayer setVideoGravity: (m_shouldMaintainAspectRatio ? AVLayerVideoGravityResizeAspect : AVLayerVideoGravityResize)];
+
+    [CATransaction commit];
 }
 
 }


### PR DESCRIPTION
#### a8b3f78d322baecab6e30c5e454410a25f542740
<pre>
MediaPlayerPrivateMediaSourceAVFObjC is not handling aspect ratio preservation signal from HTMLMediaElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=264944">https://bugs.webkit.org/show_bug.cgi?id=264944</a>
<a href="https://rdar.apple.com/118508061">rdar://118508061</a>

Reviewed by Eric Carlson and Jer Noble.

MediaPlayer is calling setShouldMaintainAspectRatio but MediaPlayerPrivateMediaSourceAVFObjC was not implementing it.
Implement it by setting the gravity to AVLayerVideoGravityResizeAspect when we should maintain aspectRatio and AVLayerVideoGravityResizeAspect otherwise.
This fixes the bug for UI side compositing.
We should do a follow-up to fix it for non UI side compositing.

* LayoutTests/http/tests/media/media-source/media-source-video-fit-fill-expected.txt: Added.
* LayoutTests/http/tests/media/media-source/media-source-video-fit-fill.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setShouldMaintainAspectRatio):

Canonical link: <a href="https://commits.webkit.org/270876@main">https://commits.webkit.org/270876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f09fe569d370c6ea56bb9164f579a2dc7aef86d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2716 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29940 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27839 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23652 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6408 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->