### PR TITLE
[SOUP] webkit_web_context_allow_tls_certificate_for_host() fails for IPv6 URIs produced by SoupURI

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -468,6 +468,9 @@ WebKitTLSErrorsPolicy webkit_network_session_get_tls_errors_policy(WebKitNetwork
  *
  * Ignore further TLS errors on the @host for the certificate present in @info.
  *
+ * If @host is an IPv6 address, it should not be surrounded by brackets. This
+ * expectation matches g_uri_get_host().
+ *
  * Since: 2.40
  */
 void webkit_network_session_allow_tls_certificate_for_host(WebKitNetworkSession* session, GTlsCertificate* certificate, const char* host)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -1749,6 +1749,9 @@ void webkit_web_context_prefetch_dns(WebKitWebContext* context, const char* host
  *
  * Ignore further TLS errors on the @host for the certificate present in @info.
  *
+ * If @host is an IPv6 address, it should not be surrounded by brackets. This
+ * expectation matches g_uri_get_host().
+ *
  * Since: 2.6
  */
 void webkit_web_context_allow_tls_certificate_for_host(WebKitWebContext* context, GTlsCertificate* certificate, const gchar* host)


### PR DESCRIPTION
#### bcd2223c93620870bc4b5dc8d077b10d1a3a0df3
<pre>
[SOUP] webkit_web_context_allow_tls_certificate_for_host() fails for IPv6 URIs produced by SoupURI
<a href="https://bugs.webkit.org/show_bug.cgi?id=195908">https://bugs.webkit.org/show_bug.cgi?id=195908</a>

Reviewed by Carlos Garcia Campos.

Nowadays SoupURI has been replaced by GUri, but the underlying problem
remains: IPv6 addresses in URLs have to be surrounded by [] brackets,
and WTF::URL considers these brackets to be part of the host component,
but SoupURI and GUri do not. Alas!

Let&apos;s also clarify expected usage of the API. It might be even better to
accept input in both forms and normalize it, but GUri documents that the
brackets are not part of the host, so probably fine for us to do so too.

Finally, note this is a little awkward to test, so I have omitted tests.
We could change WebKitTestServer::run to allow selecting IPV6 and then
run all of TestSSL again twice, and skip them if IPv6 is not enabled. I
was a little tempted to attempt this, but decided I&apos;m lazy and would
rather not spend time on it. This is already an edge case and it&apos;s not
the end of the world if it breaks again in the future.

* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::hostForComparison):
(WebCore::SoupNetworkSession::checkTLSErrors):
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:

Canonical link: <a href="https://commits.webkit.org/271013@main">https://commits.webkit.org/271013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9e588c9239ecd808374c6e63a99d4ebd1130244

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24574 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29875 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30195 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28110 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5466 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6507 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->