### PR TITLE
NativePromise should allow void as reject type.

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -123,7 +123,8 @@ template<typename Value, typename = DefaultHash<Value>, typename = HashTraits<Va
 template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits> class HashMap;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits> class HashSet;
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
-using GenericPromise = NativePromise<void, int>;
+using GenericPromise = NativePromise<void, void>;
+using GenericNonExclusivePromise = NativePromise<void, void, 1>;
 template<typename T> class NativePromiseRequest;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -150,7 +150,7 @@ private:
     const TestPromise::Result m_result;
 };
 
-static std::function<void()> doFail()
+static auto doFail()
 {
     return [] {
         EXPECT_TRUE(false);
@@ -252,7 +252,7 @@ TEST(NativePromise, BasicSettleRejected)
     });
 }
 
-// Example use with a GenericPromise which is a NativePromise<void, int>
+// Example use with a GenericPromise which is a NativePromise<void, void>
 //
 TEST(NativePromise, GenericPromise)
 {
@@ -270,10 +270,9 @@ TEST(NativePromise, GenericPromise)
                 EXPECT_TRUE(result);
             });
 
-        GenericPromise::createAndReject(123)->whenSettled(queue,
+        GenericPromise::createAndReject()->whenSettled(queue,
             [](GenericPromise::Result result) {
                 EXPECT_TRUE(!result);
-                EXPECT_EQ(result.error(), 123);
             });
 
         GenericPromise::Producer producer1;
@@ -288,13 +287,11 @@ TEST(NativePromise, GenericPromise)
 
         GenericPromise::Producer producer2;
         Ref<GenericPromise> promise2 = producer2;
-        producer2.reject(123);
+        producer2.reject();
         promise2->then(queue,
+            doFail(),
             []() {
                 EXPECT_TRUE(true);
-            },
-            [](int value) {
-                EXPECT_EQ(value, 123);
             });
 
         GenericPromise::Producer producer3;
@@ -1283,12 +1280,11 @@ TEST(NativePromise, HeterogeneousChaining)
     TestPromise::createAndResolve(1)->whenSettled(queue,
         [queue] {
             return TestPromiseExcl::createAndResolve(2)->whenSettled(queue, [] {
-                return GenericPromise::createAndReject(1);
+                return GenericPromise::createAndReject();
             });
         })->whenSettled(queue,
             [queue](GenericPromise::Result result) {
                 EXPECT_FALSE(result.has_value());
-                EXPECT_EQ(1, result.error());
                 queue->beginShutdown();
             });
 }
@@ -1313,7 +1309,7 @@ TEST(NativePromise, ImplicitConversionWithForwardPreviousReturn)
             [](const TestPromise::Result& result) {
                 return TestPromise::createAndSettle(result);
             });
-        promise->whenSettled(runLoop, [&](const TestPromise::Result& result) {
+        promise->whenSettled(runLoop, [promise](const TestPromise::Result& result) {
             EXPECT_TRUE(!result.has_value());
             EXPECT_FALSE(promise->isResolved());
         });
@@ -1471,11 +1467,29 @@ TEST(NativePromise, PromiseConversion)
             EXPECT_TRUE(!!result);
         });
 
+        // Converting a promise taking void as reject.
         auto promise4 = MyNonExclusiveLongPromise::createAndReject(1)->convert<GenericPromise>();
         static_assert(std::is_same_v<Ref<GenericPromise>, decltype(promise4)>);
         promise4->whenSettled(runLoop, [](auto&& result) {
             EXPECT_TRUE(!result);
-            EXPECT_EQ(result.error(), 1);
+        });
+
+        // Converting a promise with different type.
+        using IntPromise = NativePromise<int, int>;
+        using DoublePromise = NativePromise<double, double>;
+
+        auto promise5 = IntPromise::createAndResolve(1)->convert<DoublePromise>();
+        static_assert(std::is_same_v<Ref<DoublePromise>, decltype(promise5)>);
+        promise5->whenSettled(runLoop, [](auto&& result) {
+            static_assert(std::is_same_v<double, std::remove_reference_t<decltype(result.value())>>);
+            EXPECT_TRUE(result.has_value());
+        });
+
+        // Can convert to promise taking a data/void mix
+        using DoubleVoidPromise = NativePromise<double, void>;
+        auto promise6 = IntPromise::createAndReject(1)->convert<DoubleVoidPromise>();
+        promise6->whenSettled(runLoop, [](auto&& result) {
+            EXPECT_TRUE(!result);
         });
     });
 }
@@ -1522,20 +1536,28 @@ TEST(NativePromise, MismatchChainTo)
             EXPECT_EQ(*result, long(1));
         });
 
-        // chaining with void promise
-        auto intPromise2 = IntPromise::createAndResolve(1);
-        GenericPromise::Producer genericPromiseProducer;
-        genericPromiseProducer->whenSettled(runLoop, [](auto&& result) {
+        // Chaining non-exclusive promise to exclusive, check the end result is movable.
+        using IntPromiseNonExcl = NativePromise<int, int, PromiseOption::Default | PromiseOption::NonExclusive>;
+        auto intPromise2 = IntPromiseNonExcl::createAndResolve(1);
+        LongPromise::Producer longPromiseProducer2;
+        auto longPromise2 = longPromiseProducer2.promise();
+        intPromise2->chainTo(WTFMove(longPromiseProducer2));
+        longPromise2->whenSettled(runLoop, [](auto&& result) {
+            using NonRefQualifiedType = typename std::remove_reference<decltype(result)>::type;
+            static_assert(!std::is_const<NonRefQualifiedType>::value, "result is const qualified.");
             EXPECT_TRUE(!!result);
+            EXPECT_EQ(*result, long(1));
         });
-        intPromise2->chainTo(WTFMove(genericPromiseProducer));
+        intPromise2->whenSettled(runLoop, [](auto result) {
+            EXPECT_TRUE(!!result);
+            EXPECT_EQ(*result, 1);
+        });
 
         // chaining ThenCommand
         auto intPromise3 = IntPromise::createAndResolve(1);
-        LongPromise::Producer longPromiseProducer2;
-        auto longPromise2 = longPromiseProducer2.promise();
-
-        longPromise2->whenSettled(runLoop, [&](auto&& result) mutable {
+        LongPromise::Producer longPromiseProducer3;
+        auto longPromise3 = longPromiseProducer3.promise();
+        longPromise3->whenSettled(runLoop, [&](auto&& result) mutable {
             EXPECT_TRUE(!!result);
             EXPECT_EQ(*result, long(2));
             done = true;
@@ -1544,7 +1566,53 @@ TEST(NativePromise, MismatchChainTo)
             EXPECT_TRUE(!!result);
             EXPECT_EQ(*result, long(1));
             return IntPromise::createAndResolve(2);
-        })->chainTo(WTFMove(longPromiseProducer2));
+        })->chainTo(WTFMove(longPromiseProducer3));
+
+        auto intPromise4 = IntPromise::createAndResolve(1);
+        LongPromise::Producer longPromiseProducer4;
+        auto longPromise4 = longPromiseProducer4.promise();
+        intPromise4->whenSettled(runLoop, [](auto&& result) {
+            EXPECT_TRUE(!!result);
+            EXPECT_EQ(*result, long(1));
+            return IntPromise::createAndReject(2);
+        })->chainTo(WTFMove(longPromiseProducer4));
+        longPromise4->whenSettled(runLoop, [&](auto&& result) mutable {
+            EXPECT_TRUE(!result);
+            EXPECT_EQ(result.error(), long(2));
+            done = true;
+        });
+    });
+}
+
+TEST(NativePromise, MismatchChainToVoidPromise)
+{
+    runInCurrentRunLoopUntilDone([](auto& runLoop, bool& done) {
+        // chaining with void promise
+        using IntPromise = NativePromise<int, int>;
+        using LongPromise = NativePromise<long, long>;
+        auto intPromise1 = IntPromise::createAndResolve(1);
+        LongPromise::Producer longPromiseProducer1;
+        auto longPromise1 = longPromiseProducer1.promise();
+        intPromise1->chainTo(WTFMove(longPromiseProducer1));
+        longPromise1->whenSettled(runLoop, [](auto&& result) {
+            EXPECT_TRUE(!!result);
+            EXPECT_EQ(*result, long(1));
+        });
+
+        auto intPromise2 = IntPromise::createAndResolve(1);
+        GenericPromise::Producer genericPromiseProducer1;
+        genericPromiseProducer1->whenSettled(runLoop, [](auto&& result) {
+            EXPECT_TRUE(!!result);
+        });
+        intPromise2->chainTo(WTFMove(genericPromiseProducer1));
+
+        auto intPromise3 = IntPromise::createAndReject(1);
+        GenericPromise::Producer genericPromiseProducer2;
+        genericPromiseProducer2->whenSettled(runLoop, [&](auto&& result) {
+            EXPECT_TRUE(!result);
+            done = true;
+        });
+        intPromise3->chainTo(WTFMove(genericPromiseProducer2));
     });
 }
 


### PR DESCRIPTION
#### bb71e93437b5212b6aa81071e0881fb68d70dffe
<pre>
NativePromise should allow void as reject type.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265118">https://bugs.webkit.org/show_bug.cgi?id=265118</a>
<a href="https://rdar.apple.com/118645560">rdar://118645560</a>

Reviewed by Youenn Fablet.

Allow to set a NativePromise where RejectValueT is void.
Set GenericPromis and GenericNonExclusive to be NativePromise&lt;void, void&gt;

Add API tests and update existing API test using GenericPromise

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/NativePromise.h:
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::doFail):
(TestWebKitAPI::TEST):
(TestWebKitAPI::std::function&lt;void): Deleted.

Canonical link: <a href="https://commits.webkit.org/270995@main">https://commits.webkit.org/270995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9d6d6dde86f99a0ba4cf0ba2af5d67fdb00bb4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3043 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29880 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24617 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26219 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28115 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5471 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33672 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6490 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4473 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7293 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->