### PR TITLE
[WebRTC] Minor improvements for webrtc fuzzers

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc
@@ -187,8 +187,15 @@ void RtpReplayer::ReplayPackets(
       RTC_LOG(LS_ERROR) << "Packet error, corrupt packets or incorrect setup?";
       break;
     }
+#ifdef WEBRTC_WEBKIT_BUILD
+    // Set the clock rate if zero - always 90K for video
+    if (received_packet.payload_type_frequency() == 0) {
+        received_packet.set_payload_type_frequency(kVideoPayloadTypeFrequency);
+    }
+#else
     // Set the clock rate - always 90K for video
     received_packet.set_payload_type_frequency(kVideoPayloadTypeFrequency);
+#endif
 
     call->Receiver()->DeliverRtpPacket(
         MediaType::VIDEO, std::move(received_packet),

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Minor-improvements-for-webrtc-fuzzers.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Minor-improvements-for-webrtc-fuzzers.patch
@@ -1,0 +1,80 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_packetizer_av1_fuzzer.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_packetizer_av1_fuzzer.cc
+index e5550c1279cb..471ae9c3c67d 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_packetizer_av1_fuzzer.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_packetizer_av1_fuzzer.cc
+@@ -14,6 +14,9 @@
+ #include "modules/rtp_rtcp/source/rtp_format.h"
+ #include "modules/rtp_rtcp/source/rtp_packet_to_send.h"
+ #include "modules/rtp_rtcp/source/rtp_packetizer_av1.h"
++#ifdef WEBRTC_WEBKIT_BUILD
++#include "modules/rtp_rtcp/source/video_rtp_depacketizer_av1.h"
++#endif
+ #include "rtc_base/checks.h"
+ #include "test/fuzzers/fuzz_data_helper.h"
+ 
+@@ -45,27 +48,42 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
+   // When packetization was successful, validate NextPacket function too.
+   // While at it, check that packets respect the payload size limits.
+   RtpPacketToSend rtp_packet(nullptr);
++#ifdef WEBRTC_WEBKIT_BUILD
++  VideoRtpDepacketizerAv1 depacketizer;
++#endif
+   // Single packet.
+   if (num_packets == 1) {
+     RTC_CHECK(packetizer.NextPacket(&rtp_packet));
+     RTC_CHECK_LE(rtp_packet.payload_size(),
+                  limits.max_payload_len - limits.single_packet_reduction_len);
++#ifdef WEBRTC_WEBKIT_BUILD
++    depacketizer.Parse(rtp_packet.PayloadBuffer());
++#endif
+     return;
+   }
+   // First packet.
+   RTC_CHECK(packetizer.NextPacket(&rtp_packet));
+   RTC_CHECK_LE(rtp_packet.payload_size(),
+                limits.max_payload_len - limits.first_packet_reduction_len);
++#ifdef WEBRTC_WEBKIT_BUILD
++  depacketizer.Parse(rtp_packet.PayloadBuffer());
++#endif
+   // Middle packets.
+   for (size_t i = 1; i < num_packets - 1; ++i) {
+     RTC_CHECK(packetizer.NextPacket(&rtp_packet))
+         << "Failed to get packet#" << i;
+     RTC_CHECK_LE(rtp_packet.payload_size(), limits.max_payload_len)
+         << "Packet #" << i << " exceeds it's limit";
++#ifdef WEBRTC_WEBKIT_BUILD
++    depacketizer.Parse(rtp_packet.PayloadBuffer());
++#endif
+   }
+   // Last packet.
+   RTC_CHECK(packetizer.NextPacket(&rtp_packet));
+   RTC_CHECK_LE(rtp_packet.payload_size(),
+                limits.max_payload_len - limits.last_packet_reduction_len);
++#ifdef WEBRTC_WEBKIT_BUILD
++  depacketizer.Parse(rtp_packet.PayloadBuffer());
++#endif
+ }
+ }  // namespace webrtc
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc
+index 83f894dc28db..06a31ab881a2 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc
+@@ -187,8 +187,15 @@ void RtpReplayer::ReplayPackets(
+       RTC_LOG(LS_ERROR) << "Packet error, corrupt packets or incorrect setup?";
+       break;
+     }
++#ifdef WEBRTC_WEBKIT_BUILD
++    // Set the clock rate if zero - always 90K for video
++    if (received_packet.payload_type_frequency() == 0) {
++        received_packet.set_payload_type_frequency(kVideoPayloadTypeFrequency);
++    }
++#else
+     // Set the clock rate - always 90K for video
+     received_packet.set_payload_type_frequency(kVideoPayloadTypeFrequency);
++#endif
+ 
+     call->Receiver()->DeliverRtpPacket(
+         MediaType::VIDEO, std::move(received_packet),
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
#### 7be4320b24295ef2421e86eca0c9c66ff5ccc4e2
<pre>
[WebRTC] Minor improvements for webrtc fuzzers
<a href="https://bugs.webkit.org/show_bug.cgi?id=265110">https://bugs.webkit.org/show_bug.cgi?id=265110</a>
&lt;<a href="https://rdar.apple.com/118624993">rdar://118624993</a>&gt;

Reviewed by Eric Carlson.

* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_packetizer_av1_fuzzer.cc:
- Send generated packets through depacketizer.
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/utils/rtp_replayer.cc:
- Only set payload type frequency when it is zero.

* Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Minor-improvements-for-webrtc-fuzzers.patch: Add.

Canonical link: <a href="https://commits.webkit.org/271178@main">https://commits.webkit.org/271178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7edd714371c240ab2aab44dd693776e9d3c7a83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24595 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24477 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29751 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27999 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4352 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3561 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->