### PR TITLE
[import-w3c-tests] don't find fuzzy metadata as part of analyze_test

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_parser.py
+++ b/Tools/Scripts/webkitpy/w3c/test_parser.py
@@ -145,9 +145,6 @@ class TestParser(object):
         if test_info and self.is_slow_test():
             test_info['slow'] = True
 
-        if test_info:
-            test_info['fuzzy'] = self.fuzzy_metadata()
-
         return test_info
 
     def reference_links_of_type(self, reftest_type):

--- a/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
@@ -30,6 +30,7 @@ import logging
 import os
 import unittest
 
+from webkitpy.common.host_mock import MockHost
 from webkitpy.w3c.test_parser import TestParser
 
 from webkitcorepy import OutputCapture
@@ -352,10 +353,11 @@ CONTENT OF TEST
 
         self.assertTrue('referencefile' in test_info, 'test should be detected as reference file')
 
-    def _test_info_from_test_with_contents(self, test_contents):
+    def _fuzzy_metadata_from_test_with_contents(self, test_contents):
         test_path = os.path.join(os.path.sep, 'some', 'madeup', 'path')
         parser = TestParser({'all': True}, os.path.join(test_path, 'test-fuzzy.html'))
-        return parser.analyze_test(test_contents=test_contents)
+        parser.analyze_test(test_contents=test_contents)  # We need to analyze the test_contents
+        return parser.fuzzy_metadata()
 
     def test_simple_fuzzy_data(self):
         """ Tests basic form of fuzzy_metadata()"""
@@ -365,10 +367,10 @@ CONTENT OF TEST
 </head>
 <body>CONTENT OF TEST</body></html>
 """
-        test_info = self._test_info_from_test_with_contents(test_html)
+        actual_fuzzy = self._fuzzy_metadata_from_test_with_contents(test_html)
 
         expected_fuzzy = {None: [[15, 15], [300, 300]]}
-        self.assertEqual(test_info['fuzzy'], expected_fuzzy, 'fuzzy data did not match expected')
+        self.assertEqual(actual_fuzzy, expected_fuzzy, 'fuzzy data did not match expected')
 
     def test_nameless_fuzzy_data(self):
         """ Tests fuzzy_metadata() in short form"""
@@ -378,9 +380,9 @@ CONTENT OF TEST
 </head>
 <body>CONTENT OF TEST</body></html>
 """
-        test_info = self._test_info_from_test_with_contents(test_html)
+        actual_fuzzy = self._fuzzy_metadata_from_test_with_contents(test_html)
         expected_fuzzy = {None: [[15, 15], [300, 300]]}
-        self.assertEqual(test_info['fuzzy'], expected_fuzzy, 'fuzzy data did not match expected')
+        self.assertEqual(actual_fuzzy, expected_fuzzy, 'fuzzy data did not match expected')
 
     def test_range_fuzzy_data(self):
         """ Tests fuzzy_metadata() in range form"""
@@ -390,10 +392,10 @@ CONTENT OF TEST
 </head>
 <body>CONTENT OF TEST</body></html>
 """
-        test_info = self._test_info_from_test_with_contents(test_html)
+        actual_fuzzy = self._fuzzy_metadata_from_test_with_contents(test_html)
 
         expected_fuzzy = {None: [[5, 15], [200, 300]]}
-        self.assertEqual(test_info['fuzzy'], expected_fuzzy, 'fuzzy data did not match expected')
+        self.assertEqual(actual_fuzzy, expected_fuzzy, 'fuzzy data did not match expected')
 
     def test_nameless_range_fuzzy_data(self):
         """ Tests fuzzy_metadata() in short range form"""
@@ -403,10 +405,10 @@ CONTENT OF TEST
 </head>
 <body>CONTENT OF TEST</body></html>
 """
-        test_info = self._test_info_from_test_with_contents(test_html)
+        actual_fuzzy = self._fuzzy_metadata_from_test_with_contents(test_html)
 
         expected_fuzzy = {None: [[5, 15], [200, 300]]}
-        self.assertEqual(test_info['fuzzy'], expected_fuzzy, 'fuzzy data did not match expected')
+        self.assertEqual(actual_fuzzy, expected_fuzzy, 'fuzzy data did not match expected')
 
     def test_per_ref_fuzzy_data(self):
         """ Tests fuzzy_metadata() with values for difference reference files"""
@@ -418,11 +420,11 @@ CONTENT OF TEST
 </head>
 <body>CONTENT OF TEST</body></html>
 """
-        test_info = self._test_info_from_test_with_contents(test_html)
+        actual_fuzzy = self._fuzzy_metadata_from_test_with_contents(test_html)
 
         expected_fuzzy = {
             None: [[5, 15], [200, 300]],
             'close-match-ref.html': [[5, 5], [20, 20]],
             'worse-match-ref.html': [[15, 15], [30, 30]]
         }
-        self.assertEqual(test_info['fuzzy'], expected_fuzzy, 'fuzzy data did not match expected')
+        self.assertEqual(actual_fuzzy, expected_fuzzy, 'fuzzy data did not match expected')


### PR DESCRIPTION
#### 71c0ce6cf2ce1343ca845d2ab33a92540aef5b97
<pre>
[import-w3c-tests] don&apos;t find fuzzy metadata as part of analyze_test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263673">https://bugs.webkit.org/show_bug.cgi?id=263673</a>

Reviewed by Jonathan Bedard.

We don&apos;t actually do anything with the fuzzy field, as we only pay
attention to the metadata in the test runner. Therefore, we can fix this
throwing on data it cannot parse by just not including the field at all.

* Tools/Scripts/webkitpy/w3c/test_parser.py:
(TestParser.analyze_test):
* Tools/Scripts/webkitpy/w3c/test_parser_unittest.py:
(_fuzzy_metadata_from_test_with_contents):
(_test_info_from_test_with_contents): Deleted.

Canonical link: <a href="https://commits.webkit.org/270878@main">https://commits.webkit.org/270878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96d85a9260d7896807338e72a7f84157750dfc2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24280 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24242 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3514 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/26713 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3560 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23796 "Found 1 new test failure: platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29244 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29835 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27728 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4068 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3450 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->