### PR TITLE
Occasional debug assertion under IntlNumberFormat::initializeNumberFormat when running Speedometer 3

### DIFF
--- a/LayoutTests/fast/events/key-event-with-quirks-enabled-expected.txt
+++ b/LayoutTests/fast/events/key-event-with-quirks-enabled-expected.txt
@@ -1,0 +1,12 @@
+Tests that basic key events work, and do not trigger assertions when quirks are enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Received keydown
+PASS Received keyup
+PASS receivedKeyUp became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/key-event-with-quirks-enabled.html
+++ b/LayoutTests/fast/events/key-event-with-quirks-enabled.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ NeedsSiteSpecificQuirks=true ] -->
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<input id="textField"></input>
+<script>
+jsTestIsAsync = true;
+receivedKeyUp = false;
+
+addEventListener("load", async () => {
+    description("Tests that basic key events work, and do not trigger assertions when quirks are enabled.");
+
+    let textField = document.getElementById("textField");
+    textField.addEventListener("keydown", () => testPassed("Received keydown"));
+    textField.addEventListener("keyup", () => {
+        testPassed("Received keyup");
+        receivedKeyUp = true;
+    });
+
+    await UIHelper.activateElementAndWaitForInputSession(textField);
+    await UIHelper.keyDown("a");
+
+    await shouldBecomeEqual("receivedKeyUp", "true");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -198,6 +198,7 @@ bool JSLocalDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexi
 
     auto* thisObject = jsCast<JSLocalDOMWindow*>(object);
 
+    ASSERT(lexicalGlobalObject->vm().currentThreadIsHoldingAPILock());
     // Construct3 assumes that the presence of OffscreenCanvas implies
     // that WebGL will always be available, which isn't true yet.
     // Disable OffscreenCanvas when the Construct3 library is present
@@ -245,6 +246,7 @@ bool JSLocalDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObjec
     // Indexed getters take precendence over regular properties, so caching would be invalid.
     slot.disableCaching();
 
+    ASSERT(lexicalGlobalObject->vm().currentThreadIsHoldingAPILock());
     // These are also allowed cross-origin, so come before the access check.
     if (frame && index < frame->tree().scopedChildCount()) {
         // FIXME: <rdar://118263337> LocalDOMWindow::length needs to include RemoteFrames.

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -62,6 +62,7 @@
 #include "UserContentTypes.h"
 #include "UserScript.h"
 #include "UserScriptTypes.h"
+#include <JavaScriptCore/JSLock.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -1613,6 +1614,8 @@ bool Quirks::needsDisableDOMPasteAccessQuirk() const
         auto* globalObject = m_document->globalObject();
         if (!globalObject)
             return false;
+
+        JSC::JSLockHolder lock(globalObject->vm());
         auto tableauPrepProperty = JSC::Identifier::fromString(globalObject->vm(), "tableauPrep"_s);
         return globalObject->hasProperty(globalObject, tableauPrepProperty);
     }();


### PR DESCRIPTION
#### a6eac11140b4fc279024501242bc5f0dfc7544c3
<pre>
Occasional debug assertion under IntlNumberFormat::initializeNumberFormat when running Speedometer 3
<a href="https://bugs.webkit.org/show_bug.cgi?id=265113">https://bugs.webkit.org/show_bug.cgi?id=265113</a>
<a href="https://rdar.apple.com/118619451">rdar://118619451</a>

Reviewed by Chris Dumez.

Grab the JSC API lock before calling into `JSObject::hasProperty()` when checking for the presence
of the `tableauPrep` property.

* LayoutTests/fast/events/key-event-with-quirks-enabled-expected.txt: Added.
* LayoutTests/fast/events/key-event-with-quirks-enabled.html: Added.
* Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp:
(WebCore::JSLocalDOMWindow::getOwnPropertySlot):
(WebCore::JSLocalDOMWindow::getOwnPropertySlotByIndex):

Add a new debug assertion when reading properties off of the window object without having the JS API
lock; without the fix above, the assertion is hit in the new layout test, where site-specific quirks
are enabled.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsDisableDOMPasteAccessQuirk const):

Canonical link: <a href="https://commits.webkit.org/270961@main">https://commits.webkit.org/270961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b692ece349a64d0908efc8acb03e63174cf45b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29762 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30102 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28013 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23841 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6465 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->