### PR TITLE
Generate serialization of SandboxExtensionHandle

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -417,6 +417,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/ResourceLoadInfo.serialization.in
     Shared/ResourceLoadStatisticsParameters.serialization.in
     Shared/SameDocumentNavigationType.serialization.in
+    Shared/SandboxExtension.serialization.in
     Shared/ScrollingAccelerationCurve.serialization.in
     Shared/SessionState.serialization.in
     Shared/ShareableBitmap.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -276,6 +276,7 @@ $(PROJECT_DIR)/Shared/RemoteWorkerType.serialization.in
 $(PROJECT_DIR)/Shared/ResourceLoadInfo.serialization.in
 $(PROJECT_DIR)/Shared/ResourceLoadStatisticsParameters.serialization.in
 $(PROJECT_DIR)/Shared/SameDocumentNavigationType.serialization.in
+$(PROJECT_DIR)/Shared/SandboxExtension.serialization.in
 $(PROJECT_DIR)/Shared/ScrollingAccelerationCurve.serialization.in
 $(PROJECT_DIR)/Shared/SessionState.serialization.in
 $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -588,6 +588,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/ResourceLoadInfo.serialization.in \
 	Shared/ResourceLoadStatisticsParameters.serialization.in \
 	Shared/SameDocumentNavigationType.serialization.in \
+	Shared/SandboxExtension.serialization.in \
 	Shared/ScrollingAccelerationCurve.serialization.in \
 	Shared/SessionState.serialization.in \
 	Shared/ShareableBitmap.serialization.in \

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -35,14 +35,47 @@
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
-namespace IPC {
-class Encoder;
-class Decoder;
-}
-
 namespace WebKit {
-    
-class SandboxExtensionImpl;
+
+enum class SandboxExtensionFlags : uint8_t {
+    Default,
+    NoReport,
+    DoNotCanonicalize,
+};
+
+enum class SandboxExtensionType : uint8_t {
+    ReadOnly,
+    ReadWrite,
+    Mach,
+    IOKit,
+    Generic,
+    ReadByProcess
+};
+
+#if ENABLE(SANDBOX_EXTENSIONS)
+class SandboxExtensionImpl {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static std::unique_ptr<SandboxExtensionImpl> create(const char* path, SandboxExtensionType, std::optional<audit_token_t> = std::nullopt, OptionSet<SandboxExtensionFlags> = SandboxExtensionFlags::Default);
+    SandboxExtensionImpl(std::span<const uint8_t>);
+    ~SandboxExtensionImpl();
+
+    bool WARN_UNUSED_RETURN consume();
+    bool invalidate();
+    std::span<const uint8_t> WARN_UNUSED_RETURN getSerializedFormat();
+
+    SandboxExtensionImpl(SandboxExtensionImpl&& other)
+        : m_token(std::exchange(other.m_token, nullptr))
+        , m_handle(std::exchange(other.m_handle, 0)) { }
+private:
+    char* sandboxExtensionForType(const char* path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
+
+    SandboxExtensionImpl(const char* path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
+
+    char* m_token { nullptr };
+    int64_t m_handle { 0 };
+};
+#endif
 
 class SandboxExtensionHandle {
     WTF_MAKE_NONCOPYABLE(SandboxExtensionHandle);
@@ -51,18 +84,22 @@ public:
 #if ENABLE(SANDBOX_EXTENSIONS)
     SandboxExtensionHandle(SandboxExtensionHandle&&);
     SandboxExtensionHandle& operator=(SandboxExtensionHandle&&);
+    SandboxExtensionHandle(std::unique_ptr<SandboxExtensionImpl>&& impl)
+        : m_sandboxExtension(WTFMove(impl)) { }
 #else
     SandboxExtensionHandle(SandboxExtensionHandle&&) = default;
     SandboxExtensionHandle& operator=(SandboxExtensionHandle&&) = default;
 #endif
     ~SandboxExtensionHandle();
 
-    void encode(IPC::Encoder&) &&;
-    static std::optional<SandboxExtensionHandle> decode(IPC::Decoder&);
+#if ENABLE(SANDBOX_EXTENSIONS)
+    std::unique_ptr<SandboxExtensionImpl> takeImpl() { return std::exchange(m_sandboxExtension, nullptr); }
+#endif
 
 private:
     friend class SandboxExtension;
 #if ENABLE(SANDBOX_EXTENSIONS)
+    // FIXME: change SandboxExtension(const Handle&) to SandboxExtension(Handle&&) and make this no longer mutable.
     mutable std::unique_ptr<SandboxExtensionImpl> m_sandboxExtension;
 #endif
 };
@@ -70,27 +107,13 @@ private:
 class SandboxExtension : public RefCounted<SandboxExtension> {
 public:
     using Handle = SandboxExtensionHandle;
-
-    enum class Type : uint8_t {
-        ReadOnly,
-        ReadWrite,
-        Mach,
-        IOKit,
-        Generic,
-        ReadByProcess
-    };
-
-    enum class Flags : uint8_t {
-        Default,
-        NoReport,
-        DoNotCanonicalize,
-    };
+    using Type = SandboxExtensionType;
+    using Flags = SandboxExtensionFlags;
 
     enum class MachBootstrapOptions : uint8_t {
         DoNotEnableMachBootstrap,
         EnableMachBootstrap
     };
-
 
     static RefPtr<SandboxExtension> create(Handle&&);
     static std::optional<Handle> createHandle(StringView path, Type);
@@ -123,7 +146,7 @@ private:
     explicit SandboxExtension(const Handle&);
                      
 #if ENABLE(SANDBOX_EXTENSIONS)
-    mutable std::unique_ptr<SandboxExtensionImpl> m_sandboxExtension;
+    std::unique_ptr<SandboxExtensionImpl> m_sandboxExtension;
     size_t m_useCount { 0 };
 #endif
 };
@@ -136,8 +159,6 @@ String resolveAndCreateReadWriteDirectoryForSandboxExtension(StringView path);
 
 inline SandboxExtensionHandle::SandboxExtensionHandle() { }
 inline SandboxExtensionHandle::~SandboxExtensionHandle() { }
-inline void SandboxExtensionHandle::encode(IPC::Encoder&) && { }
-inline std::optional<SandboxExtensionHandle> SandboxExtensionHandle::decode(IPC::Decoder&) { return SandboxExtensionHandle { }; }
 inline RefPtr<SandboxExtension> SandboxExtension::create(Handle&&) { return nullptr; }
 inline auto SandboxExtension::createHandle(StringView, Type) -> std::optional<Handle> { return Handle { }; }
 inline auto SandboxExtension::createReadOnlyHandlesForFiles(ASCIILiteral, const Vector<String>&) -> Vector<Handle> { return { }; }

--- a/Source/WebKit/Shared/SandboxExtension.serialization.in
+++ b/Source/WebKit/Shared/SandboxExtension.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[CustomHeader, RValue] class WebKit::SandboxExtensionHandle {
+#if ENABLE(SANDBOX_EXTENSIONS)
+    std::unique_ptr<WebKit::SandboxExtensionImpl> takeImpl()
+#endif
+}
+
+#if ENABLE(SANDBOX_EXTENSIONS)
+[Nested, RValue] class WebKit::SandboxExtensionImpl {
+    IPC::DataReference getSerializedFormat();
+}
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7657,6 +7657,7 @@
 		F6113E27126CE19B0057D0A7 /* WKUserContentURLPattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKUserContentURLPattern.h; sourceTree = "<group>"; };
 		F634445512A885C8000612D8 /* APISecurityOrigin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APISecurityOrigin.h; sourceTree = "<group>"; };
 		F6A90811133C1F3D0082C3F4 /* WebCookieManagerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCookieManagerMac.mm; sourceTree = "<group>"; };
+		FA1473272B06EE6200765CC1 /* SandboxExtension.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SandboxExtension.serialization.in; sourceTree = "<group>"; };
 		FA651BA42AA3CBB500747576 /* NetworkTransportBidirectionalStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportBidirectionalStream.h; sourceTree = "<group>"; };
 		FA651BA52AA3CBB500747576 /* NetworkTransportBidirectionalStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportBidirectionalStream.cpp; sourceTree = "<group>"; };
 		FA651BA62AA3CBB600747576 /* NetworkTransportReceiveStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportReceiveStream.cpp; sourceTree = "<group>"; };
@@ -8505,6 +8506,7 @@
 				BC2D021612AC41CB00E732A3 /* SameDocumentNavigationType.h */,
 				44122266296A89820057E1A5 /* SameDocumentNavigationType.serialization.in */,
 				1AAB4A8C1296F0A20023952F /* SandboxExtension.h */,
+				FA1473272B06EE6200765CC1 /* SandboxExtension.serialization.in */,
 				E1E552C316AE065E004ED653 /* SandboxInitializationParameters.h */,
 				2D65D196274B8E84009C4101 /* ScrollingAccelerationCurve.cpp */,
 				2D65D195274B8E84009C4101 /* ScrollingAccelerationCurve.h */,


### PR DESCRIPTION
#### c31e0dd75e709ee3ffec35dc0ece60754149fdc8
<pre>
Generate serialization of SandboxExtensionHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=264994">https://bugs.webkit.org/show_bug.cgi?id=264994</a>
<a href="https://rdar.apple.com/118539219">rdar://118539219</a>

Reviewed by Chris Dumez.

All the transformations to get this to work are pretty straightforward,
except the if (dataReference.empty()) check to deserialize a valid, null
SandboxExtensionHandle if sandboxExtensionForType somehow returns an empty
string is replaced by a fast strlen-is-greater-than-0 check in
SandboxExtensionImpl::create to return an empty handle in the creation
process rather than failing to decode and killing the creation process.
This matches existing behavior as close as possible.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::create):
(WebKit::SandboxExtensionImpl::SandboxExtensionImpl):
(WebKit::SandboxExtensionImpl::~SandboxExtensionImpl):
(WebKit::SandboxExtensionImpl::consume):
(WebKit::SandboxExtensionImpl::invalidate):
(WebKit::SandboxExtensionImpl::getSerializedFormat):
(WebKit::SandboxExtensionImpl::sandboxExtensionForType):
(): Deleted.
(WebKit::SandboxExtensionHandle::encode): Deleted.
(WebKit::SandboxExtensionHandle::decode): Deleted.
* Source/WebKit/Shared/SandboxExtension.h:
(WebKit::SandboxExtensionImpl::SandboxExtensionImpl):
(WebKit::SandboxExtensionHandle::SandboxExtensionHandle):
(WebKit::SandboxExtensionHandle::takeImpl):
(WebKit::SandboxExtensionHandle::~SandboxExtensionHandle):
(WebKit::SandboxExtensionHandle::encode): Deleted.
(WebKit::SandboxExtensionHandle::decode): Deleted.
* Source/WebKit/Shared/SandboxExtension.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270904@main">https://commits.webkit.org/270904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c91ff0691c913c087b601a1ec5ac3db40b44ca2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24462 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2765 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3682 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3721 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27887 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4228 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3458 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->