### PR TITLE
Refactor the "All CoreIPC types" variant to work forward-delcared

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -29,10 +29,8 @@
 #if PLATFORM(COCOA)
 
 #import "ArgumentCodersCF.h"
-#import "CoreIPCData.h"
-#import "CoreIPCDate.h"
 #import "CoreIPCNSCFObject.h"
-#import "CoreIPCNumber.h"
+#import "CoreIPCTypes.h"
 #import "CoreTextHelpers.h"
 #import "DataReference.h"
 #import "LegacyGlobalSettings.h"

--- a/Source/WebKit/Shared/Cocoa/CoreIPCArray.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCArray.mm
@@ -23,12 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "CoreIPCArray.h"
+#import "config.h"
+#import "CoreIPCArray.h"
 
 #if PLATFORM(COCOA)
 
-#include "CoreIPCNSCFObject.h"
+#import "CoreIPCNSCFObject.h"
+#import "CoreIPCTypes.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm
@@ -29,8 +29,7 @@
 #if ENABLE(DATA_DETECTION)
 #if PLATFORM(COCOA)
 
-#import "CoreIPCDictionary.h"
-#import "CoreIPCNSCFObject.h"
+#import "CoreIPCTypes.h"
 #import <pal/cocoa/DataDetectorsCoreSoftLink.h>
 
 @interface DDScannerResult ()

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA)
 
+#include "CoreIPCNSCFObject.h"
 #include <wtf/ArgumentCoder.h>
 #include <wtf/KeyValuePair.h>
 #include <wtf/RetainPtr.h>
@@ -34,8 +35,6 @@
 #include <wtf/Vector.h>
 
 namespace WebKit {
-
-class CoreIPCNSCFObject;
 
 class CoreIPCDictionary {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
@@ -23,12 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "CoreIPCDictionary.h"
+#import "config.h"
+#import "CoreIPCDictionary.h"
 
 #if PLATFORM(COCOA)
 
-#include "CoreIPCNSCFObject.h"
+#import "CoreIPCTypes.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCFont.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCFont.mm
@@ -23,12 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "CoreIPCFont.h"
+#import "config.h"
+#import "CoreIPCFont.h"
 
 #if PLATFORM(COCOA)
 
 #import "CoreIPCNSCFObject.h"
+#import "CoreIPCTypes.h"
 #import "CoreTextHelpers.h"
 #import <wtf/BlockObjCExceptions.h>
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -27,47 +27,52 @@
 
 #if PLATFORM(COCOA)
 
-#include "CoreIPCArray.h"
-#include "CoreIPCCFType.h"
-#include "CoreIPCColor.h"
-#include "CoreIPCDDScannerResult.h"
-#include "CoreIPCData.h"
-#include "CoreIPCDate.h"
-#include "CoreIPCDictionary.h"
-#include "CoreIPCError.h"
-#include "CoreIPCFont.h"
-#include "CoreIPCNSValue.h"
-#include "CoreIPCNumber.h"
-#include "CoreIPCSecureCoding.h"
-#include "CoreIPCString.h"
-#include "CoreIPCURL.h"
+#include "ArgumentCodersCocoa.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/UniqueRef.h>
 
 namespace WebKit {
+
+class CoreIPCArray;
+class CoreIPCCFType;
+class CoreIPCColor;
+#if ENABLE(DATA_DETECTION)
+class CoreIPCDDScannerResult;
+#endif
+class CoreIPCData;
+class CoreIPCDate;
+class CoreIPCDictionary;
+class CoreIPCError;
+class CoreIPCFont;
+class CoreIPCNSValue;
+class CoreIPCNumber;
+class CoreIPCSecureCoding;
+class CoreIPCString;
+class CoreIPCURL;
+
+using ObjectValue = std::variant<
+    std::nullptr_t,
+    CoreIPCArray,
+    CoreIPCCFType,
+    CoreIPCColor,
+#if ENABLE(DATA_DETECTION)
+    CoreIPCDDScannerResult,
+#endif
+    CoreIPCData,
+    CoreIPCDate,
+    CoreIPCDictionary,
+    CoreIPCError,
+    CoreIPCFont,
+    CoreIPCNSValue,
+    CoreIPCNumber,
+    CoreIPCSecureCoding,
+    CoreIPCString,
+    CoreIPCURL
+>;
 
 class CoreIPCNSCFObject {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using ObjectValue = std::variant<
-        std::nullptr_t,
-        CoreIPCArray,
-        CoreIPCCFType,
-        CoreIPCColor,
-#if ENABLE(DATA_DETECTION)
-        CoreIPCDDScannerResult,
-#endif
-        CoreIPCData,
-        CoreIPCDate,
-        CoreIPCDictionary,
-        CoreIPCError,
-        CoreIPCFont,
-        CoreIPCNSValue,
-        CoreIPCNumber,
-        CoreIPCSecureCoding,
-        CoreIPCString,
-        CoreIPCURL
-    >;
-
     CoreIPCNSCFObject(id);
 
     RetainPtr<id> toID() const;
@@ -77,14 +82,22 @@ public:
 private:
     friend struct IPC::ArgumentCoder<CoreIPCNSCFObject, void>;
 
-    CoreIPCNSCFObject(ObjectValue&& value)
-        : m_value(WTFMove(value))
-    {
-    }
+    CoreIPCNSCFObject(UniqueRef<ObjectValue>&&);
 
-    ObjectValue m_value;
+    UniqueRef<ObjectValue> m_value;
 };
 
 } // namespace WebKit
+
+namespace IPC {
+
+// This ArgumentCoders specialization for UniqueRef<ObjectValue> is to allow us to use
+// makeUniqueRefWithoutFastMallocCheck<>, since we can't make the variant fast malloc'ed
+template<> struct ArgumentCoder<UniqueRef<WebKit::ObjectValue>> {
+    static void encode(Encoder&, const UniqueRef<WebKit::ObjectValue>&);
+    static std::optional<UniqueRef<WebKit::ObjectValue>> decode(Decoder&);
+};
+
+} // namespace IPC
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -25,7 +25,7 @@
 webkit_platform_headers: "ArgumentCodersCocoa.h" "ArgumentCodersCF.h" "CoreIPCNSCFObject.h"
 
 [WebKitPlatform] class WebKit::CoreIPCNSCFObject {
-    [Validator='WebKit::CoreIPCNSCFObject::valueIsAllowed(decoder, *m_value)'] WebKit::CoreIPCNSCFObject::ObjectValue m_value;
+    [Validator='WebKit::CoreIPCNSCFObject::valueIsAllowed(decoder, *m_value)'] UniqueRef<WebKit::ObjectValue> m_value;
 }
 
 #endif // USE(CF)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCTypes.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCTypes.h
@@ -25,42 +25,17 @@
 
 #pragma once
 
-#if ENABLE(DATA_DETECTION)
-
-#include "ArgumentCodersCocoa.h"
-#include "CoreIPCDictionary.h"
-#include "CoreIPCSecureCoding.h"
-#include <wtf/RetainPtr.h>
-
-OBJC_CLASS DDScannerResult;
-
-namespace WebKit {
-
-class CoreIPCDDScannerResult {
-public:
-    CoreIPCDDScannerResult(DDScannerResult *);
-    CoreIPCDDScannerResult(const RetainPtr<DDScannerResult>& result)
-        : CoreIPCDDScannerResult(result.get())
-    {
-    }
-
-    RetainPtr<id> toID() const;
-
-private:
-    friend struct IPC::ArgumentCoder<CoreIPCDDScannerResult, void>;
-
-    using Value = std::variant<CoreIPCDictionary, CoreIPCSecureCoding>;
-
-    static Value valueFromDDScannerResult(DDScannerResult *);
-
-    CoreIPCDDScannerResult(Value&& value)
-        : m_value(WTFMove(value))
-    {
-    }
-
-    Value m_value;
-};
-
-} // namespace WebKit
-
-#endif // ENABLE(DATA_DETECTION)
+#import "CoreIPCArray.h"
+#import "CoreIPCCFType.h"
+#import "CoreIPCColor.h"
+#import "CoreIPCDDScannerResult.h"
+#import "CoreIPCData.h"
+#import "CoreIPCDate.h"
+#import "CoreIPCDictionary.h"
+#import "CoreIPCError.h"
+#import "CoreIPCFont.h"
+#import "CoreIPCNSValue.h"
+#import "CoreIPCNumber.h"
+#import "CoreIPCSecureCoding.h"
+#import "CoreIPCString.h"
+#import "CoreIPCURL.h"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1227,6 +1227,7 @@
 		51D124991E763C01002B2820 /* WKHTTPCookieStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D124841E734AE3002B2820 /* WKHTTPCookieStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51D130541382EAC000351EDD /* SecItemRequestData.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D130501382EAC000351EDD /* SecItemRequestData.h */; };
 		51D130561382EAC000351EDD /* SecItemResponseData.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D130521382EAC000351EDD /* SecItemResponseData.h */; };
+		51D1B6942B09723A00FEA5CB /* CoreIPCTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D1B6932B09723A00FEA5CB /* CoreIPCTypes.h */; };
 		51D7E0AD2356555E00A67D3A /* WKPDFConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D7E0AC2356555400A67D3A /* WKPDFConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51DD9F2816367DA2001578E9 /* NetworkConnectionToWebProcessMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51DD9F2616367DA2001578E9 /* NetworkConnectionToWebProcessMessageReceiver.cpp */; };
 		51DD9F2916367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51DD9F2716367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h */; };
@@ -5347,6 +5348,7 @@
 		51D194352AEC1C8200E8E475 /* CFTypes.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CFTypes.serialization.in; sourceTree = "<group>"; };
 		51D194392AEC9BC900E8E475 /* CoreIPCBoolean.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCBoolean.h; sourceTree = "<group>"; };
 		51D1943A2AEC9BC900E8E475 /* CoreIPCBoolean.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCBoolean.serialization.in; sourceTree = "<group>"; };
+		51D1B6932B09723A00FEA5CB /* CoreIPCTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCTypes.h; sourceTree = "<group>"; };
 		51D7E0AC2356555400A67D3A /* WKPDFConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPDFConfiguration.h; sourceTree = "<group>"; };
 		51D7E0AE2356616300A67D3A /* WKPDFConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPDFConfiguration.mm; sourceTree = "<group>"; };
 		51DAAEBF2AA198DE00DB2AA4 /* com.apple.WebKit.webpushd.relocatable.mac.sb */ = {isa = PBXFileReference; lastKnownFileType = file; path = com.apple.WebKit.webpushd.relocatable.mac.sb; sourceTree = "<group>"; };
@@ -10845,6 +10847,7 @@
 				5197FAD12AFD33B0009180C5 /* CoreIPCSecureCoding.serialization.in */,
 				5197FACC2AFD33AE009180C5 /* CoreIPCString.h */,
 				5197FAD42AFD33B0009180C5 /* CoreIPCString.serialization.in */,
+				51D1B6932B09723A00FEA5CB /* CoreIPCTypes.h */,
 				5197FADB2AFD33B2009180C5 /* CoreIPCURL.h */,
 				5197FAC92AFD33AE009180C5 /* CoreIPCURL.serialization.in */,
 				1C739E872347BD0F00C621EC /* CoreTextHelpers.h */,
@@ -15056,6 +15059,7 @@
 				F4EFF36D2AF0267300479AB8 /* CoreIPCNumber.h in Headers */,
 				5197FAE92AFD33CF009180C5 /* CoreIPCSecureCoding.h in Headers */,
 				5197FAE52AFD33CF009180C5 /* CoreIPCString.h in Headers */,
+				51D1B6942B09723A00FEA5CB /* CoreIPCTypes.h in Headers */,
 				5197FAE62AFD33CF009180C5 /* CoreIPCURL.h in Headers */,
 				A15799BC2584433200528236 /* CoreMediaWrapped.h in Headers */,
 				37C21CAE1E994C0C0029D5F9 /* CorePredictionSPI.h in Headers */,


### PR DESCRIPTION
#### bee110f477b92fc7cded601ae4c995908b1e47d6
<pre>
Refactor the &quot;All CoreIPC types&quot; variant to work forward-delcared
<a href="https://bugs.webkit.org/show_bug.cgi?id=265114">https://bugs.webkit.org/show_bug.cgi?id=265114</a>

Reviewed by Dan Glastonbury.

CoreIPCNSObject and some of the other CoreIPC wrappers have a circular dependency.
This is because of the variant of all wrappers that CoreIPCNSCFObject holds.

The circular dependency will become untenable in upcoming patches, so this is a straight refactor.
It does the following:
1 - Forward declares all the types for the variant instead of include their headers
2 - Because the types are forward declared, the variant can no longer be a direct member of
    CoreIPCNSCFObject. So make it a UniqueRef&lt;&gt; instead
3 - Add a new &quot;CoreIPCTypes.h&quot; convenience header that *does* include all the wrapper headers.
4 - Include CoreIPCTypes.h in each .mm file that needs to work with the variant directly.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCArray.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDDScannerResult.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCFont.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
(WebKit::CoreIPCNSCFObject::CoreIPCNSCFObject): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
(WebKit::CoreIPCNSCFObject::CoreIPCNSCFObject):
(WebKit::CoreIPCNSCFObject::toID const):
(IPC::ArgumentCoder&lt;UniqueRef&lt;WebKit::ObjectValue&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;UniqueRef&lt;WebKit::ObjectValue&gt;&gt;::decode):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCTypes.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCArray.mm.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/270978@main">https://commits.webkit.org/270978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b32f71113a91938cde6cfa57d77bee1bbf830c0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24613 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24492 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3887 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24516 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30107 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28018 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5362 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6478 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->