### PR TITLE
[WASM-Function-References] Improve type printing for reference types

### DIFF
--- a/JSTests/wasm/function-references/local_init.js
+++ b/JSTests/wasm/function-references/local_init.js
@@ -64,7 +64,7 @@ async function testLocalInit() {
   assert.throws(
     () => module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x86\x80\x80\x80\x00\x01\x60\x01\x64\x6f\x00\x03\x82\x80\x80\x80\x00\x01\x00\x0a\x8f\x80\x80\x80\x00\x01\x89\x80\x80\x80\x00\x01\x01\x64\x6f\xd0\x6f\x21\x01\x0b"),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: set_local to type Externref expected Externref, in function at index 0"
+    "WebAssembly.Module doesn't validate: set_local to type (ref null extern) expected (ref extern), in function at index 0"
   );
 
   /*

--- a/JSTests/wasm/function-references/ref_types.js
+++ b/JSTests/wasm/function-references/ref_types.js
@@ -267,7 +267,7 @@ async function testNonNullExternrefIncompatible() {
         "\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x07\x01\x60\x01\x6f\x01\x64\x6f\x03\x02\x01\x00\x0a\x06\x01\x04\x00\x20\x00\x0b\x00\x0b\x04\x6e\x61\x6d\x65\x01\x04\x01\x00\x01\x66"
       ),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Externref is not a Externref, in function at index 0 (evaluating 'new WebAssembly.Module(buffer)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null extern) is not a (ref extern), in function at index 0 (evaluating 'new WebAssembly.Module(buffer)')"
   );
 }
 
@@ -295,7 +295,7 @@ async function testNonNullFuncrefIncompatible() {
         "\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x07\x01\x60\x01\x70\x01\x64\x70\x03\x02\x01\x00\x0a\x06\x01\x04\x00\x20\x00\x0b\x00\x0b\x04\x6e\x61\x6d\x65\x01\x04\x01\x00\x01\x66"
       ),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Funcref is not a Funcref, in function at index 0 (evaluating 'new WebAssembly.Module(buffer)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null func) is not a (ref func), in function at index 0 (evaluating 'new WebAssembly.Module(buffer)')"
   );
 }
 

--- a/JSTests/wasm/gc/any.js
+++ b/JSTests/wasm/gc/any.js
@@ -21,7 +21,7 @@ function testValidation() {
         (func (call 0 (ref.null extern))))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: argument type mismatch in call, got Externref, expected Anyref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: argument type mismatch in call, got (ref null extern), expected (ref null any), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   assert.throws(
@@ -32,7 +32,7 @@ function testValidation() {
         (func (call 0 (ref.null any))))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: argument type mismatch in call, got Anyref, expected (), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: argument type mismatch in call, got (ref null any), expected (ref null <struct:0>), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   assert.throws(
@@ -42,7 +42,7 @@ function testValidation() {
         (func (call 0 (ref.null any))))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: argument type mismatch in call, got Anyref, expected Nullref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: argument type mismatch in call, got (ref null any), expected (ref null none), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   assert.throws(
@@ -53,7 +53,7 @@ function testValidation() {
         (func (call 0 (struct.new 0))))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: argument type mismatch in call, got (), expected Nullref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: argument type mismatch in call, got (ref <struct:0>), expected (ref none), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 }
 
@@ -106,7 +106,7 @@ function testNullfuncref() {
         (func (export "f") (result nullfuncref) (ref.null func)))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Funcref is not a Nullfuncref"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null func) is not a (ref null nofunc)"
   )
 
   assert.throws(
@@ -115,7 +115,7 @@ function testNullfuncref() {
         (func (export "f") (result nullref) (ref.null nofunc)))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Nullfuncref is not a Nullref"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null nofunc) is not a (ref null none)"
   )
 
   instantiate(`
@@ -145,7 +145,7 @@ function testNullexternref() {
         (func (export "f") (result nullexternref) (ref.null extern)))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Externref is not a Nullexternref"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null extern) is not a (ref null noextern)"
   )
 
   assert.throws(
@@ -154,7 +154,7 @@ function testNullexternref() {
         (func (export "f") (result nullref) (ref.null noextern)))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Nullexternref is not a Nullref"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null noextern) is not a (ref null none)"
   )
 
   instantiate(`

--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -71,7 +71,7 @@ function testArrayDeclaration() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Arrayref is not a (I32, mutable), in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null array) is not a (ref null <array:0>), in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   assert.throws(
@@ -82,7 +82,7 @@ function testArrayDeclaration() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (I32, mutable) is not a Funcref, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null <array:0>) is not a (ref null func), in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
   );
 }
 
@@ -400,7 +400,7 @@ function testArraySet() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: array.set arrayref to type ((I32, immutable)) expected arrayref, in function at index 0"
+    "WebAssembly.Module doesn't validate: array.set arrayref to type (ref null <array:0>) expected arrayref, in function at index 0"
   );
 
   {

--- a/JSTests/wasm/gc/casts.js
+++ b/JSTests/wasm/gc/casts.js
@@ -204,7 +204,7 @@ function testFunctionCasts() {
           drop))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: ref.cast to type I31ref expected a funcref"
+    "WebAssembly.Module doesn't validate: ref.cast to type (ref i31) expected a funcref"
   );
 
   assert.throws(
@@ -214,7 +214,7 @@ function testFunctionCasts() {
           (ref.test (ref func) (ref.i31 (i32.const 42)))))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: ref.test to type I31ref expected a funcref"
+    "WebAssembly.Module doesn't validate: ref.test to type (ref i31) expected a funcref"
   );
 
   assert.throws(
@@ -730,7 +730,7 @@ function testEqCasts() {
           drop))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: ref.cast to type Funcref expected a subtype of anyref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: ref.cast to type (ref null func) expected a subtype of anyref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 }
 
@@ -813,7 +813,7 @@ function testAnyCasts() {
           drop))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: ref.cast to type Funcref expected a subtype of anyref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: ref.cast to type (ref null func) expected a subtype of anyref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 }
 
@@ -958,7 +958,7 @@ function testNullCasts() {
           drop))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: ref.cast to type Funcref expected a subtype of anyref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: ref.cast to type (ref null func) expected a subtype of anyref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 }
 

--- a/JSTests/wasm/gc/const-exprs.js
+++ b/JSTests/wasm/gc/const-exprs.js
@@ -206,7 +206,7 @@ async function testInvalidConstExprs() {
         (global (export "g") i32 (struct.new 0 (i32.const 1))))
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (I32, mutable) is not a I32"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref <struct:0>) is not a I32"
   );
 
   assert.throws(

--- a/JSTests/wasm/gc/i31.js
+++ b/JSTests/wasm/gc/i31.js
@@ -182,7 +182,7 @@ function testI31Get() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: i31.get_s ref to type Externref expected I31ref, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: i31.get_s ref to type (ref null extern) expected I31ref, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
   )
 
   assert.throws(

--- a/JSTests/wasm/gc/rec.js
+++ b/JSTests/wasm/gc/rec.js
@@ -235,7 +235,7 @@ function testRecDeclaration() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. ((() -> [Ref], () -> [Ref]).1) is not a ((() -> [Ref], () -> [Ref]).0), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref <func:1>) is not a (ref <func:0>), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   instantiate(`

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -106,7 +106,7 @@ function testStructDeclaration() {
         )
       `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (I32, mutable) is not a Structref, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null <array:0>) is not a (ref null struct), in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   // Invalid subtyping for structref.
@@ -120,7 +120,7 @@ function testStructDeclaration() {
         )
       `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. Structref is not a (), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null struct) is not a (ref null <struct:0>), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 }
 
@@ -726,7 +726,7 @@ function testStructGet() {
         )
       `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: struct.get invalid index: Structref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: struct.get invalid index: (ref null struct), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   // Test null checks.
@@ -1184,7 +1184,7 @@ function testStructTable() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: struct.get invalid index: Structref, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: struct.get invalid index: (ref null struct), in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   // Invalid non-defaultable table type.

--- a/JSTests/wasm/gc/sub.js
+++ b/JSTests/wasm/gc/sub.js
@@ -231,7 +231,7 @@ function testSubDeclaration() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. ((((())(I32, mutable))(I32, mutable, I64, mutable))(I32, mutable, I64, mutable, F32, mutable)) is not a (((())(I32, mutable))(I32, mutable, F64, mutable)), in function at index 0"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref null <struct:4>) is not a (ref null <struct:3>), in function at index 0"
   );
 
   assert.throws(
@@ -245,7 +245,7 @@ function testSubDeclaration() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (() -> []) is not a ((() -> [])() -> []), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
+    "WebAssembly.Module doesn't validate: control flow returns with unexpected type. (ref <func:0>) is not a (ref <func:1>), in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
 
   instantiate(`
@@ -470,7 +470,7 @@ function testSubDeclaration() {
       )
     `),
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: argument type mismatch in call, got (((() -> []), ((<current-rec-group>.0)() -> [])).1), expected (((() -> []), (), ((<current-rec-group>.0)() -> [])).0), in function at index 1"
+    "WebAssembly.Module doesn't validate: argument type mismatch in call, got (ref null <func:4>), expected (ref null <func:0>), in function at index 1"
   );
 
   // Check cases with a single non-recursive sub in a recursion group.

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -367,6 +367,37 @@ inline bool isValidHeapTypeKind(TypeKind kind)
     return false;
 }
 
+// FIXME: separating out heap types in wasm.json could be cleaner in the long term.
+inline const char* heapTypeKindAsString(TypeKind kind)
+{
+    ASSERT(isValidHeapTypeKind(kind));
+    switch (kind) {
+    case TypeKind::Funcref:
+        return "func";
+    case TypeKind::Externref:
+        return "extern";
+    case TypeKind::I31ref:
+        return "i31";
+    case TypeKind::Arrayref:
+        return "array";
+    case TypeKind::Structref:
+        return "struct";
+    case TypeKind::Eqref:
+        return "eq";
+    case TypeKind::Anyref:
+        return "any";
+    case TypeKind::Nullref:
+        return "none";
+    case TypeKind::Nullfuncref:
+        return "nofunc";
+    case TypeKind::Nullexternref:
+        return "noextern";
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return "";
+    }
+}
+
 inline bool isDefaultableType(Type type)
 {
     return !type.isRef();


### PR DESCRIPTION
#### fd124818fa58bc8e5a9be06c03c1e29ad2564ddd
<pre>
[WASM-Function-References] Improve type printing for reference types
<a href="https://bugs.webkit.org/show_bug.cgi?id=247746">https://bugs.webkit.org/show_bug.cgi?id=247746</a>

Reviewed by Justin Michaud.

Print reftypes when typed funcrefs are enabled in (ref null? kind)
format where `kind` is either a heap type (e.g., `i31`, `struct`)
or a concrete type index (e.g., `&lt;struct:0&gt;`, `&lt;func:3&gt;`).

This printing is only used for validation errors for now, as it
relies on being able to access the ModuleInformation.

* JSTests/wasm/function-references/local_init.js:
(async testLocalInit):
* JSTests/wasm/function-references/ref_types.js:
(async testNonNullExternrefIncompatible):
(async testNonNullFuncrefIncompatible):
* JSTests/wasm/gc/any.js:
(testValidation):
(testNullfuncref):
(testNullexternref):
* JSTests/wasm/gc/arrays.js:
(testArrayDeclaration):
* JSTests/wasm/gc/casts.js:
(testFunctionCasts):
(testEqCasts):
* JSTests/wasm/gc/const-exprs.js:
(async testInvalidConstExprs):
* JSTests/wasm/gc/i31.js:
(testI31Get):
* JSTests/wasm/gc/rec.js:
(testRecDeclaration):
* JSTests/wasm/gc/structs.js:
(testStructDeclaration):
* JSTests/wasm/gc/sub.js:
(testSubDeclaration):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::heapTypeKindAsString):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::validationFail const):
(JSC::Wasm::FunctionParser::validationFailHelper const):
(JSC::Wasm::FunctionParser::typeToStringModuleRelative const):

Canonical link: <a href="https://commits.webkit.org/270988@main">https://commits.webkit.org/270988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55cb9c0d2ca534c5152f373139f31da528211c44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29204 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24681 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24549 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29839 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23528 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30164 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26177 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28078 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5431 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33630 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6485 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4436 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7279 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->