### PR TITLE
colorDepth returns '0' on detached frame

### DIFF
--- a/LayoutTests/http/tests/dom/same-origin-detached-window-properties-expected.txt
+++ b/LayoutTests/http/tests/dom/same-origin-detached-window-properties-expected.txt
@@ -20,8 +20,8 @@ PASS w.location.reload('') did not throw exception.
 PASS !!w.screen is true
 PASS w.screen.height is 0
 PASS w.screen.width is 0
-PASS w.screen.colorDepth is 0
-PASS w.screen.pixelDepth is 0
+PASS w.screen.colorDepth is 24
+PASS w.screen.pixelDepth is 24
 PASS w.screen.availLeft is 0
 PASS w.screen.availTop is 0
 PASS w.screen.availHeight is 0
@@ -94,8 +94,8 @@ PASS w.location.reload('') did not throw exception.
 PASS !!w.screen is true
 PASS w.screen.height is 0
 PASS w.screen.width is 0
-PASS w.screen.colorDepth is 0
-PASS w.screen.pixelDepth is 0
+PASS w.screen.colorDepth is 24
+PASS w.screen.pixelDepth is 24
 PASS w.screen.availLeft is 0
 PASS w.screen.availTop is 0
 PASS w.screen.availHeight is 0

--- a/LayoutTests/http/tests/dom/same-origin-detached-window-properties.html
+++ b/LayoutTests/http/tests/dom/same-origin-detached-window-properties.html
@@ -37,8 +37,8 @@ function validateWindow(_w)
     if (w.screen) {
         shouldBe("w.screen.height", "0");
         shouldBe("w.screen.width", "0");
-        shouldBe("w.screen.colorDepth", "0");
-        shouldBe("w.screen.pixelDepth", "0");
+        shouldBe("w.screen.colorDepth", "24");
+        shouldBe("w.screen.pixelDepth", "24");
         shouldBe("w.screen.availLeft", "0");
         shouldBe("w.screen.availTop", "0");
         shouldBe("w.screen.availHeight", "0");

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -4492,6 +4492,7 @@
         "web-platform-tests/css/cssom-view/scrollTop-display-change-ref.html",
         "web-platform-tests/css/cssom-view/scrollingElement-quirks-dynamic-001-ref.html",
         "web-platform-tests/css/cssom-view/scrollingElement-quirks-dynamic-002-ref.html",
+        "web-platform-tests/css/cssom-view/window-scrollBy-display-change-ref.html",
         "web-platform-tests/css/cssom/CSSStyleSheet-constructable-concat-ref.html",
         "web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate-ref.html",
         "web-platform-tests/css/cssom/insertRule-from-script-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Window.screen on detached frame
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-window-screen">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1858977">
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe></iframe>
+<script>
+onload = function() {
+  test(() => {
+    let frame = document.querySelector("iframe");
+    let win = frame.contentWindow;
+    frame.remove();
+    assert_true(!!win.screen, "Window.screen should be available");
+    for (let prop of ["top", "left", "width", "height"]) {
+      let availProp = "avail" + prop[0].toUpperCase() + prop.substr(1);
+      if (prop == "width" || prop == "height") {
+        assert_true(prop in win.screen, prop + "must be implemented per spec")
+        assert_true(availProp in win.screen, availProp + "must be implemented per spec")
+      }
+      if (prop in win.screen) {
+        assert_equals(win.screen[prop], 0, prop);
+      }
+      if (availProp in win.screen) {
+        assert_equals(win.screen[availProp], 0, availProp);
+      }
+    }
+
+    // https://drafts.csswg.org/cssom-view/#dom-screen-colordepth
+    //   If the user agent does not know the color depth or does not want to
+    //   return it for privacy considerations, it should return 24.
+    for (let prop of ["colorDepth", "pixelDepth"]) {
+      assert_equals(win.screen[prop], 24, prop);
+    }
+  }, "Window.screen on detached frame");
+};
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/w3c-import.log
@@ -122,6 +122,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/pt-to-px-width.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/range-bounding-client-rect-with-display-contents.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/resize-event-on-initial-layout.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screenLeftTop.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-back-to-initial-position.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-default-css.html
@@ -183,3 +184,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-screen-height.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-screen-width-immutable.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-screen-width.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <div style="width: 100px; height: 100px; background: green;"></div>
+    </body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-ref.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <div style="width: 100px; height: 100px; background: green;"></div>
+    </body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Verify that scrolling the root does actually do a visual scroll</title>
+        <link rel="help" href="https://www.w3.org/TR/cssom-view-1/#dom-window-scrollby">
+        <link rel="match" href="window-scrollBy-display-change-ref.html">
+    </head>
+    <body style="overflow: hidden" onload="window.scrollBy(0, 2000);">
+        <div style="height: 2000px"></div>
+        <div style="width: 100px; height: 100px; background: green;"></div>
+        <div style="height: 2000px"></div>
+    </body>
+</html>
+

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -92,7 +92,7 @@ unsigned Screen::colorDepth() const
 {
     RefPtr frame = this->frame();
     if (!frame)
-        return 0;
+        return 24;
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::ColorDepth);
     return static_cast<unsigned>(screenDepth(frame->view()));


### PR DESCRIPTION
#### 34925ea7ad8031c79323a34e6b93b03a5e83e1d0
<pre>
colorDepth returns &apos;0&apos; on detached frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=265021">https://bugs.webkit.org/show_bug.cgi?id=265021</a>

Reviewed by Simon Fraser.

The specification requires 24 as a fallback rather than 0:
<a href="https://drafts.csswg.org/cssom-view/#dom-screen-colordepth">https://drafts.csswg.org/cssom-view/#dom-screen-colordepth</a>

Always returning 24 is tempting, but maybe not correct long term.

This synchronizes web-platforms-tests for css/cssom-view with:
<a href="https://github.com/web-platform-tests/wpt/commit/46476776fdbf0a62522621002ba8af68e4d478b6">https://github.com/web-platform-tests/wpt/commit/46476776fdbf0a62522621002ba8af68e4d478b6</a>

* LayoutTests/http/tests/dom/same-origin-detached-window-properties-expected.txt:
* LayoutTests/http/tests/dom/same-origin-detached-window-properties.html:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/window-scrollBy-display-change.html: Added.
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::colorDepth const):

Canonical link: <a href="https://commits.webkit.org/270952@main">https://commits.webkit.org/270952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/427401c7a164222c9566fa80dcbb589edccfab79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24465 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3795 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30080 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27990 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6460 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->