### PR TITLE
Adopt dynamicDowncast<>() more in html/

### DIFF
--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -227,14 +227,19 @@ inline HTMLElement::HTMLElement(const QualifiedName& tagName, Document& document
 
 inline bool Node::hasTagName(const HTMLQualifiedName& name) const
 {
-    return is<HTMLElement>(*this) && downcast<HTMLElement>(*this).hasTagName(name);
+    auto* htmlElement = dynamicDowncast<HTMLElement>(*this);
+    return htmlElement && htmlElement->hasTagName(name);
 }
 
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLElement)
     static bool isType(const WebCore::Node& node) { return node.isHTMLElement(); }
-    static bool isType(const WebCore::EventTarget& target) { return is<WebCore::Node>(target) && isType(downcast<WebCore::Node>(target)); }
+    static bool isType(const WebCore::EventTarget& target)
+    {
+        auto* node = dynamicDowncast<WebCore::Node>(target);
+        return node && isType(*node);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #include "HTMLElementTypeHelpers.h"

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -67,8 +67,8 @@ static inline RenderWidget* findWidgetRenderer(const Node* node)
 {
     if (!node->renderer())
         node = ancestorsOfType<HTMLObjectElement>(*node).first();
-    if (node && is<RenderWidget>(node->renderer()))
-        return downcast<RenderWidget>(node->renderer());
+    if (node)
+        return dynamicDowncast<RenderWidget>(node->renderer());
     return nullptr;
 }
 
@@ -190,12 +190,11 @@ bool HTMLEmbedElement::rendererIsNeeded(const RenderStyle& style)
 
     // If my parent is an <object> and is not set to use fallback content, I
     // should be ignored and not get a renderer.
-    RefPtr<ContainerNode> parent = parentNode();
-    if (is<HTMLObjectElement>(parent)) {
-        if (!parent->renderer())
+    if (RefPtr parentObject = dynamicDowncast<HTMLObjectElement>(parentNode())) {
+        if (!parentObject->renderer())
             return false;
-        if (!downcast<HTMLObjectElement>(*parent).useFallbackContent()) {
-            ASSERT(!parent->renderer()->isRenderEmbeddedObject());
+        if (!parentObject->useFallbackContent()) {
+            ASSERT(!parentObject->renderer()->isRenderEmbeddedObject());
             return false;
         }
     }

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -306,7 +306,8 @@ void HTMLFormControlElement::setAutocomplete(const AtomString& value)
 
 AutofillMantle HTMLFormControlElement::autofillMantle() const
 {
-    return is<HTMLInputElement>(*this) && downcast<HTMLInputElement>(this)->isInputTypeHidden() ? AutofillMantle::Anchor : AutofillMantle::Expectation;
+    auto* input = dynamicDowncast<HTMLInputElement>(this);
+    return input && input->isInputTypeHidden() ? AutofillMantle::Anchor : AutofillMantle::Expectation;
 }
 
 AutofillData HTMLFormControlElement::autofillData() const

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -157,6 +157,10 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFormControlElement)
     static bool isType(const WebCore::Element& element) { return element.isFormControlElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
     static bool isType(const WebCore::FormListedElement& element) { return element.isFormControlElement(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -195,13 +195,14 @@ void HTMLFormElement::submitImplicitly(Event& event, bool fromImplicitSubmission
 {
     unsigned submissionTriggerCount = 0;
     for (auto& listedElement : m_listedElements) {
-        if (!is<HTMLFormControlElement>(*listedElement))
+        auto* formElement = dynamicDowncast<HTMLFormControlElement>(*listedElement);
+        if (!formElement)
             continue;
-        HTMLFormControlElement& formElement = downcast<HTMLFormControlElement>(*listedElement);
-        if (formElement.isSuccessfulSubmitButton()) {
-            formElement.dispatchSimulatedClick(&event);
+        if (formElement->isSuccessfulSubmitButton()) {
+            formElement->dispatchSimulatedClick(&event);
             return;
-        } else if (formElement.canTriggerImplicitSubmission())
+        }
+        if (formElement->canTriggerImplicitSubmission())
             ++submissionTriggerCount;
     }
 
@@ -338,13 +339,10 @@ ExceptionOr<void> HTMLFormElement::requestSubmit(HTMLElement* submitter)
 StringPairVector HTMLFormElement::textFieldValues() const
 {
     return WTF::compactMap(m_listedElements, [](auto& weakElement) -> std::optional<std::pair<String, String>> {
-        RefPtr element { weakElement.get() };
-        if (!is<HTMLInputElement>(element))
+        RefPtr input = dynamicDowncast<HTMLInputElement>(weakElement.get());
+        if (!input || !input->isTextField())
             return std::nullopt;
-        auto& input = downcast<HTMLInputElement>(*element);
-        if (!input.isTextField())
-            return std::nullopt;
-        return std::pair { input.name().string(), input.value() };
+        return std::pair { input->name().string(), input->value() };
     });
 }
 
@@ -356,13 +354,13 @@ RefPtr<HTMLFormControlElement> HTMLFormElement::findSubmitButton(HTMLFormControl
         return nullptr;
     RefPtr<HTMLFormControlElement> firstSuccessfulSubmitButton;
     for (auto& listedElement : m_listedElements) {
-        if (!is<HTMLFormControlElement>(*listedElement))
+        auto* control = dynamicDowncast<HTMLFormControlElement>(*listedElement);
+        if (!control)
             continue;
-        auto& control = downcast<HTMLFormControlElement>(*listedElement);
-        if (control.isActivatedSubmit())
+        if (control->isActivatedSubmit())
             return nullptr;
-        if (!firstSuccessfulSubmitButton && control.isSuccessfulSubmitButton())
-            firstSuccessfulSubmitButton = &control;
+        if (!firstSuccessfulSubmitButton && control->isSuccessfulSubmitButton())
+            firstSuccessfulSubmitButton = control;
     }
     return firstSuccessfulSubmitButton;
 }
@@ -590,15 +588,12 @@ void HTMLFormElement::registerFormListedElement(FormListedElement& element)
 {
     m_listedElements.insert(formElementIndex(element), element.asHTMLElement());
 
-    if (!is<HTMLFormControlElement>(element))
-        return;
-
-    auto& control = downcast<HTMLFormControlElement>(element);
-    if (!control.isSuccessfulSubmitButton())
+    auto* control = dynamicDowncast<HTMLFormControlElement>(element);
+    if (!control || !control->isSuccessfulSubmitButton())
         return;
 
     if (!m_defaultButton)
-        control.invalidateStyleForSubtree();
+        control->invalidateStyleForSubtree();
     else
         resetDefaultButton();
 }
@@ -748,10 +743,14 @@ bool HTMLFormElement::wasUserSubmitted() const
 
 HTMLFormControlElement* HTMLFormElement::findSubmitter(const Event* event) const
 {
-    if (!event || !is<Node>(event->target()))
+    if (!event)
         return nullptr;
-    auto& node = downcast<Node>(*event->target());
-    auto* element = is<Element>(node) ? &downcast<Element>(node) : node.parentElement();
+    auto* node = dynamicDowncast<Node>(event->target());
+    if (!node)
+        return nullptr;
+    auto* element = dynamicDowncast<Element>(*node);
+    if (!element)
+        element = node->parentElement();
     return element ? lineageOfType<HTMLFormControlElement>(*element).first() : nullptr;
 }
 
@@ -760,12 +759,9 @@ HTMLFormControlElement* HTMLFormElement::defaultButton() const
     if (m_defaultButton)
         return m_defaultButton.get();
     for (auto& listedElement : m_listedElements) {
-        if (!is<HTMLFormControlElement>(*listedElement))
-            continue;
-        HTMLFormControlElement& control = downcast<HTMLFormControlElement>(*listedElement);
-        if (control.isSuccessfulSubmitButton()) {
-            m_defaultButton = control;
-            return &control;
+        if (auto* control = dynamicDowncast<HTMLFormControlElement>(*listedElement); control && control->isSuccessfulSubmitButton()) {
+            m_defaultButton = *control;
+            return control;
         }
     }
     return nullptr;
@@ -991,11 +987,10 @@ RefPtr<DOMFormData> HTMLFormElement::constructEntryList(RefPtr<HTMLFormControlEl
         auto& element = control->asHTMLElement();
         if (!element.isDisabledFormControl())
             control->appendFormData(domFormData.get());
-        if (formValues && is<HTMLInputElement>(element)) {
-            auto& input = downcast<HTMLInputElement>(element);
-            if (input.isTextField()) {
-                formValues->append({ input.name(), input.value() });
-                input.addSearchResult();
+        if (RefPtr input = dynamicDowncast<HTMLInputElement>(element); formValues && input) {
+            if (input->isTextField()) {
+                formValues->append({ input->name(), input->value() });
+                input->addSearchResult();
             }
         }
     }

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -78,5 +78,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFrameElementBase)
     static bool isType(const WebCore::HTMLElement& element) { return is<WebCore::HTMLFrameElement>(element) || is<WebCore::HTMLIFrameElement>(element); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLElement>(node) && isType(downcast<WebCore::HTMLElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* htmlElement = dynamicDowncast<WebCore::HTMLElement>(node);
+        return htmlElement && isType(*htmlElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -49,9 +49,7 @@ RenderWidget* HTMLFrameOwnerElement::renderWidget() const
 {
     // HTMLObjectElement and HTMLEmbedElement may return arbitrary renderers
     // when using fallback content.
-    if (!is<RenderWidget>(renderer()))
-        return nullptr;
-    return downcast<RenderWidget>(renderer());
+    return dynamicDowncast<RenderWidget>(renderer());
 }
 
 void HTMLFrameOwnerElement::setContentFrame(Frame& frame)

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -214,11 +214,8 @@ void HTMLFrameSetElement::removedFromAncestor(RemovalType removalType, Container
 
 WindowProxy* HTMLFrameSetElement::namedItem(const AtomString& name)
 {
-    RefPtr frameElement = children()->namedItem(name);
-    if (!is<HTMLFrameElement>(frameElement))
-        return nullptr;
-
-    return downcast<HTMLFrameElement>(*frameElement).contentWindow();
+    RefPtr frameElement = dynamicDowncast<HTMLFrameElement>(children()->namedItem(name));
+    return frameElement ? frameElement->contentWindow() : nullptr;
 }
 
 bool HTMLFrameSetElement::isSupportedPropertyName(const AtomString& name)

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -233,8 +233,8 @@ void HTMLImageElement::setBestFitURLAndDPRFromImageCandidate(const ImageCandidat
     m_currentSrc = AtomString(m_currentURL.string());
     if (candidate.density >= 0)
         m_imageDevicePixelRatio = 1 / candidate.density;
-    if (is<RenderImage>(renderer()))
-        downcast<RenderImage>(*renderer()).setImageDevicePixelRatio(m_imageDevicePixelRatio);
+    if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer()))
+        renderImage->setImageDevicePixelRatio(m_imageDevicePixelRatio);
 }
 
 static String extractMIMETypeFromTypeAttributeForLookup(const String& typeAttribute)
@@ -254,15 +254,15 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
     ImageCandidate candidate;
 
     for (RefPtr<Node> child = picture->firstChild(); child && child != this; child = child->nextSibling()) {
-        if (!is<HTMLSourceElement>(*child))
+        auto* source = dynamicDowncast<HTMLSourceElement>(*child);
+        if (!source)
             continue;
-        auto& source = downcast<HTMLSourceElement>(*child);
 
-        auto& srcset = source.attributeWithoutSynchronization(srcsetAttr);
+        auto& srcset = source->attributeWithoutSynchronization(srcsetAttr);
         if (srcset.isEmpty())
             continue;
 
-        auto& typeAttribute = source.attributeWithoutSynchronization(typeAttr);
+        auto& typeAttribute = source->attributeWithoutSynchronization(typeAttr);
         if (!typeAttribute.isNull()) {
             auto type = extractMIMETypeFromTypeAttributeForLookup(typeAttribute);
             if (!type.isEmpty() && !MIMETypeRegistry::isSupportedImageVideoOrSVGMIMEType(type))
@@ -271,7 +271,7 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
 
         RefPtr documentElement = document().documentElement();
         MQ::MediaQueryEvaluator evaluator { document().printing() ? printAtom() : screenAtom(), document(), documentElement ? documentElement->computedStyle() : nullptr };
-        auto& queries = source.parsedMediaAttribute(document());
+        auto& queries = source->parsedMediaAttribute(document());
         LOG(MediaQueries, "HTMLImageElement %p bestFitSourceFromPictureElement evaluating media queries", this);
 
         auto result = evaluator.evaluate(queries);
@@ -282,7 +282,7 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
         if (!result)
             continue;
 
-        SizesAttributeParser sizesParser(source.attributeWithoutSynchronization(sizesAttr).string(), document());
+        SizesAttributeParser sizesParser(source->attributeWithoutSynchronization(sizesAttr).string(), document());
 
         m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
 
@@ -290,7 +290,7 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
 
         candidate = bestFitSourceForImageAttributes(document().deviceScaleFactor(), nullAtom(), srcset, sourceSize);
         if (!candidate.isEmpty()) {
-            setSourceElement(&source);
+            setSourceElement(source);
             break;
         }
     }
@@ -390,14 +390,13 @@ void HTMLImageElement::attributeChanged(const QualifiedName& name, const AtomStr
         break;
     case AttributeNames::nameAttr: {
         bool willHaveName = !newValue.isEmpty();
-        if (m_hadNameBeforeAttributeChanged != willHaveName && isConnected() && !isInShadowTree() && is<HTMLDocument>(document())) {
-            HTMLDocument& document = downcast<HTMLDocument>(this->document());
+        if (auto* document = dynamicDowncast<HTMLDocument>(this->document()); m_hadNameBeforeAttributeChanged != willHaveName && isConnected() && !isInShadowTree() && document) {
             const AtomString& id = getIdAttribute();
             if (!id.isEmpty() && id != getNameAttribute()) {
                 if (willHaveName)
-                    document.addDocumentNamedItem(id, *this);
+                    document->addDocumentNamedItem(id, *this);
                 else
-                    document.removeDocumentNamedItem(id, *this);
+                    document->removeDocumentNamedItem(id, *this);
             }
         }
         m_hadNameBeforeAttributeChanged = willHaveName;
@@ -453,7 +452,8 @@ bool HTMLImageElement::isInteractiveContent() const
 
 void HTMLImageElement::didAttachRenderers()
 {
-    if (!is<RenderImage>(renderer()))
+    CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer());
+    if (!renderImage)
         return;
     if (m_imageLoader->hasPendingBeforeLoadEvent())
         return;
@@ -462,8 +462,7 @@ void HTMLImageElement::didAttachRenderers()
     ImageControlsMac::updateImageControls(*this);
 #endif
 
-    auto& renderImage = downcast<RenderImage>(*renderer());
-    RenderImageResource& renderImageResource = renderImage.imageResource();
+    RenderImageResource& renderImageResource = renderImage->imageResource();
     if (renderImageResource.cachedImage())
         return;
     renderImageResource.setCachedImage(m_imageLoader->image());
@@ -471,7 +470,7 @@ void HTMLImageElement::didAttachRenderers()
     // If we have no image at all because we have no src attribute, set
     // image height and width for the alt text instead.
     if (!m_imageLoader->image() && !renderImageResource.cachedImage())
-        renderImage.setImageSizeForAltText();
+        renderImage->setImageSizeForAltText();
 }
 
 Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
@@ -487,10 +486,10 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
     if (insertionType.treeScopeChanged && !m_parsedUsemap.isNull())
         treeScope().addImageElementByUsemap(m_parsedUsemap, *this);
 
-    if (is<HTMLPictureElement>(&parentOfInsertedTree) && &parentOfInsertedTree == parentElement()) {
+    if (auto* parentPicture = dynamicDowncast<HTMLPictureElement>(parentOfInsertedTree); parentPicture && &parentOfInsertedTree == parentElement()) {
         // FIXME: When the hack in HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface to eagerly call setPictureElement is removed, we can just assert !pictureElement().
         ASSERT(!pictureElement() || pictureElement() == &parentOfInsertedTree);
-        setPictureElement(&downcast<HTMLPictureElement>(parentOfInsertedTree));
+        setPictureElement(parentPicture);
         selectImageSource(RelevantMutation::Yes);
         return insertNotificationRequest;
     }
@@ -935,10 +934,10 @@ bool HTMLImageElement::isSystemPreviewImage() const
         return false;
 
     auto* parent = parentElement();
-    if (is<HTMLAnchorElement>(parent))
-        return downcast<HTMLAnchorElement>(parent)->isSystemPreviewLink();
-    if (is<HTMLPictureElement>(parent))
-        return downcast<HTMLPictureElement>(parent)->isSystemPreviewImage();
+    if (auto* anchorElement = dynamicDowncast<HTMLAnchorElement>(parent))
+        return anchorElement->isSystemPreviewLink();
+    if (auto* pictureElement = dynamicDowncast<HTMLPictureElement>(parent))
+        return pictureElement->isSystemPreviewImage();
     return false;
 }
 #endif
@@ -1057,8 +1056,7 @@ Ref<Element> HTMLImageElement::cloneElementWithoutAttributesAndChildren(Document
 #if ENABLE(ATTACHMENT_ELEMENT)
     if (auto attachment = attachmentElement()) {
         auto attachmentClone = attachment->cloneElementWithoutChildren(targetDocument);
-        RELEASE_ASSERT(is<HTMLAttachmentElement>(attachmentClone));
-        clone->setAttachmentElement(downcast<HTMLAttachmentElement>(attachmentClone.get()));
+        clone->setAttachmentElement(checkedDowncast<HTMLAttachmentElement>(attachmentClone.get()));
     }
 #endif
     return clone;

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -91,8 +91,10 @@ void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& 
         }
     }
 
-    if (loadError && is<HTMLObjectElement>(element()))
-        downcast<HTMLObjectElement>(element()).renderFallbackContent();
+    if (loadError) {
+        if (RefPtr objectElement = dynamicDowncast<HTMLObjectElement>(element()))
+            objectElement->renderFallbackContent();
+    }
 }
 
 }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1226,9 +1226,12 @@ void HTMLInputElement::willDispatchEvent(Event& event, InputElementClickState& s
     auto& eventNames = WebCore::eventNames();
     if (event.type() == eventNames.textInputEvent && m_inputType->shouldSubmitImplicitly(event))
         event.stopPropagation();
-    if (event.type() == eventNames.clickEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == MouseButton::Left) {
-        m_inputType->willDispatchClick(state);
-        state.stateful = true;
+    if (event.type() == eventNames.clickEvent) {
+        auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+        if (mouseEvent && mouseEvent->button() == MouseButton::Left) {
+            m_inputType->willDispatchClick(state);
+            state.stateful = true;
+        }
     }
 }
 

--- a/Source/WebCore/html/HTMLLIElement.cpp
+++ b/Source/WebCore/html/HTMLLIElement.cpp
@@ -98,9 +98,9 @@ void HTMLLIElement::collectPresentationalHintsForAttribute(const QualifiedName& 
 
 void HTMLLIElement::didAttachRenderers()
 {
-    if (!is<RenderListItem>(renderer()))
+    CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(*renderer());
+    if (!listItemRenderer)
         return;
-    auto& listItemRenderer = downcast<RenderListItem>(*renderer());
 
     // Check if there is an enclosing list.
     bool isInList = false;
@@ -114,7 +114,7 @@ void HTMLLIElement::didAttachRenderers()
     // If we are not in a list, tell the renderer so it can position us inside.
     // We don't want to change our style to say "inside" since that would affect nested nodes.
     if (!isInList)
-        listItemRenderer.setNotInList(true);
+        listItemRenderer->setNotInList(true);
 }
 
 }

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -123,15 +123,16 @@ void HTMLLabelElement::setHovered(bool over, Style::InvalidationScope invalidati
 
 bool HTMLLabelElement::isEventTargetedAtInteractiveDescendants(Event& event) const
 {
-    if (!is<Node>(event.target()))
+    auto* node = dynamicDowncast<Node>(*event.target());
+    if (!node)
         return false;
 
-    auto& node = downcast<Node>(*event.target());
-    if (!containsIncludingShadowDOM(&node))
+    if (!containsIncludingShadowDOM(node))
         return false;
 
-    for (const auto* it = &node; it && it != this; it = it->parentElementInComposedTree()) {
-        if (is<HTMLElement>(it) && downcast<HTMLElement>(*it).isInteractiveContent())
+    for (const auto* it = node; it && it != this; it = it->parentElementInComposedTree()) {
+        auto* element = dynamicDowncast<HTMLElement>(*it);
+        if (element && element->isInteractiveContent())
             return true;
     }
 
@@ -144,7 +145,8 @@ void HTMLLabelElement::defaultEventHandler(Event& event)
 
         // If we can't find a control or if the control received the click
         // event, then there's no need for us to do anything.
-        if (!control || (is<Node>(event.target()) && control->containsIncludingShadowDOM(&downcast<Node>(*event.target())))) {
+        auto* eventTarget = dynamicDowncast<Node>(event.target());
+        if (!control || (eventTarget && control->containsIncludingShadowDOM(eventTarget))) {
             HTMLElement::defaultEventHandler(event);
             return;
         }

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -52,10 +52,8 @@ HTMLFormElement* HTMLLegendElement::form() const
     // According to the specification, If the legend has a fieldset element as
     // its parent, then the form attribute must return the same value as the
     // form attribute on that fieldset element. Otherwise, it must return null.
-    RefPtr fieldset = parentNode();
-    if (!is<HTMLFieldSetElement>(fieldset))
-        return nullptr;
-    return downcast<HTMLFieldSetElement>(*fieldset).form();
+    RefPtr fieldset = dynamicDowncast<HTMLFieldSetElement>(parentNode());
+    return fieldset ? fieldset->form() : nullptr;
 }
     
 } // namespace

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -82,5 +82,9 @@ static_assert(sizeof(HTMLMaybeFormAssociatedCustomElement) == sizeof(HTMLElement
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLMaybeFormAssociatedCustomElement)
     static bool isType(const WebCore::Element& element) { return element.isMaybeFormAssociatedCustomElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1348,7 +1348,11 @@ template<> struct LogArgument<WebCore::HTMLMediaElement::SpeechSynthesisState> {
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLMediaElement)
     static bool isType(const WebCore::Element& element) { return element.isMediaElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -228,9 +228,7 @@ void HTMLMeterElement::didElementStateChange()
 
 RenderMeter* HTMLMeterElement::renderMeter() const
 {
-    if (is<RenderMeter>(renderer()))
-        return downcast<RenderMeter>(renderer());
-    return nullptr;
+    return dynamicDowncast<RenderMeter>(renderer());
 }
 
 void HTMLMeterElement::didAddUserAgentShadowRoot(ShadowRoot& root)

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -62,7 +62,8 @@ bool WindowNameCollection::elementMatches(const Element& element, const AtomStri
 
 static inline bool isObjectElementForDocumentNameCollection(const Element& element)
 {
-    return is<HTMLObjectElement>(element) && downcast<HTMLObjectElement>(element).isExposed();
+    auto* objectElement = dynamicDowncast<HTMLObjectElement>(element);
+    return objectElement && objectElement->isExposed();
 }
 
 bool DocumentNameCollection::elementMatchesIfIdAttributeMatch(const Element& element)

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -271,10 +271,10 @@ void HTMLOptionElement::childrenChanged(const ChildChange& change)
 HTMLSelectElement* HTMLOptionElement::ownerSelectElement() const
 {
     if (auto* parent = parentElement()) {
-        if (is<HTMLSelectElement>(*parent))
-            return downcast<HTMLSelectElement>(parent);
-        if (is<HTMLOptGroupElement>(*parent))
-            return downcast<HTMLOptGroupElement>(*parent).ownerSelectElement();
+        if (auto* select = dynamicDowncast<HTMLSelectElement>(*parent))
+            return select;
+        if (auto* optGroup = dynamicDowncast<HTMLOptGroupElement>(*parent))
+            return optGroup->ownerSelectElement();
     }
     return nullptr;
 }
@@ -323,20 +323,18 @@ bool HTMLOptionElement::isDisabledFormControl() const
     if (ownElementDisabled())
         return true;
 
-    if (!is<HTMLOptGroupElement>(parentNode()))
-        return false;
-
-    return downcast<HTMLOptGroupElement>(*parentNode()).isDisabledFormControl();
+    auto* parentOptGroup = dynamicDowncast<HTMLOptGroupElement>(parentNode());
+    return parentOptGroup && parentOptGroup->isDisabledFormControl();
 }
 
 String HTMLOptionElement::collectOptionInnerText() const
 {
     StringBuilder text;
     for (RefPtr node = firstChild(); node; ) {
-        if (is<Text>(*node))
-            text.append(node->nodeValue());
+        if (auto* textNode = dynamicDowncast<Text>(*node))
+            text.append(textNode->data());
         // Text nodes inside script elements are not part of the option text.
-        if (is<Element>(*node) && isScriptElement(downcast<Element>(*node)))
+        if (auto* element = dynamicDowncast<Element>(*node); element && isScriptElement(*element))
             node = NodeTraversal::nextSkippingChildren(*node, this);
         else
             node = NodeTraversal::next(*node, this);

--- a/Source/WebCore/html/HTMLPictureElement.cpp
+++ b/Source/WebCore/html/HTMLPictureElement.cpp
@@ -72,10 +72,8 @@ bool HTMLPictureElement::isSystemPreviewImage()
     if (!document().settings().systemPreviewEnabled())
         return false;
 
-    auto* parent = parentElement();
-    if (!is<HTMLAnchorElement>(parent))
-        return false;
-    return downcast<HTMLAnchorElement>(parent)->isSystemPreviewLink();
+    auto* parent = dynamicDowncast<HTMLAnchorElement>(parentElement());
+    return parent && parent->isSystemPreviewLink();
 }
 #endif
 

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -171,10 +171,12 @@ void HTMLPlugInImageElement::didAttachRenderers()
     scheduleUpdateForAfterStyleResolution();
 
     // Update the RenderImageResource of the associated RenderImage.
-    if (m_imageLoader && is<RenderImage>(renderer())) {
-        auto& renderImageResource = downcast<RenderImage>(*renderer()).imageResource();
-        if (!renderImageResource.cachedImage())
-            renderImageResource.setCachedImage(m_imageLoader->image());
+    if (m_imageLoader) {
+        if (auto* renderImage = dynamicDowncast<RenderImage>(renderer())) {
+            auto& renderImageResource = renderImage->imageResource();
+            if (!renderImageResource.cachedImage())
+                renderImageResource.setCachedImage(m_imageLoader->image());
+        }
     }
 
     HTMLPlugInElement::didAttachRenderers();

--- a/Source/WebCore/html/HTMLPlugInImageElement.h
+++ b/Source/WebCore/html/HTMLPlugInImageElement.h
@@ -94,5 +94,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLPlugInImageElement)
     static bool isType(const WebCore::HTMLPlugInElement& element) { return element.isPlugInImageElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLPlugInElement>(node) && isType(downcast<WebCore::HTMLPlugInElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* pluginElement = dynamicDowncast<WebCore::HTMLPlugInElement>(node);
+        return pluginElement && isType(*pluginElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -72,8 +72,8 @@ bool HTMLProgressElement::childShouldCreateRenderer(const Node& child) const
 
 RenderProgress* HTMLProgressElement::renderProgress() const
 {
-    if (is<RenderProgress>(renderer()))
-        return downcast<RenderProgress>(renderer());
+    if (auto* renderProgress = dynamicDowncast<RenderProgress>(renderer()))
+        return renderProgress;
     return downcast<RenderProgress>(descendantsOfType<Element>(*userAgentShadowRoot()).first()->renderer());
 }
 


### PR DESCRIPTION
#### 7ccc0ce3e7a39a98dee3312d14472abdf92d2fcc
<pre>
Adopt dynamicDowncast&lt;&gt;() more in html/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265174">https://bugs.webkit.org/show_bug.cgi?id=265174</a>

Reviewed by Jean-Yves Avenard and Tim Nguyen.

* Source/WebCore/html/HTMLElement.h:
(WebCore::Node::hasTagName const):
(isType):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::findWidgetRenderer):
(WebCore::HTMLEmbedElement::rendererIsNeeded):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::autofillMantle const):
* Source/WebCore/html/HTMLFormControlElement.h:
(isType):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitImplicitly):
(WebCore::HTMLFormElement::textFieldValues const):
(WebCore::HTMLFormElement::findSubmitButton):
(WebCore::HTMLFormElement::registerFormListedElement):
(WebCore::HTMLFormElement::findSubmitter const):
(WebCore::HTMLFormElement::defaultButton const):
(WebCore::HTMLFormElement::constructEntryList):
* Source/WebCore/html/HTMLFrameElementBase.h:
(isType):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::renderWidget const):
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::namedItem):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setBestFitURLAndDPRFromImageCandidate):
(WebCore::HTMLImageElement::bestFitSourceFromPictureElement):
(WebCore::HTMLImageElement::attributeChanged):
(WebCore::HTMLImageElement::didAttachRenderers):
(WebCore::HTMLImageElement::insertedIntoAncestor):
(WebCore::HTMLImageElement::isSystemPreviewImage const):
(WebCore::HTMLImageElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/html/HTMLImageLoader.cpp:
(WebCore::HTMLImageLoader::notifyFinished):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::willDispatchEvent):
* Source/WebCore/html/HTMLLIElement.cpp:
(WebCore::HTMLLIElement::didAttachRenderers):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::isEventTargetedAtInteractiveDescendants const):
(WebCore::HTMLLabelElement::defaultEventHandler):
* Source/WebCore/html/HTMLLegendElement.cpp:
(WebCore::HTMLLegendElement::form const):
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
(isType):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::bestMediaElementForRemoteControls):
(WebCore::HTMLMediaElement::updateActiveTextTrackCues):
(WebCore::HTMLMediaElement::textTrackRemoveCue):
(WebCore::HTMLMediaElement::setReadyState):
(WebCore::HTMLMediaElement::mediaPlayerSizeChanged):
(WebCore::HTMLMediaElement::mediaPlayerRenderingCanBeAccelerated):
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::exitFullscreen):
(WebCore::HTMLMediaElement::willBecomeFullscreenElement):
(WebCore::HTMLMediaElement::mediaState const):
(WebCore::HTMLMediaElement::isVideoTooSmallForInlinePlayback):
* Source/WebCore/html/HTMLMediaElement.h:
(isType):
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::renderMeter const):
* Source/WebCore/html/HTMLNameCollection.cpp:
(WebCore::isObjectElementForDocumentNameCollection):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::preventsParentObjectFromExposure):
(WebCore::HTMLObjectElement::updateExposedState):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::ownerSelectElement const):
(WebCore::HTMLOptionElement::isDisabledFormControl const):
(WebCore::HTMLOptionElement::collectOptionInnerText const):
* Source/WebCore/html/HTMLPictureElement.cpp:
(WebCore::HTMLPictureElement::isSystemPreviewImage):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::defaultEventHandler):
(WebCore::HTMLPlugInElement::supportsFocus const):
(WebCore::HTMLPlugInElement::setReplacement):
(WebCore::HTMLPlugInElement::isReplacementObscured):
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::didAttachRenderers):
* Source/WebCore/html/HTMLPlugInImageElement.h:
(isType):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::renderProgress const):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionToSelectFromChildChangeScope):
(WebCore::HTMLSelectElement::setLength):
(WebCore::HTMLSelectElement::nextSelectableListIndexPageAway const):
(WebCore::HTMLSelectElement::saveLastSelection):
(WebCore::HTMLSelectElement::setActiveSelectionAnchorIndex):
(WebCore::HTMLSelectElement::updateListBoxSelection):
(WebCore::HTMLSelectElement::listBoxOnChange):
(WebCore::HTMLSelectElement::scrollToSelection):
(WebCore::HTMLSelectElement::setOptionsChangedOnRenderer):
(WebCore::HTMLSelectElement::recalcListItems const):
(WebCore::HTMLSelectElement::selectedIndex const):
(WebCore::HTMLSelectElement::selectOption):
(WebCore::HTMLSelectElement::deselectItemsWithoutValidation):
(WebCore::HTMLSelectElement::saveFormControlState const):
(WebCore::HTMLSelectElement::searchOptionsForValue const):
(WebCore::HTMLSelectElement::restoreFormControlState):
(WebCore::HTMLSelectElement::appendFormData):
(WebCore::HTMLSelectElement::reset):
(WebCore::HTMLSelectElement::platformHandleKeydownEvent):
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::updateSelectedState):
(WebCore::HTMLSelectElement::listBoxDefaultEventHandler):
(WebCore::HTMLSelectElement::defaultEventHandler):
(WebCore::HTMLSelectElement::lastSelectedListIndex const):
(WebCore::HTMLSelectElement::optionAtIndex const):
(WebCore::HTMLSelectElement::accessKeySetSelectedIndex):

Canonical link: <a href="https://commits.webkit.org/271033@main">https://commits.webkit.org/271033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3832a69e2f5e0f51743edfd4127a2fca3e8084f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29979 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30278 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28199 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5565 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33772 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4564 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7318 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3509 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->