### PR TITLE
[GTK][WPE] Update `compositing/canvas/accelerated-canvas-compositing-size-limit.html` baseline

### DIFF
--- a/LayoutTests/platform/glib/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt
+++ b/LayoutTests/platform/glib/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt
@@ -1,0 +1,55 @@
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+Verifies Canvas 2D Context accelerated backing store behavior.
+
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 7
+        (GraphicsLayer
+          (position 112.00 94.00)
+          (anchor 0.50 0.49)
+          (bounds 100.00 57.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 216.00 94.00)
+          (anchor 0.50 0.49)
+          (bounds 100.00 57.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 320.00 94.00)
+          (bounds 100.00 56.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 424.00 94.00)
+          (bounds 100.00 56.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 528.00 96.00)
+          (bounds 100.00 54.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 632.00 112.00)
+          (anchor 0.50 0.49)
+          (bounds 100.00 39.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 8.00 154.00)
+          (bounds 100.00 32.00)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -360,7 +360,6 @@ webkit.org/b/99026 css3/filters/effect-drop-shadow.html [ ImageOnlyFailure ]
 webkit.org/b/99028 fast/autoresize [ Failure ]
 
 # Failures related with compositing tests.
-webkit.org/b/169918 compositing/canvas/accelerated-canvas-compositing-size-limit.html [ Failure ]
 webkit.org/b/169918 compositing/clipping/border-radius-overflow-hidden-stacking-context.html [ Failure ]
 webkit.org/b/169918 compositing/contents-opaque/control-layer.html [ Failure ]
 webkit.org/b/169918 compositing/contents-scale/animating.html [ Failure ]


### PR DESCRIPTION
#### c05882e9d7f64a7c897ff4e9baebd4cc0903231b
<pre>
[GTK][WPE] Update `compositing/canvas/accelerated-canvas-compositing-size-limit.html` baseline

Unreviewed test gardening.

We don&apos;t support accelerated drawing yet.

* LayoutTests/platform/glib/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt: Added.
* LayoutTests/platform/gtk/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/271051@main">https://commits.webkit.org/271051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22bdcd8627a40976c1e926055c107825038f4bd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24780 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24625 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29943 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30245 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28162 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5532 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6551 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->