### PR TITLE
REGRESSION (270808@main): [macOS WK1 x86] platform/mac/media/encrypted-media/fps-generateRequest.html is a flaky crash

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -210,7 +210,8 @@ protected:
     // Must be called once all samples have been processed.
     WEBCORE_EXPORT void appendCompleted(bool parsingSucceeded, Function<void()>&& = [] { });
 
-    WeakPtr<SourceBufferPrivateClient> m_client;
+    WEBCORE_EXPORT bool isAttached() const;
+    WEBCORE_EXPORT SourceBufferPrivateClient& client() const;
 
     WeakPtr<MediaSourcePrivate> m_mediaSource { nullptr };
 
@@ -224,13 +225,14 @@ private:
     void trySignalAllSamplesInTrackEnqueued(TrackBuffer&, const AtomString& trackID);
     MediaTime findPreviousSyncSamplePresentationTime(const MediaTime&);
     bool evictFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime);
-    bool isAttached() const;
     virtual Vector<PlatformTimeRanges> trackBuffersRanges() const;
     bool hasTooManySamples() const;
 
     bool m_hasAudio { false };
     bool m_hasVideo { false };
     bool m_isActive { false };
+
+    WeakPtr<SourceBufferPrivateClient> m_client;
 
     MemoryCompactRobinHoodHashMap<AtomString, UniqueRef<TrackBuffer>> m_trackBufferMap;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -608,9 +608,6 @@ Ref<GenericPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>
     ASSERT(!m_hasSessionSemaphore);
     ASSERT(!m_abortSemaphore);
 
-    if (m_client)
-        m_client->sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
-
     m_parser->setDidParseInitializationDataCallback([weakThis = WeakPtr { *this }] (InitializationSegment&& segment) {
         ASSERT(isMainThread());
         if (!weakThis)
@@ -1068,8 +1065,8 @@ void SourceBufferPrivateAVFObjC::layerDidReceiveError(AVSampleBufferDisplayLayer
 
     int errorCode = [[[error userInfo] valueForKey:@"OSStatus"] intValue];
 
-    if (m_client)
-        m_client->sourceBufferPrivateDidReceiveRenderingError(errorCode);
+    if (isAttached())
+        client().sourceBufferPrivateDidReceiveRenderingError(errorCode);
 }
 
 void SourceBufferPrivateAVFObjC::rendererWasAutomaticallyFlushed(AVSampleBufferAudioRenderer *renderer, const CMTime& time)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -84,8 +84,6 @@ SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer(MediaSourcePrivateGSt
 Ref<GenericPromise> SourceBufferPrivateGStreamer::appendInternal(Ref<SharedBuffer>&& data)
 {
     ASSERT(isMainThread());
-    ASSERT(m_mediaSource);
-    ASSERT(m_client);
 
     GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Appending %zu bytes", data->size());
 
@@ -253,7 +251,7 @@ WTFLogChannel& SourceBufferPrivateGStreamer::logChannel() const
 size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
 {
 #if PLATFORM(WPE)
-    if (!m_client)
+    if (!isAttached())
         return 0;
 
     static size_t maxBufferSizeVideo = 0;

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -169,9 +169,6 @@ Ref<GenericPromise> MockSourceBufferPrivate::appendInternal(Ref<SharedBuffer>&& 
 
 void MockSourceBufferPrivate::didReceiveInitializationSegment(const MockInitializationBox& initBox)
 {
-    if (!m_client)
-        return;
-
     SourceBufferPrivateClient::InitializationSegment segment;
     segment.duration = initBox.duration();
 
@@ -200,9 +197,6 @@ void MockSourceBufferPrivate::didReceiveInitializationSegment(const MockInitiali
 
 void MockSourceBufferPrivate::didReceiveSample(const MockSampleBox& sampleBox)
 {
-    if (!m_client)
-        return;
-
     SourceBufferPrivate::didReceiveSample(MockMediaSample::create(sampleBox));
 }
 


### PR DESCRIPTION
#### 7bce33def568ee52c281a3e95db38d735d209157
<pre>
REGRESSION (270808@main): [macOS WK1 x86] platform/mac/media/encrypted-media/fps-generateRequest.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=264975">https://bugs.webkit.org/show_bug.cgi?id=264975</a>
<a href="https://rdar.apple.com/118524493">rdar://118524493</a>

Reviewed by Jer Noble.

Ensure WeakPtr is accessed after being first checked.
We make m_client a private SourceBufferPrivate member and add a client()
method instead.

Fly-by ensure consistency for check by called `isAttached()` instead.

Covered by existing tests.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::setBufferedRanges):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::processPendingMediaSamples):
(WebCore::SourceBufferPrivate::processMediaSample):
(WebCore::SourceBufferPrivate::client const):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm: The base class already notifies the client about the size being used.
So remove this extra notification to ensure consistency between all implementations.
(WebCore::SourceBufferPrivateAVFObjC::appendInternal):
(WebCore::SourceBufferPrivateAVFObjC::layerDidReceiveError):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::appendInternal):
(WebCore::SourceBufferPrivateGStreamer::platformMaximumBufferSize const):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp: Remove the need to check for m_client, this is done in the base class already.
(WebCore::MockSourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::MockSourceBufferPrivate::didReceiveSample):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::~SourceBufferPrivateRemote):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateAppendComplete):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateHighestPresentationTimestampChanged):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDurationChanged):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidParseSample):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidDropSample):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveRenderingError):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateReportExtraMemoryCost):

Canonical link: <a href="https://commits.webkit.org/270862@main">https://commits.webkit.org/270862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e77845267d5c1da3ea0f9b49d3b540ca6c7b15b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28876 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3602 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29908 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27807 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5125 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6398 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->