### PR TITLE
Unreviewed, GTK build fix

### DIFF
--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
@@ -35,6 +35,8 @@ EdenGCActivityCallback::EdenGCActivityCallback(Heap& heap)
 {
 }
 
+EdenGCActivityCallback::~EdenGCActivityCallback() = default;
+
 void EdenGCActivityCallback::doCollection(VM& vm)
 {
     setDidGCRecently(false);

--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
@@ -39,6 +39,7 @@ public:
     JS_EXPORT_PRIVATE void doCollection(VM&) override;
 
     JS_EXPORT_PRIVATE EdenGCActivityCallback(Heap&);
+    JS_EXPORT_PRIVATE ~EdenGCActivityCallback();
 
 private:
     JS_EXPORT_PRIVATE Seconds lastGCLength(Heap&) final;

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -36,6 +36,8 @@ FullGCActivityCallback::FullGCActivityCallback(Heap& heap)
 {
 }
 
+FullGCActivityCallback::~FullGCActivityCallback() = default;
+
 void FullGCActivityCallback::doCollection(VM& vm)
 {
     Heap& heap = vm.heap;

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.h
@@ -39,6 +39,7 @@ public:
     JS_EXPORT_PRIVATE void doCollection(VM&) override;
 
     JS_EXPORT_PRIVATE FullGCActivityCallback(Heap&);
+    JS_EXPORT_PRIVATE ~FullGCActivityCallback();
 
 private:
     JS_EXPORT_PRIVATE Seconds lastGCLength(Heap&) final;


### PR DESCRIPTION
#### ec77ef00f5dabc2971dcf2e8c32190fdca2396dc
<pre>
Unreviewed, GTK build fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=265072">https://bugs.webkit.org/show_bug.cgi?id=265072</a>
<a href="https://rdar.apple.com/118585847">rdar://118585847</a>

* Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp:
* Source/JavaScriptCore/heap/EdenGCActivityCallback.h:
* Source/JavaScriptCore/heap/FullGCActivityCallback.cpp:
* Source/JavaScriptCore/heap/FullGCActivityCallback.h:

Canonical link: <a href="https://commits.webkit.org/270927@main">https://commits.webkit.org/270927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17e0aea5a6af53d56aa20f327ad960d29ba251f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29051 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2847 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27102 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/4271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/23036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/3747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/24033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/29685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/29685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/26027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/29685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/5279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/33478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/33478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3479 "Built successfully and passed tests") | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4189 "Failed to checkout and rebase branch from PR 20697") | | | 
<!--EWS-Status-Bubble-End-->