### PR TITLE
::-webkit-textfield-decoration-container should not accept writing-mode changes

### DIFF
--- a/LayoutTests/fast/forms/number/number-broken-by-container-style-expected.html
+++ b/LayoutTests/fast/forms/number/number-broken-by-container-style-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<input type=number placeholder="foo">
+<input type=number value="123456">
+<script>
+document.querySelectorAll('input')[1].focus();
+</script>

--- a/LayoutTests/fast/forms/number/number-broken-by-container-style.html
+++ b/LayoutTests/fast/forms/number/number-broken-by-container-style.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+input::-webkit-textfield-decoration-container {
+  writing-mode: vertical-rl;
+}
+</style>
+<input type=number placeholder="foo">
+<input type=number value="123456">
+<script>
+document.querySelectorAll('input')[1].focus();
+</script>

--- a/LayoutTests/fast/forms/search/search-broken-by-container-style-expected.html
+++ b/LayoutTests/fast/forms/search/search-broken-by-container-style-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<input type=search placeholder="foo">
+<input type=search value="query">
+<script>
+document.querySelectorAll('input')[1].focus();
+</script>

--- a/LayoutTests/fast/forms/search/search-broken-by-container-style.html
+++ b/LayoutTests/fast/forms/search/search-broken-by-container-style.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+input::-webkit-textfield-decoration-container {
+  writing-mode: vertical-rl;
+}
+</style>
+<input type=search placeholder="foo">
+<input type=search value="query">
+<script>
+document.querySelectorAll('input')[1].focus();
+</script>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -469,6 +469,7 @@ input::-webkit-textfield-decoration-container {
     display: flex;
     align-items: center;
     content: none !important;
+    writing-mode: inherit !important;
 }
 
 input[type="search"]::-webkit-search-cancel-button,


### PR DESCRIPTION
#### b3dced5ca5b4cd68f770ca42bc3ac2b373e3be81
<pre>
::-webkit-textfield-decoration-container should not accept writing-mode changes

<a href="https://bugs.webkit.org/show_bug.cgi?id=265111">https://bugs.webkit.org/show_bug.cgi?id=265111</a>

Reviewed by Tim Nguyen.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/2509409">https://chromium-review.googlesource.com/c/chromium/src/+/2509409</a>

Specifying a &apos;writing-mode&apos; value different from the host INPUT to its
::-webkit-textfield-decoration-container broke many things, and it was
not helpful because inner-editor always has the &apos;writing-mode&apos; value
same as the host INPUT.  This patch prohibits authors to specify
&apos;writing-mode&apos; to ::-webkit-textfield-decoration-container.

* Source/WebCore/css/html.css:
(input::-webkit-textfield-decoration-container): Updated
* LayoutTests/fast/forms/number/number-broken-by-container-style-expected.html: Add Test Case
* LayoutTests/fast/forms/number/number-broken-by-container-style.html: Add Test Case Expectation
* LayoutTests/fast/forms/search/search-broken-by-container-style.html: Add Test Case
* LayoutTests/fast/forms/search/search-broken-by-container-style-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/270953@main">https://commits.webkit.org/270953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e2d6a56ee134c377c4d2b5aecb76415135e4f3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29121 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2918 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3811 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30097 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28007 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6461 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->