### PR TITLE
Regression(267645@main) ~3MB increase in binary size

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -435,7 +435,7 @@ public:
             masm->invalidateAllTempRegisters();
         }
 
-        friend bool operator==(Label, Label) = default;
+        friend bool operator==(const Label&, const Label&) = default;
 
         bool isSet() const { return m_label.isSet(); }
     private:

--- a/Source/JavaScriptCore/b3/B3Origin.h
+++ b/Source/JavaScriptCore/b3/B3Origin.h
@@ -46,7 +46,7 @@ public:
 
     const void* data() const { return m_data; }
 
-    friend bool operator==(Origin, Origin) = default;
+    friend bool operator==(const Origin&, const Origin&) = default;
 
     // You should avoid using this. Use OriginDump instead.
     void dump(PrintStream&) const;

--- a/Source/JavaScriptCore/b3/B3Type.h
+++ b/Source/JavaScriptCore/b3/B3Type.h
@@ -77,7 +77,7 @@ public:
     inline bool isTuple() const;
     inline bool isVector() const;
 
-    friend bool operator==(Type, Type) = default;
+    friend bool operator==(const Type&, const Type&) = default;
 
 private:
     TypeKind m_kind { Void };

--- a/Source/JavaScriptCore/b3/air/AirTmp.h
+++ b/Source/JavaScriptCore/b3/air/AirTmp.h
@@ -185,7 +185,7 @@ public:
         return !!*this;
     }
 
-    friend bool operator==(Tmp, Tmp) = default;
+    friend bool operator==(const Tmp&, const Tmp&) = default;
 
     void dump(PrintStream& out) const;
 

--- a/Source/JavaScriptCore/bytecode/ArithProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArithProfile.h
@@ -53,7 +53,7 @@ struct ObservedType {
     constexpr ObservedType withNonNumber() const { return ObservedType(m_bits | TypeNonNumber); }
     constexpr ObservedType withoutNonNumber() const { return ObservedType(m_bits & ~TypeNonNumber); }
 
-    friend constexpr bool operator==(ObservedType, ObservedType) = default;
+    friend constexpr bool operator==(const ObservedType&, const ObservedType&) = default;
 
     static constexpr uint8_t TypeEmpty = 0x0;
     static constexpr uint8_t TypeInt32 = 0x1;

--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -146,7 +146,7 @@ public:
         return m_callee == deletedToken();
     }
     
-    friend bool operator==(CallVariant, CallVariant) = default;
+    friend bool operator==(const CallVariant&, const CallVariant&) = default;
     
     bool operator<(const CallVariant& other) const
     {

--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.h
@@ -64,7 +64,7 @@ public:
     void dump(PrintStream&) const;
     
     // Comparison methods useful for bisection.
-    friend bool operator==(CodeBlockHash, CodeBlockHash) = default;
+    friend bool operator==(const CodeBlockHash&, const CodeBlockHash&) = default;
     bool operator<(const CodeBlockHash& other) const { return hash() < other.hash(); }
     bool operator>(const CodeBlockHash& other) const { return hash() > other.hash(); }
     bool operator<=(const CodeBlockHash& other) const { return hash() <= other.hash(); }

--- a/Source/JavaScriptCore/bytecode/VirtualRegister.h
+++ b/Source/JavaScriptCore/bytecode/VirtualRegister.h
@@ -78,7 +78,7 @@ public:
     int offset() const { return m_virtualRegister; }
     int offsetInBytes() const { return m_virtualRegister * sizeof(Register); }
 
-    friend bool operator==(VirtualRegister, VirtualRegister) = default;
+    friend bool operator==(const VirtualRegister&, const VirtualRegister&) = default;
     bool operator<(VirtualRegister other) const { return m_virtualRegister < other.m_virtualRegister; }
     bool operator>(VirtualRegister other) const { return m_virtualRegister > other.m_virtualRegister; }
     bool operator<=(VirtualRegister other) const { return m_virtualRegister <= other.m_virtualRegister; }

--- a/Source/JavaScriptCore/debugger/DebuggerScope.h
+++ b/Source/JavaScriptCore/debugger/DebuggerScope.h
@@ -70,7 +70,7 @@ public:
         iterator& operator++() { m_node = m_node->next(); return *this; }
         // postfix ++ intentionally omitted
 
-        friend bool operator==(iterator, iterator) = default;
+        friend bool operator==(const iterator&, const iterator&) = default;
 
     private:
         DebuggerScope* m_node;

--- a/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
@@ -282,7 +282,7 @@ public:
         return WTF::IntHash<int64_t>::hash(m_value);
     }
     
-    friend bool operator==(AbstractHeap, AbstractHeap) = default;
+    friend bool operator==(const AbstractHeap&, const AbstractHeap&) = default;
     
     bool operator<(const AbstractHeap& other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGAbstractValueClobberEpoch.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValueClobberEpoch.h
@@ -64,7 +64,7 @@ public:
         m_value |= watchedFlag;
     }
     
-    friend bool operator==(AbstractValueClobberEpoch, AbstractValueClobberEpoch) = default;
+    friend bool operator==(const AbstractValueClobberEpoch&, const AbstractValueClobberEpoch&) = default;
     
     StructureClobberState structureClobberState() const
     {

--- a/Source/JavaScriptCore/dfg/DFGEdge.h
+++ b/Source/JavaScriptCore/dfg/DFGEdge.h
@@ -160,7 +160,7 @@ public:
     bool operator!() const { return !isSet(); }
     explicit operator bool() const { return isSet(); }
     
-    friend bool operator==(Edge, Edge) = default;
+    friend bool operator==(const Edge&, const Edge&) = default;
 
     void dump(PrintStream&) const;
     

--- a/Source/JavaScriptCore/dfg/DFGEpoch.h
+++ b/Source/JavaScriptCore/dfg/DFGEpoch.h
@@ -81,7 +81,7 @@ public:
         *this = next();
     }
     
-    friend bool operator==(Epoch, Epoch) = default;
+    friend bool operator==(const Epoch&, const Epoch&) = default;
     
     bool operator<(const Epoch& other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
@@ -72,7 +72,7 @@ public:
         return m_word;
     }
     
-    friend bool operator==(NodeFlowProjection, NodeFlowProjection) = default;
+    friend bool operator==(const NodeFlowProjection&, const NodeFlowProjection&) = default;
     
     bool operator<(NodeFlowProjection other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGRegisteredStructure.h
+++ b/Source/JavaScriptCore/dfg/DFGRegisteredStructure.h
@@ -40,7 +40,7 @@ public:
     ALWAYS_INLINE Structure* get() const { return m_structure; }
     Structure* operator->() const { return get(); }
 
-    friend bool operator==(RegisteredStructure, RegisteredStructure) = default;
+    friend bool operator==(const RegisteredStructure&, const RegisteredStructure&) = default;
 
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/heap/Allocator.h
+++ b/Source/JavaScriptCore/heap/Allocator.h
@@ -52,7 +52,7 @@ public:
     
     LocalAllocator* localAllocator() const { return m_localAllocator; }
     
-    friend bool operator==(Allocator, Allocator) = default;
+    friend bool operator==(const Allocator&, const Allocator&) = default;
     explicit operator bool() const { return *this != Allocator(); }
     
 private:

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -66,7 +66,7 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         { }
 
         explicit operator bool() const { return !!m_bits; }
-        friend bool operator==(CallSiteIndex, CallSiteIndex) = default;
+        friend bool operator==(const CallSiteIndex&, const CallSiteIndex&) = default;
 
         unsigned hash() const { return intHash(m_bits); }
         static CallSiteIndex deletedValue() { return fromBits(s_invalidIndex - 1); }

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -71,7 +71,7 @@ public:
     bool operator!() const { return m_gpr == InvalidGPRReg; }
     explicit operator bool() const { return m_gpr != InvalidGPRReg; }
 
-    friend constexpr bool operator==(JSValueRegs, JSValueRegs) = default;
+    friend constexpr bool operator==(const JSValueRegs&, const JSValueRegs&) = default;
 
     constexpr GPRReg gpr() const { return m_gpr; }
     constexpr GPRReg tagGPR() const { return InvalidGPRReg; }
@@ -196,7 +196,7 @@ public:
             || static_cast<GPRReg>(m_payloadGPR) != InvalidGPRReg;
     }
 
-    friend constexpr bool operator==(JSValueRegs, JSValueRegs) = default;
+    friend constexpr bool operator==(const JSValueRegs&, const JSValueRegs&) = default;
     
     constexpr GPRReg tagGPR() const { return m_tagGPR; }
     constexpr GPRReg payloadGPR() const { return m_payloadGPR; }

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -137,7 +137,7 @@ public:
             MacroAssembler::firstFPRegister() + (m_index - MacroAssembler::numberOfRegisters()));
     }
 
-    friend constexpr bool operator==(Reg, Reg) = default;
+    friend constexpr bool operator==(const Reg&, const Reg&) = default;
 
     constexpr bool operator<(const Reg& other) const
     {
@@ -188,7 +188,7 @@ public:
                 return *this;
             }
 
-            friend bool operator==(iterator, iterator) = default;
+            friend bool operator==(const iterator&, const iterator&) = default;
 
         private:
             unsigned m_regIndex;

--- a/Source/JavaScriptCore/parser/SourceCodeKey.h
+++ b/Source/JavaScriptCore/parser/SourceCodeKey.h
@@ -56,7 +56,7 @@ public:
     {
     }
 
-    friend bool operator==(SourceCodeFlags, SourceCodeFlags) = default;
+    friend bool operator==(const SourceCodeFlags&, const SourceCodeFlags&) = default;
 
     unsigned bits() { return m_flags; }
 

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -71,7 +71,7 @@ public:
 
     uint16_t bits() const { return m_bits; }
 
-    friend bool operator==(VariableEnvironmentEntry, VariableEnvironmentEntry) = default;
+    friend bool operator==(const VariableEnvironmentEntry&, const VariableEnvironmentEntry&) = default;
 
     void dump(PrintStream&) const;
 
@@ -119,7 +119,7 @@ public:
 
     uint16_t bits() const { return m_bits; }
 
-    friend bool operator==(PrivateNameEntry, PrivateNameEntry) = default;
+    friend bool operator==(const PrivateNameEntry&, const PrivateNameEntry&) = default;
 
     enum Traits : uint16_t {
         None = 0,

--- a/Source/JavaScriptCore/profiler/ProfilerUID.h
+++ b/Source/JavaScriptCore/profiler/ProfilerUID.h
@@ -60,7 +60,7 @@ public:
         return m_uid;
     }
     
-    friend bool operator==(UID, UID) = default;
+    friend bool operator==(const UID&, const UID&) = default;
     
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/runtime/GenericOffset.h
+++ b/Source/JavaScriptCore/runtime/GenericOffset.h
@@ -60,7 +60,7 @@ public:
         return m_offset;
     }
     
-    friend bool operator==(GenericOffset, GenericOffset) = default;
+    friend bool operator==(const GenericOffset&, const GenericOffset&) = default;
     bool operator<(const GenericOffset& other) const
     {
         return m_offset < other.m_offset;

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -161,7 +161,7 @@ public:
     {
         return m_epochNanoseconds <= other.m_epochNanoseconds;
     }
-    friend constexpr bool operator==(ExactTime, ExactTime) = default;
+    friend constexpr bool operator==(const ExactTime&, const ExactTime&) = default;
     constexpr bool operator>=(ExactTime other) const
     {
         return m_epochNanoseconds >= other.m_epochNanoseconds;
@@ -214,7 +214,7 @@ public:
     JSC_TEMPORAL_PLAIN_TIME_UNITS(JSC_DEFINE_ISO8601_PLAIN_TIME_FIELD);
 #undef JSC_DEFINE_ISO8601_DURATION_FIELD
 
-    friend bool operator==(PlainTime, PlainTime) = default;
+    friend bool operator==(const PlainTime&, const PlainTime&) = default;
 
 private:
     uint8_t m_hour { 0 };
@@ -245,7 +245,7 @@ public:
     {
     }
 
-    friend bool operator==(PlainDate, PlainDate) = default;
+    friend bool operator==(const PlainDate&, const PlainDate&) = default;
 
     int32_t year() const { return m_year; }
     uint8_t month() const { return m_month; }

--- a/Source/JavaScriptCore/runtime/JSScope.h
+++ b/Source/JavaScriptCore/runtime/JSScope.h
@@ -114,7 +114,7 @@ public:
 
     // postfix ++ intentionally omitted
 
-    friend bool operator==(ScopeChainIterator, ScopeChainIterator) = default;
+    friend bool operator==(const ScopeChainIterator&, const ScopeChainIterator&) = default;
 
 private:
     JSScope* m_node;

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -97,7 +97,7 @@ public:
     bool operator<(const PageCount& other) const { return m_pageCount < other.m_pageCount; }
     bool operator>(const PageCount& other) const { return m_pageCount > other.m_pageCount; }
     bool operator>=(const PageCount& other) const { return m_pageCount >= other.m_pageCount; }
-    friend bool operator==(PageCount, PageCount) = default;
+    friend bool operator==(const PageCount&, const PageCount&) = default;
     PageCount operator+(const PageCount& other) const
     {
         if (sumOverflows<uint32_t>(m_pageCount, other.m_pageCount))

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -85,7 +85,7 @@ public:
     static StructureID encode(const Structure*);
 
     explicit operator bool() const { return !!m_bits; }
-    friend bool operator==(StructureID, StructureID) = default;
+    friend bool operator==(const StructureID&, const StructureID&) = default;
     constexpr uint32_t bits() const { return m_bits; }
 
     StructureID(WTF::HashTableDeletedValueType) : m_bits(nukedStructureIDBit) { }

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -190,7 +190,7 @@ class StructureTransitionTable {
             TransitionPropertyAttributes attributes() const { return (m_encodedData >> attributesShift) & UINT8_MAX; }
             TransitionKind transitionKind() const { return static_cast<TransitionKind>(m_encodedData >> transitionKindShift); }
 
-            friend bool operator==(Key, Key) = default;
+            friend bool operator==(const Key&, const Key&) = default;
 
         private:
             uintptr_t m_encodedData { 0 };


### PR DESCRIPTION
#### 4dacd4adab9471bc6dfb8ce2c0a090a03cce1d52
<pre>
Regression(267645@main) ~3MB increase in binary size
<a href="https://bugs.webkit.org/show_bug.cgi?id=264896">https://bugs.webkit.org/show_bug.cgi?id=264896</a>
<a href="https://rdar.apple.com/118490755">rdar://118490755</a>

Reviewed by Brent Fulgham.

Pass comparison operands by const reference instead of by value, as
recommended by the clang team. This should generate code more similar
to the one before 267645@main.

* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
* Source/JavaScriptCore/b3/B3Origin.h:
* Source/JavaScriptCore/b3/B3Type.h:
* Source/JavaScriptCore/b3/air/AirTmp.h:
* Source/JavaScriptCore/bytecode/ArithProfile.h:
* Source/JavaScriptCore/bytecode/CallVariant.h:
* Source/JavaScriptCore/bytecode/CodeBlockHash.h:
* Source/JavaScriptCore/bytecode/VirtualRegister.h:
* Source/JavaScriptCore/debugger/DebuggerScope.h:
* Source/JavaScriptCore/dfg/DFGAbstractHeap.h:
* Source/JavaScriptCore/dfg/DFGAbstractValueClobberEpoch.h:
* Source/JavaScriptCore/dfg/DFGEdge.h:
* Source/JavaScriptCore/dfg/DFGEpoch.h:
* Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h:
* Source/JavaScriptCore/dfg/DFGRegisteredStructure.h:
* Source/JavaScriptCore/heap/Allocator.h:
* Source/JavaScriptCore/interpreter/CallFrame.h:
* Source/JavaScriptCore/jit/GPRInfo.h:
* Source/JavaScriptCore/jit/Reg.h:
* Source/JavaScriptCore/parser/SourceCodeKey.h:
* Source/JavaScriptCore/parser/VariableEnvironment.h:
* Source/JavaScriptCore/profiler/ProfilerUID.h:
* Source/JavaScriptCore/runtime/GenericOffset.h:
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/JSScope.h:
* Source/JavaScriptCore/runtime/PageCount.h:
* Source/JavaScriptCore/runtime/StructureID.h:
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:

Canonical link: <a href="https://commits.webkit.org/270891@main">https://commits.webkit.org/270891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f271244c27c57ceb7fc27e7e574c989175a9576e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24308 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29373 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23240 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29920 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25873 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27819 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5135 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33326 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4160 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7205 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3453 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->