### PR TITLE
[UnifiedPDF] Use the scrolling tree for UnifiedPDFPlugin

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic-expected.txt
@@ -1,0 +1,56 @@
+PASS internals.numberOfScrollableAreas() became 1
+PASS internals.numberOfScrollableAreas() became 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ Before installing PDF:
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 600)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,0))
+  (behavior for fixed 1)
+)
+
+After installing PDF:
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 600)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,0))
+  (synchronous event dispatch region for event wheel
+    at (8,23) size 300x300)
+  (behavior for fixed 1)
+)
+
+After removing PDF:
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 600)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,0))
+  (behavior for fixed 1)
+)
+
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <style>
+        embed {
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        window.jsTestIsAsync = true;
+
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+
+            if (!window.internals)
+                return;
+
+            const pdf = document.getElementById("pdf");
+
+            document.getElementById('scrollingtree').textContent = "Before installing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
+
+            pdf.src = "../../../fast/images/resources/green_rectangle.pdf";
+
+            shouldBecomeEqual("internals.numberOfScrollableAreas()", "1", function () {
+                document.getElementById('scrollingtree').textContent += "After installing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
+
+                pdf.parentElement.removeChild(pdf);
+
+                shouldBecomeEqual("internals.numberOfScrollableAreas()", "0", function () {
+
+                    document.getElementById('scrollingtree').textContent += "After removing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
+
+                    finishJSTest();
+                });
+            });
+        }, false);
+    </script>
+</head>
+<body>
+    <embed id="pdf">
+    <pre id="scrollingtree"></pre>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-expected.txt
@@ -1,0 +1,18 @@
+
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 600)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,0))
+  (synchronous event dispatch region for event wheel
+    at (8,8) size 300x300)
+  (behavior for fixed 1)
+)
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+    <style>
+        embed {
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+        }
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                document.getElementById('scrollingtree').textContent = internals.scrollingStateTreeAsText();
+            
+            testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <embed src="../../../fast/images/resources/green_rectangle.pdf">
+    <pre id="scrollingtree"></pre>
+</body>
+</html>

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2039,6 +2039,8 @@ page/scrolling/ScrollingStateFrameScrollingNode.cpp
 page/scrolling/ScrollingStateNode.cpp
 page/scrolling/ScrollingStateOverflowScrollProxyNode.cpp
 page/scrolling/ScrollingStateOverflowScrollingNode.cpp
+page/scrolling/ScrollingStatePluginHostingNode.cpp
+page/scrolling/ScrollingStatePluginScrollingNode.cpp
 page/scrolling/ScrollingStatePositionedNode.cpp
 page/scrolling/ScrollingStateScrollingNode.cpp
 page/scrolling/ScrollingStateStickyNode.cpp
@@ -2053,6 +2055,8 @@ page/scrolling/ScrollingTreeLatchingController.cpp
 page/scrolling/ScrollingTreeNode.cpp
 page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
 page/scrolling/ScrollingTreeOverflowScrollingNode.cpp
+page/scrolling/ScrollingTreePluginHostingNode.cpp
+page/scrolling/ScrollingTreePluginScrollingNode.cpp
 page/scrolling/ScrollingTreePositionedNode.cpp
 page/scrolling/ScrollingTreeScrollingNode.cpp
 page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -253,6 +253,7 @@ page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeMac.mm
 page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
+page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 platform/VideoFrame.mm
 platform/animation/AcceleratedEffectStack.mm @no-unify

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -886,6 +886,9 @@ ScrollableArea* LocalFrameView::scrollableAreaForScrollingNodeID(ScrollingNodeID
     if (!renderView)
         return nullptr;
 
+    if (auto area = m_scrollingNodeIDToPluginScrollableAreaMap.get(nodeID))
+        return area.get();
+
     return renderView->compositor().scrollableAreaForScrollingNodeID(nodeID);
 }
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -183,6 +183,8 @@ public:
 
     WEBCORE_EXPORT ScrollingNodeID scrollingNodeID() const override;
     WEBCORE_EXPORT ScrollableArea* scrollableAreaForScrollingNodeID(ScrollingNodeID) const;
+    void setPluginScrollableAreaForScrollingNodeID(ScrollingNodeID nodeID, ScrollableArea& area) { m_scrollingNodeIDToPluginScrollableAreaMap.add(nodeID, &area); }
+    void removePluginScrollableAreaForScrollingNodeID(ScrollingNodeID nodeID) { m_scrollingNodeIDToPluginScrollableAreaMap.remove(nodeID); }
     bool usesAsyncScrolling() const final;
 
     WEBCORE_EXPORT void enterCompositingMode();
@@ -949,6 +951,8 @@ private:
     HashSet<CheckedPtr<Widget>> m_widgetsInRenderTree;
     std::unique_ptr<ListHashSet<CheckedPtr<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
     std::unique_ptr<WeakHashSet<RenderElement>> m_slowRepaintObjects;
+
+    HashMap<ScrollingNodeID, WeakPtr<ScrollableArea>> m_scrollingNodeIDToPluginScrollableAreaMap;
 
     RefPtr<ContainerNode> m_maintainScrollPositionAnchor;
     RefPtr<ContainerNode> m_scheduledMaintainScrollPositionAnchor;

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -183,7 +183,7 @@ public:
     virtual bool hasSubscrollers() const { return false; }
 
     // Generated a unique id for scrolling nodes.
-    ScrollingNodeID uniqueScrollingNodeID();
+    WEBCORE_EXPORT ScrollingNodeID uniqueScrollingNodeID();
 
     bool shouldUpdateScrollLayerPositionSynchronously(const LocalFrameView&) const;
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -99,6 +99,12 @@ TextStream& operator<<(TextStream& ts, ScrollingNodeType nodeType)
     case ScrollingNodeType::FrameHosting:
         ts << "frame-hosting";
         break;
+    case ScrollingNodeType::PluginScrolling:
+        ts << "plugin-scrolling";
+        break;
+    case ScrollingNodeType::PluginHosting:
+        ts << "plugin-hosting";
+        break;
     case ScrollingNodeType::Overflow:
         ts << "overflow-scrolling";
         break;

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -47,6 +47,8 @@ enum class ScrollingNodeType : uint8_t {
     MainFrame,
     Subframe,
     FrameHosting,
+    PluginScrolling,
+    PluginHosting,
     Overflow,
     OverflowProxy,
     Fixed,

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -279,9 +279,11 @@ public:
     bool isFixedNode() const { return m_nodeType == ScrollingNodeType::Fixed; }
     bool isStickyNode() const { return m_nodeType == ScrollingNodeType::Sticky; }
     bool isPositionedNode() const { return m_nodeType == ScrollingNodeType::Positioned; }
-    bool isScrollingNode() const { return isFrameScrollingNode() || isOverflowScrollingNode(); }
+    bool isScrollingNode() const { return isFrameScrollingNode() || isOverflowScrollingNode() || isPluginScrollingNode(); }
     bool isFrameScrollingNode() const { return m_nodeType == ScrollingNodeType::MainFrame || m_nodeType == ScrollingNodeType::Subframe; }
     bool isFrameHostingNode() const { return m_nodeType == ScrollingNodeType::FrameHosting; }
+    bool isPluginScrollingNode() const { return m_nodeType == ScrollingNodeType::PluginScrolling; }
+    bool isPluginHostingNode() const { return m_nodeType == ScrollingNodeType::PluginHosting; }
     bool isOverflowScrollingNode() const { return m_nodeType == ScrollingNodeType::Overflow; }
     bool isOverflowScrollProxyNode() const { return m_nodeType == ScrollingNodeType::OverflowProxy; }
 

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginHostingNode.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollingStatePluginHostingNode.h"
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "ScrollingStateTree.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+Ref<ScrollingStatePluginHostingNode> ScrollingStatePluginHostingNode::create(ScrollingStateTree& stateTree, ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStatePluginHostingNode(stateTree, nodeID));
+}
+
+Ref<ScrollingStatePluginHostingNode> ScrollingStatePluginHostingNode::create(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID)
+{
+    return adoptRef(*new ScrollingStatePluginHostingNode(nodeID, WTFMove(children), changedProperties, layerID));
+}
+
+ScrollingStatePluginHostingNode::ScrollingStatePluginHostingNode(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID)
+    : ScrollingStateNode(ScrollingNodeType::PluginHosting, nodeID, WTFMove(children), changedProperties, layerID)
+{
+    ASSERT(isPluginHostingNode());
+}
+
+ScrollingStatePluginHostingNode::ScrollingStatePluginHostingNode(ScrollingStateTree& stateTree, ScrollingNodeID nodeID)
+    : ScrollingStateNode(ScrollingNodeType::PluginHosting, stateTree, nodeID)
+{
+    ASSERT(isPluginHostingNode());
+}
+
+ScrollingStatePluginHostingNode::ScrollingStatePluginHostingNode(const ScrollingStatePluginHostingNode& stateNode, ScrollingStateTree& adoptiveTree)
+    : ScrollingStateNode(stateNode, adoptiveTree)
+{
+}
+
+ScrollingStatePluginHostingNode::~ScrollingStatePluginHostingNode() = default;
+
+Ref<ScrollingStateNode> ScrollingStatePluginHostingNode::clone(ScrollingStateTree& adoptiveTree)
+{
+    return adoptRef(*new ScrollingStatePluginHostingNode(*this, adoptiveTree));
+}
+
+void ScrollingStatePluginHostingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
+{
+    ts << "Plugin hosting node";
+    ScrollingStateNode::dumpProperties(ts, behavior);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginHostingNode.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "ScrollingStateNode.h"
+
+namespace WebCore {
+
+class Scrollbar;
+
+class ScrollingStatePluginHostingNode final : public ScrollingStateNode {
+public:
+    WEBCORE_EXPORT static Ref<ScrollingStatePluginHostingNode> create(ScrollingStateTree&, ScrollingNodeID);
+    WEBCORE_EXPORT static Ref<ScrollingStatePluginHostingNode> create(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>);
+    Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
+
+    virtual ~ScrollingStatePluginHostingNode();
+
+    void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+
+private:
+    ScrollingStatePluginHostingNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>);
+    ScrollingStatePluginHostingNode(ScrollingStateTree&, ScrollingNodeID);
+    ScrollingStatePluginHostingNode(const ScrollingStatePluginHostingNode&, ScrollingStateTree&);
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_SCROLLING_STATE_NODE(ScrollingStatePluginHostingNode, isPluginHostingNode())
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollingStatePluginScrollingNode.h"
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "ScrollingStateTree.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
+    ScrollingNodeID scrollingNodeID,
+    Vector<Ref<WebCore::ScrollingStateNode>>&& children,
+    OptionSet<ScrollingStateNodeProperty> changedProperties,
+    std::optional<WebCore::PlatformLayerIdentifier> layerID,
+    FloatSize scrollableAreaSize,
+    FloatSize totalContentsSize,
+    FloatSize reachableContentsSize,
+    FloatPoint scrollPosition,
+    IntPoint scrollOrigin,
+    ScrollableAreaParameters&& scrollableAreaParameters,
+#if ENABLE(SCROLLING_THREAD)
+    OptionSet<SynchronousScrollingReason> synchronousScrollingReasons,
+#endif
+    RequestedScrollData&& requestedScrollData,
+    FloatScrollSnapOffsetsInfo&& snapOffsetsInfo,
+    std::optional<unsigned> currentHorizontalSnapPointIndex,
+    std::optional<unsigned> currentVerticalSnapPointIndex,
+    bool isMonitoringWheelEvents,
+    std::optional<PlatformLayerIdentifier> scrollContainerLayer,
+    std::optional<PlatformLayerIdentifier> scrolledContentsLayer,
+    std::optional<PlatformLayerIdentifier> horizontalScrollbarLayer,
+    std::optional<PlatformLayerIdentifier> verticalScrollbarLayer,
+    bool mouseIsOverContentArea,
+    MouseLocationState&& mouseLocationState,
+    ScrollbarHoverState&& scrollbarHoverState,
+    ScrollbarEnabledState&& scrollbarEnabledState
+) : ScrollingStateScrollingNode(
+    ScrollingNodeType::PluginScrolling,
+    scrollingNodeID,
+    WTFMove(children),
+    changedProperties,
+    layerID,
+    scrollableAreaSize,
+    totalContentsSize,
+    reachableContentsSize,
+    scrollPosition,
+    scrollOrigin,
+    WTFMove(scrollableAreaParameters),
+#if ENABLE(SCROLLING_THREAD)
+    synchronousScrollingReasons,
+#endif
+    WTFMove(requestedScrollData),
+    WTFMove(snapOffsetsInfo),
+    currentHorizontalSnapPointIndex,
+    currentVerticalSnapPointIndex,
+    isMonitoringWheelEvents,
+    scrollContainerLayer,
+    scrolledContentsLayer,
+    horizontalScrollbarLayer,
+    verticalScrollbarLayer,
+    mouseIsOverContentArea,
+    WTFMove(mouseLocationState),
+    WTFMove(scrollbarHoverState),
+    WTFMove(scrollbarEnabledState),
+    RequestedKeyboardScrollData { } // FIXME: This probably needs to be refactored so that this is a member of ScrollingStateFrameScrollingNode instead of ScrollingStateScrollingNode.
+)
+{
+    ASSERT(isPluginScrollingNode());
+}
+
+ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(ScrollingStateTree& stateTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
+    : ScrollingStateScrollingNode(stateTree, nodeType, nodeID)
+{
+    ASSERT(isPluginScrollingNode());
+}
+
+ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(const ScrollingStatePluginScrollingNode& stateNode, ScrollingStateTree& adoptiveTree)
+    : ScrollingStateScrollingNode(stateNode, adoptiveTree)
+{
+}
+
+ScrollingStatePluginScrollingNode::~ScrollingStatePluginScrollingNode() = default;
+
+Ref<ScrollingStateNode> ScrollingStatePluginScrollingNode::clone(ScrollingStateTree& adoptiveTree)
+{
+    return adoptRef(*new ScrollingStatePluginScrollingNode(*this, adoptiveTree));
+}
+
+void ScrollingStatePluginScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
+{
+    ts << "Plugin scrolling node";
+
+    ScrollingStateScrollingNode::dumpProperties(ts, behavior);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "EventTrackingRegions.h"
+#include "ScrollTypes.h"
+#include "ScrollbarThemeComposite.h"
+#include "ScrollingCoordinator.h"
+#include "ScrollingStateScrollingNode.h"
+
+namespace WebCore {
+
+class Scrollbar;
+
+class ScrollingStatePluginScrollingNode final : public ScrollingStateScrollingNode {
+public:
+    template<typename... Args> static Ref<ScrollingStatePluginScrollingNode> create(Args&&... args) { return adoptRef(*new ScrollingStatePluginScrollingNode(std::forward<Args>(args)...)); }
+
+    Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
+
+    virtual ~ScrollingStatePluginScrollingNode();
+
+    void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+
+private:
+    WEBCORE_EXPORT ScrollingStatePluginScrollingNode(
+        ScrollingNodeID,
+        Vector<Ref<WebCore::ScrollingStateNode>>&& children,
+        OptionSet<ScrollingStateNodeProperty> changedProperties,
+        std::optional<WebCore::PlatformLayerIdentifier>,
+        FloatSize scrollableAreaSize,
+        FloatSize totalContentsSize,
+        FloatSize reachableContentsSize,
+        FloatPoint scrollPosition,
+        IntPoint scrollOrigin,
+        ScrollableAreaParameters&&,
+#if ENABLE(SCROLLING_THREAD)
+        OptionSet<SynchronousScrollingReason> synchronousScrollingReasons,
+#endif
+        RequestedScrollData&&,
+        FloatScrollSnapOffsetsInfo&&,
+        std::optional<unsigned> currentHorizontalSnapPointIndex,
+        std::optional<unsigned> currentVerticalSnapPointIndex,
+        bool isMonitoringWheelEvents,
+        std::optional<PlatformLayerIdentifier> scrollContainerLayer,
+        std::optional<PlatformLayerIdentifier> scrolledContentsLayer,
+        std::optional<PlatformLayerIdentifier> horizontalScrollbarLayer,
+        std::optional<PlatformLayerIdentifier> verticalScrollbarLayer,
+        bool mouseIsOverContentArea,
+        MouseLocationState&&,
+        ScrollbarHoverState&&,
+        ScrollbarEnabledState&&
+    );
+
+    ScrollingStatePluginScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
+    ScrollingStatePluginScrollingNode(const ScrollingStatePluginScrollingNode&, ScrollingStateTree&);
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_SCROLLING_STATE_NODE(ScrollingStatePluginScrollingNode, isPluginScrollingNode())
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -35,6 +35,8 @@
 #include "ScrollingStateFrameScrollingNode.h"
 #include "ScrollingStateOverflowScrollProxyNode.h"
 #include "ScrollingStateOverflowScrollingNode.h"
+#include "ScrollingStatePluginHostingNode.h"
+#include "ScrollingStatePluginScrollingNode.h"
 #include "ScrollingStatePositionedNode.h"
 #include "ScrollingStateStickyNode.h"
 #include <wtf/text/CString.h>
@@ -130,6 +132,10 @@ Ref<ScrollingStateNode> ScrollingStateTree::createNode(ScrollingNodeType nodeTyp
         return ScrollingStateFrameScrollingNode::create(*this, nodeType, nodeID);
     case ScrollingNodeType::FrameHosting:
         return ScrollingStateFrameHostingNode::create(*this, nodeID);
+    case ScrollingNodeType::PluginScrolling:
+        return ScrollingStatePluginScrollingNode::create(*this, nodeType, nodeID);
+    case ScrollingNodeType::PluginHosting:
+        return ScrollingStatePluginHostingNode::create(*this, nodeID);
     case ScrollingNodeType::Overflow:
         return ScrollingStateOverflowScrollingNode::create(*this, nodeID);
     case ScrollingNodeType::OverflowProxy:
@@ -370,6 +376,10 @@ bool ScrollingStateTree::isValid() const
         case ScrollingNodeType::Subframe:
             break;
         case ScrollingNodeType::FrameHosting:
+            break;
+        case ScrollingNodeType::PluginScrolling:
+            break;
+        case ScrollingNodeType::PluginHosting:
             break;
         case ScrollingNodeType::Overflow:
             break;

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -64,9 +64,11 @@ public:
     bool isPositionedNodeNicosia() const { return isPositionedNode(); }
     bool isOverflowScrollProxyNodeNicosia() const { return isOverflowScrollProxyNode(); }
 #endif
-    bool isScrollingNode() const { return isFrameScrollingNode() || isOverflowScrollingNode(); }
+    bool isScrollingNode() const { return isFrameScrollingNode() || isOverflowScrollingNode() || isPluginScrollingNode(); }
     bool isFrameScrollingNode() const { return nodeType() == ScrollingNodeType::MainFrame || nodeType() == ScrollingNodeType::Subframe; }
     bool isFrameHostingNode() const { return nodeType() == ScrollingNodeType::FrameHosting; }
+    bool isPluginScrollingNode() const { return nodeType() == ScrollingNodeType::PluginScrolling; }
+    bool isPluginHostingNode() const { return nodeType() == ScrollingNodeType::PluginHosting; }
     bool isOverflowScrollingNode() const { return nodeType() == ScrollingNodeType::Overflow; }
     bool isOverflowScrollProxyNode() const { return nodeType() == ScrollingNodeType::OverflowProxy; }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollingTreePluginHostingNode.h"
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "Logging.h"
+#include "ScrollingStatePluginHostingNode.h"
+#include "ScrollingStateTree.h"
+#include "ScrollingTree.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+Ref<ScrollingTreePluginHostingNode> ScrollingTreePluginHostingNode::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingTreePluginHostingNode(scrollingTree, nodeID));
+}
+
+ScrollingTreePluginHostingNode::ScrollingTreePluginHostingNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
+    : ScrollingTreeNode(scrollingTree, ScrollingNodeType::PluginHosting, nodeID)
+{
+    ASSERT(isPluginHostingNode());
+}
+
+ScrollingTreePluginHostingNode::~ScrollingTreePluginHostingNode() = default;
+
+bool ScrollingTreePluginHostingNode::commitStateBeforeChildren(const ScrollingStateNode&)
+{
+    return true;
+}
+
+void ScrollingTreePluginHostingNode::applyLayerPositions()
+{
+}
+
+void ScrollingTreePluginHostingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
+{
+    ts << "plugin hosting node";
+    ScrollingTreeNode::dumpProperties(ts, behavior);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "ScrollingTreeNode.h"
+
+namespace WebCore {
+
+class ScrollingTree;
+
+class ScrollingTreePluginHostingNode : public ScrollingTreeNode {
+public:
+    WEBCORE_EXPORT static Ref<ScrollingTreePluginHostingNode> create(ScrollingTree&, ScrollingNodeID);
+    virtual ~ScrollingTreePluginHostingNode();
+
+private:
+    ScrollingTreePluginHostingNode(ScrollingTree&, ScrollingNodeID);
+
+    bool commitStateBeforeChildren(const ScrollingStateNode&) final;
+    void applyLayerPositions() final;
+
+    WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_SCROLLING_NODE(ScrollingTreePluginHostingNode, isPluginHostingNode())
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollingTreePluginScrollingNode.h"
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "LocalFrameView.h"
+#include "Logging.h"
+#include "ScrollingStatePluginScrollingNode.h"
+#include "ScrollingStateTree.h"
+#include "ScrollingTree.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+ScrollingTreePluginScrollingNode::ScrollingTreePluginScrollingNode(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
+    : ScrollingTreeScrollingNode(scrollingTree, ScrollingNodeType::PluginScrolling, nodeID)
+{
+    ASSERT(isPluginScrollingNode());
+}
+
+ScrollingTreePluginScrollingNode::~ScrollingTreePluginScrollingNode() = default;
+
+void ScrollingTreePluginScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
+{
+    ts << "plugin scrolling node";
+    ScrollingTreeScrollingNode::dumpProperties(ts, behavior);
+}
+
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include "ScrollingTreeScrollingNode.h"
+
+namespace WebCore {
+
+class PlatformWheelEvent;
+class ScrollingTree;
+
+class WEBCORE_EXPORT ScrollingTreePluginScrollingNode : public ScrollingTreeScrollingNode {
+public:
+    virtual ~ScrollingTreePluginScrollingNode();
+
+protected:
+    ScrollingTreePluginScrollingNode(ScrollingTree&, ScrollingNodeID);
+
+private:
+    void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_SCROLLING_NODE(ScrollingTreePluginScrollingNode, isPluginScrollingNode())
+
+#endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -34,6 +34,8 @@
 #import "ScrollingTreeFrameScrollingNodeMac.h"
 #import "ScrollingTreeOverflowScrollProxyNodeCocoa.h"
 #import "ScrollingTreeOverflowScrollingNodeMac.h"
+#import "ScrollingTreePluginHostingNode.h"
+#import "ScrollingTreePluginScrollingNodeMac.h"
 #import "ScrollingTreePositionedNodeCocoa.h"
 #import "ScrollingTreeStickyNodeCocoa.h"
 #import "WebCoreCALayerExtras.h"
@@ -64,6 +66,10 @@ Ref<ScrollingTreeNode> ScrollingTreeMac::createScrollingTreeNode(ScrollingNodeTy
         return ScrollingTreeFrameScrollingNodeMac::create(*this, nodeType, nodeID);
     case ScrollingNodeType::FrameHosting:
         return ScrollingTreeFrameHostingNode::create(*this, nodeID);
+    case ScrollingNodeType::PluginScrolling:
+        return ScrollingTreePluginScrollingNodeMac::create(*this, nodeID);
+    case ScrollingNodeType::PluginHosting:
+        return ScrollingTreePluginHostingNode::create(*this, nodeID);
     case ScrollingNodeType::Overflow:
         return ScrollingTreeOverflowScrollingNodeMac::create(*this, nodeID);
     case ScrollingNodeType::OverflowProxy:

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
+
+#include "ScrollingTreePluginScrollingNode.h"
+
+OBJC_CLASS CALayer;
+
+namespace WebCore {
+
+class ScrollingTreeScrollingNodeDelegateMac;
+
+class WEBCORE_EXPORT ScrollingTreePluginScrollingNodeMac : public ScrollingTreePluginScrollingNode {
+public:
+    static Ref<ScrollingTreePluginScrollingNodeMac> create(ScrollingTree&, ScrollingNodeID);
+    virtual ~ScrollingTreePluginScrollingNodeMac();
+
+protected:
+    ScrollingTreePluginScrollingNodeMac(ScrollingTree&, ScrollingNodeID);
+
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
+
+    void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
+    void willDoProgrammaticScroll(const FloatPoint&) final;
+
+    void repositionScrollingLayers() override;
+    void repositionRelatedLayers() override;
+
+    WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
+
+private:
+    ScrollingTreeScrollingNodeDelegateMac& delegate() const;
+
+    void willBeDestroyed() final;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ScrollingTreePluginScrollingNodeMac.h"
+
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
+
+#import "Logging.h"
+#import "ScrollingStatePluginScrollingNode.h"
+#import "ScrollingTree.h"
+#import "ScrollingTreeScrollingNodeDelegateMac.h"
+#import "WebCoreCALayerExtras.h"
+#import <wtf/BlockObjCExceptions.h>
+#import <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+Ref<ScrollingTreePluginScrollingNodeMac> ScrollingTreePluginScrollingNodeMac::create(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingTreePluginScrollingNodeMac(scrollingTree, nodeID));
+}
+
+ScrollingTreePluginScrollingNodeMac::ScrollingTreePluginScrollingNodeMac(ScrollingTree& scrollingTree, ScrollingNodeID nodeID)
+    : ScrollingTreePluginScrollingNode(scrollingTree, nodeID)
+{
+    m_delegate = makeUnique<ScrollingTreeScrollingNodeDelegateMac>(*this);
+}
+
+ScrollingTreePluginScrollingNodeMac::~ScrollingTreePluginScrollingNodeMac() = default;
+
+ScrollingTreeScrollingNodeDelegateMac& ScrollingTreePluginScrollingNodeMac::delegate() const
+{
+    return *static_cast<ScrollingTreeScrollingNodeDelegateMac*>(m_delegate.get());
+}
+
+void ScrollingTreePluginScrollingNodeMac::willBeDestroyed()
+{
+    delegate().nodeWillBeDestroyed();
+}
+
+bool ScrollingTreePluginScrollingNodeMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+{
+    if (!ScrollingTreePluginScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStatePluginScrollingNode>(stateNode))
+        return false;
+
+    m_delegate->updateFromStateNode(downcast<ScrollingStatePluginScrollingNode>(stateNode));
+    return true;
+}
+
+WheelEventHandlingResult ScrollingTreePluginScrollingNodeMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
+{
+#if ENABLE(SCROLLING_THREAD)
+    if (hasSynchronousScrollingReasons() && eventTargeting != EventTargeting::NodeOnly)
+        return { { WheelEventProcessingSteps::SynchronousScrolling, WheelEventProcessingSteps::NonBlockingDOMEventDispatch }, false };
+#endif
+
+    if (!canHandleWheelEvent(wheelEvent, eventTargeting))
+        return WheelEventHandlingResult::unhandled();
+
+    return WheelEventHandlingResult::result(delegate().handleWheelEvent(wheelEvent));
+}
+
+void ScrollingTreePluginScrollingNodeMac::willDoProgrammaticScroll(const FloatPoint& targetScrollPosition)
+{
+    delegate().willDoProgrammaticScroll(targetScrollPosition);
+}
+
+void ScrollingTreePluginScrollingNodeMac::currentScrollPositionChanged(ScrollType scrollType, ScrollingLayerPositionAction action)
+{
+    ScrollingTreePluginScrollingNode::currentScrollPositionChanged(scrollType, action);
+    delegate().currentScrollPositionChanged();
+}
+
+void ScrollingTreePluginScrollingNodeMac::repositionScrollingLayers()
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    [static_cast<CALayer*>(scrollContainerLayer()) _web_setLayerBoundsOrigin:currentScrollOffset()];
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+void ScrollingTreePluginScrollingNodeMac::repositionRelatedLayers()
+{
+    delegate().updateScrollbarPainters();
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
@@ -71,6 +71,9 @@ Ref<ScrollingTreeNode> ScrollingTreeNicosia::createScrollingTreeNode(ScrollingNo
         return ScrollingTreeStickyNodeNicosia::create(*this, nodeID);
     case ScrollingNodeType::Positioned:
         return ScrollingTreePositionedNodeNicosia::create(*this, nodeID);
+    case ScrollingNodeType::PluginScrolling:
+    case ScrollingNodeType::PluginHosting:
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -63,6 +63,9 @@ public:
     virtual bool shouldAllowNavigationFromDrags() const { return false; }
     virtual void willDetachRenderer() { }
 
+    virtual bool usesAsyncScrolling() const { return false; }
+    virtual ScrollingNodeID scrollingNodeID() const { return 0; }
+
 #if PLATFORM(COCOA)
     virtual id accessibilityAssociatedPluginParentForElement(Element*) const { return nullptr; }
 #endif

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -47,12 +47,12 @@ class RenderStyle;
 
 class EventRegionContext : public RegionContext {
 public:
-    explicit EventRegionContext(EventRegion&);
-    virtual ~EventRegionContext();
+    WEBCORE_EXPORT explicit EventRegionContext(EventRegion&);
+    WEBCORE_EXPORT virtual ~EventRegionContext();
 
     bool isEventRegionContext() const final { return true; }
 
-    void unite(const Region&, RenderObject&, const RenderStyle&, bool overrideUserModifyIsEditable = false);
+    WEBCORE_EXPORT void unite(const Region&, RenderObject&, const RenderStyle&, bool overrideUserModifyIsEditable = false);
     bool contains(const IntRect&) const;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -111,6 +111,22 @@ bool RenderEmbeddedObject::requiresAcceleratedCompositing() const
     return pluginViewBase->layerHostingStrategy() != PluginLayerHostingStrategy::None;
 }
 
+bool RenderEmbeddedObject::usesAsyncScrolling() const
+{
+    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    if (!pluginViewBase)
+        return false;
+    return pluginViewBase->usesAsyncScrolling();
+}
+
+ScrollingNodeID RenderEmbeddedObject::scrollingNodeID() const
+{
+    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    if (!pluginViewBase)
+        return false;
+    return pluginViewBase->scrollingNodeID();
+}
+
 #if !PLATFORM(IOS_FAMILY)
 static String unavailablePluginReplacementText(RenderEmbeddedObject::PluginUnavailabilityReason pluginUnavailabilityReason)
 {

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -61,6 +61,9 @@ public:
 
     const String& pluginReplacementTextIfUnavailable() const { return m_unavailablePluginReplacementText; }
 
+    bool usesAsyncScrolling() const;
+    ScrollingNodeID scrollingNodeID() const;
+
 private:
     void paintReplaced(PaintInfo&, const LayoutPoint&) final;
     void paint(PaintInfo&, const LayoutPoint&) final;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6134,6 +6134,7 @@ static void outputPaintOrderTreeRecursive(TextStream& stream, const WebCore::Ren
 
         auto scrollingNodeID = backing.scrollingNodeIDForRole(WebCore::ScrollCoordinationRole::Scrolling);
         auto frameHostingNodeID = backing.scrollingNodeIDForRole(WebCore::ScrollCoordinationRole::FrameHosting);
+        auto pluginHostingNodeID = backing.scrollingNodeIDForRole(WebCore::ScrollCoordinationRole::PluginHosting);
         auto viewportConstrainedNodeID = backing.scrollingNodeIDForRole(WebCore::ScrollCoordinationRole::ViewportConstrained);
         auto positionedNodeID = backing.scrollingNodeIDForRole(WebCore::ScrollCoordinationRole::Positioning);
 
@@ -6149,6 +6150,13 @@ static void outputPaintOrderTreeRecursive(TextStream& stream, const WebCore::Ren
                 if (!first)
                     stream << ", ";
                 stream << "fh " << frameHostingNodeID;
+                first = false;
+            }
+
+            if (pluginHostingNodeID) {
+                if (!first)
+                    stream << ", ";
+                stream << "ph " << pluginHostingNodeID;
                 first = false;
             }
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -492,8 +492,8 @@ public:
     bool isForcedStackingContext() const { return m_forcedStackingContext; }
     bool isOpportunisticStackingContext() const { return m_isOpportunisticStackingContext; }
 
-    RenderLayerCompositor& compositor() const;
-    
+    WEBCORE_EXPORT RenderLayerCompositor& compositor() const;
+
     // Notification from the renderer that its content changed (e.g. current frame of image changed).
     // Allows updates of layer content without repainting.
     void contentChanged(ContentChangeType);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -270,6 +270,7 @@ RenderLayerBacking::~RenderLayerBacking()
     ASSERT(!m_viewportConstrainedNodeID);
     ASSERT(!m_scrollingNodeID);
     ASSERT(!m_frameHostingNodeID);
+    ASSERT(!m_pluginHostingNodeID);
     ASSERT(!m_positioningNodeID);
 
     destroyGraphicsLayers();
@@ -2557,7 +2558,7 @@ bool RenderLayerBacking::updateScrollingLayers(bool needsScrollingLayers)
 
 void RenderLayerBacking::detachFromScrollingCoordinator(OptionSet<ScrollCoordinationRole> roles)
 {
-    if (!m_scrollingNodeID && !m_ancestorClippingStack && !m_frameHostingNodeID && !m_viewportConstrainedNodeID && !m_positioningNodeID)
+    if (!m_scrollingNodeID && !m_ancestorClippingStack && !m_frameHostingNodeID && !m_pluginHostingNodeID && !m_viewportConstrainedNodeID && !m_positioningNodeID)
         return;
 
     auto* scrollingCoordinator = m_owningLayer.page().scrollingCoordinator();
@@ -2590,6 +2591,12 @@ void RenderLayerBacking::detachFromScrollingCoordinator(OptionSet<ScrollCoordina
         LOG_WITH_STREAM(Compositing, stream << "Detaching FrameHosting node " << m_frameHostingNodeID);
         scrollingCoordinator->unparentChildrenAndDestroyNode(m_frameHostingNodeID);
         m_frameHostingNodeID = 0;
+    }
+
+    if (roles.contains(ScrollCoordinationRole::PluginHosting) && m_pluginHostingNodeID) {
+        LOG_WITH_STREAM(Compositing, stream << "Detaching PluginHosting node " << m_pluginHostingNodeID);
+        scrollingCoordinator->unparentChildrenAndDestroyNode(m_pluginHostingNodeID);
+        m_pluginHostingNodeID = 0;
     }
 
     if (roles.contains(ScrollCoordinationRole::ViewportConstrained) && m_viewportConstrainedNodeID) {
@@ -2631,6 +2638,9 @@ void RenderLayerBacking::setScrollingNodeIDForRole(ScrollingNodeID nodeID, Scrol
         break;
     case ScrollCoordinationRole::FrameHosting:
         m_frameHostingNodeID = nodeID;
+        break;
+    case ScrollCoordinationRole::PluginHosting:
+        m_pluginHostingNodeID = nodeID;
         break;
     case ScrollCoordinationRole::ViewportConstrained:
         m_viewportConstrainedNodeID = nodeID;
@@ -4303,6 +4313,8 @@ TextStream& operator<<(TextStream& ts, const RenderLayerBacking& backing)
 
     if (auto nodeID = backing.scrollingNodeIDForRole(ScrollCoordinationRole::FrameHosting))
         ts << " frame hosting node " << nodeID;
+    if (auto nodeID = backing.scrollingNodeIDForRole(ScrollCoordinationRole::PluginHosting))
+        ts << " plugin hosting node " << nodeID;
     if (auto nodeID = backing.scrollingNodeIDForRole(ScrollCoordinationRole::Positioning))
         ts << " positioning node " << nodeID;
     return ts;

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -134,6 +134,8 @@ public:
             return 0;
         case ScrollCoordinationRole::FrameHosting:
             return m_frameHostingNodeID;
+        case ScrollCoordinationRole::PluginHosting:
+            return m_pluginHostingNodeID;
         case ScrollCoordinationRole::ViewportConstrained:
             return m_viewportConstrainedNodeID;
         case ScrollCoordinationRole::Positioning:
@@ -441,6 +443,7 @@ private:
     ScrollingNodeID m_viewportConstrainedNodeID { 0 };
     ScrollingNodeID m_scrollingNodeID { 0 };
     ScrollingNodeID m_frameHostingNodeID { 0 };
+    ScrollingNodeID m_pluginHostingNodeID { 0 };
     ScrollingNodeID m_positioningNodeID { 0 };
 
     bool m_artificiallyInflatedBounds { false }; // bounds had to be made non-zero to make transform-origin work

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -91,7 +91,8 @@ enum class ScrollCoordinationRole {
     Scrolling           = 1 << 1,
     ScrollingProxy      = 1 << 2,
     FrameHosting        = 1 << 3,
-    Positioning         = 1 << 4,
+    PluginHosting       = 1 << 4,
+    Positioning         = 1 << 5,
 };
 
 static constexpr OptionSet<ScrollCoordinationRole> allScrollCoordinationRoles()
@@ -101,6 +102,7 @@ static constexpr OptionSet<ScrollCoordinationRole> allScrollCoordinationRoles()
         ScrollCoordinationRole::ScrollingProxy,
         ScrollCoordinationRole::ViewportConstrained,
         ScrollCoordinationRole::FrameHosting,
+        ScrollCoordinationRole::PluginHosting,
         ScrollCoordinationRole::Positioning
     };
 }
@@ -213,7 +215,7 @@ public:
 
     // Returns the ScrollingNodeID for the containing async-scrollable layer that scrolls this renderer's border box.
     // May return 0 for position-fixed content.
-    static ScrollingNodeID asyncScrollableContainerNodeID(const RenderObject&);
+    WEBCORE_EXPORT static ScrollingNodeID asyncScrollableContainerNodeID(const RenderObject&);
 
     // Whether layer's backing needs a graphics layer to clip z-order children of the given layer.
     static bool clipsCompositingDescendants(const RenderLayer&);
@@ -349,6 +351,7 @@ public:
     bool useCoordinatedScrollingForLayer(const RenderLayer&) const;
     ScrollPositioningBehavior computeCoordinatedPositioningForLayer(const RenderLayer&, const RenderLayer* compositingAncestor) const;
     bool isLayerForIFrameWithScrollCoordinatedContents(const RenderLayer&) const;
+    bool isLayerForPluginWithScrollCoordinatedContents(const RenderLayer&) const;
 
     ScrollableArea* scrollableAreaForScrollingNodeID(ScrollingNodeID) const;
 
@@ -524,6 +527,7 @@ private:
     ScrollingNodeID updateScrollingNodeForScrollingRole(RenderLayer&, struct ScrollingTreeState&, OptionSet<ScrollingNodeChangeFlags>);
     ScrollingNodeID updateScrollingNodeForScrollingProxyRole(RenderLayer&, struct ScrollingTreeState&, OptionSet<ScrollingNodeChangeFlags>);
     ScrollingNodeID updateScrollingNodeForFrameHostingRole(RenderLayer&, struct ScrollingTreeState&, OptionSet<ScrollingNodeChangeFlags>);
+    ScrollingNodeID updateScrollingNodeForPluginHostingRole(RenderLayer&, struct ScrollingTreeState&, OptionSet<ScrollingNodeChangeFlags>);
     ScrollingNodeID updateScrollingNodeForPositioningRole(RenderLayer&, const RenderLayer* compositingAncestor, struct ScrollingTreeState&, OptionSet<ScrollingNodeChangeFlags>);
 
     void updateScrollingNodeLayers(ScrollingNodeID, RenderLayer&, ScrollingCoordinator&);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -36,6 +36,8 @@
 #include <WebCore/ScrollingStateFrameScrollingNode.h>
 #include <WebCore/ScrollingStateOverflowScrollProxyNode.h>
 #include <WebCore/ScrollingStateOverflowScrollingNode.h>
+#include <WebCore/ScrollingStatePluginHostingNode.h>
+#include <WebCore/ScrollingStatePluginScrollingNode.h>
 #include <WebCore/ScrollingStatePositionedNode.h>
 #include <WebCore/ScrollingStateStickyNode.h>
 #include <WebCore/ScrollingStateTree.h>
@@ -219,6 +221,15 @@ static void dump(TextStream& ts, const ScrollingStateStickyNode& node, bool chan
         ts << node.viewportConstraints();
 }
 
+static void dump(TextStream& ts, const ScrollingStatePluginHostingNode& node, bool changedPropertiesOnly)
+{
+}
+
+static void dump(TextStream& ts, const ScrollingStatePluginScrollingNode& node, bool changedPropertiesOnly)
+{
+    dump(ts, static_cast<const ScrollingStateScrollingNode&>(node), changedPropertiesOnly);
+}
+
 static void dump(TextStream& ts, const ScrollingStatePositionedNode& node, bool changedPropertiesOnly)
 {
     if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes))
@@ -242,6 +253,12 @@ static void dump(TextStream& ts, const ScrollingStateNode& node, bool changedPro
         break;
     case ScrollingNodeType::FrameHosting:
         dump(ts, downcast<ScrollingStateFrameHostingNode>(node), changedPropertiesOnly);
+        break;
+    case ScrollingNodeType::PluginScrolling:
+        dump(ts, downcast<ScrollingStatePluginScrollingNode>(node), changedPropertiesOnly);
+        break;
+    case ScrollingNodeType::PluginHosting:
+        dump(ts, downcast<ScrollingStatePluginHostingNode>(node), changedPropertiesOnly);
         break;
     case ScrollingNodeType::Overflow:
         dump(ts, downcast<ScrollingStateOverflowScrollingNode>(node), changedPropertiesOnly);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -36,6 +36,8 @@ class WebKit::RemoteScrollingCoordinatorTransaction {
 header: <WebCore/ScrollingStateFrameScrollingNode.h>
 header: <WebCore/ScrollingStateOverflowScrollingNode.h>
 header: <WebCore/ScrollingStateOverflowScrollProxyNode.h>
+header: <WebCore/ScrollingStatePluginHostingNode.h>
+header: <WebCore/ScrollingStatePluginScrollingNode.h>
 header: <WebCore/ScrollingStateFixedNode.h>
 header: <WebCore/ScrollingStateStickyNode.h>
 header: <WebCore/ScrollingStatePositionedNode.h>
@@ -45,6 +47,8 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     WebCore::ScrollingStateFrameHostingNode,
     WebCore::ScrollingStateOverflowScrollingNode,
     WebCore::ScrollingStateOverflowScrollProxyNode,
+    WebCore::ScrollingStatePluginScrollingNode,
+    WebCore::ScrollingStatePluginHostingNode,
     WebCore::ScrollingStateFixedNode,
     WebCore::ScrollingStateStickyNode,
     WebCore::ScrollingStatePositionedNode,
@@ -138,6 +142,43 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
 };
+
+[RefCounted] class WebCore::ScrollingStatePluginHostingNode {
+    WebCore::ScrollingNodeID scrollingNodeID()
+    Vector<Ref<WebCore::ScrollingStateNode>> children()
+    [OptionalTupleBits] OptionSet<WebCore::ScrollingStateNodeProperty> changedProperties()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Layer] std::optional<WebCore::PlatformLayerIdentifier> layer().layerIDForEncoding()
+}
+
+[RefCounted] class WebCore::ScrollingStatePluginScrollingNode {
+    WebCore::ScrollingNodeID scrollingNodeID()
+    Vector<Ref<WebCore::ScrollingStateNode>> children()
+    [OptionalTupleBits] OptionSet<WebCore::ScrollingStateNodeProperty> changedProperties()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Layer] std::optional<WebCore::PlatformLayerIdentifier> layer().layerIDForEncoding()
+
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollableAreaSize] WebCore::FloatSize scrollableAreaSize()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::TotalContentsSize] WebCore::FloatSize totalContentsSize()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ReachableContentsSize] WebCore::FloatSize reachableContentsSize()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollPosition] WebCore::FloatPoint scrollPosition()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollOrigin] WebCore::IntPoint scrollOrigin()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollableAreaParams] WebCore::ScrollableAreaParameters scrollableAreaParameters()
+#if ENABLE(SCROLLING_THREAD)
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ReasonsForSynchronousScrolling] OptionSet<WebCore::SynchronousScrollingReason> synchronousScrollingReasons()
+#endif
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RequestedScrollPosition] WebCore::RequestedScrollData requestedScrollData()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::SnapOffsetsInfo] WebCore::FloatScrollSnapOffsetsInfo snapOffsetsInfo()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex] std::optional<unsigned> currentHorizontalSnapPointIndex()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex] std::optional<unsigned> currentVerticalSnapPointIndex()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::IsMonitoringWheelEvents] bool isMonitoringWheelEvents()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollContainerLayer] std::optional<WebCore::PlatformLayerIdentifier> scrollContainerLayer().layerIDForEncoding();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrolledContentsLayer] std::optional<WebCore::PlatformLayerIdentifier> scrolledContentsLayer().layerIDForEncoding();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::HorizontalScrollbarLayer] std::optional<WebCore::PlatformLayerIdentifier> horizontalScrollbarLayer().layerIDForEncoding();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::VerticalScrollbarLayer] std::optional<WebCore::PlatformLayerIdentifier> verticalScrollbarLayer().layerIDForEncoding();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ContentAreaHoverState] bool mouseIsOverContentArea()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MouseActivityState] WebCore::MouseLocationState mouseLocationState();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
+}
 
 [CustomHeader] struct WebCore::ScrollbarHoverState {
     bool mouseIsOverHorizontalScrollbar;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -559,6 +559,7 @@ UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
 UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.cpp
 
 UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
 UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -566,6 +567,7 @@ UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
 UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
 UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
 UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
+UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
 UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
 
 UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -34,6 +34,8 @@
 #include <WebCore/ScrollingTreeFrameHostingNode.h>
 #include <WebCore/ScrollingTreeFrameScrollingNode.h>
 #include <WebCore/ScrollingTreeOverflowScrollProxyNodeCocoa.h>
+#include <WebCore/ScrollingTreePluginHostingNode.h>
+#include <WebCore/ScrollingTreePluginScrollingNode.h>
 #include <WebCore/ScrollingTreePositionedNodeCocoa.h>
 #include <WebCore/ScrollingTreeStickyNodeCocoa.h>
 
@@ -145,11 +147,14 @@ Ref<ScrollingTreeNode> RemoteScrollingTree::createScrollingTreeNode(ScrollingNod
     case ScrollingNodeType::MainFrame:
     case ScrollingNodeType::Subframe:
     case ScrollingNodeType::Overflow:
+    case ScrollingNodeType::PluginScrolling:
         ASSERT_NOT_REACHED(); // Subclass should have handled this.
         break;
 
     case ScrollingNodeType::FrameHosting:
         return ScrollingTreeFrameHostingNode::create(*this, nodeID);
+    case ScrollingNodeType::PluginHosting:
+        return ScrollingTreePluginHostingNode::create(*this, nodeID);
     case ScrollingNodeType::OverflowProxy:
         return ScrollingTreeOverflowScrollProxyNodeCocoa::create(*this, nodeID);
     case ScrollingNodeType::Fixed:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -31,6 +31,7 @@
 #include "RemoteScrollingCoordinatorProxy.h"
 #include "ScrollingTreeFrameScrollingNodeRemoteIOS.h"
 #include "ScrollingTreeOverflowScrollingNodeIOS.h"
+#include "ScrollingTreePluginScrollingNodeIOS.h"
 #include <WebCore/ScrollingTreeFixedNodeCocoa.h>
 
 namespace WebKit {
@@ -64,7 +65,11 @@ Ref<ScrollingTreeNode> RemoteScrollingTreeIOS::createScrollingTreeNode(Scrolling
     case ScrollingNodeType::Overflow:
         return ScrollingTreeOverflowScrollingNodeIOS::create(*this, nodeID);
 
+    case ScrollingNodeType::PluginScrolling:
+        return ScrollingTreePluginScrollingNodeIOS::create(*this, nodeID);
+
     case ScrollingNodeType::FrameHosting:
+    case ScrollingNodeType::PluginHosting:
     case ScrollingNodeType::OverflowProxy:
     case ScrollingNodeType::Fixed:
     case ScrollingNodeType::Sticky:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(IOS_FAMILY)
+
+#include <WebCore/ScrollingTreePluginScrollingNode.h>
+
+OBJC_CLASS UIScrollView;
+
+namespace WebKit {
+
+class ScrollingTreeScrollingNodeDelegateIOS;
+
+class ScrollingTreePluginScrollingNodeIOS final : public WebCore::ScrollingTreePluginScrollingNode {
+public:
+    static Ref<ScrollingTreePluginScrollingNodeIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
+    virtual ~ScrollingTreePluginScrollingNodeIOS();
+
+    UIScrollView* scrollView() const;
+
+private:
+    ScrollingTreePluginScrollingNodeIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
+
+    ScrollingTreeScrollingNodeDelegateIOS& delegate() const;
+
+    bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) final;
+    bool commitStateAfterChildren(const WebCore::ScrollingStateNode&) final;
+
+    void repositionScrollingLayers() final;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(ASYNC_SCROLLING) && PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ScrollingTreePluginScrollingNodeIOS.h"
+
+#if PLATFORM(IOS_FAMILY)
+#if ENABLE(ASYNC_SCROLLING)
+
+#import "ScrollingTreeScrollingNodeDelegateIOS.h"
+
+#import <WebCore/ScrollingStatePluginScrollingNode.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<ScrollingTreePluginScrollingNodeIOS> ScrollingTreePluginScrollingNodeIOS::create(WebCore::ScrollingTree& scrollingTree, WebCore::ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingTreePluginScrollingNodeIOS(scrollingTree, nodeID));
+}
+
+ScrollingTreePluginScrollingNodeIOS::ScrollingTreePluginScrollingNodeIOS(WebCore::ScrollingTree& scrollingTree, WebCore::ScrollingNodeID nodeID)
+    : ScrollingTreePluginScrollingNode(scrollingTree, nodeID)
+{
+    m_delegate = makeUnique<ScrollingTreeScrollingNodeDelegateIOS>(*this);
+}
+
+ScrollingTreePluginScrollingNodeIOS::~ScrollingTreePluginScrollingNodeIOS()
+{
+}
+
+ScrollingTreeScrollingNodeDelegateIOS& ScrollingTreePluginScrollingNodeIOS::delegate() const
+{
+    return *static_cast<ScrollingTreeScrollingNodeDelegateIOS*>(m_delegate.get());
+}
+
+UIScrollView* ScrollingTreePluginScrollingNodeIOS::scrollView() const
+{
+    return delegate().scrollView();
+}
+
+bool ScrollingTreePluginScrollingNodeIOS::commitStateBeforeChildren(const WebCore::ScrollingStateNode& stateNode)
+{
+    if (!is<ScrollingStateScrollingNode>(stateNode))
+        return false;
+
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
+        delegate().resetScrollViewDelegate();
+
+    if (!ScrollingTreePluginScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
+    delegate().commitStateBeforeChildren(downcast<ScrollingStateScrollingNode>(stateNode));
+    return true;
+}
+
+bool ScrollingTreePluginScrollingNodeIOS::commitStateAfterChildren(const ScrollingStateNode& stateNode)
+{
+    if (!is<ScrollingStateScrollingNode>(stateNode))
+        return false;
+
+    const auto& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
+    delegate().commitStateAfterChildren(scrollingStateNode);
+
+    return ScrollingTreePluginScrollingNode::commitStateAfterChildren(stateNode);
+}
+
+void ScrollingTreePluginScrollingNodeIOS::repositionScrollingLayers()
+{
+    delegate().repositionScrollingLayers();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(ASYNC_SCROLLING)
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -34,11 +34,13 @@
 #import <WebCore/ScrollingStateFrameScrollingNode.h>
 #import <WebCore/ScrollingStateOverflowScrollProxyNode.h>
 #import <WebCore/ScrollingStateOverflowScrollingNode.h>
+#import <WebCore/ScrollingStatePluginScrollingNode.h>
 #import <WebCore/ScrollingStatePositionedNode.h>
 #import <WebCore/ScrollingStateTree.h>
 #import <WebCore/ScrollingTreeFrameScrollingNode.h>
 #import <WebCore/ScrollingTreeOverflowScrollProxyNode.h>
 #import <WebCore/ScrollingTreeOverflowScrollingNode.h>
+#import <WebCore/ScrollingTreePluginScrollingNode.h>
 #import <WebCore/ScrollingTreePositionedNode.h>
 #import <WebCore/WheelEventDeltaFilter.h>
 
@@ -217,8 +219,24 @@ void RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers(ScrollingStateTr
                 scrollingStateNode.setHorizontalScrollbarLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.horizontalScrollbarLayer() }));
             break;
         }
+        case ScrollingNodeType::PluginScrolling: {
+            ScrollingStatePluginScrollingNode& scrollingStateNode = downcast<ScrollingStatePluginScrollingNode>(currNode);
+            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
+                scrollingStateNode.setScrollContainerLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrollContainerLayer() }));
+
+            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
+                scrollingStateNode.setScrolledContentsLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrolledContentsLayer() }));
+
+            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer))
+                scrollingStateNode.setVerticalScrollbarLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.verticalScrollbarLayer() }));
+
+            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer))
+                scrollingStateNode.setHorizontalScrollbarLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.horizontalScrollbarLayer() }));
+            break;
+        }
         case ScrollingNodeType::OverflowProxy:
         case ScrollingNodeType::FrameHosting:
+        case ScrollingNodeType::PluginHosting:
         case ScrollingNodeType::Fixed:
         case ScrollingNodeType::Sticky:
         case ScrollingNodeType::Positioned:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -33,6 +33,8 @@
 #import "RemoteScrollingCoordinatorProxy.h"
 #import "ScrollingTreeFrameScrollingNodeRemoteMac.h"
 #import "ScrollingTreeOverflowScrollingNodeRemoteMac.h"
+#import "ScrollingTreePluginScrollingNodeRemoteMac.h"
+#import <WebCore/EventRegion.h>
 #import <WebCore/FrameView.h>
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/ScrollingThread.h>
@@ -123,7 +125,11 @@ Ref<ScrollingTreeNode> RemoteScrollingTreeMac::createScrollingTreeNode(Scrolling
     case ScrollingNodeType::Overflow:
         return ScrollingTreeOverflowScrollingNodeRemoteMac::create(*this, nodeID);
 
+    case ScrollingNodeType::PluginScrolling:
+        return ScrollingTreePluginScrollingNodeRemoteMac::create(*this, nodeID);
+
     case ScrollingNodeType::FrameHosting:
+    case ScrollingNodeType::PluginHosting:
     case ScrollingNodeType::OverflowProxy:
     case ScrollingNodeType::Fixed:
     case ScrollingNodeType::Sticky:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollingTreePluginScrollingNodeRemoteMac.h"
+
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
+
+#include "RemoteScrollingTree.h"
+#include <WebCore/ScrollingStatePluginScrollingNode.h>
+#include <WebCore/ScrollingTreeScrollingNodeDelegate.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<ScrollingTreePluginScrollingNodeRemoteMac> ScrollingTreePluginScrollingNodeRemoteMac::create(ScrollingTree& tree, ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingTreePluginScrollingNodeRemoteMac(tree, nodeID));
+}
+
+ScrollingTreePluginScrollingNodeRemoteMac::ScrollingTreePluginScrollingNodeRemoteMac(ScrollingTree& tree, ScrollingNodeID nodeID)
+    : ScrollingTreePluginScrollingNodeMac(tree, nodeID)
+{
+    m_delegate->initScrollbars();
+}
+
+ScrollingTreePluginScrollingNodeRemoteMac::~ScrollingTreePluginScrollingNodeRemoteMac() = default;
+
+void ScrollingTreePluginScrollingNodeRemoteMac::repositionRelatedLayers()
+{
+    ScrollingTreePluginScrollingNodeMac::repositionRelatedLayers();
+    m_delegate->updateScrollbarLayers();
+}
+
+void ScrollingTreePluginScrollingNodeRemoteMac::handleWheelEventPhase(const PlatformWheelEventPhase phase)
+{
+    m_delegate->handleWheelEventPhase(phase);
+}
+
+String ScrollingTreePluginScrollingNodeRemoteMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
+{
+    return m_delegate->scrollbarStateForOrientation(orientation);
+}
+
+}
+
+#endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
+
+#include <WebCore/ScrollingTreePluginScrollingNodeMac.h>
+
+namespace WebKit {
+
+class ScrollerPairMac;
+
+class ScrollingTreePluginScrollingNodeRemoteMac : public WebCore::ScrollingTreePluginScrollingNodeMac {
+public:
+    static Ref<ScrollingTreePluginScrollingNodeRemoteMac> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
+    virtual ~ScrollingTreePluginScrollingNodeRemoteMac();
+
+private:
+    ScrollingTreePluginScrollingNodeRemoteMac(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
+
+    void handleWheelEventPhase(const WebCore::PlatformWheelEventPhase) override;
+    void repositionRelatedLayers() override;
+    String scrollbarStateForOrientation(WebCore::ScrollbarOrientation) const override;
+};
+
+}
+
+#endif // ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -28,6 +28,8 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import <wtf/RetainPtr.h>
+
 namespace WebKit {
 
 static constexpr auto selectionHighlightAlphaComponent = 0.2;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -34,6 +34,7 @@
 #import "WKFullscreenStackView.h"
 #import "WKScrollView.h"
 #import "WKWebView.h"
+#import "WKWebViewIOS.h"
 #import "WKWebViewInternal.h"
 #import "WKWebViewPrivateForTesting.h"
 #import "WebFullScreenManagerProxy.h"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4163,6 +4163,8 @@
 		2D1DE35B2AFA46BA00D955D4 /* FileSystemStorageError.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = FileSystemStorageError.serialization.in; sourceTree = "<group>"; };
 		2D1E8221216FFF5000A15265 /* WKWebEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKWebEvent.h; path = ios/WKWebEvent.h; sourceTree = "<group>"; };
 		2D1E8222216FFF5100A15265 /* WKWebEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKWebEvent.mm; path = ios/WKWebEvent.mm; sourceTree = "<group>"; };
+		2D222D3E2B04B363009F4ADD /* ScrollingTreePluginScrollingNodeIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScrollingTreePluginScrollingNodeIOS.h; sourceTree = "<group>"; };
+		2D222D3F2B04B364009F4ADD /* ScrollingTreePluginScrollingNodeIOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollingTreePluginScrollingNodeIOS.mm; sourceTree = "<group>"; };
 		2D25F32825758E9000231A8B /* ImageBufferRemoteIOSurfaceBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferRemoteIOSurfaceBackend.h; sourceTree = "<group>"; };
 		2D25F32925758E9100231A8B /* ImageBufferRemoteIOSurfaceBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferRemoteIOSurfaceBackend.cpp; sourceTree = "<group>"; };
 		2D279E1826955768004B3EEB /* PrototypeToolsSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrototypeToolsSPI.h; sourceTree = "<group>"; };
@@ -4238,6 +4240,8 @@
 		2D6CD117189058A500E5A4A0 /* ViewSnapshotStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewSnapshotStore.h; sourceTree = "<group>"; };
 		2D6CD118189058A500E5A4A0 /* ViewSnapshotStoreMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ViewSnapshotStoreMac.mm; sourceTree = "<group>"; };
 		2D6CD11A189058A500E5A4A0 /* ViewSnapshotStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ViewSnapshotStore.cpp; sourceTree = "<group>"; };
+		2D6FC80E2B05C98B00C87B49 /* ScrollingTreePluginScrollingNodeRemoteMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScrollingTreePluginScrollingNodeRemoteMac.h; sourceTree = "<group>"; };
+		2D6FC80F2B05C98B00C87B49 /* ScrollingTreePluginScrollingNodeRemoteMac.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollingTreePluginScrollingNodeRemoteMac.cpp; sourceTree = "<group>"; };
 		2D7303781A7C2B7500F8F487 /* WKPageNavigationClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPageNavigationClient.h; sourceTree = "<group>"; };
 		2D790A9C1AD7050D00AB90B3 /* _WKLayoutMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKLayoutMode.h; sourceTree = "<group>"; };
 		2D790A9E1AD7164900AB90B3 /* WKLayoutMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKLayoutMode.h; sourceTree = "<group>"; };
@@ -9697,6 +9701,8 @@
 				E40C1F9521F0B97F00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.mm */,
 				0F931C1A18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.h */,
 				0F931C1B18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.mm */,
+				2D222D3E2B04B363009F4ADD /* ScrollingTreePluginScrollingNodeIOS.h */,
+				2D222D3F2B04B364009F4ADD /* ScrollingTreePluginScrollingNodeIOS.mm */,
 				0F931C1A18C5711900DBB8D4 /* ScrollingTreeScrollingNodeDelegateIOS.h */,
 				0F931C1B18C5711900DBB8D4 /* ScrollingTreeScrollingNodeDelegateIOS.mm */,
 			);
@@ -14570,6 +14576,8 @@
 				E404907321DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.h */,
 				0F73B767222B38C600805316 /* ScrollingTreeOverflowScrollingNodeRemoteMac.cpp */,
 				0F73B768222B38C600805316 /* ScrollingTreeOverflowScrollingNodeRemoteMac.h */,
+				2D6FC80F2B05C98B00C87B49 /* ScrollingTreePluginScrollingNodeRemoteMac.cpp */,
+				2D6FC80E2B05C98B00C87B49 /* ScrollingTreePluginScrollingNodeRemoteMac.h */,
 			);
 			path = mac;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -176,6 +176,7 @@ private:
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
+    bool wantsWheelEvents() const override { return true; }
     bool handleMouseEvent(const WebMouseEvent&) override;
     bool handleWheelEvent(const WebWheelEvent&) override;
     bool handleMouseEnterEvent(const WebMouseEvent&) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -109,7 +109,7 @@ public:
 
     virtual RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const = 0;
 
-    virtual bool wantsWheelEvents() const { return true; }
+    virtual bool wantsWheelEvents() const = 0;
     virtual bool handleMouseEvent(const WebMouseEvent&) = 0;
     virtual bool handleWheelEvent(const WebWheelEvent&) = 0;
     virtual bool handleMouseEnterEvent(const WebMouseEvent&) = 0;
@@ -233,6 +233,7 @@ protected:
 
     WeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;
+    WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> m_element;
 
     PDFPluginIdentifier m_identifier;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -87,6 +87,7 @@ PluginInfo PDFPluginBase::pluginInfo()
 
 PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
     : m_frame(*WebFrame::fromCoreFrame(*element.document().frame()))
+    , m_element(element)
     , m_identifier(PDFPluginIdentifier::generate())
 {
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -65,8 +65,9 @@ private:
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
+    bool wantsWheelEvents() const override { return false; }
     bool handleMouseEvent(const WebMouseEvent&) override;
-    bool handleWheelEvent(const WebWheelEvent&) override;
+    bool handleWheelEvent(const WebWheelEvent&) override { return false; }
     bool handleMouseEnterEvent(const WebMouseEvent&) override;
     bool handleMouseLeaveEvent(const WebMouseEvent&) override;
     bool handleContextMenuEvent(const WebMouseEvent&) override;
@@ -100,8 +101,13 @@ private:
 
     void didChangeSettings() override;
 
+    bool usesAsyncScrolling() const final { return true; }
+    WebCore::ScrollingNodeID scrollingNodeID() const final { return m_scrollingNodeID; }
+
     void invalidateScrollbarRect(WebCore::Scrollbar&, const WebCore::IntRect&) override;
     void invalidateScrollCornerRect(const WebCore::IntRect&) override;
+    void updateScrollingExtents();
+    ScrollingCoordinator* scrollingCoordinator();
 
     // HUD Actions.
 #if ENABLE(PDF_HUD)
@@ -115,9 +121,11 @@ private:
 
     PDFDocumentLayout m_documentLayout;
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;
-    RefPtr<WebCore::GraphicsLayer> m_clippingLayer;
-    RefPtr<WebCore::GraphicsLayer> m_scrollingLayer;
+    RefPtr<WebCore::GraphicsLayer> m_scrollContainerLayer;
+    RefPtr<WebCore::GraphicsLayer> m_scrolledContentsLayer;
     RefPtr<WebCore::GraphicsLayer> m_contentsLayer;
+
+    WebCore::ScrollingNodeID m_scrollingNodeID { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -642,6 +642,23 @@ void PluginView::willDetachRenderer()
     m_plugin->willDetachRenderer();
 }
 
+bool PluginView::usesAsyncScrolling() const
+{
+    if (!m_isInitialized)
+        return false;
+
+    return m_plugin->usesAsyncScrolling();
+}
+
+
+ScrollingNodeID PluginView::scrollingNodeID() const
+{
+    if (!m_isInitialized)
+        return 0;
+
+    return m_plugin->scrollingNodeID();
+}
+
 RefPtr<FragmentedSharedBuffer> PluginView::liveResourceData() const
 {
     if (!m_isInitialized) {

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -142,6 +142,9 @@ private:
     bool shouldAllowNavigationFromDrags() const final;
     void willDetachRenderer() final;
 
+    bool usesAsyncScrolling() const final;
+    WebCore::ScrollingNodeID scrollingNodeID() const final;
+
     // WebCore::Widget
     void setFrameRect(const WebCore::IntRect&) final;
     void paint(WebCore::GraphicsContext&, const WebCore::IntRect&, WebCore::Widget::SecurityOriginPaintPolicy, WebCore::RegionContext*) final;


### PR DESCRIPTION
#### 34b37bd8fc5607f6eb809a7fc0ee4a5edd83a688
<pre>
[UnifiedPDF] Use the scrolling tree for UnifiedPDFPlugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=265007">https://bugs.webkit.org/show_bug.cgi?id=265007</a>
<a href="https://rdar.apple.com/118154855">rdar://118154855</a>

Reviewed by Simon Fraser.

Adopt async scrolling for Unified PDF plugin, improving scrolling performance,
getting scrolling working for the first time on iOS, and paving the way towards
UI-side scrollbars on macOS.

* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollableAreaForScrollingNodeID const):
* Source/WebCore/page/LocalFrameView.h:
Make it possible to install a non-RenderLayer-owned ScrollableArea as associated
with a ScrollingNodeID.

* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::usesAsyncScrolling):
(WebCore::PluginViewBase::scrollingNodeID):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::usesAsyncScrolling):
(WebCore::RenderEmbeddedObject::scrollingNodeID):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::usesAsyncScrolling):
(WebKit::PluginView::scrollingNodeID):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
Make it possible to ask a plugin if it wants to host a coordinated scroller,
and to retrieve the scroller&apos;s ScrollingNodeID.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::attachWidgetContentLayers):
Connect the plugin scrolling node as a child of the plugin hosting node.

(WebCore::RenderLayerCompositor::isLayerForPluginWithScrollCoordinatedContents const):
(WebCore::scrollCoordinationRoleForNodeType):
(WebCore::RenderLayerCompositor::detachScrollCoordinatedLayer):
(WebCore::RenderLayerCompositor::coordinatedScrollingRolesForLayer const):
(WebCore::RenderLayerCompositor::updateScrollCoordinationForLayer):
(WebCore::RenderLayerCompositor::updateScrollingNodeForPluginHostingRole):
Create a plugin hosting node if the plugin wants to host a coordinated scroller.

(WebCore::RenderLayerCompositor::updateScrollingNodeLayers):
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingRole):
Avoid some irrelevant work which would stomp UnifiedPDFPlugin&apos;s scrolling node layers and geometry.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::wantsWheelEvents const): Deleted.
De-hoist wantsWheelEvents, since we don&apos;t want them in UnifiedPDFPlugin anymore.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
Turn on rubber-banding.

(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
Create a plugin scrolling node, which RenderLayerCompositor will plug into the hosting node.

(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::didChangeScrollOffset):
Use boundsOrigin instead of position to scroll, matching what the UI-side scrolling code will do.

(WebKit::UnifiedPDFPlugin::updateScrollbars):
Push plugin geometry changes down to both the scrolling tree and event regions.

(WebKit::UnifiedPDFPlugin::handleWheelEvent): Deleted.

* Source/WebCore/page/scrolling/ScrollingStatePluginHostingNode.cpp: Added.
* Source/WebCore/page/scrolling/ScrollingStatePluginHostingNode.h: Added.
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp: Added.
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h: Added.
* Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.cpp: Added.
* Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h: Added.
* Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.cpp: Added.
* Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h: Added.
* Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h: Added.
* Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.cpp: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.h: Added.
Add plugin-scrolling-specific scrolling tree nodes.

* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::isScrollingNode const):
(WebCore::ScrollingStateNode::isPluginScrollingNode const):
(WebCore::ScrollingStateNode::isPluginHostingNode const):
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::createNode):
(WebCore::ScrollingStateTree::isValid const):
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
(WebCore::ScrollingTreeNode::isScrollingNode const):
(WebCore::ScrollingTreeNode::isPluginScrollingNode const):
(WebCore::ScrollingTreeNode::isPluginHostingNode const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(ScrollingTreeMac::createScrollingTreeNode):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::outputPaintOrderTreeRecursive):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::~RenderLayerBacking):
(WebCore::RenderLayerBacking::detachFromScrollingCoordinator):
(WebCore::RenderLayerBacking::setScrollingNodeIDForRole):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.h:
(WebCore::allScrollCoordinationRoles):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::dump):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::createScrollingTreeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollViewForScrollingNodeID const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp:
(WebKit::RemoteScrollingTreeIOS::createScrollingTreeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::createScrollingTreeNode):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Plumbing for plugin-scrolling-specific scrolling tree nodes.

* Source/WebCore/rendering/EventRegion.h:
Extra exports!

Canonical link: <a href="https://commits.webkit.org/270917@main">https://commits.webkit.org/270917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/342e24ef777d8cfe9f5280d364248b00e260157c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2818 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4240 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/23009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3721 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29502 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24407 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/27920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23742 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6442 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->