### PR TITLE
[JSC] Optimize C++ -> JS calls more by removing unnecessary callee storing to VMEntryRecord

### DIFF
--- a/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -350,8 +350,12 @@ void CallFrame::convertToStackOverflowFrame(VM& vm, CodeBlock* codeBlockToKeepAl
         throwOriginFrame = throwOriginFrame->callerFrame(entryFrame);
     } while (throwOriginFrame && throwOriginFrame->callee().isNativeCallee());
 
-    JSObject* originCallee = throwOriginFrame ? throwOriginFrame->jsCallee() : vmEntryRecord(vm.topEntryFrame)->callee();
-    JSObject* stackOverflowCallee = originCallee->globalObject()->stackOverflowFrameCallee();
+    JSGlobalObject* globalObject = nullptr;
+    if (throwOriginFrame)
+        globalObject = throwOriginFrame->jsCallee()->globalObject();
+    else
+        globalObject = vm.entryScope->globalObject();
+    JSObject* stackOverflowCallee = globalObject->stackOverflowFrameCallee();
 
     setCodeBlock(codeBlockToKeepAliveUntilFrameIsUnwound);
     setCallee(stackOverflowCallee);

--- a/Source/JavaScriptCore/interpreter/VMEntryRecord.h
+++ b/Source/JavaScriptCore/interpreter/VMEntryRecord.h
@@ -43,9 +43,6 @@ struct VMEntryRecord {
     VM* const m_vm;
     CallFrame* const m_prevTopCallFrame;
     EntryFrame* const m_prevTopEntryFrame;
-    JSObject* const m_callee;
-
-    JSObject* callee() const { return m_callee; }
 
 #if !ENABLE(C_LOOP) && NUMBER_OF_CALLEE_SAVES_REGISTERS > 0
     CPURegister calleeSaveRegistersBuffer[NUMBER_OF_CALLEE_SAVES_REGISTERS];

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -241,8 +241,6 @@ macro doVMEntry(makeCall)
     storep t4, VMEntryRecord::m_prevTopCallFrame[sp]
     loadp VM::topEntryFrame[vm], t4
     storep t4, VMEntryRecord::m_prevTopEntryFrame[sp]
-    loadp ProtoCallFrame::calleeValue[protoCallFrame], t4
-    storep t4, VMEntryRecord::m_callee[sp]
 
     # Align stack pointer
     if X86_WIN or MIPS

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -250,8 +250,6 @@ macro doVMEntry(makeCall)
         loadp VM::topEntryFrame[vm], t4
         storep t4, VMEntryRecord::m_prevTopEntryFrame[sp]
     end
-    loadp ProtoCallFrame::calleeValue[protoCallFrame], t4
-    storep t4, VMEntryRecord::m_callee[sp]
 
     loadi ProtoCallFrame::paddedArgCount[protoCallFrame], t4
     addp CallFrameHeaderSlots, t4, t4


### PR DESCRIPTION
#### 70ed411a86beb021b7cfd8a152196da979efeef4
<pre>
[JSC] Optimize C++ -&gt; JS calls more by removing unnecessary callee storing to VMEntryRecord
<a href="https://bugs.webkit.org/show_bug.cgi?id=265178">https://bugs.webkit.org/show_bug.cgi?id=265178</a>
<a href="https://rdar.apple.com/118672952">rdar://118672952</a>

Reviewed by Ross Kirsling.

This remoes unnecessary callee storing in VMEntryRecord. We are using it only in one place, and it is just getting JSGlobalObject
when there is no JS CallFrame (then, instead, it is querying to VMEntryRecord). In this case, we can just use VMEntryScope&apos;s
JSGlobalObject, which is also created before VMEntryRecord is instantiated. This removes some more unnecessary code in LowLevelInterpreter&apos;s
doVMEntry.

    cpp-to-js-cached-call       12.8405+-0.0760     ^     12.5615+-0.0582        ^ definitely 1.0222x faster

* Source/JavaScriptCore/interpreter/CallFrame.cpp:
(JSC::CallFrame::convertToStackOverflowFrame):
* Source/JavaScriptCore/interpreter/VMEntryRecord.h:
(JSC::VMEntryRecord::callee const): Deleted.
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/271027@main">https://commits.webkit.org/271027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2de640a84fd3380f4e224a54dc1e873a33e4e5bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24737 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3926 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29900 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23578 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30212 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26238 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4026 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2218 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-content-use-007.svg, imported/w3c/web-platform-tests/workers/semantics/multiple-workers/exposure.any.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28128 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5488 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33692 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4491 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7303 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3505 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->