### PR TITLE
history properties should throw SecurityError when not in a fully active Document

### DIFF
--- a/LayoutTests/http/tests/dom/same-origin-detached-window-properties-expected.txt
+++ b/LayoutTests/http/tests/dom/same-origin-detached-window-properties-expected.txt
@@ -27,13 +27,13 @@ PASS w.screen.availTop is 0
 PASS w.screen.availHeight is 0
 PASS w.screen.availWidth is 0
 PASS !!w.history is true
-PASS w.history.length is 0
-PASS w.history.state is null
-PASS w.history.back() did not throw exception.
-PASS w.history.forward() did not throw exception.
-PASS w.history.go(-1) did not throw exception.
-PASS w.history.pushState({}, null) did not throw exception.
-PASS w.history.replaceState({}, null) did not throw exception.
+PASS w.history.length threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.state threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.back() threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.forward() threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.go(-1) threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.pushState({}, null) threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.replaceState({}, null) threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
 PASS !!w.crypto is true
 PASS !!w.locationbar is true
 PASS w.locationbar.visible is false
@@ -96,13 +96,13 @@ PASS w.screen.availTop is 0
 PASS w.screen.availHeight is 0
 PASS w.screen.availWidth is 0
 PASS !!w.history is true
-PASS w.history.length is 0
-PASS w.history.state is null
-PASS w.history.back() did not throw exception.
-PASS w.history.forward() did not throw exception.
-PASS w.history.go(-1) did not throw exception.
-PASS w.history.pushState({}, null) did not throw exception.
-PASS w.history.replaceState({}, null) did not throw exception.
+PASS w.history.length threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.state threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.back() threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.forward() threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.go(-1) threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.pushState({}, null) threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
+PASS w.history.replaceState({}, null) threw exception SecurityError: Attempt to use History API from a document that isn't fully active.
 PASS !!w.crypto is true
 PASS !!w.locationbar is true
 PASS w.locationbar.visible is false

--- a/LayoutTests/http/tests/dom/same-origin-detached-window-properties.html
+++ b/LayoutTests/http/tests/dom/same-origin-detached-window-properties.html
@@ -51,13 +51,13 @@ function validateWindow(_w)
     try {
     shouldBeTrue("!!w.history");
     if (w.history) {
-        shouldBe("w.history.length", "0");
-        shouldBeNull("w.history.state");
-        shouldNotThrow("w.history.back()");
-        shouldNotThrow("w.history.forward()");
-        shouldNotThrow("w.history.go(-1)");
-        shouldNotThrow("w.history.pushState({}, null)");
-        shouldNotThrow("w.history.replaceState({}, null)");
+        shouldThrowErrorName("w.history.length", "SecurityError");
+        shouldThrowErrorName("w.history.state", "SecurityError");
+        shouldThrowErrorName("w.history.back()", "SecurityError");
+        shouldThrowErrorName("w.history.forward()", "SecurityError");
+        shouldThrowErrorName("w.history.go(-1)", "SecurityError");
+        shouldThrowErrorName("w.history.pushState({}, null)", "SecurityError");
+        shouldThrowErrorName("w.history.replaceState({}, null)", "SecurityError");
     }
     } catch (e) {
         debug(e);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_properties_only_fully_active-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_properties_only_fully_active-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL history properties should throw SecurityError when not in a fully active Document assert_throws_dom: function "function() { cached_history.length; }" did not throw
+PASS history properties should throw SecurityError when not in a fully active Document
 

--- a/Source/WebCore/bindings/js/JSHistoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHistoryCustom.cpp
@@ -39,8 +39,12 @@ using namespace JSC;
 JSValue JSHistory::state(JSGlobalObject& lexicalGlobalObject) const
 {
     auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
-    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedState(), [this, &lexicalGlobalObject](JSC::ThrowScope&) {
-        auto* serialized = wrapped().state();
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedState(), [this, &throwScope, &lexicalGlobalObject](JSC::ThrowScope&) {
+        if (UNLIKELY(wrapped().state().hasException())) {
+            propagateException(lexicalGlobalObject, throwScope, wrapped().state().releaseException());
+            return jsNull();
+        }
+        auto* serialized = wrapped().state().releaseReturnValue();
         return serialized ? serialized->deserialize(lexicalGlobalObject, globalObject()) : jsNull();
     });
 }

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -41,8 +41,8 @@ class History final : public ScriptWrappable, public RefCounted<History>, public
 public:
     static Ref<History> create(LocalDOMWindow& window) { return adoptRef(*new History(window)); }
 
-    unsigned length() const;
-    
+    ExceptionOr<unsigned> length() const;
+
     enum class ScrollRestoration {
         Auto,
         Manual
@@ -51,17 +51,17 @@ public:
     ExceptionOr<ScrollRestoration> scrollRestoration() const;
     ExceptionOr<void> setScrollRestoration(ScrollRestoration);
 
-    SerializedScriptValue* state();
+    ExceptionOr<SerializedScriptValue*> state();
     JSValueInWrappedObject& cachedState();
     JSValueInWrappedObject& cachedStateForGC() { return m_cachedState; }
 
-    void back();
-    void forward();
-    void go(int);
+    ExceptionOr<void> back();
+    ExceptionOr<void> forward();
+    ExceptionOr<void> go(int);
 
-    void back(Document&);
-    void forward(Document&);
-    void go(Document&, int);
+    ExceptionOr<void> back(Document&);
+    ExceptionOr<void> forward(Document&);
+    ExceptionOr<void> go(Document&, int);
 
     bool isSameAsCurrentState(SerializedScriptValue*) const;
 


### PR DESCRIPTION
#### e4cbd15de56a52641bcdd542c0276fd48c0bcc9d
<pre>
history properties should throw SecurityError when not in a fully active Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=264962">https://bugs.webkit.org/show_bug.cgi?id=264962</a>

Reviewed by Darin Adler and Ryosuke Niwa.

This change makes all History API methods and getters and setters throw
a SecurityError if called from a document that isn’t fully active (has
no Frame) — as required by the series of algorithms in the HTML spec
starting at <a href="https://html.spec.whatwg.org/multipage/#dom-history-length">https://html.spec.whatwg.org/multipage/#dom-history-length</a>

* LayoutTests/http/tests/dom/same-origin-detached-window-properties-expected.txt:
* LayoutTests/http/tests/dom/same-origin-detached-window-properties.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_properties_only_fully_active-expected.txt:
* Source/WebCore/bindings/js/JSHistoryCustom.cpp:
(WebCore::JSHistory::state const):
* Source/WebCore/page/History.cpp:
(WebCore::isDocumentFullyActive):
(WebCore::documentNotFullyActive):
(WebCore::History::length const):
(WebCore::History::scrollRestoration const):
(WebCore::History::setScrollRestoration):
(WebCore::History::back):
(WebCore::History::forward):
(WebCore::History::go):
(WebCore::History::stateObjectAdded):
(WebCore::History::state): Deleted.
* Source/WebCore/page/History.h:

Canonical link: <a href="https://commits.webkit.org/274260@main">https://commits.webkit.org/274260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19896dbf4a63f5e12d8ac6705d88f38686903100

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32925 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31495 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35614 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8642 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->