### PR TITLE
Stop using Vector::unsafeAppendWithoutCapacityCheck() in MarkedBlock::Handle::specializedSweep()

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -229,6 +229,27 @@ inline bool MarkedBlock::Handle::areMarksStaleForSweep()
 //
 // Only the DoesNotNeedDestruction one should be specialized by MarkedBlock.
 
+template<size_t storageSize, bool alwaysFitsOnStack>
+class DeadCellStorage {
+public:
+    DeadCellStorage() = default;
+    void append(MarkedBlock::AtomNumberType cell) { return m_deadCells.append(cell); }
+    std::span<const MarkedBlock::AtomNumberType> span() const { return m_deadCells.span(); }
+private:
+    Vector<MarkedBlock::AtomNumberType, storageSize> m_deadCells;
+};
+
+template<size_t storageSize>
+class DeadCellStorage<storageSize, true> {
+public:
+    DeadCellStorage() = default;
+    void append(MarkedBlock::AtomNumberType cell) { m_deadCells[m_size++] = cell; }
+    std::span<const MarkedBlock::AtomNumberType> span() const { return { m_deadCells.data(), m_size }; }
+private:
+    std::array<MarkedBlock::AtomNumberType, storageSize> m_deadCells;
+    size_t m_size { 0 };
+};
+
 template<bool specialize, MarkedBlock::Handle::EmptyMode specializedEmptyMode, MarkedBlock::Handle::SweepMode specializedSweepMode, MarkedBlock::Handle::SweepDestructionMode specializedDestructionMode, MarkedBlock::Handle::ScribbleMode specializedScribbleMode, MarkedBlock::Handle::NewlyAllocatedMode specializedNewlyAllocatedMode, MarkedBlock::Handle::MarksMode specializedMarksMode, typename DestroyFunc>
 void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Handle::EmptyMode emptyMode, MarkedBlock::Handle::SweepMode sweepMode, MarkedBlock::Handle::SweepDestructionMode destructionMode, MarkedBlock::Handle::ScribbleMode scribbleMode, MarkedBlock::Handle::NewlyAllocatedMode newlyAllocatedMode, MarkedBlock::Handle::MarksMode marksMode, const DestroyFunc& destroyFunc)
 {
@@ -323,7 +344,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
     constexpr size_t deadCellBufferBytes = std::min(atomsPerBlock * sizeof(AtomNumberType), maxDeadCellBufferBytes);
     static_assert(deadCellBufferBytes <= maxDeadCellBufferBytes);
     constexpr bool deadCellsAlwaysFitsOnStack = (deadCellBufferBytes / sizeof(AtomNumberType)) <= atomsPerBlock;
-    Vector<AtomNumberType, deadCellBufferBytes / sizeof(AtomNumberType)> deadCells;
+    DeadCellStorage<deadCellBufferBytes / sizeof(AtomNumberType), deadCellsAlwaysFitsOnStack> deadCells;
 
     auto handleDeadCell = [&] (size_t i) {
         HeapCell* cell = reinterpret_cast_ptr<HeapCell*>(&block.atoms()[i]);
@@ -374,12 +395,9 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
             continue;
         }
 
-        if (destructionMode == BlockHasDestructorsAndCollectorIsRunning) {
-            if constexpr (deadCellsAlwaysFitsOnStack)
-                deadCells.unsafeAppendWithoutCapacityCheck(i);
-            else
-                deadCells.append(i);
-        } else
+        if (destructionMode == BlockHasDestructorsAndCollectorIsRunning)
+            deadCells.append(i);
+        else
             handleDeadCell(i);
     }
     if (destructionMode != BlockHasDestructorsAndCollectorIsRunning)
@@ -394,7 +412,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
         header.m_lock.unlock();
 
     if (destructionMode == BlockHasDestructorsAndCollectorIsRunning) {
-        for (size_t i : deadCells)
+        for (size_t i : deadCells.span())
             handleDeadCell(i);
         checkForFinalInterval();
     }


### PR DESCRIPTION
#### c30ca46c17f83c30ac12f3b92d72ed6add7bbeba
<pre>
Stop using Vector::unsafeAppendWithoutCapacityCheck() in MarkedBlock::Handle::specializedSweep()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265078">https://bugs.webkit.org/show_bug.cgi?id=265078</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::DeadCellStorage::append):
(JSC::DeadCellStorage::span const):
(JSC::MarkedBlock::Handle::specializedSweep):

Canonical link: <a href="https://commits.webkit.org/270939@main">https://commits.webkit.org/270939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f4fbd846a9f6e5b9f8b39b222f86517ec0b05c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29058 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24537 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24423 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3754 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29693 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23391 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30038 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26034 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27946 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5286 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33485 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4295 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7242 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3483 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->