### PR TITLE
[CSS] Add @scope rule to RuleSet

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6902,6 +6902,9 @@ imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthet
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/no-args.html [ Pass ]
 
+# @scope is not yet fully implemented
+fast/css/scope-at-rule.html [ ImageOnlyFailure ]
+
 # View Transitions
 imported/w3c/web-platform-tests/css/css-view-transitions [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/parsing [ Pass ]

--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -1,0 +1,27 @@
+<style>
+.green { color: green; }
+</style>
+
+<div class="a">
+  <span class="green">should be green</span>
+  <div class="b">
+    <span>should not be green</span>
+      <div class="j">
+        <span>should not be green</span>
+      </div>
+  </div>
+</div>
+
+<div class="a">
+  <div class="b">
+    <span class="green">should be green</span>
+  </div>
+</div>
+
+<div class="a">
+  <span class="green-3">should not be green</span>
+</div>
+
+<div>
+  <span class="green-4">should not be green</span>
+</div>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -1,0 +1,44 @@
+<style>
+@scope (.a) to (.b) {
+  .green-1 { color: green; }
+}
+@scope (.a) {
+  @scope (.b) {
+    .green-2 { color: green; }
+  }
+}
+div {
+  @scope (.a) {
+    .green-3 { color: green; }
+  }
+}
+video {
+  @scope (.a) {
+    .green-4 { color: green; }
+  }
+}
+</style>
+
+<div class="a">
+  <span class="green-1">should be green</span>
+  <div class="b">
+    <span class="green-1">should not be green</span>
+      <div class="j">
+        <span class="green-1">should not be green</span>
+      </div>
+  </div>
+</div>
+
+<div class="a">
+  <div class="b">
+    <span class="green-2">should be green</span>
+  </div>
+</div>
+
+<div class="a">
+  <span class="green-3">should not be green</span>
+</div>
+
+<div>
+  <span class="green-4">should not be green</span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-name-defining-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-name-defining-rules-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL @keyframes is unaffected by @scope assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL @keyframes is unaffected by non-matching @scope assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL @property is unaffected by @scope assert_equals: expected "2px" but got ""
-FAIL @property is unaffected by non-matching @scope assert_equals: expected "2px" but got ""
+PASS @keyframes is unaffected by @scope
+PASS @keyframes is unaffected by non-matching @scope
+PASS @property is unaffected by @scope
+PASS @property is unaffected by non-matching @scope
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -32,6 +32,7 @@
 #include "CSSKeyframeRule.h"
 #include "CSSRuleList.h"
 #include "CSSSelector.h"
+#include "CSSSelectorList.h"
 #include "CSSValueKeywords.h"
 #include "CascadeLevel.h"
 #include "ContainerQueryEvaluator.h"
@@ -539,6 +540,9 @@ void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVe
         if (matchRequest.ruleSet.hasContainerQueries() && !containerQueriesMatch(ruleData, matchRequest))
             continue;
 
+        if (matchRequest.ruleSet.hasScopeRules() && !scopeRulesMatch(ruleData, matchRequest))
+            continue;
+
         auto& rule = ruleData.styleRule();
 
         // If the rule has no properties to apply, then ignore it in the non-debug mode.
@@ -576,6 +580,18 @@ bool ElementRuleCollector::containerQueriesMatch(const RuleData& ruleData, const
             return false;
     }
     return true;
+}
+
+bool ElementRuleCollector::scopeRulesMatch(const RuleData& ruleData, const MatchRequest& matchRequest)
+{
+    auto queries = matchRequest.ruleSet.scopeRulesFor(ruleData);
+
+    if (queries.isEmpty())
+        return true;
+
+    // FIXME: to implement
+    // https://bugs.webkit.org/show_bug.cgi?id=265241
+    return false;
 }
 
 static inline bool compareRules(MatchedRule r1, MatchedRule r2)

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -118,6 +118,7 @@ private:
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
     bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal);
     bool containerQueriesMatch(const RuleData&, const MatchRequest&);
+    bool scopeRulesMatch(const RuleData&, const MatchRequest&);
 
     void sortMatchedRules();
 

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "CSSSelectorList.h"
 #include "MediaQuery.h"
 #include "RuleData.h"
 #include "RuleFeature.h"
@@ -118,6 +119,9 @@ public:
     bool hasContainerQueries() const { return !m_containerQueries.isEmpty(); }
     Vector<const CQ::ContainerQuery*> containerQueriesFor(const RuleData&) const;
 
+    bool hasScopeRules() const { return !m_scopeRules.isEmpty(); }
+    Vector<Ref<const StyleRuleScope>> scopeRulesFor(const RuleData&) const;
+
 private:
     friend class RuleSetBuilder;
 
@@ -125,8 +129,9 @@ private:
 
     using CascadeLayerIdentifier = unsigned;
     using ContainerQueryIdentifier = unsigned;
+    using ScopeRuleIdentifier = unsigned;
 
-    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier);
+    void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier);
 
     struct ResolverMutatingRule {
         Ref<StyleRuleBase> rule;
@@ -150,6 +155,11 @@ private:
     CascadeLayer& cascadeLayerForIdentifier(CascadeLayerIdentifier identifier) { return m_cascadeLayers[identifier - 1]; }
     const CascadeLayer& cascadeLayerForIdentifier(CascadeLayerIdentifier identifier) const { return m_cascadeLayers[identifier - 1]; }
     CascadeLayerPriority cascadeLayerPriorityForIdentifier(CascadeLayerIdentifier) const;
+
+    struct ScopeAndParent {
+        Ref<const StyleRuleScope> scopeRule;
+        ScopeRuleIdentifier parent;
+    };
 
     struct ContainerQueryAndParent {
         Ref<StyleRuleContainer> containerRule;
@@ -201,6 +211,10 @@ private:
 
     Vector<ContainerQueryAndParent> m_containerQueries;
     Vector<ContainerQueryIdentifier> m_containerQueryIdentifierForRulePosition;
+
+    // @scope
+    Vector<ScopeAndParent> m_scopeRules;
+    Vector<ScopeRuleIdentifier> m_scopeRuleIdentifierForRulePosition;
 
     bool m_hasHostPseudoClassRulesMatchingInShadowTree { false };
     bool m_hasViewportDependentMediaQueries { false };

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -117,10 +117,18 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
             addStyleRule(downcast<StyleRule>(rule));
         return;
 
-    case StyleRuleType::Scope:
-        // FIXME: to implement
-        // https://bugs.webkit.org/show_bug.cgi?id=264500
+    case StyleRuleType::Scope: {
+        auto scopeRule = downcast<StyleRuleScope>(WTFMove(rule));
+        auto previousScopeIdentifier = m_currentScopeIdentifier;
+        if (m_ruleSet) {
+            m_ruleSet->m_scopeRules.append({ scopeRule.copyRef(), previousScopeIdentifier });
+            m_currentScopeIdentifier = m_ruleSet->m_scopeRules.size();
+        }
+        addChildRules(scopeRule->childRules());
+        if (m_ruleSet)
+            m_currentScopeIdentifier = previousScopeIdentifier;
         return;
+    }
 
     case StyleRuleType::Page:
         if (m_ruleSet)
@@ -243,7 +251,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
         for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
             RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount());
             m_mediaQueryCollector.addRuleIfNeeded(ruleData);
-            m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier);
+            m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier);
             ++selectorListIndex;
         }
     }

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -89,6 +89,7 @@ private:
     const ShouldResolveNesting m_shouldResolveNesting { ShouldResolveNesting::No };
 
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
+    RuleSet::ScopeRuleIdentifier m_currentScopeIdentifier { 0 };
 
     Vector<RuleSet::ResolverMutatingRule> m_collectedResolverMutatingRules;
     bool requiresStaticMediaQueryEvaluation { false };

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -194,6 +194,18 @@ bool ScopeRuleSets::hasContainerQueries() const
     return false;
 }
 
+bool ScopeRuleSets::hasScopeRules() const
+{
+    if (m_authorStyle->hasScopeRules())
+        return true;
+    if (m_userStyle && m_userStyle->hasScopeRules())
+        return true;
+    if (m_userAgentMediaQueryStyle && m_userAgentMediaQueryStyle->hasScopeRules())
+        return true;
+
+    return false;
+}
+
 std::optional<DynamicMediaQueryEvaluationChanges> ScopeRuleSets::evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator& evaluator)
 {
     std::optional<DynamicMediaQueryEvaluationChanges> evaluationChanges;

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -87,6 +87,7 @@ public:
 
     bool hasViewportDependentMediaQueries() const;
     bool hasContainerQueries() const;
+    bool hasScopeRules() const;
 
     std::optional<DynamicMediaQueryEvaluationChanges> evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator&);
 

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -111,6 +111,8 @@ std::unique_ptr<RenderStyle> SharingResolver::resolve(const Styleable& searchSty
     // FIXME: Do something smarter here, for example RuleSet based matching like with attribute/sibling selectors.
     if (Scope::forNode(element).usesHasPseudoClass())
         return nullptr;
+    if (m_ruleSets.hasScopeRules())
+        return nullptr;
 
     Context context {
         update,


### PR DESCRIPTION
#### 5d2ddd6e61126370c7da861fd5f2034818a7960c
<pre>
[CSS] Add @scope rule to RuleSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=264500">https://bugs.webkit.org/show_bug.cgi?id=264500</a>
<a href="https://rdar.apple.com/118181109">rdar://118181109</a>

Reviewed by Antti Koivisto.

This patch implements the mechanism to get the ancestor @scope rules (if any)
during element rule collection.

It also desactivates style sharing for scoped rules.

The actual matching is not implemented yet.

<a href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">https://drafts.csswg.org/css-cascade-6/#scoped-styles</a>

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/scope-at-rule-expected.html: Added.
* LayoutTests/fast/css/scope-at-rule.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-name-defining-rules-expected.txt:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::RuleSet::scopeRulesFor const):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::hasScopeRules const):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::hasScopeRules const):
* Source/WebCore/style/StyleScopeRuleSets.h:
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::resolve):

Canonical link: <a href="https://commits.webkit.org/271078@main">https://commits.webkit.org/271078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/464f95085acf3647d1830c660db83fa88286f758

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24766 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4091 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30113 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28315 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6571 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4695 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->