### PR TITLE
Move RenderStyle animation data to a dedicated substructure

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2389,6 +2389,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/SVGRenderStyleDefs.h
     rendering/style/ShadowData.h
     rendering/style/ShapeValue.h
+    rendering/style/StyleAnimationData.h
     rendering/style/StyleBackgroundData.h
     rendering/style/StyleBoxData.h
     rendering/style/StyleColorScheme.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2731,6 +2731,7 @@ rendering/style/ScrollbarColor.cpp
 rendering/style/ScrollbarGutter.cpp
 rendering/style/ShadowData.cpp
 rendering/style/ShapeValue.cpp
+rendering/style/StyleAnimationData.cpp
 rendering/style/StyleBackgroundData.cpp
 rendering/style/StyleBoxData.cpp
 rendering/style/StyleCachedImage.cpp

--- a/Source/WebCore/platform/animation/AnimationList.cpp
+++ b/Source/WebCore/platform/animation/AnimationList.cpp
@@ -35,15 +35,11 @@ if (i) { \
 
 AnimationList::AnimationList() = default;
 
-AnimationList::AnimationList(const AnimationList& other, CopyBehavior copyBehavior)
+AnimationList::AnimationList(const AnimationList& other)
 {
-    if (copyBehavior == CopyBehavior::Reference)
-        m_animations = other.m_animations;
-    else {
-        m_animations = other.m_animations.map([](auto& animation) {
-            return Animation::create(animation.get());
-        });
-    }
+    m_animations = other.m_animations.map([](auto& animation) {
+        return Animation::create(animation.get());
+    });
 }
 
 void AnimationList::fillUnsetProperties()

--- a/Source/WebCore/platform/animation/AnimationList.h
+++ b/Source/WebCore/platform/animation/AnimationList.h
@@ -35,8 +35,7 @@ class AnimationList : public RefCounted<AnimationList> {
 public:
     static Ref<AnimationList> create() { return adoptRef(*new AnimationList); }
 
-    Ref<AnimationList> copy() const { return adoptRef(*new AnimationList(*this, CopyBehavior::Clone)); }
-    Ref<AnimationList> shallowCopy() const { return adoptRef(*new AnimationList(*this, CopyBehavior::Reference)); }
+    Ref<AnimationList> copy() const { return adoptRef(*new AnimationList(*this)); }
 
     void fillUnsetProperties();
     bool operator==(const AnimationList&) const;
@@ -61,12 +60,11 @@ public:
 private:
     AnimationList();
 
-    enum class CopyBehavior : uint8_t { Clone, Reference };
-    AnimationList(const AnimationList&, CopyBehavior);
+    AnimationList(const AnimationList&);
 
     AnimationList& operator=(const AnimationList&);
 
-    Vector<Ref<Animation>, 0, CrashOnOverflow, 0> m_animations;
+    Vector<Ref<Animation>, 1> m_animations;
 };    
 
 WTF::TextStream& operator<<(WTF::TextStream&, const AnimationList&);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2642,53 +2642,65 @@ const AtomString& RenderStyle::textEmphasisMarkString() const
 
 void RenderStyle::adjustAnimations()
 {
-    auto* animationList = m_nonInheritedData->miscData->animations.get();
+    auto* animationList = animations();
     if (!animationList)
         return;
 
-    // Get rid of empty animations and anything beyond them
-    for (size_t i = 0, size = animationList->size(); i < size; ++i) {
-        if (animationList->animation(i).isEmpty()) {
-            animationList->resize(i);
-            break;
+    // Get rid of empty transitions and anything beyond them
+    auto emptyIndex = [&]() -> std::optional<size_t> {
+        for (size_t i = 0, size = animationList->size(); i < size; ++i) {
+            if (animationList->animation(i).isEmpty())
+                return i;
         }
-    }
+        return { };
+    }();
 
-    if (animationList->isEmpty()) {
-        clearAnimations();
+    if (!emptyIndex)
+        return;
+
+    auto& mutableAnimationList = m_nonInheritedData.access().miscData.access().animationData.access().animations;
+    if (!*emptyIndex) {
+        mutableAnimationList = nullptr;
         return;
     }
 
+    mutableAnimationList->resize(*emptyIndex);
     // Repeat patterns into layers that don't have some properties set.
-    animationList->fillUnsetProperties();
+    mutableAnimationList->fillUnsetProperties();
 }
 
 void RenderStyle::adjustTransitions()
 {
-    auto* transitionList = m_nonInheritedData->miscData->transitions.get();
+    auto* transitionList = transitions();
     if (!transitionList)
         return;
 
     // Get rid of empty transitions and anything beyond them
-    for (size_t i = 0, size = transitionList->size(); i < size; ++i) {
-        if (transitionList->animation(i).isEmpty()) {
-            transitionList->resize(i);
-            break;
+    auto emptyIndex = [&]() -> std::optional<size_t> {
+        for (size_t i = 0, size = transitionList->size(); i < size; ++i) {
+            if (transitionList->animation(i).isEmpty())
+                return i;
         }
-    }
+        return { };
+    }();
 
-    if (transitionList->isEmpty()) {
-        clearTransitions();
+    if (!emptyIndex)
+        return;
+
+    auto& mutableTransitionList = m_nonInheritedData.access().miscData.access().animationData.access().transitions;
+    if (!*emptyIndex) {
+        mutableTransitionList = nullptr;
         return;
     }
 
+    mutableTransitionList->resize(*emptyIndex);
     // Repeat patterns into layers that don't have some properties set.
-    transitionList->fillUnsetProperties();
+    mutableTransitionList->fillUnsetProperties();
 }
 
 AnimationList& RenderStyle::ensureAnimations()
 {
-    auto& animations = m_nonInheritedData.access().miscData.access().animations;
+    auto& animations = m_nonInheritedData.access().miscData.access().animationData.access().animations;
     if (!animations)
         animations = AnimationList::create();
     return *animations;
@@ -2696,7 +2708,7 @@ AnimationList& RenderStyle::ensureAnimations()
 
 AnimationList& RenderStyle::ensureTransitions()
 {
-    auto& transitions = m_nonInheritedData.access().miscData.access().transitions;
+    auto& transitions = m_nonInheritedData.access().miscData.access().animationData.access().transitions;
     if (!transitions)
         transitions = AnimationList::create();
     return *transitions;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -928,9 +928,6 @@ public:
     inline const AnimationList* animations() const;
     inline const AnimationList* transitions() const;
 
-    AnimationList* animations();
-    AnimationList* transitions();
-    
     inline bool hasAnimationsOrTransitions() const;
 
     AnimationList& ensureAnimations();
@@ -1496,9 +1493,6 @@ public:
     inline void setLineAlign(LineAlign);
 
     void setPointerEvents(PointerEvents p) { m_inheritedFlags.pointerEvents = static_cast<unsigned>(p); }
-
-    inline void clearAnimations();
-    inline void clearTransitions();
 
     void adjustAnimations();
     void adjustTransitions();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -33,6 +33,7 @@
 #include "RenderStyle.h"
 #include "ScrollTypes.h"
 #include "ScrollbarColor.h"
+#include "StyleAnimationData.h"
 #include "StyleAppearance.h"
 #include "StyleBackgroundData.h"
 #include "StyleBoxData.h"
@@ -64,8 +65,7 @@ inline const StyleContentAlignmentData& RenderStyle::alignContent() const { retu
 inline const StyleSelfAlignmentData& RenderStyle::alignItems() const { return m_nonInheritedData->miscData->alignItems; }
 inline const StyleSelfAlignmentData& RenderStyle::alignSelf() const { return m_nonInheritedData->miscData->alignSelf; }
 constexpr auto RenderStyle::allTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::TransformOrigin, TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
-inline const AnimationList* RenderStyle::animations() const { return m_nonInheritedData->miscData->animations.get(); }
-inline AnimationList* RenderStyle::animations() { return m_nonInheritedData->miscData->animations.get(); }
+inline const AnimationList* RenderStyle::animations() const { return m_nonInheritedData->miscData->animationData->animations.get(); }
 inline StyleAppearance RenderStyle::appearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->appearance); }
 inline const FilterOperations& RenderStyle::appleColorFilter() const { return m_rareInheritedData->appleColorFilter->operations; }
 inline double RenderStyle::aspectRatioHeight() const { return m_nonInheritedData->miscData->aspectRatioHeight; }
@@ -697,8 +697,7 @@ inline LengthPoint RenderStyle::transformOriginXY() const { return m_nonInherite
 inline const Length& RenderStyle::transformOriginY() const { return m_nonInheritedData->miscData->transform->y; }
 inline float RenderStyle::transformOriginZ() const { return m_nonInheritedData->miscData->transform->z; }
 inline TransformStyle3D RenderStyle::transformStyle3D() const { return static_cast<TransformStyle3D>(m_nonInheritedData->rareData->transformStyle3D); }
-inline const AnimationList* RenderStyle::transitions() const { return m_nonInheritedData->miscData->transitions.get(); }
-inline AnimationList* RenderStyle::transitions() { return m_nonInheritedData->miscData->transitions.get(); }
+inline const AnimationList* RenderStyle::transitions() const { return m_nonInheritedData->miscData->animationData->transitions.get(); }
 inline TranslateTransformOperation* RenderStyle::translate() const { return m_nonInheritedData->rareData->translate.get(); }
 inline bool RenderStyle::useSmoothScrolling() const { return m_nonInheritedData->rareData->useSmoothScrolling; }
 inline float RenderStyle::usedPerspective() const { return std::max(1.0f, perspective()); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -49,10 +49,8 @@ namespace WebCore {
 template<typename T, typename U> inline bool compareEqual(const T& a, const U& b) { return a == b; }
 
 inline void RenderStyle::addToTextDecorationsInEffect(OptionSet<TextDecorationLine> value) { m_inheritedFlags.textDecorationLines |= static_cast<unsigned>(value.toRaw()); }
-inline void RenderStyle::clearAnimations() { m_nonInheritedData.access().miscData.access().animations = nullptr; }
 inline void RenderStyle::clearBackgroundLayers() { m_nonInheritedData.access().backgroundData.access().background = FillLayer::create(FillLayerType::Background); }
 inline void RenderStyle::clearMaskLayers() { m_nonInheritedData.access().miscData.access().mask = FillLayer::create(FillLayerType::Mask); }
-inline void RenderStyle::clearTransitions() { m_nonInheritedData.access().miscData.access().transitions = nullptr; }
 inline FillLayer& RenderStyle::ensureBackgroundLayers() { return m_nonInheritedData.access().backgroundData.access().background.access(); }
 inline FillLayer& RenderStyle::ensureMaskLayers() { return m_nonInheritedData.access().miscData.access().mask.access(); }
 inline void RenderStyle::inheritBackgroundLayers(const FillLayer& parent) { m_nonInheritedData.access().backgroundData.access().background = FillLayer::create(parent); }

--- a/Source/WebCore/rendering/style/StyleAnimationData.cpp
+++ b/Source/WebCore/rendering/style/StyleAnimationData.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleAnimationData.h"
+
+#include "AnimationList.h"
+
+namespace WebCore {
+
+StyleAnimationData::StyleAnimationData() = default;
+
+StyleAnimationData::StyleAnimationData(const StyleAnimationData& other)
+    : animations(other.animations ? other.animations->copy() : other.animations)
+    , transitions(other.transitions ? other.transitions->copy() : other.transitions)
+{
+}
+
+StyleAnimationData::~StyleAnimationData() = default;
+
+Ref<StyleAnimationData> StyleAnimationData::copy() const
+{
+    return adoptRef(*new StyleAnimationData(*this));
+}
+
+bool StyleAnimationData::operator==(const StyleAnimationData& other) const
+{
+    return arePointingToEqualData(animations, other.animations)
+        && arePointingToEqualData(transitions, other.transitions);
+}
+
+}

--- a/Source/WebCore/rendering/style/StyleAnimationData.h
+++ b/Source/WebCore/rendering/style/StyleAnimationData.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/DataRef.h>
+
+namespace WebCore {
+
+class AnimationList;
+
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleAnimationData);
+class StyleAnimationData : public RefCounted<StyleAnimationData> {
+public:
+    static Ref<StyleAnimationData> create() { return adoptRef(*new StyleAnimationData); }
+    Ref<StyleAnimationData> copy() const;
+    ~StyleAnimationData();
+
+    bool operator==(const StyleAnimationData&) const;
+
+    RefPtr<AnimationList> animations;
+    RefPtr<AnimationList> transitions;
+
+private:
+    StyleAnimationData();
+    StyleAnimationData(const StyleAnimationData&);
+};
+
+}

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -26,11 +26,11 @@
 #include "config.h"
 #include "StyleMiscNonInheritedData.h"
 
-#include "AnimationList.h"
 #include "ContentData.h"
 #include "FillLayer.h"
 #include "RenderStyleInlines.h"
 #include "ShadowData.h"
+#include "StyleAnimationData.h"
 #include "StyleDeprecatedFlexibleBoxData.h"
 #include "StyleFilterData.h"
 #include "StyleFlexibleBoxData.h"
@@ -52,6 +52,7 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData()
     , transform(StyleTransformData::create())
     , mask(FillLayer::create(FillLayerType::Mask))
     , visitedLinkColor(StyleVisitedLinkColorData::create())
+    , animationData(StyleAnimationData::create())
     , aspectRatioWidth(RenderStyle::initialAspectRatioWidth())
     , aspectRatioHeight(RenderStyle::initialAspectRatioHeight())
     , alignContent(RenderStyle::initialContentAlignment())
@@ -82,8 +83,7 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData(const StyleMiscNonInherited
     , transform(o.transform)
     , mask(o.mask)
     , visitedLinkColor(o.visitedLinkColor)
-    , animations(o.animations ? o.animations->copy() : o.animations)
-    , transitions(o.transitions ? o.transitions->copy() : o.transitions)
+    , animationData(o.animationData)
     , content(o.content ? o.content->clone() : nullptr)
     , boxShadow(o.boxShadow ? makeUnique<ShadowData>(*o.boxShadow) : nullptr)
     , altText(o.altText)
@@ -128,8 +128,7 @@ bool StyleMiscNonInheritedData::operator==(const StyleMiscNonInheritedData& o) c
         && transform == o.transform
         && mask == o.mask
         && visitedLinkColor == o.visitedLinkColor
-        && arePointingToEqualData(animations, o.animations)
-        && arePointingToEqualData(transitions, o.transitions)
+        && animationData == o.animationData
         && contentDataEquivalent(o)
         && arePointingToEqualData(boxShadow, o.boxShadow)
         && altText == o.altText

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -40,6 +40,7 @@ class AnimationList;
 class ContentData;
 class FillLayer;
 class ShadowData;
+class StyleAnimationData;
 class StyleDeprecatedFlexibleBoxData;
 class StyleFilterData;
 class StyleFlexibleBoxData;
@@ -73,9 +74,8 @@ public:
     DataRef<StyleTransformData> transform; // Transform properties (rotate, scale, skew, etc.)
     DataRef<FillLayer> mask;
     DataRef<StyleVisitedLinkColorData> visitedLinkColor;
+    DataRef<StyleAnimationData> animationData;
 
-    RefPtr<AnimationList> animations;
-    RefPtr<AnimationList> transitions;
     std::unique_ptr<ContentData> content;
     std::unique_ptr<ShadowData> boxShadow; // For box-shadow decorations.
     String altText;


### PR DESCRIPTION
#### 3cb2f7fd88270f4b54a5d42e1181fd3bc58b6a23
<pre>
Move RenderStyle animation data to a dedicated substructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=265185">https://bugs.webkit.org/show_bug.cgi?id=265185</a>
<a href="https://rdar.apple.com/118680203">rdar://118680203</a>

Reviewed by NOBODY (OOPS!).

Add StyleAnimationData so we avoid copying animation lists when StyleMiscNonInheritedData
is copied by a copy-on-write.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/animation/AnimationList.cpp:
(WebCore::AnimationList::AnimationList):
* Source/WebCore/platform/animation/AnimationList.h:
(WebCore::AnimationList::copy const):
(WebCore::AnimationList::shallowCopy const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::adjustAnimations):
(WebCore::RenderStyle::adjustTransitions):
(WebCore::RenderStyle::ensureAnimations):
(WebCore::RenderStyle::ensureTransitions):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::animations const):
(WebCore::RenderStyle::transitions const):
(WebCore::RenderStyle::animations): Deleted.
(WebCore::RenderStyle::transitions): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::addToTextDecorationsInEffect):
(WebCore::RenderStyle::clearMaskLayers):
(WebCore::RenderStyle::clearAnimations): Deleted.
(WebCore::RenderStyle::clearTransitions): Deleted.
* Source/WebCore/rendering/style/StyleAnimationData.cpp: Added.
(WebCore::StyleAnimationData::StyleAnimationData):
(WebCore::StyleAnimationData::copy const):
(WebCore::StyleAnimationData::operator== const):
* Source/WebCore/rendering/style/StyleAnimationData.h: Added.
(WebCore::StyleAnimationData::create):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp:
(WebCore::StyleMiscNonInheritedData::StyleMiscNonInheritedData):
(WebCore::StyleMiscNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cb2f7fd88270f4b54a5d42e1181fd3bc58b6a23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24763 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3093 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24614 "Found 23 new test failures: animations/fill-unset-properties.html, imported/w3c/web-platform-tests/css/css-animations/animation-delay-011.html, imported/w3c/web-platform-tests/css/css-logical/animation-004.html, imported/w3c/web-platform-tests/css/css-transitions/events-004.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27344 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4559 "Found 7 new test failures: animations/fill-unset-properties.html, transitions/svg-transitions.html, transitions/transition-end-event-multiple-01.html, transitions/transition-end-event-multiple-02.html, transitions/transition-end-event-multiple-03.html, transitions/transition-end-event-nested.html, transitions/transition-end-event-set-none.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3948 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4078 "Found 16 new test failures: imported/w3c/web-platform-tests/css/css-animations/animation-delay-011.html, imported/w3c/web-platform-tests/css/css-logical/animation-004.html, imported/w3c/web-platform-tests/css/css-transitions/events-004.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24244 "Found 23 new test failures: animations/fill-unset-properties.html, imported/w3c/web-platform-tests/css/css-animations/animation-delay-011.html, imported/w3c/web-platform-tests/css/css-logical/animation-004.html, imported/w3c/web-platform-tests/css/css-transitions/events-004.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29926 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24761 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24655 "Found 22 new test failures: animations/fill-unset-properties.html, imported/w3c/web-platform-tests/css/css-animations/animation-delay-011.html, imported/w3c/web-platform-tests/css/css-logical/animation-004.html, imported/w3c/web-platform-tests/css/css-transitions/events-004.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30234 "Found 23 new test failures: animations/fill-unset-properties.html, imported/w3c/web-platform-tests/css/css-animations/animation-delay-011.html, imported/w3c/web-platform-tests/css/css-logical/animation-004.html, imported/w3c/web-platform-tests/css/css-transitions/events-004.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name.html ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4050 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2242 "Found 22 new test failures: animations/fill-unset-properties.html, imported/w3c/web-platform-tests/css/css-animations/animation-delay-011.html, imported/w3c/web-platform-tests/css/css-logical/animation-004.html, imported/w3c/web-platform-tests/css/css-transitions/events-004.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28151 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->