### PR TITLE
[WebRTC] Make H265 packetizing more resilient to bad input

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.cc
@@ -17,6 +17,7 @@ namespace H265 {
 
 const uint8_t kNaluTypeMask = 0x7E;
 
+#ifndef WEBRTC_WEBKIT_BUILD
 std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
                                        size_t buffer_size) {
   std::vector<H264::NaluIndex> indices =
@@ -28,6 +29,7 @@ std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
   }
   return results;
 }
+#endif
 
 NaluType ParseNaluType(uint8_t data) {
   return static_cast<NaluType>((data & kNaluTypeMask) >> 1);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.h
@@ -14,6 +14,9 @@
 #include <memory>
 #include <vector>
 
+#ifdef WEBRTC_WEBKIT_BUILD
+#include "common_video/h264/h264_common.h"
+#endif
 #include "rtc_base/buffer.h"
 
 namespace webrtc {
@@ -58,6 +61,9 @@ enum NaluType : uint8_t {
 
 enum SliceType : uint8_t { kB = 0, kP = 1, kI = 2 };
 
+#ifdef WEBRTC_WEBKIT_BUILD
+using NaluIndex = H264::NaluIndex;
+#else
 struct NaluIndex {
   // Start index of NALU, including start sequence.
   size_t start_offset;
@@ -66,10 +72,18 @@ struct NaluIndex {
   // Length of NALU payload, in bytes, counting from payload_start_offset.
   size_t payload_size;
 };
+#endif
 
 // Returns a vector of the NALU indices in the given buffer.
+#ifdef WEBRTC_WEBKIT_BUILD
+inline std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
+                                              size_t buffer_size) {
+  return H264::FindNaluIndices(buffer, buffer_size);
+}
+#else
 std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
                                        size_t buffer_size);
+#endif
 
 // Get the NAL type from the header byte immediately following start sequence.
 NaluType ParseNaluType(uint8_t data);

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-Make-H265-packetizing-more-resilient-to-bad-input.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-Make-H265-packetizing-more-resilient-to-bad-input.patch
@@ -1,0 +1,137 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.cc
+index 6dc8a79ae35d..9307a5087d3b 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.cc
+@@ -17,6 +17,7 @@ namespace H265 {
+ 
+ const uint8_t kNaluTypeMask = 0x7E;
+ 
++#ifndef WEBRTC_WEBKIT_BUILD
+ std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
+                                        size_t buffer_size) {
+   std::vector<H264::NaluIndex> indices =
+@@ -28,6 +29,7 @@ std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
+   }
+   return results;
+ }
++#endif
+ 
+ NaluType ParseNaluType(uint8_t data) {
+   return static_cast<NaluType>((data & kNaluTypeMask) >> 1);
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.h b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.h
+index a829195a1007..459ee5b33b3e 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.h
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.h
+@@ -14,6 +14,9 @@
+ #include <memory>
+ #include <vector>
+ 
++#ifdef WEBRTC_WEBKIT_BUILD
++#include "common_video/h264/h264_common.h"
++#endif
+ #include "rtc_base/buffer.h"
+ 
+ namespace webrtc {
+@@ -58,6 +61,9 @@ enum NaluType : uint8_t {
+ 
+ enum SliceType : uint8_t { kB = 0, kP = 1, kI = 2 };
+ 
++#ifdef WEBRTC_WEBKIT_BUILD
++using NaluIndex = H264::NaluIndex;
++#else
+ struct NaluIndex {
+   // Start index of NALU, including start sequence.
+   size_t start_offset;
+@@ -66,10 +72,18 @@ struct NaluIndex {
+   // Length of NALU payload, in bytes, counting from payload_start_offset.
+   size_t payload_size;
+ };
++#endif
+ 
+ // Returns a vector of the NALU indices in the given buffer.
++#ifdef WEBRTC_WEBKIT_BUILD
++inline std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
++                                              size_t buffer_size) {
++  return H264::FindNaluIndices(buffer, buffer_size);
++}
++#else
+ std::vector<NaluIndex> FindNaluIndices(const uint8_t* buffer,
+                                        size_t buffer_size);
++#endif
+ 
+ // Get the NAL type from the header byte immediately following start sequence.
+ NaluType ParseNaluType(uint8_t data);
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
+index 9865d7cb8244..122eb98d4b38 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc
+@@ -8,7 +8,9 @@
+ 
+ #include "absl/types/optional.h"
+ #include "absl/types/variant.h"
++#ifndef WEBRTC_WEBKIT_BUILD
+ #include "common_video/h264/h264_common.h"
++#endif
+ #include "common_video/h265/h265_common.h"
+ #include "common_video/h265/h265_pps_parser.h"
+ #include "common_video/h265/h265_sps_parser.h"
+@@ -84,11 +86,19 @@ RtpPacketizerH265::RtpPacketizerH265(rtc::ArrayView<const uint8_t> payload,
+   RTC_CHECK(packetization_mode == H265PacketizationMode::NonInterleaved ||
+             packetization_mode == H265PacketizationMode::SingleNalUnit);
+ 
++#ifdef WEBRTC_WEBKIT_BUILD
++  for (const auto& nalu :
++       H265::FindNaluIndices(payload.data(), payload.size())) {
++    input_fragments_.push_back(
++        payload.subview(nalu.payload_start_offset, nalu.payload_size));
++  }
++#else
+   for (const auto& nalu :
+        H264::FindNaluIndices(payload.data(), payload.size())) {
+     input_fragments_.push_back(
+         payload.subview(nalu.payload_start_offset, nalu.payload_size));
+   }
++#endif
+ 
+   if (!GeneratePackets(packetization_mode)) {
+     // If failed to generate all the packets, discard already generated
+@@ -124,10 +134,22 @@ bool RtpPacketizerH265::GeneratePackets(
+       single_packet_capacity -= limits_.last_packet_reduction_len;
+     }
+     if (fragment_len > single_packet_capacity) {
++#ifdef WEBRTC_WEBKIT_BUILD
++      if (!PacketizeFu(i)) {
++        return false;
++      }
++#else
+       PacketizeFu(i);
++#endif
+       ++i;
+     } else {
++#ifdef WEBRTC_WEBKIT_BUILD
++      if (!PacketizeSingleNalu(i)) {
++        return false;
++      }
++#else
+       PacketizeSingleNalu(i);
++#endif
+       ++i;
+     }
+   }
+@@ -201,7 +223,13 @@ bool RtpPacketizerH265::PacketizeSingleNalu(size_t fragment_index) {
+                       << limits_.max_payload_len;
+     return false;
+   }
++#ifdef WEBRTC_WEBKIT_BUILD
++  if (fragment.size() == 0u) {
++    return false;
++  }
++#else
+   RTC_CHECK_GT(fragment.size(), 0u);
++#endif
+   packets_.push(PacketUnit(fragment, true /* first */, true /* last */,
+                            false /* aggregated */, fragment[0]));
+   ++num_packets_left_;
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
#### 7e7d41f82f4f250cf24d7f6b0e116ffefe42ef94
<pre>
[WebRTC] Make H265 packetizing more resilient to bad input
<a href="https://bugs.webkit.org/show_bug.cgi?id=265043">https://bugs.webkit.org/show_bug.cgi?id=265043</a>
&lt;<a href="https://rdar.apple.com/118460064">rdar://118460064</a>&gt;

Reviewed by Youenn Fablet.

Change a release assert to runtime failure to prevent easily hit
crashes.

Also improve performance of H265::FindNaluIndices() by making
H265::NaluIndex the same as H264::NaluIndex so there is no need to copy
identical data structures.

* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.cc:
(webrtc::H265::FindNaluIndices): Remove.
- This code is no longer necessary because all it did was call
  H264::FindNaluIndices() and then translate H264::NaluIndex objects to
  H265::NaluIndex objects.  Changes in h265_common.h make this code
  obsolete.
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_common.h:
(struct H265::NaluIndex):
- Change to make identical to H264::NaluIndex with a using statement.
(webrtc::H265::FindNaluIndices):
- Change to an inline method that calls H264::FindNaluIndices().

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h265.cc:
(webrtc::RtpPacketizerH265::RtpPacketizerH265):
- Fix typo that called H264::FindNaluIndices() instead of
  H265::FindNaluIndices().  Because of how H265::FindNaluIndices() was
  defined, this did not result in a bug, was likely a copy-paste
  mistake.
(webrtc::RtpPacketizerH265::GeneratePackets):
- Add missing checks for return values from PacketizeFu() and
  PacketizeSingleNalu().
(webrtc::RtpPacketizerH265::PacketizeSingleNalu):
- Change release assert into runtime check that returns early if
  fragment.size() is zero.

* Source/ThirdParty/libwebrtc/WebKit/0001-Make-H265-packetizing-more-resilient-to-bad-input.patch: Add.

Canonical link: <a href="https://commits.webkit.org/271214@main">https://commits.webkit.org/271214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c036c8ab47501974e53d19b278bf396a60e88972

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24473 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3692 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29464 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29992 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27897 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5220 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4239 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3578 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->