### PR TITLE
[Site Isolation][iOS] Send touch events to isolated frames

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6895,3 +6895,5 @@ imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthetic-event.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/no-args.html [ Pass ]
+
+http/tests/site-isolation/touch-events [ Skip ]

--- a/LayoutTests/http/tests/site-isolation/touch-events/resources/post-message-coordinates.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/resources/post-message-coordinates.html
@@ -1,0 +1,9 @@
+<script>
+function coordinates(event) {
+    return event.pageX + "," + event.pageY;
+}
+
+addEventListener("touchstart", (event) => window.parent.postMessage("touchstart " + coordinates(event), "*"));
+addEventListener("touchmove", (event) => window.parent.postMessage("touchmove " + coordinates(event), "*"));
+addEventListener("touchend", (event) => window.parent.postMessage("touchend " + coordinates(event), "*"));
+</script>

--- a/LayoutTests/http/tests/site-isolation/touch-events/touch-event-coordinates-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/touch-events/touch-event-coordinates-expected.txt
@@ -1,0 +1,12 @@
+Verifies that the iframe receives touch events with the expected coordinates.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS events[0] is 'touchstart 40,10'
+PASS events[1] is 'touchmove 140,60'
+PASS events[2] is 'touchend 140,60'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/touch-events/touch-event-coordinates.html
+++ b/LayoutTests/http/tests/site-isolation/touch-events/touch-event-coordinates.html
@@ -1,0 +1,25 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Verifies that the iframe receives touch events with the expected coordinates.");
+jsTestIsAsync = true;
+
+let events = [];
+addEventListener("message", (event) => {
+    events.push(event.data);
+    if (events.length == 3) {
+        shouldBe("events[0]", "'touchstart 40,10'");
+        shouldBe("events[1]", "'touchmove 140,60'");
+        shouldBe("events[2]", "'touchend 140,60'");
+        finishJSTest();
+    }
+});
+
+addEventListener("touchstart", () => { testFailed("This event listener should not be called.") });
+
+function onLoad() {
+    UIHelper.dragFromPointToPoint(50, 100, 150, 150);
+}
+</script>
+<iframe onload="onLoad()" width="300" height="300" src="http://localhost:8000/site-isolation/touch-events/resources/post-message-coordinates.html"></iframe>

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -72,6 +72,7 @@ class Element;
 class Event;
 class EventTarget;
 class FloatQuad;
+class Frame;
 class HTMLFrameSetElement;
 class HandleUserInputEventResult;
 class HitTestResult;
@@ -240,7 +241,7 @@ public:
     void updateTouchLastGlobalPositionAndDelta(PointerID, const IntPoint&, InTouchEventHandling, InMotion);
     bool dispatchTouchEvent(const PlatformTouchEvent&, const AtomString&, const EventTargetTouchArrayMap&, float, float);
     bool dispatchSimulatedTouchEvent(IntPoint location);
-    LocalFrame* touchEventTargetSubframe() const { return m_touchEventTargetSubframe.get(); }
+    Frame* touchEventTargetSubframe() const { return m_touchEventTargetSubframe.get(); }
     const TouchArray& touches() const { return m_touches; }
 #endif
 
@@ -329,7 +330,7 @@ public:
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
-    WEBCORE_EXPORT bool handleTouchEvent(const PlatformTouchEvent&);
+    WEBCORE_EXPORT HandleUserInputEventResult handleTouchEvent(const PlatformTouchEvent&);
 #endif
 
     bool useHandCursor(Node*, bool isOverLink, bool shiftKey);
@@ -441,7 +442,7 @@ private:
     bool isInsideScrollbar(const IntPoint&) const;
 
 #if ENABLE(TOUCH_EVENTS)
-    bool dispatchSyntheticTouchEventIfEnabled(const PlatformMouseEvent&);
+    HandleUserInputEventResult dispatchSyntheticTouchEventIfEnabled(const PlatformMouseEvent&);
 #endif
     
     enum class FireMouseOverOut : bool { No, Yes };
@@ -599,7 +600,7 @@ private:
     bool canMouseDownStartSelect(const MouseEventWithHitTestResults&);
     bool mouseDownMayStartSelect() const;
 
-    std::optional<RemoteUserInputEventData> mouseEventDataForRemoteFrame(const RemoteFrame*, const IntPoint&);
+    std::optional<RemoteUserInputEventData> userInputEventDataForRemoteFrame(const RemoteFrame*, const IntPoint&);
 
     bool isCapturingMouseEventsElement() const { return m_capturingMouseEventsElement || m_isCapturingRootElementForMouseEvents; }
     void resetCapturingMouseEventsElement()
@@ -712,7 +713,7 @@ private:
     unsigned m_touchIdentifierForPrimaryTouch { 0 };
 
     TouchArray m_touches;
-    RefPtr<LocalFrame> m_touchEventTargetSubframe;
+    RefPtr<Frame> m_touchEventTargetSubframe;
     HashMap<PointerID, std::pair<IntPoint, IntPoint>, WTF::IntHash<PointerID>, WTF::UnsignedWithZeroKeyHashTraits<PointerID>> m_touchLastGlobalPositionAndDeltaMap;
 #endif
 

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -130,8 +130,8 @@ bool EventHandler::wheelEvent(WebEvent *event)
 
 bool EventHandler::dispatchSimulatedTouchEvent(IntPoint location)
 {
-    bool handled = handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::Type::TouchStart, location));
-    handled |= handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::Type::TouchEnd, location));
+    bool handled = handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::Type::TouchStart, location)).wasHandled();
+    handled |= handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::Type::TouchEnd, location)).wasHandled();
     return handled;
 }
     
@@ -139,7 +139,7 @@ void EventHandler::touchEvent(WebEvent *event)
 {
     CurrentEventScope scope(event);
 
-    event.wasHandled = handleTouchEvent(PlatformEventFactory::createPlatformTouchEvent(event));
+    event.wasHandled = handleTouchEvent(PlatformEventFactory::createPlatformTouchEvent(event)).wasHandled();
 }
 #endif
 

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -130,6 +130,7 @@ public:
     const Vector<WebPlatformTouchPoint>& touchPoints() const { return m_touchPoints; }
 
     WebCore::IntPoint position() const { return m_position; }
+    void setPosition(WebCore::IntPoint position) { m_position = position; }
 
     bool isPotentialTap() const { return m_isPotentialTap; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2853,6 +2853,9 @@ private:
     template<typename M, typename C> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&, C&&);
     template<typename M> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&);
 
+    void sendPreventableTouchEvent(WebCore::FrameIdentifier, const NativeWebTouchEvent&);
+    void sendUnpreventableTouchEvent(WebCore::FrameIdentifier, const NativeWebTouchEvent&);
+
     struct Internals;
     Internals& internals() { return m_internals; }
     const Internals& internals() const { return m_internals; }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -48,6 +48,10 @@
 
 #include <WebCore/DisplayRefreshMonitorManager.h>
 
+#if ENABLE(IOS_TOUCH_EVENTS)
+#include <WebCore/RemoteUserInputEventData.h>
+#endif
+
 #if ENABLE(SCROLLING_THREAD)
 #include <WebCore/ScrollingThread.h>
 #include <WebCore/ScrollingTreeNode.h>
@@ -206,12 +210,7 @@ void EventDispatcher::takeQueuedTouchEventsForPage(const WebPage& webPage, Touch
     destinationQueue = m_touchEvents.take(webPage.identifier());
 }
 
-void EventDispatcher::touchEventWithoutCallback(PageIdentifier pageID, const WebTouchEvent& touchEvent)
-{
-    this->touchEvent(pageID, touchEvent, nullptr);
-}
-
-void EventDispatcher::touchEvent(PageIdentifier pageID, const WebTouchEvent& touchEvent, CompletionHandler<void(bool)>&& completionHandler)
+void EventDispatcher::touchEvent(PageIdentifier pageID, FrameIdentifier frameID, const WebTouchEvent& touchEvent, CompletionHandler<void(bool, std::optional<RemoteUserInputEventData>)>&& completionHandler)
 {
     bool updateListWasEmpty;
     {
@@ -219,16 +218,16 @@ void EventDispatcher::touchEvent(PageIdentifier pageID, const WebTouchEvent& tou
         updateListWasEmpty = m_touchEvents.isEmpty();
         auto addResult = m_touchEvents.add(pageID, TouchEventQueue());
         if (addResult.isNewEntry)
-            addResult.iterator->value.append({ touchEvent, WTFMove(completionHandler) });
+            addResult.iterator->value.append({ frameID, touchEvent, WTFMove(completionHandler) });
         else {
             auto& queuedEvents = addResult.iterator->value;
             ASSERT(!queuedEvents.isEmpty());
-            auto& lastEventAndCallback = queuedEvents.last();
+            auto& touchEventData = queuedEvents.last();
             // Coalesce touch move events.
-            if (touchEvent.type() == WebEventType::TouchMove && lastEventAndCallback.first.type() == WebEventType::TouchMove && !completionHandler && !lastEventAndCallback.second)
-                queuedEvents.last() = { touchEvent, nullptr };
+            if (touchEvent.type() == WebEventType::TouchMove && touchEventData.event.type() == WebEventType::TouchMove)
+                queuedEvents.last() = { frameID, touchEvent, WTFMove(completionHandler) };
             else
-                queuedEvents.append({ touchEvent, WTFMove(completionHandler) });
+                queuedEvents.append({ frameID, touchEvent, WTFMove(completionHandler) });
         }
     }
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -23,8 +23,7 @@
 messages -> EventDispatcher NotRefCounted {
     WheelEvent(WebCore::PageIdentifier pageID, WebKit::WebWheelEvent event, WebCore::RectEdges<bool> rubberBandableEdges)
 #if ENABLE(IOS_TOUCH_EVENTS)
-    TouchEvent(WebCore::PageIdentifier pageID, WebKit::WebTouchEvent event) -> (bool handled) MainThreadCallback
-    TouchEventWithoutCallback(WebCore::PageIdentifier pageID, WebKit::WebTouchEvent event)
+    TouchEvent(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, WebKit::WebTouchEvent event) -> (bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteTouchEventData) MainThreadCallback
 #endif
 #if ENABLE(MAC_GESTURE_EVENTS)
     GestureEvent(WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event) -> (std::optional<WebKit::WebEventType> eventType, bool handled) MainThreadCallback

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -292,6 +292,10 @@ struct ViewportArguments;
 class HTMLAttachmentElement;
 #endif
 
+#if ENABLE(IOS_TOUCH_EVENTS)
+class HandleUserInputEventResult;
+#endif
+
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
 struct TranslationContextMenuInfo;
 #endif
@@ -937,8 +941,8 @@ public:
     void didChangeSelectionForAccessibility() { m_isChangingSelectionForAccessibility = false; }
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(IOS_TOUCH_EVENTS)
-    void dispatchAsynchronousTouchEvents(Vector<std::pair<WebTouchEvent, CompletionHandler<void(bool)>>, 1>&&);
-    void cancelAsynchronousTouchEvents(Vector<std::pair<WebTouchEvent, CompletionHandler<void(bool)>>, 1>&&);
+    void dispatchAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&&);
+    void cancelAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&&);
 #endif
 
     bool hasRichlyEditableSelection() const;
@@ -1233,7 +1237,7 @@ public:
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-    bool dispatchTouchEvent(const WebTouchEvent&);
+    WebCore::HandleUserInputEventResult dispatchTouchEvent(WebCore::FrameIdentifier, const WebTouchEvent&);
 #endif
 
     bool shouldUseCustomContentProviderForResponse(const WebCore::ResourceResponse&);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4505,20 +4505,20 @@ void WebPage::willStartUserTriggeredZooming()
 }
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-void WebPage::dispatchAsynchronousTouchEvents(Vector<std::pair<WebTouchEvent, CompletionHandler<void(bool)>>, 1>&& queue)
+void WebPage::dispatchAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&& queue)
 {
-    for (auto& eventAndCallbackID : queue) {
-        bool handled = dispatchTouchEvent(eventAndCallbackID.first);
-        if (auto& completionHandler = eventAndCallbackID.second)
-            completionHandler(handled);
+    for (auto& touchEventData : queue) {
+        auto handleTouchEventResult = dispatchTouchEvent(touchEventData.frameID, touchEventData.event);
+        if (auto& completionHandler = touchEventData.completionHandler)
+            completionHandler(handleTouchEventResult.wasHandled(), handleTouchEventResult.remoteUserInputEventData());
     }
 }
 
-void WebPage::cancelAsynchronousTouchEvents(Vector<std::pair<WebTouchEvent, CompletionHandler<void(bool)>>, 1>&& queue)
+void WebPage::cancelAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&& queue)
 {
-    for (auto& eventAndCallbackID : queue) {
-        if (auto& completionHandler = eventAndCallbackID.second)
-            completionHandler(true);
+    for (auto& touchEventData : queue) {
+        if (auto& completionHandler = touchEventData.completionHandler)
+            completionHandler(true, std::nullopt);
     }
 }
 #endif


### PR DESCRIPTION
#### 355bf0478f6ed4d5f7bbb0543140776b8af74dea
<pre>
[Site Isolation][iOS] Send touch events to isolated frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=264998">https://bugs.webkit.org/show_bug.cgi?id=264998</a>
<a href="https://rdar.apple.com/116837559">rdar://116837559</a>

Reviewed by Alex Christensen.

This patch makes changes to send touch events to isolated frames with corrected coordinates.

Similar to mouse and drag events, IPC will be sent between the UI process and web processes until the
target frame is reached. More details below.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::userInputEventDataForRemoteFrame):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::handleTouchEvent):
(WebCore::EventHandler::dispatchSyntheticTouchEventIfEnabled):
(WebCore::EventHandler::mouseEventDataForRemoteFrame): Deleted.
* Source/WebCore/page/EventHandler.h:
(WebCore::EventHandler::touchEventTargetSubframe const):

I renamed `mouseEventDataForRemoteFrame()` to `userInputEventDataForRemoteFrame()` since this function
won’t only be used for mouse events.

* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::dispatchSimulatedTouchEvent):
(WebCore::EventHandler::touchEvent):

* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebTouchEvent::setPosition):

We need `setPosition()` to correct the coordinates of the touch event before forwarding it to the iframe
process.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::handlePreventableTouchEvent):
(WebKit::WebPageProxy::sendUnpreventableTouchEvent):
(WebKit::WebPageProxy::handleUnpreventableTouchEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:

I added `sendPreventableTouchEvent()` and `sendUnpreventableTouchEvent()` so we can specify a frame to
send the touch event to. If the touch event needs to be forwarded to an iframe process the event
coordinates will be corrected and we’ll send another IPC call to the target frame.

* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::touchEvent):
(WebKit::EventDispatcher::touchEventWithoutCallback): Deleted.
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in:

We now need a completion handler even if the touch event is unpreventable, so I removed
`touchEventWithoutCallback()` and made both preventable and unpreventable touch events call directly
into `touchEvent()`. If the touch event is unpreventable the `handled` bool passed back through the
completion handler will be ignored. I also needed to store the completion handler for unpreventable
touch events in the touch event queue.

I added a frame identifier to be associated with each queued touch event. Also store these values in a
new struct.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::handleTouchEvent):
(WebKit::WebPage::dispatchTouchEvent):
(WebKit::WebPage::touchEvent):
(WebKit::WebPage::updatePotentialTapSecurityOrigin):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Change these functions to expect a frame identifier to be passed, and use the event handler associated
with that frame to handle touch events.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::dispatchAsynchronousTouchEvents):
(WebKit::WebPage::cancelAsynchronousTouchEvents):

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/site-isolation/touch-events/resources/post-message-coordinates.html: Added.
* LayoutTests/http/tests/site-isolation/touch-events/touch-event-coordinates-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/touch-events/touch-event-coordinates.html: Added.

This test verifies the isolated iframe receives the touch events with the expected coordinates. Also
make sure touch event listeners on the main frame are not called.

Canonical link: <a href="https://commits.webkit.org/270954@main">https://commits.webkit.org/270954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1761bb4489128e8557237286b5589106c62e75e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28905 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24407 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24316 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29931 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27830 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23643 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4171 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3491 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->