### PR TITLE
Safari blocking JS reading nonce for <style> and <link>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document-expected.txt
@@ -1,0 +1,5 @@
+What color is this?
+
+
+PASS Nonce isn't lost on document move
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="style-src 'self' 'nonce-allowme';">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1831328">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<title>Nonce isn't lost on document move</title>
+<style type="text/css" nonce="allowme">
+  p {
+    color: red;
+  }
+</style>
+<p>What color is this?</p>
+<script>
+test(function() {
+  const doc = document.implementation.createDocument("http://www.w3.org/1999/xhtml","html");
+  const style = document.createElement("style");
+  style.setAttribute("nonce", "allowme");
+  style.textContent = "p { color: lime }";
+
+  doc.documentElement.appendChild(style);
+  document.body.appendChild(style);
+  assert_equals(style.nonce, "allowme", "Nonce should not have been lost");
+  assert_equals(getComputedStyle(document.querySelector("p")).color, "rgb(0, 255, 0)", "Style should apply");
+})
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces-expected.txt
@@ -17,4 +17,10 @@ PASS Test empty nonces for svg in SVG namespace
 PASS Basic nonce tests for script in SVG namespace
 PASS Ensure that removal of content attribute does not affect IDL attribute for script in SVG namespace
 PASS Test empty nonces for script in SVG namespace
+PASS Basic nonce tests for style in HTML namespace
+PASS Ensure that removal of content attribute does not affect IDL attribute for style in HTML namespace
+PASS Test empty nonces for style in HTML namespace
+PASS Basic nonce tests for link in HTML namespace
+PASS Ensure that removal of content attribute does not affect IDL attribute for link in HTML namespace
+PASS Test empty nonces for link in HTML namespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces.html
@@ -14,6 +14,8 @@
     ["meh"    , "SVG"],
     ["svg"    , "SVG"],
     ["script" , "SVG"],
+    ["style"  , "HTML"],
+    ["link"   , "HTML"]
   ];
 
   test_cases.forEach(([localName, namespace]) => {

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/script-nonces-hidden-meta.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/reflection-metadata-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/reflection-metadata-expected.txt
@@ -1773,23 +1773,23 @@ PASS link.nonce: setAttribute() to "\0"
 PASS link.nonce: setAttribute() to null
 PASS link.nonce: setAttribute() to object "test-toString"
 PASS link.nonce: setAttribute() to object "test-valueOf"
-PASS link.nonce: IDL set to ""
-PASS link.nonce: IDL set to " \0\x01\x02\x03\x04\x05\x06\x07 \b\t\n\v\f\r\x0e\x0f \x10\x11\x12\x13\x14\x15\x16\x17 \x18\x19\x1a\x1b\x1c\x1d\x1e\x1f  foo "
-PASS link.nonce: IDL set to undefined
-PASS link.nonce: IDL set to 7
-PASS link.nonce: IDL set to 1.5
-PASS link.nonce: IDL set to "5%"
-PASS link.nonce: IDL set to "+100"
-PASS link.nonce: IDL set to ".5"
-PASS link.nonce: IDL set to true
-PASS link.nonce: IDL set to false
-PASS link.nonce: IDL set to object "[object Object]"
-PASS link.nonce: IDL set to NaN
-PASS link.nonce: IDL set to Infinity
-PASS link.nonce: IDL set to -Infinity
-PASS link.nonce: IDL set to "\0"
-PASS link.nonce: IDL set to null
-PASS link.nonce: IDL set to object "test-toString"
+FAIL link.nonce: IDL set to "" assert_equals: getAttribute() expected "" but got "test-valueOf"
+FAIL link.nonce: IDL set to " \0\x01\x02\x03\x04\x05\x06\x07 \b\t\n\v\f\r\x0e\x0f \x10\x11\x12\x13\x14\x15\x16\x17 \x18\x19\x1a\x1b\x1c\x1d\x1e\x1f  foo " assert_equals: getAttribute() expected " \0\x01\x02\x03\x04\x05\x06\x07 \b\t\n\v\f\r\x0e\x0f \x10\x11\x12\x13\x14\x15\x16\x17 \x18\x19\x1a\x1b\x1c\x1d\x1e\x1f  foo " but got "test-valueOf"
+FAIL link.nonce: IDL set to undefined assert_equals: getAttribute() expected "undefined" but got "test-valueOf"
+FAIL link.nonce: IDL set to 7 assert_equals: getAttribute() expected "7" but got "test-valueOf"
+FAIL link.nonce: IDL set to 1.5 assert_equals: getAttribute() expected "1.5" but got "test-valueOf"
+FAIL link.nonce: IDL set to "5%" assert_equals: getAttribute() expected "5%" but got "test-valueOf"
+FAIL link.nonce: IDL set to "+100" assert_equals: getAttribute() expected "+100" but got "test-valueOf"
+FAIL link.nonce: IDL set to ".5" assert_equals: getAttribute() expected ".5" but got "test-valueOf"
+FAIL link.nonce: IDL set to true assert_equals: getAttribute() expected "true" but got "test-valueOf"
+FAIL link.nonce: IDL set to false assert_equals: getAttribute() expected "false" but got "test-valueOf"
+FAIL link.nonce: IDL set to object "[object Object]" assert_equals: getAttribute() expected "[object Object]" but got "test-valueOf"
+FAIL link.nonce: IDL set to NaN assert_equals: getAttribute() expected "NaN" but got "test-valueOf"
+FAIL link.nonce: IDL set to Infinity assert_equals: getAttribute() expected "Infinity" but got "test-valueOf"
+FAIL link.nonce: IDL set to -Infinity assert_equals: getAttribute() expected "-Infinity" but got "test-valueOf"
+FAIL link.nonce: IDL set to "\0" assert_equals: getAttribute() expected "\0" but got "test-valueOf"
+FAIL link.nonce: IDL set to null assert_equals: getAttribute() expected "null" but got "test-valueOf"
+FAIL link.nonce: IDL set to object "test-toString" assert_equals: getAttribute() expected "test-toString" but got "test-valueOf"
 PASS link.nonce: IDL set to object "test-valueOf"
 PASS link.integrity: typeof IDL attribute
 PASS link.integrity: IDL get with DOM attribute unset
@@ -3043,23 +3043,23 @@ PASS style.nonce: setAttribute() to "\0"
 PASS style.nonce: setAttribute() to null
 PASS style.nonce: setAttribute() to object "test-toString"
 PASS style.nonce: setAttribute() to object "test-valueOf"
-PASS style.nonce: IDL set to ""
-PASS style.nonce: IDL set to " \0\x01\x02\x03\x04\x05\x06\x07 \b\t\n\v\f\r\x0e\x0f \x10\x11\x12\x13\x14\x15\x16\x17 \x18\x19\x1a\x1b\x1c\x1d\x1e\x1f  foo "
-PASS style.nonce: IDL set to undefined
-PASS style.nonce: IDL set to 7
-PASS style.nonce: IDL set to 1.5
-PASS style.nonce: IDL set to "5%"
-PASS style.nonce: IDL set to "+100"
-PASS style.nonce: IDL set to ".5"
-PASS style.nonce: IDL set to true
-PASS style.nonce: IDL set to false
-PASS style.nonce: IDL set to object "[object Object]"
-PASS style.nonce: IDL set to NaN
-PASS style.nonce: IDL set to Infinity
-PASS style.nonce: IDL set to -Infinity
-PASS style.nonce: IDL set to "\0"
-PASS style.nonce: IDL set to null
-PASS style.nonce: IDL set to object "test-toString"
+FAIL style.nonce: IDL set to "" assert_equals: getAttribute() expected "" but got "test-valueOf"
+FAIL style.nonce: IDL set to " \0\x01\x02\x03\x04\x05\x06\x07 \b\t\n\v\f\r\x0e\x0f \x10\x11\x12\x13\x14\x15\x16\x17 \x18\x19\x1a\x1b\x1c\x1d\x1e\x1f  foo " assert_equals: getAttribute() expected " \0\x01\x02\x03\x04\x05\x06\x07 \b\t\n\v\f\r\x0e\x0f \x10\x11\x12\x13\x14\x15\x16\x17 \x18\x19\x1a\x1b\x1c\x1d\x1e\x1f  foo " but got "test-valueOf"
+FAIL style.nonce: IDL set to undefined assert_equals: getAttribute() expected "undefined" but got "test-valueOf"
+FAIL style.nonce: IDL set to 7 assert_equals: getAttribute() expected "7" but got "test-valueOf"
+FAIL style.nonce: IDL set to 1.5 assert_equals: getAttribute() expected "1.5" but got "test-valueOf"
+FAIL style.nonce: IDL set to "5%" assert_equals: getAttribute() expected "5%" but got "test-valueOf"
+FAIL style.nonce: IDL set to "+100" assert_equals: getAttribute() expected "+100" but got "test-valueOf"
+FAIL style.nonce: IDL set to ".5" assert_equals: getAttribute() expected ".5" but got "test-valueOf"
+FAIL style.nonce: IDL set to true assert_equals: getAttribute() expected "true" but got "test-valueOf"
+FAIL style.nonce: IDL set to false assert_equals: getAttribute() expected "false" but got "test-valueOf"
+FAIL style.nonce: IDL set to object "[object Object]" assert_equals: getAttribute() expected "[object Object]" but got "test-valueOf"
+FAIL style.nonce: IDL set to NaN assert_equals: getAttribute() expected "NaN" but got "test-valueOf"
+FAIL style.nonce: IDL set to Infinity assert_equals: getAttribute() expected "Infinity" but got "test-valueOf"
+FAIL style.nonce: IDL set to -Infinity assert_equals: getAttribute() expected "-Infinity" but got "test-valueOf"
+FAIL style.nonce: IDL set to "\0" assert_equals: getAttribute() expected "\0" but got "test-valueOf"
+FAIL style.nonce: IDL set to null assert_equals: getAttribute() expected "null" but got "test-valueOf"
+FAIL style.nonce: IDL set to object "test-toString" assert_equals: getAttribute() expected "test-toString" but got "test-valueOf"
 PASS style.nonce: IDL set to object "test-valueOf"
 PASS style.type: typeof IDL attribute
 PASS style.type: IDL get with DOM attribute unset

--- a/Source/WebCore/html/HTMLLinkElement.idl
+++ b/Source/WebCore/html/HTMLLinkElement.idl
@@ -46,7 +46,6 @@
 
     [PutForwards=value] readonly attribute DOMTokenList relList;
 
-    [Reflect] attribute DOMString nonce;
     [CEReactions=NotNeeded, Reflect] attribute DOMString integrity;
 };
 

--- a/Source/WebCore/html/HTMLStyleElement.idl
+++ b/Source/WebCore/html/HTMLStyleElement.idl
@@ -24,8 +24,6 @@
     attribute boolean disabled;
     [CEReactions=NotNeeded, Reflect] attribute DOMString media;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
-
-    [Reflect] attribute DOMString nonce;
 };
 
 HTMLStyleElement includes LinkStyle;


### PR DESCRIPTION
#### 9ea548224a0026f1f4fb920e849ed48454ebee0e
<pre>
Safari blocking JS reading nonce for &lt;style&gt; and &lt;link&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=265173">https://bugs.webkit.org/show_bug.cgi?id=265173</a>
<a href="https://rdar.apple.com/118676659">rdar://118676659</a>

Reviewed by Antti Koivisto.

Some leftover nonce IDL included [Reflect] and therefore those elements
had the older-but-now-bogus nonce semantics.

Tests have been synchronized and new tests in nonces.html are
upstreamed here:
<a href="https://github.com/web-platform-tests/wpt/pull/43280">https://github.com/web-platform-tests/wpt/pull/43280</a>

The new test failures in WPT html/dom/reflection-metadata.html are
expected and match all other browsers. I filed an upstream issue on
that test here:
<a href="https://github.com/web-platform-tests/wpt/issues/43286">https://github.com/web-platform-tests/wpt/issues/43286</a>

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonces.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/reflection-metadata-expected.txt:
* Source/WebCore/html/HTMLLinkElement.idl:
* Source/WebCore/html/HTMLStyleElement.idl:

Canonical link: <a href="https://commits.webkit.org/271046@main">https://commits.webkit.org/271046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5821778c1aeb52bd35ab98ecfa18d868dea00730

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24769 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24617 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30238 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28155 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6546 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->