### PR TITLE
Sync and remove [NotEnumerable] from `toString` as per Selection API IDL Specification

### DIFF
--- a/LayoutTests/js/dom/toString-dontEnum-expected.txt
+++ b/LayoutTests/js/dom/toString-dontEnum-expected.txt
@@ -1,6 +1,5 @@
 This tests that the toString() function does not enumerate.
 
-PASS: the toString function is not enumerable for Selection.
 PASS: the toString function is not enumerable for HTMLDivElement.
 PASS: the toString function is not enumerable for HTMLDocument.
 PASS: the toString function is not enumerable for Object.

--- a/LayoutTests/js/dom/toString-dontEnum.html
+++ b/LayoutTests/js/dom/toString-dontEnum.html
@@ -24,9 +24,6 @@
             if (window.testRunner)
                 testRunner.dumpAsText();
 
-            // DOM objects with custom toString() functions
-            test(window.getSelection(), "Selection");
-
             // Other DOM objects
             test(document.createElement('div'), "HTMLDivElement");
             test(document, "HTMLDocument");

--- a/Source/WebCore/page/DOMSelection.idl
+++ b/Source/WebCore/page/DOMSelection.idl
@@ -27,7 +27,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://www.w3.org/TR/selection-api/#idl-def-Selection
+// https://w3c.github.io/selection-api/#selection-interface
 [
     GenerateIsReachable=ReachableFromDOMWindow,
     InterfaceName=Selection,
@@ -67,7 +67,7 @@
     [CEReactions=Needed] undefined deleteFromDocument();
     boolean containsNode(Node node, optional boolean allowPartialContainment = false);
 
-    [NotEnumerable] DOMString toString();
+    DOMString toString();
 
     // Non-standard methods and attributes.
 


### PR DESCRIPTION
#### 6b9b667d2d27aa82c075e0a8e8b04e3353d05531
<pre>
Sync and remove [NotEnumerable] from `toString` as per Selection API IDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=264991">https://bugs.webkit.org/show_bug.cgi?id=264991</a>

Reviewed by Ryosuke Niwa.

This change is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification [1] by removing
[NoEnumerable] from &apos;toString&apos; (stringifier).

[1] <a href="https://w3c.github.io/selection-api/#selection-interface">https://w3c.github.io/selection-api/#selection-interface</a>

* Source/WebCore/page/DOMSelection.idl:
* LayoutTests/js/dom/toString-dontEnum.html: Rebaselined
* LayoutTests/js/dom/toString-dontEnum-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/270933@main">https://commits.webkit.org/270933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b42a7525c06f75f53984d74a0613e941e3fc1441

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24411 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3787 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30022 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27930 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23764 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6452 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->