### PR TITLE
[GTK] Get rid of EnumTraits for DMABufRendererBuffer enums

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -62,7 +62,10 @@ list(APPEND WebKit_MESSAGES_IN_FILES
     WebProcess/gtk/GtkSettingsManagerProxy
 )
 
-list(APPEND WebKit_SERIALIZATION_IN_FILES Shared/glib/DMABufRendererBufferFormat.serialization.in)
+list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/glib/DMABufRendererBufferFormat.serialization.in
+    Shared/glib/DMABufRendererBufferMode.serialization.in
+)
 
 list(APPEND WebCore_SERIALIZATION_IN_FILES SoupNetworkProxySettings.serialization.in)
 

--- a/Source/WebKit/Shared/glib/DMABufRendererBufferFormat.h
+++ b/Source/WebKit/Shared/glib/DMABufRendererBufferFormat.h
@@ -27,36 +27,23 @@
 
 #if USE(GBM)
 
-#include <wtf/EnumTraits.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 
-struct DMABufRendererBufferFormat {
-    enum class Usage : uint8_t {
-        Rendering,
-        Mapping,
-        Scanout
-    };
+enum class DMABufRendererBufferFormatUsage : uint8_t {
+    Rendering,
+    Mapping,
+    Scanout
+};
 
+struct DMABufRendererBufferFormat {
+    using Usage = DMABufRendererBufferFormatUsage;
     Usage usage { Usage::Rendering };
     uint32_t fourcc { 0 };
     Vector<uint64_t, 1> modifiers;
 };
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::DMABufRendererBufferFormat::Usage> {
-    using values = EnumValues<
-        WebKit::DMABufRendererBufferFormat::Usage,
-        WebKit::DMABufRendererBufferFormat::Usage::Rendering,
-        WebKit::DMABufRendererBufferFormat::Usage::Mapping,
-        WebKit::DMABufRendererBufferFormat::Usage::Scanout
-    >;
-};
-
-} // namespace WTF
 
 #endif // USE(GBM)

--- a/Source/WebKit/Shared/glib/DMABufRendererBufferMode.h
+++ b/Source/WebKit/Shared/glib/DMABufRendererBufferMode.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebKit {
 
 enum class DMABufRendererBufferMode : uint8_t {
@@ -35,15 +33,3 @@ enum class DMABufRendererBufferMode : uint8_t {
 };
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::DMABufRendererBufferMode> {
-    using values = EnumValues<
-        WebKit::DMABufRendererBufferMode,
-        WebKit::DMABufRendererBufferMode::Hardware,
-        WebKit::DMABufRendererBufferMode::SharedMemory
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/glib/DMABufRendererBufferMode.serialization.in
+++ b/Source/WebKit/Shared/glib/DMABufRendererBufferMode.serialization.in
@@ -22,18 +22,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-#if USE(GBM)
-
-struct WebKit::DMABufRendererBufferFormat {
-    WebKit::DMABufRendererBufferFormat::Usage usage;
-    uint32_t fourcc;
-    Vector<uint64_t, 1> modifiers;
+[Nested, OptionSet] enum class WebKit::DMABufRendererBufferMode : uint8_t {
+    Hardware,
+    SharedMemory,
 };
-
-[Nested] enum class WebKit::DMABufRendererBufferFormatUsage : uint8_t {
-    Rendering,
-    Mapping,
-    Scanout
-};
-
-#endif


### PR DESCRIPTION
#### 6226d4c168b66ce1788461b8255a261e65f0d47b
<pre>
[GTK] Get rid of EnumTraits for DMABufRendererBuffer enums
<a href="https://bugs.webkit.org/show_bug.cgi?id=264958">https://bugs.webkit.org/show_bug.cgi?id=264958</a>

Reviewed by Chris Dumez.

Port the DMABufRendererBuffer enums to the new IPC serialization
format, and get rid of the EnumTraits bits.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/Shared/glib/DMABufRendererBufferFormat.h:
* Source/WebKit/Shared/glib/DMABufRendererBufferFormat.serialization.in:
* Source/WebKit/Shared/glib/DMABufRendererBufferMode.h:
* Source/WebKit/Shared/glib/DMABufRendererBufferMode.serialization.in: added

Canonical link: <a href="https://commits.webkit.org/270894@main">https://commits.webkit.org/270894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616f39b8fe050ca2175b8927cd554d1ac7a575c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24286 "Built successfully") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3524 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3568 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29836 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27729 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5036 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6425 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->