### PR TITLE
[WebXR] Fix WKARPresentationSession compilation

### DIFF
--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBXR) && USE(ARKITXR_IOS)
 
 #import <Metal/Metal.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -28,8 +28,13 @@
 
 #if ENABLE(WEBXR) && USE(ARKITXR_IOS)
 
+#import "Logging.h"
+
 #import <Metal/Metal.h>
+#import <wtf/RunLoop.h>
 #import <wtf/WeakObjCPtr.h>
+
+#import "ARKitSoftLink.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -122,19 +127,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - WKARPresentationSession
 
--(ARFrame *)currentFrame {
+- (ARFrame *)currentFrame {
     return [_session currentFrame];
 }
 
--(ARSession *)session {
+- (ARSession *)session {
     return (ARSession *) _session;
 }
 
--(nonnull id<MTLSharedEvent>)completionEvent {
+- (nonnull id<MTLSharedEvent>)completionEvent {
     return (id<MTLSharedEvent>) _completionEvent;
 }
 
--(nullable id<MTLTexture>)colorTexture {
+- (nullable id<MTLTexture>)colorTexture {
     return [_currentDrawable texture];
 }
 


### PR DESCRIPTION
#### 01fd632e382f7de076c70b6a6217823ac3b63a8d
<pre>
[WebXR] Fix WKARPresentationSession compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=265116">https://bugs.webkit.org/show_bug.cgi?id=265116</a>
<a href="https://rdar.apple.com/118631258">rdar://118631258</a>

Unreviewed build fix.

Due to unity build file globbing changes, WKARPresentationSession.mm not long
compiles. Added required header imports to restore sucessful compilation.

Bonus: minor style changes to address review comments.

* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[_WKARPresentationSession currentFrame]):
(-[_WKARPresentationSession session]):
(-[_WKARPresentationSession completionEvent]):
(-[_WKARPresentationSession colorTexture]):

Canonical link: <a href="https://commits.webkit.org/270958@main">https://commits.webkit.org/270958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99d4550f639322a6c5adf0da10141a28c1073177

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24614 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2932 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27186 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/4366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/23114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/3824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29770 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3903 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5363 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4370 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3492 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->