### PR TITLE
FontFace with data: URI crashes Worker

### DIFF
--- a/LayoutTests/http/wpt/workers/font-loading-error.any-expected.txt
+++ b/LayoutTests/http/wpt/workers/font-loading-error.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Data URL should not trigger CORS errors and if failing should reject the promise.
+

--- a/LayoutTests/http/wpt/workers/font-loading-error.any.html
+++ b/LayoutTests/http/wpt/workers/font-loading-error.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/workers/font-loading-error.any.js
+++ b/LayoutTests/http/wpt/workers/font-loading-error.any.js
@@ -1,0 +1,5 @@
+promise_test(async () => {
+    return new FontFace("ABC", "url(data:font/woff2,abcd) format('woff2')").load().catch(e => {
+        assert_equals(e.name, "NetworkError");
+    });
+}, "Data URL should not trigger CORS errors and if failing should reject the promise.");

--- a/LayoutTests/http/wpt/workers/font-loading-error.any.worker-expected.txt
+++ b/LayoutTests/http/wpt/workers/font-loading-error.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Data URL should not trigger CORS errors and if failing should reject the promise.
+

--- a/LayoutTests/http/wpt/workers/font-loading-error.any.worker.html
+++ b/LayoutTests/http/wpt/workers/font-loading-error.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -56,6 +56,7 @@ CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiat
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.contentSecurityPolicyImposition = isInitiatingElementInUserAgentShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
     options.loadedFromOpaqueSource = loadedFromOpaqueSource;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
 
     CachedResourceRequest request(ResourceRequest(WTFMove(url)), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -64,6 +64,7 @@ void WorkerFontLoadRequest::load(WorkerGlobalScope& workerGlobalScope)
     options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;
     options.contentSecurityPolicyEnforcement = m_context->shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective;
     options.loadedFromOpaqueSource = m_loadedFromOpaqueSource;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
 
     options.serviceWorkersMode = ServiceWorkersMode::All;
     if (auto* activeServiceWorker = workerGlobalScope.activeServiceWorker())
@@ -136,6 +137,8 @@ void WorkerFontLoadRequest::didFinishLoading(ResourceLoaderIdentifier, const Net
 void WorkerFontLoadRequest::didFail(const ResourceError&)
 {
     m_errorOccurred = true;
+    if (m_fontLoadRequestClient)
+        m_fontLoadRequestClient->fontLoaded(*this);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### b1f4d8147c3c426fe7c4dcbc11dd7d7689064b6c
<pre>
FontFace with data: URI crashes Worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=265000">https://bugs.webkit.org/show_bug.cgi?id=265000</a>
<a href="https://rdar.apple.com/118546120">rdar://118546120</a>

Reviewed by Alex Christensen.

Make sure to reject the promise when font loading fails in a worker.
Align implementation with spec on data URL font loading by allowing them.

* LayoutTests/http/wpt/workers/font-loading-error.any-expected.txt: Added.
* LayoutTests/http/wpt/workers/font-loading-error.any.html: Added.
* LayoutTests/http/wpt/workers/font-loading-error.any.js: Added.
(promise_test.async return):
(promise_test):
* LayoutTests/http/wpt/workers/font-loading-error.any.worker-expected.txt: Added.
* LayoutTests/http/wpt/workers/font-loading-error.any.worker.html: Added.
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::cachedFont):
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::load):
(WebCore::WorkerFontLoadRequest::didFail):

Canonical link: <a href="https://commits.webkit.org/271213@main">https://commits.webkit.org/271213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8fecd207368ade07bd0d92c2433918386162641

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30144 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28058 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6654 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->