### PR TITLE
[macOS] Create a VPIO unit in a background thread

### DIFF
--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -876,6 +876,11 @@ private:
         // Defined -> operator for consistency in calling pattern.
         ThenCommand* operator->() { return this; }
 
+        operator RefPtr<PromiseType>()
+        {
+            return Ref<PromiseType>(*this);
+        }
+
         // Allow conversion from ThenCommand to Ref<NativePromise> like:
         // Ref<NativePromise> p = somePromise->then(...);
         // p->then(thread1, ...);

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -55,6 +55,7 @@ public:
     virtual bool isProducingData() const = 0;
 
     virtual void delaySamples(Seconds) { }
+    virtual void prewarmAudioUnitCreation(CompletionHandler<void()>&& callback) { callback(); };
 
     void prepareForNewCapture();
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -343,6 +343,15 @@ void CoreAudioCaptureSource::setIsInBackground(bool value)
 }
 #endif
 
+#if PLATFORM(MAC)
+void CoreAudioCaptureSource::whenReady(CompletionHandler<void(CaptureSourceError&&)>&& callback)
+{
+    unit().prewarmAudioUnitCreation([callback = WTFMove(callback)] () mutable {
+        callback({ });
+    });
+}
+#endif
+
 void CoreAudioCaptureSource::audioUnitWillStart()
 {
     forEachObserver([](auto& observer) {

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -88,6 +88,9 @@ private:
 #if PLATFORM(IOS_FAMILY)
     void setIsInBackground(bool) final;
 #endif
+#if PLATFORM(MAC)
+    void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
+#endif
 
     std::optional<Vector<int>> discreteSampleRates() const final { return { { 8000, 16000, 32000, 44100, 48000, 96000 } }; }
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -42,8 +42,10 @@
 #include <wtf/Algorithms.h>
 #include <wtf/Lock.h>
 #include <wtf/MainThread.h>
+#include <wtf/NativePromise.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
+#include <wtf/WorkQueue.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "AVAudioSessionCaptureDeviceManager.h"
@@ -63,11 +65,16 @@ namespace WebCore {
 const UInt32 outputBus = 0;
 const UInt32 inputBus = 1;
 
+void CoreAudioSharedUnit::AudioUnitDeallocator::operator()(AudioUnit unit) const
+{
+    PAL::AudioComponentInstanceDispose(unit);
+}
+
 class CoreAudioSharedInternalUnit final :  public CoreAudioSharedUnit::InternalUnit {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Expected<UniqueRef<InternalUnit>, OSStatus> create(bool shouldUseVPIO);
-    CoreAudioSharedInternalUnit(AudioUnit, bool shouldUseVPIO);
+    CoreAudioSharedInternalUnit(CoreAudioSharedUnit::StoredAudioUnit&&, bool shouldUseVPIO);
     ~CoreAudioSharedInternalUnit() final;
 
 private:
@@ -80,22 +87,13 @@ private:
     OSStatus render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32, UInt32, AudioBufferList*) final;
     OSStatus defaultInputDevice(uint32_t*) final;
     OSStatus defaultOutputDevice(uint32_t*) final;
-    void storeVPIOUnitIfNeeded() final;
 
-    AudioUnit m_ioUnit { nullptr };
+    CoreAudioSharedUnit::StoredAudioUnit m_ioUnit;
     bool m_shouldUseVPIO { false };
 };
 
-Expected<UniqueRef<CoreAudioSharedUnit::InternalUnit>, OSStatus> CoreAudioSharedInternalUnit::create(bool shouldUseVPIO)
+static Expected<CoreAudioSharedUnit::StoredAudioUnit, OSStatus> createAudioUnit(bool shouldUseVPIO)
 {
-    if (shouldUseVPIO) {
-        if (auto ioUnit = CoreAudioSharedUnit::unit().takeStoredVPIOUnit()) {
-            RELEASE_LOG(WebRTC, "Creating a CoreAudioSharedInternalUnit wilth a stored VPIO unit");
-            UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(ioUnit, shouldUseVPIO);
-            return result;
-        }
-    }
-
     OSType unitSubType = kAudioUnitSubType_VoiceProcessingIO;
     if (!shouldUseVPIO) {
 #if PLATFORM(MAC)
@@ -130,63 +128,77 @@ Expected<UniqueRef<CoreAudioSharedUnit::InternalUnit>, OSStatus> CoreAudioShared
         return makeUnexpected(err);
     }
 
-    RELEASE_LOG(WebRTC, "Successfully created a CoreAudioSharedInternalUnit");
+    return CoreAudioSharedUnit::StoredAudioUnit(ioUnit);
+}
 
-    UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(ioUnit, shouldUseVPIO);
+Expected<UniqueRef<CoreAudioSharedUnit::InternalUnit>, OSStatus> CoreAudioSharedInternalUnit::create(bool shouldUseVPIO)
+{
+#if PLATFORM(MAC)
+    if (shouldUseVPIO) {
+        if (auto ioUnit = CoreAudioSharedUnit::unit().takeStoredVPIOUnit()) {
+            RELEASE_LOG(WebRTC, "Creating a CoreAudioSharedInternalUnit with a stored VPIO unit");
+            UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(WTFMove(ioUnit), shouldUseVPIO);
+            return result;
+        }
+    }
+#endif
+
+    auto audioUnitOrError = createAudioUnit(shouldUseVPIO);
+    if (!audioUnitOrError.has_value())
+        return makeUnexpected(audioUnitOrError.error());
+
+    RELEASE_LOG(WebRTC, "Successfully created a CoreAudioSharedInternalUnit");
+    UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(WTFMove(audioUnitOrError.value()), shouldUseVPIO);
     return result;
 }
 
-CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit(AudioUnit ioUnit, bool shouldUseVPIO)
-    : m_ioUnit(ioUnit)
+CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit(CoreAudioSharedUnit::StoredAudioUnit&& ioUnit, bool shouldUseVPIO)
+    : m_ioUnit(WTFMove(ioUnit))
     , m_shouldUseVPIO(shouldUseVPIO)
 {
 }
 
 CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit()
 {
-    if (!CoreAudioSharedUnit::unit().iStoredVPIOUnit(m_ioUnit))
-        PAL::AudioComponentInstanceDispose(m_ioUnit);
-}
-
-void CoreAudioSharedInternalUnit::storeVPIOUnitIfNeeded()
-{
+#if PLATFORM(MAC)
     if (m_shouldUseVPIO)
-        CoreAudioSharedUnit::unit().setStoredVPIOUnit(m_ioUnit);
+        CoreAudioSharedUnit::unit().setStoredVPIOUnit(std::exchange(m_ioUnit, { }));
+#endif
 }
 
 OSStatus CoreAudioSharedInternalUnit::initialize()
 {
-    return PAL::AudioUnitInitialize(m_ioUnit);
+    return PAL::AudioUnitInitialize(m_ioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::uninitialize()
 {
-    return PAL::AudioUnitUninitialize(m_ioUnit);
+    return PAL::AudioUnitUninitialize(m_ioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::start()
 {
-    return PAL::AudioOutputUnitStart(m_ioUnit);
+    return PAL::AudioOutputUnitStart(m_ioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::stop()
 {
-    return PAL::AudioOutputUnitStop(m_ioUnit);
+    return PAL::AudioOutputUnitStop(m_ioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::set(AudioUnitPropertyID propertyID, AudioUnitScope scope, AudioUnitElement element, const void* value, UInt32 size)
 {
-    return PAL::AudioUnitSetProperty(m_ioUnit, propertyID, scope, element, value, size);
+    return PAL::AudioUnitSetProperty(m_ioUnit.get(), propertyID, scope, element, value, size);
 }
 
 OSStatus CoreAudioSharedInternalUnit::get(AudioUnitPropertyID propertyID, AudioUnitScope scope, AudioUnitElement element, void* value, UInt32* size)
 {
-    return PAL::AudioUnitGetProperty(m_ioUnit, propertyID, scope, element, value, size);
+    return PAL::AudioUnitGetProperty(m_ioUnit.get(), propertyID, scope, element, value, size);
 }
 
 OSStatus CoreAudioSharedInternalUnit::render(AudioUnitRenderActionFlags* ioActionFlags, const AudioTimeStamp* inTimeStamp, UInt32 inOutputBusNumber, UInt32 inNumberFrames, AudioBufferList* list)
 {
-    return PAL::AudioUnitRender(m_ioUnit, ioActionFlags, inTimeStamp, inOutputBusNumber, inNumberFrames, list);
+    return PAL::AudioUnitRender(m_ioUnit.get(), ioActionFlags, inTimeStamp, inOutputBusNumber, inNumberFrames, list);
 }
 
 OSStatus CoreAudioSharedInternalUnit::defaultInputDevice(uint32_t* deviceID)
@@ -241,14 +253,14 @@ CoreAudioSharedUnit::CoreAudioSharedUnit()
 
 CoreAudioSharedUnit::~CoreAudioSharedUnit()
 {
-    ASSERT(!m_storedVPIOUnit);
 }
 
-void CoreAudioSharedUnit::setStoredVPIOUnit(AudioUnit unit)
+#if PLATFORM(MAC)
+void CoreAudioSharedUnit::setStoredVPIOUnit(StoredAudioUnit&& unit)
 {
-    ASSERT(!m_storedVPIOUnit);
-    m_storedVPIOUnit = unit;
+    m_storedVPIOUnit = WTFMove(unit);
 }
+#endif
 
 void CoreAudioSharedUnit::resetSampleRate()
 {
@@ -577,16 +589,6 @@ OSStatus CoreAudioSharedUnit::reconfigureAudioUnit()
         }
     }
 
-#if PLATFORM(MAC)
-    m_ioUnit->storeVPIOUnitIfNeeded();
-    auto scopeVPIOUnit = makeScopeExit([this] {
-        if (auto unit = takeStoredVPIOUnit()) {
-            RELEASE_LOG_INFO(WebRTC, "CoreAudioSharedUnit::reconfigureAudioUnit disposing VPIO unit");
-            PAL::AudioComponentInstanceDispose(unit);
-        }
-    });
-#endif
-
     cleanupAudioUnit();
     if (auto err = setupAudioUnit())
         return err;
@@ -681,8 +683,22 @@ bool CoreAudioSharedUnit::migrateToNewDefaultDevice(const CaptureDevice& capture
     handleNewCurrentMicrophoneDevice(WTFMove(*device));
     return true;
 }
-#endif
 
+void CoreAudioSharedUnit::prewarmAudioUnitCreation(CompletionHandler<void()>&& callback)
+{
+    if (!m_audioUnitCreationWarmupPromise) {
+        m_audioUnitCreationWarmupPromise = invokeAsync(WorkQueue::create("CoreAudioSharedUnit AudioUnit creation").get(), [] {
+            return createAudioUnit(true);
+        })->whenSettled(RunLoop::main(), [weakThis = WeakPtr { *this }] (auto&& vpioUnitOrError) {
+            if (weakThis && vpioUnitOrError.has_value())
+                weakThis->setStoredVPIOUnit(WTFMove(vpioUnitOrError.value()));
+            return GenericNonExclusivePromise::createAndResolve();
+        });
+    }
+
+    m_audioUnitCreationWarmupPromise->whenSettled(RunLoop::main(), WTFMove(callback));
+}
+#endif
 
 void CoreAudioSharedUnit::verifyIsCapturing()
 {

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -42,8 +42,10 @@ struct AudioTimeStamp;
 
 #if TARGET_OS_IPHONE || (defined(AUDIOCOMPONENT_NOCARBONINSTANCES) && AUDIOCOMPONENT_NOCARBONINSTANCES)
 typedef struct OpaqueAudioComponentInstance* AudioComponentInstance;
+using AudioUnitStruct = OpaqueAudioComponentInstance;
 #else
 typedef struct ComponentInstanceRecord* AudioComponentInstance;
+using AudioUnitStruct = ComponentInstanceRecord;
 #endif
 typedef AudioComponentInstance AudioUnit;
 
@@ -71,7 +73,6 @@ public:
         virtual OSStatus defaultOutputDevice(uint32_t*) = 0;
         virtual void delaySamples(Seconds) { }
         virtual Seconds verifyCaptureInterval(bool isProducingSamples) const { return isProducingSamples ? 20_s : 2_s; }
-        virtual void storeVPIOUnitIfNeeded() { }
     };
 
     WEBCORE_EXPORT static CoreAudioSharedUnit& unit();
@@ -96,9 +97,15 @@ public:
 
     bool isUsingVPIO() const { return m_shouldUseVPIO; }
 
-    void setStoredVPIOUnit(AudioUnit);
-    bool iStoredVPIOUnit(AudioUnit unit) const { return unit == m_storedVPIOUnit; }
-    AudioUnit takeStoredVPIOUnit() { return std::exchange(m_storedVPIOUnit, nullptr); }
+    struct AudioUnitDeallocator {
+        void operator()(AudioUnit) const;
+    };
+    using StoredAudioUnit = std::unique_ptr<AudioUnitStruct, AudioUnitDeallocator>;
+
+#if PLATFORM(MAC)
+    void setStoredVPIOUnit(StoredAudioUnit&&);
+    StoredAudioUnit takeStoredVPIOUnit() { return std::exchange(m_storedVPIOUnit, nullptr); }
+#endif
 
 private:
     static size_t preferredIOBufferSize();
@@ -120,6 +127,7 @@ private:
     void validateOutputDevice(uint32_t deviceID) final;
 #if PLATFORM(MAC)
     bool migrateToNewDefaultDevice(const CaptureDevice&) final;
+    void prewarmAudioUnitCreation(CompletionHandler<void()>&&) final;
 #endif
     int actualSampleRate() const final;
     void resetSampleRate();
@@ -183,7 +191,10 @@ private:
 #endif
 
     bool m_shouldUseVPIO { true };
-    AudioUnit m_storedVPIOUnit { nullptr };
+#if PLATFORM(MAC)
+    StoredAudioUnit m_storedVPIOUnit { nullptr };
+    RefPtr<GenericNonExclusivePromise> m_audioUnitCreationWarmupPromise;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -524,12 +524,20 @@ void UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstrai
     auto proxy = makeUnique<SourceProxy>(id, WTFMove(connection), ProcessIdentity { m_connectionProxy->resourceOwner() }, WTFMove(source), WTFMove(remoteVideoFrameObjectHeap));
     proxy->observeMedia();
 
-    auto completeSetup = [this](std::unique_ptr<SourceProxy>&& proxy, RealtimeMediaSourceIdentifier id, CreateSourceCallback&& completionHandler) mutable {
-        auto settings = proxy->settings();
-        auto capabilities = proxy->source().capabilities();
-        m_proxies.add(id, WTFMove(proxy));
+    auto completeSetup = [weakThis = WeakPtr { *this }, this](std::unique_ptr<SourceProxy>&& proxy, RealtimeMediaSourceIdentifier id, CreateSourceCallback&& completionHandler) mutable {
+        if (!weakThis) {
+            completionHandler({ "Capture proxy disappeared"_s, WebCore::MediaAccessDenialReason::OtherFailure }, { }, { });
+            return;
+        }
 
-        completionHandler({ }, WTFMove(settings), WTFMove(capabilities));
+        proxy->source().whenReady([completionHandler = WTFMove(completionHandler), proxy = WeakPtr { *proxy }] (auto&& error) mutable {
+            if (!!error || !proxy) {
+                completionHandler(error, { }, { });
+                return;
+            }
+            completionHandler({ }, proxy->settings(), proxy->source().capabilities());
+        });
+        m_proxies.add(id, WTFMove(proxy));
     };
 
     if (!constraints || proxy->source().type() != RealtimeMediaSource::Type::Video) {

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -85,7 +85,7 @@ private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    using CreateSourceCallback = CompletionHandler<void(WebCore::CaptureSourceError&&, WebCore::RealtimeMediaSourceSettings&&, WebCore::RealtimeMediaSourceCapabilities&&)>;
+    using CreateSourceCallback = CompletionHandler<void(const WebCore::CaptureSourceError&, const WebCore::RealtimeMediaSourceSettings&, const WebCore::RealtimeMediaSourceCapabilities&)>;
     void createMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice& deviceID, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints&, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier, CreateSourceCallback&&);
     void startProducingData(WebCore::RealtimeMediaSourceIdentifier);
     void stopProducingData(WebCore::RealtimeMediaSourceIdentifier);


### PR DESCRIPTION
#### 4f1a121947d3614fbc3edf5f372ec7c297c38074
<pre>
[macOS] Create a VPIO unit in a background thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=265017">https://bugs.webkit.org/show_bug.cgi?id=265017</a>
<a href="https://rdar.apple.com/118520768">rdar://118520768</a>

Reviewed by Jean-Yves Avenard.

A VPIO Unit may take a few seconds to be created.
This might block the GPU process main thread, which might block the WebProcess main thread.
The impact might be a page freeze.
To prevent this, we create the VPIO unit in a background queue and asynchronously start capturing.

To do so, CoreAudioCaptureSource is implementing RealtimeMediaSource::whenReady, where we prewarm the audio unit.
The impact is to delay the resolution of the getUserMedia promise.

To improve the handling of AudioUnit, we introduce StoredAudioUnit to make sure we always dispose a created audio unit.
We then refactor the code to use move-only audio units.

Covered by existing tests in macOS with MockAudioSharedUnit.
Manually tested as well.

* Source/WTF/wtf/NativePromise.h:
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::prewarmAudioUnitCreation):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::whenReady):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::AudioUnitDeallocator::operator() const):
(WebCore::createAudioUnit):
(WebCore::CoreAudioSharedInternalUnit::create):
(WebCore::CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit):
(WebCore::CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit):
(WebCore::CoreAudioSharedInternalUnit::initialize):
(WebCore::CoreAudioSharedInternalUnit::uninitialize):
(WebCore::CoreAudioSharedInternalUnit::start):
(WebCore::CoreAudioSharedInternalUnit::stop):
(WebCore::CoreAudioSharedInternalUnit::set):
(WebCore::CoreAudioSharedInternalUnit::get):
(WebCore::CoreAudioSharedInternalUnit::render):
(WebCore::CoreAudioSharedUnit::~CoreAudioSharedUnit):
(WebCore::CoreAudioSharedUnit::setStoredVPIOUnit):
(WebCore::CoreAudioSharedUnit::reconfigureAudioUnit):
(WebCore::CoreAudioSharedUnit::migrateToNewDefaultDevice):
(WebCore::CoreAudioSharedUnit::prewarmAudioUnitCreation):
(WebCore::CoreAudioSharedInternalUnit::storeVPIOUnitIfNeeded): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):

Canonical link: <a href="https://commits.webkit.org/271050@main">https://commits.webkit.org/271050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb8f9925a924110cac1f11861559a3aabb64930b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24685 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30024 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23647 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30309 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26357 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28236 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5629 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33813 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6549 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4622 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7321 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->