### PR TITLE
Use dynamicDowncast<T> even more in the DOM

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2498,5 +2498,9 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Document&);
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Document)
     static bool isType(const WebCore::ScriptExecutionContext& context) { return context.isDocument(); }
     static bool isType(const WebCore::Node& node) { return node.isDocumentNode(); }
-    static bool isType(const WebCore::EventTarget& target) { return is<WebCore::Node>(target) && isType(downcast<WebCore::Node>(target)); }
+    static bool isType(const WebCore::EventTarget& target)
+    {
+        auto* node = dynamicDowncast<WebCore::Node>(target);
+        return node && isType(*node);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3004,8 +3004,7 @@ ShadowRoot& Element::createUserAgentShadowRoot()
 
 inline void Node::setCustomElementState(CustomElementState state)
 {
-    RELEASE_ASSERT(is<Element>(this));
-    Style::PseudoClassChangeInvalidation styleInvalidation(downcast<Element>(*this),
+    Style::PseudoClassChangeInvalidation styleInvalidation(checkedDowncast<Element>(*this),
         CSSSelector::PseudoClassType::Defined,
         state == CustomElementState::Custom || state == CustomElementState::Uncustomized
     );
@@ -5421,10 +5420,10 @@ void Element::setAttributeStyleMap(Ref<StylePropertyMap>&& map)
 
 void Element::ensureFormAssociatedCustomElement()
 {
-    RELEASE_ASSERT(is<HTMLMaybeFormAssociatedCustomElement>(*this));
+    auto& customElement = checkedDowncast<HTMLMaybeFormAssociatedCustomElement>(*this);
     auto& data = ensureElementRareData();
     if (!data.formAssociatedCustomElement())
-        data.setFormAssociatedCustomElement(makeUniqueWithoutRefCountedCheck<FormAssociatedCustomElement>(downcast<HTMLMaybeFormAssociatedCustomElement>(*this)));
+        data.setFormAssociatedCustomElement(makeUniqueWithoutRefCountedCheck<FormAssociatedCustomElement>(customElement));
 }
 
 FormAssociatedCustomElement& Element::formAssociatedCustomElementUnsafe() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -950,5 +950,9 @@ inline bool isInTopLayerOrBackdrop(const RenderStyle&, const Element*);
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Element)
     static bool isType(const WebCore::Node& node) { return node.isElementNode(); }
-    static bool isType(const WebCore::EventTarget& target) { return is<WebCore::Node>(target) && isType(downcast<WebCore::Node>(target)); }
+    static bool isType(const WebCore::EventTarget& target)
+    {
+        auto* node = dynamicDowncast<WebCore::Node>(target);
+        return node && isType(*node);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/ElementAncestorIteratorInlines.h
+++ b/Source/WebCore/dom/ElementAncestorIteratorInlines.h
@@ -57,8 +57,8 @@ template<> inline ElementAncestorRange<Element> lineageOfType<Element>(Element& 
 template <typename ElementType>
 inline ElementAncestorRange<ElementType> lineageOfType(Element& first)
 {
-    if (is<ElementType>(first))
-        return ElementAncestorRange<ElementType>(&downcast<ElementType>(first));
+    if (auto* element = dynamicDowncast<ElementType>(first))
+        return ElementAncestorRange<ElementType>(element);
     return ancestorsOfType<ElementType>(first);
 }
 
@@ -70,24 +70,24 @@ template<> inline ElementAncestorRange<const Element> lineageOfType<Element>(con
 template <typename ElementType>
 inline ElementAncestorRange<const ElementType> lineageOfType(const Element& first)
 {
-    if (is<ElementType>(first))
-        return ElementAncestorRange<const ElementType>(&downcast<ElementType>(first));
+    if (auto* element = dynamicDowncast<ElementType>(first))
+        return ElementAncestorRange<const ElementType>(element);
     return ancestorsOfType<ElementType>(first);
 }
 
 template <typename ElementType>
 inline ElementAncestorRange<ElementType> lineageOfType(Node& first)
 {
-    if (is<ElementType>(first))
-        return ElementAncestorRange<ElementType>(&downcast<ElementType>(first));
+    if (auto* element = dynamicDowncast<ElementType>(first))
+        return ElementAncestorRange<ElementType>(element);
     return ancestorsOfType<ElementType>(first);
 }
 
 template <typename ElementType>
 inline ElementAncestorRange<const ElementType> lineageOfType(const Node& first)
 {
-    if (is<ElementType>(first))
-        return ElementAncestorRange<const ElementType>(&downcast<ElementType>(first));
+    if (auto* element = dynamicDowncast<ElementType>(first))
+        return ElementAncestorRange<const ElementType>(element);
     return ancestorsOfType<ElementType>(first);
 }
 

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -42,8 +42,8 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ShareableElementData);
 
 void ElementData::destroy()
 {
-    if (is<UniqueElementData>(*this))
-        delete downcast<UniqueElementData>(this);
+    if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this))
+        delete uniqueData;
     else
         delete downcast<ShareableElementData>(this);
 }

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -243,29 +243,29 @@ inline void ElementData::deref()
 
 inline unsigned ElementData::length() const
 {
-    if (is<UniqueElementData>(*this))
-        return downcast<UniqueElementData>(*this).m_attributeVector.size();
+    if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this))
+        return uniqueData->m_attributeVector.size();
     return arraySize();
 }
 
 inline const Attribute* ElementData::attributeBase() const
 {
-    if (is<UniqueElementData>(*this))
-        return downcast<UniqueElementData>(*this).m_attributeVector.data();
+    if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this))
+        return uniqueData->m_attributeVector.data();
     return downcast<ShareableElementData>(*this).m_attributeArray;
 }
 
 inline const ImmutableStyleProperties* ElementData::presentationalHintStyle() const
 {
-    if (!is<UniqueElementData>(*this))
-        return nullptr;
-    return downcast<UniqueElementData>(*this).m_presentationalHintStyle.get();
+    if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this))
+        return uniqueData->m_presentationalHintStyle.get();
+    return nullptr;
 }
 
 inline AttributeIteratorAccessor ElementData::attributesIterator() const
 {
-    if (is<UniqueElementData>(*this)) {
-        const Vector<Attribute, 4>& attributeVector = downcast<UniqueElementData>(*this).m_attributeVector;
+    if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this)) {
+        auto& attributeVector = uniqueData->m_attributeVector;
         return AttributeIteratorAccessor(attributeVector.data(), attributeVector.size());
     }
     return AttributeIteratorAccessor(downcast<ShareableElementData>(*this).m_attributeArray, arraySize());

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -51,12 +51,15 @@ inline unsigned Element::findAttributeIndexByName(const AtomString& name, bool s
 
 inline bool Node::hasAttributes() const
 {
-    return is<Element>(*this) && downcast<Element>(*this).hasAttributes();
+    auto* element = dynamicDowncast<Element>(*this);
+    return element && element->hasAttributes();
 }
 
 inline NamedNodeMap* Node::attributes() const
 {
-    return is<Element>(*this) ? &downcast<Element>(*this).attributes() : nullptr;
+    if (auto* element = dynamicDowncast<Element>(*this))
+        return &element->attributes();
+    return nullptr;
 }
 
 inline Element* Node::parentElement() const

--- a/Source/WebCore/dom/ElementIteratorInlines.h
+++ b/Source/WebCore/dom/ElementIteratorInlines.h
@@ -105,8 +105,8 @@ template <typename ElementType>
 inline ElementType* findElementAncestorOfType(const Node& current)
 {
     for (Element* ancestor = current.parentElement(); ancestor; ancestor = ancestor->parentElement()) {
-        if (is<ElementType>(*ancestor))
-            return downcast<ElementType>(ancestor);
+        if (auto* element = dynamicDowncast<ElementType>(*ancestor))
+            return element;
     }
     return nullptr;
 }

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -315,9 +315,9 @@ inline ElementRareData* Element::elementRareData() const
 
 inline ShadowRoot* Node::shadowRoot() const
 {
-    if (!is<Element>(*this))
-        return nullptr;
-    return downcast<Element>(*this).shadowRoot();
+    if (auto* element = dynamicDowncast<Element>(*this))
+        return element->shadowRoot();
+    return nullptr;
 }
 
 inline ShadowRoot* Element::shadowRoot() const

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -78,7 +78,8 @@ static void callDefaultEventHandlersInBubblingOrder(Event& event, const EventPat
 
 static bool isInShadowTree(EventTarget* target)
 {
-    return is<Node>(target) && downcast<Node>(*target).isInShadowTree();
+    auto* node = dynamicDowncast<Node>(target);
+    return node && node->isInShadowTree();
 }
 
 static void dispatchEventInDOM(Event& event, const EventPath& path)
@@ -127,10 +128,8 @@ static bool shouldSuppressEventDispatchInDOM(Node& node, Event& event)
     if (!localFrame->checkedLoader()->shouldSuppressTextInputFromEditing())
         return false;
 
-    if (is<TextEvent>(event)) {
-        auto& textEvent = downcast<TextEvent>(event);
-        return textEvent.isKeyboard() || textEvent.isComposition();
-    }
+    if (auto* textEvent = dynamicDowncast<TextEvent>(event))
+        return textEvent->isKeyboard() || textEvent->isComposition();
 
     return is<CompositionEvent>(event) || is<InputEvent>(event) || is<KeyboardEvent>(event);
 }
@@ -139,9 +138,9 @@ static HTMLInputElement* findInputElementInEventPath(const EventPath& path)
 {
     size_t size = path.size();
     for (size_t i = 0; i < size; ++i) {
-        const EventContext& eventContext = path.contextAt(i);
-        if (is<HTMLInputElement>(eventContext.currentTarget()))
-            return downcast<HTMLInputElement>(eventContext.currentTarget());
+        auto& eventContext = path.contextAt(i);
+        if (auto* inputElement = dynamicDowncast<HTMLInputElement>(eventContext.currentTarget()))
+            return inputElement;
     }
     return nullptr;
 }

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -135,7 +135,6 @@ inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomString& key, const Tre
     if (auto* currentScope = ContainerChildRemovalScope::currentScope()) {
         ASSERT(&scope.rootNode() == &currentScope->parentOfRemovedTree().rootNode());
         Ref removedTree = currentScope->removedChild();
-        ASSERT(is<ContainerNode>(removedTree));
         for (Ref element : descendantsOfType<Element>(downcast<ContainerNode>(removedTree.get()))) {
             if (!keyMatches(key, element))
                 continue;

--- a/Source/WebCore/dom/XMLDocument.h
+++ b/Source/WebCore/dom/XMLDocument.h
@@ -57,5 +57,9 @@ protected:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::XMLDocument)
     static bool isType(const WebCore::Document& document) { return document.isXMLDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -371,7 +371,7 @@ bool AlternativeTextController::canEnableAutomaticSpellingCorrection() const
     if (RefPtr control = enclosingTextFormControl(position)) {
         if (!control->shouldAutocorrect())
             return false;
-    } else if (RefPtr editableRoot = position.rootEditableElement(); is<HTMLElement>(editableRoot) && !downcast<HTMLElement>(*editableRoot).shouldAutocorrect())
+    } else if (RefPtr editableRoot = dynamicDowncast<HTMLElement>(position.rootEditableElement()); editableRoot && !editableRoot->shouldAutocorrect())
         return false;
 #endif
 

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -298,20 +298,25 @@ VisiblePosition ApplyBlockElementCommand::endOfNextParagraphSplittingTextNodesIf
     splitTextNode(*text, 1);
     RefPtr previousSiblingOfText { text->previousSibling() };
 
-    if (text == start.containerNode() && previousSiblingOfText && is<Text>(previousSiblingOfText)) {
-        ASSERT(start.offsetInContainerNode() < position.offsetInContainerNode());
-        start = Position(downcast<Text>(text->previousSibling()), start.offsetInContainerNode());
+    if (text == start.containerNode() && previousSiblingOfText) {
+        if (auto* previousText = dynamicDowncast<Text>(*previousSiblingOfText)) {
+            ASSERT(start.offsetInContainerNode() < position.offsetInContainerNode());
+            start = Position(previousText, start.offsetInContainerNode());
+        }
     }
-    if (text == end.containerNode() && previousSiblingOfText && is<Text>(previousSiblingOfText)) {
-        ASSERT(end.offsetInContainerNode() < position.offsetInContainerNode());
-        end = Position(downcast<Text>(text->previousSibling()), end.offsetInContainerNode());
+    if (text == end.containerNode() && previousSiblingOfText) {
+        if (auto* previousText = dynamicDowncast<Text>(*previousSiblingOfText)) {
+            ASSERT(end.offsetInContainerNode() < position.offsetInContainerNode());
+            end = Position(previousText, end.offsetInContainerNode());
+        }
     }
     if (text == m_endOfLastParagraph.containerNode()) {
         if (m_endOfLastParagraph.offsetInContainerNode() < position.offsetInContainerNode()) {
             // We can only fix endOfLastParagraph if the previous node was still text and hasn't been modified by script.
-            if (previousSiblingOfText && is<Text>(previousSiblingOfText)
-                && static_cast<unsigned>(m_endOfLastParagraph.offsetInContainerNode()) <= downcast<Text>(text->previousSibling())->length())
-                m_endOfLastParagraph = Position(downcast<Text>(text->previousSibling()), m_endOfLastParagraph.offsetInContainerNode());
+            if (auto* previousText = dynamicDowncast<Text>(previousSiblingOfText.get())) {
+                if (static_cast<unsigned>(m_endOfLastParagraph.offsetInContainerNode()) <= previousText->length())
+                    m_endOfLastParagraph = Position(previousText, m_endOfLastParagraph.offsetInContainerNode());
+            }
         } else
             m_endOfLastParagraph = Position(text.get(), m_endOfLastParagraph.offsetInContainerNode() - 1);
     }


### PR DESCRIPTION
#### b8691e2f033a54cff3a2cf58adebc46e72ce37cf
<pre>
Use dynamicDowncast&lt;T&gt; even more in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=265087">https://bugs.webkit.org/show_bug.cgi?id=265087</a>

Reviewed by Jean-Yves Avenard.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayoutIfDimensionsOutOfDate):
(WebCore::Document::beginLoadingFontSoon):
(WebCore::Document::enqueueOverflowEvent):
* Source/WebCore/dom/Document.h:
(isType):
* Source/WebCore/dom/Element.cpp:
(WebCore::Node::setCustomElementState):
(WebCore::Element::ensureFormAssociatedCustomElement):
* Source/WebCore/dom/Element.h:
(isType):
* Source/WebCore/dom/ElementAncestorIteratorInlines.h:
(WebCore::lineageOfType):
* Source/WebCore/dom/ElementData.cpp:
(WebCore::ElementData::destroy):
* Source/WebCore/dom/ElementData.h:
(WebCore::ElementData::length const):
(WebCore::ElementData::attributeBase const):
(WebCore::ElementData::presentationalHintStyle const):
(WebCore::ElementData::attributesIterator const):
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Node::hasAttributes const):
(WebCore::Node::attributes const):
* Source/WebCore/dom/ElementIteratorInlines.h:
(WebCore::findElementAncestorOfType):
* Source/WebCore/dom/ElementRareData.h:
(WebCore::Node::shadowRoot const):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::isInShadowTree):
(WebCore::shouldSuppressEventDispatchInDOM):
(WebCore::findInputElementInEventPath):
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::get const):
* Source/WebCore/dom/XMLDocument.h:
(isType):
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::canEnableAutomaticSpellingCorrection const):
* Source/WebCore/editing/ApplyBlockElementCommand.cpp:
(WebCore::ApplyBlockElementCommand::endOfNextParagraphSplittingTextNodesIfNeeded):

Canonical link: <a href="https://commits.webkit.org/270959@main">https://commits.webkit.org/270959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78791941232a65fe62d22288d3fe86f87eb41719

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24490 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28016 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4364 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->