### PR TITLE
Don't fire dblclick on disabled form control elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
@@ -20,8 +20,8 @@ PASS Testing click events when clicking child of disabled button.
 PASS Testing click events when clicking child of disabled my-control.
 PASS Testing click events when clicking disabled button.
 PASS Testing click events when clicking disabled my-control.
-FAIL Testing dblclick events when clicking child of disabled button. assert_equals: parent element received dblclick events expected false but got true
-FAIL Testing dblclick events when clicking child of disabled my-control. assert_equals: parent element received dblclick events expected false but got true
-FAIL Testing dblclick events when clicking disabled button. assert_equals: parent element received dblclick events expected false but got true
-FAIL Testing dblclick events when clicking disabled my-control. assert_equals: parent element received dblclick events expected false but got true
+PASS Testing dblclick events when clicking child of disabled button.
+PASS Testing dblclick events when clicking child of disabled my-control.
+PASS Testing dblclick events when clicking disabled button.
+PASS Testing dblclick events when clicking disabled my-control.
 

--- a/LayoutTests/platform/ios-simulator-16-wk2/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/platform/ios-simulator-16-wk2/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
@@ -20,8 +20,8 @@ PASS Testing click events when clicking child of disabled button.
 PASS Testing click events when clicking child of disabled my-control.
 PASS Testing click events when clicking disabled button.
 PASS Testing click events when clicking disabled my-control.
-FAIL Testing dblclick events when clicking child of disabled button. assert_equals: child element received dblclick events expected true but got false
-FAIL Testing dblclick events when clicking child of disabled my-control. assert_equals: child element received dblclick events expected true but got false
+PASS Testing dblclick events when clicking child of disabled button.
+PASS Testing dblclick events when clicking child of disabled my-control.
 PASS Testing dblclick events when clicking disabled button.
 PASS Testing dblclick events when clicking disabled my-control.
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
@@ -20,8 +20,8 @@ PASS Testing click events when clicking child of disabled button.
 PASS Testing click events when clicking child of disabled my-control.
 PASS Testing click events when clicking disabled button.
 PASS Testing click events when clicking disabled my-control.
-FAIL Testing dblclick events when clicking child of disabled button. assert_equals: child element received dblclick events expected true but got false
-FAIL Testing dblclick events when clicking child of disabled my-control. assert_equals: child element received dblclick events expected true but got false
+PASS Testing dblclick events when clicking child of disabled button.
+PASS Testing dblclick events when clicking child of disabled my-control.
 PASS Testing dblclick events when clicking disabled button.
 PASS Testing dblclick events when clicking disabled my-control.
 

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -158,7 +158,7 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
     EventPath eventPath { node, event };
 
     if (node.document().settings().sendMouseEventsToDisabledFormControlsEnabled() && event.isTrusted() && event.isMouseEvent()
-        && (event.type() == eventNames().mousedownEvent || event.type() == eventNames().mouseupEvent || event.type() == eventNames().clickEvent)) {
+        && (event.type() == eventNames().mousedownEvent || event.type() == eventNames().mouseupEvent || event.type() == eventNames().clickEvent || event.type() == eventNames().dblclickEvent)) {
         eventPath.adjustForDisabledFormControl();
     }
 


### PR DESCRIPTION
#### 74ae3ea8d68e6bc52dc58bae5064a8ec4e2e09ae
<pre>
Don&apos;t fire dblclick on disabled form control elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=265071">https://bugs.webkit.org/show_bug.cgi?id=265071</a>
<a href="https://rdar.apple.com/problem/118584431">rdar://problem/118584431</a>

Reviewed by Tim Nguyen.

This patch extends to not fire double click events on disabled elements similar to click event aligning with
Gecko / Firefox, Blink / Chromium and agreed behavior in web specification issue [1]:

[1] <a href="https://github.com/whatwg/html/issues/2368#issuecomment-1791704780">https://github.com/whatwg/html/issues/2368#issuecomment-1791704780</a>

* Source/WebCore/dom/EventDispatcher.cpp:
(EventDispatcher::dispatchEvent):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt: Rebaselined
* LayoutTests/platform/ios-simulator-16-wk2/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt: Rebaselined
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/270951@main">https://commits.webkit.org/270951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/229ccb5974ec38517a736da818256c8f5e46617d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24471 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30085 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27995 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5336 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6459 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->