### PR TITLE
Remove non-standard 'initTouchEvent' from TouchEvent Interface

### DIFF
--- a/Source/WebCore/dom/TouchEvent.cpp
+++ b/Source/WebCore/dom/TouchEvent.cpp
@@ -58,24 +58,6 @@ TouchEvent::TouchEvent(const AtomString& type, const Init& initializer, IsTruste
 
 TouchEvent::~TouchEvent() = default;
 
-void TouchEvent::initTouchEvent(TouchList* touches, TouchList* targetTouches,
-        TouchList* changedTouches, const AtomString& type, 
-        RefPtr<WindowProxy>&& view, int screenX, int screenY, int clientX, int clientY,
-        bool ctrlKey, bool altKey, bool shiftKey, bool metaKey)
-{
-    if (isBeingDispatched())
-        return;
-
-    initUIEvent(type, true, true, WTFMove(view), 0);
-
-    m_touches = touches;
-    m_targetTouches = targetTouches;
-    m_changedTouches = changedTouches;
-    m_screenLocation = IntPoint(screenX, screenY);
-    setModifierKeys(ctrlKey, altKey, shiftKey, metaKey);
-    initCoordinates(IntPoint(clientX, clientY));
-}
-
 EventInterface TouchEvent::eventInterface() const
 {
     return TouchEventInterfaceType;

--- a/Source/WebCore/dom/TouchEvent.h
+++ b/Source/WebCore/dom/TouchEvent.h
@@ -61,9 +61,6 @@ public:
         return adoptRef(*new TouchEvent(type, initializer, isTrusted));
     }
 
-    void initTouchEvent(TouchList* touches, TouchList* targetTouches, TouchList* changedTouches, const AtomString& type,
-        RefPtr<WindowProxy>&&, int screenX, int screenY, int clientX, int clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
-
     TouchList* touches() const { return m_touches.get(); }
     TouchList* targetTouches() const { return m_targetTouches.get(); }
     TouchList* changedTouches() const { return m_changedTouches.get(); }

--- a/Source/WebCore/dom/TouchEvent.idl
+++ b/Source/WebCore/dom/TouchEvent.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/touch-events/#touchevent-interface
+
 [
     Conditional=TOUCH_EVENTS,
     Exposed=Window
@@ -36,20 +38,6 @@
     readonly attribute boolean shiftKey;
     readonly attribute boolean altKey;
     readonly attribute boolean metaKey;
-
-    undefined initTouchEvent(optional TouchList? touches = null,
-                        optional TouchList? targetTouches = null,
-                        optional TouchList? changedTouches = null,
-                        optional [AtomString] DOMString type,
-                        optional WindowProxy? view = null,
-                        optional long screenX = 0,
-                        optional long screenY = 0,
-                        optional long clientX = 0,
-                        optional long clientY = 0,
-                        optional boolean ctrlKey = false,
-                        optional boolean altKey = false,
-                        optional boolean shiftKey = false,
-                        optional boolean metaKey = false);
 };
 
 dictionary TouchEventInit : UIEventInit {


### PR DESCRIPTION
#### 0465e17aaa0e8480046c16c135c930383bbe5c3c
<pre>
Remove non-standard &apos;initTouchEvent&apos; from TouchEvent Interface

<a href="https://bugs.webkit.org/show_bug.cgi?id=265109">https://bugs.webkit.org/show_bug.cgi?id=265109</a>

Reviewed by Michael Catanzaro.

This patch aligns WebKit with Web-Specification [1] &amp; [2] by removing non-standard &quot;initTouchEvent&quot; interface.

[1] <a href="https://w3c.github.io/touch-events/#touchevent-interface">https://w3c.github.io/touch-events/#touchevent-interface</a>
[2] <a href="https://github.com/w3c/touch-events/commit/a939fbb51f3eb0fd1c7cf1980ad4ac1640988e74">https://github.com/w3c/touch-events/commit/a939fbb51f3eb0fd1c7cf1980ad4ac1640988e74</a>

* Source/WebCore/dom/TouchEvent.cpp:
(TouchEvent::initTouchEvent): Deleted
* Source/WebCore/dom/TouchEvent.h: &apos;initTouchEvent&apos; deleted
* Source/WebCore/dom/TouchEvent.idl:

Canonical link: <a href="https://commits.webkit.org/270956@main">https://commits.webkit.org/270956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c91a82d131275ff7b46efab5567cc5d3c4c99828

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24475 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30090 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28000 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5343 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6462 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->