### PR TITLE
Replace `-layoutHasChanged` and `-updateForChangedSelection` with `-[UIAsyncTextInputDelegate invalidateTextEntryContext]`

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1261,11 +1261,12 @@ typedef struct {
 @property (nonatomic, assign, readwrite) BOOL shouldEvaluateForInputSystemHandling;
 @end
 
-#endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
-
-@interface UIResponder (Staging_118307558)
-- (void)replace:(id)sender;
+@protocol UIAsyncTextInputDelegate_Staging<UIAsyncTextInputDelegate>
+- (void)invalidateTextEntryContext; // Added in rdar://118536368.
+- (void)replaceText:(id)sender; // Added in rdar://118307558.
 @end
+
+#endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
 
 WTF_EXTERN_C_BEGIN
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -569,7 +569,7 @@ struct ImageAnalysisContextMenuActionData {
     std::optional<WebKit::RemoveBackgroundData> _removeBackgroundData;
 #endif
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    __weak id<UIAsyncTextInputDelegate> _asyncSystemInputDelegate;
+    __weak id<UIAsyncTextInputDelegate_Staging> _asyncSystemInputDelegate;
 #endif
 }
 


### PR DESCRIPTION
#### 0b4f1f99201e4820a2b8727d68a6ba57b3785457
<pre>
Replace `-layoutHasChanged` and `-updateForChangedSelection` with `-[UIAsyncTextInputDelegate invalidateTextEntryContext]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=265054">https://bugs.webkit.org/show_bug.cgi?id=265054</a>
<a href="https://rdar.apple.com/118467892">rdar://118467892</a>

Reviewed by Megan Gardner.

Adopt `-[UIAsyncTextInputDelegate invalidateTextEntryContext]`, which is a direct replacement for
`-[UIKeyboardImpl updateForChangedSelection]`. Since the latter also updates marked text UI if
needed, we can also replace the `-layoutHasChanged` call with this new method as well.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKRelativeTextRange isEmpty]):

Some drive-by fixes after the introduction of `WKRelativeTextRange` in 270847@main:

1.  Enforce type safety in `-selectionRectsForRange:` and `-caretRectForPosition:`, in case any
    system client calls these methods using a relative range.

2.  Fix `-[WKRelativeTextRange isEmpty]` so that it returns `YES` only in the case where the offsets
    are equal, *and* the anchors are the same.

3.  Return `nil` in `-positionFromPosition:offset:` and `-textRangeFromPosition:toPosition:` instead
    of `WKRelativeText{Range|Position}`, if the given positions are either not already relative to
    the selection, or the given positions are not identical to the selection start/end. This is
    possible if UIKit asks for `-markedTextRange`, and then asks for positions offset from the start
    or end of the marked text.

(-[WKContentView replaceForWebView:]):

Another drive-by fix: the plan for handling `-replace:` has pivoted slightly, such that we&apos;re going
to instead call a new protocol method on the sytem input delegate, instead of calling into the
superclass. Adjust for that here.

(-[WKContentView caretRectForPosition:]):
(-[WKContentView selectionRectsForRange:]):
(-[WKContentView _isAnchoredToCurrentSelection:]):
(-[WKContentView textRangeFromPosition:toPosition:]):
(-[WKContentView positionFromPosition:offset:]):
(-[WKContentView _updateInputContextAfterBlurringAndRefocusingElement]):
(-[WKContentView _selectionChanged]):
(-[WKContentView setAsyncSystemInputDelegate:]):

Canonical link: <a href="https://commits.webkit.org/270918@main">https://commits.webkit.org/270918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa117f85bdc4b61bc4908d13be9ad3918d14ce43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24493 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2806 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22999 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3710 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3752 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30003 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27909 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5240 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6443 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->