### PR TITLE
Add a runtime flag for ImageCapture

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3111,6 +3111,21 @@ ImageAnimationControlEnabled:
     WebCore:
       default: true
 
+ImageCaptureEnabled:
+  type: bool
+  status: testable
+  category: media
+  humanReadableName: "Image Capture API"
+  humanReadableDescription: "Enable Image Capture API"
+  condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ImageControlsEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/Modules/mediastream/ImageCapture.idl
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.idl
@@ -28,6 +28,8 @@
     Conditional=MEDIA_STREAM,
     SecureContext,
     JSGenerateToNativeObject,
+    EnabledBySetting=ImageCaptureEnabled,
+    DisabledByQuirk=shouldDisableImageCapture,
     Exposed=Window
 ] interface ImageCapture {
     [CallWith=CurrentDocument] constructor(MediaStreamTrack videoTrack);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -984,6 +984,18 @@ bool Quirks::shouldEnableLegacyGetUserMediaQuirk() const
     }
     return m_shouldEnableLegacyGetUserMediaQuirk.value();
 }
+
+// zoom.us rdar://118185086
+bool Quirks::shouldDisableImageCaptureQuirk() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_shouldDisableImageCaptureQuirk)
+        m_shouldDisableImageCaptureQuirk = isDomain("zoom.us"_s);
+
+    return m_shouldDisableImageCaptureQuirk.value();
+}
 #endif
 
 // hulu.com rdar://55041979

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -117,6 +117,7 @@ public:
 
 #if ENABLE(MEDIA_STREAM)
     bool shouldEnableLegacyGetUserMediaQuirk() const;
+    bool shouldDisableImageCaptureQuirk() const;
 #endif
 
     bool needsCanPlayAfterSeekedQuirk() const;
@@ -218,6 +219,7 @@ private:
     mutable std::optional<bool> m_requiresUserGestureToLoadInPictureInPicture;
 #if ENABLE(MEDIA_STREAM)
     mutable std::optional<bool> m_shouldEnableLegacyGetUserMediaQuirk;
+    mutable std::optional<bool> m_shouldDisableImageCaptureQuirk;
 #endif
     mutable std::optional<bool> m_blocksReturnToFullscreenFromPictureInPictureQuirk;
     mutable std::optional<bool> m_blocksEnteringStandardFullscreenFromPictureInPictureQuirk;


### PR DESCRIPTION
#### 41ea8e9bb119d2c158e03bb18e96f8688c254d34
<pre>
Add a runtime flag for ImageCapture
<a href="https://bugs.webkit.org/show_bug.cgi?id=265188">https://bugs.webkit.org/show_bug.cgi?id=265188</a>
<a href="https://rdar.apple.com/118185086">rdar://118185086</a>

Reviewed by Eric Carlson.

We add a runtime flag for ImageCapture to enable it or disable it.
We make it off by default.
We disable it even if enabled by default for zoom until we figure out what the issue might be.

Manually tested.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediastream/ImageCapture.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldAllowImageCaptureQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/271048@main">https://commits.webkit.org/271048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd5b7bc666faf22c3077840c39ce6c7c59b56b28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29330 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24645 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3979 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29965 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23619 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30269 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26302 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28190 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5554 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33758 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4553 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7316 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->