### PR TITLE
Provide ability to convert one type of NativePromise into another

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -1435,6 +1435,24 @@ TEST(NativePromise, RunSynchronouslyOnTarget)
     });
 }
 
+// Test that you can convert a NativePromise of different types (exclusive vs non-exclusive)
+TEST(NativePromise, PromiseConversion)
+{
+    using MyPromise = NativePromise<void, int>;
+    using MyNonExclusivePromise = NativePromise<void, int, PromiseOption::Default | PromiseOption::NonExclusive>;
+    runInCurrentRunLoop([](auto& runLoop) {
+        auto nonExclusivePromise = MyNonExclusivePromise::createAndResolve();
+        Ref<MyPromise> promise1 = nonExclusivePromise.get();
+        promise1->whenSettled(runLoop, [](auto&& result) {
+            EXPECT_TRUE(!!result);
+        });
+        Ref<MyPromise> promise2 = nonExclusivePromise.get();
+        promise2->whenSettled(runLoop, [](auto&& result) {
+            EXPECT_TRUE(!!result);
+        });
+    });
+}
+
 // Example:
 // Consider a PhotoProducer class that can take a photo and returns an image and its mimetype.
 // The PhotoProducer uses some system framework that takes a completion handler which will receive the photo once taken.


### PR DESCRIPTION
#### 58d6b89cf67c1a4eb67918398bd471a7b54d36c6
<pre>
Provide ability to convert one type of NativePromise into another
<a href="https://bugs.webkit.org/show_bug.cgi?id=265096">https://bugs.webkit.org/show_bug.cgi?id=265096</a>
<a href="https://rdar.apple.com/118610126">rdar://118610126</a>

Reviewed by NOBODY (OOPS!).

This is achieved by creating a producer for the target promise and chaining it to the current promise.
As the target producer is only ever moved, we can guarantee that it won&apos;t be accessed on different thread
concurrently and as such remove the need to dispatch a new task.
We add a new whenSettled method that will immediately invoke the callback when the source promise is settled.

* Source/WTF/wtf/NativePromise.h:
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58d6b89cf67c1a4eb67918398bd471a7b54d36c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24463 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29733 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30077 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26074 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27987 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5326 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33525 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4335 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7253 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->