### PR TITLE
Stop using Vector::unsafeAppendWithoutCapacityCheck() in JSObject::putOwnDataPropertyBatching()

### DIFF
--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -4064,36 +4064,31 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl
     unsigned i = 0;
     Structure* structure = this->structure();
     if (!(structure->isDictionary() || (structure->transitionCountEstimate() + size) > Structure::s_maxTransitionLength || !structure->canPerformFastPropertyEnumerationCommon())) {
-        Vector<PropertyOffset, 16> offsets;
-        offsets.reserveInitialCapacity(size);
-
-        for (unsigned index = 0; index < size; ++index) {
+        Vector<PropertyOffset, 16> offsets(size, [&](size_t index) -> std::optional<PropertyOffset> {
             PropertyName propertyName(properties[index].get());
 
             PropertyOffset offset;
             if (Structure* newStructure = Structure::addPropertyTransitionToExistingStructure(structure, propertyName, 0, offset)) {
                 structure = newStructure;
-                offsets.unsafeAppendWithoutCapacityCheck(offset);
-                continue;
+                return offset;
             }
 
             unsigned currentAttributes;
             offset = structure->get(vm, propertyName, currentAttributes);
             if (offset != invalidOffset) {
                 structure->didReplaceProperty(offset);
-                offsets.unsafeAppendWithoutCapacityCheck(offset);
-                continue;
+                return offset;
             }
 
             // If we detect that this structure requires transition watchpoint firing, then we need to stop this batching and rest of the values
             // should be put via generic way.
             if (UNLIKELY(structure->transitionWatchpointSet().isBeingWatched() && structure->transitionWatchpointSet().isStillValid()))
-                break;
+                return std::nullopt;
 
             // It will go to the cacheable dictionary case. We stop the batching here and fall though to the generic case.
             // We break here before adding offset to offsets since this property itself should be put via generic path.
             if (UNLIKELY(structure->shouldDoCacheableDictionaryTransitionForAdd(PutPropertySlot::UnknownContext)))
-                break;
+                return std::nullopt;
 
             Structure* newStructure = Structure::addNewPropertyTransition(vm, structure, propertyName, 0, offset, PutPropertySlot::UnknownContext, nullptr);
 
@@ -4101,8 +4096,8 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl
             ASSERT(newStructure->isValidOffset(offset));
 
             structure = newStructure;
-            offsets.unsafeAppendWithoutCapacityCheck(offset);
-        }
+            return offset;
+        });
 
         // Flush batching here. Note that it is possible that offsets.size() is not equal to size, if we stop batching due to transition-watchpoint-firing.
 

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -714,8 +714,17 @@ public:
 
         asanSetInitialBufferSizeTo(size);
 
-        for (size_t i = 0; i < size; ++i)
-            unsafeAppendWithoutCapacityCheck(valueGenerator(i));
+        if constexpr (std::is_same_v<std::invoke_result_t<Functor, size_t>, std::optional<T>>) {
+            for (size_t i = 0; i < size; ++i) {
+                if (auto item = valueGenerator(i))
+                    unsafeAppendWithoutCapacityCheck(WTFMove(*item));
+                else
+                    return;
+            }
+        } else {
+            for (size_t i = 0; i < size; ++i)
+                unsafeAppendWithoutCapacityCheck(valueGenerator(i));
+        }
     }
 
     template<typename U = T>


### PR DESCRIPTION
#### b12bca52a799310cd7338160834a167d4ca67252
<pre>
Stop using Vector::unsafeAppendWithoutCapacityCheck() in JSObject::putOwnDataPropertyBatching()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265084">https://bugs.webkit.org/show_bug.cgi?id=265084</a>

Reviewed by Darin Adler.

Update the `Vector&lt;T&gt;(size_t, Functor)` to abort appending if the Functor
returns a std::optional&lt;T&gt; type that is std::nullopt.

Adopt it in JSObject::putOwnDataPropertyBatching() to avoid calling
Vector::unsafeAppendWithoutCapacityCheck() explicitly.

* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putOwnDataPropertyBatching):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):

Canonical link: <a href="https://commits.webkit.org/270980@main">https://commits.webkit.org/270980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c337758e1c3642b8d4b068450d603073b4066dc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24609 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29765 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23460 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30106 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26105 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28017 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5358 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33557 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6479 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4365 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7259 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->