### PR TITLE
Links using a border-bottom instead of text-decoration should still get the default InteractionRegion border-radius

### DIFF
--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -1,4 +1,4 @@
-This is a link. This is a wiki-style link. This is a link with visible edges. This is a JavaScript link. This link does nothing.
+This is a link. This is a wiki-style link. This is a link with visible edges. border-bottom link This is a JavaScript link. This link does nothing.
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -20,7 +20,9 @@ This is a link. This is a wiki-style link. This is a link with visible edges. Th
         (borderRadius 0.00),
         (interaction (250,0) width=29 height=19)
         (borderRadius 0.00),
-        (interaction (456,-4) width=38 height=27)
+        (interaction (456,-4) width=130 height=27)
+        (borderRadius 8.00),
+        (interaction (581,-4) width=38 height=27)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/inline-link.html
+++ b/LayoutTests/interaction-region/inline-link.html
@@ -7,6 +7,7 @@
 <a href="#">This</a> is a link.
 <a href="#" style="border: 0; background: none;">This</a> is a wiki-style link.
 <a href="#" style="background: green;">This</a> is a link with visible edges.
+<a href="#" style="text-decoration: none; border-bottom: 1px blue solid;">border-bottom link</a>
 <a onclick="alert('click!')">This</a> is a JavaScript link.
 <a>This</a> link does nothing.
 

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -311,7 +311,16 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         }
     }
 
-    if (!regionRenderer.hasVisibleBoxDecorations() && !renderer.hasVisibleBoxDecorations() && !renderer.style().hasExplicitlySetBorderRadius()) {
+    auto& style = regionRenderer.style();
+    bool canTweakShape = !style.hasBackground()
+        && !style.hasOutline()
+        && !style.boxShadow()
+        && !style.hasExplicitlySetBorderRadius()
+        // No visible borders or borders that do not create a complete box.
+        && (!style.hasVisibleBorder()
+            || !(style.borderTopWidth() && style.borderRightWidth() && style.borderBottomWidth() && style.borderLeftWidth()));
+
+    if (canTweakShape) {
         // We can safely tweak the bounds and radius without causing visual mismatch.
         borderRadius = std::max<float>(borderRadius, regionRenderer.document().settings().interactionRegionMinimumCornerRadius());
         if (isInlineNonBlock)


### PR DESCRIPTION
#### ce815ebcee431e984977ea22d1eec549ea29c100
<pre>
Links using a border-bottom instead of text-decoration should still get the default InteractionRegion border-radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=265040">https://bugs.webkit.org/show_bug.cgi?id=265040</a>
&lt;<a href="https://rdar.apple.com/118173683">rdar://118173683</a>&gt;

Reviewed by Tim Horton.

Instead of opting out of the default radius if any visible border is
present, check to see if the visible borders form a box around the
element.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Introduce a specific check to gate the default radius and region
inflation instead of relying on `hasVisibleBoxDecorations()`.

* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link.html:
Update the test to cover this case.

Canonical link: <a href="https://commits.webkit.org/271167@main">https://commits.webkit.org/271167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/273509b255808385e298ec924b413f5056732cbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29446 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29982 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27885 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6629 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->