### PR TITLE
Clean up ResourceResponseBase.h

### DIFF
--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -732,15 +732,142 @@ std::optional<WebCore::SecurityOriginData> Coder<WebCore::SecurityOriginData>::d
 
 void Coder<WebCore::ResourceResponse>::encodeForPersistence(Encoder& encoder, const WebCore::ResourceResponse& instance)
 {
-    instance.encode(encoder);
+    encoder << instance.m_isNull;
+    if (instance.m_isNull)
+        return;
+    instance.lazyInit(WebCore::ResourceResponseBase::AllFields);
+
+    encoder << instance.m_url;
+    encoder << instance.m_mimeType;
+    encoder << static_cast<int64_t>(instance.m_expectedContentLength);
+    encoder << instance.m_textEncodingName;
+    encoder << instance.m_httpStatusText;
+    encoder << instance.m_httpVersion;
+    encoder << instance.m_httpHeaderFields;
+
+    encoder << instance.m_httpStatusCode;
+    encoder << instance.m_certificateInfo;
+    encoder << instance.m_source;
+    encoder << instance.m_type;
+    encoder << instance.m_tainting;
+    encoder << instance.m_isRedirected;
+    WebCore::UsedLegacyTLS usedLegacyTLS = instance.m_usedLegacyTLS;
+    encoder << usedLegacyTLS;
+    WebCore::WasPrivateRelayed wasPrivateRelayed = instance.m_wasPrivateRelayed;
+    encoder << wasPrivateRelayed;
+    encoder << instance.m_isRangeRequested;
 }
 
 std::optional<WebCore::ResourceResponse> Coder<WebCore::ResourceResponse>::decodeForPersistence(Decoder& decoder)
 {
     WebCore::ResourceResponse response;
-    if (!WebCore::ResourceResponseBase::decode(decoder, response))
+    ASSERT(response.m_isNull);
+    std::optional<bool> responseIsNull;
+    decoder >> responseIsNull;
+    if (!responseIsNull)
         return std::nullopt;
-    return response;
+    if (*responseIsNull)
+        return { WTFMove(response) };
+
+    response.m_isNull = false;
+
+    std::optional<URL> url;
+    decoder >> url;
+    if (!url)
+        return std::nullopt;
+    response.m_url = WTFMove(*url);
+
+    std::optional<AtomString> mimeType;
+    decoder >> mimeType;
+    if (!mimeType)
+        return std::nullopt;
+    response.m_mimeType = WTFMove(*mimeType);
+
+    std::optional<int64_t> expectedContentLength;
+    decoder >> expectedContentLength;
+    if (!expectedContentLength)
+        return std::nullopt;
+    response.m_expectedContentLength = *expectedContentLength;
+
+    std::optional<AtomString> textEncodingName;
+    decoder >> textEncodingName;
+    if (!textEncodingName)
+        return std::nullopt;
+    response.m_textEncodingName = WTFMove(*textEncodingName);
+
+    std::optional<AtomString> httpStatusText;
+    decoder >> httpStatusText;
+    if (!httpStatusText)
+        return std::nullopt;
+    response.m_httpStatusText = WTFMove(*httpStatusText);
+
+    std::optional<AtomString> httpVersion;
+    decoder >> httpVersion;
+    if (!httpVersion)
+        return std::nullopt;
+    response.m_httpVersion = WTFMove(*httpVersion);
+
+    std::optional<WebCore::HTTPHeaderMap> httpHeaderFields;
+    decoder >> httpHeaderFields;
+    if (!httpHeaderFields)
+        return std::nullopt;
+    response.m_httpHeaderFields = WTFMove(*httpHeaderFields);
+
+    std::optional<short> httpStatusCode;
+    decoder >> httpStatusCode;
+    if (!httpStatusCode)
+        return std::nullopt;
+    response.m_httpStatusCode = WTFMove(*httpStatusCode);
+
+    std::optional<std::optional<WebCore::CertificateInfo>> certificateInfo;
+    decoder >> certificateInfo;
+    if (!certificateInfo)
+        return std::nullopt;
+    response.m_certificateInfo = WTFMove(*certificateInfo);
+
+    std::optional<WebCore::ResourceResponseBase::Source> source;
+    decoder >> source;
+    if (!source)
+        return std::nullopt;
+    response.m_source = WTFMove(*source);
+
+    std::optional<WebCore::ResourceResponseBase::Type> type;
+    decoder >> type;
+    if (!type)
+        return std::nullopt;
+    response.m_type = WTFMove(*type);
+
+    std::optional<WebCore::ResourceResponseBase::Tainting> tainting;
+    decoder >> tainting;
+    if (!tainting)
+        return std::nullopt;
+    response.m_tainting = WTFMove(*tainting);
+
+    std::optional<bool> isRedirected;
+    decoder >> isRedirected;
+    if (!isRedirected)
+        return std::nullopt;
+    response.m_isRedirected = WTFMove(*isRedirected);
+
+    std::optional<WebCore::UsedLegacyTLS> usedLegacyTLS;
+    decoder >> usedLegacyTLS;
+    if (!usedLegacyTLS)
+        return std::nullopt;
+    response.m_usedLegacyTLS = WTFMove(*usedLegacyTLS);
+
+    std::optional<WebCore::WasPrivateRelayed> wasPrivateRelayed;
+    decoder >> wasPrivateRelayed;
+    if (!wasPrivateRelayed)
+        return std::nullopt;
+    response.m_wasPrivateRelayed = WTFMove(*wasPrivateRelayed);
+
+    std::optional<bool> isRangeRequested;
+    decoder >> isRangeRequested;
+    if (!isRangeRequested)
+        return std::nullopt;
+    response.m_isRangeRequested = WTFMove(*isRangeRequested);
+
+    return { WTFMove(response) };
 }
 
 void Coder<WebCore::FetchOptions>::encodeForPersistence(Encoder& encoder, const WebCore::FetchOptions& instance)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -581,8 +581,9 @@ std::unique_ptr<BackgroundFetch> BackgroundFetch::createFromStore(std::span<cons
         if (!responseHeaders)
             return nullptr;
 
-        WebCore::ResourceResponse response;
-        if (!WebCore::ResourceResponse::decode(decoder, response))
+        std::optional<ResourceResponse> unusedResponseData;
+        decoder >> unusedResponseData;
+        if (!unusedResponseData)
             return nullptr;
 
         std::optional<bool> isCompleted;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -431,7 +431,7 @@ enum class WebCore::ScrollGranularity : uint8_t {
     WebCore::FetchOptions options;
     String referrer;
     WebCore::FetchHeadersGuard responseHeadersGuard;
-    WebCore::ResourceResponse::CrossThreadData response;
+    WebCore::ResourceResponseData response;
     std::variant<std::nullptr_t, Ref<WebCore::FormData>, Ref<WebCore::SharedBuffer>> responseBody;
     uint64_t responseBodySize;
 };
@@ -3023,38 +3023,15 @@ using WebCore::ResourceResponseBase::Type = WebCore::ResourceResponseBaseType;
 using WebCore::ResourceResponseBase::Tainting = WebCore::ResourceResponseBaseTainting;
 using WebCore::ResourceResponseBase::Source = WebCore::ResourceResponseBaseSource;
 
-[Nested] struct WebCore::ResourceResponseBase::ResponseData {
-    URL m_url;
-    AtomString m_mimeType;
-    long long m_expectedContentLength;
-    AtomString m_textEncodingName;
-    AtomString m_httpStatusText;
-    AtomString m_httpVersion;
-    WebCore::HTTPHeaderMap m_httpHeaderFields;
-    Box<WebCore::NetworkLoadMetrics> m_networkLoadMetrics;
-
-    short m_httpStatusCode;
-    std::optional<WebCore::CertificateInfo> m_certificateInfo;
-
-    WebCore::ResourceResponseBase::Source m_source;
-    WebCore::ResourceResponseBase::Type m_type;
-    WebCore::ResourceResponseBase::Tainting m_tainting;
-
-    bool m_isRedirected;
-    WebCore::UsedLegacyTLS m_usedLegacyTLS;
-    WebCore::WasPrivateRelayed m_wasPrivateRelayed;
-    bool m_isRangeRequested;
-}
-
 class WebCore::ResourceResponseBase {
-    std::optional<WebCore::ResourceResponseBase::ResponseData> getResponseData()
+    std::optional<WebCore::ResourceResponseData> getResponseData()
 }
 
 class WebCore::ResourceResponse : WebCore::ResourceResponseBase {
 }
 
 header: <WebCore/ResourceResponseBase.h>
-[CustomHeader] struct WebCore::ResourceResponseBaseCrossThreadData {
+[CustomHeader] struct WebCore::ResourceResponseData {
     URL url;
     String mimeType;
     long long expectedContentLength;
@@ -3073,8 +3050,6 @@ header: <WebCore/ResourceResponseBase.h>
     bool isRangeRequested;
     std::optional<WebCore::CertificateInfo> certificateInfo;
 };
-
-using WebCore::ResourceResponseBase::CrossThreadData = WebCore::ResourceResponseBaseCrossThreadData;
 
 enum class WebCore::ReferrerPolicy : uint8_t {
     EmptyString,


### PR DESCRIPTION
#### ea1e46c69adf276a5ef275623dfd32980ebb3670
<pre>
Clean up ResourceResponseBase.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=265051">https://bugs.webkit.org/show_bug.cgi?id=265051</a>
<a href="https://rdar.apple.com/118572034">rdar://118572034</a>

Reviewed by Chris Dumez.

We had two structs that contained the exact same members,
ResourceResponseBaseCrossThreadData and ResponseData.  I made them be one
struct named ResourceResponseData.  ResourceResponseData::isolatedCopy
still safely calls isolatedCopy like it did before.  Also, I move the
encoding/decoding code from the header to
Coder&lt;WebCore::ResourceResponse&gt;::encodeForPersistence and
Coder&lt;WebCore::ResourceResponse&gt;::decodeForPersistence without changing
the order of the persistently-serialized members.

* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::decodeForPersistence):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::ResourceResponseBase):
(WebCore::m_mimeType):
(WebCore::m_textEncodingName):
(WebCore::m_httpStatusText):
(WebCore::m_httpVersion):
(WebCore::m_httpHeaderFields):
(WebCore::m_networkLoadMetrics):
(WebCore::m_type):
(WebCore::ResourceResponseData::isolatedCopy const):
(WebCore::ResourceResponseBase::crossThreadData const):
(WebCore::ResourceResponseBase::getResponseData const):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseData&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseData&gt;::decodeForPersistence):
(WebCore::ResourceResponseBaseCrossThreadData::isolatedCopy const): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::encodeForPersistence): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::decodeForPersistence): Deleted.
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseData::ResourceResponseData):
(WebCore::ResourceResponseBaseCrossThreadData::ResourceResponseBaseCrossThreadData): Deleted.
(WebCore::ResourceResponseBase::encode const): Deleted.
(WebCore::ResourceResponseBase::decode): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::createFromStore):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/270946@main">https://commits.webkit.org/270946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d50171e15e221ed94ac1d2dafa9a5a8c9b3a4ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29024 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24401 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24452 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30014 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27922 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4269 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3488 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->