### PR TITLE
Fix build with -DENABLE_GPU_PROCESS=ON in GPUConnectionToWebProcess.cpp

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
@@ -74,7 +74,7 @@ struct DMABufReleaseFlag {
             return;
 
         uint64_t value { 1 };
-        if (write(fd.value(), &value, sizeof(value)) != sizeof(value))
+        if (::write(fd.value(), &value, sizeof(value)) != sizeof(value))
             WTFLogAlways("Error writing to the eventfd at DMABufReleaseFlag: %s", safeStrerror(errno).data());
     }
 


### PR DESCRIPTION
#### 1ed9a7f11ad3d0a692896bc3d863e95ed3edea6c
<pre>
Fix build with -DENABLE_GPU_PROCESS=ON in GPUConnectionToWebProcess.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=265035">https://bugs.webkit.org/show_bug.cgi?id=265035</a>

Reviewed by Carlos Alberto Lopez Perez.

Explicitly use global namespace for write function from &lt;unistd.h&gt;.
This avoids the conflict with the WebCore::write() defined in
WebCore/PrivateHeaders/WebCore/RenderTreeAsText.h.

* Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h:

Canonical link: <a href="https://commits.webkit.org/271018@main">https://commits.webkit.org/271018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a4cbf8bda8c2a1d477efc8dee1136fd20d9950

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24613 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3947 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30235 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28152 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5515 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6510 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->