### PR TITLE
[WGSL] Add support for f16

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1663,3 +1663,7 @@
 #if __has_include(<UIKit/UIAsyncTextInteractionDelegate.h>)
 #define HAVE_UI_ASYNC_TEXT_INTERACTION_DELEGATE 1
 #endif
+
+#if CPU(ARM64)
+#define HAVE_FP16_HALF_SUPPORT 1
+#endif

--- a/Source/WebGPU/WGSL/AST/AST.h
+++ b/Source/WebGPU/WGSL/AST/AST.h
@@ -51,6 +51,7 @@
 #include "ASTElaboratedTypeExpression.h"
 #include "ASTExpression.h"
 #include "ASTFieldAccessExpression.h"
+#include "ASTFloat16Literal.h"
 #include "ASTFloat32Literal.h"
 #include "ASTForStatement.h"
 #include "ASTFunction.h"

--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -89,6 +89,7 @@ static bool isType(const WGSL::AST::Node& node)
     case WGSL::AST::NodeKind::AbstractIntegerLiteral:
     case WGSL::AST::NodeKind::BoolLiteral:
     case WGSL::AST::NodeKind::Float32Literal:
+    case WGSL::AST::NodeKind::Float16Literal:
     case WGSL::AST::NodeKind::Signed32Literal:
     case WGSL::AST::NodeKind::Unsigned32Literal:
         return true;

--- a/Source/WebGPU/WGSL/AST/ASTFloat16Literal.h
+++ b/Source/WebGPU/WGSL/AST/ASTFloat16Literal.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTExpression.h"
+
+namespace WGSL::AST {
+
+class Float16Literal final : public Expression {
+    WGSL_AST_BUILDER_NODE(Float16Literal);
+public:
+    NodeKind kind() const final;
+    half value() const { return m_value; }
+
+private:
+    Float16Literal(SourceSpan span, half value)
+        : Expression(span)
+        , m_value(value)
+    { }
+
+    half m_value;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(Float16Literal)

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -55,6 +55,7 @@ class BoolLiteral;
 class CallExpression;
 class FieldAccessExpression;
 class Float32Literal;
+class Float16Literal;
 class IdentifierExpression;
 class IdentityExpression;
 class IndexAccessExpression;

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -74,6 +74,7 @@ enum class NodeKind : uint8_t {
     AbstractIntegerLiteral,
     BoolLiteral,
     Float32Literal,
+    Float16Literal,
     Signed32Literal,
     Unsigned32Literal,
 

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -248,6 +248,11 @@ void StringDumper::visit(Float32Literal& literal)
     m_out.print(literal.value(), "f");
 }
 
+void StringDumper::visit(Float16Literal& literal)
+{
+    m_out.print(String::number(literal.value()), "h");
+}
+
 void StringDumper::visit(IdentifierExpression& identifier)
 {
     m_out.print(identifier.identifier());

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -70,6 +70,7 @@ public:
     void visit(CallExpression&) override;
     void visit(FieldAccessExpression&) override;
     void visit(Float32Literal&) override;
+    void visit(Float16Literal&) override;
     void visit(IdentifierExpression&) override;
     void visit(IndexAccessExpression&) override;
     void visit(PointerDereferenceExpression&) override;

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -219,6 +219,9 @@ void Visitor::visit(Expression& expression)
     case AST::NodeKind::Float32Literal:
         checkErrorAndVisit(downcast<AST::Float32Literal>(expression));
         break;
+    case AST::NodeKind::Float16Literal:
+        checkErrorAndVisit(downcast<AST::Float16Literal>(expression));
+        break;
     case AST::NodeKind::IdentifierExpression:
         checkErrorAndVisit(downcast<AST::IdentifierExpression>(expression));
         break;
@@ -287,6 +290,10 @@ void Visitor::visit(AST::FieldAccessExpression& fieldAccessExpression)
 }
 
 void Visitor::visit(AST::Float32Literal&)
+{
+}
+
+void Visitor::visit(AST::Float16Literal&)
 {
 }
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -75,6 +75,7 @@ public:
     virtual void visit(AST::CallExpression&);
     virtual void visit(AST::FieldAccessExpression&);
     virtual void visit(AST::Float32Literal&);
+    virtual void visit(AST::Float16Literal&);
     virtual void visit(AST::IdentifierExpression&);
     virtual void visit(AST::IdentityExpression&);
     virtual void visit(AST::IndexAccessExpression&);

--- a/Source/WebGPU/WGSL/ConstantValue.cpp
+++ b/Source/WebGPU/WGSL/ConstantValue.cpp
@@ -60,6 +60,11 @@ void ConstantValue::dump(PrintStream& out) const
             if (std::isfinite(f))
                 out.print("f");
         },
+        [&](half h) {
+            out.print(String::number(h));
+            if (std::isfinite(static_cast<double>(h)))
+                out.print("h");
+        },
         [&](int64_t i) {
             out.print(String::number(i));
         },

--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -53,8 +53,8 @@ bool satisfies(const Type* type, Constraint constraint)
         return constraint & Constraints::U32;
     case Types::Primitive::F32:
         return constraint & Constraints::F32;
-    // FIXME: Add F16 support
-    // https://bugs.webkit.org/show_bug.cgi?id=254668
+    case Types::Primitive::F16:
+        return constraint & Constraints::F16;
     case Types::Primitive::Bool:
         return constraint & Constraints::Bool;
 
@@ -95,11 +95,8 @@ const Type* satisfyOrPromote(const Type* type, Constraint constraint, const Type
             return types.abstractFloatType();
         if (constraint & Constraints::F32)
             return types.f32Type();
-        if (constraint & Constraints::F16) {
-            // FIXME: Add F16 support
-            // https://bugs.webkit.org/show_bug.cgi?id=254668
-            RELEASE_ASSERT_NOT_REACHED();
-        }
+        if (constraint & Constraints::F16)
+            return types.f16Type();
         RELEASE_ASSERT_NOT_REACHED();
     case Types::Primitive::AbstractFloat:
         if (constraint < Constraints::AbstractFloat)
@@ -108,11 +105,8 @@ const Type* satisfyOrPromote(const Type* type, Constraint constraint, const Type
             return type;
         if (constraint & Constraints::F32)
             return types.f32Type();
-        if (constraint & Constraints::F16) {
-            // FIXME: Add F16 support
-            // https://bugs.webkit.org/show_bug.cgi?id=254668
-            RELEASE_ASSERT_NOT_REACHED();
-        }
+        if (constraint & Constraints::F16)
+            return types.f16Type();
         RELEASE_ASSERT_NOT_REACHED();
     case Types::Primitive::I32:
         if (!(constraint & Constraints::I32))
@@ -126,8 +120,10 @@ const Type* satisfyOrPromote(const Type* type, Constraint constraint, const Type
         if (!(constraint & Constraints::F32))
             return nullptr;
         return type;
-    // FIXME: Add F16 support
-    // https://bugs.webkit.org/show_bug.cgi?id=254668
+    case Types::Primitive::F16:
+        if (!(constraint & Constraints::F16))
+            return nullptr;
+        return type;
     case Types::Primitive::Bool:
         if (!(constraint & Constraints::Bool))
             return nullptr;

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -323,6 +323,9 @@ auto RewriteGlobalVariables::pack(Packing expectedPacking, AST::Expression& expr
             case Types::Primitive::F32:
                 operation = packing == Packing::Packed ? "float3"_s : "packed_float3"_s;
                 break;
+            case Types::Primitive::F16:
+                operation = packing == Packing::Packed ? "half3"_s : "packed_half3"_s;
+                break;
             default:
                 RELEASE_ASSERT_NOT_REACHED();
             }
@@ -840,6 +843,7 @@ static BindGroupLayoutEntry::BindingMember bindingMemberForGlobal(auto& global)
         case Types::Primitive::U32:
         case Types::Primitive::AbstractFloat:
         case Types::Primitive::F32:
+        case Types::Primitive::F16:
         case Types::Primitive::Void:
         case Types::Primitive::Bool:
             return BufferBindingLayout {
@@ -1032,6 +1036,7 @@ void RewriteGlobalVariables::usesOverride(AST::Variable& variable)
         constantType = Reflection::SpecializationConstantType::Boolean;
         break;
     case Types::Primitive::F32:
+    case Types::Primitive::F16: // Is this correct?
         constantType = Reflection::SpecializationConstantType::Float;
         break;
     case Types::Primitive::I32:

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -945,7 +945,8 @@ Token Lexer<T>::lexNumber()
             break;
         }
         case 'h':
-            // FIXME: add support for f16
+            if (auto result = convertFloat<half>(value))
+                return makeLiteralToken(TokenType::HalfLiteral, *result);
             break;
         default:
             if constexpr (std::is_floating_point_v<decltype(value)>) {

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -82,6 +82,7 @@ public:
     void visit(AST::Expression&) override;
     void visit(AST::FieldAccessExpression&) override;
     void visit(AST::Float32Literal&) override;
+    void visit(AST::Float16Literal&) override;
     void visit(AST::IdentifierExpression&) override;
     void visit(AST::IndexAccessExpression&) override;
     void visit(AST::PointerDereferenceExpression&) override;
@@ -489,6 +490,9 @@ bool FunctionDefinitionWriter::emitPackedVector(const Types::Vector& vector)
     case Types::Primitive::F32:
         m_stringBuilder.append("packed_float", String::number(vector.size));
         break;
+    case Types::Primitive::F16:
+        m_stringBuilder.append("packed_half", String::number(vector.size));
+        break;
     case Types::Primitive::Bool:
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
@@ -745,6 +749,9 @@ void FunctionDefinitionWriter::visit(const Type* type)
             case Types::Primitive::AbstractFloat:
             case Types::Primitive::F32:
                 m_stringBuilder.append("float");
+                break;
+            case Types::Primitive::F16:
+                m_stringBuilder.append("half");
                 break;
             case Types::Primitive::Void:
             case Types::Primitive::Bool:
@@ -1832,6 +1839,14 @@ void FunctionDefinitionWriter::visit(AST::Float32Literal& literal)
     m_stringBuilder.append(&buffer[0]);
 }
 
+void FunctionDefinitionWriter::visit(AST::Float16Literal& literal)
+{
+    NumberToStringBuffer buffer;
+    WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
+
+    m_stringBuilder.append(&buffer[0]);
+}
+
 void FunctionDefinitionWriter::visit(AST::Statement& statement)
 {
     AST::Visitor::visit(statement);
@@ -2033,6 +2048,12 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
                 NumberToStringBuffer buffer;
                 WTF::numberToStringWithTrailingPoint(std::get<float>(value), buffer);
                 m_stringBuilder.append(&buffer[0]);
+                break;
+            }
+            case Primitive::F16: {
+                NumberToStringBuffer buffer;
+                WTF::numberToStringWithTrailingPoint(std::get<half>(value), buffer);
+                m_stringBuilder.append(&buffer[0], "h");
                 break;
             }
             case Primitive::Bool:

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -1620,6 +1620,10 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
         CONSUME_TYPE_NAMED(lit, FloatLiteral);
         RETURN_ARENA_NODE(Float32Literal, lit.literalValue);
     }
+    case TokenType::HalfLiteral: {
+        CONSUME_TYPE_NAMED(lit, HalfLiteral);
+        RETURN_ARENA_NODE(Float16Literal, lit.literalValue);
+    }
     // TODO: bitcast expression
 
     default:

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -45,6 +45,8 @@ String toString(TokenType type)
         return "IntegerLiteralUnsigned"_s;
     case TokenType::FloatLiteral:
         return "FloatLiteral"_s;
+    case TokenType::HalfLiteral:
+        return "HalfLiteral"_s;
     case TokenType::Identifier:
         return "Identifier"_s;
     case TokenType::ReservedWord:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -74,6 +74,7 @@ enum class TokenType: uint32_t {
     IntegerLiteralSigned,
     IntegerLiteralUnsigned,
     FloatLiteral,
+    HalfLiteral,
 
     Identifier,
 
@@ -154,7 +155,8 @@ struct Token {
             && type != TokenType::IntegerLiteral
             && type != TokenType::IntegerLiteralSigned
             && type != TokenType::IntegerLiteralUnsigned
-            && type != TokenType::FloatLiteral);
+            && type != TokenType::FloatLiteral
+            && type != TokenType::HalfLiteral);
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, double literalValue)
@@ -166,7 +168,8 @@ struct Token {
             || type == TokenType::IntegerLiteral
             || type == TokenType::IntegerLiteralSigned
             || type == TokenType::IntegerLiteralUnsigned
-            || type == TokenType::FloatLiteral);
+            || type == TokenType::FloatLiteral
+            || type == TokenType::HalfLiteral);
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, String&& ident)
@@ -196,6 +199,7 @@ struct Token {
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
         case TokenType::FloatLiteral:
+        case TokenType::HalfLiteral:
             literalValue = other.literalValue;
             break;
         default:
@@ -220,6 +224,7 @@ struct Token {
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
         case TokenType::FloatLiteral:
+        case TokenType::HalfLiteral:
             literalValue = other.literalValue;
             break;
         default:
@@ -243,6 +248,7 @@ struct Token {
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
         case TokenType::FloatLiteral:
+        case TokenType::HalfLiteral:
             literalValue = other.literalValue;
             break;
         default:

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1,5 +1,6 @@
 suffixes = {
     f: f32,
+    h: f16,
     i: i32,
     u: u32,
 }
@@ -10,9 +11,8 @@ suffixes = {
     end
 
     [2, 3, 4].each do |m|
-        # FIXME: add alias for F16 once we support it
-        #type_alias :"mat#{n}x#{m}f", mat[n][m](f32)[f32, n, m]
         type_alias :"mat#{n}x#{m}f", mat[n,m][f32]
+        type_alias :"mat#{n}x#{m}h", mat[n,m][f16]
     end
 end
 
@@ -248,6 +248,13 @@ constructor :f32, {
     [].() => f32,
 }
 
+constructor :f16, {
+    must_use: true,
+    const: true,
+
+    [].() => f16,
+}
+
 constructor :vec2, {
     must_use: true,
     const: true,
@@ -293,8 +300,13 @@ constructor :bool, {
     [T < ConcreteScalar].(T) => bool,
 }
 
-# 16.1.2.3. f16
-# FIXME: add support for f16
+# 16.1.2.3.
+constructor :f16, {
+    must_use: true,
+    const: true,
+
+    [T < ConcreteScalar].(T) => f16,
+}
 
 # 16.1.2.4.
 constructor :f32, {

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -119,6 +119,7 @@ TypeStore::TypeStore()
     m_i32 = allocateType<Primitive>(Primitive::I32);
     m_u32 = allocateType<Primitive>(Primitive::U32);
     m_f32 = allocateType<Primitive>(Primitive::F32);
+    m_f16 = allocateType<Primitive>(Primitive::F16);
     m_sampler = allocateType<Primitive>(Primitive::Sampler);
     m_samplerComparison = allocateType<Primitive>(Primitive::SamplerComparison);
     m_textureExternal = allocateType<Primitive>(Primitive::TextureExternal);

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -78,6 +78,7 @@ public:
 
     const Type* abstractFloatType() const { return m_abstractFloat; }
     const Type* f32Type() const { return m_f32; }
+    const Type* f16Type() const { return m_f16; }
     const Type* samplerType() const { return m_sampler; }
     const Type* samplerComparisonType() const { return m_samplerComparison; }
     const Type* textureExternalType() const { return m_textureExternal; }
@@ -119,6 +120,7 @@ private:
     const Type* m_i32;
     const Type* m_u32;
     const Type* m_f32;
+    const Type* m_f16;
     const Type* m_sampler;
     const Type* m_samplerComparison;
     const Type* m_textureExternal;

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -199,7 +199,8 @@ ConversionRank conversionRank(const Type* from, const Type* to)
         switch (primitivePair(fromPrimitive->kind, toPrimitive->kind)) {
         case primitivePair(Primitive::AbstractFloat, Primitive::F32):
             return { 1 };
-        // FIXME: AbstractFloat to f16 should return 2
+        case primitivePair(Primitive::AbstractFloat, Primitive::F16):
+            return { 2 };
         case primitivePair(Primitive::AbstractInt, Primitive::I32):
             return { 3 };
         case primitivePair(Primitive::AbstractInt, Primitive::U32):
@@ -208,7 +209,8 @@ ConversionRank conversionRank(const Type* from, const Type* to)
             return { 5 };
         case primitivePair(Primitive::AbstractInt, Primitive::F32):
             return { 6 };
-        // FIXME: AbstractInt to f16 should return 7
+        case primitivePair(Primitive::AbstractInt, Primitive::F16):
+            return { 7 };
         default:
             return std::nullopt;
         }
@@ -273,6 +275,8 @@ unsigned Type::size() const
     return WTF::switchOn(*this,
         [&](const Primitive& primitive) -> unsigned {
             switch (primitive.kind) {
+            case Types::Primitive::F16:
+                return 2;
             case Types::Primitive::F32:
             case Types::Primitive::I32:
             case Types::Primitive::U32:
@@ -345,6 +349,8 @@ unsigned Type::alignment() const
     return WTF::switchOn(*this,
         [&](const Primitive& primitive) -> unsigned {
             switch (primitive.kind) {
+            case Types::Primitive::F16:
+                return 2;
             case Types::Primitive::F32:
             case Types::Primitive::I32:
             case Types::Primitive::U32:

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -47,6 +47,7 @@ namespace Types {
     f(I32, "i32") \
     f(U32, "u32") \
     f(AbstractFloat, "<AbstractFloat>") \
+    f(F16, "f16") \
     f(F32, "f32") \
     f(Void, "void") \
     f(Bool, "bool") \

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -449,6 +449,7 @@ module DSL
         i32 = PrimitiveType.new(:I32)
         u32 = PrimitiveType.new(:U32)
         f32 = PrimitiveType.new(:F32)
+        f16 = PrimitiveType.new(:F16)
         sampler = PrimitiveType.new(:Sampler)
         sampler_comparison = PrimitiveType.new(:SamplerComparison)
         texture_external = PrimitiveType.new(:TextureExternal)

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
 		97D398E62B06A85B00D8C4AA /* ASTDiagnosticDirective.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */; };
 		97D398E72B06A85B00D8C4AA /* ASTDiagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */; };
+		97D398E32B05106000D8C4AA /* ASTFloat16Literal.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */; };
 		97E21C8B2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */; };
 		97E21C972A2512F7009CEB0E /* ConstantValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C942A2512F7009CEB0E /* ConstantValue.cpp */; };
 		97E21C982A2512F7009CEB0E /* ConstantValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E21C952A2512F7009CEB0E /* ConstantValue.h */; };
@@ -452,6 +453,7 @@
 		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
 		97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnosticDirective.h; sourceTree = "<group>"; };
 		97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnostic.h; sourceTree = "<group>"; };
+		97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTFloat16Literal.h; sourceTree = "<group>"; };
 		97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTDecrementIncrementStatement.cpp; sourceTree = "<group>"; };
 		97E21C942A2512F7009CEB0E /* ConstantValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConstantValue.cpp; sourceTree = "<group>"; };
 		97E21C952A2512F7009CEB0E /* ConstantValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantValue.h; sourceTree = "<group>"; };
@@ -724,6 +726,7 @@
 				97099ABE2AA60D58003B41F8 /* ASTElaboratedTypeExpression.h */,
 				33EA186B27BC1CBC00A1DD52 /* ASTExpression.h */,
 				33EA188327BC268600A1DD52 /* ASTFieldAccessExpression.h */,
+				97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */,
 				3A12AED228FCFC5500C1B975 /* ASTFloat32Literal.h */,
 				3A12AE9628FCE94B00C1B975 /* ASTForStatement.h */,
 				3A1337E928FBD56E00F29B73 /* ASTForward.h */,
@@ -838,6 +841,7 @@
 				97099AC12AA60D58003B41F8 /* ASTElaboratedTypeExpression.h in Headers */,
 				33EA186C27BC1CBC00A1DD52 /* ASTExpression.h in Headers */,
 				33EA188427BC268600A1DD52 /* ASTFieldAccessExpression.h in Headers */,
+				97D398E32B05106000D8C4AA /* ASTFloat16Literal.h in Headers */,
 				3A12AED828FCFC5600C1B975 /* ASTFloat32Literal.h in Headers */,
 				3A12AEB028FCE94C00C1B975 /* ASTForStatement.h in Headers */,
 				3A1337EA28FBD56E00F29B73 /* ASTForward.h in Headers */,


### PR DESCRIPTION
#### a6558404e75ec86ed1931fb2144eb4080e47133a
<pre>
[WGSL] Add support for f16
<a href="https://bugs.webkit.org/show_bug.cgi?id=265024">https://bugs.webkit.org/show_bug.cgi?id=265024</a>
<a href="https://rdar.apple.com/118561000">rdar://118561000</a>

Reviewed by Mike Wyrzykowski.

Add support for f16 values and operations. Tests will be included in a follow-up
patch, as I ended up rewriting a lot of the tests, but this was also tested against
the CTS and passes all of the f16 binary expression tests.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTExpression.h:
(isType):
* Source/WebGPU/WGSL/AST/ASTFloat16Literal.h: Added.
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::zeroValue):
(WGSL::constantUnaryOperation):
(WGSL::constantBinaryOperation):
(WGSL::constantTernaryOperation):
(WGSL::constantConstructor):
(WGSL::CONSTANT_FUNCTION):
(WGSL::BINARY_OPERATION):
* Source/WebGPU/WGSL/ConstantValue.cpp:
(WGSL::ConstantValue::dump const):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantValue::isBool const):
(WGSL::ConstantValue::toBool const):
(WGSL::convertFloat):
(WGSL::ConstantValue::isI32 const): Deleted.
(WGSL::ConstantValue::isU32 const): Deleted.
(WGSL::ConstantValue::isAbstractInt const): Deleted.
(WGSL::ConstantValue::isF32 const): Deleted.
(WGSL::ConstantValue::isAbstractFloat const): Deleted.
(WGSL::ConstantValue::toF32 const): Deleted.
* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::bindingMemberForGlobal):
(WGSL::RewriteGlobalVariables::usesOverride):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lexNumber):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitPackedVector):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
(WGSL::Token::Token):
(WGSL::Token::operator=):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::convertValue):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::TypeStore):
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::f16Type const):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::conversionRank):
(WGSL::Type::size const):
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WTF/wtf/PlatformHave.h:

Canonical link: <a href="https://commits.webkit.org/270970@main">https://commits.webkit.org/270970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c94f33e3bfc2bd322e8835de02bfe53ffc7ead

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24426 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3757 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/27010 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29696 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23394 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30042 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26037 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27950 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/26622 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23778 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33488 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6471 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4298 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7244 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->