### PR TITLE
Adopt ASCIILiteral in TextEncoding code

### DIFF
--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -26,6 +26,7 @@
 #include <wtf/HashFunctions.h>
 #include <wtf/KeyValuePair.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ASCIILiteral.h>
 
 #ifdef __OBJC__
 #include <CoreFoundation/CoreFoundation.h>
@@ -199,6 +200,13 @@ template<typename T> struct HashTraits<UniqueRef<T>> : SimpleClassHashTraits<Uni
     using TakeType = std::unique_ptr<T>;
     static TakeType take(UniqueRef<T>&& value) { return value.moveToUniquePtr(); }
     static TakeType take(std::nullptr_t) { return nullptr; }
+};
+
+template<> struct HashTraits<ASCIILiteral> : SimpleClassHashTraits<ASCIILiteral> {
+    static ASCIILiteral emptyValue() { return { }; }
+
+    static void constructDeletedValue(ASCIILiteral& slot) { slot = ASCIILiteral::fromLiteralUnsafe(reinterpret_cast<const char*>(-1)); }
+    static bool isDeletedValue(const ASCIILiteral& value) { return value.characters() == reinterpret_cast<const char*>(-1); }
 };
 
 template<typename P, typename Q, typename R> struct HashTraits<RefPtr<P, Q, R>> : SimpleClassHashTraits<RefPtr<P, Q, R>> {

--- a/Source/WebCore/PAL/pal/text/TextCodec.h
+++ b/Source/WebCore/PAL/pal/text/TextCodec.h
@@ -58,9 +58,9 @@ public:
 
 Function<void(UChar32, Vector<uint8_t>&)> unencodableHandler(UnencodableHandling);
 
-using EncodingNameRegistrar = void (*)(const char* alias, const char* name);
+using EncodingNameRegistrar = void (*)(ASCIILiteral alias, ASCIILiteral name);
 
 using NewTextCodecFunction = Function<std::unique_ptr<TextCodec>()>;
-using TextCodecRegistrar = void (*)(const char* name, NewTextCodecFunction&&);
+using TextCodecRegistrar = void (*)(ASCIILiteral name, NewTextCodecFunction&&);
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -53,111 +53,111 @@ TextCodecCJK::TextCodecCJK(Encoding encoding)
 void TextCodecCJK::registerEncodingNames(EncodingNameRegistrar registrar)
 {
     // https://encoding.spec.whatwg.org/#names-and-labels
-    auto registerAliases = [&] (std::initializer_list<const char*> list) {
-        for (auto* alias : list)
+    auto registerAliases = [&] (std::initializer_list<ASCIILiteral> list) {
+        for (auto& alias : list)
             registrar(alias, *list.begin());
     };
 
     registerAliases({
-        "Big5",
-        "big5-hkscs",
-        "cn-big5",
-        "csbig5",
-        "x-x-big5"
+        "Big5"_s,
+        "big5-hkscs"_s,
+        "cn-big5"_s,
+        "csbig5"_s,
+        "x-x-big5"_s
     });
 
     registerAliases({
-        "EUC-JP",
-        "cseucpkdfmtjapanese",
-        "x-euc-jp"
+        "EUC-JP"_s,
+        "cseucpkdfmtjapanese"_s,
+        "x-euc-jp"_s
     });
 
     registerAliases({
-        "Shift_JIS",
-        "csshiftjis",
-        "ms932",
-        "ms_kanji",
-        "shift-jis",
-        "sjis",
-        "windows-31j",
-        "x-sjis"
+        "Shift_JIS"_s,
+        "csshiftjis"_s,
+        "ms932"_s,
+        "ms_kanji"_s,
+        "shift-jis"_s,
+        "sjis"_s,
+        "windows-31j"_s,
+        "x-sjis"_s
     });
 
     registerAliases({
-        "EUC-KR",
-        "cseuckr",
-        "csksc56011987",
-        "iso-ir-149",
-        "korean",
-        "ks_c_5601-1987",
-        "ks_c_5601-1989",
-        "ksc5601",
-        "ksc_5601",
-        "windows-949",
+        "EUC-KR"_s,
+        "cseuckr"_s,
+        "csksc56011987"_s,
+        "iso-ir-149"_s,
+        "korean"_s,
+        "ks_c_5601-1987"_s,
+        "ks_c_5601-1989"_s,
+        "ksc5601"_s,
+        "ksc_5601"_s,
+        "windows-949"_s,
 
         // These aliases are not in the specification, but WebKit has historically supported them.
-        "x-windows-949",
-        "x-uhc",
+        "x-windows-949"_s,
+        "x-uhc"_s,
     });
 
     registerAliases({
-        "ISO-2022-JP",
-        "csiso2022jp"
+        "ISO-2022-JP"_s,
+        "csiso2022jp"_s
     });
 
     registerAliases({
-        "GBK",
-        "chinese",
-        "csgb2312",
-        "csiso58gb231280",
-        "gb2312",
-        "gb_2312",
-        "gb_2312-80",
-        "iso-ir-58",
-        "x-gbk",
+        "GBK"_s,
+        "chinese"_s,
+        "csgb2312"_s,
+        "csiso58gb231280"_s,
+        "gb2312"_s,
+        "gb_2312"_s,
+        "gb_2312-80"_s,
+        "iso-ir-58"_s,
+        "x-gbk"_s,
 
         // These aliases are not in the specification, but WebKit has historically supported them.
-        "cn-gb",
-        "csgb231280",
-        "x-euc-cn",
-        "euc-cn",
-        "cp936",
-        "ms936",
-        "gb2312-1980",
-        "windows-936",
-        "windows-936-2000"
+        "cn-gb"_s,
+        "csgb231280"_s,
+        "x-euc-cn"_s,
+        "euc-cn"_s,
+        "cp936"_s,
+        "ms936"_s,
+        "gb2312-1980"_s,
+        "windows-936"_s,
+        "windows-936-2000"_s
     });
 
     registerAliases({
-        "gb18030",
+        "gb18030"_s,
 
         // These aliases are not in the specification, but WebKit has historically supported them.
-        "ibm-1392",
-        "windows-54936"
+        "ibm-1392"_s,
+        "windows-54936"_s
     });
 }
 
 void TextCodecCJK::registerCodecs(TextCodecRegistrar registrar)
 {
-    registrar("EUC-JP", [] {
+    registrar("EUC-JP"_s, [] {
         return makeUnique<TextCodecCJK>(Encoding::EUC_JP);
     });
-    registrar("Big5", [] {
+    registrar("Big5"_s, [] {
         return makeUnique<TextCodecCJK>(Encoding::Big5);
     });
-    registrar("Shift_JIS", [] {
+    registrar("Shift_JIS"_s, [] {
         return makeUnique<TextCodecCJK>(Encoding::Shift_JIS);
     });
-    registrar("EUC-KR", [] {
+    registrar("EUC-KR"_s, [] {
         return makeUnique<TextCodecCJK>(Encoding::EUC_KR);
     });
-    registrar("ISO-2022-JP", [] {
+    registrar("ISO-2022-JP"_s, [] {
         return makeUnique<TextCodecCJK>(Encoding::ISO2022JP);
     });
-    registrar("GBK", [] {
+    registrar("GBK"_s, [] {
         return makeUnique<TextCodecCJK>(Encoding::GBK);
     });
-    registrar("gb18030", [] {
+    registrar("gb18030"_s, [] {
         return makeUnique<TextCodecCJK>(Encoding::GB18030);
     });
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -43,29 +43,29 @@ namespace PAL {
 const size_t ConversionBufferSize = 16384;
 
 #define DECLARE_ALIASES(encoding, ...) \
-    static const char* const encoding##_aliases[] { __VA_ARGS__ }
+    static constexpr ASCIILiteral encoding##_aliases[] { __VA_ARGS__ }
 
 // From https://encoding.spec.whatwg.org. Plus a few extra aliases that macOS had historically from TEC.
-DECLARE_ALIASES(ISO_8859_2, "csisolatin2", "iso-ir-101", "iso8859-2", "iso88592", "iso_8859-2", "iso_8859-2:1987", "l2", "latin2");
-DECLARE_ALIASES(ISO_8859_4, "csisolatin4", "iso-ir-110", "iso8859-4", "iso88594", "iso_8859-4", "iso_8859-4:1988", "l4", "latin4");
-DECLARE_ALIASES(ISO_8859_5, "csisolatincyrillic", "cyrillic", "iso-ir-144", "iso8859-5", "iso88595", "iso_8859-5", "iso_8859-5:1988");
-DECLARE_ALIASES(ISO_8859_10, "csisolatin6", "iso-ir-157", "iso8859-10", "iso885910", "l6", "latin6", "iso8859101992", "isoir157");
-DECLARE_ALIASES(ISO_8859_13, "iso8859-13", "iso885913");
-DECLARE_ALIASES(ISO_8859_14, "iso8859-14", "iso885914", "isoceltic", "iso8859141998", "isoir199", "latin8", "l8");
-DECLARE_ALIASES(ISO_8859_15, "csisolatin9", "iso8859-15", "iso885915", "iso_8859-15", "l9");
-DECLARE_ALIASES(ISO_8859_16, "isoir226", "iso8859162001", "l10", "latin10");
-DECLARE_ALIASES(KOI8_R, "cskoi8r", "koi", "koi8", "koi8_r");
-DECLARE_ALIASES(macintosh, "csmacintosh", "mac", "x-mac-roman", "macroman", "x-macroman");
-DECLARE_ALIASES(windows_1250, "cp1250", "x-cp1250", "winlatin2");
-DECLARE_ALIASES(windows_1251, "cp1251", "wincyrillic", "x-cp1251");
-DECLARE_ALIASES(windows_1254, "winturkish", "cp1254", "csisolatin5", "iso-8859-9", "iso-ir-148", "iso8859-9", "iso88599", "iso_8859-9", "iso_8859-9:1989", "l5", "latin5", "x-cp1254");
-DECLARE_ALIASES(windows_1256, "winarabic", "cp1256", "x-cp1256");
-DECLARE_ALIASES(windows_1258, "winvietnamese", "cp1258", "x-cp1258");
-DECLARE_ALIASES(x_mac_cyrillic, "maccyrillic", "x-mac-ukrainian", "windows-10007", "mac-cyrillic", "maccy", "x-MacCyrillic", "x-MacUkraine");
+DECLARE_ALIASES(ISO_8859_2, "csisolatin2"_s, "iso-ir-101"_s, "iso8859-2"_s, "iso88592"_s, "iso_8859-2"_s, "iso_8859-2:1987"_s, "l2"_s, "latin2"_s);
+DECLARE_ALIASES(ISO_8859_4, "csisolatin4"_s, "iso-ir-110"_s, "iso8859-4"_s, "iso88594"_s, "iso_8859-4"_s, "iso_8859-4:1988"_s, "l4"_s, "latin4"_s);
+DECLARE_ALIASES(ISO_8859_5, "csisolatincyrillic"_s, "cyrillic"_s, "iso-ir-144"_s, "iso8859-5"_s, "iso88595"_s, "iso_8859-5"_s, "iso_8859-5:1988"_s);
+DECLARE_ALIASES(ISO_8859_10, "csisolatin6"_s, "iso-ir-157"_s, "iso8859-10"_s, "iso885910"_s, "l6"_s, "latin6"_s, "iso8859101992"_s, "isoir157"_s);
+DECLARE_ALIASES(ISO_8859_13, "iso8859-13"_s, "iso885913"_s);
+DECLARE_ALIASES(ISO_8859_14, "iso8859-14"_s, "iso885914"_s, "isoceltic"_s, "iso8859141998"_s, "isoir199"_s, "latin8"_s, "l8"_s);
+DECLARE_ALIASES(ISO_8859_15, "csisolatin9"_s, "iso8859-15"_s, "iso885915"_s, "iso_8859-15"_s, "l9"_s);
+DECLARE_ALIASES(ISO_8859_16, "isoir226"_s, "iso8859162001"_s, "l10"_s, "latin10"_s);
+DECLARE_ALIASES(KOI8_R, "cskoi8r"_s, "koi"_s, "koi8"_s, "koi8_r"_s);
+DECLARE_ALIASES(macintosh, "csmacintosh"_s, "mac"_s, "x-mac-roman"_s, "macroman"_s, "x-macroman"_s);
+DECLARE_ALIASES(windows_1250, "cp1250"_s, "x-cp1250"_s, "winlatin2"_s);
+DECLARE_ALIASES(windows_1251, "cp1251"_s, "wincyrillic"_s, "x-cp1251"_s);
+DECLARE_ALIASES(windows_1254, "winturkish"_s, "cp1254"_s, "csisolatin5"_s, "iso-8859-9"_s, "iso-ir-148"_s, "iso8859-9"_s, "iso88599"_s, "iso_8859-9"_s, "iso_8859-9:1989"_s, "l5"_s, "latin5"_s, "x-cp1254"_s);
+DECLARE_ALIASES(windows_1256, "winarabic"_s, "cp1256"_s, "x-cp1256"_s);
+DECLARE_ALIASES(windows_1258, "winvietnamese"_s, "cp1258"_s, "x-cp1258"_s);
+DECLARE_ALIASES(x_mac_cyrillic, "maccyrillic"_s, "x-mac-ukrainian"_s, "windows-10007"_s, "mac-cyrillic"_s, "maccy"_s, "x-MacCyrillic"_s, "x-MacUkraine"_s);
 // Encodings below are not in the standard.
-DECLARE_ALIASES(x_mac_greek, "windows-10006", "macgr", "x-MacGreek");
-DECLARE_ALIASES(x_mac_centraleurroman, "windows-10029", "x-mac-ce", "macce", "maccentraleurope", "x-MacCentralEurope");
-DECLARE_ALIASES(x_mac_turkish, "windows-10081", "mactr", "x-MacTurkish");
+DECLARE_ALIASES(x_mac_greek, "windows-10006"_s, "macgr"_s, "x-MacGreek"_s);
+DECLARE_ALIASES(x_mac_centraleurroman, "windows-10029"_s, "x-mac-ce"_s, "macce"_s, "maccentraleurope"_s, "x-MacCentralEurope"_s);
+DECLARE_ALIASES(x_mac_turkish, "windows-10081"_s, "mactr"_s, "x-MacTurkish"_s);
 
 #define DECLARE_ENCODING_NAME(encoding, alias_array) \
     { encoding, std::size(alias_array##_aliases), alias_array##_aliases }
@@ -74,31 +74,31 @@ DECLARE_ALIASES(x_mac_turkish, "windows-10081", "mactr", "x-MacTurkish");
     { encoding, 0, nullptr }
 
 static const struct EncodingName {
-    const char* name;
+    ASCIILiteral name;
     unsigned aliasCount;
-    const char* const * aliases;
+    const ASCIILiteral* aliases;
 } encodingNames[] = {
-    DECLARE_ENCODING_NAME("ISO-8859-2", ISO_8859_2),
-    DECLARE_ENCODING_NAME("ISO-8859-4", ISO_8859_4),
-    DECLARE_ENCODING_NAME("ISO-8859-5", ISO_8859_5),
-    DECLARE_ENCODING_NAME("ISO-8859-10", ISO_8859_10),
-    DECLARE_ENCODING_NAME("ISO-8859-13", ISO_8859_13),
-    DECLARE_ENCODING_NAME("ISO-8859-14", ISO_8859_14),
-    DECLARE_ENCODING_NAME("ISO-8859-15", ISO_8859_15),
-    DECLARE_ENCODING_NAME("ISO-8859-16", ISO_8859_16),
-    DECLARE_ENCODING_NAME("KOI8-R", KOI8_R),
-    DECLARE_ENCODING_NAME("macintosh", macintosh),
-    DECLARE_ENCODING_NAME("windows-1250", windows_1250),
-    DECLARE_ENCODING_NAME("windows-1251", windows_1251),
-    DECLARE_ENCODING_NAME("windows-1254", windows_1254),
-    DECLARE_ENCODING_NAME("windows-1256", windows_1256),
-    DECLARE_ENCODING_NAME("windows-1258", windows_1258),
-    DECLARE_ENCODING_NAME("x-mac-cyrillic", x_mac_cyrillic),
+    DECLARE_ENCODING_NAME("ISO-8859-2"_s, ISO_8859_2),
+    DECLARE_ENCODING_NAME("ISO-8859-4"_s, ISO_8859_4),
+    DECLARE_ENCODING_NAME("ISO-8859-5"_s, ISO_8859_5),
+    DECLARE_ENCODING_NAME("ISO-8859-10"_s, ISO_8859_10),
+    DECLARE_ENCODING_NAME("ISO-8859-13"_s, ISO_8859_13),
+    DECLARE_ENCODING_NAME("ISO-8859-14"_s, ISO_8859_14),
+    DECLARE_ENCODING_NAME("ISO-8859-15"_s, ISO_8859_15),
+    DECLARE_ENCODING_NAME("ISO-8859-16"_s, ISO_8859_16),
+    DECLARE_ENCODING_NAME("KOI8-R"_s, KOI8_R),
+    DECLARE_ENCODING_NAME("macintosh"_s, macintosh),
+    DECLARE_ENCODING_NAME("windows-1250"_s, windows_1250),
+    DECLARE_ENCODING_NAME("windows-1251"_s, windows_1251),
+    DECLARE_ENCODING_NAME("windows-1254"_s, windows_1254),
+    DECLARE_ENCODING_NAME("windows-1256"_s, windows_1256),
+    DECLARE_ENCODING_NAME("windows-1258"_s, windows_1258),
+    DECLARE_ENCODING_NAME("x-mac-cyrillic"_s, x_mac_cyrillic),
     // Encodings below are not in the standard.
-    DECLARE_ENCODING_NAME("x-mac-greek", x_mac_greek),
-    DECLARE_ENCODING_NAME("x-mac-centraleurroman", x_mac_centraleurroman),
-    DECLARE_ENCODING_NAME("x-mac-turkish", x_mac_turkish),
-    DECLARE_ENCODING_NAME_NO_ALIASES("EUC-TW"),
+    DECLARE_ENCODING_NAME("x-mac-greek"_s, x_mac_greek),
+    DECLARE_ENCODING_NAME("x-mac-centraleurroman"_s, x_mac_centraleurroman),
+    DECLARE_ENCODING_NAME("x-mac-turkish"_s, x_mac_turkish),
+    DECLARE_ENCODING_NAME_NO_ALIASES("EUC-TW"_s),
 };
 
 void TextCodecICU::registerEncodingNames(EncodingNameRegistrar registrar)
@@ -113,7 +113,7 @@ void TextCodecICU::registerEncodingNames(EncodingNameRegistrar registrar)
 void TextCodecICU::registerCodecs(TextCodecRegistrar registrar)
 {
     for (auto& encodingName : encodingNames) {
-        const char* name = encodingName.name;
+        ASCIILiteral name = encodingName.name;
 
         UErrorCode error = U_ZERO_ERROR;
         const char* canonicalConverterName = ucnv_getCanonicalName(name, "IANA", &error);
@@ -129,16 +129,18 @@ void TextCodecICU::registerCodecs(TextCodecRegistrar registrar)
             }
         }
         registrar(name, [name, canonicalConverterName] {
-            return makeUnique<TextCodecICU>(name, canonicalConverterName);
+            // ucnv_getCanonicalName() returns a static string owned by libicu so the call to
+            // ASCIILiteral::fromLiteralUnsafe() should be safe.
+            return makeUnique<TextCodecICU>(name, ASCIILiteral::fromLiteralUnsafe(canonicalConverterName));
         });
     }
 }
 
-TextCodecICU::TextCodecICU(const char* encoding, const char* canonicalConverterName)
+TextCodecICU::TextCodecICU(ASCIILiteral encoding, ASCIILiteral canonicalConverterName)
     : m_encodingName(encoding)
     , m_canonicalConverterName(canonicalConverterName)
 {
-    ASSERT(m_canonicalConverterName);
+    ASSERT(!m_canonicalConverterName.isNull());
 }
 
 TextCodecICU::~TextCodecICU()

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.h
@@ -28,6 +28,7 @@
 
 #include "TextCodec.h"
 #include <unicode/ucnv.h>
+#include <wtf/text/ASCIILiteral.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace PAL {
@@ -39,7 +40,7 @@ public:
     static void registerEncodingNames(EncodingNameRegistrar);
     static void registerCodecs(TextCodecRegistrar);
 
-    explicit TextCodecICU(const char* encoding, const char* canonicalConverterName);
+    explicit TextCodecICU(ASCIILiteral encoding, ASCIILiteral canonicalConverterName);
     virtual ~TextCodecICU();
 
 private:
@@ -51,8 +52,8 @@ private:
 
     int decodeToBuffer(UChar* buffer, UChar* bufferLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode&);
 
-    const char* const m_encodingName;
-    const char* const m_canonicalConverterName;
+    ASCIILiteral m_encodingName;
+    ASCIILiteral const m_canonicalConverterName;
     mutable ICUConverterPtr m_converter;
 };
 

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -71,28 +71,28 @@ static const UChar latin1ConversionTable[256] = {
 void TextCodecLatin1::registerEncodingNames(EncodingNameRegistrar registrar)
 {
     // From https://encoding.spec.whatwg.org.
-    registrar("windows-1252", "windows-1252");
-    registrar("ansi_x3.4-1968", "windows-1252");
-    registrar("ascii", "windows-1252");
-    registrar("cp1252", "windows-1252");
-    registrar("cp819", "windows-1252");
-    registrar("csisolatin1", "windows-1252");
-    registrar("ibm819", "windows-1252");
-    registrar("iso-8859-1", "windows-1252");
-    registrar("iso-ir-100", "windows-1252");
-    registrar("iso8859-1", "windows-1252");
-    registrar("iso88591", "windows-1252");
-    registrar("iso_8859-1", "windows-1252");
-    registrar("iso_8859-1:1987", "windows-1252");
-    registrar("l1", "windows-1252");
-    registrar("latin1", "windows-1252");
-    registrar("us-ascii", "windows-1252");
-    registrar("x-cp1252", "windows-1252");
+    registrar("windows-1252"_s, "windows-1252"_s);
+    registrar("ansi_x3.4-1968"_s, "windows-1252"_s);
+    registrar("ascii"_s, "windows-1252"_s);
+    registrar("cp1252"_s, "windows-1252"_s);
+    registrar("cp819"_s, "windows-1252"_s);
+    registrar("csisolatin1"_s, "windows-1252"_s);
+    registrar("ibm819"_s, "windows-1252"_s);
+    registrar("iso-8859-1"_s, "windows-1252"_s);
+    registrar("iso-ir-100"_s, "windows-1252"_s);
+    registrar("iso8859-1"_s, "windows-1252"_s);
+    registrar("iso88591"_s, "windows-1252"_s);
+    registrar("iso_8859-1"_s, "windows-1252"_s);
+    registrar("iso_8859-1:1987"_s, "windows-1252"_s);
+    registrar("l1"_s, "windows-1252"_s);
+    registrar("latin1"_s, "windows-1252"_s);
+    registrar("us-ascii"_s, "windows-1252"_s);
+    registrar("x-cp1252"_s, "windows-1252"_s);
 }
 
 void TextCodecLatin1::registerCodecs(TextCodecRegistrar registrar)
 {
-    registrar("windows-1252", [] {
+    registrar("windows-1252"_s, [] {
         return makeUnique<TextCodecLatin1>();
     });
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp
@@ -34,18 +34,18 @@ namespace PAL {
 
 void TextCodecReplacement::registerEncodingNames(EncodingNameRegistrar registrar)
 {
-    registrar("replacement", "replacement");
+    registrar("replacement"_s, "replacement"_s);
 
-    registrar("csiso2022kr", "replacement");
-    registrar("hz-gb-2312", "replacement");
-    registrar("iso-2022-cn", "replacement");
-    registrar("iso-2022-cn-ext", "replacement");
-    registrar("iso-2022-kr", "replacement");
+    registrar("csiso2022kr"_s, "replacement"_s);
+    registrar("hz-gb-2312"_s, "replacement"_s);
+    registrar("iso-2022-cn"_s, "replacement"_s);
+    registrar("iso-2022-cn-ext"_s, "replacement"_s);
+    registrar("iso-2022-kr"_s, "replacement"_s);
 }
 
 void TextCodecReplacement::registerCodecs(TextCodecRegistrar registrar)
 {
-    registrar("replacement", [] {
+    registrar("replacement"_s, [] {
         return makeUnique<TextCodecReplacement>();
     });
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
@@ -315,147 +315,147 @@ TextCodecSingleByte::TextCodecSingleByte(Encoding encoding)
 void TextCodecSingleByte::registerEncodingNames(EncodingNameRegistrar registrar)
 {
     // https://encoding.spec.whatwg.org/#names-and-labels
-    auto registerAliases = [&] (std::initializer_list<const char*> list) {
-        for (auto* alias : list)
+    auto registerAliases = [&] (std::initializer_list<ASCIILiteral> list) {
+        for (auto& alias : list)
             registrar(alias, *list.begin());
     };
     registerAliases({
-        "ISO-8859-3",
-        "csisolatin3",
-        "iso-ir-109",
-        "iso8859-3",
-        "iso88593",
-        "iso_8859-3",
-        "iso_8859-3:1988",
-        "l3",
-        "latin3"
+        "ISO-8859-3"_s,
+        "csisolatin3"_s,
+        "iso-ir-109"_s,
+        "iso8859-3"_s,
+        "iso88593"_s,
+        "iso_8859-3"_s,
+        "iso_8859-3:1988"_s,
+        "l3"_s,
+        "latin3"_s
     });
 
     registerAliases({
-        "ISO-8859-6",
-        "arabic",
-        "asmo-708",
-        "csiso88596e",
-        "csiso88596i",
-        "csisolatinarabic",
-        "ecma-114",
-        "iso-8859-6-e",
-        "iso-8859-6-i",
-        "iso-ir-127",
-        "iso8859-6",
-        "iso88596",
-        "iso_8859-6",
-        "iso_8859-6:1987"
+        "ISO-8859-6"_s,
+        "arabic"_s,
+        "asmo-708"_s,
+        "csiso88596e"_s,
+        "csiso88596i"_s,
+        "csisolatinarabic"_s,
+        "ecma-114"_s,
+        "iso-8859-6-e"_s,
+        "iso-8859-6-i"_s,
+        "iso-ir-127"_s,
+        "iso8859-6"_s,
+        "iso88596"_s,
+        "iso_8859-6"_s,
+        "iso_8859-6:1987"_s
     });
 
     registerAliases({
-        "ISO-8859-7",
-        "csisolatingreek",
-        "ecma-118",
-        "elot_928",
-        "greek",
-        "greek8",
-        "iso-ir-126",
-        "iso8859-7",
-        "iso88597",
-        "iso_8859-7",
-        "iso_8859-7:1987",
-        "sun_eu_greek"
+        "ISO-8859-7"_s,
+        "csisolatingreek"_s,
+        "ecma-118"_s,
+        "elot_928"_s,
+        "greek"_s,
+        "greek8"_s,
+        "iso-ir-126"_s,
+        "iso8859-7"_s,
+        "iso88597"_s,
+        "iso_8859-7"_s,
+        "iso_8859-7:1987"_s,
+        "sun_eu_greek"_s
     });
 
     registerAliases({
-        "ISO-8859-8",
-        "csiso88598e",
-        "csisolatinhebrew",
-        "hebrew",
-        "iso-8859-8-e",
-        "iso-ir-138",
-        "iso8859-8",
-        "iso88598",
-        "iso_8859-8",
-        "iso_8859-8:1988",
-        "visual"
+        "ISO-8859-8"_s,
+        "csiso88598e"_s,
+        "csisolatinhebrew"_s,
+        "hebrew"_s,
+        "iso-8859-8-e"_s,
+        "iso-ir-138"_s,
+        "iso8859-8"_s,
+        "iso88598"_s,
+        "iso_8859-8"_s,
+        "iso_8859-8:1988"_s,
+        "visual"_s
     });
 
     registerAliases({
-        "ISO-8859-8-I",
-        "csiso88598i",
-        "logical"
+        "ISO-8859-8-I"_s,
+        "csiso88598i"_s,
+        "logical"_s
     });
 
     registerAliases({
-        "windows-874",
-        "dos-874",
-        "iso-8859-11",
-        "iso8859-11",
-        "iso885911",
-        "tis-620"
+        "windows-874"_s,
+        "dos-874"_s,
+        "iso-8859-11"_s,
+        "iso8859-11"_s,
+        "iso885911"_s,
+        "tis-620"_s
     });
 
     registerAliases({
-        "windows-1253",
-        "cp1253",
-        "x-cp1253"
+        "windows-1253"_s,
+        "cp1253"_s,
+        "x-cp1253"_s
     });
     
     registerAliases({
-        "windows-1255",
-        "cp1255",
-        "x-cp1255"
+        "windows-1255"_s,
+        "cp1255"_s,
+        "x-cp1255"_s
     });
     
     registerAliases({
-        "windows-1257",
-        "cp1257",
-        "x-cp1257"
+        "windows-1257"_s,
+        "cp1257"_s,
+        "x-cp1257"_s
     });
     
     registerAliases({
-        "KOI8-U",
-        "koi8-ru"
+        "KOI8-U"_s,
+        "koi8-ru"_s
     });
 
     registerAliases({
-        "IBM866",
-        "866",
-        "cp866",
-        "csibm866"
+        "IBM866"_s,
+        "866"_s,
+        "cp866"_s,
+        "csibm866"_s
     });
 }
 
 void TextCodecSingleByte::registerCodecs(TextCodecRegistrar registrar)
 {
-    registrar("ISO-8859-3", [] {
+    registrar("ISO-8859-3"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::ISO_8859_3);
     });
-    registrar("ISO-8859-6", [] {
+    registrar("ISO-8859-6"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::ISO_8859_6);
     });
-    registrar("ISO-8859-7", [] {
+    registrar("ISO-8859-7"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::ISO_8859_7);
     });
-    registrar("ISO-8859-8", [] {
+    registrar("ISO-8859-8"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::ISO_8859_8);
     });
-    registrar("ISO-8859-8-I", [] {
+    registrar("ISO-8859-8-I"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::ISO_8859_8);
     });
-    registrar("windows-874", [] {
+    registrar("windows-874"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::Windows_874);
     });
-    registrar("windows-1253", [] {
+    registrar("windows-1253"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::Windows_1253);
     });
-    registrar("windows-1255", [] {
+    registrar("windows-1255"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::Windows_1255);
     });
-    registrar("windows-1257", [] {
+    registrar("windows-1257"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::Windows_1257);
     });
-    registrar("KOI8-U", [] {
+    registrar("KOI8-U"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::KOI8U);
     });
-    registrar("IBM866", [] {
+    registrar("IBM866"_s, [] {
         return makeUnique<TextCodecSingleByte>(Encoding::IBM866);
     });
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
@@ -40,25 +40,25 @@ inline TextCodecUTF16::TextCodecUTF16(bool littleEndian)
 
 void TextCodecUTF16::registerEncodingNames(EncodingNameRegistrar registrar)
 {
-    registrar("UTF-16LE", "UTF-16LE");
-    registrar("UTF-16BE", "UTF-16BE");
+    registrar("UTF-16LE"_s, "UTF-16LE"_s);
+    registrar("UTF-16BE"_s, "UTF-16BE"_s);
 
-    registrar("ISO-10646-UCS-2", "UTF-16LE");
-    registrar("UCS-2", "UTF-16LE");
-    registrar("UTF-16", "UTF-16LE");
-    registrar("Unicode", "UTF-16LE");
-    registrar("csUnicode", "UTF-16LE");
-    registrar("unicodeFEFF", "UTF-16LE");
+    registrar("ISO-10646-UCS-2"_s, "UTF-16LE"_s);
+    registrar("UCS-2"_s, "UTF-16LE"_s);
+    registrar("UTF-16"_s, "UTF-16LE"_s);
+    registrar("Unicode"_s, "UTF-16LE"_s);
+    registrar("csUnicode"_s, "UTF-16LE"_s);
+    registrar("unicodeFEFF"_s, "UTF-16LE"_s);
 
-    registrar("unicodeFFFE", "UTF-16BE");
+    registrar("unicodeFFFE"_s, "UTF-16BE"_s);
 }
 
 void TextCodecUTF16::registerCodecs(TextCodecRegistrar registrar)
 {
-    registrar("UTF-16LE", [] {
+    registrar("UTF-16LE"_s, [] {
         return makeUnique<TextCodecUTF16>(true);
     });
-    registrar("UTF-16BE", [] {
+    registrar("UTF-16BE"_s, [] {
         return makeUnique<TextCodecUTF16>(false);
     });
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -41,17 +41,17 @@ const int nonCharacter = -1;
 void TextCodecUTF8::registerEncodingNames(EncodingNameRegistrar registrar)
 {
     // From https://encoding.spec.whatwg.org.
-    registrar("UTF-8", "UTF-8");
-    registrar("utf8", "UTF-8");
-    registrar("unicode-1-1-utf-8", "UTF-8");
+    registrar("UTF-8"_s, "UTF-8"_s);
+    registrar("utf8"_s, "UTF-8"_s);
+    registrar("unicode-1-1-utf-8"_s, "UTF-8"_s);
 
     // Additional aliases that originally were present in the encoding
     // table in WebKit on Macintosh, and subsequently added by
     // TextCodecICU. Perhaps we can prove some are not used on the web
     // and remove them.
-    registrar("unicode11utf8", "UTF-8");
-    registrar("unicode20utf8", "UTF-8");
-    registrar("x-unicode20utf8", "UTF-8");
+    registrar("unicode11utf8"_s, "UTF-8"_s);
+    registrar("unicode20utf8"_s, "UTF-8"_s);
+    registrar("x-unicode20utf8"_s, "UTF-8"_s);
 }
 
 std::unique_ptr<TextCodecUTF8> TextCodecUTF8::codec()
@@ -61,7 +61,7 @@ std::unique_ptr<TextCodecUTF8> TextCodecUTF8::codec()
 
 void TextCodecUTF8::registerCodecs(TextCodecRegistrar registrar)
 {
-    registrar("UTF-8", [] {
+    registrar("UTF-8"_s, [] {
         return codec();
     });
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -35,12 +35,12 @@ namespace PAL {
 
 void TextCodecUserDefined::registerEncodingNames(EncodingNameRegistrar registrar)
 {
-    registrar("x-user-defined", "x-user-defined");
+    registrar("x-user-defined"_s, "x-user-defined"_s);
 }
 
 void TextCodecUserDefined::registerCodecs(TextCodecRegistrar registrar)
 {
-    registrar("x-user-defined", [] {
+    registrar("x-user-defined"_s, [] {
         return makeUnique<TextCodecUserDefined>();
     });
 }

--- a/Source/WebCore/PAL/pal/text/TextEncoding.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.cpp
@@ -62,7 +62,7 @@ TextEncoding::TextEncoding(const String& name)
 
 String TextEncoding::decode(const char* data, size_t length, bool stopOnError, bool& sawError) const
 {
-    if (!m_name)
+    if (m_name.isNull())
         return String();
 
     return newTextCodec(*this)->decode(data, length, true, stopOnError, sawError);
@@ -70,7 +70,7 @@ String TextEncoding::decode(const char* data, size_t length, bool stopOnError, b
 
 Vector<uint8_t> TextEncoding::encode(StringView string, PAL::UnencodableHandling handling, NFCNormalize normalize) const
 {
-    if (!m_name || string.isEmpty())
+    if (m_name.isNull() || string.isEmpty())
         return { };
 
     // FIXME: What's the right place to do normalization?
@@ -81,7 +81,7 @@ Vector<uint8_t> TextEncoding::encode(StringView string, PAL::UnencodableHandling
     return newTextCodec(*this)->encode(string, handling);
 }
 
-const char* TextEncoding::domName() const
+ASCIILiteral TextEncoding::domName() const
 {
     if (noExtendedTextEncodingNameUsed())
         return m_name;
@@ -93,9 +93,9 @@ const char* TextEncoding::domName() const
     // FIXME: This is not thread-safe. At the moment, this function is
     // only accessed in a single thread, but eventually has to be made
     // thread-safe along with usesVisualOrdering().
-    static const char* const a = atomCanonicalTextEncodingName("windows-949");
-    if (m_name == a)
-        return "EUC-KR";
+    static const ASCIILiteral windows949 = atomCanonicalTextEncodingName("windows-949");
+    if (m_name == windows949)
+        return "EUC-KR"_s;
     return m_name;
 }
 
@@ -104,8 +104,8 @@ bool TextEncoding::usesVisualOrdering() const
     if (noExtendedTextEncodingNameUsed())
         return false;
 
-    static const char* const a = atomCanonicalTextEncodingName("ISO-8859-8");
-    return m_name == a;
+    static const ASCIILiteral iso88598 = atomCanonicalTextEncodingName("ISO-8859-8");
+    return m_name == iso88598;
 }
 
 bool TextEncoding::isJapanese() const

--- a/Source/WebCore/PAL/pal/text/TextEncoding.h
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.h
@@ -40,9 +40,9 @@ public:
     PAL_EXPORT TextEncoding(StringView name);
     PAL_EXPORT TextEncoding(const String& name);
 
-    bool isValid() const { return m_name; }
-    const char* name() const { return m_name; }
-    PAL_EXPORT const char* domName() const; // name exposed via DOM
+    bool isValid() const { return !m_name.isNull(); }
+    ASCIILiteral name() const { return m_name; }
+    PAL_EXPORT ASCIILiteral domName() const; // name exposed via DOM
     bool usesVisualOrdering() const;
     bool isJapanese() const;
 
@@ -62,7 +62,7 @@ private:
     bool isNonByteBasedEncoding() const;
     bool isUTF7Encoding() const;
 
-    const char* m_name { nullptr };
+    ASCIILiteral m_name;
     UChar m_backslashAsCurrencySymbol;
 };
 

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -46,6 +46,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/StringHash.h>
 
 namespace PAL {
 
@@ -81,77 +82,87 @@ struct TextEncodingNameHash {
                 return h;
             }
             h += toASCIILower(c);
-            h += (h << 10); 
-            h ^= (h >> 6); 
+            h += (h << 10);
+            h ^= (h >> 6);
         }
     }
 
     static const bool safeToCompareToEmptyOrDeleted = false;
 };
 
-using TextEncodingNameMap = HashMap<const char*, const char*, TextEncodingNameHash>;
-using TextCodecMap = HashMap<const char*, NewTextCodecFunction>;
+struct HashTranslatorTextEncodingName {
+    static unsigned hash(const char* literal)
+    {
+        return TextEncodingNameHash::hash(literal);
+    }
+
+    static bool equal(const ASCIILiteral& a, const char* b)
+    {
+        return TextEncodingNameHash::equal(a.characters(), b);
+    }
+};
+
+using TextEncodingNameMap = HashMap<ASCIILiteral, ASCIILiteral, TextEncodingNameHash>;
+using TextCodecMap = HashMap<ASCIILiteral, NewTextCodecFunction>;
 
 static Lock encodingRegistryLock;
 
 static TextEncodingNameMap* textEncodingNameMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
 static TextCodecMap* textCodecMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
 static bool didExtendTextCodecMaps;
-static HashSet<const char*>* japaneseEncodings;
-static HashSet<const char*>* nonBackslashEncodings;
+static HashSet<ASCIILiteral>* japaneseEncodings;
+static HashSet<ASCIILiteral>* nonBackslashEncodings;
 
-static const char* const textEncodingNameBlocklist[] = { "UTF-7", "BOCU-1", "SCSU" };
+static constexpr ASCIILiteral textEncodingNameBlocklist[] = { "UTF-7"_s, "BOCU-1"_s, "SCSU"_s };
 
-static bool isUndesiredAlias(const char* alias)
+static bool isUndesiredAlias(ASCIILiteral alias)
 {
     // Reject aliases with version numbers that are supported by some back-ends (such as "ISO_2022,locale=ja,version=0" in ICU).
-    for (const char* p = alias; *p; ++p) {
-        if (*p == ',')
-            return true;
-    }
+    if (strchr(alias.characters(), ','))
+        return true;
     // 8859_1 is known to (at least) ICU, but other browsers don't support this name - and having it caused a compatibility
     // problem, see bug 43554.
-    if (!strcmp(alias, "8859_1"))
+    if (alias == "8859_1"_s)
         return true;
     return false;
 }
 
-static void addToTextEncodingNameMap(const char* alias, const char* name) WTF_REQUIRES_LOCK(encodingRegistryLock)
+static void addToTextEncodingNameMap(ASCIILiteral alias, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
     ASSERT(strlen(alias) <= maxEncodingNameLength);
     if (isUndesiredAlias(alias))
         return;
-    const char* atomName = textEncodingNameMap->get(name);
-    ASSERT(!strcmp(alias, name) || atomName);
-    if (!atomName)
+    ASCIILiteral atomName = textEncodingNameMap->get(name);
+    ASSERT((alias == name) || !atomName.isNull());
+    if (atomName.isNull())
         atomName = name;
 
-    ASSERT_WITH_MESSAGE(!textEncodingNameMap->get(alias), "Duplicate text encoding name %s for %s (previously registered as %s)", alias, atomName, textEncodingNameMap->get(alias));
+    ASSERT_WITH_MESSAGE(textEncodingNameMap->get(alias).isNull(), "Duplicate text encoding name %s for %s (previously registered as %s)", alias.characters(), atomName.characters(), textEncodingNameMap->get(alias).characters());
 
     textEncodingNameMap->add(alias, atomName);
 }
 
-static void addToTextCodecMap(const char* name, NewTextCodecFunction&& function) WTF_REQUIRES_LOCK(encodingRegistryLock)
+static void addToTextCodecMap(ASCIILiteral name, NewTextCodecFunction&& function) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
-    const char* atomName = textEncodingNameMap->get(name);
-    ASSERT(atomName);
+    ASCIILiteral atomName = textEncodingNameMap->get(name);
+    ASSERT(!atomName.isNull());
     textCodecMap->add(atomName, WTFMove(function));
 }
 
 static void pruneBlocklistedCodecs() WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
     for (auto& nameFromBlocklist : textEncodingNameBlocklist) {
-        auto* atomName = textEncodingNameMap->get(nameFromBlocklist);
-        if (!atomName)
+        ASCIILiteral atomName = textEncodingNameMap->get(nameFromBlocklist);
+        if (atomName.isNull())
             continue;
 
-        Vector<const char*> names;
+        Vector<ASCIILiteral> names;
         for (auto& entry : *textEncodingNameMap) {
             if (entry.value == atomName)
                 names.append(entry.key);
         }
 
-        for (auto* name : names)
+        for (auto& name : names)
             textEncodingNameMap->remove(name);
 
         textCodecMap->remove(atomName);
@@ -179,12 +190,12 @@ static void buildBaseTextCodecMaps() WTF_REQUIRES_LOCK(encodingRegistryLock)
     TextCodecUserDefined::registerCodecs(addToTextCodecMap);
 }
 
-static void addEncodingName(HashSet<const char*>* set, const char* name) WTF_REQUIRES_LOCK(encodingRegistryLock)
+static void addEncodingName(HashSet<ASCIILiteral>& set, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
     // We must not use atomCanonicalTextEncodingName() because this function is called in it.
-    const char* atomName = textEncodingNameMap->get(name);
-    if (atomName)
-        set->add(atomName);
+    ASCIILiteral atomName = textEncodingNameMap->get(name);
+    if (!atomName.isNull())
+        set.add(atomName);
 }
 
 static void buildQuirksSets() WTF_REQUIRES_LOCK(encodingRegistryLock)
@@ -195,41 +206,41 @@ static void buildQuirksSets() WTF_REQUIRES_LOCK(encodingRegistryLock)
     ASSERT(!japaneseEncodings);
     ASSERT(!nonBackslashEncodings);
 
-    japaneseEncodings = new HashSet<const char*>;
-    addEncodingName(japaneseEncodings, "EUC-JP");
-    addEncodingName(japaneseEncodings, "ISO-2022-JP");
-    addEncodingName(japaneseEncodings, "ISO-2022-JP-1");
-    addEncodingName(japaneseEncodings, "ISO-2022-JP-2");
-    addEncodingName(japaneseEncodings, "ISO-2022-JP-3");
-    addEncodingName(japaneseEncodings, "JIS_C6226-1978");
-    addEncodingName(japaneseEncodings, "JIS_X0201");
-    addEncodingName(japaneseEncodings, "JIS_X0208-1983");
-    addEncodingName(japaneseEncodings, "JIS_X0208-1990");
-    addEncodingName(japaneseEncodings, "JIS_X0212-1990");
-    addEncodingName(japaneseEncodings, "Shift_JIS");
-    addEncodingName(japaneseEncodings, "Shift_JIS_X0213-2000");
-    addEncodingName(japaneseEncodings, "cp932");
-    addEncodingName(japaneseEncodings, "x-mac-japanese");
+    japaneseEncodings = new HashSet<ASCIILiteral>;
+    addEncodingName(*japaneseEncodings, "EUC-JP"_s);
+    addEncodingName(*japaneseEncodings, "ISO-2022-JP"_s);
+    addEncodingName(*japaneseEncodings, "ISO-2022-JP-1"_s);
+    addEncodingName(*japaneseEncodings, "ISO-2022-JP-2"_s);
+    addEncodingName(*japaneseEncodings, "ISO-2022-JP-3"_s);
+    addEncodingName(*japaneseEncodings, "JIS_C6226-1978"_s);
+    addEncodingName(*japaneseEncodings, "JIS_X0201"_s);
+    addEncodingName(*japaneseEncodings, "JIS_X0208-1983"_s);
+    addEncodingName(*japaneseEncodings, "JIS_X0208-1990"_s);
+    addEncodingName(*japaneseEncodings, "JIS_X0212-1990"_s);
+    addEncodingName(*japaneseEncodings, "Shift_JIS"_s);
+    addEncodingName(*japaneseEncodings, "Shift_JIS_X0213-2000"_s);
+    addEncodingName(*japaneseEncodings, "cp932"_s);
+    addEncodingName(*japaneseEncodings, "x-mac-japanese"_s);
 
-    nonBackslashEncodings = new HashSet<const char*>;
+    nonBackslashEncodings = new HashSet<ASCIILiteral>;
     // The text encodings below treat backslash as a currency symbol for IE compatibility.
     // See http://blogs.msdn.com/michkap/archive/2005/09/17/469941.aspx for more information.
-    addEncodingName(nonBackslashEncodings, "x-mac-japanese");
-    addEncodingName(nonBackslashEncodings, "ISO-2022-JP");
-    addEncodingName(nonBackslashEncodings, "EUC-JP");
+    addEncodingName(*nonBackslashEncodings, "x-mac-japanese"_s);
+    addEncodingName(*nonBackslashEncodings, "ISO-2022-JP"_s);
+    addEncodingName(*nonBackslashEncodings, "EUC-JP"_s);
     // Shift_JIS_X0213-2000 is not the same encoding as Shift_JIS on Mac. We need to register both of them.
-    addEncodingName(nonBackslashEncodings, "Shift_JIS");
-    addEncodingName(nonBackslashEncodings, "Shift_JIS_X0213-2000");
+    addEncodingName(*nonBackslashEncodings, "Shift_JIS"_s);
+    addEncodingName(*nonBackslashEncodings, "Shift_JIS_X0213-2000"_s);
 }
 
-bool isJapaneseEncoding(const char* canonicalEncodingName)
+bool isJapaneseEncoding(ASCIILiteral canonicalEncodingName)
 {
-    return canonicalEncodingName && japaneseEncodings && japaneseEncodings->contains(canonicalEncodingName);
+    return !canonicalEncodingName.isNull() && japaneseEncodings && japaneseEncodings->contains(canonicalEncodingName);
 }
 
-bool shouldShowBackslashAsCurrencySymbolIn(const char* canonicalEncodingName)
+bool shouldShowBackslashAsCurrencySymbolIn(ASCIILiteral canonicalEncodingName)
 {
-    return canonicalEncodingName && nonBackslashEncodings && nonBackslashEncodings->contains(canonicalEncodingName);
+    return !canonicalEncodingName.isNull() && nonBackslashEncodings && nonBackslashEncodings->contains(canonicalEncodingName);
 }
 
 static void extendTextCodecMaps() WTF_REQUIRES_LOCK(encodingRegistryLock)
@@ -261,53 +272,53 @@ std::unique_ptr<TextCodec> newTextCodec(const TextEncoding& encoding)
     }
     auto result = textCodecMap->find(encoding.name());
     if (result == textCodecMap->end()) {
-        RELEASE_LOG_ERROR(TextEncoding, "Can't find codec for valid encoding %" PUBLIC_LOG_STRING ". Will default to UTF-8.", encoding.name());
+        RELEASE_LOG_ERROR(TextEncoding, "Can't find codec for valid encoding %" PUBLIC_LOG_STRING ". Will default to UTF-8.", encoding.name().characters());
         return TextCodecUTF8::codec();
     }
     if (!result->value) {
-        RELEASE_LOG_ERROR(TextEncoding, "Codec for encoding %" PUBLIC_LOG_STRING " is null. Will default to UTF-8", encoding.name());
+        RELEASE_LOG_ERROR(TextEncoding, "Codec for encoding %" PUBLIC_LOG_STRING " is null. Will default to UTF-8", encoding.name().characters());
         return TextCodecUTF8::codec();
     }
     return result->value();
 }
 
-const char* atomCanonicalTextEncodingName(const char* name)
+ASCIILiteral atomCanonicalTextEncodingName(const char* name)
 {
     if (!name || !name[0])
-        return nullptr;
+        return { };
 
     Locker locker { encodingRegistryLock };
 
     if (!textEncodingNameMap)
         buildBaseTextCodecMaps();
 
-    if (const char* atomName = textEncodingNameMap->get(name))
+    if (ASCIILiteral atomName = textEncodingNameMap->get<HashTranslatorTextEncodingName>(name))
         return atomName;
     if (didExtendTextCodecMaps)
-        return nullptr;
+        return { };
 
     extendTextCodecMaps();
     didExtendTextCodecMaps = true;
-    return textEncodingNameMap->get(name);
+    return textEncodingNameMap->get<HashTranslatorTextEncodingName>(name);
 }
 
-template<typename CharacterType> static const char* atomCanonicalTextEncodingName(const CharacterType* characters, size_t length)
+template<typename CharacterType> static ASCIILiteral atomCanonicalTextEncodingName(const CharacterType* characters, size_t length)
 {
     char buffer[maxEncodingNameLength + 1];
     size_t j = 0;
     for (size_t i = 0; i < length; ++i) {
         if (j == maxEncodingNameLength)
-            return nullptr;
+            return { };
         buffer[j++] = characters[i];
     }
     buffer[j] = 0;
     return atomCanonicalTextEncodingName(buffer);
 }
 
-const char* atomCanonicalTextEncodingName(StringView alias)
+ASCIILiteral atomCanonicalTextEncodingName(StringView alias)
 {
     if (alias.isEmpty() || !alias.containsOnlyASCII())
-        return nullptr;
+        return { };
 
     if (alias.is8Bit())
         return atomCanonicalTextEncodingName(alias.characters8(), alias.length());

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.h
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.h
@@ -42,11 +42,11 @@ class TextEncoding;
 PAL_EXPORT std::unique_ptr<TextCodec> newTextCodec(const TextEncoding&);
 
 // Only TextEncoding should use the following functions directly.
-const char* atomCanonicalTextEncodingName(const char* alias);
-const char* atomCanonicalTextEncodingName(StringView);
+ASCIILiteral atomCanonicalTextEncodingName(const char* alias);
+ASCIILiteral atomCanonicalTextEncodingName(StringView);
 bool noExtendedTextEncodingNameUsed();
-bool isJapaneseEncoding(const char* canonicalEncodingName);
-bool shouldShowBackslashAsCurrencySymbolIn(const char* canonicalEncodingName);
+bool isJapaneseEncoding(ASCIILiteral canonicalEncodingName);
+bool shouldShowBackslashAsCurrencySymbolIn(ASCIILiteral canonicalEncodingName);
 
 PAL_EXPORT String defaultTextEncodingNameForSystemLanguage();
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1696,6 +1696,12 @@ String Document::contentType() const
     return "application/xml"_s;
 }
 
+AtomString Document::encoding() const
+{
+    auto encoding = textEncoding().domName();
+    return encoding.isNull() ? nullAtom() : AtomString { encoding };
+}
+
 RefPtr<Range> Document::caretRangeFromPoint(int x, int y)
 {
     auto boundary = caretPositionFromPoint(LayoutPoint(x, y));

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -508,7 +508,7 @@ public:
     WEBCORE_EXPORT String characterSetWithUTF8Fallback() const;
     inline PAL::TextEncoding textEncoding() const;
 
-    inline AtomString encoding() const;
+    WEBCORE_EXPORT AtomString encoding() const;
 
     WEBCORE_EXPORT void setCharset(const String&); // Used by ObjC / GOBject bindings only.
 

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -51,8 +51,6 @@ inline PAL::TextEncoding Document::textEncoding() const
     return PAL::TextEncoding();
 }
 
-inline AtomString Document::encoding() const { return AtomString::fromLatin1(textEncoding().domName()); }
-
 inline String Document::charset() const { return Document::encoding(); }
 
 inline const Document* Document::templateDocument() const


### PR DESCRIPTION
#### e59e03e1df5b9d3dce970b9590767ceaabb9da47
<pre>
Adopt ASCIILiteral in TextEncoding code
<a href="https://bugs.webkit.org/show_bug.cgi?id=264988">https://bugs.webkit.org/show_bug.cgi?id=264988</a>

Reviewed by Darin Adler.

Adopt ASCIILiteral in TextEncoding code instead of `const char*` to
clarify the lifetime of these strings.

* Source/WTF/wtf/HashTraits.h:
(WTF::HashTraits&lt;ASCIILiteral&gt;::emptyValue):
(WTF::HashTraits&lt;ASCIILiteral&gt;::constructDeletedValue):
(WTF::HashTraits&lt;ASCIILiteral&gt;::isDeletedValue):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::ASCIILiteral::hash const):
(WTF::ASCIILiteralHash::hash):
(WTF::ASCIILiteralHash::equal):
* Source/WebCore/PAL/pal/text/TextCodec.h:
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::TextCodecCJK::registerEncodingNames):
(PAL::TextCodecCJK::registerCodecs):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::registerCodecs):
(PAL::TextCodecICU::TextCodecICU):
* Source/WebCore/PAL/pal/text/TextCodecICU.h:
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::TextCodecLatin1::registerEncodingNames):
(PAL::TextCodecLatin1::registerCodecs):
* Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp:
(PAL::TextCodecReplacement::registerEncodingNames):
(PAL::TextCodecReplacement::registerCodecs):
* Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp:
(PAL::TextCodecSingleByte::registerEncodingNames):
(PAL::TextCodecSingleByte::registerCodecs):
* Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp:
(PAL::TextCodecUTF16::registerEncodingNames):
(PAL::TextCodecUTF16::registerCodecs):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::registerEncodingNames):
(PAL::TextCodecUTF8::registerCodecs):
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
(PAL::TextCodecUserDefined::registerEncodingNames):
(PAL::TextCodecUserDefined::registerCodecs):
* Source/WebCore/PAL/pal/text/TextEncoding.cpp:
(PAL::TextEncoding::decode const):
(PAL::TextEncoding::encode const):
(PAL::TextEncoding::domName const):
(PAL::TextEncoding::usesVisualOrdering const):
* Source/WebCore/PAL/pal/text/TextEncoding.h:
(PAL::TextEncoding::isValid const):
(PAL::TextEncoding::name const):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::TextEncodingNameHash::hash):
(PAL::HashTranslatorTextEncodingName::hash):
(PAL::HashTranslatorTextEncodingName::equal):
(PAL::isUndesiredAlias):
(PAL::WTF_REQUIRES_LOCK):
(PAL::isJapaneseEncoding):
(PAL::shouldShowBackslashAsCurrencySymbolIn):
(PAL::newTextCodec):
(PAL::atomCanonicalTextEncodingName):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.h:
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::encoding const):

Canonical link: <a href="https://commits.webkit.org/270903@main">https://commits.webkit.org/270903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57f4979ea240a9950846a8d52b762be21d3c87d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24460 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2763 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3678 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29449 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23306 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29983 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25945 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5206 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33393 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6430 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4226 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7214 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->