### PR TITLE
[GStreamer][WebCodecs][Debug] ASSERTs in video encoder

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
@@ -36,11 +36,10 @@ class GStreamerAudioEncoder : public AudioEncoder {
 public:
     static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    GStreamerAudioEncoder(const String& codecName, DescriptionCallback&&,  OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
+    GStreamerAudioEncoder(DescriptionCallback&&,  OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
     ~GStreamerAudioEncoder();
 
 private:
-    String initialize(const AudioEncoder::Config&);
     void encode(RawFrame&&, EncodeCallback&&) final;
     void flush(Function<void()>&&) final;
     void reset() final;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
@@ -35,11 +35,10 @@ class GStreamerVideoEncoder : public VideoEncoder {
 public:
     static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    GStreamerVideoEncoder(const String& codecName, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    GStreamerVideoEncoder(DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
     ~GStreamerVideoEncoder();
 
 private:
-    String initialize(const VideoEncoder::Config&);
     void encode(RawFrame&&, bool shouldGenerateKeyFrame, EncodeCallback&&) final;
     void flush(Function<void()>&&) final;
     void reset() final;


### PR DESCRIPTION
#### 6656a3ab02122919cbd5b37b73d026f3b2652f08
<pre>
[GStreamer][WebCodecs][Debug] ASSERTs in video encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=264935">https://bugs.webkit.org/show_bug.cgi?id=264935</a>
&lt;<a href="https://rdar.apple.com/problem/118559880">rdar://problem/118559880</a>&gt;

Reviewed by Xabier Rodriguez-Calvar.

Refactor encoders to avoid storing the codecName string in the internal encoders. This should
hopefully prevent any String-related crash during destruction.

* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::create):
(WebCore::GStreamerAudioEncoder::create):
(WebCore::GStreamerAudioEncoder::GStreamerAudioEncoder):
(WebCore::GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder):
(WebCore::GStreamerInternalAudioEncoder::initialize):
(WebCore::GStreamerAudioEncoder::initialize): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::GStreamerVideoEncoder):
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder):
(WebCore::GStreamerInternalVideoEncoder::initialize):
(WebCore::GStreamerVideoEncoder::initialize): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/270966@main">https://commits.webkit.org/270966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0683d3c18b95c78b48ef81dfd97808bad48a6234

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29064 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24543 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24429 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30045 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5292 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6466 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->