### PR TITLE
Remove various unused functions across WebCore

### DIFF
--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -80,11 +80,6 @@ void MediaController::removeMediaElement(HTMLMediaElement& element)
     m_mediaElements.remove(m_mediaElements.find(&element));
 }
 
-bool MediaController::containsMediaElement(HTMLMediaElement& element) const
-{
-    return m_mediaElements.contains(&element);
-}
-
 Ref<TimeRanges> MediaController::buffered() const
 {
     if (m_mediaElements.isEmpty())

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -104,7 +104,6 @@ private:
 
     void addMediaElement(HTMLMediaElement&);
     void removeMediaElement(HTMLMediaElement&);
-    bool containsMediaElement(HTMLMediaElement&) const;
 
     const String& mediaGroup() const { return m_mediaGroup; }
 

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -192,17 +192,4 @@ void PluginDocument::detachFromPluginElement()
     m_pluginElement = nullptr;
 }
 
-void PluginDocument::cancelManualPluginLoad()
-{
-    // PluginDocument::cancelManualPluginLoad should only be called once, but there are issues
-    // with how many times we call beforeload on object elements. <rdar://problem/8441094>.
-    if (!shouldLoadPluginManually())
-        return;
-
-    auto& frameLoader = frame()->loader();
-    if (auto documentLoader = frameLoader.activeDocumentLoader())
-        documentLoader->cancelMainResourceLoad(frameLoader.cancelledError(documentLoader->request()));
-    m_shouldLoadPluginManually = false;
-}
-
 }

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -46,9 +46,6 @@ public:
 
     void setPluginElement(HTMLPlugInElement&);
     void detachFromPluginElement();
-
-    void cancelManualPluginLoad();
-
     bool shouldLoadPluginManually() const { return m_shouldLoadPluginManually; }
 
 private:

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -140,12 +140,6 @@ bool WebGLProgram::getLinkStatus()
     return m_linkStatus;
 }
 
-void WebGLProgram::setLinkStatus(bool status)
-{
-    cacheInfoIfNeeded();
-    m_linkStatus = status;
-}
-
 void WebGLProgram::increaseLinkCount()
 {
     ++m_linkCount;

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -64,7 +64,6 @@ public:
     bool isUsingVertexAttrib0();
 
     bool getLinkStatus();
-    void setLinkStatus(bool);
 
     unsigned getLinkCount() const { return m_linkCount; }
 

--- a/Source/WebCore/svg/SVGGlyphElement.h
+++ b/Source/WebCore/svg/SVGGlyphElement.h
@@ -30,9 +30,6 @@ class SVGGlyphElement final : public SVGElement {
 public:
     static Ref<SVGGlyphElement> create(const QualifiedName&, Document&);
 
-    // Helper function used by SVGFont
-    static String querySVGFontLanguage(const SVGElement*);
-
 private:
     SVGGlyphElement(const QualifiedName&, Document&);
 


### PR DESCRIPTION
#### be6ad6822306074f1289674664045a3d851e9ec1
<pre>
Remove various unused functions across WebCore

<a href="https://bugs.webkit.org/show_bug.cgi?id=265069">https://bugs.webkit.org/show_bug.cgi?id=265069</a>

Reviewed by Ryosuke Niwa.

This PR is to remove unused functions across various WebCore ares i.e., SVG, HTML, Canvas etc.

* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebGLProgram::setLinkStatus):
* Source/WebCore/html/canvas/WebGLProgram.h:
* Source/WebCore/html/MediaController.cpp:
(MediaController::containsMediaElement):
* Source/WebCore/html/MediaController.h:
* Source/WebCore/html/PluginDocument.cpp:
(PluginDocument::cancelManualPluginLoad):
* Source/WebCore/html/PluginDocument.h:
* Source/WebCore/svg/SVGGlyphElement.h:

Canonical link: <a href="https://commits.webkit.org/270949@main">https://commits.webkit.org/270949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/491d5f0f94c81274f5834274c5aa300078259275

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24439 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3765 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30050 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27958 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5297 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6458 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->