### PR TITLE
Use dynamicDowncast<T> more in html/

### DIFF
--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -359,15 +359,15 @@ void BaseDateAndTimeInputType::updateInnerTextValue()
     createShadowSubtreeIfNeeded();
 
     if (!m_dateTimeEditElement) {
-        auto node = element()->userAgentShadowRoot()->firstChild();
-        if (!is<HTMLElement>(node))
+        RefPtr firstChildElement = dynamicDowncast<HTMLElement>(element()->userAgentShadowRoot()->firstChild());
+        if (!firstChildElement)
             return;
         auto displayValue = visibleValue();
         if (displayValue.isEmpty()) {
             // Need to put something to keep text baseline.
             displayValue = " "_s;
         }
-        downcast<HTMLElement>(*node).setInnerText(WTFMove(displayValue));
+        firstChildElement->setInnerText(WTFMove(displayValue));
         return;
     }
 

--- a/Source/WebCore/html/CachedHTMLCollectionInlines.h
+++ b/Source/WebCore/html/CachedHTMLCollectionInlines.h
@@ -92,7 +92,8 @@ static inline bool nameShouldBeVisibleInDocumentAll(HTMLElement& element)
 
 static inline bool nameShouldBeVisibleInDocumentAll(Element& element)
 {
-    return is<HTMLElement>(element) && nameShouldBeVisibleInDocumentAll(downcast<HTMLElement>(element));
+    auto* htmlElement = dynamicDowncast<HTMLElement>(element);
+    return htmlElement && nameShouldBeVisibleInDocumentAll(*htmlElement);
 }
 
 template <typename HTMLCollectionClass, CollectionTraversalType traversalType>

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -229,10 +229,11 @@ HashSet<Element*> CanvasBase::cssCanvasClients() const
 {
     HashSet<Element*> cssCanvasClients;
     for (auto& observer : m_observers) {
-        if (!is<StyleCanvasImage>(observer))
+        auto* image = dynamicDowncast<StyleCanvasImage>(observer);
+        if (!image)
             continue;
 
-        for (auto entry : downcast<StyleCanvasImage>(observer).clients()) {
+        for (auto entry : image->clients()) {
             auto& client = entry.key;
             if (auto element = client.element())
                 cssCanvasClients.add(element);

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -63,9 +63,10 @@ RefPtr<PaintRenderingContext2D> CustomPaintCanvas::getContext()
     if (m_context)
         return &downcast<PaintRenderingContext2D>(*m_context);
 
-    m_context = PaintRenderingContext2D::create(*this);
-
-    return &downcast<PaintRenderingContext2D>(*m_context);
+    auto context = PaintRenderingContext2D::create(*this);
+    auto* contextPtr = context.get();
+    m_context = WTFMove(context);
+    return contextPtr;
 }
 
 void CustomPaintCanvas::replayDisplayList(GraphicsContext& target)

--- a/Source/WebCore/html/DOMFormData.cpp
+++ b/Source/WebCore/html/DOMFormData.cpp
@@ -93,13 +93,12 @@ static auto createFileEntry(const String& name, Blob& blob, const String& filena
 {
     auto usvName = replaceUnpairedSurrogatesWithReplacementCharacter(String(name));
 
-    if (!blob.isFile())
-        return { usvName, File::create(blob.scriptExecutionContext(), blob, filename.isNull() ? "blob"_s : filename) };
-
-    if (!filename.isNull())
-        return { usvName, File::create(blob.scriptExecutionContext(), downcast<File>(blob), filename) };
-
-    return { usvName, RefPtr<File> { &downcast<File>(blob) } };
+    if (RefPtr file = dynamicDowncast<File>(blob)) {
+        if (!filename.isNull())
+            return { usvName, File::create(blob.scriptExecutionContext(), *file, filename) };
+        return { usvName, WTFMove(file) };
+    }
+    return { usvName, File::create(blob.scriptExecutionContext(), blob, filename.isNull() ? "blob"_s : filename) };
 }
 
 void DOMFormData::append(const String& name, const String& value)

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -304,12 +304,11 @@ bool FTPDirectoryDocumentParser::loadDocumentTemplate()
     RefPtr foundElement = document.getElementById(StringView { "ftpDirectoryTable"_s });
     if (!foundElement)
         LOG_ERROR("Unable to find element by id \"ftpDirectoryTable\" in the template document.");
-    else if (!is<HTMLTableElement>(foundElement))
-        LOG_ERROR("Element of id \"ftpDirectoryTable\" is not a table element");
-    else {
-        m_tableElement = downcast<HTMLTableElement>(foundElement.get());
+    else if (RefPtr tableElement = dynamicDowncast<HTMLTableElement>(*foundElement)) {
+        m_tableElement = WTFMove(tableElement);
         return true;
-    }
+    } else
+        LOG_ERROR("Element of id \"ftpDirectoryTable\" is not a table element");
 
     m_tableElement = HTMLTableElement::create(document);
     m_tableElement->setAttributeWithoutSynchronization(HTMLNames::idAttr, "ftpDirectoryTable"_s);

--- a/Source/WebCore/html/FeaturePolicy.cpp
+++ b/Source/WebCore/html/FeaturePolicy.cpp
@@ -94,11 +94,11 @@ bool isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type type, cons
         }
 
         auto* ownerElement = ancestorDocument->ownerElement();
-        if (is<HTMLIFrameElement>(ownerElement)) {
-            const auto& featurePolicy = downcast<HTMLIFrameElement>(ownerElement)->featurePolicy();
+        if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(ownerElement)) {
+            const auto& featurePolicy = iframe->featurePolicy();
             if (!featurePolicy.allows(type, ancestorDocument->securityOrigin().data())) {
                 if (logFailure == LogFeaturePolicyFailure::Yes && document.domWindow()) {
-                    auto& allowValue = downcast<HTMLIFrameElement>(ownerElement)->attributeWithoutSynchronization(HTMLNames::allowAttr);
+                    auto& allowValue = iframe->attributeWithoutSynchronization(HTMLNames::allowAttr);
                     document.domWindow()->printErrorMessage(makeString("Feature policy '", policyTypeName(type), "' check failed for iframe with origin '", document.securityOrigin().toString(), "' and allow attribute '", allowValue, "'."));
                 }
                 return false;

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -62,7 +62,11 @@ class UploadButtonElement;
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::UploadButtonElement)
     static bool isType(const WebCore::Element& element) { return element.isUploadButton(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WebCore {

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -174,10 +174,10 @@ private:
 
 static bool shouldBeUsedForFormSignature(const Element& element)
 {
-    if (is<HTMLFormControlElement>(element))
-        return downcast<HTMLFormControlElement>(element).shouldSaveAndRestoreFormControlState();
-    if (is<HTMLMaybeFormAssociatedCustomElement>(element))
-        return downcast<HTMLMaybeFormAssociatedCustomElement>(element).hasFormAssociatedInterface() || element.isCustomElementUpgradeCandidate();
+    if (auto* formControl = dynamicDowncast<HTMLFormControlElement>(element))
+        return formControl->shouldSaveAndRestoreFormControlState();
+    if (auto* customElement = dynamicDowncast<HTMLMaybeFormAssociatedCustomElement>(element))
+        return customElement->hasFormAssociatedInterface() || element.isCustomElementUpgradeCandidate();
     return false;
 }
 

--- a/Source/WebCore/html/GenericCachedHTMLCollection.cpp
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.cpp
@@ -68,8 +68,10 @@ bool GenericCachedHTMLCollection<traversalType>::elementMatches(Element& element
         return element.hasTagName(tdTag) || element.hasTagName(thTag);
     case CollectionType::TSectionRows:
         return element.hasTagName(trTag);
-    case CollectionType::SelectedOptions:
-        return is<HTMLOptionElement>(element) && downcast<HTMLOptionElement>(element).selected();
+    case CollectionType::SelectedOptions: {
+        auto* optionElement = dynamicDowncast<HTMLOptionElement>(element);
+        return optionElement && optionElement->selected();
+    }
     case CollectionType::DataListOptions:
         return is<HTMLOptionElement>(element);
     case CollectionType::MapAreas:

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -159,23 +159,23 @@ bool HTMLAnchorElement::isKeyboardFocusable(KeyboardEvent* event) const
 
 static void appendServerMapMousePosition(StringBuilder& url, Event& event)
 {
-    if (!is<MouseEvent>(event))
-        return;
-    auto& mouseEvent = downcast<MouseEvent>(event);
-
-    if (!is<HTMLImageElement>(mouseEvent.target()))
+    auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+    if (!mouseEvent)
         return;
 
-    auto& imageElement = downcast<HTMLImageElement>(*mouseEvent.target());
-    if (!imageElement.isServerMap())
+    auto* imageElement = dynamicDowncast<HTMLImageElement>(mouseEvent->target());
+    if (!imageElement)
         return;
 
-    auto* renderer = imageElement.renderer();
-    if (!is<RenderImage>(renderer))
+    if (!imageElement->isServerMap())
+        return;
+
+    CheckedPtr renderer = dynamicDowncast<RenderImage>(imageElement->renderer());
+    if (!renderer)
         return;
 
     // FIXME: This should probably pass UseTransforms in the OptionSet<MapCoordinatesMode>.
-    auto absolutePosition = downcast<RenderImage>(*renderer).absoluteToLocal(FloatPoint(mouseEvent.pageX(), mouseEvent.pageY()));
+    auto absolutePosition = renderer->absoluteToLocal(FloatPoint(mouseEvent->pageX(), mouseEvent->pageY()));
     url.append('?', std::lround(absolutePosition.x()), ',', std::lround(absolutePosition.y()));
 }
 
@@ -197,9 +197,9 @@ void HTMLAnchorElement::defaultEventHandler(Event& event)
             // This keeps track of the editable block that the selection was in (if it was in one) just before the link was clicked
             // for the LiveWhenNotFocused editable link behavior
             auto& eventNames = WebCore::eventNames();
-            if (event.type() == eventNames.mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() != MouseButton::Right && document().frame()) {
+            if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); event.type() == eventNames.mousedownEvent && mouseEvent && mouseEvent->button() != MouseButton::Right && document().frame()) {
                 setRootEditableElementForSelectionOnMouseDown(document().frame()->selection().selection().rootEditableElement());
-                m_wasShiftKeyDownOnMouseDown = downcast<MouseEvent>(event).shiftKey();
+                m_wasShiftKeyDownOnMouseDown = mouseEvent->shiftKey();
             } else if (event.type() == eventNames.mouseoverEvent) {
                 // These are cleared on mouseover and not mouseout because their values are needed for drag events,
                 // but drag events happen after mouse out events.
@@ -664,9 +664,9 @@ AtomString HTMLAnchorElement::effectiveTarget() const
 
 HTMLAnchorElement::EventType HTMLAnchorElement::eventType(Event& event)
 {
-    if (!is<MouseEvent>(event))
-        return NonMouseEvent;
-    return downcast<MouseEvent>(event).shiftKey() ? MouseEventWithShiftKey : MouseEventWithoutShiftKey;
+    if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event))
+        return mouseEvent->shiftKey() ? MouseEventWithShiftKey : MouseEventWithoutShiftKey;
+    return NonMouseEvent;
 }
 
 bool HTMLAnchorElement::treatLinkAsLiveForEventType(EventType eventType) const
@@ -697,7 +697,10 @@ bool HTMLAnchorElement::treatLinkAsLiveForEventType(EventType eventType) const
 
 bool isEnterKeyKeydownEvent(Event& event)
 {
-    return event.type() == eventNames().keydownEvent && is<KeyboardEvent>(event) && downcast<KeyboardEvent>(event).keyIdentifier() == "Enter"_s;
+    if (event.type() != eventNames().keydownEvent)
+        return false;
+    auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event);
+    return keyboardEvent && keyboardEvent->keyIdentifier() == "Enter"_s;
 }
 
 bool shouldProhibitLinks(Element* element)

--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -198,11 +198,9 @@ Path HTMLAreaElement::getRegion(const LayoutSize& size) const
 
 RefPtr<HTMLImageElement> HTMLAreaElement::imageElement() const
 {
-    RefPtr<Node> mapElement = parentNode();
-    if (!is<HTMLMapElement>(mapElement))
-        return nullptr;
-    
-    return downcast<HTMLMapElement>(*mapElement).imageElement();
+    if (RefPtr mapElement = dynamicDowncast<HTMLMapElement>(parentNode()))
+        return mapElement->imageElement();
+    return nullptr;
 }
 
 bool HTMLAreaElement::isKeyboardFocusable(KeyboardEvent*) const
@@ -235,11 +233,8 @@ void HTMLAreaElement::setFocus(bool shouldBeFocused, FocusVisibility visibility)
     if (!imageElement)
         return;
 
-    auto* renderer = imageElement->renderer();
-    if (!is<RenderImage>(renderer))
-        return;
-
-    downcast<RenderImage>(*renderer).areaElementFocusChanged(this);
+    if (CheckedPtr renderer = dynamicDowncast<RenderImage>(imageElement->renderer()))
+        renderer->areaElementFocusChanged(this);
 }
 
 RefPtr<Element> HTMLAreaElement::focusAppearanceUpdateTarget()

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -488,10 +488,7 @@ void HTMLAttachmentElement::setUniqueIdentifier(const String& uniqueIdentifier)
 
 RefPtr<HTMLImageElement> HTMLAttachmentElement::enclosingImageElement() const
 {
-    if (auto hostElement = shadowHost(); is<HTMLImageElement>(hostElement))
-        return downcast<HTMLImageElement>(hostElement);
-
-    return { };
+    return dynamicDowncast<HTMLImageElement>(shadowHost());
 }
 
 void HTMLAttachmentElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLAudioElement.h
+++ b/Source/WebCore/html/HTMLAudioElement.h
@@ -50,8 +50,16 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLAudioElement)
     static bool isType(const WebCore::HTMLMediaElement& element) { return element.hasTagName(WebCore::HTMLNames::audioTag); }
-    static bool isType(const WebCore::Element& element) { return is<WebCore::HTMLMediaElement>(element) && isType(downcast<WebCore::HTMLMediaElement>(element)); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLMediaElement>(node) && isType(downcast<WebCore::HTMLMediaElement>(node)); }
+    static bool isType(const WebCore::Element& element)
+    {
+        auto* mediaElement = dynamicDowncast<WebCore::HTMLMediaElement>(element);
+        return mediaElement && isType(*mediaElement);
+    }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* mediaElement = dynamicDowncast<WebCore::HTMLMediaElement>(node);
+        return mediaElement && isType(*mediaElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -159,29 +159,28 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
             handlePopoverTargetAction();
     }
 
-    if (is<KeyboardEvent>(event)) {
-        KeyboardEvent& keyboardEvent = downcast<KeyboardEvent>(event);
-        if (keyboardEvent.type() == eventNames.keydownEvent && keyboardEvent.keyIdentifier() == "U+0020"_s) {
+    if (RefPtr keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
+        if (keyboardEvent->type() == eventNames.keydownEvent && keyboardEvent->keyIdentifier() == "U+0020"_s) {
             setActive(true);
             // No setDefaultHandled() - IE dispatches a keypress in this case.
             return;
         }
-        if (keyboardEvent.type() == eventNames.keypressEvent) {
-            switch (keyboardEvent.charCode()) {
+        if (keyboardEvent->type() == eventNames.keypressEvent) {
+            switch (keyboardEvent->charCode()) {
                 case '\r':
-                    dispatchSimulatedClick(&keyboardEvent);
-                    keyboardEvent.setDefaultHandled();
+                    dispatchSimulatedClick(keyboardEvent.get());
+                    keyboardEvent->setDefaultHandled();
                     return;
                 case ' ':
                     // Prevent scrolling down the page.
-                    keyboardEvent.setDefaultHandled();
+                    keyboardEvent->setDefaultHandled();
                     return;
             }
         }
-        if (keyboardEvent.type() == eventNames.keyupEvent && keyboardEvent.keyIdentifier() == "U+0020"_s) {
+        if (keyboardEvent->type() == eventNames.keyupEvent && keyboardEvent->keyIdentifier() == "U+0020"_s) {
             if (active())
-                dispatchSimulatedClick(&keyboardEvent);
-            keyboardEvent.setDefaultHandled();
+                dispatchSimulatedClick(keyboardEvent.get());
+            keyboardEvent->setDefaultHandled();
             return;
         }
     }

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -219,6 +219,10 @@ private:
     static bool checkTagName(const WebCore::CanvasBase& base) { return base.isHTMLCanvasElement(); }
     static bool checkTagName(const WebCore::HTMLElement& element) { return element.hasTagName(WebCore::HTMLNames::canvasTag); }
     static bool checkTagName(const WebCore::Node& node) { return node.hasTagName(WebCore::HTMLNames::canvasTag); }
-    static bool checkTagName(const WebCore::EventTarget& target) { return is<WebCore::Node>(target) && checkTagName(downcast<WebCore::Node>(target)); }
+    static bool checkTagName(const WebCore::EventTarget& target)
+    {
+        auto* node = dynamicDowncast<WebCore::Node>(target);
+        return node && checkTagName(*node);
+    }
 };
 }

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -213,10 +213,11 @@ void HTMLCollection::updateNamedElementCache() const
         const AtomString& id = element.getIdAttribute();
         if (!id.isEmpty())
             cache->appendToIdCache(id, element);
-        if (!is<HTMLElement>(element))
+        auto* htmlElement = dynamicDowncast<HTMLElement>(element);
+        if (!htmlElement)
             continue;
         const AtomString& name = element.getNameAttribute();
-        if (!name.isEmpty() && id != name && (type() != CollectionType::DocAll || nameShouldBeVisibleInDocumentAll(downcast<HTMLElement>(element))))
+        if (!name.isEmpty() && id != name && (type() != CollectionType::DocAll || nameShouldBeVisibleInDocumentAll(*htmlElement)))
             cache->appendToNameCache(name, element);
     }
 

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -72,9 +72,7 @@ void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElemen
 
 const AtomString& DetailsSlotAssignment::slotNameForHostChild(const Node& child) const
 {
-    auto& parent = *child.parentNode();
-    ASSERT(is<HTMLDetailsElement>(parent));
-    auto& details = downcast<HTMLDetailsElement>(parent);
+    auto& details = downcast<HTMLDetailsElement>(*child.parentNode());
 
     // The first summary child gets assigned to the summary slot.
     if (is<HTMLSummaryElement>(child)) {

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -134,8 +134,8 @@ std::optional<std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLColl
     }
 
     auto& element = *documentNamedItem(name);
-    if (UNLIKELY(is<HTMLIFrameElement>(element))) {
-        if (RefPtr domWindow = downcast<HTMLIFrameElement>(element).contentWindow())
+    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element); UNLIKELY(iframe)) {
+        if (RefPtr domWindow = iframe->contentWindow())
             return std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { WTFMove(domWindow) };
     }
 

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -78,5 +78,9 @@ inline Ref<HTMLDocument> HTMLDocument::create(LocalFrame* frame, const Settings&
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLDocument)
     static bool isType(const WebCore::Document& document) { return document.isHTMLDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### ac618086768466d0f522c205131a65006d0dcb9a
<pre>
Use dynamicDowncast&lt;T&gt; more in html/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265092">https://bugs.webkit.org/show_bug.cgi?id=265092</a>

Reviewed by Jean-Yves Avenard.

Use dynamicDowncast&lt;T&gt; more in html/.

I did a little bit of smart pointer adoption on the lines I
changed too.

* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::updateInnerTextValue):
* Source/WebCore/html/CachedHTMLCollectionInlines.h:
(WebCore::nameShouldBeVisibleInDocumentAll):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore:: const):
* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::getContext):
* Source/WebCore/html/DOMFormData.cpp:
(WebCore::createFileEntry):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::loadDocumentTemplate):
* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::isFeaturePolicyAllowedByDocumentAndAllOwners):
* Source/WebCore/html/FileInputType.cpp:
(isType):
* Source/WebCore/html/FormController.cpp:
(WebCore::shouldBeUsedForFormSignature):
* Source/WebCore/html/GenericCachedHTMLCollection.cpp:
(WebCore::GenericCachedHTMLCollection&lt;traversalType&gt;::elementMatches const):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::appendServerMapMousePosition):
(WebCore::HTMLAnchorElement::defaultEventHandler):
(WebCore::HTMLAnchorElement::eventType):
(WebCore::isEnterKeyKeydownEvent):
* Source/WebCore/html/HTMLAreaElement.cpp:
(WebCore::HTMLAreaElement::imageElement const):
(WebCore::HTMLAreaElement::setFocus):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::enclosingImageElement const):
* Source/WebCore/html/HTMLAudioElement.h:
(isType):
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::defaultEventHandler):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
(WebCore::HTMLCanvasElement::didDraw):
(WebCore::HTMLCanvasElement::reset):
(WebCore::HTMLCanvasElement::getImageData):
(WebCore::HTMLCanvasElement::toVideoFrame):
(WebCore::HTMLCanvasElement::setImageBufferAndMarkDirty):
(WebCore::HTMLCanvasElement::clearImageBuffer const):
(WebCore::HTMLCanvasElement::virtualHasPendingActivity const):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::updateNamedElementCache const):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::DetailsSlotAssignment::slotNameForHostChild const):
* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::namedItem):
* Source/WebCore/html/HTMLDocument.h:
(isType):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::elementAffectsDirectionality):
(WebCore::HTMLElement::editabilityFromContentEditableAttr):
(WebCore::HTMLElement::insertedIntoAncestor):
(WebCore::HTMLElement::setOuterText):
(WebCore::HTMLElement::computeDirectionalityFromText const):
(WebCore::HTMLElement::dirAttributeChanged):
(WebCore::HTMLElement::canBeActuallyDisabled const):
(WebCore::checkPopoverValidity):

Canonical link: <a href="https://commits.webkit.org/270960@main">https://commits.webkit.org/270960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b0a8ec3c71da9bf31db7237f1eb10d8d39cf25b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24489 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29767 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30104 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28015 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4367 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3493 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->