### PR TITLE
Don't wait 8 minutes to suspend background tabs on iOS

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6113,7 +6113,7 @@ ShouldTakeNearSuspendedAssertions:
     WebKitLegacy:
       default: true
     WebKit:
-      default: true
+      default: defaultShouldTakeNearSuspendedAssertion()
     WebCore:
       default: true
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -55,6 +55,7 @@ enum class SDKAlignedBehavior {
     ExpiredOnlyReloadBehavior,
     ForbidsDotPrefixedFonts,
     FullySuspendsBackgroundContent,
+    FullySuspendsBackgroundContentImmediately,
     HasUIContextMenuInteraction,
     HTMLDocumentSupportedPropertyNames,
     InitializeWebKit2MainThreadAssertion,

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -232,6 +232,16 @@ bool defaultShouldDropNearSuspendedAssertionAfterDelay()
 #endif
 }
 
+bool defaultShouldTakeNearSuspendedAssertion()
+{
+#if PLATFORM(IOS_FAMILY)
+    static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::FullySuspendsBackgroundContentImmediately);
+    return !newSDK;
+#else
+    return true;
+#endif
+}
+
 bool defaultLiveRangeSelectionEnabled()
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -99,6 +99,7 @@ bool defaultGamepadVibrationActuatorEnabled();
 
 bool defaultRunningBoardThrottlingEnabled();
 bool defaultShouldDropNearSuspendedAssertionAfterDelay();
+bool defaultShouldTakeNearSuspendedAssertion();
 bool defaultShowModalDialogEnabled();
 bool defaultLiveRangeSelectionEnabled();
 


### PR DESCRIPTION
#### 6f851d213cb6f24609321384728316b6425e3ec7
<pre>
Don&apos;t wait 8 minutes to suspend background tabs on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=265064">https://bugs.webkit.org/show_bug.cgi?id=265064</a>
<a href="https://rdar.apple.com/problem/118578232">rdar://problem/118578232</a>

Reviewed by NOBODY (OOPS!).

In the past, once a WebProcess would finish background work, we would
drop its background assertion and take a suspended assertion instead.
The idea of the suspended assertion was to actually suspend the process.

However, we found out ~1 year ago that those processes wouldn&apos;t actually
suspend when holding a suspended assertion until the whole app gets
suspended. When we discovered this, we renamed suspended assertion to
near-suspended and we started dropping it after 8 minutes, behind a
linked-on-after flag. The idea was to enable true background tab
suspension while minimizing the compatibility risk.

Now, one year later, I propose we drop the near-suspended assertion
entirely on iOS and suspended background tabs promptly. We&apos;d still do
this behind a linked-on-after flag to minimize risk but this would have
many performance benefits.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultShouldTakeNearSuspendedAssertion):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f851d213cb6f24609321384728316b6425e3ec7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24501 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24395 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29498 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23363 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24446 "Found 26 new API test failures: TestWebKitAPI.ProcessSwap.APIControlledProcessSwappingThenBackWithDelay, TestWebKitAPI.ProcessSwap.PageCache1, TestWebKitAPI.ProcessSwap.SessionStorage, TestWebKitAPI.ProcessSwap.GoToSecondItemInBackHistory, TestWebKitAPI.ProcessSwap.PageShowHide, TestWebKitAPI.ProcessSwap.ProcessReuse, TestWebKitAPI.ProcessSwap.ReuseSuspendedProcessForRegularNavigationRetainBundlePage, TestWebKitAPI.ProcessSwap.SuspendedPageLimit, TestWebKitAPI.ProcessSwap.SuspendedPageDiesAfterBackForwardListItemIsGone, TestWebKitAPI.ProcessSwap.Back ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30009 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/25994 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (cancelled)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27916 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5248 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33447 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4263 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7230 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->