### PR TITLE
HTML notes is showing gray underline for autocorrection

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1889,7 +1889,7 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
     // On iOS, we want to fall back to the tintColor, and only override if CSS has explicitly specified a custom color.
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
     UNUSED_PARAM(node);
-    if (elementStyle.hasAutoCaretColor() && !elementStyle.hasExplicitlySetColor())
+    if (elementStyle.hasAutoCaretColor())
         return { };
     return elementStyle.colorResolvingCurrentColor(elementStyle.caretColor());
 #elif HAVE(REDESIGNED_TEXT_CURSOR)


### PR DESCRIPTION
#### a20779d6520da7441b3bc16829f21bc39ca6294d
<pre>
HTML notes is showing gray underline for autocorrection
<a href="https://bugs.webkit.org/show_bug.cgi?id=265050">https://bugs.webkit.org/show_bug.cgi?id=265050</a>
<a href="https://rdar.apple.com/118401826">rdar://118401826</a>

Reviewed by Wenson Hsieh.

Before 266070@main, the caret color on iOS was almost always blue (specifically, always except for
when the caret color was explicitly set by the CSS author). The change was needed on macOS because
otherwise some sites would have overlapping carets. The commit changed both macOS and iOS to be more
consistent, and more compliant with the CSS spec. However, while this did technically improve web
compatibility in iOS, it made things worse than they were before:

- The caret on iOS is now almost always black (it is on macOS too, but it is worse on iOS because
the caret was always blue previously)

- It has caused several issues in apps with custom tint colors (like <a href="https://bugs.webkit.org/show_bug.cgi?id=263123">https://bugs.webkit.org/show_bug.cgi?id=263123</a>
and several others)

This specific bug is due to the fact that the correct underlines directly use the caret color. The
reason the commit that addressed the color of the caret itself on iOS and not this color as well
is because the two colors come from different paths, and the fix only fixed the actual caret
(insertion point) color.

To fix, and prevent similar bugs, undo the part of 266070@main that changed the iOS behavior. This
restores the previous behavior, in addition to fixing this bug.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::computeCaretColor):

Canonical link: <a href="https://commits.webkit.org/271278@main">https://commits.webkit.org/271278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07c34dd4ab656859d7a127977263e34f3a931f30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30384 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25184 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4529 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24907 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31069 "Hash 07c34dd4 for PR 20681 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25349 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/31069 "Hash 07c34dd4 for PR 20681 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2868 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/31069 "Hash 07c34dd4 for PR 20681 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6234 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6696 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->