### PR TITLE
Port IPC::SharedFileHandle to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/FileHandle.cpp
+++ b/Source/WebCore/platform/FileHandle.cpp
@@ -52,8 +52,8 @@ FileHandle::FileHandle(const String& path, FileSystem::FileOpenMode mode, Option
 {
 }
 
-FileHandle::FileHandle(FileSystem::PlatformFileHandle&& handle)
-    : m_fileHandle(WTFMove(handle))
+FileHandle::FileHandle(FileSystem::PlatformFileHandle handle)
+    : m_fileHandle(handle)
 {
 }
 

--- a/Source/WebCore/platform/FileHandle.h
+++ b/Source/WebCore/platform/FileHandle.h
@@ -43,7 +43,7 @@ public:
     FileHandle& operator=(FileHandle&& other);
     FileHandle(const FileHandle&) = delete;
     FileHandle& operator=(const FileHandle&) = delete;
-    explicit FileHandle(FileSystem::PlatformFileHandle&&);
+    explicit FileHandle(FileSystem::PlatformFileHandle);
 
     explicit operator bool() const;
 

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -374,6 +374,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Platform/IPC/FormDataReference.serialization.in
     Platform/IPC/IPCSemaphore.serialization.in
     Platform/IPC/SharedBufferReference.serialization.in
+    Platform/IPC/SharedFileHandle.serialization.in
     Platform/IPC/StreamServerConnection.serialization.in
 
     Platform/SharedMemory.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -148,6 +148,7 @@ $(PROJECT_DIR)/NetworkProcess/webtransport/NetworkTransportSession.messages.in
 $(PROJECT_DIR)/Platform/IPC/FormDataReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/IPCSemaphore.serialization.in
 $(PROJECT_DIR)/Platform/IPC/SharedBufferReference.serialization.in
+$(PROJECT_DIR)/Platform/IPC/SharedFileHandle.serialization.in
 $(PROJECT_DIR)/Platform/IPC/StreamServerConnection.serialization.in
 $(PROJECT_DIR)/Platform/SharedMemory.serialization.in
 $(PROJECT_DIR)/PluginProcess/PluginControllerProxy.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -500,6 +500,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Platform/IPC/FormDataReference.serialization.in \
 	Platform/IPC/IPCSemaphore.serialization.in \
 	Platform/IPC/SharedBufferReference.serialization.in \
+        Platform/IPC/SharedFileHandle.serialization.in \
 	Platform/IPC/StreamServerConnection.serialization.in \
 	Platform/SharedMemory.serialization.in \
 	Shared/AuxiliaryProcessCreationParameters.serialization.in \

--- a/Source/WebKit/Platform/IPC/SharedFileHandle.cpp
+++ b/Source/WebKit/Platform/IPC/SharedFileHandle.cpp
@@ -30,20 +30,10 @@ namespace IPC {
 
 #if !PLATFORM(COCOA)
 
-std::optional<SharedFileHandle> SharedFileHandle::create(FileSystem::PlatformFileHandle&& handle)
+std::optional<SharedFileHandle> SharedFileHandle::create(FileSystem::PlatformFileHandle handle)
 {
-    auto currentHandle = WTFMove(handle);
-    FileSystem::closeFile(currentHandle);
+    FileSystem::closeFile(handle);
 
-    return std::nullopt;
-}
-
-void SharedFileHandle::encode(Encoder&) const
-{
-}
-
-std::optional<SharedFileHandle> SharedFileHandle::decode(Decoder&)
-{
     return std::nullopt;
 }
 

--- a/Source/WebKit/Platform/IPC/SharedFileHandle.h
+++ b/Source/WebKit/Platform/IPC/SharedFileHandle.h
@@ -36,17 +36,19 @@ class Encoder;
 
 class SharedFileHandle {
 public:
-    static std::optional<SharedFileHandle> create(FileSystem::PlatformFileHandle&&);
+    static std::optional<SharedFileHandle> create(FileSystem::PlatformFileHandle);
+
+#if PLATFORM(COCOA)
+    explicit SharedFileHandle(MachSendRight&&);
+    MachSendRight toMachSendRight() const;
+#endif
 
     SharedFileHandle() = default;
     WebCore::FileHandle release() { return std::exchange(m_handle, { }); }
 
-    void encode(Encoder&) const;
-    static std::optional<SharedFileHandle> decode(Decoder&);
-    
 private:
-    explicit SharedFileHandle(FileSystem::PlatformFileHandle&& handle)
-        : m_handle(WTFMove(handle))
+    explicit SharedFileHandle(FileSystem::PlatformFileHandle handle)
+        : m_handle(handle)
     {
     }
 

--- a/Source/WebKit/Platform/IPC/SharedFileHandle.serialization.in
+++ b/Source/WebKit/Platform/IPC/SharedFileHandle.serialization.in
@@ -1,0 +1,29 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "SharedFileHandle.h"
+
+[CustomHeader] class IPC::SharedFileHandle {
+#if PLATFORM(COCOA)
+    MachSendRight toMachSendRight();
+#endif
+};


### PR DESCRIPTION
#### 92895f30aa1f9b8964c9a9fe531f2d1447f27c87
<pre>
Port IPC::SharedFileHandle to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=265061">https://bugs.webkit.org/show_bug.cgi?id=265061</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/SharedFileHandle.h:
* Source/WebKit/Platform/IPC/SharedFileHandle.serialization.in:
* Source/WebKit/Platform/IPC/cocoa/SharedFileHandleCocoa.cpp:
(IPC::SharedFileHandle::SharedFileHandle):
(IPC::SharedFileHandle::toMachSendRight const):
(IPC::SharedFileHandle::encode const): Deleted.
(IPC::SharedFileHandle::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/271219@main">https://commits.webkit.org/271219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43cf7c3af29e2e107234177042cd5b2d28defe28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25262 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25027 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23706 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4364 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30495 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30656 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28619 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5014 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3582 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->