### PR TITLE
[check-webkit-style] only check a diff from git

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/diff_parser.py
+++ b/Tools/Scripts/webkitpy/common/checkout/diff_parser.py
@@ -31,6 +31,7 @@
 
 import logging
 import re
+import sys
 
 from webkitcorepy import string_utils
 
@@ -198,6 +199,11 @@ class DiffParser(object):
                     # Nothing to do.  We may still have some added lines.
                     pass
                 else:
+                    line_repr = repr(line)
+                    if sys.version_info < (3,):
+                        assert isinstance(line, unicode)
+                        assert line_repr[0] == "u"
+                        line_repr = line_repr[1:]
                     _log.error('Unexpected diff format when parsing a '
-                               'chunk: %r' % line)
+                               'chunk: %s' % line_repr)
         return files

--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -336,7 +336,7 @@ class Git(SCM, SVNRepository):
         config_path = self._filesystem.dirname(self._filesystem.path_to_module('webkitpy.common.config'))
         order_file = self._filesystem.join(config_path, 'orderfile')
         if self._filesystem.exists(order_file):
-            command += ['-O', order_file]
+            command += ['-O{}'.format(order_file)]
 
         if git_index:
             assert command[1] == 'diff'
@@ -344,7 +344,10 @@ class Git(SCM, SVNRepository):
         elif git_commit:
             command += [merge_base]
         elif merge_base != head:
-            command += ['HEAD...{}'.format(merge_base)]
+            # Because the merge_base is a parent of HEAD, <rev1>..<rev2> finds the same
+            # total set of change for both git-format-patch (a revision range), and
+            # git-diff (viewing the changes between the two commits).
+            command += ['{}..HEAD'.format(merge_base)]
         else:
             command += ['HEAD']
 

--- a/Tools/Scripts/webkitpy/style/main.py
+++ b/Tools/Scripts/webkitpy/style/main.py
@@ -154,7 +154,7 @@ class CheckWebKitStyle(object):
             file_reader.do_association_check(host.scm().checkout_root)
         else:
             changed_files = paths if options.diff_files else None
-            patch = host.scm().create_patch(options.git_commit, changed_files=changed_files, git_index=options.git_index, find_branch=True)
+            patch = host.scm().create_patch(options.git_commit, changed_files=changed_files, git_index=options.git_index, commit_message=False, find_branch=True)
             patch_checker = PatchReader(file_reader)
             patch_checker.check(patch)
 


### PR DESCRIPTION
#### 81bfcf01ed2bbe1c1f6ae0f80b910dc657557c1a
<pre>
[check-webkit-style] only check a diff from git
<a href="https://bugs.webkit.org/show_bug.cgi?id=265030">https://bugs.webkit.org/show_bug.cgi?id=265030</a>

Reviewed by Jonathan Bedard.

Previously, we passed commit_message=True, which led us to get
git-format-tree output (an mbox, with patches formatted as a sequence of
emails with commit messages and a diffstat prior to the actual patch)
from Scm.create_patch, rather than the output of git-diff, which
DiffParser can actually parse.

Change the call to Scm.create_patch to ensure we only get a diff, and
not other metadata.

However, this exposed the fact that Git.create_patch didn&apos;t account for
the difference in command-line arguments between git-format-tree and
git-diff, thus we need to correctly pass the correct set of revisions we
wish to obtain a diff for, nor did it correctly pass the order file.

As a drive-by, add a test that we get an error from DiffParser given an
mbox.

Lastly, skip SCM tests that involve svn if it is not installed.

* Tools/Scripts/webkitpy/common/checkout/diff_parser.py:
(DiffParser._parse_into_diff_files):
* Tools/Scripts/webkitpy/common/checkout/diff_parser_unittest.py:
(DiffParserTest.setUp):
(DiffParserTest):
(DiffParserTest.tearDown):
(test_git_format_patch_multiple):
* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.create_patch):
* Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py:
(SVNTest.setUp):
(GitTest.test_create_patch_merge_base_without_commit_message):
(GitTest):
(GitTest.test_create_patch_merge_base_with_commit_message):
(GitSVNTest.setUp):
* Tools/Scripts/webkitpy/style/main.py:
(CheckWebKitStyle.main):

Canonical link: <a href="https://commits.webkit.org/273780@main">https://commits.webkit.org/273780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6555baeb20d557eb52071d3647131266c47a1d92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31040 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11003 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/36059 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39838 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36949 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35039 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11687 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4740 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->