### PR TITLE
InteractionRegions: guards should not interfere with other regions

### DIFF
--- a/LayoutTests/interaction-region/guard-overlap-expected.txt
+++ b/LayoutTests/interaction-region/guard-overlap-expected.txt
@@ -1,0 +1,29 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (0,0) width=100 height=10)
+        (borderRadius 0.00),
+        (interaction (0,10) width=50 height=10)
+        (borderRadius 0.00),
+        (interaction (0,40) width=100 height=25)
+        (borderRadius 0.00),
+        (guard (-10,55) width=30 height=30)
+        (borderRadius 0.00),
+        (interaction (0,65) width=10 height=10)
+        (borderRadius 0.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/guard-overlap.html
+++ b/LayoutTests/interaction-region/guard-overlap.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    .interaction {
+        height: 10px;
+        background-color: green;
+
+        cursor: pointer;
+    }
+</style>
+<body>
+<div class="interaction" style="width: 100px" onclick="click()"></div>
+<div class="interaction" style="width: 50px" onclick="click()"></div>
+
+<br />
+
+<div class="interaction" style="height: 25px; width: 100px" onclick="click()"></div>
+<div class="interaction" style="width: 10px" onclick="click()"></div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -33,12 +33,8 @@ Line
         (borderRadius 0 8 0 0),
         (interaction (6,109) width=107 height=12)
         (borderRadius 0 0 8 0),
-        (guard (6,111) width=71 height=32)
-        (borderRadius 0.00),
         (interaction (6,121) width=71 height=12)
         (borderRadius 0 0 8 0),
-        (guard (6,123) width=38 height=32)
-        (borderRadius 0.00),
         (interaction (6,133) width=38 height=12)
         (borderRadius 0 0 8 8)])
       )

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -58,6 +58,7 @@ public:
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     void uniteInteractionRegions(const Region&, RenderObject&);
     bool shouldConsolidateInteractionRegion(IntRect, RenderObject&);
+    void removeSuperfluousInteractionRegions();
     void shrinkWrapInteractionRegions();
     void copyInteractionRegionsToEventRegion();
 #endif


### PR DESCRIPTION
#### 3991417995d368c11e163508d7fcaf80bdb231d4
<pre>
InteractionRegions: guards should not interfere with other regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=265200">https://bugs.webkit.org/show_bug.cgi?id=265200</a>
&lt;<a href="https://rdar.apple.com/115893635">rdar://115893635</a>&gt;

Reviewed by Tim Horton.

When multiple small links are laid out in close proximity, the &quot;guards&quot;
regions we generate end up hurting more than they help.

At the end of the InteractionRegion generation process, filter out guards
that overlap with other regions too much.

* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
(WebCore::EventRegionContext::removeSuperfluousInteractionRegions):
Extract the final `removeAllMatching` pass on InteractionRegions to its
own method and add the guards filtering logic.
A guard shouldn&apos;t overlap with any interaction too much except:
- the interaction it is guarding
- any container interaction that fully contains the guard itself.
(WebCore::EventRegionContext::uniteInteractionRegions):
Stop adding guards for multi-rect regions. They are easily targetable as
a whole.

* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
Update expectations now that multi-rect regions don&apos;t get guards.
* LayoutTests/interaction-region/guard-overlap-expected.txt: Added.
* LayoutTests/interaction-region/guard-overlap.html: Added.
Add a new test covering the guards filtering logic.

Canonical link: <a href="https://commits.webkit.org/271269@main">https://commits.webkit.org/271269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebbd4d6a21da2198035460392b9a02eb1c7feac0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24634 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29950 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30257 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28178 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23999 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6688 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->