### PR TITLE
Adopt dynamicDowncast<>() more in html/

### DIFF
--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -88,9 +88,11 @@ Node::InsertedIntoAncestorResult HTMLTrackElement::insertedIntoAncestor(Insertio
 {
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 
-    if (parentNode() == &parentOfInsertedTree && is<HTMLMediaElement>(parentOfInsertedTree)) {
-        downcast<HTMLMediaElement>(parentOfInsertedTree).didAddTextTrack(*this);
-        scheduleLoad();
+    if (parentNode() == &parentOfInsertedTree) {
+        if (auto* mediaElement = dynamicDowncast<HTMLMediaElement>(parentOfInsertedTree)) {
+            mediaElement->didAddTextTrack(*this);
+            scheduleLoad();
+        }
     }
 
     return InsertedIntoAncestorResult::Done;
@@ -100,8 +102,10 @@ void HTMLTrackElement::removedFromAncestor(RemovalType removalType, ContainerNod
 {
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 
-    if (!parentNode() && is<HTMLMediaElement>(oldParentOfRemovedTree))
-        downcast<HTMLMediaElement>(oldParentOfRemovedTree).didRemoveTextTrack(*this);
+    if (!parentNode()) {
+        if (auto* mediaElement = dynamicDowncast<HTMLMediaElement>(oldParentOfRemovedTree))
+            mediaElement->didRemoveTextTrack(*this);
+    }
 }
 
 void HTMLTrackElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -307,10 +311,7 @@ void HTMLTrackElement::textTrackModeChanged(TextTrack&)
 
 RefPtr<HTMLMediaElement> HTMLTrackElement::mediaElement() const
 {
-    RefPtr parent = parentElement();
-    if (!is<HTMLMediaElement>(parent))
-        return nullptr;
-    return downcast<HTMLMediaElement>(parent.get());
+    return dynamicDowncast<HTMLMediaElement>(parentElement());
 }
 
 const char* HTMLTrackElement::activeDOMObjectName() const

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -179,9 +179,12 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLVideoElement)
-    static bool isType(const WebCore::HTMLMediaElement& element) { return element.hasTagName(WebCore::HTMLNames::videoTag); }
-    static bool isType(const WebCore::Element& element) { return is<WebCore::HTMLMediaElement>(element) && isType(downcast<WebCore::HTMLMediaElement>(element)); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLMediaElement>(node) && isType(downcast<WebCore::HTMLMediaElement>(node)); }
+    static bool isType(const WebCore::HTMLElement& element) { return element.hasTagName(WebCore::HTMLNames::videoTag); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::HTMLElement>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -422,10 +422,8 @@ void ImageDocument::imageClicked(int x, int y)
 
 void ImageEventListener::handleEvent(ScriptExecutionContext&, Event& event)
 {
-    if (event.type() == eventNames().clickEvent && is<MouseEvent>(event)) {
-        MouseEvent& mouseEvent = downcast<MouseEvent>(event);
-        m_document.imageClicked(mouseEvent.offsetX(), mouseEvent.offsetY());
-    }
+    if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && event.type() == eventNames().clickEvent)
+        m_document.imageClicked(mouseEvent->offsetX(), mouseEvent->offsetY());
 }
 
 bool ImageEventListener::operator==(const EventListener& other) const

--- a/Source/WebCore/html/ImageDocument.h
+++ b/Source/WebCore/html/ImageDocument.h
@@ -88,5 +88,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ImageDocument)
     static bool isType(const WebCore::Document& document) { return document.isImageDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -90,10 +90,9 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
     m_clickLocation = IntPoint();
     if (event.underlyingEvent()) {
         Event& underlyingEvent = *event.underlyingEvent();
-        if (is<MouseEvent>(underlyingEvent)) {
-            MouseEvent& mouseEvent = downcast<MouseEvent>(underlyingEvent);
-            if (!mouseEvent.isSimulated())
-                m_clickLocation = IntPoint(mouseEvent.offsetX(), mouseEvent.offsetY());
+        if (auto* mouseEvent = dynamicDowncast<MouseEvent>(underlyingEvent)) {
+            if (!mouseEvent->isSimulated())
+                m_clickLocation = IntPoint(mouseEvent->offsetX(), mouseEvent->offsetY());
         }
     }
 
@@ -119,8 +118,8 @@ void ImageInputType::attributeChanged(const QualifiedName& name)
     if (name == altAttr) {
         if (auto* element = this->element()) {
             auto* renderer = element->renderer();
-            if (is<RenderImage>(renderer))
-                downcast<RenderImage>(*renderer).updateAltText();
+            if (auto* renderImage = dynamicDowncast<RenderImage>(renderer))
+                renderImage->updateAltText();
         }
     } else if (name == srcAttr) {
         if (auto* element = this->element()) {

--- a/Source/WebCore/html/LabelsNodeList.cpp
+++ b/Source/WebCore/html/LabelsNodeList.cpp
@@ -54,7 +54,8 @@ LabelsNodeList::~LabelsNodeList()
     
 bool LabelsNodeList::elementMatches(Element& testNode) const
 {
-    return is<HTMLLabelElement>(testNode) && downcast<HTMLLabelElement>(testNode).control() == &ownerNode();
+    auto* label = dynamicDowncast<HTMLLabelElement>(testNode);
+    return label && label->control() == &ownerNode();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -53,10 +53,9 @@ private:
         for (auto& entry : entries) {
             if (!entry->isIntersecting())
                 continue;
-            auto* element = entry->target();
-            if (is<HTMLIFrameElement>(element)) {
-                downcast<HTMLIFrameElement>(*element).lazyLoadFrameObserver().unobserve();
-                downcast<HTMLIFrameElement>(*element).loadDeferredFrame();
+            if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(entry->target())) {
+                iframe->lazyLoadFrameObserver().unobserve();
+                iframe->loadDeferredFrame();
             }
         }
         return { };

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -51,9 +51,8 @@ private:
         for (auto& entry : entries) {
             if (!entry->isIntersecting())
                 continue;
-            auto* element = entry->target();
-            if (is<HTMLImageElement>(element)) {
-                downcast<HTMLImageElement>(*element).loadDeferredImage();
+            if (RefPtr element = dynamicDowncast<HTMLImageElement>(entry->target())) {
+                element->loadDeferredImage();
                 element->document().lazyLoadImageObserver().unobserve(*element, element->document());
             }
         }

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -158,8 +158,8 @@ Ref<DocumentParser> MediaDocument::createParser()
 
 static inline HTMLVideoElement* descendantVideoElement(ContainerNode& node)
 {
-    if (is<HTMLVideoElement>(node))
-        return downcast<HTMLVideoElement>(&node);
+    if (auto* video = dynamicDowncast<HTMLVideoElement>(node))
+        return video;
 
     return descendantsOfType<HTMLVideoElement>(node).first();
 }
@@ -167,10 +167,11 @@ static inline HTMLVideoElement* descendantVideoElement(ContainerNode& node)
 #if !ENABLE(MODERN_MEDIA_CONTROLS)
 static inline HTMLVideoElement* ancestorVideoElement(Node* node)
 {
-    while (node && !is<HTMLVideoElement>(*node))
-        node = node->parentOrShadowHostNode();
-
-    return downcast<HTMLVideoElement>(node);
+    for (; node; node = node->parentOrShadowHostNode()) {
+        if (auto* video = dynamicDowncast<HTMLVideoElement>(node))
+            return video;
+    }
+    return nullptr;
 }
 #endif
 
@@ -179,11 +180,11 @@ void MediaDocument::defaultEventHandler(Event& event)
 #if !ENABLE(MODERN_MEDIA_CONTROLS)
     // Match the default Quicktime plugin behavior to allow
     // clicking and double-clicking to pause and play the media.
-    if (!is<Node>(event.target()))
+    auto* targetNode = dynamicDowncast<Node>(*event.target());
+    if (!targetNode)
         return;
-    auto& targetNode = downcast<Node>(*event.target());
 
-    if (RefPtr video = ancestorVideoElement(&targetNode)) {
+    if (RefPtr video = ancestorVideoElement(targetNode)) {
         if (event.type() == eventNames().clickEvent) {
             if (!video->canPlay()) {
                 video->pause();
@@ -197,23 +198,22 @@ void MediaDocument::defaultEventHandler(Event& event)
         }
     }
 
-    if (!is<ContainerNode>(targetNode))
+    auto* targetContainer = dynamicDowncast<ContainerNode>(*targetNode);
+    if (!targetContainer)
         return;
-    auto& targetContainer = downcast<ContainerNode>(targetNode);
 
-    if (event.type() == eventNames().keydownEvent && is<KeyboardEvent>(event)) {
-        RefPtr video = descendantVideoElement(targetContainer);
+    if (auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event); keyboardEvent && event.type() == eventNames().keydownEvent) {
+        RefPtr video = descendantVideoElement(*targetContainer);
         if (!video)
             return;
 
-        auto& keyboardEvent = downcast<KeyboardEvent>(event);
-        if (keyboardEvent.keyIdentifier() == "U+0020"_s) { // space
+        if (keyboardEvent->keyIdentifier() == "U+0020"_s) { // space
             if (video->paused()) {
                 if (video->canPlay())
                     video->play();
             } else
                 video->pause();
-            keyboardEvent.setDefaultHandled();
+            keyboardEvent->setDefaultHandled();
         }
     }
 #else // !ENABLE(MODERN_MEDIA_CONTROLS)

--- a/Source/WebCore/html/MediaDocument.h
+++ b/Source/WebCore/html/MediaDocument.h
@@ -61,7 +61,11 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaDocument)
     static bool isType(const WebCore::Document& document) { return document.isMediaDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -866,7 +866,6 @@ bool MediaElementSession::requiresFullscreenForVideoPlayback() const
         return false;
 
     if (m_element.document().isMediaDocument()) {
-        ASSERT(is<HTMLVideoElement>(m_element));
         const HTMLVideoElement& videoElement = *downcast<const HTMLVideoElement>(&m_element);
         if (m_element.readyState() < HTMLVideoElement::HAVE_METADATA || !videoElement.hasEverHadVideo())
             return false;

--- a/Source/WebCore/html/ModelDocument.h
+++ b/Source/WebCore/html/ModelDocument.h
@@ -57,7 +57,11 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ModelDocument)
     static bool isType(const WebCore::Document& document) { return document.isModelDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/html/PDFDocument.h
+++ b/Source/WebCore/html/PDFDocument.h
@@ -69,7 +69,11 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::PDFDocument)
     static bool isType(const WebCore::Document& document) { return document.isPDFDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(PDFJS)

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -61,5 +61,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::PluginDocument)
     static bool isType(const WebCore::Document& document) { return document.isPluginDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -142,9 +142,9 @@ auto RadioInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
         if (is<HTMLFormElement>(*node))
             break;
         // Look for more radio buttons.
-        if (!is<HTMLInputElement>(*node))
+        RefPtr inputElement = dynamicDowncast<HTMLInputElement>(*node);
+        if (!inputElement)
             continue;
-        RefPtr inputElement = downcast<HTMLInputElement>(node);
         if (inputElement->form() != element()->form())
             break;
         if (inputElement->isRadioButton() && inputElement->name() == element()->name() && inputElement->isFocusable()) {
@@ -187,10 +187,9 @@ bool RadioInputType::isKeyboardFocusable(KeyboardEvent* event) const
 
     // Never allow keyboard tabbing to leave you in the same radio group.  Always
     // skip any other elements in the group.
-    RefPtr<Element> currentFocusedNode = element()->document().focusedElement();
-    if (is<HTMLInputElement>(currentFocusedNode)) {
-        HTMLInputElement& focusedInput = downcast<HTMLInputElement>(*currentFocusedNode);
-        if (focusedInput.isRadioButton() && focusedInput.form() == element()->form() && focusedInput.name() == element()->name())
+    RefPtr currentFocusedNode = element()->document().focusedElement();
+    if (auto* focusedInput = dynamicDowncast<HTMLInputElement>(currentFocusedNode.get())) {
+        if (focusedInput->isRadioButton() && focusedInput->form() == element()->form() && focusedInput->name() == element()->name())
             return false;
     }
 

--- a/Source/WebCore/html/RadioNodeList.cpp
+++ b/Source/WebCore/html/RadioNodeList.cpp
@@ -59,13 +59,13 @@ RadioNodeList::~RadioNodeList()
 
 static RefPtr<HTMLInputElement> nonEmptyRadioButton(Node& node)
 {
-    if (!is<HTMLInputElement>(node))
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(node);
+    if (!inputElement)
         return nullptr;
 
-    auto& inputElement = downcast<HTMLInputElement>(node);
-    if (!inputElement.isRadioButton() || inputElement.value().isEmpty())
+    if (!inputElement->isRadioButton() || inputElement->value().isEmpty())
         return nullptr;
-    return &inputElement;
+    return inputElement;
 }
 
 String RadioNodeList::value() const
@@ -98,7 +98,7 @@ bool RadioNodeList::elementMatches(Element& element) const
     if (!element.isFormListedElement())
         return false;
 
-    if (is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isImageButton())
+    if (auto* input = dynamicDowncast<HTMLInputElement>(element); input && input->isImageButton())
         return false;
 
     if (is<HTMLFormElement>(ownerNode())) {

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -136,14 +136,18 @@ void RangeInputType::handleMouseDownEvent(MouseEvent& event)
     if (element()->isDisabledFormControl())
         return;
 
-    if (event.button() != MouseButton::Left || !is<Node>(event.target()))
+    if (event.button() != MouseButton::Left)
         return;
+
+    auto* targetNode = dynamicDowncast<Node>(event.target());
+    if (!targetNode)
+        return;
+
     ASSERT(element()->shadowRoot());
-    auto& targetNode = downcast<Node>(*event.target());
-    if (&targetNode != element() && !targetNode.isDescendantOf(element()->userAgentShadowRoot().get()))
+    if (targetNode != element() && !targetNode->isDescendantOf(element()->userAgentShadowRoot().get()))
         return;
     auto& thumb = typedSliderThumbElement();
-    if (&targetNode == &thumb)
+    if (targetNode == &thumb)
         return;
     thumb.dragFrom(event.absoluteLocation());
 }

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -63,8 +63,8 @@ void SearchInputType::addSearchResult()
     // we don't update the associated renderers until after the next tree update, so we could actually end up here
     // with a mismatched renderer (e.g. through form submission).
     ASSERT(element());
-    if (is<RenderSearchField>(element()->renderer()))
-        downcast<RenderSearchField>(*element()->renderer()).addSearchResult();
+    if (CheckedPtr renderer = dynamicDowncast<RenderSearchField>(element()->renderer()))
+        renderer->addSearchResult();
 #endif
 }
 
@@ -199,8 +199,10 @@ bool SearchInputType::searchEventsShouldBeDispatched() const
 void SearchInputType::didSetValueByUserEdit()
 {
     ASSERT(element());
-    if (m_cancelButton && is<RenderSearchField>(element()->renderer()))
-        downcast<RenderSearchField>(*element()->renderer()).updateCancelButtonVisibility();
+    if (m_cancelButton) {
+        if (CheckedPtr renderer = dynamicDowncast<RenderSearchField>(element()->renderer()))
+            renderer->updateCancelButtonVisibility();
+    }
     // If the incremental attribute is set, then dispatch the search event
     if (searchEventsShouldBeDispatched())
         startSearchEventTimer();

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -305,7 +305,8 @@ void TextFieldInputType::handleBlurEvent()
 
 bool TextFieldInputType::shouldSubmitImplicitly(Event& event)
 {
-    return (event.type() == eventNames().textInputEvent && is<TextEvent>(event) && downcast<TextEvent>(event).data() == "\n"_s)
+    auto* textEvent = dynamicDowncast<TextEvent>(event);
+    return (event.type() == eventNames().textInputEvent && textEvent && textEvent->data() == "\n"_s)
         || InputType::shouldSubmitImplicitly(event);
 }
 

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -226,19 +226,21 @@ void ValidatedFormListedElement::setDisabledInternal(bool disabled, bool disable
 
 static void addInvalidElementToAncestorFromInsertionPoint(const HTMLElement& element, ContainerNode* insertionPoint)
 {
-    if (!is<Element>(insertionPoint))
+    auto* insertionPointElement = dynamicDowncast<Element>(insertionPoint);
+    if (!insertionPointElement)
         return;
 
-    for (auto& ancestor : lineageOfType<HTMLFieldSetElement>(downcast<Element>(*insertionPoint)))
+    for (auto& ancestor : lineageOfType<HTMLFieldSetElement>(*insertionPointElement))
         ancestor.addInvalidDescendant(element);
 }
 
 static void removeInvalidElementToAncestorFromInsertionPoint(const HTMLElement& element, ContainerNode* insertionPoint)
 {
-    if (!is<Element>(insertionPoint))
+    auto* insertionPointElement = dynamicDowncast<Element>(insertionPoint);
+    if (!insertionPointElement)
         return;
 
-    for (auto& ancestor : lineageOfType<HTMLFieldSetElement>(downcast<Element>(*insertionPoint)))
+    for (auto& ancestor : lineageOfType<HTMLFieldSetElement>(*insertionPointElement))
         ancestor.removeInvalidDescendant(element);
 }
 
@@ -368,8 +370,8 @@ bool ValidatedFormListedElement::computeIsDisabledByFieldsetAncestor() const
 {
     RefPtr<const Element> previousAncestor;
     for (auto& ancestor : ancestorsOfType<Element>(asHTMLElement())) {
-        if (is<HTMLFieldSetElement>(ancestor) && ancestor.hasAttributeWithoutSynchronization(disabledAttr)) {
-            bool isInFirstLegend = is<HTMLLegendElement>(previousAncestor) && previousAncestor == downcast<HTMLFieldSetElement>(ancestor).legend();
+        if (auto* fieldset = dynamicDowncast<HTMLFieldSetElement>(ancestor); fieldset && ancestor.hasAttributeWithoutSynchronization(disabledAttr)) {
+            bool isInFirstLegend = is<HTMLLegendElement>(previousAncestor) && previousAncestor == fieldset->legend();
             return !isInFirstLegend;
         }
         previousAncestor = &ancestor;

--- a/Source/WebCore/html/canvas/CanvasStyle.cpp
+++ b/Source/WebCore/html/canvas/CanvasStyle.cpp
@@ -59,8 +59,8 @@ Color parseColor(const String& colorString, CanvasBase& canvasBase)
 #endif
 
     Color color;
-    if (is<HTMLCanvasElement>(canvasBase))
-        color = CSSParser::parseColor(colorString, downcast<HTMLCanvasElement>(canvasBase).cssParserContext());
+    if (auto* canvas = dynamicDowncast<HTMLCanvasElement>(canvasBase))
+        color = CSSParser::parseColor(colorString, canvas->cssParserContext());
     else
         color = CSSParser::parseColorWithoutContext(colorString);
 
@@ -79,13 +79,13 @@ Color parseColor(const String& colorString)
 
 Color currentColor(CanvasBase& canvasBase)
 {
-    if (!is<HTMLCanvasElement>(canvasBase))
+    RefPtr canvas = dynamicDowncast<HTMLCanvasElement>(canvasBase);
+    if (!canvas)
         return Color::black;
 
-    auto& canvas = downcast<HTMLCanvasElement>(canvasBase);
-    if (!canvas.isConnected() || !canvas.inlineStyle())
+    if (!canvas->isConnected() || !canvas->inlineStyle())
         return Color::black;
-    Color color = CSSParser::parseColorWithoutContext(canvas.inlineStyle()->getPropertyValue(CSSPropertyColor));
+    Color color = CSSParser::parseColorWithoutContext(canvas->inlineStyle()->getPropertyValue(CSSPropertyColor));
     if (!color.isValid())
         return Color::black;
     return color;

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
@@ -40,10 +40,7 @@ GPUBasedCanvasRenderingContext::GPUBasedCanvasRenderingContext(CanvasBase& canva
 
 HTMLCanvasElement* GPUBasedCanvasRenderingContext::htmlCanvas() const
 {
-    auto& base = canvasBase();
-    if (!is<HTMLCanvasElement>(base))
-        return nullptr;
-    return &downcast<HTMLCanvasElement>(base);
+    return dynamicDowncast<HTMLCanvasElement>(canvasBase());
 }
 
 void GPUBasedCanvasRenderingContext::notifyCanvasContentChanged()

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -136,11 +136,7 @@ GPUCanvasContextCocoa::CanvasType GPUCanvasContextCocoa::htmlOrOffscreenCanvas()
 {
     if (auto* c = htmlCanvas())
         return c;
-
-    auto& base = canvasBase();
-    RELEASE_ASSERT(is<OffscreenCanvas>(base));
-
-    return &downcast<OffscreenCanvas>(base);
+    return &checkedDowncast<OffscreenCanvas>(canvasBase());
 }
 
 GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, GPU& gpu)

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -59,8 +59,8 @@ ImageBitmapCanvas ImageBitmapRenderingContext::canvas()
 {
     auto& base = canvasBase();
 #if ENABLE(OFFSCREEN_CANVAS)
-    if (is<OffscreenCanvas>(base))
-        return &downcast<OffscreenCanvas>(base);
+    if (auto* offscreenCanvas = dynamicDowncast<OffscreenCanvas>(base))
+        return offscreenCanvas;
 #endif
     return &downcast<HTMLCanvasElement>(base);
 }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -46,10 +46,7 @@ PlaceholderRenderingContext::PlaceholderRenderingContext(CanvasBase& canvas)
 
 HTMLCanvasElement* PlaceholderRenderingContext::canvas() const
 {
-    auto& base = canvasBase();
-    if (!is<HTMLCanvasElement>(base))
-        return nullptr;
-    return &downcast<HTMLCanvasElement>(base);
+    return dynamicDowncast<HTMLCanvasElement>(canvasBase());
 }
 
 void PlaceholderRenderingContext::setContentsToLayer(GraphicsLayer& layer)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -484,8 +484,8 @@ WebGLCanvas WebGLRenderingContextBase::canvas()
 {
     auto& base = canvasBase();
 #if ENABLE(OFFSCREEN_CANVAS)
-    if (is<OffscreenCanvas>(base))
-        return &downcast<OffscreenCanvas>(base);
+    if (auto* offscreenCanvas = dynamicDowncast<OffscreenCanvas>(base))
+        return offscreenCanvas;
 #endif
     return &downcast<HTMLCanvasElement>(base);
 }
@@ -493,10 +493,7 @@ WebGLCanvas WebGLRenderingContextBase::canvas()
 #if ENABLE(OFFSCREEN_CANVAS)
 OffscreenCanvas* WebGLRenderingContextBase::offscreenCanvas()
 {
-    auto& base = canvasBase();
-    if (!is<OffscreenCanvas>(base))
-        return nullptr;
-    return &downcast<OffscreenCanvas>(base);
+    return dynamicDowncast<OffscreenCanvas>(canvasBase());
 }
 #endif
 
@@ -4544,7 +4541,6 @@ void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
     // Extend the base useProgram method instead of overriding it in
     // WebGL2RenderingContext to keep the preceding validations in the same order.
     if (isWebGL2()) {
-        ASSERT(is<WebGL2RenderingContext>(*this));
         if (downcast<WebGL2RenderingContext>(*this).isTransformFeedbackActiveAndNotPaused()) {
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "useProgram", "transform feedback is active and not paused");
             return;

--- a/Source/WebCore/html/parser/HTMLStackItem.h
+++ b/Source/WebCore/html/parser/HTMLStackItem.h
@@ -68,9 +68,9 @@ public:
     bool matchesHTMLTag(const AtomString&) const;
 
 private:
-    RefPtr<ContainerNode> m_node;
     ElementName m_elementName = ElementName::Unknown;
     Namespace m_namespace = Namespace::Unknown;
+    RefPtr<ContainerNode> m_node;
     Vector<Attribute> m_attributes;
 };
 
@@ -79,25 +79,25 @@ bool isNumberedHeaderElement(const HTMLStackItem&);
 bool isSpecialNode(const HTMLStackItem&);
 
 inline HTMLStackItem::HTMLStackItem(Ref<Element>&& element, AtomHTMLToken&& token)
-    : m_node(WTFMove(element))
-    , m_elementName(downcast<Element>(*m_node).elementName())
-    , m_namespace(downcast<Element>(*m_node).nodeNamespace())
+    : m_elementName(element->elementName())
+    , m_namespace(element->nodeNamespace())
+    , m_node(WTFMove(element))
     , m_attributes(WTFMove(token.attributes()))
 {
 }
 
 inline HTMLStackItem::HTMLStackItem(Ref<Element>&& element, Vector<Attribute>&& attributes)
-    : m_node(WTFMove(element))
-    , m_elementName(downcast<Element>(*m_node).elementName())
-    , m_namespace(downcast<Element>(*m_node).nodeNamespace())
+    : m_elementName(element->elementName())
+    , m_namespace(element->nodeNamespace())
+    , m_node(WTFMove(element))
     , m_attributes(WTFMove(attributes))
 {
 }
 
 inline HTMLStackItem::HTMLStackItem(Element& element)
-    : m_node(&element)
-    , m_elementName(element.elementName())
+    : m_elementName(element.elementName())
     , m_namespace(element.nodeNamespace())
+    , m_node(&element)
 {
 }
 

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -279,7 +279,8 @@ HTMLTreeBuilder::HTMLTreeBuilder(HTMLDocumentParser& parser, DocumentFragment& f
 
     resetInsertionModeAppropriately();
 
-    m_tree.setForm(is<HTMLFormElement>(contextElement) ? &downcast<HTMLFormElement>(contextElement) : HTMLFormElement::findClosestFormAncestor(contextElement));
+    auto* formElement = dynamicDowncast<HTMLFormElement>(contextElement);
+    m_tree.setForm(formElement ? formElement : HTMLFormElement::findClosestFormAncestor(contextElement));
 
 #if ASSERT_ENABLED
     m_destructionProhibited = false;
@@ -972,8 +973,7 @@ bool HTMLTreeBuilder::processTemplateEndTag(AtomHTMLToken&& token)
     if (m_tree.currentStackItem().elementName() != HTML::template_)
         parseError(token);
     m_tree.openElements().popUntil(HTML::template_);
-    RELEASE_ASSERT(is<HTMLTemplateElement>(m_tree.openElements().top()));
-    Ref templateElement = downcast<HTMLTemplateElement>(m_tree.openElements().top());
+    Ref templateElement = checkedDowncast<HTMLTemplateElement>(m_tree.openElements().top());
     m_tree.openElements().pop();
 
     auto& item = adjustedCurrentStackItem();
@@ -2497,10 +2497,11 @@ static inline bool disallowTelephoneNumberParsing(const ContainerNode& node)
     if (node.isLink() || is<HTMLFormControlElement>(node))
         return true;
 
-    if (!is<Element>(node))
+    auto* element = dynamicDowncast<Element>(node);
+    if (!element)
         return false;
 
-    switch (downcast<Element>(node).elementName()) {
+    switch (element->elementName()) {
     case HTML::a:
     case HTML::script:
     case HTML::style:

--- a/Source/WebCore/html/shadow/AutoFillButtonElement.cpp
+++ b/Source/WebCore/html/shadow/AutoFillButtonElement.cpp
@@ -52,15 +52,14 @@ AutoFillButtonElement::AutoFillButtonElement(Document& document, AutoFillButtonO
 
 void AutoFillButtonElement::defaultEventHandler(Event& event)
 {
-    if (!is<MouseEvent>(event)) {
+    auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+    if (!mouseEvent) {
         if (!event.defaultHandled())
             HTMLDivElement::defaultEventHandler(event);
         return;
     }
 
-    MouseEvent& mouseEvent = downcast<MouseEvent>(event);
-
-    if (mouseEvent.type() == eventNames().clickEvent) {
+    if (mouseEvent->type() == eventNames().clickEvent) {
         m_owner.autoFillButtonElementWasClicked();
         event.setDefaultHandled();
     }

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -55,15 +55,14 @@ DataListButtonElement::~DataListButtonElement() { }
 
 void DataListButtonElement::defaultEventHandler(Event& event)
 {
-    if (!is<MouseEvent>(event)) {
+    auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+    if (!mouseEvent) {
         if (!event.defaultHandled())
             HTMLDivElement::defaultEventHandler(event);
         return;
     }
 
-    MouseEvent& mouseEvent = downcast<MouseEvent>(event);
-
-    if (mouseEvent.type() == eventNames().clickEvent) {
+    if (mouseEvent->type() == eventNames().clickEvent) {
         m_owner.dataListButtonElementWasClicked();
         event.setDefaultHandled();
     }

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -83,16 +83,15 @@ void DateTimeFieldElement::defaultEventHandler(Event& event)
     if (event.type() == eventNames().blurEvent)
         handleBlurEvent(event);
 
-    if (is<KeyboardEvent>(event)) {
-        auto& keyboardEvent = downcast<KeyboardEvent>(event);
+    if (auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
         if (!isFieldOwnerDisabled() && !isFieldOwnerReadOnly()) {
-            handleKeyboardEvent(keyboardEvent);
-            if (keyboardEvent.defaultHandled())
+            handleKeyboardEvent(*keyboardEvent);
+            if (keyboardEvent->defaultHandled())
                 return;
         }
 
-        defaultKeyboardEventHandler(keyboardEvent);
-        if (keyboardEvent.defaultHandled())
+        defaultKeyboardEventHandler(*keyboardEvent);
+        if (keyboardEvent->defaultHandled())
             return;
     }
 

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -312,7 +312,8 @@ void SliderThumbElement::stopDragging()
 
 void SliderThumbElement::defaultEventHandler(Event& event)
 {
-    if (!is<MouseEvent>(event)) {
+    auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+    if (!mouseEvent) {
         HTMLDivElement::defaultEventHandler(event);
         return;
     }
@@ -325,9 +326,8 @@ void SliderThumbElement::defaultEventHandler(Event& event)
         return;
     }
 
-    MouseEvent& mouseEvent = downcast<MouseEvent>(event);
-    bool isLeftButton = mouseEvent.button() == MouseButton::Left;
-    const AtomString& eventType = mouseEvent.type();
+    bool isLeftButton = mouseEvent->button() == MouseButton::Left;
+    const AtomString& eventType = mouseEvent->type();
 
     // We intentionally do not call event->setDefaultHandled() here because
     // MediaControlTimelineElement::defaultEventHandler() wants to handle these
@@ -341,11 +341,11 @@ void SliderThumbElement::defaultEventHandler(Event& event)
         return;
     } else if (eventType == eventNames().mousemoveEvent) {
         if (m_inDragMode)
-            setPositionFromPoint(mouseEvent.absoluteLocation());
+            setPositionFromPoint(mouseEvent->absoluteLocation());
         return;
     }
 
-    HTMLDivElement::defaultEventHandler(mouseEvent);
+    HTMLDivElement::defaultEventHandler(*mouseEvent);
 }
 
 bool SliderThumbElement::willRespondToMouseMoveEvents() const

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -123,10 +123,18 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SliderThumbElement)
     static bool isType(const WebCore::Element& element) { return element.isSliderThumbElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SliderContainerElement)
     static bool isType(const WebCore::Element& element) { return element.isSliderContainerElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -74,7 +74,8 @@ void SpinButtonElement::willDetachRenderers()
 
 void SpinButtonElement::defaultEventHandler(Event& event)
 {
-    if (!is<MouseEvent>(event)) {
+    auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+    if (!mouseEvent) {
         if (!event.defaultHandled())
             HTMLDivElement::defaultEventHandler(event);
         return;
@@ -93,9 +94,8 @@ void SpinButtonElement::defaultEventHandler(Event& event)
         return;
     }
 
-    MouseEvent& mouseEvent = downcast<MouseEvent>(event);
-    IntPoint local = roundedIntPoint(box->absoluteToLocal(mouseEvent.absoluteLocation(), UseTransforms));
-    if (mouseEvent.type() == eventNames().mousedownEvent && mouseEvent.button() == MouseButton::Left) {
+    IntPoint local = roundedIntPoint(box->absoluteToLocal(mouseEvent->absoluteLocation(), UseTransforms));
+    if (mouseEvent->type() == eventNames().mousedownEvent && mouseEvent->button() == MouseButton::Left) {
         if (box->borderBoxRect().contains(local)) {
             // The following functions of HTMLInputElement may run JavaScript
             // code which detaches this shadow node. We need to take a reference
@@ -114,11 +114,11 @@ void SpinButtonElement::defaultEventHandler(Event& event)
                     doStepAction(m_upDownState == Up ? 1 : -1);
                 }
             }
-            mouseEvent.setDefaultHandled();
+            mouseEvent->setDefaultHandled();
         }
-    } else if (mouseEvent.type() == eventNames().mouseupEvent && mouseEvent.button() == MouseButton::Left)
+    } else if (mouseEvent->type() == eventNames().mouseupEvent && mouseEvent->button() == MouseButton::Left)
         stopRepeatingTimer();
-    else if (mouseEvent.type() == eventNames().mousemoveEvent) {
+    else if (mouseEvent->type() == eventNames().mousemoveEvent) {
         if (box->borderBoxRect().contains(local)) {
             if (!m_capturing) {
                 if (RefPtr frame = document().frame()) {
@@ -148,8 +148,8 @@ void SpinButtonElement::defaultEventHandler(Event& event)
         }
     }
 
-    if (!mouseEvent.defaultHandled())
-        HTMLDivElement::defaultEventHandler(mouseEvent);
+    if (!mouseEvent->defaultHandled())
+        HTMLDivElement::defaultEventHandler(*mouseEvent);
 }
 
 void SpinButtonElement::willOpenPopup()
@@ -160,7 +160,8 @@ void SpinButtonElement::willOpenPopup()
 
 void SpinButtonElement::forwardEvent(Event& event)
 {
-    if (!is<WheelEvent>(event))
+    auto* wheelEvent = dynamicDowncast<WheelEvent>(event);
+    if (!wheelEvent)
         return;
 
     if (!m_spinButtonOwner)
@@ -169,8 +170,8 @@ void SpinButtonElement::forwardEvent(Event& event)
     if (!m_spinButtonOwner->shouldSpinButtonRespondToWheelEvents())
         return;
 
-    doStepAction(downcast<WheelEvent>(event).wheelDeltaY());
-    event.setDefaultHandled();
+    doStepAction(wheelEvent->wheelDeltaY());
+    wheelEvent->setDefaultHandled();
 }
 
 bool SpinButtonElement::willRespondToMouseMoveEvents() const

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -96,5 +96,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SpinButtonElement)
     static bool isType(const WebCore::Element& element) { return element.isSpinButtonElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/shadow/TextControlInnerElements.h
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.h
@@ -138,10 +138,18 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TextControlInnerTextElement)
     static bool isType(const WebCore::HTMLElement& element) { return element.isTextControlInnerTextElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLElement>(node) && isType(downcast<WebCore::HTMLElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* htmlElement = dynamicDowncast<WebCore::HTMLElement>(node);
+        return htmlElement && isType(*htmlElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SearchFieldResultsButtonElement)
     static bool isType(const WebCore::HTMLElement& element) { return element.isSearchFieldResultsButtonElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLElement>(node) && isType(downcast<WebCore::HTMLElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* htmlElement = dynamicDowncast<WebCore::HTMLElement>(node);
+        return htmlElement && isType(*htmlElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/shadow/TextPlaceholderElement.cpp
+++ b/Source/WebCore/html/shadow/TextPlaceholderElement.cpp
@@ -53,8 +53,8 @@ TextPlaceholderElement::TextPlaceholderElement(Document& document, const LayoutS
 auto TextPlaceholderElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
 {
     if (insertionType.treeScopeChanged) {
-        if (RefPtr shadowHost = parentOfInsertedTree.shadowHost(); is<HTMLTextFormControlElement>(shadowHost))
-            downcast<HTMLTextFormControlElement>(*shadowHost).setCanShowPlaceholder(false);
+        if (RefPtr shadowHost = dynamicDowncast<HTMLTextFormControlElement>(parentOfInsertedTree.shadowHost()))
+            shadowHost->setCanShowPlaceholder(false);
     }
     return HTMLDivElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 }
@@ -62,8 +62,8 @@ auto TextPlaceholderElement::insertedIntoAncestor(InsertionType insertionType, C
 void TextPlaceholderElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged) {
-        if (RefPtr shadowHost = oldParentOfRemovedTree.shadowHost(); is<HTMLTextFormControlElement>(shadowHost))
-            downcast<HTMLTextFormControlElement>(*shadowHost).setCanShowPlaceholder(true);
+        if (RefPtr shadowHost = dynamicDowncast<HTMLTextFormControlElement>(oldParentOfRemovedTree.shadowHost()))
+            shadowHost->setCanShowPlaceholder(true);
     }
     HTMLDivElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 }

--- a/Source/WebCore/html/shadow/TextPlaceholderElement.h
+++ b/Source/WebCore/html/shadow/TextPlaceholderElement.h
@@ -47,5 +47,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TextPlaceholderElement)
     static bool isType(const WebCore::Element& element) { return element.isTextPlaceholderElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -134,42 +134,41 @@ enum RequiredNodes {
 
 static ExceptionOr<void> tagPseudoObjects(Node& node, OptionSet<RequiredNodes>& nodeTypes)
 {
-    if (!is<Element>(node))
+    RefPtr element = dynamicDowncast<Element>(node);
+    if (!element)
         return { };
 
-    auto& element = downcast<Element>(node);
-
-    if (element.hasAttributeWithoutSynchronization(HTMLNames::cuebackgroundAttr)) {
-        element.setPseudo(ShadowPseudoIds::webkitMediaTextTrackDisplayBackdrop());
+    if (element->hasAttributeWithoutSynchronization(HTMLNames::cuebackgroundAttr)) {
+        element->setPseudo(ShadowPseudoIds::webkitMediaTextTrackDisplayBackdrop());
         nodeTypes.add(RequiredNodes::CueBackground);
     }
 
-    if (element.hasAttributeWithoutSynchronization(HTMLNames::cueAttr)) {
-        if (!nodeTypes.contains(RequiredNodes::CueBackground) || !element.closest("[cuebackground]"_s).returnValue())
+    if (element->hasAttributeWithoutSynchronization(HTMLNames::cueAttr)) {
+        if (!nodeTypes.contains(RequiredNodes::CueBackground) || !element->closest("[cuebackground]"_s).returnValue())
             return Exception { ExceptionCode::HierarchyRequestError, "Found cue attribute but no cuebackground attribute in hierarchy "_s };
 
-        element.setPseudo(ShadowPseudoIds::cue());
+        element->setPseudo(ShadowPseudoIds::cue());
         nodeTypes.add(RequiredNodes::Cue);
     }
 
     if (nodeTypes.contains(RequiredNodes::CueBackground) && nodeTypes.contains(RequiredNodes::Cue))
         return { };
 
-    for (auto* child = element.firstChild(); child; child = child->nextSibling())
+    for (RefPtr child = element->firstChild(); child; child = child->nextSibling())
         tagPseudoObjects(*child, nodeTypes);
     return { };
 }
 
 static void removePseudoAttributes(Node& node)
 {
-    if (!is<Element>(node))
+    RefPtr element = dynamicDowncast<Element>(node);
+    if (!element)
         return;
 
-    auto& element = downcast<Element>(node);
-    if (element.hasAttributeWithoutSynchronization(HTMLNames::cueAttr) || element.hasAttributeWithoutSynchronization(HTMLNames::cuebackgroundAttr))
-        element.removeAttribute(HTMLNames::pseudoAttr);
+    if (element->hasAttributeWithoutSynchronization(HTMLNames::cueAttr) || element->hasAttributeWithoutSynchronization(HTMLNames::cuebackgroundAttr))
+        element->removeAttribute(HTMLNames::pseudoAttr);
 
-    for (auto* child = element.firstChild(); child; child = child->nextSibling())
+    for (RefPtr child = element->firstChild(); child; child = child->nextSibling())
         removePseudoAttributes(*child);
 }
 

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -217,10 +217,10 @@ bool TextTrackCueGeneric::isOrderedBefore(const TextTrackCue* that) const
     if (VTTCue::isOrderedBefore(that))
         return true;
 
-    if (is<TextTrackCueGeneric>(*that) && startTime() == that->startTime() && endTime() == that->endTime()) {
+    if (auto* thatCue = dynamicDowncast<TextTrackCueGeneric>(*that); thatCue && startTime() == that->startTime() && endTime() == that->endTime()) {
         // Further order generic cues by their calculated line value.
         auto thisPosition = getPositionCoordinates();
-        auto thatPosition = downcast<TextTrackCueGeneric>(*that).getPositionCoordinates();
+        auto thatPosition = thatCue->getPositionCoordinates();
         return thisPosition.second > thatPosition.second || (thisPosition.second == thatPosition.second && thisPosition.first < thatPosition.first);
     }
 
@@ -229,14 +229,14 @@ bool TextTrackCueGeneric::isOrderedBefore(const TextTrackCue* that) const
 
 bool TextTrackCueGeneric::isPositionedAbove(const TextTrackCue* that) const
 {
-    if (is<TextTrackCueGeneric>(*that)) {
-        if (startTime() == that->startTime() && endTime() == that->endTime()) {
+    if (auto* thatCue = dynamicDowncast<TextTrackCueGeneric>(*that)) {
+        if (startTime() == thatCue->startTime() && endTime() == thatCue->endTime()) {
             // Further order generic cues by their calculated line value.
             auto thisPosition = getPositionCoordinates();
-            auto thatPosition = downcast<TextTrackCueGeneric>(*that).getPositionCoordinates();
+            auto thatPosition = thatCue->getPositionCoordinates();
             return thisPosition.second > thatPosition.second || (thisPosition.second == thatPosition.second && thisPosition.first < thatPosition.first);
         }
-        return startTime() > that->startTime();
+        return startTime() > thatCue->startTime();
     }
 
     return VTTCue::isOrderedBefore(that);

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -54,8 +54,8 @@ unsigned TextTrackList::length() const
 
 int TextTrackList::getTrackIndex(TextTrack& textTrack)
 {
-    if (is<LoadableTextTrack>(textTrack))
-        return downcast<LoadableTextTrack>(textTrack).trackElementIndex();
+    if (auto* loadableTextTrack = dynamicDowncast<LoadableTextTrack>(textTrack))
+        return loadableTextTrack->trackElementIndex();
 
     if (textTrack.trackType() == TextTrack::AddTrack)
         return m_elementTracks.size() + m_addTrackTracks.find(&textTrack);
@@ -175,9 +175,9 @@ void TextTrackList::append(Ref<TextTrack>&& track)
 {
     if (track->trackType() == TextTrack::AddTrack)
         m_addTrackTracks.append(track.ptr());
-    else if (is<LoadableTextTrack>(track)) {
+    else if (auto* textTrack = dynamicDowncast<LoadableTextTrack>(track.get())) {
         // Insert tracks added for <track> element in tree order.
-        size_t index = downcast<LoadableTextTrack>(track.get()).trackElementIndex();
+        size_t index = textTrack->trackElementIndex();
         m_elementTracks.insert(index, track.ptr());
     } else if (track->trackType() == TextTrack::InBand) {
         // Insert tracks added for in-band in the media file order.


### PR DESCRIPTION
#### a63f311f92d49dd5b950d3680da12d25bb9f7375
<pre>
Adopt dynamicDowncast&lt;&gt;() more in html/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265122">https://bugs.webkit.org/show_bug.cgi?id=265122</a>

Reviewed by Dan Glastonbury.

* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::insertedIntoAncestor):
(WebCore::HTMLTrackElement::removedFromAncestor):
(WebCore::HTMLTrackElement::mediaElement const):
* Source/WebCore/html/HTMLVideoElement.h:
(isType):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageEventListener::handleEvent):
* Source/WebCore/html/ImageDocument.h:
(isType):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::handleDOMActivateEvent):
(WebCore::ImageInputType::attributeChanged):
* Source/WebCore/html/LabelsNodeList.cpp:
(WebCore::LabelsNodeList::elementMatches const):
* Source/WebCore/html/LazyLoadFrameObserver.cpp:
* Source/WebCore/html/LazyLoadImageObserver.cpp:
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::descendantVideoElement):
(WebCore::ancestorVideoElement):
(WebCore::MediaDocument::defaultEventHandler):
* Source/WebCore/html/MediaDocument.h:
(isType):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::requiresFullscreenForVideoPlayback const):
* Source/WebCore/html/ModelDocument.h:
(isType):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::setSize):
(WebCore::OffscreenCanvas::createContextWebGL):
(WebCore::OffscreenCanvas::getContext):
(WebCore::OffscreenCanvas::transferToImageBitmap):
(WebCore::OffscreenCanvas::securityOrigin const):
(WebCore::OffscreenCanvas::reset):
* Source/WebCore/html/PDFDocument.h:
(isType):
* Source/WebCore/html/PluginDocument.h:
(isType):
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::handleKeydownEvent):
(WebCore::RadioInputType::isKeyboardFocusable const):
* Source/WebCore/html/RadioNodeList.cpp:
(WebCore::nonEmptyRadioButton):
(WebCore::RadioNodeList::elementMatches const):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleMouseDownEvent):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::addSearchResult):
(WebCore::SearchInputType::didSetValueByUserEdit):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::shouldSubmitImplicitly):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::addInvalidElementToAncestorFromInsertionPoint):
(WebCore::removeInvalidElementToAncestorFromInsertionPoint):
(WebCore::ValidatedFormListedElement::computeIsDisabledByFieldsetAncestor const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::size):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::parseColor):
(WebCore::currentColor):
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp:
(WebCore::GPUBasedCanvasRenderingContext::htmlCanvas const):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::htmlOrOffscreenCanvas const):
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::canvas):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::canvas const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::canvas):
(WebCore::WebGLRenderingContextBase::offscreenCanvas):
(WebCore::WebGLRenderingContextBase::useProgram):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::shouldUseLengthLimit):
(WebCore::HTMLConstructionSite::insertHTMLTemplateElement):
(WebCore::HTMLConstructionSite::ownerDocumentForCurrentNode):
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
* Source/WebCore/html/parser/HTMLStackItem.h:
(WebCore::HTMLStackItem::HTMLStackItem):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::HTMLTreeBuilder):
(WebCore::HTMLTreeBuilder::processTemplateEndTag):
(WebCore::disallowTelephoneNumberParsing):
* Source/WebCore/html/shadow/AutoFillButtonElement.cpp:
(WebCore::AutoFillButtonElement::defaultEventHandler):
* Source/WebCore/html/shadow/DataListButtonElement.cpp:
(WebCore::DataListButtonElement::defaultEventHandler):
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::defaultEventHandler):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateVideoDisplaySize):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::defaultEventHandler):
* Source/WebCore/html/shadow/SliderThumbElement.h:
(isType):
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::defaultEventHandler):
(WebCore::SpinButtonElement::forwardEvent):
* Source/WebCore/html/shadow/SpinButtonElement.h:
(isType):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::isStrongPasswordTextField):
(WebCore::TextControlPlaceholderElement::resolveCustomStyle):
(WebCore::SearchFieldResultsButtonElement::defaultEventHandler):
(WebCore::SearchFieldCancelButtonElement::defaultEventHandler):
(WebCore::SearchFieldCancelButtonElement::willRespondToMouseClickEventsWithEditability const):
* Source/WebCore/html/shadow/TextControlInnerElements.h:
(isType):
* Source/WebCore/html/shadow/TextPlaceholderElement.cpp:
(WebCore::TextPlaceholderElement::insertedIntoAncestor):
(WebCore::TextPlaceholderElement::removedFromAncestor):
* Source/WebCore/html/shadow/TextPlaceholderElement.h:
(isType):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::tagPseudoObjects):
(WebCore::removePseudoAttributes):
* Source/WebCore/html/track/TextTrackCueGeneric.cpp:
(WebCore::TextTrackCueGeneric::isOrderedBefore const):
(WebCore::TextTrackCueGeneric::isPositionedAbove const):
* Source/WebCore/html/track/TextTrackList.cpp:
(WebCore::TextTrackList::getTrackIndex):
(WebCore::TextTrackList::append):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSPropertiesWithRegion):
(WebCore::VTTCueBox::applyCSSProperties):
(WebCore::copyWebVTTNodeToDOMTree):
(WebCore::VTTCue::markFutureAndPastNodes):

Canonical link: <a href="https://commits.webkit.org/270996@main">https://commits.webkit.org/270996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b318dcff5860800d64a1888cc8ae70ba95766e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26995 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24553 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29841 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30170 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28084 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4438 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3500 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->