### PR TITLE
Sync 'VideoTrack+MediaSource.idl', 'AudioTrack+MediaSource.idl' and 'TextTrack+MediaSource.idl' with WebIDL Specification

### DIFF
--- a/Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl
@@ -24,10 +24,13 @@
  */
 
 // https://w3c.github.io/media-source/#audio-track-extensions
+// FIXME: Extend this interface to 'DedicatedWorker' in future.
+
 [
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled,
-    ImplementedBy=AudioTrackMediaSource
+    ImplementedBy=AudioTrackMediaSource,
+    Exposed=Window
 ] partial interface AudioTrack {
     readonly attribute SourceBuffer? sourceBuffer;
 };

--- a/Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl
@@ -24,10 +24,13 @@
  */
 
 // https://w3c.github.io/media-source/#text-track-extensions
+// FIXME: Extend this interface to 'DedicatedWorker' in future.
+
 [
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled,
-    ImplementedBy=TextTrackMediaSource
+    ImplementedBy=TextTrackMediaSource,
+    Exposed=Window
 ] partial interface TextTrack {
     readonly attribute SourceBuffer? sourceBuffer;
 };

--- a/Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl
@@ -23,10 +23,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://w3c.github.io/media-source/#video-track-extensions
+// FIXME: Extend this interface to 'DedicatedWorker' in future.
+
 [
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled ,
-    ImplementedBy=VideoTrackMediaSource
+    ImplementedBy=VideoTrackMediaSource,
+    Exposed=Window
 ] partial interface VideoTrack {
     readonly attribute SourceBuffer? sourceBuffer;
 };


### PR DESCRIPTION
#### 83b09d3dc32378852d0113ca53dde5ff4c10e451
<pre>
Sync &apos;VideoTrack+MediaSource.idl&apos;, &apos;AudioTrack+MediaSource.idl&apos; and &apos;TextTrack+MediaSource.idl&apos; with WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=264939">https://bugs.webkit.org/show_bug.cgi?id=264939</a>

Reviewed by Jean-Yves Avenard.

This PR is to sync WebKit with Web-Specifications [1], [2] and [3] by exposing it to &apos;Window&apos;
and also add FIXME for &apos;DedicatedWorker&apos; [4].

[1] <a href="https://w3c.github.io/media-source/#audio-track-extensions">https://w3c.github.io/media-source/#audio-track-extensions</a>
[2] <a href="https://w3c.github.io/media-source/#text-track-extensions">https://w3c.github.io/media-source/#text-track-extensions</a>
[3] <a href="https://w3c.github.io/media-source/#video-track-extensions">https://w3c.github.io/media-source/#video-track-extensions</a>
[4] <a href="https://github.com/w3c/media-source/issues/280">https://github.com/w3c/media-source/issues/280</a>

* Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl:
* Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl:
* Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl:

Canonical link: <a href="https://commits.webkit.org/270873@main">https://commits.webkit.org/270873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6a64d93885cd5a56809a9c9c437e865a54a54e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24288 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29889 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27787 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5108 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6405 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->