### PR TITLE
Fix PlayStation build following 270852@main

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
@@ -101,7 +101,7 @@ inline Ref<SharedTask<void(Visitor&)>> MarkedSpace::forEachWeakInParallel()
                         continue;
                     results[resultsSize++] = block;
                     if (resultsSize == batchSize)
-                        return std::span { results.begin(), resultsSize };
+                        return std::span { results.data(), resultsSize };
                     continue;
                 }
 
@@ -116,7 +116,7 @@ inline Ref<SharedTask<void(Visitor&)>> MarkedSpace::forEachWeakInParallel()
                     ++m_activeCursor;
                     continue;
                 }
-                return std::span { results.begin(), resultsSize };
+                return std::span { results.data(), resultsSize };
             }
         }
 


### PR DESCRIPTION
#### 130fd1385553a7a6e82ff7c836e0a4018e35f27e
<pre>
Fix PlayStation build following 270852@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=264997">https://bugs.webkit.org/show_bug.cgi?id=264997</a>

Unreviewed build fix.

* Source/JavaScriptCore/heap/MarkedSpaceInlines.h:
(JSC::MarkedSpace::forEachWeakInParallel):
.begin() is an iterator, .data() is the pointer that we&apos;re looking for.

Canonical link: <a href="https://commits.webkit.org/270859@main">https://commits.webkit.org/270859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a04ce8bd43b90afe894924ea0e4ce2d8b8f169fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28877 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/24386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2675 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26926 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/4096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3601 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29362 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23230 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25863 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27806 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/5126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33318 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/7203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3446 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->