### PR TITLE
Fix build with -DENABLE_GPU_PROCESS=ON in FontPlatformDataFreeType.cpp

### DIFF
--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -322,4 +322,41 @@ HbUniquePtr<hb_font_t> FontPlatformData::createOpenTypeMathHarfBuzzFont() const
 }
 #endif
 
+FontPlatformData FontPlatformData::create(const Attributes& data, const FontCustomPlatformData* custom)
+{
+    static FcPattern* pattern = nullptr;
+    static bool fixedWidth = false;
+
+    RefPtr<cairo_font_face_t> fontFace;
+    if (custom && custom->m_fontFace)
+        fontFace = custom->m_fontFace;
+    else {
+        // Get some generic default settings from fontconfig for web fonts. Strategy
+        // from Behdad Esfahbod in https://code.google.com/p/chromium/issues/detail?id=173207#c35
+        // For web fonts, the hint style is overridden in FontCustomPlatformData::FontCustomPlatformData
+        // so Fontconfig will not affect the hint style, but it may disable hinting completely.
+        static std::once_flag flag;
+        std::call_once(flag, [](FcPattern*) {
+            pattern = FcPatternCreate();
+            FcConfigSubstitute(nullptr, pattern, FcMatchPattern);
+            cairo_ft_font_options_substitute(getDefaultCairoFontOptions(), pattern);
+            FcDefaultSubstitute(pattern);
+            FcPatternDel(pattern, FC_FAMILY);
+            FcConfigSubstitute(nullptr, pattern, FcMatchFont);
+        }, pattern);
+
+        int spacing;
+        if (FcPatternGetInteger(pattern, FC_SPACING, 0, &spacing) == FcResultMatch && spacing == FC_MONO)
+            fixedWidth = true;
+        fontFace = adoptRef(cairo_ft_font_face_create_for_pattern(pattern));
+    }
+
+    return FontPlatformData(fontFace.get(), adoptRef(pattern), data.m_size, fixedWidth, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, custom);
+}
+
+FontPlatformData::Attributes FontPlatformData::attributes() const
+{
+    return Attributes(m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique);
+}
+
 } // namespace WebCore


### PR DESCRIPTION
#### 231055e2de887f89b2856dd7af4c17a48e3dc337
<pre>
Fix build with -DENABLE_GPU_PROCESS=ON in FontPlatformDataFreeType.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=265037">https://bugs.webkit.org/show_bug.cgi?id=265037</a>

Reviewed by Carlos Garcia Campos.

Add the FontPlatformData::create() method for the freetype specialization
of the FontPlatformData factory.

The create() method brings back the lost code from the 4b35edbdccf87
&apos;[FreeType] Add initial implementation of variation fonts&apos; commit.

* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
(WebCore::FontPlatformData::create):
(WebCore::FontPlatformData::attributes const):

Canonical link: <a href="https://commits.webkit.org/271015@main">https://commits.webkit.org/271015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f79db6fd8fc2ca0c7499b2c0c6cfe0060b9e088d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24606 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30228 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28144 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5509 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6508 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4510 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->