### PR TITLE
[UIAsyncTextInput] Adopt new unprefixed responder action names

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1268,6 +1268,21 @@ typedef struct {
 
 #endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
 
+@interface UIResponder (Staging_118307086)
+
+- (void)addShortcut:(id)sender;
+- (void)define:(id)sender;
+- (void)promptForReplace:(id)sender;
+- (void)share:(id)sender;
+- (void)translate:(id)sender;
+- (void)transliterateChinese:(id)sender;
+
+#if HAVE(UIFINDINTERACTION)
+- (void)findSelected:(id)sender;
+#endif
+
+@end
+
 WTF_EXTERN_C_BEGIN
 
 BOOL UIKeyboardEnabledInputModesAllowOneToManyShortcuts(void);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -163,6 +163,7 @@ typedef std::pair<WebKit::InteractionInformationRequest, InteractionInformationC
 #if HAVE(UIFINDINTERACTION)
 #define FOR_EACH_FIND_WKCONTENTVIEW_ACTION(M) \
     M(useSelectionForFind) \
+    M(findSelected) \
     M(_findSelected)
 #else
 #define FOR_EACH_FIND_WKCONTENTVIEW_ACTION(M)
@@ -171,12 +172,18 @@ typedef std::pair<WebKit::InteractionInformationRequest, InteractionInformationC
 #define FOR_EACH_WKCONTENTVIEW_ACTION(M) \
     FOR_EACH_INSERT_TEXT_FROM_CAMERA_WKCONTENTVIEW_ACTION(M) \
     FOR_EACH_FIND_WKCONTENTVIEW_ACTION(M) \
+    M(addShortcut) \
     M(_addShortcut) \
+    M(define) \
     M(_define) \
     M(_lookup) \
+    M(translate) \
     M(_translate) \
+    M(promptForReplace) \
     M(_promptForReplace) \
+    M(share) \
     M(_share) \
+    M(transliterateChinese) \
     M(_transliterateChinese) \
     M(_nextAccessoryTab) \
     M(_previousAccessoryTab) \

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3965,6 +3965,13 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_lookupForWebView:(id)sender
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self defineForWebView:sender];
+}
+
+- (void)defineForWebView:(id)sender
+{
     _page->getSelectionContext([view = retainPtr(self)](const String& selectedText, const String& textBefore, const String& textAfter) {
         if (!selectedText)
             return;
@@ -3989,6 +3996,13 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_shareForWebView:(id)sender
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self shareForWebView:sender];
+}
+
+- (void)shareForWebView:(id)sender
+{
     RetainPtr<WKContentView> view = self;
     _page->getSelectionOrContentsAsString([view](const String& string) {
         if (!view->_textInteractionWrapper || !string || !view->_page->editorState().hasVisualData())
@@ -4003,6 +4017,13 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 }
 
 - (void)_translateForWebView:(id)sender
+{
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self translateForWebView:sender];
+}
+
+- (void)translateForWebView:(id)sender
 {
     _page->getSelectionOrContentsAsString([weakSelf = WeakObjCPtr<WKContentView>(self)] (const String& string) {
         if (!weakSelf)
@@ -4023,6 +4044,13 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 }
 
 - (void)_addShortcutForWebView:(id)sender
+{
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self addShortcutForWebView:sender];
+}
+
+- (void)addShortcutForWebView:(id)sender
 {
     if (!_page->editorState().visualData)
         return;
@@ -4078,6 +4106,13 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 
 - (void)_promptForReplaceForWebView:(id)sender
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self promptForReplaceForWebView:sender];
+}
+
+- (void)promptForReplaceForWebView:(id)sender
+{
     if (!_page->editorState().postLayoutData)
         return;
     const auto& wordAtSelection = _page->editorState().postLayoutData->wordAtSelection;
@@ -4088,6 +4123,13 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 }
 
 - (void)_transliterateChineseForWebView:(id)sender
+{
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self transliterateChineseForWebView:sender];
+}
+
+- (void)transliterateChineseForWebView:(id)sender
 {
     if (!_page->editorState().postLayoutData)
         return;
@@ -4399,7 +4441,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return editorState.selectionIsRange;
     }
 
-    if (action == @selector(_define:)) {
+    if (action == @selector(_define:) || action == @selector(define:)) {
         if (editorState.isInPasswordField || !editorState.selectionIsRange)
             return NO;
 
@@ -4430,14 +4472,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return editorState.selectionIsRange;
     }
 
-    if (action == @selector(_share:)) {
+    if (action == @selector(_share:) || action == @selector(share:)) {
         if (editorState.isInPasswordField || !editorState.selectionIsRange)
             return NO;
 
         return editorState.postLayoutData && editorState.postLayoutData->selectedTextLength > 0;
     }
 
-    if (action == @selector(_addShortcut:)) {
+    if (action == @selector(_addShortcut:) || action == @selector(addShortcut:)) {
         if (editorState.isInPasswordField || !editorState.selectionIsRange)
             return NO;
 
@@ -4452,7 +4494,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return YES;
     }
 
-    if (action == @selector(_promptForReplace:)) {
+    if (action == @selector(_promptForReplace:) || action == @selector(promptForReplace:)) {
         if (!editorState.selectionIsRange || !editorState.postLayoutData || !editorState.postLayoutData->isReplaceAllowed || ![[UIKeyboardImpl activeInstance] autocorrectSpellingEnabled])
             return NO;
         if ([[self selectedText] _containsCJScriptsOnly])
@@ -4460,14 +4502,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return YES;
     }
 
-    if (action == @selector(_transliterateChinese:)) {
+    if (action == @selector(_transliterateChinese:) || action == @selector(transliterateChinese:)) {
         if (!editorState.selectionIsRange || !editorState.postLayoutData || !editorState.postLayoutData->isReplaceAllowed || ![[UIKeyboardImpl activeInstance] autocorrectSpellingEnabled])
             return NO;
         return UIKeyboardEnabledInputModesAllowChineseTransliterationForText([self selectedText]);
     }
 
 #if HAVE(TRANSLATION_UI_SERVICES)
-    if (action == @selector(_translate:)) {
+    if (action == @selector(_translate:) || action == @selector(translate:)) {
         if (!PAL::isTranslationUIServicesFrameworkAvailable() || ![PAL::getLTUITranslationViewControllerClass() isAvailable])
             return NO;
         return !editorState.isInPasswordField && editorState.selectionIsRange;
@@ -4525,7 +4567,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif // ENABLE(IMAGE_ANALYSIS)
 
 #if HAVE(UIFINDINTERACTION)
-    if (action == @selector(useSelectionForFind:) || action == @selector(_findSelected:)) {
+    if (action == @selector(useSelectionForFind:) || action == @selector(findSelected:) || action == @selector(_findSelected:)) {
         if (!self.webView._findInteractionEnabled)
             return NO;
 
@@ -4659,7 +4701,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_defineForWebView:(id)sender
 {
-    [self _lookupForWebView:sender];
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self _defineForWebView:sender];
 }
 
 - (void)accessibilityRetrieveSpeakSelectionContent
@@ -11458,6 +11502,13 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 }
 
 - (void)_findSelectedForWebView:(id)sender
+{
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
+    [self findSelectedForWebView:sender];
+}
+
+- (void)findSelectedForWebView:(id)sender
 {
     [self useSelectionForFindForWebView:sender];
     [self.webView find:sender];


### PR DESCRIPTION
#### 8c078c7748a666fa6c3d57152d4a7d86fa89d460
<pre>
[UIAsyncTextInput] Adopt new unprefixed responder action names
<a href="https://bugs.webkit.org/show_bug.cgi?id=265117">https://bugs.webkit.org/show_bug.cgi?id=265117</a>
<a href="https://rdar.apple.com/118631896">rdar://118631896</a>

Reviewed by Megan Gardner.

Adopt the following unprefixed responder action selector names:

`-_addShortcut:`            →    `-addShortcut:`
`-_define:`                 →    `-define:`
`-_promptForReplace:`       →    `-promptForReplace:`
`-_share:`                  →    `-share:`
`-_translate:`              →    `-translate:`
`-_transliterateChinese:`   →    `-transliterateChinese:`
`-_findSelected:`           →    `-findSelected:`

...while maintaining compatibility with the legacy, underscore-prefixed versions.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _lookupForWebView:]):

Since `-_lookup:` was only used as an alias for `_define:`, there&apos;s no new, unprefixed name that
corresponds to this selector. Instead, we simply call through to `-defineForWebView:`.

(-[WKContentView defineForWebView:]):
(-[WKContentView _shareForWebView:]):
(-[WKContentView shareForWebView:]):
(-[WKContentView _translateForWebView:]):
(-[WKContentView translateForWebView:]):
(-[WKContentView _addShortcutForWebView:]):
(-[WKContentView addShortcutForWebView:]):
(-[WKContentView _promptForReplaceForWebView:]):
(-[WKContentView promptForReplaceForWebView:]):

Add the corresponding unprefixed `-actionForWebView:` methods on the content view as well, and make
the legacy underscore-prefixed methods wrap these new names (while release asserting that the async
text input feature flag is disabled).

(-[WKContentView _transliterateChineseForWebView:]):
(-[WKContentView transliterateChineseForWebView:]):
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _defineForWebView:]):
(-[WKContentView _findSelectedForWebView:]):
(-[WKContentView findSelectedForWebView:]):

Canonical link: <a href="https://commits.webkit.org/271119@main">https://commits.webkit.org/271119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27ef982125ad71308daf6075f4b8d89321d28bb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24495 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3891 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29773 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2106 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28022 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5366 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6596 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->