### PR TITLE
RemoteLayerTree transaction build blocked by GPUP ImageBuffer destruction

### DIFF
--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -32,6 +32,7 @@
 #include "GraphicsContextCG.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/text/TextStream.h>
 
 static const Seconds collectionInterval { 500_ms };
@@ -401,6 +402,12 @@ String IOSurfacePool::poolStatistics() const
 #else
     return emptyString();
 #endif
+}
+
+WorkQueue& ioSurfaceCleanupQueue()
+{
+    static auto& queue = WorkQueue::create("org.webkit.IOSurfaceCleanupQueue", WorkQueue::QOS::Utility).leakRef();
+    return queue;
 }
 
 }

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -39,6 +39,9 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
+namespace WTF {
+class WorkQueue;
+}
 namespace WebCore {
 
 class DestinatationColorSpace;
@@ -123,6 +126,8 @@ private:
     size_t m_inUseBytesCached WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     size_t m_maximumBytesCached WTF_GUARDED_BY_LOCK(m_lock) { defaultMaximumBytesCached };
 };
+
+WEBCORE_EXPORT WTF::WorkQueue& ioSurfaceCleanupQueue();
 
 }
 #endif // HAVE(IOSURFACE)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -38,6 +38,7 @@
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/WorkQueue.h>
 
 namespace WebCore {
 
@@ -106,8 +107,11 @@ ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend(const Parameters& param
 ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend()
 {
     ensureNativeImagesHaveCopiedBackingStore();
-    releaseGraphicsContext();
-    IOSurface::moveToPool(WTFMove(m_surface), m_ioSurfacePool.get());
+    m_context = nullptr;
+    ioSurfaceCleanupQueue().dispatch([context = WTFMove(m_platformContext), surface = WTFMove(m_surface), pool = WTFMove(m_ioSurfacePool)] () mutable {
+        context = nullptr;
+        IOSurface::moveToPool(WTFMove(surface), pool.get());
+    });
 }
 
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/IOSurfacePool.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 
 namespace WebKit {
@@ -70,7 +71,9 @@ ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSu
 ImageBufferShareableMappedIOSurfaceBitmapBackend::~ImageBufferShareableMappedIOSurfaceBitmapBackend()
 {
     releaseGraphicsContext();
-    IOSurface::moveToPool(WTFMove(m_surface), m_ioSurfacePool.get());
+    ioSurfaceCleanupQueue().dispatch([surface = WTFMove(m_surface), pool = WTFMove(m_ioSurfacePool)] () mutable {
+        IOSurface::moveToPool(WTFMove(surface), pool.get());
+    });
 }
 
 std::optional<ImageBufferBackendHandle> ImageBufferShareableMappedIOSurfaceBitmapBackend::createBackendHandle(SharedMemory::Protection) const


### PR DESCRIPTION
#### 1f6dc69812ee8b823a03d327529152e617a57806
<pre>
RemoteLayerTree transaction build blocked by GPUP ImageBuffer destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=264963">https://bugs.webkit.org/show_bug.cgi?id=264963</a>
<a href="https://rdar.apple.com/118514999">rdar://118514999</a>

Reviewed by NOBODY (OOPS!).

Destruction of CGContext drawing to a IOSurface is a slow operation.
Move that to a separate work queue.
This fixes the cases where ImageBuffer creation is slow because
GPUP is executing previous ImageBuffer destructions.

* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::ioSurfaceCleanupQueue):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::~ImageBufferShareableMappedIOSurfaceBitmapBackend):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f6dc69812ee8b823a03d327529152e617a57806

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24254 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3606 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23804 "Found 1 new test failure: platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29261 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29842 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27738 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->