### PR TITLE
Enable specifying webkit-test-runner header values from a command-line option

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -108,7 +108,7 @@ class SingleTestRunner(object):
         image_hash = None
         if self._should_fetch_expected_checksum():
             image_hash = self._port.expected_checksum(self._test_name, device_type=self._driver.host.device_type)
-        return DriverInput(self._test_name, self._timeout, image_hash, self._should_run_pixel_test, self._should_dump_jsconsolelog_in_stderr)
+        return DriverInput(self._test_name, self._timeout, image_hash, self._should_run_pixel_test, self._should_dump_jsconsolelog_in_stderr, self._options.additional_header)
 
     def run(self):
         self_comparison_header = self._port.get_option('self_compare_with_header')

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -311,6 +311,7 @@ def parse_args(args):
             help="Set the maximum number of locked shards"),
         optparse.make_option("--additional-env-var", type="string", action="append", default=[],
             help="Passes that environment variable to the tests (--additional-env-var=NAME=VALUE)"),
+        optparse.make_option("--additional-header", help="Passes that webkit-test-runner header value to the tests (--additional-header='KEY=VALUE KEY=VALUE ...')"),
         optparse.make_option("--profile", action="store_true",
             help="Output per-test profile information."),
         optparse.make_option("--profiler", action="store",

--- a/Tools/Scripts/webkitpy/layout_tests/views/printing.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/printing.py
@@ -82,6 +82,8 @@ class Printer(object):
             self._print_default("Placing new baselines in %s" % self._port.baseline_path())
 
         self._print_default("Using %s build" % self._options.configuration)
+        if self._options.additional_header:
+            self._print_default("Using additional header: '%s'" % self._options.additional_header)
         if self._options.pixel_tests:
             self._print_default("Pixel tests enabled")
         else:

--- a/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
@@ -103,11 +103,13 @@ class  Testprinter(unittest.TestCase):
         printer._options.new_baseline = True
         printer._options.time_out_ms = 6000
         printer._options.slow_time_out_ms = 12000
+        printer._options.additional_header = 'useEphemeralSession=false'
         printer.print_config('/tmp')
         self.assertIn("Using port 'test-mac-leopard'", err.getvalue())
         self.assertIn('Test configuration: <leopard, x86, release>', err.getvalue())
         self.assertIn('Placing test results in /tmp', err.getvalue())
         self.assertIn('Using Release build', err.getvalue())
+        self.assertIn('Using additional header: ', err.getvalue())
         self.assertIn('Pixel tests enabled', err.getvalue())
         self.assertIn('Command line:', err.getvalue())
         self.assertIn('Regular timeout: ', err.getvalue())

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -46,7 +46,7 @@ _log = logging.getLogger(__name__)
 
 
 class DriverInput(object):
-    def __init__(self, test_name, timeout, image_hash, should_run_pixel_test, should_dump_jsconsolelog_in_stderr=None, args=None, self_comparison_header=None, force_dump_pixels=False):
+    def __init__(self, test_name, timeout, image_hash, should_run_pixel_test, should_dump_jsconsolelog_in_stderr=None, additional_header=None, args=None, self_comparison_header=None, force_dump_pixels=False):
         self.test_name = test_name
         self.timeout = timeout  # in ms
         self.image_hash = image_hash
@@ -54,10 +54,11 @@ class DriverInput(object):
         self.should_dump_jsconsolelog_in_stderr = should_dump_jsconsolelog_in_stderr
         self.args = args or []
         self.self_comparison_header = self_comparison_header
+        self.additional_header = additional_header
         self.force_dump_pixels = force_dump_pixels
 
     def __repr__(self):
-        return "DriverInput(test_name='{}', timeout={}, image_hash={}, should_run_pixel_test={}, should_dump_jsconsolelog_in_stderr={}, self_comparison_header={}, force_dump_pixels={}'".format(self.test_name, self.timeout, self.image_hash, self.should_run_pixel_test, self.should_dump_jsconsolelog_in_stderr, self.self_comparison_header, self.force_dump_pixels)
+        return "DriverInput(test_name='{}', timeout={}, image_hash={}, should_run_pixel_test={}, should_dump_jsconsolelog_in_stderr={}, additional_header={}, self_comparison_header={}, force_dump_pixels={}'".format(self.test_name, self.timeout, self.image_hash, self.should_run_pixel_test, self.should_dump_jsconsolelog_in_stderr, self.additional_header, self.self_comparison_header, self.force_dump_pixels)
 
 
 class DriverOutput(object):
@@ -679,6 +680,8 @@ class Driver(object):
             command += "'--dump-jsconsolelog-in-stderr"
         if driver_input.self_comparison_header:
             command += "'--self-compare-with-header'%s" % driver_input.self_comparison_header
+        if driver_input.additional_header:
+            command += "'--additional-header'%s" % driver_input.additional_header
         if driver_input.force_dump_pixels:
             command += "'--force-dump-pixels"
 

--- a/Tools/TestRunnerShared/TestCommand.cpp
+++ b/Tools/TestRunnerShared/TestCommand.cpp
@@ -103,6 +103,11 @@ TestCommand parseInputLine(const std::string& inputLine)
                 result.selfComparisonHeader = tokenizer.next();
             else
                 die(inputLine);
+        } else if (arg == "--additional-header") {
+            if (tokenizer.hasNext())
+                result.additionalHeader = tokenizer.next();
+            else
+                die(inputLine);
         } else if (arg == std::string("--dump-jsconsolelog-in-stderr"))
             result.dumpJSConsoleLogInStdErr = true;
         else if (arg == std::string("--absolutePath"))

--- a/Tools/TestRunnerShared/TestCommand.h
+++ b/Tools/TestRunnerShared/TestCommand.h
@@ -36,6 +36,7 @@ struct TestCommand {
     std::filesystem::path absolutePath;
     std::string expectedPixelHash;
     std::string selfComparisonHeader;
+    std::string additionalHeader;
     WTF::Seconds timeout;
     bool shouldDumpPixels { false };
     bool forceDumpPixels { false };

--- a/Tools/TestRunnerShared/TestFeatures.h
+++ b/Tools/TestRunnerShared/TestFeatures.h
@@ -72,5 +72,6 @@ enum class TestHeaderKeyType : uint8_t {
 };
 TestFeatures featureDefaultsFromTestHeaderForTest(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
 TestFeatures featureDefaultsFromSelfComparisonHeader(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
+TestFeatures featureFromAdditionalHeaderOption(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
 
 }

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -156,6 +156,11 @@ static bool handleOptionInternalFeature(Options& options, const char*, const cha
     return parseFeature(feature, options.features);
 }
 
+static bool handleOptionAdditionalHeader(Options& options, const char*, const char* feature)
+{
+    return parseFeature(feature, options.features);
+}
+
 static bool handleOptionWebCoreLogging(Options& options, const char*, const char* channels)
 {
     options.webCoreLogChannels = channels;
@@ -212,6 +217,7 @@ OptionsHandler::OptionsHandler(Options& o)
     optionList.append(Option("--no-enable-all-experimental-features", "Do not enable all experimental features by default", handleOptionNoEnableAllExperimentalFeatures));
     optionList.append(Option("--experimental-feature", "Enable experimental feature", handleOptionExperimentalFeature, true));
     optionList.append(Option("--internal-feature", "Enable internal feature", handleOptionInternalFeature, true));
+    optionList.append(Option("--additional-header", "Passes webkit-test-runner header value to tests", handleOptionAdditionalHeader, true));
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     optionList.append(Option("--accessibility-isolated-tree", "Enable accessibility isolated tree mode for tests", handleOptionAccessibilityIsolatedTreeMode));
 #endif

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1526,6 +1526,7 @@ TestOptions TestController::testOptionsForTest(const TestCommand& command) const
     merge(features, platformSpecificFeatureDefaultsForTest(command));
     merge(features, featureDefaultsFromSelfComparisonHeader(command, TestOptions::keyTypeMapping()));
     merge(features, featureDefaultsFromTestHeaderForTest(command, TestOptions::keyTypeMapping()));
+    merge(features, featureFromAdditionalHeaderOption(command, TestOptions::keyTypeMapping()));
     merge(features, platformSpecificFeatureOverridesDefaultsForTest(command));
 
     return TestOptions { features };


### PR DESCRIPTION
#### b3cdd4ed520fc96cff30af68e3ccc444a4c94a56
<pre>
Enable specifying webkit-test-runner header values from a command-line option
<a href="https://bugs.webkit.org/show_bug.cgi?id=264948">https://bugs.webkit.org/show_bug.cgi?id=264948</a>

Reviewed by Jonathan Bedard and Tim Horton.

This change adds a new “--additional-header” option to run-webkit-tests
(and WebKitTestRunner) to enable specifying webkit-test-runner Foo=bar
header values for test runs — as if those values were provided in a
“&lt;!-- webkit-test-runner [ Foo=Bar ] --&gt;” header in each test being run.

For example, given the following command-line invocation:

  run-webkit-tests --additional-header=&apos;useEphemeralSession=true&apos; PATH

…that invocation would cause the test(s) at the given PATH value to be
run (once) in an ephemeral session — that is, as if the test itself had a
“&lt;!-- webkit-test-runner [ useEphemeralSession=true ] --&gt;” header.

This differs from the “--self-compare-with-header” option, which causes each
test to be run twice — once with the given header value, and once without —
and then does a pixel-diff comparison between the results. That’s useful
for reftests, but not so useful for JavaScript tests or other test types.

In contrast to that, the “--additional-header” option causes the tests to be
run just once, with the given header value, and does no separate comparison
against the results without the given header value (other than just the
normal reporting whether the actual results matched the expected results).
So the option is generally useful for all test types, not just for reftests.

* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner._driver_input):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
* Tools/Scripts/webkitpy/layout_tests/views/printing.py:
(Printer.print_config):
* Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py:
(Testprinter.test_print_config):
* Tools/Scripts/webkitpy/port/driver.py:
(DriverInput.__init__):
(DriverInput.__repr__):
(Driver._command_from_driver_input):
* Tools/TestRunnerShared/TestCommand.cpp:
(WTR::parseInputLine):
* Tools/TestRunnerShared/TestCommand.h:
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::parseTestHeaderString):
(WTR::featureFromAdditionalHeaderOption):
* Tools/TestRunnerShared/TestFeatures.h:
* Tools/WebKitTestRunner/Options.cpp:
(WTR::handleOptionAdditionalHeader):
(WTR::OptionsHandler::OptionsHandler):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::testOptionsForTest const):

Canonical link: <a href="https://commits.webkit.org/273763@main">https://commits.webkit.org/273763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2ca5254577f8331ca5dff2b0af822f061f53a01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24413 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3744 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/26996 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29679 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30025 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27932 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5275 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8295 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->