### PR TITLE
[iPad] Fullscreening a Youtube video while in Light Mode causes a white bar across the top and bottom of the screen

### DIFF
--- a/LayoutTests/fullscreen/full-screen-document-background-color-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-document-background-color-expected.txt
@@ -1,5 +1,28 @@
 
+RUN(frame.src = "resources/green.html")
+EVENT(load)
 EXPECTED (internals.documentBackgroundColor() == 'rgb(255, 255, 255)') OK
+RUN(enterFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(0, 0, 0)') OK
+RUN(exitFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(255, 255, 255)') OK
+
+RUN(frame.src = "resources/empty.html")
+EVENT(load)
+RUN(enterFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(0, 0, 0)') OK
+RUN(exitFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(255, 255, 255)') OK
+
+RUN(frame.src = "resources/backdrop-green.html")
+EVENT(load)
+RUN(enterFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(0, 128, 0)') OK
+RUN(exitFullscreen())
+EXPECTED (internals.documentBackgroundColor() == 'rgb(255, 255, 255)') OK
+
+RUN(frame.src = "resources/backdrop-red-on-green.html")
+EVENT(load)
 RUN(enterFullscreen())
 EXPECTED (internals.documentBackgroundColor() == 'rgb(0, 128, 0)') OK
 RUN(exitFullscreen())

--- a/LayoutTests/fullscreen/full-screen-document-background-color.html
+++ b/LayoutTests/fullscreen/full-screen-document-background-color.html
@@ -24,7 +24,34 @@
     }
 
     async function runTest() {
+        run('frame.src = "resources/green.html"');
+        await waitFor(frame, 'load');
+
         testExpected('internals.documentBackgroundColor()', 'rgb(255, 255, 255)');
+        await run('enterFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(0, 0, 0)');
+        await run('exitFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(255, 255, 255)');
+
+        consoleWrite('');
+        run('frame.src = "resources/empty.html"');
+        await waitFor(frame, 'load');
+        await run('enterFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(0, 0, 0)');
+        await run('exitFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(255, 255, 255)');
+
+        consoleWrite('');
+        run('frame.src = "resources/backdrop-green.html"');
+        await waitFor(frame, 'load');
+        await run('enterFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(0, 128, 0)');
+        await run('exitFullscreen()');
+        testExpected('internals.documentBackgroundColor()', 'rgb(255, 255, 255)');
+
+        consoleWrite('');
+        run('frame.src = "resources/backdrop-red-on-green.html"');
+        await waitFor(frame, 'load');
         await run('enterFullscreen()');
         testExpected('internals.documentBackgroundColor()', 'rgb(0, 128, 0)');
         await run('exitFullscreen()');
@@ -36,5 +63,5 @@
     </script>
 </head>
 <body>
-    <iframe id=frame width=100 height=50 src="resources/green.html"></iframe>
+    <iframe id=frame width=100 height=50></iframe>
 </body>

--- a/LayoutTests/fullscreen/resources/backdrop-green.html
+++ b/LayoutTests/fullscreen/resources/backdrop-green.html
@@ -1,0 +1,8 @@
+<html>
+  <style>
+    :fullscreen::backdrop {
+      background-color: green;
+    }
+  </style>
+  <body></body>
+</html>

--- a/LayoutTests/fullscreen/resources/backdrop-red-on-green.html
+++ b/LayoutTests/fullscreen/resources/backdrop-red-on-green.html
@@ -1,0 +1,11 @@
+<html>
+  <style>
+    body {
+      background-color: red;
+    }
+    :fullscreen::backdrop {
+      background-color: green;
+    }
+  </style>
+  <body></body>
+</html>


### PR DESCRIPTION
#### 634bc0b60bf0013b8d061f8e1dd3faeeb93653e4
<pre>
[iPad] Fullscreening a Youtube video while in Light Mode causes a white bar across the top and bottom of the screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=264985">https://bugs.webkit.org/show_bug.cgi?id=264985</a>
<a href="https://rdar.apple.com/118530255">rdar://118530255</a>

Reviewed by Tim Nguyen.

Tests updated: fullscreen/full-screen-document-background-color.html

Take the :fullscreen::backdrop element into account when calculating the documentBackgroundColor.
This will be black by default, so even for websites that have a clear background color on their
fullscreen element, the documentBackgroundColor should usually calculate to black. (Unless they
override the backdrop color, in which case this would the site&apos;s preferred behavior).

* LayoutTests/fullscreen/full-screen-document-background-color-expected.txt:
* LayoutTests/fullscreen/full-screen-document-background-color.html:
* LayoutTests/fullscreen/resources/backdrop-green-on-red.html: Added.
* LayoutTests/fullscreen/resources/backdrop-green.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::documentBackgroundColor const):

Canonical link: <a href="https://commits.webkit.org/271535@main">https://commits.webkit.org/271535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/007d256dac292adf0b98282a32e915df4536d4da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26141 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26222 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31622 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5346 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3518 "Found 1 new test failure: http/wpt/webrtc/video-script-transform.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29400 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6867 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->