### PR TITLE
[NativePromise] Remove need to provide SerialFunctionDispatch to all and allSettled

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -247,7 +247,7 @@ void MediaSource::completeSeek()
     auto seekTarget = *m_pendingSeekTarget;
     m_pendingSeekTarget.reset();
 
-    Ref<MediaTimePromise> promise = SourceBuffer::ComputeSeekPromise::all(RunLoop::current(), WTF::map(*m_activeSourceBuffers, [&](auto&& sourceBuffer) {
+    Ref<MediaTimePromise> promise = SourceBuffer::ComputeSeekPromise::all(WTF::map(*m_activeSourceBuffers, [&](auto&& sourceBuffer) {
         return sourceBuffer->computeSeekTime(seekTarget);
     }))->whenSettled(RunLoop::current(), [time = seekTarget.time, protectedThis = Ref { *this }] (auto&& results) mutable {
         if (!results)

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -716,7 +716,7 @@ Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
         }
         client().sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
 
-        return MediaPromise::all(RunLoop::current(), promises).get();
+        return MediaPromise::all(promises).get();
     });
     return m_currentSourceBufferOperation.get();
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -726,7 +726,7 @@ TEST(NativePromise, PromiseAllResolve)
         promises.append(TestPromise::createAndResolve(32));
         promises.append(TestPromise::createAndResolve(42));
 
-        TestPromise::all(queue, promises)->then(queue,
+        TestPromise::all(promises)->then(queue,
             [queue](const Vector<int>& resolveValues) {
                 EXPECT_EQ(resolveValues.size(), 3UL);
                 EXPECT_EQ(resolveValues[0], 22);
@@ -748,13 +748,13 @@ TEST(NativePromise, PromiseVoidAllResolve)
         promises.append(GenericPromise::createAndResolve());
         promises.append(GenericPromise::createAndResolve());
 
-        GenericPromise::all(queue, promises)->then(queue,
+        GenericPromise::all(promises)->then(queue,
             [] () {
                 EXPECT_TRUE(true);
             },
             doFail());
 
-        GenericPromise::all(queue, Vector<Ref<GenericPromise>>(10, [](size_t) {
+        GenericPromise::all(Vector<Ref<GenericPromise>>(10, [](size_t) {
             return GenericPromise::createAndResolve();
         }))->then(queue,
             [queue] () {
@@ -780,7 +780,7 @@ TEST(NativePromise, PromiseAllResolveAsync)
             return TestPromise::createAndResolve(42);
         }));
 
-        TestPromise::all(queue, promises)->then(queue,
+        TestPromise::all(promises)->then(queue,
             [queue](const Vector<int>& resolveValues) {
                 EXPECT_EQ(resolveValues.size(), 3UL);
                 EXPECT_EQ(resolveValues[0], 22);
@@ -804,7 +804,7 @@ TEST(NativePromise, PromiseAllReject)
         // Ensure that more than one rejection doesn't cause a crash
         promises.append(TestPromise::createAndReject(52.0));
 
-        TestPromise::all(queue, promises)->then(queue,
+        TestPromise::all(promises)->then(queue,
             doFail(),
             [queue](float rejectValue) {
                 EXPECT_EQ(rejectValue, 32.0);
@@ -833,7 +833,7 @@ TEST(NativePromise, PromiseAllRejectAsync)
             return TestPromise::createAndReject(52.0);
         }));
 
-        TestPromise::all(queue, promises)->then(queue,
+        TestPromise::all(promises)->then(queue,
             doFail(),
             [queue](float rejectValue) {
                 EXPECT_EQ(rejectValue, 32.0);
@@ -853,7 +853,7 @@ TEST(NativePromise, PromiseAllSettled)
         promises.append(TestPromise::createAndResolve(42));
         promises.append(TestPromise::createAndReject(52.0));
 
-        TestPromise::allSettled(queue, promises)->then(
+        TestPromise::allSettled(promises)->then(
             queue,
             [queue](const TestPromise::AllSettledPromiseType::ResolveValueType& resolveValues) {
                 EXPECT_EQ(resolveValues.size(), 4UL);
@@ -891,7 +891,7 @@ TEST(NativePromise, PromiseAllSettledAsync)
             return TestPromise::createAndReject(52.0);
         }));
 
-        TestPromise::allSettled(queue, promises)->then(queue,
+        TestPromise::allSettled(promises)->then(queue,
             [queue](const TestPromise::AllSettledPromiseType::ResolveValueType& resolveValues) {
                 EXPECT_EQ(resolveValues.size(), 4UL);
                 EXPECT_TRUE(resolveValues[0].has_value());


### PR DESCRIPTION
#### 9cfcc4e4e46b498f90c5c83c1b0f340ec588e795
<pre>
[NativePromise] Remove need to provide SerialFunctionDispatch to all and allSettled
<a href="https://bugs.webkit.org/show_bug.cgi?id=265102">https://bugs.webkit.org/show_bug.cgi?id=265102</a>
<a href="https://rdar.apple.com/118612313">rdar://118612313</a>

Reviewed by Dan Glastonbury.

use new whenSettled option that provides immediate dispatch and use locks instead to protect class members.
API tests added

* Source/WTF/wtf/NativePromise.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::completeSeek):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::append):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271032@main">https://commits.webkit.org/271032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96dff0ad76319f0f305be69b9b0f9fe0eaa58280

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29271 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24597 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29907 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23579 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30218 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26245 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28134 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5495 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33699 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6519 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4498 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7306 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->