### PR TITLE
Adjust GC Timer a bit with heuristics to avoid running it while critical tasks are waiting

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -764,9 +764,11 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     heap/DeferGCInlines.h
     heap/DeleteAllCodeEffort.h
     heap/DestructionMode.h
+    heap/EdenGCActivityCallback.h
     heap/FastMallocAlignedMemoryAllocator.h
     heap/FreeList.h
     heap/FreeListInlines.h
+    heap/FullGCActivityCallback.h
     heap/GCActivityCallback.h
     heap/GCAssertions.h
     heap/GCConductor.h

--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
@@ -30,13 +30,14 @@
 
 namespace JSC {
 
-EdenGCActivityCallback::EdenGCActivityCallback(Heap* heap)
+EdenGCActivityCallback::EdenGCActivityCallback(Heap& heap)
     : GCActivityCallback(heap)
 {
 }
 
 void EdenGCActivityCallback::doCollection(VM& vm)
 {
+    setDidGCRecently(false);
     vm.heap.collectAsync(CollectionScope::Eden);
 }
 

--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
@@ -29,21 +29,21 @@
 
 namespace JSC {
 
-class JS_EXPORT_PRIVATE EdenGCActivityCallback final : public GCActivityCallback {
+class EdenGCActivityCallback : public GCActivityCallback {
 public:
-    EdenGCActivityCallback(Heap*);
+    static RefPtr<EdenGCActivityCallback> tryCreate(Heap& heap)
+    {
+        return s_shouldCreateGCTimer ? adoptRef(new EdenGCActivityCallback(heap)) : nullptr;
+    }
 
-    void doCollection(VM&) final;
+    JS_EXPORT_PRIVATE void doCollection(VM&) override;
+
+    JS_EXPORT_PRIVATE EdenGCActivityCallback(Heap&);
 
 private:
-    Seconds lastGCLength(Heap&) final;
-    double gcTimeSlice(size_t bytes) final;
-    double deathRate(Heap&) final;
+    JS_EXPORT_PRIVATE Seconds lastGCLength(Heap&) final;
+    JS_EXPORT_PRIVATE double gcTimeSlice(size_t bytes) final;
+    JS_EXPORT_PRIVATE double deathRate(Heap&) final;
 };
-
-inline RefPtr<GCActivityCallback> GCActivityCallback::tryCreateEdenTimer(Heap* heap)
-{
-    return s_shouldCreateGCTimer ? adoptRef(new EdenGCActivityCallback(heap)) : nullptr;
-}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-FullGCActivityCallback::FullGCActivityCallback(Heap* heap)
+FullGCActivityCallback::FullGCActivityCallback(Heap& heap)
     : GCActivityCallback(heap)
 {
 }
@@ -39,7 +39,7 @@ FullGCActivityCallback::FullGCActivityCallback(Heap* heap)
 void FullGCActivityCallback::doCollection(VM& vm)
 {
     Heap& heap = vm.heap;
-    m_didGCRecently = false;
+    setDidGCRecently(false);
 
 #if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
     MonotonicTime startTime = MonotonicTime::now();

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.h
@@ -29,26 +29,21 @@
 
 namespace JSC {
 
-class JS_EXPORT_PRIVATE FullGCActivityCallback final : public GCActivityCallback {
+class FullGCActivityCallback : public GCActivityCallback {
 public:
-    FullGCActivityCallback(Heap*);
+    static RefPtr<FullGCActivityCallback> tryCreate(Heap& heap)
+    {
+        return s_shouldCreateGCTimer ? adoptRef(new FullGCActivityCallback(heap)) : nullptr;
+    }
 
-    void doCollection(VM&) final;
+    JS_EXPORT_PRIVATE void doCollection(VM&) override;
 
-    bool didGCRecently() const { return m_didGCRecently; }
-    void setDidGCRecently() { m_didGCRecently = true; }
+    JS_EXPORT_PRIVATE FullGCActivityCallback(Heap&);
 
 private:
-    Seconds lastGCLength(Heap&) final;
-    double gcTimeSlice(size_t bytes) final;
-    double deathRate(Heap&) final;
-
-    bool m_didGCRecently { false };
+    JS_EXPORT_PRIVATE Seconds lastGCLength(Heap&) final;
+    JS_EXPORT_PRIVATE double gcTimeSlice(size_t bytes) final;
+    JS_EXPORT_PRIVATE double deathRate(Heap&) final;
 };
-
-inline RefPtr<FullGCActivityCallback> GCActivityCallback::tryCreateFullTimer(Heap* heap)
-{
-    return s_shouldCreateGCTimer ? adoptRef(new FullGCActivityCallback(heap)) : nullptr;
-}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/GCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.cpp
@@ -38,10 +38,17 @@ bool GCActivityCallback::s_shouldCreateGCTimer = true;
 
 const double timerSlop = 2.0; // Fudge factor to avoid performance cost of resetting timer.
 
-GCActivityCallback::GCActivityCallback(Heap* heap)
-    : GCActivityCallback(heap->vm())
+GCActivityCallback::GCActivityCallback(Heap& heap)
+    : GCActivityCallback(heap.vm())
 {
 }
+
+GCActivityCallback::GCActivityCallback(VM& vm)
+    : Base(vm)
+{
+}
+
+GCActivityCallback::~GCActivityCallback() = default;
 
 void GCActivityCallback::doWork(VM& vm)
 {
@@ -65,9 +72,8 @@ void GCActivityCallback::scheduleTimer(Seconds newDelay)
     Seconds delta = m_delay - newDelay;
     m_delay = newDelay;
     if (auto timeUntilFire = this->timeUntilFire())
-        setTimeUntilFire(*timeUntilFire - delta);
-    else
-        setTimeUntilFire(newDelay);
+        newDelay = *timeUntilFire - delta;
+    setTimeUntilFire(newDelay);
 }
 
 void GCActivityCallback::didAllocate(Heap& heap, size_t bytes)

--- a/Source/JavaScriptCore/heap/GCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.h
@@ -31,32 +31,29 @@
 #include "JSRunLoopTimer.h"
 #include <wtf/RefPtr.h>
 
-#if USE(CF)
-#include <CoreFoundation/CoreFoundation.h>
-#endif
-
 namespace JSC {
 
 class FullGCActivityCallback;
 class Heap;
 
-class JS_EXPORT_PRIVATE GCActivityCallback : public JSRunLoopTimer {
+class GCActivityCallback : public JSRunLoopTimer {
 public:
     using Base = JSRunLoopTimer;
-    static RefPtr<FullGCActivityCallback> tryCreateFullTimer(Heap*);
-    static RefPtr<GCActivityCallback> tryCreateEdenTimer(Heap*);
 
-    GCActivityCallback(Heap*);
+    JS_EXPORT_PRIVATE GCActivityCallback(Heap&);
+    JS_EXPORT_PRIVATE ~GCActivityCallback();
 
-    void doWork(VM&) override;
+    JS_EXPORT_PRIVATE void doWork(VM&) override;
 
     virtual void doCollection(VM&) = 0;
 
     void didAllocate(Heap&, size_t);
     void willCollect();
-    void cancel();
+    JS_EXPORT_PRIVATE void cancel();
     bool isEnabled() const { return m_enabled; }
     void setEnabled(bool enabled) { m_enabled = enabled; }
+    bool didGCRecently() const { return m_didGCRecently; }
+    void setDidGCRecently(bool didGCRecently) { m_didGCRecently = didGCRecently; }
 
     static bool s_shouldCreateGCTimer;
 
@@ -64,21 +61,13 @@ protected:
     virtual Seconds lastGCLength(Heap&) = 0;
     virtual double gcTimeSlice(size_t bytes) = 0;
     virtual double deathRate(Heap&) = 0;
+    JS_EXPORT_PRIVATE void scheduleTimer(Seconds);
 
-    GCActivityCallback(VM& vm)
-        : Base(vm)
-        , m_enabled(true)
-        , m_delay(s_decade)
-    {
-    }
+    GCActivityCallback(VM&);
 
-    bool m_enabled;
-
-protected:
-    void scheduleTimer(Seconds);
-
-private:
-    Seconds m_delay;
+    bool m_enabled { true };
+    bool m_didGCRecently { false };
+    Seconds m_delay { s_decade };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -291,8 +291,8 @@ Heap::Heap(VM& vm, HeapType heapType)
     , m_jitStubRoutines(makeUnique<JITStubRoutineSet>())
     // We seed with 10ms so that GCActivityCallback::didAllocate doesn't continuously
     // schedule the timer if we've never done a collection.
-    , m_fullActivityCallback(GCActivityCallback::tryCreateFullTimer(this))
-    , m_edenActivityCallback(GCActivityCallback::tryCreateEdenTimer(this))
+    , m_fullActivityCallback(FullGCActivityCallback::tryCreate(*this))
+    , m_edenActivityCallback(EdenGCActivityCallback::tryCreate(*this))
     , m_sweeper(adoptRef(*new IncrementalSweeper(this)))
     , m_stopIfNecessaryTimer(adoptRef(*new StopIfNecessaryTimer(vm)))
     , m_sharedCollectorMarkStack(makeUnique<MarkStackArray>())
@@ -1199,9 +1199,10 @@ void Heap::collect(Synchronousness synchronousness, GCRequest request)
         return;
 
     switch (synchronousness) {
-    case Async:
+    case Async: {
         collectAsync(request);
         return;
+    }
     case Sync:
         collectSync(request);
         return;
@@ -2392,10 +2393,7 @@ void Heap::updateAllocationLimits()
 {
     constexpr bool verbose = false;
     
-    if (verbose) {
-        dataLog("\n");
-        dataLog("bytesAllocatedThisCycle = ", m_bytesAllocatedThisCycle, "\n");
-    }
+    dataLogLnIf(verbose, "\nbytesAllocatedThisCycle = ", m_bytesAllocatedThisCycle);
     
     // Calculate our current heap size threshold for the purpose of figuring out when we should
     // run another collection. This isn't the same as either size() or capacity(), though it should
@@ -2410,8 +2408,7 @@ void Heap::updateAllocationLimits()
     // of fragmentation, this may be substantial. Fortunately, marked space rarely fragments because
     // cells usually have a narrow range of sizes. So, the underestimation is probably OK.
     currentHeapSize += m_totalBytesVisited;
-    if (verbose)
-        dataLog("totalBytesVisited = ", m_totalBytesVisited, ", currentHeapSize = ", currentHeapSize, "\n");
+    dataLogLnIf(verbose, "totalBytesVisited = ", m_totalBytesVisited, ", currentHeapSize = ", currentHeapSize);
 
     // It's up to the user to ensure that extraMemorySize() ends up corresponding to allocation-time
     // extra memory reporting.
@@ -2422,48 +2419,38 @@ void Heap::updateAllocationLimits()
         ASSERT(!checkedCurrentHeapSize.hasOverflowed() && checkedCurrentHeapSize == currentHeapSize);
     }
 
-    if (verbose)
-        dataLog("extraMemorySize() = ", extraMemorySize(), ", currentHeapSize = ", currentHeapSize, "\n");
+    dataLogLnIf(verbose, "extraMemorySize() = ", extraMemorySize(), ", currentHeapSize = ", currentHeapSize);
     
     if (m_collectionScope && m_collectionScope.value() == CollectionScope::Full) {
         // To avoid pathological GC churn in very small and very large heaps, we set
         // the new allocation limit based on the current size of the heap, with a
         // fixed minimum.
-        if (!m_isInOpportunisticTask) {
+        if (!m_isInOpportunisticTask)
             m_maxHeapSize = std::max(minHeapSize(m_heapType, m_ramSize), proportionalHeapSize(currentHeapSize, m_ramSize));
-            if (verbose)
-                dataLog("Full: maxHeapSize = ", m_maxHeapSize, "\n");
-        }
+        dataLogLnIf(verbose, "Full: maxHeapSize = ", m_maxHeapSize);
         m_maxEdenSize = m_maxHeapSize - currentHeapSize;
-        if (verbose)
-            dataLog("Full: maxEdenSize = ", m_maxEdenSize, "\n");
+        dataLogLnIf(verbose, "Full: maxEdenSize = ", m_maxEdenSize);
         m_sizeAfterLastFullCollect = currentHeapSize;
-        if (verbose)
-            dataLog("Full: sizeAfterLastFullCollect = ", currentHeapSize, "\n");
+        dataLogLnIf(verbose, "Full: sizeAfterLastFullCollect = ", currentHeapSize);
         m_bytesAbandonedSinceLastFullCollect = 0;
-        if (verbose)
-            dataLog("Full: bytesAbandonedSinceLastFullCollect = ", 0, "\n");
+        dataLogLnIf(verbose, "Full: bytesAbandonedSinceLastFullCollect = ", 0);
     } else {
         ASSERT(currentHeapSize >= m_sizeAfterLastCollect);
         // Theoretically, we shouldn't ever scan more memory than the heap size we planned to have.
         // But we are sloppy, so we have to defend against the overflow.
         m_maxEdenSize = currentHeapSize > m_maxHeapSize ? 0 : m_maxHeapSize - currentHeapSize;
-        if (verbose)
-            dataLog("Eden: maxEdenSize = ", m_maxEdenSize, "\n");
+        dataLogLnIf(verbose, "Eden: maxEdenSize = ", m_maxEdenSize);
         m_sizeAfterLastEdenCollect = currentHeapSize;
-        if (verbose)
-            dataLog("Eden: sizeAfterLastEdenCollect = ", currentHeapSize, "\n");
+        dataLogLnIf(verbose, "Eden: sizeAfterLastEdenCollect = ", currentHeapSize);
         double edenToOldGenerationRatio = (double)m_maxEdenSize / (double)m_maxHeapSize;
         double minEdenToOldGenerationRatio = 1.0 / 3.0;
         if (edenToOldGenerationRatio < minEdenToOldGenerationRatio)
             m_shouldDoFullCollection = true;
         // This seems suspect at first, but what it does is ensure that the nursery size is fixed.
         m_maxHeapSize += currentHeapSize - m_sizeAfterLastCollect;
-        if (verbose)
-            dataLog("Eden: maxHeapSize = ", m_maxHeapSize, "\n");
+        dataLogLnIf(verbose, "Eden: maxHeapSize = ", m_maxHeapSize);
         m_maxEdenSize = m_maxHeapSize - currentHeapSize;
-        if (verbose)
-            dataLog("Eden: maxEdenSize = ", m_maxEdenSize, "\n");
+        dataLogLnIf(verbose, "Eden: maxEdenSize = ", m_maxEdenSize);
         if (m_fullActivityCallback) {
             ASSERT(currentHeapSize >= m_sizeAfterLastFullCollect);
             m_fullActivityCallback->didAllocate(*this, currentHeapSize - m_sizeAfterLastFullCollect);
@@ -2476,8 +2463,7 @@ void Heap::updateAllocationLimits()
 #endif
 
     m_sizeAfterLastCollect = currentHeapSize;
-    if (verbose)
-        dataLog("sizeAfterLastCollect = ", m_sizeAfterLastCollect, "\n");
+    dataLogLnIf(verbose, "sizeAfterLastCollect = ", m_sizeAfterLastCollect);
     m_bytesAllocatedThisCycle = 0;
 
     dataLogIf(Options::logGC(), "=> ", currentHeapSize / 1024, "kb, ");
@@ -2591,8 +2577,18 @@ void Heap::collectNowFullIfNotDoneRecently(Synchronousness synchronousness)
         return;
     }
 
-    m_fullActivityCallback->setDidGCRecently();
+    m_fullActivityCallback->setDidGCRecently(true);
     collectNow(synchronousness, CollectionScope::Full);
+}
+
+void Heap::setFullActivityCallback(RefPtr<GCActivityCallback>&& callback)
+{
+    m_fullActivityCallback = WTFMove(callback);
+}
+
+void Heap::setEdenActivityCallback(RefPtr<GCActivityCallback>&& callback)
+{
+    m_edenActivityCallback = WTFMove(callback);
 }
 
 bool Heap::useGenerationalGC()

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -327,6 +327,10 @@ public:
 
     JS_EXPORT_PRIVATE GCActivityCallback* fullActivityCallback();
     JS_EXPORT_PRIVATE GCActivityCallback* edenActivityCallback();
+
+    JS_EXPORT_PRIVATE void setFullActivityCallback(RefPtr<GCActivityCallback>&&);
+    JS_EXPORT_PRIVATE void setEdenActivityCallback(RefPtr<GCActivityCallback>&&);
+
     JS_EXPORT_PRIVATE void setGarbageCollectionTimerEnabled(bool);
     JS_EXPORT_PRIVATE void scheduleOpportunisticFullCollection();
 
@@ -831,7 +835,7 @@ private:
 
     Vector<String> m_possiblyAccessedStringsFromConcurrentThreads;
     
-    RefPtr<FullGCActivityCallback> m_fullActivityCallback;
+    RefPtr<GCActivityCallback> m_fullActivityCallback;
     RefPtr<GCActivityCallback> m_edenActivityCallback;
     Ref<IncrementalSweeper> m_sweeper;
     Ref<StopIfNecessaryTimer> m_stopIfNecessaryTimer;

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -386,7 +386,12 @@ void MarkedSpace::shrink()
 
 void MarkedSpace::beginMarking()
 {
-    if (heap().collectionScope() == CollectionScope::Full) {
+    switch (heap().collectionScope().value()) {
+    case CollectionScope::Eden: {
+        m_edenVersion = nextVersion(m_edenVersion);
+        break;
+    }
+    case CollectionScope::Full: {
         forEachDirectory(
             [&] (BlockDirectory& directory) -> IterationStatus {
                 directory.beginMarkingForFullCollection();
@@ -399,11 +404,14 @@ void MarkedSpace::beginMarking()
                     handle->block().resetMarks();
                 });
         }
-        
+
         m_markingVersion = nextVersion(m_markingVersion);
-        
+
         for (PreciseAllocation* allocation : m_preciseAllocations)
             allocation->flip();
+
+        break;
+    }
     }
 
     if (ASSERT_ENABLED) {

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -154,6 +154,7 @@ public:
     
     HeapVersion markingVersion() const { return m_markingVersion; }
     HeapVersion newlyAllocatedVersion() const { return m_newlyAllocatedVersion; }
+    HeapVersion edenVersion() const { return m_edenVersion; }
 
     const Vector<PreciseAllocation*>& preciseAllocations() const { return m_preciseAllocations; }
     unsigned preciseAllocationsNurseryOffset() const { return m_preciseAllocationsNurseryOffset; }
@@ -214,6 +215,7 @@ private:
     size_t m_capacity { 0 };
     HeapVersion m_markingVersion { initialVersion };
     HeapVersion m_newlyAllocatedVersion { initialVersion };
+    HeapVersion m_edenVersion { initialVersion };
     bool m_isIterating { false };
     bool m_isMarking { false };
     Lock m_directoryLock;

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -41,7 +41,7 @@ class JSPromise;
 class VM;
 class JSCell;
 
-class JS_EXPORT_PRIVATE DeferredWorkTimer final : public JSRunLoopTimer {
+class DeferredWorkTimer final : public JSRunLoopTimer {
 public:
     using Base = JSRunLoopTimer;
 
@@ -65,7 +65,7 @@ public:
 
     void doWork(VM&) final;
 
-    Ticket addPendingWork(VM&, JSObject* target, Vector<Strong<JSCell>>&& dependencies);
+    JS_EXPORT_PRIVATE Ticket addPendingWork(VM&, JSObject* target, Vector<Strong<JSCell>>&& dependencies);
     bool hasAnyPendingWork() const;
     bool hasPendingWork(Ticket);
     bool hasDependancyInPendingWork(Ticket, JSCell* dependency);
@@ -77,11 +77,11 @@ public:
     // this occurs. The easiest way is to make sure everything is either owned
     // by a GC'd value in dependencies or by the Task lambda.
     using Task = Function<void(Ticket)>;
-    void scheduleWorkSoon(Ticket, Task&&);
-    void didResumeScriptExecutionOwner();
+    JS_EXPORT_PRIVATE void scheduleWorkSoon(Ticket, Task&&);
+    JS_EXPORT_PRIVATE void didResumeScriptExecutionOwner();
 
     void stopRunningTasks() { m_runTasks = false; }
-    void runRunLoop();
+    JS_EXPORT_PRIVATE void runRunLoop();
 
     static Ref<DeferredWorkTimer> create(VM& vm) { return adoptRef(*new DeferredWorkTimer(vm)); }
 private:

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -83,7 +83,7 @@ public:
     JS_EXPORT_PRIVATE virtual ~JSRunLoopTimer();
     virtual void doWork(VM&) = 0;
 
-    void setTimeUntilFire(Seconds intervalInSeconds);
+    JS_EXPORT_PRIVATE void setTimeUntilFire(Seconds intervalInSeconds);
     void cancelTimer();
     bool isScheduled() const { return m_isScheduled; }
 

--- a/Source/WebCore/bindings/js/CommonVM.cpp
+++ b/Source/WebCore/bindings/js/CommonVM.cpp
@@ -28,8 +28,11 @@
 
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
+#include "OpportunisticTaskScheduler.h"
 #include "ScriptController.h"
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/EdenGCActivityCallback.h>
+#include <JavaScriptCore/FullGCActivityCallback.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/MachineStackMarker.h>
 #include <JavaScriptCore/VM.h>
@@ -62,6 +65,10 @@ JSC::VM& commonVMSlow()
 #endif
 
     auto& vm = JSC::VM::create(JSC::HeapType::Large, runLoop).leakRef();
+#if !PLATFORM(IOS_FAMILY)
+    vm.heap.setFullActivityCallback(OpportunisticTaskScheduler::FullGCActivityCallback::create(vm.heap));
+    vm.heap.setEdenActivityCallback(OpportunisticTaskScheduler::EdenGCActivityCallback::create(vm.heap));
+#endif
 
     g_commonVMOrNull = &vm;
 

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "RunLoopObserver.h"
+#include <JavaScriptCore/EdenGCActivityCallback.h>
+#include <JavaScriptCore/FullGCActivityCallback.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
@@ -51,7 +53,7 @@ private:
     WeakPtr<OpportunisticTaskScheduler> m_scheduler;
 };
 
-class OpportunisticTaskScheduler : public RefCounted<OpportunisticTaskScheduler>, public CanMakeWeakPtr<OpportunisticTaskScheduler> {
+class OpportunisticTaskScheduler final : public RefCounted<OpportunisticTaskScheduler>, public CanMakeWeakPtr<OpportunisticTaskScheduler> {
 public:
     static Ref<OpportunisticTaskScheduler> create(Page& page)
     {
@@ -66,6 +68,46 @@ public:
     bool hasImminentlyScheduledWork() const { return m_imminentlyScheduledWorkCount; }
 
     WARN_UNUSED_RETURN Ref<ImminentlyScheduledWorkScope> makeScheduledWorkScope();
+
+    class FullGCActivityCallback final : public JSC::FullGCActivityCallback {
+    public:
+        using Base = JSC::FullGCActivityCallback;
+
+        static Ref<FullGCActivityCallback> create(JSC::Heap& heap)
+        {
+            return adoptRef(*new FullGCActivityCallback(heap));
+        }
+
+        void doCollection(JSC::VM&) final;
+
+    private:
+        FullGCActivityCallback(JSC::Heap& heap)
+            : Base(heap)
+        { }
+
+        JSC::HeapVersion m_version { 0 };
+        unsigned m_deferCount { 0 };
+    };
+
+    class EdenGCActivityCallback final : public JSC::EdenGCActivityCallback {
+    public:
+        using Base = JSC::EdenGCActivityCallback;
+
+        static Ref<EdenGCActivityCallback> create(JSC::Heap& heap)
+        {
+            return adoptRef(*new EdenGCActivityCallback(heap));
+        }
+
+        void doCollection(JSC::VM&) final;
+
+    private:
+        EdenGCActivityCallback(JSC::Heap& heap)
+            : Base(heap)
+        { }
+
+        JSC::HeapVersion m_version { 0 };
+        unsigned m_deferCount { 0 };
+    };
 
 private:
     friend class ImminentlyScheduledWorkScope;


### PR DESCRIPTION
#### 5c9eac47597dd0447d181e32ef2436cfce67791c
<pre>
Adjust GC Timer a bit with heuristics to avoid running it while critical tasks are waiting
<a href="https://bugs.webkit.org/show_bug.cgi?id=265055">https://bugs.webkit.org/show_bug.cgi?id=265055</a>
<a href="https://rdar.apple.com/118574205">rdar://118574205</a>

Reviewed by Wenson Hsieh and Justin Michaud.

We found that GC timer fires randomly and it runs GC at random timing. We should avoid
running it when there is critical tasks are waiting. This patch starts with a naive simple
approach which just defers this GC invocation with some threshold when there is a waiting task.
We are not directly using OpportunisticTaskScheduler since it is active only when a page is visible
and active, but we would like to run this GC for background page too. Eventually we would like
to unify both into one global mechanism but we put it as a future work.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp:
(JSC::EdenGCActivityCallback::EdenGCActivityCallback):
(JSC::EdenGCActivityCallback::doCollection):
* Source/JavaScriptCore/heap/EdenGCActivityCallback.h:
(JSC::EdenGCActivityCallback::tryCreate):
(): Deleted.
(JSC::GCActivityCallback::tryCreateEdenTimer): Deleted.
* Source/JavaScriptCore/heap/FullGCActivityCallback.cpp:
(JSC::FullGCActivityCallback::FullGCActivityCallback):
(JSC::FullGCActivityCallback::doCollection):
* Source/JavaScriptCore/heap/FullGCActivityCallback.h:
(JSC::FullGCActivityCallback::tryCreate):
(): Deleted.
(JSC::GCActivityCallback::tryCreateFullTimer): Deleted.
* Source/JavaScriptCore/heap/GCActivityCallback.cpp:
(JSC::GCActivityCallback::GCActivityCallback):
(JSC::GCActivityCallback::scheduleTimer):
* Source/JavaScriptCore/heap/GCActivityCallback.h:
(JSC::GCActivityCallback::didGCRecently const):
(JSC::GCActivityCallback::setDidGCRecently):
(JSC::GCActivityCallback::GCActivityCallback):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
(JSC::Heap::collect):
(JSC::Heap::updateAllocationLimits):
(JSC::Heap::collectNowFullIfNotDoneRecently):
(JSC::Heap::setFullActivityCallback):
(JSC::Heap::setEdenActivityCallback):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::beginMarking):
* Source/JavaScriptCore/heap/MarkedSpace.h:
(JSC::MarkedSpace::edenVersion const):
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/JSRunLoopTimer.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::performOpportunisticallyScheduledTasks):
* Source/WebCore/bindings/js/CommonVM.cpp:
(WebCore::commonVMSlow):
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):
(WebCore::isBusyForTimerBasedGC):
(WebCore::OpportunisticTaskScheduler::FullGCActivityCallback::doCollection):
(WebCore::OpportunisticTaskScheduler::EdenGCActivityCallback::doCollection):
* Source/WebCore/page/OpportunisticTaskScheduler.h:
(WebCore::OpportunisticTaskScheduler::create): Deleted.
(WebCore::OpportunisticTaskScheduler::willQueueIdleCallback): Deleted.
(WebCore::OpportunisticTaskScheduler::hasImminentlyScheduledWork const): Deleted.

Canonical link: <a href="https://commits.webkit.org/270919@main">https://commits.webkit.org/270919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3d0b0bb0ea6c7a6eaa0d79856c5b7b76b9ccb95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29026 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2822 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3723 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24010 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29506 "Hash b3d0b0bb for PR 20688 does not build (failure)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24411 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/29506 "Hash b3d0b0bb for PR 20688 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26002 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/29506 "Hash b3d0b0bb for PR 20688 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5256 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33455 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4270 "Build is in progress. Recent messages:") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7232 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3472 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->