### PR TITLE
Adopt UIExtendedTextInputTraits and -[UIAsyncTextInput extendedTraitsDelegate]

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1238,6 +1238,17 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 @end
 
+@protocol UIExtendedTextInputTraits_Staging_117880911<UITextInputTraits>
+@optional
+
+@property (nonatomic, readonly) BOOL isSingleLineDocument;
+@property (nonatomic, readonly) BOOL typingAdaptationDisabled;
+@property (nonatomic, readonly) UIColor *insertionPointColor;
+@property (nonatomic, readonly) UIColor *selectionBarColor;
+@property (nonatomic, readonly) UIColor *selectionHighlightColor;
+
+@end
+
 #if !defined(UI_DIRECTIONAL_TEXT_RANGE_STRUCT)
 
 typedef struct {

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -486,6 +486,7 @@ UIProcess/ios/WKApplicationStateTrackingView.mm
 UIProcess/ios/WKContentView.mm @no-unify
 UIProcess/ios/WKContentViewInteraction.mm @no-unify
 UIProcess/ios/WKDeferringGestureRecognizer.mm
+UIProcess/ios/WKExtendedTextInputTraits.mm
 UIProcess/ios/WKGeolocationProviderIOS.mm
 UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm
 UIProcess/ios/WKImageAnalysisGestureRecognizer.mm

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -277,6 +277,7 @@ struct ImageAnalysisContextMenuActionData {
 
 } // namespace WebKit
 
+@class WKExtendedTextInputTraits;
 @class WKFocusedElementInfo;
 @protocol UIMenuBuilder;
 @protocol WKFormControl;
@@ -346,7 +347,8 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<WKTextInteractionWrapper> _textInteractionWrapper;
     OptionSet<WebKit::SuppressSelectionAssistantReason> _suppressSelectionAssistantReasons;
 
-    RetainPtr<UITextInputTraits> _traits;
+    RetainPtr<UITextInputTraits> _legacyTextInputTraits;
+    RetainPtr<WKExtendedTextInputTraits> _extendedTextInputTraits;
     RetainPtr<WKFormAccessoryView> _formAccessoryView;
     RetainPtr<WKTapHighlightView> _tapHighlightView;
     RetainPtr<UIView> _interactionViewsContainerView;

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "UIKitSPI.h"
+
+@interface WKExtendedTextInputTraits : NSObject
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    <UIExtendedTextInputTraits_Staging_117880911>
+#endif
+
+@property (nonatomic) UITextAutocapitalizationType autocapitalizationType;
+@property (nonatomic) UITextAutocorrectionType autocorrectionType;
+@property (nonatomic) UITextSpellCheckingType spellCheckingType;
+@property (nonatomic) UITextSmartQuotesType smartQuotesType;
+@property (nonatomic) UITextSmartDashesType smartDashesType;
+@property (nonatomic) UITextInlinePredictionType inlinePredictionType;
+@property (nonatomic) UIKeyboardType keyboardType;
+@property (nonatomic) UIKeyboardAppearance keyboardAppearance;
+@property (nonatomic) UIReturnKeyType returnKeyType;
+@property (nonatomic, getter=isSecureTextEntry) BOOL secureTextEntry;
+@property (nonatomic, getter=isSingleLineDocument) BOOL singleLineDocument;
+@property (nonatomic) BOOL typingAdaptationDisabled;
+@property (nonatomic, copy) UITextContentType textContentType;
+
+@property (nonatomic, strong) UIColor *insertionPointColor;
+@property (nonatomic, strong) UIColor *selectionBarColor;
+@property (nonatomic, strong) UIColor *selectionHighlightColor;
+
+- (void)setSelectionColorsToMatchTintColor:(UIColor *)tintColor;
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKExtendedTextInputTraits.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+namespace WebKit {
+
+static constexpr auto selectionHighlightAlphaComponent = 0.2;
+
+static UIColor *defaultInsertionPointColor()
+{
+#if PLATFORM(MACCATALYST)
+    return UIColor.systemBlueColor;
+#else
+    static NeverDestroyed<RetainPtr<UIColor>> color = [UIColor colorWithRed:0.26 green:0.42 blue:0.95 alpha:1];
+    return color->get();
+#endif
+}
+
+static UIColor *defaultSelectionGrabberColor()
+{
+    static NeverDestroyed<RetainPtr<UIColor>> color = [UIColor colorWithRed:0.078 green:0.435 blue:0.882 alpha:1];
+    return color->get();
+}
+
+static UIColor *defaultSelectionHighlightColor()
+{
+    static NeverDestroyed<RetainPtr<UIColor>> color = [UIColor colorWithRed:0.33 green:0.65 blue:0.2 alpha:1];
+    return color->get();
+}
+
+} // namespace WebKit
+
+@implementation WKExtendedTextInputTraits {
+    RetainPtr<UITextContentType> _textContentType;
+    RetainPtr<UIColor> _insertionPointColor;
+    RetainPtr<UIColor> _selectionBarColor;
+    RetainPtr<UIColor> _selectionHighlightColor;
+}
+
+- (void)setTextContentType:(UITextContentType)type
+{
+    _textContentType = adoptNS(type.copy);
+}
+
+- (UITextContentType)textContentType
+{
+    return _textContentType.get();
+}
+
+- (void)setInsertionPointColor:(UIColor *)color
+{
+    _insertionPointColor = color;
+}
+
+- (UIColor *)insertionPointColor
+{
+    return _insertionPointColor.get();
+}
+
+- (void)setSelectionBarColor:(UIColor *)color
+{
+    _selectionBarColor = color;
+}
+
+- (UIColor *)selectionBarColor
+{
+    return _selectionBarColor.get();
+}
+
+- (void)setSelectionHighlightColor:(UIColor *)color
+{
+    _selectionHighlightColor = color;
+}
+
+- (UIColor *)selectionHighlightColor
+{
+    return _selectionHighlightColor.get();
+}
+
+- (void)setSelectionColorsToMatchTintColor:(UIColor *)tintColor
+{
+    BOOL shouldUseTintColor = tintColor && tintColor != UIColor.systemBlueColor;
+    self.insertionPointColor = shouldUseTintColor ? tintColor : WebKit::defaultInsertionPointColor();
+    self.selectionBarColor = shouldUseTintColor ? tintColor : WebKit::defaultSelectionGrabberColor();
+    self.selectionHighlightColor = shouldUseTintColor ? [tintColor colorWithAlphaComponent:WebKit::selectionHighlightAlphaComponent] : WebKit::defaultSelectionHighlightColor();
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2352,6 +2352,7 @@
 		F4DB54E62319E733009E3155 /* WKHighlightLongPressGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DB54E42319E733009E3155 /* WKHighlightLongPressGestureRecognizer.h */; };
 		F4DBC0BE276AA6A70001D169 /* _WKModalContainerInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DBC0BC276AA6A70001D169 /* _WKModalContainerInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F4DBC0C1276AA6CA0001D169 /* _WKModalContainerInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DBC0C0276AA6CA0001D169 /* _WKModalContainerInfoInternal.h */; };
+		F4DF71E82B069AC6009A4522 /* WKExtendedTextInputTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
 		F4EC94E32356CC57000BB614 /* ApplicationServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 29D04E2821F7C73D0076741D /* ApplicationServicesSPI.h */; };
@@ -7623,6 +7624,8 @@
 		F4DBC0C0276AA6CA0001D169 /* _WKModalContainerInfoInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKModalContainerInfoInternal.h; sourceTree = "<group>"; };
 		F4DD79EE2AD59BA6000C6821 /* WKVelocityTrackingScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKVelocityTrackingScrollView.h; path = ios/WKVelocityTrackingScrollView.h; sourceTree = "<group>"; };
 		F4DD79EF2AD59BA6000C6821 /* WKVelocityTrackingScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKVelocityTrackingScrollView.mm; path = ios/WKVelocityTrackingScrollView.mm; sourceTree = "<group>"; };
+		F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKExtendedTextInputTraits.h; path = ios/WKExtendedTextInputTraits.h; sourceTree = "<group>"; };
+		F4DF71D82B0689A5009A4522 /* WKExtendedTextInputTraits.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKExtendedTextInputTraits.mm; path = ios/WKExtendedTextInputTraits.mm; sourceTree = "<group>"; };
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
 		F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTouchEventsGestureRecognizerTypes.h; path = ios/WKTouchEventsGestureRecognizerTypes.h; sourceTree = "<group>"; };
@@ -10169,6 +10172,8 @@
 				0FCB4E6B18BBF26A000FCFC9 /* WKContentViewInteraction.mm */,
 				F44815622387820000982657 /* WKDeferringGestureRecognizer.h */,
 				F44815632387820000982657 /* WKDeferringGestureRecognizer.mm */,
+				F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */,
+				F4DF71D82B0689A5009A4522 /* WKExtendedTextInputTraits.mm */,
 				0FCB4E3F18BBE044000FCFC9 /* WKGeolocationProviderIOS.h */,
 				0FCB4E4018BBE044000FCFC9 /* WKGeolocationProviderIOS.mm */,
 				F4DB54E42319E733009E3155 /* WKHighlightLongPressGestureRecognizer.h */,
@@ -15982,6 +15987,7 @@
 				37B5045219EEF31300CE2CF8 /* WKErrorPrivate.h in Headers */,
 				BC4075FC124FF0270068F20A /* WKErrorRef.h in Headers */,
 				BC40783D1250FADD0068F20A /* WKEvent.h in Headers */,
+				F4DF71E82B069AC6009A4522 /* WKExtendedTextInputTraits.h in Headers */,
 				27A2BDFC28932C4200758E99 /* WKFeature.h in Headers */,
 				A58B6F0818FCA733008CBA53 /* WKFileUploadPanel.h in Headers */,
 				514AB9F02360D2A900EDC396 /* WKFindConfiguration.h in Headers */,


### PR DESCRIPTION
#### 7fe2f32f2d486d5a1a92e0095b108bede6790568
<pre>
Adopt UIExtendedTextInputTraits and -[UIAsyncTextInput extendedTraitsDelegate]
<a href="https://bugs.webkit.org/show_bug.cgi?id=264977">https://bugs.webkit.org/show_bug.cgi?id=264977</a>
<a href="https://rdar.apple.com/118526529">rdar://118526529</a>

Reviewed by Tim Horton.

Adopt the new `UIExtendedTextInputTraits` protocol (which offers additional properties in addition
to the existing API properties on `UITextInputTraits`); this is passed from WebKit to UIKit via a
new `UIAsyncTextInput` delegate method, `-extendedTraitsDelegate`.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Rename the existing `_traits` object (a concrete `UITextInputTraits` object) to
`_legacyTextInputTraits`, and introduce a new `_extendedTextInputTraits` object, which is returned
from the new `UIAsyncTextInput` delegate method.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateTextInputTraitsForInteractionTintColor]):
(-[WKContentView tintColorDidChange]):
(-[WKContentView textInputTraits]):
(-[WKContentView textInputTraitsForWebView]):
(-[WKContentView _updateTextInputTraits:]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView extendedTraitsDelegate]):
(-[WKContentView _updateInteractionTintColor:]): Deleted.

Update this to set colors on either `_extendedTextInputTraits` or `_legacyTextInputTraits`, instead
of having the caller pass in the traits object. This is only ever used to update the currently
cached traits object, so there&apos;s no change in behavior here.

* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h: Added.
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm: Added.
(WebKit::defaultInsertionPointColor):
(WebKit::defaultSelectionGrabberColor):
(WebKit::defaultSelectionHighlightColor):
(-[WKExtendedTextInputTraits setTextContentType:]):
(-[WKExtendedTextInputTraits textContentType]):
(-[WKExtendedTextInputTraits setInsertionPointColor:]):
(-[WKExtendedTextInputTraits insertionPointColor]):
(-[WKExtendedTextInputTraits setSelectionBarColor:]):
(-[WKExtendedTextInputTraits selectionBarColor]):
(-[WKExtendedTextInputTraits setSelectionHighlightColor:]):
(-[WKExtendedTextInputTraits selectionHighlightColor]):
(-[WKExtendedTextInputTraits setSelectionColorsToMatchTintColor:]):

Add a new concrete implementation of `UIExtendedTextInputTraits` that&apos;s instantiated in WebKit and
returned via `-[UIAsyncTextInput extendedTraitsDelegate]`. This also eliminates use of another SPI
method, `-_setColorsToMatchTintColor:`, albeit at the cost of hard-coding some system colors related
to text interaction.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270854@main">https://commits.webkit.org/270854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1868a18790d03f96db0608613934e1476cb861c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2631 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3569 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29307 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29875 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27773 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5086 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->