### PR TITLE
Rename CoreIPCDDScannerResult to CoreIPCWebKitSecureCoding for more general use

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -204,10 +204,12 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDictionary.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCError.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCFont.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSType.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSValue.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCString.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCWebKitSecureCoding.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/InsertTextOptions.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -517,17 +517,18 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCArray.serialization.in \
 	Shared/Cocoa/CoreIPCCFType.serialization.in \
 	Shared/Cocoa/CoreIPCColor.serialization.in \
-	Shared/Cocoa/CoreIPCDDScannerResult.serialization.in \
 	Shared/Cocoa/CoreIPCData.serialization.in \
 	Shared/Cocoa/CoreIPCDate.serialization.in \
 	Shared/Cocoa/CoreIPCDictionary.serialization.in \
 	Shared/Cocoa/CoreIPCError.serialization.in \
 	Shared/Cocoa/CoreIPCFont.serialization.in \
 	Shared/Cocoa/CoreIPCNSCFObject.serialization.in \
+	Shared/Cocoa/CoreIPCNSType.serialization.in \
 	Shared/Cocoa/CoreIPCNSValue.serialization.in \
 	Shared/Cocoa/CoreIPCSecureCoding.serialization.in \
 	Shared/Cocoa/CoreIPCString.serialization.in \
 	Shared/Cocoa/CoreIPCURL.serialization.in \
+	Shared/Cocoa/CoreIPCWebKitSecureCoding.serialization.in \
 	Shared/Cocoa/DataDetectionResult.serialization.in \
 	Shared/Cocoa/InsertTextOptions.serialization.in \
 	Shared/Cocoa/RevealItem.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -30,7 +30,6 @@
 #include "CoreIPCArray.h"
 #include "CoreIPCCFType.h"
 #include "CoreIPCColor.h"
-#include "CoreIPCDDScannerResult.h"
 #include "CoreIPCData.h"
 #include "CoreIPCDate.h"
 #include "CoreIPCDictionary.h"
@@ -41,6 +40,7 @@
 #include "CoreIPCSecureCoding.h"
 #include "CoreIPCString.h"
 #include "CoreIPCURL.h"
+#include "CoreIPCWebKitSecureCoding.h"
 #include <wtf/RetainPtr.h>
 
 namespace WebKit {
@@ -54,7 +54,7 @@ public:
         CoreIPCCFType,
         CoreIPCColor,
 #if ENABLE(DATA_DETECTION)
-        CoreIPCDDScannerResult,
+        CoreIPCWebKitSecureCoding,
 #endif
         CoreIPCData,
         CoreIPCDate,

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -45,7 +45,7 @@ static CoreIPCNSCFObject::ObjectValue valueFromID(id object)
         return CoreIPCColor((WebCore::CocoaColor *)object);
 #if ENABLE(DATA_DETECTION)
     case IPC::NSType::DDScannerResult:
-        return CoreIPCDDScannerResult((DDScannerResult *)object);
+        return CoreIPCWebKitSecureCoding((NSObject<NSSecureCoding> *)object);
 #endif
     case IPC::NSType::Data:
         return CoreIPCData((NSData *)object);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSType.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSType.serialization.in
@@ -1,0 +1,47 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "ArgumentCodersCocoa.h"
+
+[WebKitPlatform] enum class IPC::NSType : uint8_t {
+    Array,
+    Color,
+#if ENABLE(DATA_DETECTION)
+    DDScannerResult,
+#endif
+    Data,
+    Date,
+    Error,
+    Dictionary,
+    Font,
+    Number,
+    SecureCoding,
+    String,
+    URL,
+    NSValue,
+    CF,
+    Unknown,
+};
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCWebKitSecureCoding.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCWebKitSecureCoding.h
@@ -26,45 +26,43 @@
 #pragma once
 
 #if ENABLE(DATA_DETECTION)
-#if PLATFORM(COCOA)
 
 #include "ArgumentCodersCocoa.h"
 #include "CoreIPCDictionary.h"
 #include "CoreIPCSecureCoding.h"
 #include <wtf/RetainPtr.h>
 
-OBJC_CLASS DDScannerResult;
-
 namespace WebKit {
 
 class CoreIPCNSCFObject;
 
-class CoreIPCDDScannerResult {
+class CoreIPCWebKitSecureCoding {
 public:
-    CoreIPCDDScannerResult(DDScannerResult *);
-    CoreIPCDDScannerResult(const RetainPtr<DDScannerResult>& result)
-        : CoreIPCDDScannerResult(result.get())
+    CoreIPCWebKitSecureCoding(NSObject<NSSecureCoding> *);
+    CoreIPCWebKitSecureCoding(const RetainPtr<NSObject<NSSecureCoding>>& object)
+        : CoreIPCWebKitSecureCoding(object.get())
     {
     }
 
     RetainPtr<id> toID() const;
 
 private:
-    friend struct IPC::ArgumentCoder<CoreIPCDDScannerResult, void>;
+    friend struct IPC::ArgumentCoder<CoreIPCWebKitSecureCoding, void>;
 
     using Value = std::variant<CoreIPCDictionary, CoreIPCSecureCoding>;
 
-    static Value valueFromDDScannerResult(DDScannerResult *);
+    static Value valueFromNSSecureCoding(NSObject<NSSecureCoding> *);
 
-    CoreIPCDDScannerResult(Value&& value)
-        : m_value(WTFMove(value))
+    CoreIPCWebKitSecureCoding(IPC::NSType type, Value&& value)
+        : m_type(type)
+        , m_value(WTFMove(value))
     {
     }
 
+    IPC::NSType m_type;
     Value m_value;
 };
 
 } // namespace WebKit
 
-#endif // PLATFORM(COCOA)
 #endif // ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCWebKitSecureCoding.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCWebKitSecureCoding.serialization.in
@@ -22,10 +22,11 @@
 
 #if PLATFORM(COCOA) && ENABLE(DATA_DETECTION)
 
-webkit_platform_headers: "CoreIPCDDScannerResult.h"
+webkit_platform_headers: "CoreIPCWebKitSecureCoding.h"
 
-[WebKitPlatform] class WebKit::CoreIPCDDScannerResult {
-    WebKit::CoreIPCDDScannerResult::Value m_value
+[WebKitPlatform] class WebKit::CoreIPCWebKitSecureCoding {
+    IPC::NSType m_type;
+    WebKit::CoreIPCWebKitSecureCoding::Value m_value;
 }
 
 #endif // PLATFORM(COCOA) && ENABLE(DATA_DETECTION)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1203,10 +1203,10 @@
 		51A9E10B1315CD18009E7031 /* WKKeyValueStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A9E1091315CD18009E7031 /* WKKeyValueStorageManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51ACBB82127A8BAD00D203B9 /* WebContextMenuProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACBB81127A8BAD00D203B9 /* WebContextMenuProxy.h */; };
 		51ACBBA0127A8F2C00D203B9 /* WebContextMenuProxyMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACBB9E127A8F2C00D203B9 /* WebContextMenuProxyMac.h */; };
-		51ACFFD92B048804001331A2 /* CoreIPCDDScannerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACFFD62B048804001331A2 /* CoreIPCDDScannerResult.h */; };
 		51ACFFDF2B048821001331A2 /* CoreIPCNSValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */; };
 		51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */; };
-		51ACFFE12B048831001331A2 /* CoreIPCDDScannerResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51ACFFD42B048803001331A2 /* CoreIPCDDScannerResult.mm */; };
+		51ACFFEE2B06ACEC001331A2 /* CoreIPCWebKitSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACFFEB2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.h */; };
+		51ACFFEF2B06ACF0001331A2 /* CoreIPCWebKitSecureCoding.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51ACFFEC2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.mm */; };
 		51B15A8513843A3900321AD8 /* EnvironmentUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B15A8313843A3900321AD8 /* EnvironmentUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51BE6C572AA92480001745C1 /* WebPushToolMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F64275A8D7E002DC22D /* WebPushToolMain.mm */; };
 		51BE6C5A2AA9250D001745C1 /* webpushtool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51BE6C582AA92503001745C1 /* webpushtool.cpp */; };
@@ -5279,12 +5279,13 @@
 		51ACBB9F127A8F2C00D203B9 /* WebContextMenuProxyMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContextMenuProxyMac.mm; sourceTree = "<group>"; };
 		51ACC9341628064800342550 /* NetworkProcessMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkProcessMessageReceiver.cpp; sourceTree = "<group>"; };
 		51ACC9351628064800342550 /* NetworkProcessMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcessMessages.h; sourceTree = "<group>"; };
-		51ACFFD42B048803001331A2 /* CoreIPCDDScannerResult.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDDScannerResult.mm; sourceTree = "<group>"; };
-		51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCDDScannerResult.serialization.in; sourceTree = "<group>"; };
-		51ACFFD62B048804001331A2 /* CoreIPCDDScannerResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCDDScannerResult.h; sourceTree = "<group>"; };
 		51ACFFDA2B048820001331A2 /* CoreIPCNSValue.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNSValue.serialization.in; sourceTree = "<group>"; };
 		51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSValue.mm; sourceTree = "<group>"; };
 		51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSValue.h; sourceTree = "<group>"; };
+		51ACFFEB2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCWebKitSecureCoding.h; sourceTree = "<group>"; };
+		51ACFFEC2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCWebKitSecureCoding.mm; sourceTree = "<group>"; };
+		51ACFFED2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCWebKitSecureCoding.serialization.in; sourceTree = "<group>"; };
+		51ACFFF02B06B870001331A2 /* CoreIPCNSType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCNSType.serialization.in; sourceTree = "<group>"; };
 		51B15A8213843A3900321AD8 /* EnvironmentUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EnvironmentUtilities.cpp; path = unix/EnvironmentUtilities.cpp; sourceTree = "<group>"; };
 		51B15A8313843A3900321AD8 /* EnvironmentUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EnvironmentUtilities.h; path = unix/EnvironmentUtilities.h; sourceTree = "<group>"; };
 		51BE6C552AA92406001745C1 /* WebPushToolMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPushToolMain.h; sourceTree = "<group>"; };
@@ -10779,9 +10780,6 @@
 				F48C81E52AE0E1DF00073850 /* CoreIPCData.serialization.in */,
 				F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */,
 				F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */,
-				51ACFFD62B048804001331A2 /* CoreIPCDDScannerResult.h */,
-				51ACFFD42B048803001331A2 /* CoreIPCDDScannerResult.mm */,
-				51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */,
 				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
 				5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */,
 				5197FADE2AFD33B3009180C5 /* CoreIPCDictionary.serialization.in */,
@@ -10794,6 +10792,7 @@
 				5197FACE2AFD33AF009180C5 /* CoreIPCNSCFObject.h */,
 				5197FADC2AFD33B2009180C5 /* CoreIPCNSCFObject.mm */,
 				5197FAD02AFD33AF009180C5 /* CoreIPCNSCFObject.serialization.in */,
+				51ACFFF02B06B870001331A2 /* CoreIPCNSType.serialization.in */,
 				51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */,
 				51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */,
 				51ACFFDA2B048820001331A2 /* CoreIPCNSValue.serialization.in */,
@@ -10804,6 +10803,9 @@
 				5197FAD42AFD33B0009180C5 /* CoreIPCString.serialization.in */,
 				5197FADB2AFD33B2009180C5 /* CoreIPCURL.h */,
 				5197FAC92AFD33AE009180C5 /* CoreIPCURL.serialization.in */,
+				51ACFFEB2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.h */,
+				51ACFFEC2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.mm */,
+				51ACFFED2B06ACE9001331A2 /* CoreIPCWebKitSecureCoding.serialization.in */,
 				1C739E872347BD0F00C621EC /* CoreTextHelpers.h */,
 				1C739E852347BCF600C621EC /* CoreTextHelpers.mm */,
 				C55F916C1C595E440029E92D /* DataDetectionResult.h */,
@@ -14993,7 +14995,6 @@
 				5197FAE82AFD33CF009180C5 /* CoreIPCColor.h in Headers */,
 				F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */,
 				F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */,
-				51ACFFD92B048804001331A2 /* CoreIPCDDScannerResult.h in Headers */,
 				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
 				F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */,
 				5197FAE32AFD33CF009180C5 /* CoreIPCFont.h in Headers */,
@@ -15003,6 +15004,7 @@
 				5197FAE92AFD33CF009180C5 /* CoreIPCSecureCoding.h in Headers */,
 				5197FAE52AFD33CF009180C5 /* CoreIPCString.h in Headers */,
 				5197FAE62AFD33CF009180C5 /* CoreIPCURL.h in Headers */,
+				51ACFFEE2B06ACEC001331A2 /* CoreIPCWebKitSecureCoding.h in Headers */,
 				A15799BC2584433200528236 /* CoreMediaWrapped.h in Headers */,
 				37C21CAE1E994C0C0029D5F9 /* CorePredictionSPI.h in Headers */,
 				1C62900D28EE2CD300C26B60 /* CoreSVGSPI.h in Headers */,
@@ -17819,13 +17821,13 @@
 				51FFD3092AE9A9FC00B0AB70 /* ArgumentCodersCocoa.mm in Sources */,
 				5131D5442AE9D4370016EF39 /* ArgumentCodersCocoa.mm in Sources */,
 				5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */,
-				51ACFFE12B048831001331A2 /* CoreIPCDDScannerResult.mm in Sources */,
 				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,
 				F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */,
 				5187BDF02B007445008A6EE5 /* CoreIPCFont.mm in Sources */,
 				5197FAF22AFD33FF009180C5 /* CoreIPCNSCFObject.mm in Sources */,
 				51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */,
 				5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */,
+				51ACFFEF2B06ACF0001331A2 /* CoreIPCWebKitSecureCoding.mm in Sources */,
 				5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */,
 				7B9FC5D128A53014007570E7 /* PlatformUnifiedSource1-mm.mm in Sources */,
 				7B9FC5A828A38D1E007570E7 /* PlatformUnifiedSource1.cpp in Sources */,


### PR DESCRIPTION
#### 1bce07556eaa7f75414b5d0ddeeee98fcfa31352
<pre>
Rename CoreIPCDDScannerResult to CoreIPCWebKitSecureCoding for more general use
<a href="https://bugs.webkit.org/show_bug.cgi?id=264976">https://bugs.webkit.org/show_bug.cgi?id=264976</a>

Reviewed by NOBODY (OOPS!).

We&apos;re going to be adding more Obj-C types that work exactly like DDScannerResult
other than their class, so this wrapper class should just be general purpose.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCNSType.serialization.in: Copied from Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in.
* Source/WebKit/Shared/Cocoa/CoreIPCWebKitSecureCoding.h: Renamed from Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h.
(WebKit::CoreIPCWebKitSecureCoding::CoreIPCWebKitSecureCoding):
* Source/WebKit/Shared/Cocoa/CoreIPCWebKitSecureCoding.mm: Renamed from Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm.
(WebKit::webKitSecureCodingClassFromNSType):
(WebKit::shouldWrapWithPropertyList):
(WebKit::CoreIPCWebKitSecureCoding::valueFromNSSecureCoding):
(WebKit::CoreIPCWebKitSecureCoding::CoreIPCWebKitSecureCoding):
(WebKit::CoreIPCWebKitSecureCoding::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCWebKitSecureCoding.serialization.in: Renamed from Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bce07556eaa7f75414b5d0ddeeee98fcfa31352

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24325 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24274 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3611 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29870 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27767 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->