### PR TITLE
Update Temporal.Now.timeZone() to timeZoneId()

### DIFF
--- a/JSTests/complex/temporal-now-timezone-check.js
+++ b/JSTests/complex/temporal-now-timezone-check.js
@@ -3,4 +3,4 @@ function shouldBe(actual, expected) {
         throw new Error('bad value: ' + actual);
 }
 
-shouldBe(Temporal.Now.timeZone().id, `America/Los_Angeles`);
+shouldBe(Temporal.Now.timeZoneId(), `America/Los_Angeles`);

--- a/JSTests/complex/temporal-now-timezone-with-broken-tz.js
+++ b/JSTests/complex/temporal-now-timezone-with-broken-tz.js
@@ -3,4 +3,4 @@ function shouldBe(actual, expected) {
         throw new Error('bad value: ' + actual);
 }
 
-shouldBe(Temporal.Now.timeZone().id, `UTC`);
+shouldBe(Temporal.Now.timeZoneId(), `UTC`);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -340,24 +340,6 @@ test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfTrunc.js:
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-trunc.js:
   default: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
   strict mode: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
-test/built-ins/Temporal/Now/timeZoneId/extensible.js:
-  default: 'Test262Error: Object.isExtensible(Temporal.Now.timeZoneId) must return true'
-  strict mode: 'Test262Error: Object.isExtensible(Temporal.Now.timeZoneId) must return true'
-test/built-ins/Temporal/Now/timeZoneId/length.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
-test/built-ins/Temporal/Now/timeZoneId/name.js:
-  default: "TypeError: undefined is not an object (evaluating 'Temporal.Now.timeZoneId.name')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Temporal.Now.timeZoneId.name')"
-test/built-ins/Temporal/Now/timeZoneId/not-a-constructor.js:
-  default: 'Test262Error: isConstructor invoked with a non-function value'
-  strict mode: 'Test262Error: isConstructor invoked with a non-function value'
-test/built-ins/Temporal/Now/timeZoneId/prop-desc.js:
-  default: 'Test262Error: typeof is function Expected SameValue(«undefined», «function») to be true'
-  strict mode: 'Test262Error: typeof is function Expected SameValue(«undefined», «function») to be true'
-test/built-ins/Temporal/Now/timeZoneId/return-value.js:
-  default: "TypeError: Temporal.Now.timeZoneId is not a function. (In 'Temporal.Now.timeZoneId()', 'Temporal.Now.timeZoneId' is undefined)"
-  strict mode: "TypeError: Temporal.Now.timeZoneId is not a function. (In 'Temporal.Now.timeZoneId()', 'Temporal.Now.timeZoneId' is undefined)"
 test/built-ins/Temporal/PlainDate/calendar-case-insensitive.js:
   default: 'Test262Error: Calendar is case-insensitive Expected SameValue(«undefined», «iso8601») to be true'
   strict mode: 'Test262Error: Calendar is case-insensitive Expected SameValue(«undefined», «iso8601») to be true'

--- a/Source/JavaScriptCore/runtime/TemporalNow.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalNow.cpp
@@ -33,7 +33,7 @@ namespace JSC {
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(TemporalNow);
 
 static JSC_DECLARE_HOST_FUNCTION(temporalNowFuncInstant);
-static JSC_DECLARE_HOST_FUNCTION(temporalNowFuncTimeZone);
+static JSC_DECLARE_HOST_FUNCTION(temporalNowFuncTimeZoneId);
 
 } // namespace JSC
 
@@ -44,7 +44,7 @@ namespace JSC {
 /* Source for TemporalNow.lut.h
 @begin temporalNowTable
     instant         temporalNowFuncInstant      DontEnum|Function 0
-    timeZone        temporalNowFuncTimeZone     DontEnum|Function 0
+    timeZoneId      temporalNowFuncTimeZoneId   DontEnum|Function 0
 @end
 */
 
@@ -80,17 +80,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalNowFuncInstant, (JSGlobalObject* globalObject, 
     return JSValue::encode(TemporalInstant::tryCreateIfValid(globalObject, ISO8601::ExactTime::now()));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.now.timezone
-// https://tc39.es/proposal-temporal/#sec-temporal-systemtimezone
-JSC_DEFINE_HOST_FUNCTION(temporalNowFuncTimeZone, (JSGlobalObject* globalObject, CallFrame*))
+// https://tc39.es/proposal-temporal/#sec-temporal.now.timezoneid
+// https://tc39.es/proposal-temporal/#sec-temporal-systemtimezoneidentifier
+JSC_DEFINE_HOST_FUNCTION(temporalNowFuncTimeZoneId, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
-
-    String timeZoneString = vm.dateCache.defaultTimeZone();
-    std::optional<TimeZoneID> identifier = ISO8601::parseTimeZoneName(timeZoneString);
-    if (!identifier)
-        return JSValue::encode(TemporalTimeZone::createFromUTCOffset(vm, globalObject->timeZoneStructure(), 0));
-    return JSValue::encode(TemporalTimeZone::createFromID(vm, globalObject->timeZoneStructure(), identifier.value()));
+    return JSValue::encode(jsNontrivialString(vm, vm.dateCache.defaultTimeZone()));
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 8ec78f06da8511b07238023ff6115cf08436c9b9
<pre>
Update Temporal.Now.timeZone() to timeZoneId()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265121">https://bugs.webkit.org/show_bug.cgi?id=265121</a>

Reviewed by Yusuke Suzuki.

The Temporal API spec has changed such that Temporal.Now now has a timeZoneId method instead of a timeZone method.
This patch adapts our implementation accordingly.

* JSTests/complex/temporal-now-timezone-check.js:
* JSTests/complex/temporal-now-timezone-with-broken-tz.js:
* JSTests/test262/expectations.yaml: Mark 12 test cases as passing.
* Source/JavaScriptCore/runtime/TemporalNow.cpp:

Canonical link: <a href="https://commits.webkit.org/271003@main">https://commits.webkit.org/271003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62df629d4ae05879309fc896e7b45a4c5e4e0ee1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24626 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24501 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29782 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30117 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26122 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28028 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5374 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33574 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6498 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4382 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7265 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->