### PR TITLE
Make a couple more http/tests/security tests use window.internals.isFullyActive(Document&)

### DIFF
--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-expected.txt
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-expected.txt
@@ -1,1 +1,2 @@
+CONSOLE MESSAGE: Victim loaded.
 This page doesn't do anything special.

--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2.html
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2.html
@@ -39,8 +39,8 @@ if (document.location.search.indexOf("?actually-attack") !== -1) {
 
 function checkDidLoadVictim()
 {
-    if (openerDocument.location.href == "http://127.0.0.1:8000/security/xss-DENIED-script-inject-into-inactive-window2.html") {
-        // Victim loaded.
+    if (window.internals && !window.internals.isFullyActive(openerDocument)) {
+        console.log("Victim loaded.");
         window.clearInterval(intervalId);
 
         // Run code in victim.

--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3-expected.txt
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3-expected.txt
@@ -1,1 +1,2 @@
+CONSOLE MESSAGE: Victim loaded.
 This page doesn't do anything special.

--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3.html
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3.html
@@ -57,8 +57,8 @@ if (!window.location.search) {
 
 function checkDidLoadVictim()
 {
-    if (secondOpenerDocument.location.href == "http://127.0.0.1:8000/security/xss-DENIED-script-inject-into-inactive-window3.html?actually-actually-attack") {
-        // Victim loaded.
+    if (window.internals && !window.internals.isFullyActive(secondOpenerDocument)) {
+        console.log("Victim loaded.");
         window.clearInterval(intervalId);
 
         // Run code in victim.


### PR DESCRIPTION
#### a2d071de9311b41a64f727f86be2f2e2bd0fc68e
<pre>
Make a couple more http/tests/security tests use window.internals.isFullyActive(Document&amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265101">https://bugs.webkit.org/show_bug.cgi?id=265101</a>

Reviewed by David Kilzer.

This change updates two http/tests/security tests to use the (recently-added)
window.internals.isFullyActive(Document&amp;) function.

<a href="https://commits.webkit.org/270737">https://commits.webkit.org/270737</a> added a window.internals.isFullyActive(Document&amp;)
function — for cases where it’s necessary for a test to ensure whether or not a
particular document is fully active — and used that to update (fix) the test at
http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html,
which its last update in <a href="https://commits.webkit.org/269235@main">https://commits.webkit.org/269235@main</a> had made flaky.

And in the <a href="https://commits.webkit.org/269235@main">https://commits.webkit.org/269235@main</a> change which caused
that http/tests/security test to become flaky, two companion tests had
also been updated in the same way that had caused the flakiness in that
other test (before it was subsequently fixed).

So, while the two other companion tests have not yet been flaky,
applying the same window.internals.isFullyActive(Document&amp;) fix to them
ensures they’re actually working as expected — that is, actually testing
what they’re intended to be testing — and not at risk of becoming flaky
later due to the same underlying problem.

* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-expected.txt:
* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2.html:
* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3-expected.txt:
* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3.html:

Canonical link: <a href="https://commits.webkit.org/271565@main">https://commits.webkit.org/271565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b843b1aef42e0cc554da0d8d245299b9f691473

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24567 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24453 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29723 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30068 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27978 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23805 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4325 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3716 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->