### PR TITLE
Port IPC::SharedBufferReference to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -376,6 +376,7 @@ set(WebKit_SERIALIZATION_IN_FILES
 
     Platform/IPC/FormDataReference.serialization.in
     Platform/IPC/IPCSemaphore.serialization.in
+    Platform/IPC/SharedBufferReference.serialization.in
     Platform/IPC/StreamServerConnection.serialization.in
 
     Platform/SharedMemory.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -147,6 +147,7 @@ $(PROJECT_DIR)/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.i
 $(PROJECT_DIR)/NetworkProcess/webtransport/NetworkTransportSession.messages.in
 $(PROJECT_DIR)/Platform/IPC/FormDataReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/IPCSemaphore.serialization.in
+$(PROJECT_DIR)/Platform/IPC/SharedBufferReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/StreamServerConnection.serialization.in
 $(PROJECT_DIR)/Platform/SharedMemory.serialization.in
 $(PROJECT_DIR)/PluginProcess/PluginControllerProxy.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -500,6 +500,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	NetworkProcess/storage/FileSystemStorageError.serialization.in \
 	Platform/IPC/FormDataReference.serialization.in \
 	Platform/IPC/IPCSemaphore.serialization.in \
+	Platform/IPC/SharedBufferReference.serialization.in \
 	Platform/IPC/StreamServerConnection.serialization.in \
 	Platform/SharedMemory.serialization.in \
 	Shared/AuxiliaryProcessCreationParameters.serialization.in \

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.h
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.h
@@ -35,9 +35,6 @@
 
 namespace IPC {
 
-class Decoder;
-class Encoder;
-
 class SharedBufferReference {
 public:
     SharedBufferReference() = default;
@@ -58,6 +55,14 @@ public:
         : m_size(buffer.size())
         , m_buffer(const_cast<WebCore::FragmentedSharedBuffer*>(&buffer)) { }
 
+#if !USE(UNIX_DOMAIN_SOCKETS)
+    struct SerializableBuffer {
+        size_t size;
+        std::optional<WebKit::SharedMemory::Handle> handle;
+    };
+    SharedBufferReference(std::optional<SerializableBuffer>&&);
+#endif
+
     SharedBufferReference(const SharedBufferReference&) = default;
     SharedBufferReference(SharedBufferReference&&) = default;
     SharedBufferReference& operator=(const SharedBufferReference&) = default;
@@ -67,15 +72,18 @@ public:
     bool isEmpty() const { return !size(); }
     bool isNull() const { return isEmpty() && !m_buffer; }
 
+#if USE(UNIX_DOMAIN_SOCKETS)
+    RefPtr<WebCore::FragmentedSharedBuffer> buffer() const { return m_buffer; }
+#else
+    std::optional<SerializableBuffer> serializableBuffer() const;
+#endif
+
     // The following method must only be used on the receiver's IPC side.
     // It relies on an implementation detail that makes m_buffer become a contiguous SharedBuffer
     // once it's deserialised over IPC.
     RefPtr<WebCore::SharedBuffer> unsafeBuffer() const;
     const uint8_t* data() const;
     RefPtr<WebKit::SharedMemory> sharedCopy() const;
-
-    void encode(Encoder&) const;
-    static WARN_UNUSED_RETURN std::optional<SharedBufferReference> decode(Decoder&);
 
 private:
     SharedBufferReference(Ref<WebKit::SharedMemory>&& memory, size_t size)

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.serialization.in
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.serialization.in
@@ -1,0 +1,38 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "SharedBufferReference.h"
+
+#if !USE(UNIX_DOMAIN_SOCKETS)
+[Nested, RValue] struct IPC::SharedBufferReference::SerializableBuffer {
+    size_t size;
+    std::optional<WebKit::SharedMemory::Handle> handle;
+};
+#endif
+
+[CustomHeader] class IPC::SharedBufferReference {
+#if USE(UNIX_DOMAIN_SOCKETS)
+    RefPtr<WebCore::FragmentedSharedBuffer> buffer();
+#else
+    std::optional<IPC::SharedBufferReference::SerializableBuffer> serializableBuffer();
+#endif
+};

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4953,6 +4953,7 @@
 		463FD47F1EB9458400A2982C /* WKProcessTerminationReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKProcessTerminationReason.h; sourceTree = "<group>"; };
 		463FD4811EB94EAD00A2982C /* ProcessTerminationReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessTerminationReason.h; sourceTree = "<group>"; };
 		46411E3D2AFDA94400CC00E4 /* WebCompiledContentRuleListData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCompiledContentRuleListData.serialization.in; sourceTree = "<group>"; };
+		4648114E2B067D1E00430618 /* SharedBufferReference.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SharedBufferReference.serialization.in; sourceTree = "<group>"; };
 		4651ECE622178A850067EB95 /* WebProcessCacheCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebProcessCacheCocoa.mm; sourceTree = "<group>"; };
 		465237FA2B055C41005B3097 /* FormDataReference.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FormDataReference.serialization.in; sourceTree = "<group>"; };
 		465250E51ECF52CD002025CB /* WebKit2InitializeCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKit2InitializeCocoa.mm; sourceTree = "<group>"; };
@@ -8940,6 +8941,7 @@
 				7BAB110F25DD02B2008FC479 /* ScopedActiveMessageReceiveQueue.h */,
 				2DC18001D90DDD15FC6991A9 /* SharedBufferReference.cpp */,
 				5CC5DB9121488E16006CB8A8 /* SharedBufferReference.h */,
+				4648114E2B067D1E00430618 /* SharedBufferReference.serialization.in */,
 				93468E6A2714AF47009983E3 /* SharedFileHandle.cpp */,
 				93122C852710CCDE001D819F /* SharedFileHandle.h */,
 				7B73123625CC8524003B2796 /* StreamClientConnection.cpp */,


### PR DESCRIPTION
#### e3633fb4dca3f877787ad9a6518db345e11215a5
<pre>
Port IPC::SharedBufferReference to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=264957">https://bugs.webkit.org/show_bug.cgi?id=264957</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::SharedBufferReference):
(IPC::SharedBufferReference::bufferHandle const):
(IPC::SharedBufferReference::encode const): Deleted.
(IPC::SharedBufferReference::decode): Deleted.
* Source/WebKit/Platform/IPC/SharedBufferReference.h:
(IPC::SharedBufferReference::buffer const):
* Source/WebKit/Platform/IPC/SharedBufferReference.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270893@main">https://commits.webkit.org/270893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10247fa5d81ab559482f703d5de0f9522be9a7bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24392 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24303 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3645 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29369 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29914 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27813 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5132 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6423 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->