### PR TITLE
Initial <input type=checkbox switch> animation support

### DIFF
--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -181,6 +181,7 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
         return;
 
     InputElementClickState clickHandlingState;
+    clickHandlingState.trusted = event.isTrusted();
 
     RefPtr inputForLegacyPreActivationBehavior = dynamicDowncast<HTMLInputElement>(node);
     if (!inputForLegacyPreActivationBehavior && event.bubbles() && event.type() == eventNames().clickEvent)

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -34,6 +34,8 @@
 
 namespace WebCore {
 
+enum class WasSetByJavaScript : bool;
+
 class CheckboxInputType final : public BaseCheckableInputType {
 public:
     static Ref<CheckboxInputType> create(HTMLInputElement& element)
@@ -42,6 +44,9 @@ public:
     }
 
     bool valueMissing(const String&) const final;
+
+    void performSwitchCheckedChangeAnimation(WasSetByJavaScript);
+    float switchCheckedChangeAnimationProgress() const;
 
 private:
     explicit CheckboxInputType(HTMLInputElement& element)
@@ -57,6 +62,11 @@ private:
     void didDispatchClick(Event&, const InputElementClickState&) final;
     bool matchesIndeterminatePseudoClass() const final;
     bool shouldAppearIndeterminate() const final;
+
+    void switchCheckedChangeAnimationTimerFired();
+
+    Seconds m_switchCheckedChangeAnimationStartTime { 0_s };
+    std::unique_ptr<Timer> m_switchCheckedChangeAnimationTimer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -34,6 +34,7 @@
 #include "CSSGradientValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSValuePool.h"
+#include "CheckboxInputType.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "ColorInputType.h"
@@ -1029,7 +1030,7 @@ void HTMLInputElement::setDefaultCheckedState(bool isDefaultChecked)
     m_isDefaultChecked = isDefaultChecked;
 }
 
-void HTMLInputElement::setChecked(bool isChecked)
+void HTMLInputElement::setChecked(bool isChecked, WasSetByJavaScript wasCheckedByJavaScript)
 {
     m_dirtyCheckednessFlag = true;
     if (checked() == isChecked)
@@ -1043,8 +1044,11 @@ void HTMLInputElement::setChecked(bool isChecked)
 
     if (auto* buttons = radioButtonGroups())
         buttons->updateCheckedState(*this);
-    if (auto* renderer = this->renderer(); renderer && renderer->style().hasEffectiveAppearance())
+    if (auto* renderer = this->renderer(); renderer && renderer->style().hasEffectiveAppearance()) {
+        if (isSwitch())
+            downcast<CheckboxInputType>(*m_inputType).performSwitchCheckedChangeAnimation(wasCheckedByJavaScript);
         renderer->theme().stateChanged(*renderer, ControlStates::States::Checked);
+    }
     updateValidity();
 
     // Ideally we'd do this from the render tree (matching
@@ -2309,6 +2313,12 @@ String HTMLInputElement::placeholder() const
 bool HTMLInputElement::dirAutoUsesValue() const
 {
     return m_inputType->dirAutoUsesValue();
+}
+
+float HTMLInputElement::switchCheckedChangeAnimationProgress() const
+{
+    ASSERT(isSwitch());
+    return downcast<CheckboxInputType>(*m_inputType).switchCheckedChangeAnimationProgress();
 }
 
 } // namespace

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -52,6 +52,7 @@ struct InputElementClickState {
     bool stateful { false };
     bool checked { false };
     bool indeterminate { false };
+    bool trusted { false };
     RefPtr<HTMLInputElement> checkedRadioButton;
 };
 
@@ -64,7 +65,7 @@ public:
     virtual ~HTMLInputElement();
 
     bool checked() const { return m_isChecked; }
-    WEBCORE_EXPORT void setChecked(bool);
+    WEBCORE_EXPORT void setChecked(bool, WasSetByJavaScript = WasSetByJavaScript::Yes);
     WEBCORE_EXPORT FileList* files();
     WEBCORE_EXPORT void setFiles(RefPtr<FileList>&&, WasSetByJavaScript = WasSetByJavaScript::No);
     FileList* filesForBindings() { return files(); }
@@ -340,6 +341,8 @@ public:
     void finishParsingChildren() final;
 
     bool hasEverBeenPasswordField() const { return m_hasEverBeenPasswordField; }
+
+    float switchCheckedChangeAnimationProgress() const;
 
 protected:
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);

--- a/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
@@ -33,8 +33,22 @@ class SwitchThumbPart final : public ControlPart {
 public:
     static Ref<SwitchThumbPart> create()
     {
-        return adoptRef(*new SwitchThumbPart());
+        return adoptRef(*new SwitchThumbPart(0.0f));
     }
+
+    static Ref<SwitchThumbPart> create(float progress)
+    {
+        return adoptRef(*new SwitchThumbPart(progress));
+    }
+
+    SwitchThumbPart(float progress)
+        : ControlPart(StyleAppearance::SwitchThumb)
+        , m_progress(progress)
+    {
+    }
+
+    float progress() const { return m_progress; }
+    void setProgress(float progress) { m_progress = progress; }
 
 private:
     SwitchThumbPart()
@@ -46,6 +60,10 @@ private:
     {
         return controlFactory().createPlatformSwitchThumb(*this);
     }
+
+    float m_progress;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CONTROL_PART(SwitchThumb)

--- a/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
@@ -33,8 +33,22 @@ class SwitchTrackPart final : public ControlPart {
 public:
     static Ref<SwitchTrackPart> create()
     {
-        return adoptRef(*new SwitchTrackPart());
+        return adoptRef(*new SwitchTrackPart(0.0f));
     }
+
+    static Ref<SwitchTrackPart> create(float progress)
+    {
+        return adoptRef(*new SwitchTrackPart(progress));
+    }
+
+    SwitchTrackPart(float progress)
+        : ControlPart(StyleAppearance::SwitchTrack)
+        , m_progress(progress)
+    {
+    }
+
+    float progress() const { return m_progress; }
+    void setProgress(float progress) { m_progress = progress; }
 
 private:
     SwitchTrackPart()
@@ -46,6 +60,10 @@ private:
     {
         return controlFactory().createPlatformSwitchTrack(*this);
     }
+
+    float m_progress;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CONTROL_PART(SwitchTrack)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
@@ -32,6 +32,7 @@ static IntSize cellSize(NSControlSize);
 static IntOutsets cellOutsets(NSControlSize);
 static FloatRect rectForBounds(const FloatRect&);
 static NSString *coreUISizeForControlSize(const NSControlSize);
+static float easeInOut(float);
 
 } // namespace WebCore::SwitchMacUtilities
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
@@ -77,6 +77,11 @@ static NSString *coreUISizeForControlSize(const NSControlSize controlSize)
     return (__bridge NSString *)kCUISizeRegular;
 }
 
+static float easeInOut(const float progress)
+{
+    return -2.0f * pow(progress, 3.0f) + 3.0f * pow(progress, 2.0f);
+}
+
 } // namespace WebCore::SwitchMacUtilities
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
@@ -27,16 +27,17 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import "SwitchThumbPart.h"
 
 namespace WebCore {
-
-class SwitchThumbPart;
 
 class SwitchThumbMac final : public ControlMac {
 public:
     SwitchThumbMac(SwitchThumbPart&, ControlFactoryMac&);
 
 private:
+    const SwitchThumbPart& owningPart() const { return downcast<SwitchThumbPart>(m_owningPart); }
+
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
     FloatRect rectForBounds(const FloatRect&, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
@@ -27,16 +27,17 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import "SwitchTrackPart.h"
 
 namespace WebCore {
-
-class SwitchTrackMac;
 
 class SwitchTrackMac final : public ControlMac {
 public:
     SwitchTrackMac(SwitchTrackPart&, ControlFactoryMac&);
 
 private:
+    const SwitchTrackPart& owningPart() const { return downcast<SwitchTrackPart>(m_owningPart); }
+
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
     FloatRect rectForBounds(const FloatRect&, const ControlStyle&) const override;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -601,6 +601,22 @@ static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, c
     sliderTrackPart.setTickRatios(WTFMove(tickRatios));
 }
 
+static void updateSwitchThumbPartForRenderer(SwitchThumbPart& switchThumbPart, const RenderObject& renderer)
+{
+    auto& input = checkedDowncast<HTMLInputElement>(*renderer.node()->shadowHost());
+    ASSERT(input.isSwitch());
+
+    switchThumbPart.setProgress(input.switchCheckedChangeAnimationProgress());
+}
+
+static void updateSwitchTrackPartForRenderer(SwitchTrackPart& switchTrackPart, const RenderObject& renderer)
+{
+    auto& input = checkedDowncast<HTMLInputElement>(*renderer.node()->shadowHost());
+    ASSERT(input.isSwitch());
+
+    switchTrackPart.setProgress(input.switchCheckedChangeAnimationProgress());
+}
+
 RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer) const
 {
     auto appearance = renderer.style().effectiveAppearance();
@@ -720,6 +736,16 @@ void RenderTheme::updateControlPartForRenderer(ControlPart& part, const RenderOb
 
     if (auto* sliderTrackPart = dynamicDowncast<SliderTrackPart>(part)) {
         updateSliderTrackPartForRenderer(*sliderTrackPart, renderer);
+        return;
+    }
+
+    if (auto* switchThumbPart = dynamicDowncast<SwitchThumbPart>(part)) {
+        updateSwitchThumbPartForRenderer(*switchThumbPart, renderer);
+        return;
+    }
+
+    if (auto* switchTrackPart = dynamicDowncast<SwitchTrackPart>(part)) {
+        updateSwitchTrackPartForRenderer(*switchTrackPart, renderer);
         return;
     }
 

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -265,6 +265,7 @@ public:
 #if USE(SYSTEM_PREVIEW)
     virtual void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&);
 #endif
+    virtual Seconds switchCheckedChangeAnimationDuration() const { return 0_s; }
 
 protected:
     virtual bool canPaint(const PaintInfo&, const Settings&, StyleAppearance) const { return true; }

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -94,6 +94,8 @@ public:
 
     WEBCORE_EXPORT static RetainPtr<NSImage> iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
 
+    Seconds switchCheckedChangeAnimationDuration() const final { return 300_ms; }
+
 private:
     RenderThemeMac();
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1231,7 +1231,7 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
 
     case WebCore::StyleAppearance::SearchField:
         break;
-            
+
 #if ENABLE(APPLE_PAY)
     case WebCore::StyleAppearance::ApplePayButton:
         encoder << downcast<WebCore::ApplePayButtonPart>(part);
@@ -1262,8 +1262,14 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
     case WebCore::StyleAppearance::SliderThumbHorizontal:
     case WebCore::StyleAppearance::SliderThumbVertical:
     case WebCore::StyleAppearance::Switch:
+        break;
+
     case WebCore::StyleAppearance::SwitchThumb:
+        encoder << downcast<WebCore::SwitchThumbPart>(part);
+        break;
+
     case WebCore::StyleAppearance::SwitchTrack:
+        encoder << downcast<WebCore::SwitchTrackPart>(part);
         break;
     }
 }
@@ -1389,11 +1395,22 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::StyleAppearance::Switch:
         break;
 
-    case WebCore::StyleAppearance::SwitchThumb:
-        return WebCore::SwitchThumbPart::create();
+    case WebCore::StyleAppearance::SwitchThumb: {
+        std::optional<Ref<WebCore::SwitchThumbPart>> switchThumbPart;
+        decoder >> switchThumbPart;
+        if (switchThumbPart)
+            return WTFMove(*switchThumbPart);
+        break;
+    }
 
-    case WebCore::StyleAppearance::SwitchTrack:
-        return WebCore::SwitchTrackPart::create();
+    case WebCore::StyleAppearance::SwitchTrack: {
+        std::optional<Ref<WebCore::SwitchTrackPart>> switchTrackPart;
+        decoder >> switchTrackPart;
+        if (switchTrackPart)
+            return WTFMove(*switchTrackPart);
+        break;
+    }
+
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3274,6 +3274,14 @@ enum class WebCore::ApplePayButtonStyle : uint8_t {
     Vector<double> tickRatios();
 }
 
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SwitchThumbPart {
+    [Validator='progress >= 0.0f && progress <= 1.0f'] float progress();
+};
+
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SwitchTrackPart {
+    [Validator='progress >= 0.0f && progress <= 1.0f'] float progress();
+};
+
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DistantLightSource {
     float azimuth();
     float elevation();


### PR DESCRIPTION
#### 0a64dd54421137c48a57e6e0aab15a99139a8776
<pre>
Initial &lt;input type=checkbox switch&gt; animation support
<a href="https://bugs.webkit.org/show_bug.cgi?id=265108">https://bugs.webkit.org/show_bug.cgi?id=265108</a>

Reviewed by Aditya Keerthi.

This adds the infrastructure needed to start the animation, somewhat
based on our &lt;progress&gt; implementation. And also implements the macOS
animation.

Thanks to Aditya, smfr, Tim Horton, Antoine, and Kimmo for much needed
guidance.

* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::EventDispatcher::dispatchEvent):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::willDispatchClick):
(WebCore::switchCheckedChangeAnimationUpdateInterval):
(WebCore::CheckboxInputType::performSwitchCheckedChangeAnimation):
(WebCore::CheckboxInputType::switchCheckedChangeAnimationProgress const):
(WebCore::CheckboxInputType::switchCheckedChangeAnimationTimerFired):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setChecked):
(WebCore::HTMLInputElement::switchCheckedChangeAnimationProgress const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/platform/graphics/controls/SwitchThumbPart.h:
* Source/WebCore/platform/graphics/controls/SwitchTrackPart.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm:
(WebCore::SwitchMacUtilities::easeInOut):
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
(WebCore::SwitchThumbMac::cellSize const):
(WebCore::SwitchThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm:
(WebCore::trackMaskImage):
(WebCore::trackImage):
(WebCore::SwitchTrackMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateSwitchThumbPartForRenderer):
(WebCore::updateSwitchTrackPartForRenderer):
(WebCore::RenderTheme::updateControlPartForRenderer const):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::switchCheckedChangeAnimationDuration const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271118@main">https://commits.webkit.org/271118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134ca945fd9bf29657228ad611cd00985a70466d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24900 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4226 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30516 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28475 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24269 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6595 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->