### PR TITLE
[MSE] Change canPlayThroughRange to check buffered data at the current position https://bugs.webkit.org/show_bug.cgi?id=265023

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-resume-after-stall-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-stall-expected.txt
@@ -16,6 +16,10 @@ RUN(sourceBuffer.appendBuffer(loader.mediaSegment(2)))
 EVENT(update)
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(3)))
 EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(4)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(5)))
+EVENT(update)
 EXPECTED (video.currentTime >= '3.5') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-managedmse-resume-after-stall.html
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-stall.html
@@ -35,19 +35,26 @@
         run('sourceBuffer.appendBuffer(loader.initSegment())');
         await waitFor(sourceBuffer, 'update');
 
+        // Buffer a minimum of 3s to reach canPlayThrough and therefore autoplay.
         run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
         await waitFor(sourceBuffer, 'update');
         run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
         await waitFor(sourceBuffer, 'update');
-
-        await sleepFor(2000);
-        sourceBuffer.timestampOffset = -0.5;
-
         run('sourceBuffer.appendBuffer(loader.mediaSegment(2))');
         await waitFor(sourceBuffer, 'update');
+
+        await sleepFor(3000);
+        sourceBuffer.timestampOffset = -0.5;
+
+        // Again, buffer a minimum of 3s, see reasons above.
         run('sourceBuffer.appendBuffer(loader.mediaSegment(3))');
         await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(4))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(5))');
+        await waitFor(sourceBuffer, 'update');
 
+        // Marching beyond 3s (range buffered before the stall) is enough to prove that playback has continued.
         await testExpectedEventually("video.currentTime", 3.5, ">=");
 
         endTest();

--- a/LayoutTests/media/media-source/media-source-monitor-playing-event-expected.txt
+++ b/LayoutTests/media/media-source/media-source-monitor-playing-event-expected.txt
@@ -16,7 +16,7 @@ RUN(sourceBuffer.appendBuffer(sample))
 EVENT(canplaythrough)
 EVENT(playing)
 EVENT(updateend)
-video.readyState : HAVE_ENOUGH_DATA
+EXPECTED (video.readyState >= readyStateString.indexOf("HAVE_CURRENT_DATA") == 'true') OK
 RUN(sourceBuffer.remove(0,10))
 EVENT(waiting)
 EVENT(updateend)

--- a/LayoutTests/media/media-source/media-source-monitor-playing-event.html
+++ b/LayoutTests/media/media-source/media-source-monitor-playing-event.html
@@ -11,7 +11,6 @@
     var sample;
     var handleVideoEvents = [
         "loadstart",
-        "waiting",
         "loadedmetadata",
         "loadeddata",
         "canplay",
@@ -62,18 +61,26 @@
         run('sourceBuffer.appendBuffer(sample)');
         await Promise.all([waitFor(mediaElement, 'playing'), waitFor(sourceBuffer, 'updateend')]);
 
-        consoleWrite('video.readyState : ' + readyStateString[video.readyState]);
+        // As per the MockMediaPlayerMediaSource implementation, currentTime=10 (the maximum playable time) at
+        // this point, right after playback has started (at least in WebKitGTK), so we no longer have
+        // HAVE_ENOUGH_DATA. We have HAVE_CURRENT_DATA instead. We can't test for HAVE_ENOUGH_DATA and for
+        // canplaythrough at the same time in a single test with the current MockMediaPlayerMediaSource
+        // implementation. However, we get HAVE_ENOUGH_DATA on some Apple implementations. To avoid problems,
+        // let's just check for >= HAVE_CURRENT_DATA.
+        testExpected('video.readyState >= readyStateString.indexOf("HAVE_CURRENT_DATA")', true);
         // This remove changes ready state to HAVE_METADATA.
         run('sourceBuffer.remove(0,10)');
-        await waitFor(sourceBuffer, 'updateend');
+        // Waiting is time-dependant and can happen more than once. We're only interested in at least one occurence.
+        await Promise.all([waitFor(mediaElement, 'waiting'), waitFor(sourceBuffer, 'updateend')]);
 
         consoleWrite('video.readyState : ' + readyStateString[video.readyState]);
         sample = makeASample(0, 0, 1, 1, 1, SAMPLE_FLAG.SYNC, 1);
         run('sourceBuffer.appendBuffer(sample)');
         await waitFor(sourceBuffer, 'updateend');
 
+        // Append at least 3s more than currentTime (10) to create an additional playable range that can trigger canPlayThrough.
         consoleWrite('video.readyState : ' + readyStateString[video.readyState]);
-        sample = makeASample(1, 1, 9, 1, 1, SAMPLE_FLAG.SYNC, 1);
+        sample = makeASample(1, 1, 12, 1, 1, SAMPLE_FLAG.SYNC, 1);
         // This append changes the ready state to HAVE_ENOUGH_DATA and fires the playing event.
         run('sourceBuffer.appendBuffer(sample)');
         await Promise.all([waitFor(mediaElement, 'playing'), waitFor(sourceBuffer, 'updateend')]);

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -89,7 +89,6 @@ SourceBuffer::SourceBuffer(Ref<SourceBufferPrivate>&& sourceBufferPrivate, Media
     , m_appendWindowStart(MediaTime::zeroTime())
     , m_appendWindowEnd(MediaTime::positiveInfiniteTime())
     , m_appendState(WaitingForSegment)
-    , m_timeOfBufferingMonitor(MonotonicTime::fromRawSeconds(0))
     , m_buffered(TimeRanges::create())
 #if !RELEASE_LOG_DISABLED
     , m_logger(m_private->sourceBufferLogger())
@@ -229,7 +228,6 @@ ExceptionOr<void> SourceBuffer::setAppendWindowEnd(double newValue)
 
 ExceptionOr<void> SourceBuffer::appendBuffer(const BufferSource& data)
 {
-    monitorBufferingRate();
     return appendBufferInternal(static_cast<const unsigned char*>(data.data()), data.length());
 }
 
@@ -592,7 +590,6 @@ void SourceBuffer::sourceBufferPrivateAppendComplete(MediaPromise::Result&& resu
     scheduleEvent(eventNames().updateendEvent);
 
     m_source->monitorSourceBuffers();
-    monitorBufferingRate();
     m_private->reenqueueMediaIfNeeded(m_source->currentTime());
 
     ALWAYS_LOG(LOGIDENTIFIER, "buffered = ", m_buffered->ranges(), ", totalBufferSize: ", m_private->totalTrackBufferSizeInBytes());
@@ -1123,11 +1120,6 @@ void SourceBuffer::textTrackLanguageChanged(TextTrack& track)
         m_textTracks->scheduleChangeEvent();
 }
 
-void SourceBuffer::sourceBufferPrivateDidParseSample(double frameDuration)
-{
-    m_bufferedSinceLastMonitor += frameDuration;
-}
-
 Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDurationChanged(const MediaTime& duration)
 {
     if (isRemoved())
@@ -1150,51 +1142,28 @@ void SourceBuffer::sourceBufferPrivateDidDropSample()
         m_source->mediaElement()->incrementDroppedFrameCount();
 }
 
-void SourceBuffer::monitorBufferingRate()
-{
-    // We avoid the first update of m_averageBufferRate on purpose, but in exchange we get a more accurate m_timeOfBufferingMonitor initial time.
-    if (!m_timeOfBufferingMonitor) {
-        m_timeOfBufferingMonitor = MonotonicTime::now();
-        return;
-    }
-
-    MonotonicTime now = MonotonicTime::now();
-    Seconds interval = now - m_timeOfBufferingMonitor;
-    double rateSinceLastMonitor = m_bufferedSinceLastMonitor / interval.seconds();
-
-    m_timeOfBufferingMonitor = now;
-    m_bufferedSinceLastMonitor = 0;
-
-    m_averageBufferRate += (interval.seconds() * ExponentialMovingAverageCoefficient) * (rateSinceLastMonitor - m_averageBufferRate);
-
-    DEBUG_LOG(LOGIDENTIFIER, m_averageBufferRate);
-}
-
 bool SourceBuffer::canPlayThroughRange(const PlatformTimeRanges& ranges)
 {
     if (isRemoved())
         return false;
 
-    monitorBufferingRate();
-
-    // Assuming no fluctuations in the buffering rate, loading 1 second per second or greater
-    // means indefinite playback. This could be improved by taking jitter into account.
-    if (m_averageBufferRate > 1)
-        return true;
-
-    // Add up all the time yet to be buffered.
-    MediaTime currentTime = m_source->currentTime();
     MediaTime duration = m_source->duration();
+    if (!duration.isValid())
+        return false;
 
-    PlatformTimeRanges unbufferedRanges = ranges;
-    unbufferedRanges.invert();
-    unbufferedRanges.intersectWith(PlatformTimeRanges(currentTime, std::max(currentTime, duration)));
-    MediaTime unbufferedTime = unbufferedRanges.totalDuration();
-    if (!unbufferedTime.isValid())
+    MediaTime currentTime = m_source->currentTime();
+    if (duration <= currentTime)
         return true;
 
-    MediaTime timeRemaining = duration - currentTime;
-    return unbufferedTime.toDouble() / m_averageBufferRate < timeRemaining.toDouble();
+    // If we have data up to the mediasource's duration or 3s ahead, we can
+    // assume that we can play without interruption.
+    MediaTime bufferedEnd = ranges.maximumBufferedTime();
+    // Same tolerance as contiguousFrameTolerance in SourceBufferPrivate::processMediaSample(),
+    // to account for small errors.
+    const MediaTime tolerance = MediaTime(1, 1000);
+    MediaTime timeAhead = std::min(duration, currentTime + MediaTime(3, 1)) - tolerance;
+
+    return bufferedEnd >= timeAhead;
 }
 
 void SourceBuffer::reportExtraMemoryAllocated(uint64_t extraMemory)

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -165,7 +165,6 @@ private:
     Ref<MediaPromise> sourceBufferPrivateBufferedChanged(const Vector<PlatformTimeRanges>&, uint64_t) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;
     Ref<MediaPromise> sourceBufferPrivateDurationChanged(const MediaTime& duration) final;
-    void sourceBufferPrivateDidParseSample(double sampleDuration) final;
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
 
@@ -201,8 +200,6 @@ private:
     bool validateInitializationSegment(const InitializationSegment&);
 
     uint64_t maximumBufferSize() const;
-
-    void monitorBufferingRate();
 
     void reportExtraMemoryAllocated(uint64_t extraMemory);
 
@@ -244,9 +241,6 @@ private:
     enum AppendStateType { WaitingForSegment, ParsingInitSegment, ParsingMediaSegment };
     AppendStateType m_appendState;
 
-    MonotonicTime m_timeOfBufferingMonitor;
-    double m_bufferedSinceLastMonitor { 0 };
-    double m_averageBufferRate { 0 };
     bool m_bufferedDirty { true };
 
     // Can only grow.

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -971,6 +971,7 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
         // For instance, most WebM files are muxed rounded to the millisecond (the default TimecodeScale of the format)
         // but their durations use a finer timescale (causing a sub-millisecond overlap). More rarely, there are also
         // MP4 files with slightly off tfdt boxes, presenting a similar problem at the beginning of each fragment.
+        // Same as tolerance in SourceBuffer::canPlayThroughRange().
         const MediaTime contiguousFrameTolerance = MediaTime(1, 1000);
 
         // If highest presentation timestamp for track buffer is set and less than or equal to presentation timestamp
@@ -1106,8 +1107,6 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
 
         auto presentationEndTime = presentationTimestamp + frameDuration;
         trackBuffer.addBufferedRange(presentationTimestamp, presentationEndTime, AddTimeRangeOption::EliminateSmallGaps);
-        client.sourceBufferPrivateDidParseSample(frameDuration.toDouble());
-
         break;
     } while (true);
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -73,7 +73,6 @@ public:
     virtual Ref<MediaPromise> sourceBufferPrivateBufferedChanged(const Vector<PlatformTimeRanges>&, uint64_t) = 0;
     virtual Ref<MediaPromise> sourceBufferPrivateDurationChanged(const MediaTime&) = 0;
     virtual void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) = 0;
-    virtual void sourceBufferPrivateDidParseSample(double frameDuration) = 0;
     virtual void sourceBufferPrivateDidDropSample() = 0;
     virtual void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) = 0;
 };

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -141,14 +141,6 @@ Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged(co
     });
 }
 
-void RemoteSourceBufferProxy::sourceBufferPrivateDidParseSample(double sampleDuration)
-{
-    if (!m_connectionToWebProcess)
-        return;
-
-    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateDidParseSample(sampleDuration), m_identifier);
-}
-
 void RemoteSourceBufferProxy::sourceBufferPrivateDidDropSample()
 {
     if (!m_connectionToWebProcess)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -72,7 +72,6 @@ private:
     Ref<WebCore::MediaPromise> sourceBufferPrivateBufferedChanged(const Vector<WebCore::PlatformTimeRanges>&, uint64_t) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;
     Ref<WebCore::MediaPromise> sourceBufferPrivateDurationChanged(const MediaTime&) final;
-    void sourceBufferPrivateDidParseSample(double sampleDuration) final;
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -450,12 +450,6 @@ void SourceBufferPrivateRemote::sourceBufferPrivateBufferedChanged(Vector<WebCor
         completionHandler();
 }
 
-void SourceBufferPrivateRemote::sourceBufferPrivateDidParseSample(double sampleDuration)
-{
-    if (RefPtr client = this->client())
-        client->sourceBufferPrivateDidParseSample(sampleDuration);
-}
-
 void SourceBufferPrivateRemote::sourceBufferPrivateDidDropSample()
 {
     if (RefPtr client = this->client())

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -115,7 +115,6 @@ private:
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
     void sourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges>&&, uint64_t, CompletionHandler<void()>&&);
     void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&);
-    void sourceBufferPrivateDidParseSample(double sampleDuration);
     void sourceBufferPrivateDidDropSample();
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
     MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) override;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
@@ -31,7 +31,6 @@ messages -> SourceBufferPrivateRemote NotRefCounted {
     SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)
     SourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges> trackBuffers, uint64_t extraMemory) -> ()
     SourceBufferPrivateDurationChanged(MediaTime duration) -> ()
-    SourceBufferPrivateDidParseSample(double sampleDuration)
     SourceBufferPrivateDidDropSample()
     SourceBufferPrivateDidReceiveRenderingError(int64_t errorCode)
 }


### PR DESCRIPTION
#### c55cda1034c1186dcc545119f1e5f108b86a5159
<pre>
[MSE] Change canPlayThroughRange to check buffered data at the current position <a href="https://bugs.webkit.org/show_bug.cgi?id=265023">https://bugs.webkit.org/show_bug.cgi?id=265023</a>

Reviewed by Xabier Rodriguez-Calvar.

The current SourceBuffer::canPlayThroughRange() implementation is based on average buffering
rate. While this approach makes sense in a context of continuous playback, where the JS app
is always trying to append data, this isn&apos;t always the case in some real life apps. For
instance, an app may append a lot of data on page load (enough for sustained playback), then
decide to wait for whatever reason, and then start playback. In those circumstances, wait
would cause the average buffering rate to be artificially low. There are more examples of
the kind of problems that a time-based/average buffering rate-based approach may cause.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/928">https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/928</a>

This patch uses the Firefox strategy to this problem[1]: if the ranges to be checked have 3
seconds or more buffered after the current position, we consider that sustained playback is
possible. This solves the issues seen in some real world apps.

All the logic to monitor and compute the buffering rate has been removed, because it would
have remained unused after this change.

Based on code from Arnaud Vrac &lt;avrac@freebox.fr&gt; and Jean-Yves Avenard &lt;jyavenard@mozilla.com&gt;.

[1] <a href="https://github.com/mozilla/gecko-dev/blob/master/dom/media/mediasource/MediaSourceDecoder.cpp#L320">https://github.com/mozilla/gecko-dev/blob/master/dom/media/mediasource/MediaSourceDecoder.cpp#L320</a>

* LayoutTests/media/media-source/media-source-monitor-playing-event-expected.txt: Changed expectation after second append to be HAVE_CURRENT_DATA instead of HAVE_ENOUGH_DATA because the current playback implementation in MockMediaPlayerMediaSource advances playback to the end of the buffered range, so there&apos;s no 3s buffered slack after that (needed to get enough data).
* LayoutTests/media/media-source/media-source-monitor-playing-event.html: Added some clarification comments. Coalesce multiple &apos;waiting&apos; events, since they&apos;re time dependant and can change between platforms.
* LayoutTests/media/media-source/media-managedmse-resume-after-stall-expected.txt: Changed expectation to conform to 3s + 3s buffered segments.
* LayoutTests/media/media-source/media-managedmse-resume-after-stall.html: Buffer a minimum of 3s (3 segments) instead of 2, because 3s is the new limit to reach canPlayThrough.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::appendBuffer): Remove call to monitorBufferingRate().
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete): Ditto.
(WebCore::SourceBuffer::canPlayThroughRange): Removed implementation based on m_averageBufferRate. Now return true if the ranges have at least 3 seconds of data after currentTime (with a special case that accounts for the end of the video). Use a tolerance to prevent small errors.
(WebCore::SourceBuffer::sourceBufferPrivateDidParseSample): Deleted.
(WebCore::SourceBuffer::monitorBufferingRate): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h: Deleted sourceBufferPrivateDidParseSample() and monitorBufferingRate().
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample): Remove call to sourceBufferPrivateDidParseSample(). Added comment about the tolerance being the same as in SourceBuffer::canPlayThroughRange().
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h: Deleted sourceBufferPrivateDidParseSample().
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidParseSample): Deleted.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h: Deleted sourceBufferPrivateDidParseSample().
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidParseSample): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h: Deleted sourceBufferPrivateDidParseSample().
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in: Deleted sourceBufferPrivateDidParseSample message.

Canonical link: <a href="https://commits.webkit.org/272762@main">https://commits.webkit.org/272762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03423fa97b2e3910794d743a20a7cf8bddc5c17d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8935 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36970 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34926 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8933 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32781 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29090 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7649 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->