### PR TITLE
[v2] fast/mediastream/device-change-event-2.html is flaky

### DIFF
--- a/LayoutTests/fast/mediastream/device-change-event-2-expected.txt
+++ b/LayoutTests/fast/mediastream/device-change-event-2-expected.txt
@@ -1,5 +1,3 @@
-CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
-CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
 
 PASS 'devicechange' event fired when device list changes
 PASS 'devicechange' events fired quickly are coalesced

--- a/LayoutTests/fast/mediastream/device-change-event-2.html
+++ b/LayoutTests/fast/mediastream/device-change-event-2.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
#### 0761ccfa932e205efbea79bf7219a8d9094ca4c6
<pre>
[v2] fast/mediastream/device-change-event-2.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=265180">https://bugs.webkit.org/show_bug.cgi?id=265180</a>
<a href="https://rdar.apple.com/118675428">rdar://118675428</a>

Reviewed by Eric Carlson.

We retry several times the coalescing event.
This migth trigger varying console log messages.
To prevent flakiness, we put these log messages in stderr.

* LayoutTests/fast/mediastream/device-change-event-2-expected.txt:
* LayoutTests/fast/mediastream/device-change-event-2.html:

Canonical link: <a href="https://commits.webkit.org/271012@main">https://commits.webkit.org/271012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65b51e69cee1d0a3c9bf420a920d64566adb3179

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24742 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24593 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30221 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28137 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23958 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6505 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->