### PR TITLE
expose `<address>` and `<fieldset>` as aria group

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-expected.txt
@@ -53,7 +53,7 @@ x
 x
 x
 
-FAIL el-address assert_equals: <address data-testname="el-address" data-expectedrole="group" class="ex">x</address> expected "group" but got ""
+PASS el-address
 PASS el-article
 PASS el-blockquote
 PASS el-button
@@ -64,7 +64,7 @@ FAIL el-details assert_equals: <details data-testname="el-details" data-expected
 FAIL el-dfn assert_equals: <dfn data-testname="el-dfn" data-expectedrole="term" class="ex">x</dfn> expected "term" but got "definition"
 FAIL el-dt assert_equals: <dt data-testname="el-dt" data-expectedrole="term" class="ex">x</dt> expected "term" but got ""
 FAIL el-em assert_equals: <em data-testname="el-em" data-expectedrole="emphasis" class="ex">x</em> expected "emphasis" but got ""
-FAIL el-fieldset assert_equals: <fieldset data-testname="el-fieldset" data-expectedrole="group" class="ex"><legend>x</legend><input></fieldset> expected "group" but got ""
+PASS el-fieldset
 PASS el-figure
 PASS el-form
 PASS el-h1

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html-aam/roles-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html-aam/roles-expected.txt
@@ -53,7 +53,7 @@ x
 x
 x
 
-FAIL el-address assert_equals: <address data-testname="el-address" data-expectedrole="group" class="ex">x</address> expected "group" but got ""
+PASS el-address
 PASS el-article
 PASS el-blockquote
 PASS el-button
@@ -64,7 +64,7 @@ FAIL el-details assert_equals: <details data-testname="el-details" data-expected
 FAIL el-dfn assert_equals: <dfn data-testname="el-dfn" data-expectedrole="term" class="ex">x</dfn> expected "term" but got "definition"
 FAIL el-dt assert_equals: <dt data-testname="el-dt" data-expectedrole="term" class="ex">x</dt> expected "term" but got ""
 FAIL el-em assert_equals: <em data-testname="el-em" data-expectedrole="emphasis" class="ex">x</em> expected "emphasis" but got ""
-FAIL el-fieldset assert_equals: <fieldset data-testname="el-fieldset" data-expectedrole="group" class="ex"><legend>x</legend><input></fieldset> expected "group" but got ""
+PASS el-fieldset
 PASS el-figure
 PASS el-form
 PASS el-h1

--- a/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
@@ -19,7 +19,7 @@ abbr[title]
 
 address
       AXRole: AXGroup
-      AXSubrole:
+      AXSubrole: AXApplicationGroup
       AXRoleDescription: group
 
 article

--- a/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
@@ -19,7 +19,7 @@ abbr[title]
 
 address
       AXRole: AXGroup
-      AXSubrole:
+      AXSubrole: AXApplicationGroup
       AXRoleDescription: group
 
 article

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -425,7 +425,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     if (node()->hasTagName(menuTag) || node()->hasTagName(olTag) || node()->hasTagName(ulTag))
         return AccessibilityRole::List;
     if (node()->hasTagName(fieldsetTag))
-        return AccessibilityRole::Group;
+        return AccessibilityRole::ApplicationGroup;
     if (node()->hasTagName(figureTag))
         return AccessibilityRole::Figure;
     if (node()->hasTagName(pTag))
@@ -467,7 +467,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     if (node()->hasTagName(sectionTag))
         return hasAttribute(aria_labelAttr) || hasAttribute(aria_labelledbyAttr) ? AccessibilityRole::LandmarkRegion : AccessibilityRole::TextGroup;
     if (node()->hasTagName(addressTag))
-        return AccessibilityRole::Group;
+        return AccessibilityRole::ApplicationGroup;
     if (node()->hasTagName(blockquoteTag))
         return AccessibilityRole::Blockquote;
     if (node()->hasTagName(captionTag) || node()->hasTagName(figcaptionTag))


### PR DESCRIPTION
#### 51444d307f7ed388229f99fbf2284a5d1b6cca3b
<pre>
expose `&lt;address&gt;` and `&lt;fieldset&gt;` as aria group
<a href="https://bugs.webkit.org/show_bug.cgi?id=255621">https://bugs.webkit.org/show_bug.cgi?id=255621</a>

Reviewed by Tyler Wilcock.

Address and Fieldset were incorrectly marked as &quot;Group&quot; which is a
generic AccessibilityRole that does not get exposed as the ARIA &quot;Group&quot;
role. The correct role to expose as &quot;Group&quot; is &quot;ApplicationGroup&quot;.

This changes both address tags and fieldset tags to be
&quot;ApplicationGroup&quot;.

Co-authored-by: Kate Higa &lt;16447748+khiga8@users.noreply.github.com&gt;
Co-authored-by: Lindsey Wild &lt;35239154+lindseywild@users.noreply.github.com&gt;

* LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html-aam/roles-expected.txt:
* LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt:
* LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):

Canonical link: <a href="https://commits.webkit.org/271021@main">https://commits.webkit.org/271021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6392eb55a31e601d66ed05f98f4b50a098d5793

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24598 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30216 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28132 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5497 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6512 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->