### PR TITLE
[WGSL] Add parsing for directives

### DIFF
--- a/Source/WebGPU/WGSL/AST/AST.h
+++ b/Source/WebGPU/WGSL/AST/AST.h
@@ -45,6 +45,7 @@
 #include "ASTContinueStatement.h"
 #include "ASTDecrementIncrementStatement.h"
 #include "ASTDiagnosticAttribute.h"
+#include "ASTDiagnosticDirective.h"
 #include "ASTDirective.h"
 #include "ASTDiscardStatement.h"
 #include "ASTElaboratedTypeExpression.h"

--- a/Source/WebGPU/WGSL/AST/ASTDiagnostic.h
+++ b/Source/WebGPU/WGSL/AST/ASTDiagnostic.h
@@ -25,26 +25,18 @@
 
 #pragma once
 
-#include "ASTAttribute.h"
-#include "ASTBuilder.h"
-#include "ASTDiagnostic.h"
+#include "WGSLEnums.h"
 
 namespace WGSL::AST {
 
-class DiagnosticAttribute final : public Attribute {
-    WGSL_AST_BUILDER_NODE(DiagnosticAttribute);
-public:
-    NodeKind kind() const override;
+struct TriggeringRule {
+    Identifier name;
+    std::optional<Identifier> suffix;
+};
 
-private:
-    DiagnosticAttribute(SourceSpan span, Diagnostic&& diagnostic)
-        : Attribute(span)
-        , m_diagnostic(WTFMove(diagnostic))
-    { }
-
-    Diagnostic m_diagnostic;
+struct Diagnostic {
+    SeverityControl severity;
+    TriggeringRule triggeringRule;
 };
 
 } // namespace WGSL::AST
-
-SPECIALIZE_TYPE_TRAITS_WGSL_AST(DiagnosticAttribute)

--- a/Source/WebGPU/WGSL/AST/ASTDiagnosticDirective.h
+++ b/Source/WebGPU/WGSL/AST/ASTDiagnosticDirective.h
@@ -25,20 +25,20 @@
 
 #pragma once
 
-#include "ASTAttribute.h"
 #include "ASTBuilder.h"
 #include "ASTDiagnostic.h"
+#include "ASTDirective.h"
 
 namespace WGSL::AST {
 
-class DiagnosticAttribute final : public Attribute {
-    WGSL_AST_BUILDER_NODE(DiagnosticAttribute);
+class DiagnosticDirective final : public Directive {
+    WGSL_AST_BUILDER_NODE(DiagnosticDirective);
 public:
     NodeKind kind() const override;
 
 private:
-    DiagnosticAttribute(SourceSpan span, Diagnostic&& diagnostic)
-        : Attribute(span)
+    DiagnosticDirective(SourceSpan span, Diagnostic&& diagnostic)
+        : Directive(span)
         , m_diagnostic(WTFMove(diagnostic))
     { }
 
@@ -47,4 +47,4 @@ private:
 
 } // namespace WGSL::AST
 
-SPECIALIZE_TYPE_TRAITS_WGSL_AST(DiagnosticAttribute)
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(DiagnosticDirective)

--- a/Source/WebGPU/WGSL/AST/ASTDirective.h
+++ b/Source/WebGPU/WGSL/AST/ASTDirective.h
@@ -35,15 +35,10 @@ class Directive : public Node {
 public:
     using List = ReferenceWrapperVector<Directive>;
 
-    const String& name() const { return m_name.id(); }
-
-private:
-    Directive(SourceSpan span, Identifier&& name)
+protected:
+    Directive(SourceSpan span)
         : Node(span)
-        , m_name(WTFMove(name))
     { }
-
-    Identifier m_name;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -28,6 +28,7 @@
 namespace WGSL::AST {
 
 class Directive;
+class DiagnosticDirective;
 
 class Attribute;
 class AlignAttribute;
@@ -99,6 +100,7 @@ class Variable;
 class VariableQualifier;
 
 struct SwitchClause;
+struct Diagnostic;
 
 enum class BinaryOperation : uint8_t;
 enum class ParameterRole : uint8_t;

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -51,6 +51,7 @@ enum class NodeKind : uint8_t {
     WorkgroupSizeAttribute,
 
     Directive,
+    DiagnosticDirective,
 
     // Expression
     BinaryExpression,

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -88,9 +88,9 @@ void StringDumper::visit(ShaderModule& shaderModule)
         m_out.printf("\n\n");
 }
 
-void StringDumper::visit(Directive& directive)
+void StringDumper::visit(DiagnosticDirective&)
 {
-    m_out.print(m_indent, "enable ", directive.name(), ";");
+    // FIXME: we still don't do anything with diagnostics
 }
 
 // Attribute

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -45,7 +45,9 @@ public:
 
     // Visitor
     void visit(ShaderModule&) override;
-    void visit(Directive&) override;
+
+    // Directive
+    void visit(DiagnosticDirective&) override;
 
     // Attribute
     void visit(BindingAttribute&) override;

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -55,7 +55,20 @@ void Visitor::visit(ShaderModule& shaderModule)
         checkErrorAndVisit(function);
 }
 
-void Visitor::visit(AST::Directive&)
+// Directive
+
+void Visitor::visit(AST::Directive& directive)
+{
+    switch (directive.kind()) {
+    case AST::NodeKind::DiagnosticDirective:
+        checkErrorAndVisit(downcast<AST::DiagnosticDirective>(directive));
+        break;
+    default:
+        ASSERT_NOT_REACHED("Unhandled Directive");
+    }
+}
+
+void Visitor::visit(AST::DiagnosticDirective&)
 {
 }
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -43,7 +43,10 @@ public:
 
     // Shader Module
     virtual void visit(ShaderModule&);
+
+    // Directive
     virtual void visit(AST::Directive&);
+    virtual void visit(AST::DiagnosticDirective&);
 
     // Attribute
     virtual void visit(AST::Attribute&);

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -61,6 +61,8 @@ public:
 
     // AST::<type>::Ref whenever it can return multiple types.
     Result<AST::Identifier> parseIdentifier();
+    Result<void> parseEnableDirective();
+    Result<void> parseRequireDirective();
     Result<void> parseGlobalDecl();
     Result<AST::Attribute::List> parseAttributes();
     Result<AST::Attribute::Ref> parseAttribute();
@@ -102,6 +104,7 @@ public:
     Result<AST::Expression::Ref> parseLHSExpression();
     Result<AST::Expression::Ref> parseCoreLHSExpression();
     Result<AST::Expression::List> parseArgumentExpressionList();
+    Result<AST::Diagnostic> parseDiagnostic();
 
 private:
     Expected<Token, TokenType> consumeType(TokenType);

--- a/Source/WebGPU/WGSL/WGSLEnums.cpp
+++ b/Source/WebGPU/WGSL/WGSLEnums.cpp
@@ -81,6 +81,8 @@ ENUM_DEFINE(InterpolationSampling);
 ENUM_DEFINE(ShaderStage);
 ENUM_DEFINE(SeverityControl);
 ENUM_DEFINE(Builtin);
+ENUM_DEFINE(Extension);
+ENUM_DEFINE(LanguageFeature);
 
 #undef ENUM_DEFINE
 #undef ENUM_DEFINE_PRINT_INTERNAL

--- a/Source/WebGPU/WGSL/WGSLEnums.h
+++ b/Source/WebGPU/WGSL/WGSLEnums.h
@@ -99,6 +99,12 @@ namespace WGSL {
     value(VertexIndex, vertex_index) \
     value(WorkgroupId, workgroup_id) \
 
+#define ENUM_Extension(value) \
+    value(F16, f16, 1 << 0) \
+
+#define ENUM_LanguageFeature(value) \
+    value(ReadonlyAndReadwriteStorageTextures, readonly_and_readwrite_storage_textures, 1 << 0)
+
 #define ENUM_DECLARE_VALUE(__value, _, ...) \
     __value __VA_OPT__(=) __VA_ARGS__,
 
@@ -123,6 +129,8 @@ ENUM_DECLARE(InterpolationSampling);
 ENUM_DECLARE(ShaderStage);
 ENUM_DECLARE(SeverityControl);
 ENUM_DECLARE(Builtin);
+ENUM_DECLARE(Extension);
+ENUM_DECLARE(LanguageFeature);
 
 #undef ENUM_DECLARE
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -33,7 +33,9 @@
 #include "ASTVariable.h"
 #include "TypeStore.h"
 #include "WGSL.h"
+#include "WGSLEnums.h"
 
+#include <wtf/OptionSet.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -219,6 +221,9 @@ public:
         AST::Builder::State m_builderState;
     };
 
+    OptionSet<Extension>& enabledExtensions() { return m_enabledExtensions; }
+    OptionSet<LanguageFeature> requiredFeatures() { return m_requiredFeatures; }
+
 private:
     String m_source;
     bool m_usesExternalTextures { false };
@@ -229,6 +234,8 @@ private:
     bool m_usesDivision { false };
     bool m_usesModulo { false };
     bool m_usesFrexp { false };
+    OptionSet<Extension> m_enabledExtensions;
+    OptionSet<LanguageFeature> m_requiredFeatures;
     Configuration m_configuration;
     AST::Directive::List m_directives;
     AST::Function::List m_functions;

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -165,6 +165,8 @@
 		97BCD6AE29D7422B00A82577 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */; };
 		97C36CFE29F1730100CFB379 /* Constraints.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C36CFC29F1730000CFB379 /* Constraints.h */; };
 		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
+		97D398E62B06A85B00D8C4AA /* ASTDiagnosticDirective.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */; };
+		97D398E72B06A85B00D8C4AA /* ASTDiagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */; };
 		97E21C8B2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */; };
 		97E21C972A2512F7009CEB0E /* ConstantValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C942A2512F7009CEB0E /* ConstantValue.cpp */; };
 		97E21C982A2512F7009CEB0E /* ConstantValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E21C952A2512F7009CEB0E /* ConstantValue.h */; };
@@ -448,6 +450,8 @@
 		97A448A52AE3546700A4E147 /* ASTCallStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTCallStatement.h; sourceTree = "<group>"; };
 		97C36CFC29F1730000CFB379 /* Constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constraints.h; sourceTree = "<group>"; };
 		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
+		97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnosticDirective.h; sourceTree = "<group>"; };
+		97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnostic.h; sourceTree = "<group>"; };
 		97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTDecrementIncrementStatement.cpp; sourceTree = "<group>"; };
 		97E21C942A2512F7009CEB0E /* ConstantValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConstantValue.cpp; sourceTree = "<group>"; };
 		97E21C952A2512F7009CEB0E /* ConstantValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantValue.h; sourceTree = "<group>"; };
@@ -712,7 +716,9 @@
 				3AD0D2302988D3C10080D728 /* ASTDeclaration.h */,
 				97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */,
 				3A12AEA428FCE94C00C1B975 /* ASTDecrementIncrementStatement.h */,
+				97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */,
 				97A448A42AE3546700A4E147 /* ASTDiagnosticAttribute.h */,
+				97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */,
 				33EA185F27BC198100A1DD52 /* ASTDirective.h */,
 				3A12AEA828FCE94C00C1B975 /* ASTDiscardStatement.h */,
 				97099ABE2AA60D58003B41F8 /* ASTElaboratedTypeExpression.h */,
@@ -824,7 +830,9 @@
 				3A12AEBC28FCE94C00C1B975 /* ASTContinueStatement.h in Headers */,
 				3AD0D2332988D3C10080D728 /* ASTDeclaration.h in Headers */,
 				3A12AEBE28FCE94C00C1B975 /* ASTDecrementIncrementStatement.h in Headers */,
+				97D398E72B06A85B00D8C4AA /* ASTDiagnostic.h in Headers */,
 				97A448A72AE3546700A4E147 /* ASTDiagnosticAttribute.h in Headers */,
+				97D398E62B06A85B00D8C4AA /* ASTDiagnosticDirective.h in Headers */,
 				33EA186027BC198100A1DD52 /* ASTDirective.h in Headers */,
 				3A12AEC228FCE94C00C1B975 /* ASTDiscardStatement.h in Headers */,
 				97099AC12AA60D58003B41F8 /* ASTElaboratedTypeExpression.h in Headers */,


### PR DESCRIPTION
#### 5aa9fe80938ed403d06efbba763ddf77d24913ab
<pre>
[WGSL] Add parsing for directives
<a href="https://bugs.webkit.org/show_bug.cgi?id=264973">https://bugs.webkit.org/show_bug.cgi?id=264973</a>
<a href="https://rdar.apple.com/118522832">rdar://118522832</a>

Reviewed by Mike Wyrzykowski.

Add support for parsing enable, requires and diagnostic directives.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTDiagnostic.h: Copied from Source/WebGPU/WGSL/AST/ASTDirective.h.
* Source/WebGPU/WGSL/AST/ASTDiagnosticAttribute.h:
* Source/WebGPU/WGSL/AST/ASTDiagnosticDirective.h: Copied from Source/WebGPU/WGSL/AST/ASTDirective.h.
* Source/WebGPU/WGSL/AST/ASTDirective.h:
(WGSL::AST::Directive::Directive):
(WGSL::AST::Directive::name const): Deleted.
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseShader):
(WGSL::Parser&lt;Lexer&gt;::parseEnableDirective):
(WGSL::Parser&lt;Lexer&gt;::parseRequireDirective):
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
(WGSL::Parser&lt;Lexer&gt;::parseDiagnostic):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/WGSLEnums.cpp:
* Source/WebGPU/WGSL/WGSLEnums.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::enabledExtensions):
(WGSL::ShaderModule::requiredFeatures):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270879@main">https://commits.webkit.org/270879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95d790b5ec91d4e2e6a3c8ce2353a59e6de21cb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24317 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24266 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3595 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29862 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27759 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5067 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6410 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->