### PR TITLE
[CSS Fonts] Implement font-size-adjust:ic-height in ports with OPENTYPE_VERTICAL enabled

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov
+ * Copyright (C) 2025 ChangSeok Oh <changseok@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -96,12 +97,9 @@ Font::Font(const FontPlatformData& platformData, Origin origin, IsInterstitial i
     platformInit();
     platformGlyphInit();
     platformCharWidthInit();
-#if ENABLE(OPENTYPE_VERTICAL)
-    if (platformData.orientation() == FontOrientation::Vertical && orientationFallback == IsOrientationFallback::No) {
-        m_verticalData = FontCache::forCurrentThread()->verticalData(platformData);
-        m_hasVerticalGlyphs = m_verticalData.get() && m_verticalData->hasVerticalMetrics();
-    }
-#endif
+
+    if (platformData.orientation() == FontOrientation::Vertical && orientationFallback == IsOrientationFallback::No)
+        platformGlyphVerticalDataInit();
 }
 
 Font::Font(IsSystemFallbackFontPlaceholder isSystemFontFallbackPlaceholder)
@@ -172,6 +170,10 @@ void Font::platformGlyphInit()
     if (RefPtr page = glyphPage(GlyphPage::pageNumberForCodePoint(cjkWater))) {
         auto glyph = page->glyphDataForCharacter(cjkWater).glyph;
         m_fontMetrics.setIdeogramWidth(widthForGlyph(glyph));
+
+        platformGlyphVerticalDataInit();
+        if (auto height = heightForGlyph(glyph))
+            m_fontMetrics.setIdeogramHeight(*height);
     } else
         m_fontMetrics.setIdeogramWidth(platformData().size());
 
@@ -180,6 +182,16 @@ void Font::platformGlyphInit()
     m_fontMetrics.setLineGap(m_fontMetrics.lineGap() - amountToAdjustLineGap);
     m_fontMetrics.setLineSpacing(m_fontMetrics.lineSpacing() - amountToAdjustLineGap);
     determinePitch();
+}
+
+void Font::platformGlyphVerticalDataInit()
+{
+#if ENABLE(OPENTYPE_VERTICAL)
+    std::call_once(m_verticalDataOnceFlag, [this] {
+        m_verticalData = FontCache::forCurrentThread()->verticalData(m_platformData);
+        m_hasVerticalGlyphs = m_verticalData.get() && m_verticalData->hasVerticalMetrics();
+    });
+#endif
 }
 
 Font::~Font()
@@ -648,6 +660,17 @@ bool Font::canRenderCombiningCharacterSequence(StringView stringView) const
             return false;
     }
     return true;
+}
+
+std::optional<float> Font::heightForGlyph(Glyph glyph) const
+{
+#if ENABLE(OPENTYPE_VERTICAL)
+    if (m_verticalData)
+        return m_verticalData->advanceHeight(this, glyph);
+#else
+    UNUSED_PARAM(glyph);
+#endif
+    return std::nullopt;
 }
 
 Path Font::pathForGlyph(Glyph glyph) const

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -194,6 +194,7 @@ public:
     };
 
     float widthForGlyph(Glyph, SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const;
+    std::optional<float> heightForGlyph(Glyph) const;
 
     Path pathForGlyph(Glyph) const;
 
@@ -278,6 +279,7 @@ private:
 
     void platformInit();
     void platformGlyphInit();
+    void platformGlyphVerticalDataInit();
     void platformCharWidthInit();
     void platformDestroy();
 
@@ -348,6 +350,7 @@ private:
     mutable RefPtr<OpenTypeMathData> m_mathData;
 #endif
 #if ENABLE(OPENTYPE_VERTICAL)
+    std::once_flag m_verticalDataOnceFlag;
     RefPtr<OpenTypeVerticalData> m_verticalData;
 #endif
 
@@ -516,8 +519,8 @@ ALWAYS_INLINE float Font::widthForGlyph(Glyph glyph, SyntheticBoldInclusion Synt
         return width + (SyntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
 
 #if ENABLE(OPENTYPE_VERTICAL)
-    if (m_verticalData)
-        width = m_verticalData->advanceHeight(this, glyph);
+    if (m_platformData.orientation() == FontOrientation::Vertical && !isTextOrientationFallback())
+        width = heightForGlyph(glyph).value_or(platformWidthForGlyph(glyph));
     else
 #endif
         width = platformWidthForGlyph(glyph);

--- a/Source/WebCore/platform/graphics/FontMetrics.h
+++ b/Source/WebCore/platform/graphics/FontMetrics.h
@@ -108,6 +108,9 @@ public:
     Markable<float> zeroWidth() const { return m_zeroWidth; }
     void setZeroWidth(float zeroWidth) { m_zeroWidth = zeroWidth; }
 
+    Markable<float> ideogramHeight() const { return m_ideogramHeight; };
+    void setIdeogramHeight(float ideogramHeight) { m_ideogramHeight = ideogramHeight; }
+
     Markable<float> ideogramWidth() const { return m_ideogramWidth; }
     void setIdeogramWidth(float ideogramWidth) { m_ideogramWidth = ideogramWidth; }
 
@@ -134,6 +137,7 @@ private:
         m_ascent = { };
         m_capHeight = { };
         m_descent = { };
+        m_ideogramHeight = { };
         m_ideogramWidth = { };
         m_lineGap = { };
         m_lineSpacing = { };
@@ -154,6 +158,7 @@ private:
     Markable<float> m_ascent;
     Markable<float> m_capHeight;
     Markable<float> m_descent;
+    Markable<float> m_ideogramHeight;
     Markable<float> m_ideogramWidth;
     Markable<float> m_lineGap;
     Markable<float> m_lineSpacing;

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -43,8 +43,11 @@ struct FontSizeAdjust {
         IcHeight
     };
 
-    std::optional<float> resolve(float computedSize, const FontMetrics& fontMetrics) const
+    std::optional<float> resolve(float size, const FontMetrics& fontMetrics) const
     {
+        if (!size)
+            return std::nullopt;
+
         std::optional<float> metricValue;
         switch (metric) {
         case FontSizeAdjust::Metric::CapHeight:
@@ -53,19 +56,23 @@ struct FontSizeAdjust {
         case FontSizeAdjust::Metric::ChWidth:
             metricValue = fontMetrics.zeroWidth();
             break;
-        // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
         case FontSizeAdjust::Metric::IcWidth:
-        case FontSizeAdjust::Metric::IcHeight:
             metricValue = fontMetrics.ideogramWidth();
+            break;
+        case FontSizeAdjust::Metric::IcHeight:
+            metricValue = fontMetrics.ideogramHeight();
             break;
         case FontSizeAdjust::Metric::ExHeight:
         default:
             metricValue = fontMetrics.xHeight();
         }
 
-        return metricValue.has_value() && computedSize
-            ? std::make_optional(*metricValue / computedSize)
-            : std::nullopt;
+        // We use the size as fallback values when required font metrics are missing.
+        // Thus, we return 1.0 (= size / size) in such cases.
+        // https://github.com/w3c/csswg-drafts/issues/6384
+        return metricValue.has_value()
+            ? std::make_optional(*metricValue / size)
+            : std::make_optional(1.0f);
     }
 
     bool isNone() const { return !value && type != ValueType::FromFont; }

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -194,20 +194,20 @@ static float adjustedFontSize(float size, float sizeAdjust, float metricValue)
 
 float adjustedFontSize(float size, const WebCore::FontSizeAdjust& sizeAdjust, const FontMetrics& metrics)
 {
-    // FIXME: The behavior for missing metrics has yet to be defined.
+    // We use size as fallback values when required font metrics are missing.
     // https://github.com/w3c/csswg-drafts/issues/6384
     switch (sizeAdjust.metric) {
     case WebCore::FontSizeAdjust::Metric::CapHeight:
-        return metrics.capHeight() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.capHeight()) : size;
+        return adjustedFontSize(size, *sizeAdjust.value, metrics.capHeight() ? *metrics.capHeight() : size);
     case WebCore::FontSizeAdjust::Metric::ChWidth:
-        return metrics.zeroWidth() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.zeroWidth()) : size;
-    // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
-    case WebCore::FontSizeAdjust::Metric::IcWidth:
+        return adjustedFontSize(size, *sizeAdjust.value, metrics.zeroWidth() ? *metrics.zeroWidth(): size);
     case WebCore::FontSizeAdjust::Metric::IcHeight:
-        return metrics.ideogramWidth() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.ideogramWidth()) : size;
+        return adjustedFontSize(size, *sizeAdjust.value, metrics.ideogramHeight() ? *metrics.ideogramHeight() : size);
+    case WebCore::FontSizeAdjust::Metric::IcWidth:
+        return adjustedFontSize(size, *sizeAdjust.value, metrics.ideogramWidth() ? *metrics.ideogramWidth(): size);
     case WebCore::FontSizeAdjust::Metric::ExHeight:
     default:
-        return metrics.xHeight() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.xHeight()) : size;
+        return adjustedFontSize(size, *sizeAdjust.value, metrics.xHeight() ? *metrics.xHeight() : size);
     }
 
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 7d23d13d9a139cff7ff38f21469dad6f2769e7f5
<pre>
[CSS Fonts] Implement font-size-adjust:ic-height in ports with OPENTYPE_VERTICAL enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=264064">https://bugs.webkit.org/show_bug.cgi?id=264064</a>

Reviewed by NOBODY (OOPS!).

This change implements the ic-height metric used by font-size-adjust [1] in ports
utilizing OpenType. We initialize the vertical glyph data when available.
If the selected font does not specify the height of the CJK water glyph, we use
its size as a fallback [2], since the glyph typically has equal width and height.

[1] <a href="https://www.w3.org/TR/css-fonts-5/#valdef-font-size-adjust-ic-height">https://www.w3.org/TR/css-fonts-5/#valdef-font-size-adjust-ic-height</a>
[2] <a href="https://github.com/w3c/csswg-drafts/issues/6384">https://github.com/w3c/csswg-drafts/issues/6384</a>

Test: imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-ic-height.html

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::m_shouldNotBeUsedForArabic):
(WebCore::Font::platformGlyphInit):
(WebCore::Font::platformGlyphVerticalDataInit):
(WebCore::Font::heightForGlyph const):
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::widthForGlyph const):
* Source/WebCore/platform/graphics/FontMetrics.h:
(WebCore::FontMetrics::ideogramHeight const):
(WebCore::FontMetrics::setIdeogramHeight):
(WebCore::FontMetrics::reset):
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
(WebCore::FontSizeAdjust::resolve const):
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::adjustedFontSize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d23d13d9a139cff7ff38f21469dad6f2769e7f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127748 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/48024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97237 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65140 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77719 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32531 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137504 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105759 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105411 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52028 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60577 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53580 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/57035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->