### PR TITLE
[GTK][WPE] Generate serializators for InputMethodState enumerations

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -65,6 +65,7 @@ list(APPEND WebKit_MESSAGES_IN_FILES
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/DMABufRendererBufferFormat.serialization.in
     Shared/glib/DMABufRendererBufferMode.serialization.in
+    Shared/glib/InputMethodState.serialization.in
 )
 
 list(APPEND WebCore_SERIALIZATION_IN_FILES SoupNetworkProxySettings.serialization.in)

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -91,6 +91,8 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 
 list(APPEND WebCore_SERIALIZATION_IN_FILES SoupNetworkProxySettings.serialization.in)
 
+list(APPEND WebKit_SERIALIZATION_IN_FILES Shared/glib/InputMethodState.serialization.in)
+
 list(APPEND WebKit_DERIVED_SOURCES
     ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c
     ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp

--- a/Source/WebKit/Shared/glib/InputMethodState.h
+++ b/Source/WebKit/Shared/glib/InputMethodState.h
@@ -27,7 +27,6 @@
 
 #include <WebCore/AutocapitalizeTypes.h>
 #include <WebCore/InputMode.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace IPC {
@@ -41,26 +40,29 @@ class HTMLInputElement;
 
 namespace WebKit {
 
-struct InputMethodState {
-    enum class Purpose {
-        FreeForm,
-        Digits,
-        Number,
-        Phone,
-        Url,
-        Email,
-        Password
-    };
+enum class InputMethodStatePurpose : uint8_t {
+    FreeForm,
+    Digits,
+    Number,
+    Phone,
+    Url,
+    Email,
+    Password
+};
 
-    enum class Hint : uint8_t {
-        None = 0,
-        Spellcheck = 1 << 0,
-        Lowercase = 1 << 1,
-        UppercaseChars = 1 << 2,
-        UppercaseWords = 1 << 3,
-        UppercaseSentences = 1 << 4,
-        InhibitOnScreenKeyboard = 1 << 5
-    };
+enum class InputMethodStateHint : uint8_t {
+    None = 0,
+    Spellcheck = 1 << 0,
+    Lowercase = 1 << 1,
+    UppercaseChars = 1 << 2,
+    UppercaseWords = 1 << 3,
+    UppercaseSentences = 1 << 4,
+    InhibitOnScreenKeyboard = 1 << 5
+};
+
+struct InputMethodState {
+    using Purpose = InputMethodStatePurpose;
+    using Hint = InputMethodStateHint;
 
     void setPurposeOrHintForInputMode(WebCore::InputMode);
     void setPurposeForInputElement(WebCore::HTMLInputElement&);
@@ -76,33 +78,3 @@ struct InputMethodState {
 };
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::InputMethodState::Hint> {
-    using values = EnumValues<
-        WebKit::InputMethodState::Hint,
-        WebKit::InputMethodState::Hint::None,
-        WebKit::InputMethodState::Hint::Spellcheck,
-        WebKit::InputMethodState::Hint::Lowercase,
-        WebKit::InputMethodState::Hint::UppercaseChars,
-        WebKit::InputMethodState::Hint::UppercaseWords,
-        WebKit::InputMethodState::Hint::UppercaseSentences,
-        WebKit::InputMethodState::Hint::InhibitOnScreenKeyboard
-    >;
-};
-
-template<> struct EnumTraits<WebKit::InputMethodState::Purpose> {
-    using values = EnumValues<
-        WebKit::InputMethodState::Purpose,
-        WebKit::InputMethodState::Purpose::FreeForm,
-        WebKit::InputMethodState::Purpose::Digits,
-        WebKit::InputMethodState::Purpose::Number,
-        WebKit::InputMethodState::Purpose::Phone,
-        WebKit::InputMethodState::Purpose::Url,
-        WebKit::InputMethodState::Purpose::Email,
-        WebKit::InputMethodState::Purpose::Password
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/glib/InputMethodState.serialization.in
+++ b/Source/WebKit/Shared/glib/InputMethodState.serialization.in
@@ -1,0 +1,44 @@
+# Copyright (C) 2023 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+header: "InputMethodState.h"
+enum class WebKit::InputMethodStatePurpose : uint8_t {
+    FreeForm,
+    Digits,
+    Number,
+    Phone,
+    Url,
+    Email,
+    Password
+};
+
+[OptionSet] enum class WebKit::InputMethodStateHint : uint8_t {
+    None,
+    Spellcheck,
+    Lowercase,
+    UppercaseChars,
+    UppercaseWords,
+    UppercaseSentences,
+    InhibitOnScreenKeyboard,
+};


### PR DESCRIPTION
#### ee55f47782fa1001fcb04d1b7e5c8ade9b718471
<pre>
[GTK][WPE] Generate serializators for InputMethodState enumerations
<a href="https://bugs.webkit.org/show_bug.cgi?id=265145">https://bugs.webkit.org/show_bug.cgi?id=265145</a>

Reviewed by Carlos Garcia Campos.

Add the generator for InputMethodState enums serialization, get
rid of the EnumTraits bits, and move the enums out of the InputMethodState
struct to ease things.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Shared/glib/InputMethodState.h:
* Source/WebKit/Shared/glib/InputMethodState.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/271002@main">https://commits.webkit.org/271002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef1a6b2d1320a0e0c8edd79de22259b6ab5ad91a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24673 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24542 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3948 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29831 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30155 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28069 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5423 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6497 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->