### PR TITLE
style.display setter should be fast

### DIFF
--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
@@ -219,16 +219,7 @@ bool JSTestIndexedSetterNoIdentifier::put(JSCell* cell, JSGlobalObject* lexicalG
     }
 
     throwScope.assertNoException();
-    PropertyDescriptor ownDescriptor;
-    PropertySlot slot(thisObject, PropertySlot::InternalMethodType::GetOwnProperty);;
-    bool ignoreNamedProperties = true;
-    bool hasOwnProperty = legacyPlatformObjectGetOwnProperty(thisObject, lexicalGlobalObject, propertyName, slot, ignoreNamedProperties);
-    RETURN_IF_EXCEPTION(throwScope, false);
-    if (hasOwnProperty) {
-        ownDescriptor.setPropertySlot(lexicalGlobalObject, propertyName, slot);
-        RETURN_IF_EXCEPTION(throwScope, false);
-    }
-    RELEASE_AND_RETURN(throwScope, ordinarySetWithOwnDescriptor(lexicalGlobalObject, thisObject, propertyName, value, putPropertySlot.thisValue(), WTFMove(ownDescriptor), putPropertySlot.isStrictMode()));
+    RELEASE_AND_RETURN(throwScope, JSObject::put(thisObject, lexicalGlobalObject, propertyName, value, putPropertySlot));
 }
 
 bool JSTestIndexedSetterNoIdentifier::putByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalObject, unsigned index, JSValue value, bool shouldThrow)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
@@ -219,16 +219,7 @@ bool JSTestIndexedSetterThrowingException::put(JSCell* cell, JSGlobalObject* lex
     }
 
     throwScope.assertNoException();
-    PropertyDescriptor ownDescriptor;
-    PropertySlot slot(thisObject, PropertySlot::InternalMethodType::GetOwnProperty);;
-    bool ignoreNamedProperties = true;
-    bool hasOwnProperty = legacyPlatformObjectGetOwnProperty(thisObject, lexicalGlobalObject, propertyName, slot, ignoreNamedProperties);
-    RETURN_IF_EXCEPTION(throwScope, false);
-    if (hasOwnProperty) {
-        ownDescriptor.setPropertySlot(lexicalGlobalObject, propertyName, slot);
-        RETURN_IF_EXCEPTION(throwScope, false);
-    }
-    RELEASE_AND_RETURN(throwScope, ordinarySetWithOwnDescriptor(lexicalGlobalObject, thisObject, propertyName, value, putPropertySlot.thisValue(), WTFMove(ownDescriptor), putPropertySlot.isStrictMode()));
+    RELEASE_AND_RETURN(throwScope, JSObject::put(thisObject, lexicalGlobalObject, propertyName, value, putPropertySlot));
 }
 
 bool JSTestIndexedSetterThrowingException::putByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalObject, unsigned index, JSValue value, bool shouldThrow)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
@@ -228,16 +228,7 @@ bool JSTestIndexedSetterWithIdentifier::put(JSCell* cell, JSGlobalObject* lexica
     }
 
     throwScope.assertNoException();
-    PropertyDescriptor ownDescriptor;
-    PropertySlot slot(thisObject, PropertySlot::InternalMethodType::GetOwnProperty);;
-    bool ignoreNamedProperties = true;
-    bool hasOwnProperty = legacyPlatformObjectGetOwnProperty(thisObject, lexicalGlobalObject, propertyName, slot, ignoreNamedProperties);
-    RETURN_IF_EXCEPTION(throwScope, false);
-    if (hasOwnProperty) {
-        ownDescriptor.setPropertySlot(lexicalGlobalObject, propertyName, slot);
-        RETURN_IF_EXCEPTION(throwScope, false);
-    }
-    RELEASE_AND_RETURN(throwScope, ordinarySetWithOwnDescriptor(lexicalGlobalObject, thisObject, propertyName, value, putPropertySlot.thisValue(), WTFMove(ownDescriptor), putPropertySlot.isStrictMode()));
+    RELEASE_AND_RETURN(throwScope, JSObject::put(thisObject, lexicalGlobalObject, propertyName, value, putPropertySlot));
 }
 
 bool JSTestIndexedSetterWithIdentifier::putByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalObject, unsigned index, JSValue value, bool shouldThrow)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2749,6 +2749,9 @@ bool JSTestObj::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, PropertyN
     auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
 
     throwScope.assertNoException();
+    if (!parseIndex(propertyName))
+        RELEASE_AND_RETURN(throwScope, JSObject::put(thisObject, lexicalGlobalObject, propertyName, value, putPropertySlot));
+
     PropertyDescriptor ownDescriptor;
     PropertySlot slot(thisObject, PropertySlot::InternalMethodType::GetOwnProperty);;
     bool ignoreNamedProperties = true;

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -62,42 +62,42 @@ struct CSSParserContext {
     String charset;
     CSSParserMode mode { HTMLStandardMode };
     std::optional<StyleRuleType> enclosingRuleType;
-    bool isHTMLDocument { false };
+    bool isHTMLDocument : 1 { false };
 
     // This is only needed to support getMatchedCSSRules.
-    bool hasDocumentSecurityOrigin { false };
+    bool hasDocumentSecurityOrigin : 1 { false };
 
-    bool isContentOpaque { false };
-    bool useSystemAppearance { false };
-    bool shouldIgnoreImportRules { false };
+    bool isContentOpaque : 1 { false };
+    bool useSystemAppearance : 1 { false };
+    bool shouldIgnoreImportRules : 1 { false };
 
     // Settings, excluding those affecting properties.
-    bool colorContrastEnabled { false };
-    bool colorMixEnabled { false };
-    bool constantPropertiesEnabled { false };
-    bool counterStyleAtRuleImageSymbolsEnabled { false };
-    bool relativeColorSyntaxEnabled { false };
-    bool springTimingFunctionEnabled { false };
+    bool colorContrastEnabled : 1 { false };
+    bool colorMixEnabled : 1 { false };
+    bool constantPropertiesEnabled : 1 { false };
+    bool counterStyleAtRuleImageSymbolsEnabled : 1 { false };
+    bool relativeColorSyntaxEnabled : 1 { false };
+    bool springTimingFunctionEnabled : 1 { false };
 #if ENABLE(CSS_TRANSFORM_STYLE_OPTIMIZED_3D)
-    bool transformStyleOptimized3DEnabled { false };
+    bool transformStyleOptimized3DEnabled : 1 { false };
 #endif
-    bool useLegacyBackgroundSizeShorthandBehavior { false };
-    bool focusVisibleEnabled { false };
-    bool hasPseudoClassEnabled { false };
-    bool cascadeLayersEnabled { false };
-    bool overflowClipEnabled { false };
-    bool gradientPremultipliedAlphaInterpolationEnabled { false };
-    bool gradientInterpolationColorSpacesEnabled { false };
-    bool subgridEnabled { false };
-    bool masonryEnabled { false };
-    bool cssNestingEnabled { false };
-    bool cssPaintingAPIEnabled { false };
-    bool cssScopeAtRuleEnabled { false };
-    bool cssTextUnderlinePositionLeftRightEnabled { false };
-    bool cssWordBreakAutoPhraseEnabled { false };
-    bool popoverAttributeEnabled { false };
-    bool sidewaysWritingModesEnabled { false };
-    bool cssTextWrapPrettyEnabled { false };
+    bool useLegacyBackgroundSizeShorthandBehavior : 1 { false };
+    bool focusVisibleEnabled : 1 { false };
+    bool hasPseudoClassEnabled : 1 { false };
+    bool cascadeLayersEnabled : 1 { false };
+    bool overflowClipEnabled : 1 { false };
+    bool gradientPremultipliedAlphaInterpolationEnabled : 1 { false };
+    bool gradientInterpolationColorSpacesEnabled : 1 { false };
+    bool subgridEnabled : 1 { false };
+    bool masonryEnabled : 1 { false };
+    bool cssNestingEnabled : 1 { false };
+    bool cssPaintingAPIEnabled : 1 { false };
+    bool cssScopeAtRuleEnabled : 1 { false };
+    bool cssTextUnderlinePositionLeftRightEnabled : 1 { false };
+    bool cssWordBreakAutoPhraseEnabled : 1 { false };
+    bool popoverAttributeEnabled : 1 { false };
+    bool sidewaysWritingModesEnabled : 1 { false };
+    bool cssTextWrapPrettyEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -901,6 +901,47 @@ static RefPtr<CSSValue> parseSimpleTransform(CSSPropertyID propertyID, StringVie
     return parseSimpleTransformList(string.characters16(), string.length());
 }
 
+static RefPtr<CSSValue> parseDisplay(StringView string)
+{
+    ASSERT(!string.isEmpty());
+    auto valueID = cssValueKeywordID(string);
+
+    switch (valueID) {
+    // <display-outside>
+    case CSSValueBlock:
+    case CSSValueInline:
+    // <display-inside> (except for CSSValueFlow since it becomes "block")
+    case CSSValueFlex:
+    case CSSValueFlowRoot:
+    case CSSValueGrid:
+    case CSSValueTable:
+    // <display-internal>
+    case CSSValueTableCaption:
+    case CSSValueTableCell:
+    case CSSValueTableColumnGroup:
+    case CSSValueTableColumn:
+    case CSSValueTableHeaderGroup:
+    case CSSValueTableFooterGroup:
+    case CSSValueTableRow:
+    case CSSValueTableRowGroup:
+    // <display-legacy>
+    case CSSValueInlineBlock:
+    case CSSValueInlineFlex:
+    case CSSValueInlineGrid:
+    case CSSValueInlineTable:
+    // Prefixed values
+    case CSSValueWebkitInlineBox:
+    case CSSValueWebkitBox:
+    // No layout support for the full <display-listitem> syntax, so treat it as <display-legacy>
+    case CSSValueListItem:
+        return CSSPrimitiveValue::create(valueID);
+    default:
+        if (isCSSWideKeyword(valueID))
+            return CSSPrimitiveValue::create(valueID);
+        return nullptr;
+    }
+}
+
 static RefPtr<CSSValue> parseColorWithAuto(StringView string, const CSSParserContext& context)
 {
     ASSERT(!string.isEmpty());
@@ -913,6 +954,8 @@ RefPtr<CSSValue> CSSParserFastPaths::maybeParseValue(CSSPropertyID propertyID, S
 {
     if (auto result = parseSimpleLengthValue(propertyID, string, context.mode))
         return result;
+    if (propertyID == CSSPropertyDisplay)
+        return parseDisplay(string);
     if ((propertyID == CSSPropertyCaretColor || propertyID == CSSPropertyAccentColor) && isExposed(propertyID, &context.propertySettings))
         return parseColorWithAuto(string, context);
     if (CSSProperty::isColorProperty(propertyID))

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -5097,6 +5097,7 @@ RefPtr<CSSValue> consumeAspectRatio(CSSParserTokenRange& range)
     return CSSValueList::createSpaceSeparated(autoValue.releaseNonNull(), ratioList.releaseNonNull());
 }
 
+// Keep in sync with the single keyword value fast path of CSSParserFastPaths's parseDisplay.
 RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange& range, CSSParserMode mode)
 {
     // Parse single keyword values

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3012,7 +3012,7 @@ class GenerateCSSPropertyNames:
         to.newline()
 
     def _generate_css_property_names_h_property_settings(self, *, to):
-        settings_variable_declarations = (f"bool {flag} {{ false }};" for flag in self.properties_and_descriptors.settings_flags)
+        settings_variable_declarations = (f"bool {flag} : 1 {{ false }};" for flag in self.properties_and_descriptors.settings_flags)
 
         to.write(f"struct CSSPropertySettings {{")
         with to.indent():


### PR DESCRIPTION
#### 373b5f1310c1d92cb0aef4b501a3bef651d07bf1
<pre>
style.display setter should be fast
<a href="https://bugs.webkit.org/show_bug.cgi?id=265009">https://bugs.webkit.org/show_bug.cgi?id=265009</a>
<a href="https://rdar.apple.com/118548941">rdar://118548941</a>

Reviewed by Chris Dumez.

While `style.display` setter can be called frequently, this isn&apos;t optimized well.
This patch optimizes it in three ways.

1. We should have CSSParserFastPaths for display with simple one keyword, like, `style.display = &quot;none&quot;`.
2. We found that JSCSSStyleDeclaration::put is completely disabling IC and using the slowest path.
   Since JSCSSStyleDeclaration does not have any named getters / setters, we should use JSObject::put when
   we access to named property. We add a path which uses JSObject::put when propertyName is not index.
3. CSSParserContext is frequently created. We should use bitfields to make it much smaller (from 110 =&gt; 64).

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GeneratePut):
(InstanceOverridesIndexedDefineOwnProperty):
(InstanceOverridesNamedDefineOwnProperty):
(InstanceOverridesDefineOwnProperty):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseDisplay):
(WebCore::CSSParserFastPaths::maybeParseValue):

Canonical link: <a href="https://commits.webkit.org/270914@main">https://commits.webkit.org/270914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0086020192cfc2a4f0ecb9636d6a7698903404e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24376 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3693 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29990 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27895 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4240 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3467 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->