### PR TITLE
Cleanup pathFromGraphicsElement

### DIFF
--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -59,7 +59,7 @@ ReferencePathOperation::ReferencePathOperation(const String& url, const AtomStri
     , m_fragment(fragment)
 {
     if (is<SVGPathElement>(element) || is<SVGGeometryElement>(element))
-        m_path = pathFromGraphicsElement(element.get());
+        m_path = pathFromGraphicsElement(*element);
 }
 
 ReferencePathOperation::ReferencePathOperation(std::optional<Path>&& path)

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -277,7 +277,7 @@ Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
     if (layer()->isTransformed())
         transform.multiply(layer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
 
-    return pathFromGraphicsElement(&downcast<SVGGraphicsElement>(element()));
+    return pathFromGraphicsElement(downcast<SVGGraphicsElement>(element()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -430,7 +430,7 @@ Path& RenderSVGShape::ensurePath()
 
 std::unique_ptr<Path> RenderSVGShape::createPath() const
 {
-    return makeUnique<Path>(pathFromGraphicsElement(&graphicsElement()));
+    return makeUnique<Path>(pathFromGraphicsElement(graphicsElement()));
 }
 
 void RenderSVGShape::styleWillChange(StyleDifference diff, const RenderStyle& newStyle)

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -59,11 +59,11 @@ SVGGeometryElement* RenderSVGTextPath::targetElement() const
 
 Path RenderSVGTextPath::layoutPath() const
 {
-    auto element = targetElement();
+    RefPtr element = targetElement();
     if (!is<SVGGeometryElement>(element))
         return { };
 
-    auto path = pathFromGraphicsElement(element);
+    auto path = pathFromGraphicsElement(*element);
 
     // Spec:  The transform attribute on the referenced 'path' element represents a
     // supplemental transformation relative to the current user coordinate system for

--- a/Source/WebCore/rendering/svg/SVGPathData.cpp
+++ b/Source/WebCore/rendering/svg/SVGPathData.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "SVGPathData.h"
 
+#include "NodeName.h"
 #include "Path.h"
 #include "RenderElement.h"
 #include "RenderStyle.h"
@@ -182,26 +183,27 @@ static Path pathFromRectElement(const SVGElement& element)
     return path;
 }
 
-Path pathFromGraphicsElement(const SVGElement* element)
+Path pathFromGraphicsElement(const SVGElement& element)
 {
-    ASSERT(element);
-
-    typedef Path (*PathFromFunction)(const SVGElement&);
-    static HashMap<AtomStringImpl*, PathFromFunction>* map = 0;
-    if (!map) {
-        map = new HashMap<AtomStringImpl*, PathFromFunction>;
-        map->set(SVGNames::circleTag->localName().impl(), pathFromCircleElement);
-        map->set(SVGNames::ellipseTag->localName().impl(), pathFromEllipseElement);
-        map->set(SVGNames::lineTag->localName().impl(), pathFromLineElement);
-        map->set(SVGNames::pathTag->localName().impl(), pathFromPathElement);
-        map->set(SVGNames::polygonTag->localName().impl(), pathFromPolygonElement);
-        map->set(SVGNames::polylineTag->localName().impl(), pathFromPolylineElement);
-        map->set(SVGNames::rectTag->localName().impl(), pathFromRectElement);
+    switch (element.tagQName().nodeName()) {
+    case ElementNames::SVG::circle:
+        return pathFromCircleElement(element);
+    case ElementNames::SVG::ellipse:
+        return pathFromEllipseElement(element);
+    case ElementNames::SVG::line:
+        return pathFromLineElement(element);
+    case ElementNames::SVG::path:
+        return pathFromPathElement(element);
+    case ElementNames::SVG::polygon:
+        return pathFromPolygonElement(element);
+    case ElementNames::SVG::polyline:
+        return pathFromPolylineElement(element);
+    case ElementNames::SVG::rect:
+        return pathFromRectElement(element);
+    default:
+        break;
     }
 
-    if (PathFromFunction pathFromFunction = map->get(element->localName().impl()))
-        return (*pathFromFunction)(*element);
-    
     return { };
 }
 

--- a/Source/WebCore/rendering/svg/SVGPathData.h
+++ b/Source/WebCore/rendering/svg/SVGPathData.h
@@ -24,6 +24,6 @@ namespace WebCore {
 class SVGElement;
 class Path;
 
-Path pathFromGraphicsElement(const SVGElement*);
+Path pathFromGraphicsElement(const SVGElement&);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -445,7 +445,7 @@ Path& LegacyRenderSVGShape::ensurePath()
 
 std::unique_ptr<Path> LegacyRenderSVGShape::createPath() const
 {
-    return makeUnique<Path>(pathFromGraphicsElement(&graphicsElement()));
+    return makeUnique<Path>(pathFromGraphicsElement(graphicsElement()));
 }
 
 }

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -128,7 +128,7 @@ void SVGAnimateMotionElement::updateAnimationPath()
     for (auto& mPath : childrenOfType<SVGMPathElement>(*this)) {
         auto pathElement = mPath.pathElement();
         if (pathElement) {
-            m_animationPath = pathFromGraphicsElement(pathElement.get());
+            m_animationPath = pathFromGraphicsElement(*pathElement);
             foundMPath = true;
             break;
         }

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -208,7 +208,7 @@ void SVGGraphicsElement::didAttachRenderers()
 Path SVGGraphicsElement::toClipPath()
 {
     // FIXME: [LBSE] Stop mutating the path here and stop calling animatedLocalTransform().
-    Path path = pathFromGraphicsElement(this);
+    Path path = pathFromGraphicsElement(*this);
     // FIXME: How do we know the element has done a layout?
     path.transform(animatedLocalTransform());
     return path;


### PR DESCRIPTION
#### 0296432a0f5167d0ece4e378c50b85bfa2cc82ce
<pre>
Cleanup pathFromGraphicsElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=264967">https://bugs.webkit.org/show_bug.cgi?id=264967</a>

Reviewed by Chris Dumez.

Use switch statement instead of a HashMap in pathFromGraphicsElement.
Also make pathFromGraphicsElement take a reference, not a pointer, to SVGElement.

* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ReferencePathOperation::ReferencePathOperation):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::computeClipPath const):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::createPath const):
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
(WebCore::RenderSVGTextPath::layoutPath const):
* Source/WebCore/rendering/svg/SVGPathData.cpp:
(WebCore::pathFromGraphicsElement):
* Source/WebCore/rendering/svg/SVGPathData.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::createPath const):
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::updateAnimationPath):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::toClipPath):

Canonical link: <a href="https://commits.webkit.org/270850@main">https://commits.webkit.org/270850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/783a58b05b6ee416d6cea817cbbfcd175521c469

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2600 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29274 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29857 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27754 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4095 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3441 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->