### PR TITLE
Move `verticalAlign` from `NonInheritedFlags` to `StyleBoxData`

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -210,7 +210,6 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.originalDisplay = static_cast<unsigned>(initialDisplay());
     m_nonInheritedFlags.overflowX = static_cast<unsigned>(initialOverflowX());
     m_nonInheritedFlags.overflowY = static_cast<unsigned>(initialOverflowY());
-    m_nonInheritedFlags.verticalAlign = static_cast<unsigned>(initialVerticalAlign());
     m_nonInheritedFlags.clear = static_cast<unsigned>(initialClear());
     m_nonInheritedFlags.position = static_cast<unsigned>(initialPosition());
     m_nonInheritedFlags.unicodeBidi = static_cast<unsigned>(initialUnicodeBidi());
@@ -393,7 +392,6 @@ inline void RenderStyle::NonInheritedFlags::copyNonInheritedFrom(const NonInheri
     originalDisplay = other.originalDisplay;
     overflowX = other.overflowX;
     overflowY = other.overflowY;
-    verticalAlign = other.verticalAlign;
     clear = other.clear;
     position = other.position;
     unicodeBidi = other.unicodeBidi;
@@ -959,7 +957,8 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
                 || m_nonInheritedData->boxData->maxHeight() != other.m_nonInheritedData->boxData->maxHeight())
                 return true;
 
-            if (m_nonInheritedData->boxData->verticalAlign() != other.m_nonInheritedData->boxData->verticalAlign())
+            if (m_nonInheritedData->boxData->verticalAlign() != other.m_nonInheritedData->boxData->verticalAlign()
+                || m_nonInheritedData->boxData->verticalAlignLength() != other.m_nonInheritedData->boxData->verticalAlignLength())
                 return true;
 
             if (m_nonInheritedData->boxData->boxSizing() != other.m_nonInheritedData->boxData->boxSizing())
@@ -1032,8 +1031,7 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
         || m_inheritedFlags.rtlOrdering != other.m_inheritedFlags.rtlOrdering
         || m_nonInheritedFlags.position != other.m_nonInheritedFlags.position
         || m_nonInheritedFlags.floating != other.m_nonInheritedFlags.floating
-        || m_nonInheritedFlags.originalDisplay != other.m_nonInheritedFlags.originalDisplay
-        || m_nonInheritedFlags.verticalAlign != other.m_nonInheritedFlags.verticalAlign)
+        || m_nonInheritedFlags.originalDisplay != other.m_nonInheritedFlags.originalDisplay)
         return true;
 
     if (static_cast<DisplayType>(m_nonInheritedFlags.effectiveDisplay) >= DisplayType::Table) {
@@ -1542,8 +1540,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyOverflowX);
         if (first.overflowY != second.overflowY)
             changingProperties.m_properties.set(CSSPropertyOverflowY);
-        if (first.verticalAlign != second.verticalAlign)
-            changingProperties.m_properties.set(CSSPropertyVerticalAlign);
         if (first.clear != second.clear)
             changingProperties.m_properties.set(CSSPropertyClear);
         if (first.position != second.position)
@@ -1601,7 +1597,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyMinHeight);
         if (first.maxHeight() != second.maxHeight())
             changingProperties.m_properties.set(CSSPropertyMaxHeight);
-        if (first.verticalAlign() != second.verticalAlign())
+        if (first.verticalAlign() != second.verticalAlign() || first.verticalAlignLength() != second.verticalAlignLength())
             changingProperties.m_properties.set(CSSPropertyVerticalAlign);
         if (first.specifiedZIndex() != second.specifiedZIndex() || first.hasAutoSpecifiedZIndex() != second.hasAutoSpecifiedZIndex())
             changingProperties.m_properties.set(CSSPropertyZIndex);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -505,7 +505,7 @@ public:
     inline OverscrollBehavior overscrollBehaviorY() const;
     
     Visibility visibility() const { return static_cast<Visibility>(m_inheritedFlags.visibility); }
-    VerticalAlign verticalAlign() const { return static_cast<VerticalAlign>(m_nonInheritedFlags.verticalAlign); }
+    VerticalAlign verticalAlign() const;
     const Length& verticalAlignLength() const;
 
     inline const Length& clipLeft() const;
@@ -1179,7 +1179,7 @@ public:
     inline void setOverscrollBehaviorX(OverscrollBehavior);
     inline void setOverscrollBehaviorY(OverscrollBehavior);
     void setVisibility(Visibility v) { m_inheritedFlags.visibility = static_cast<unsigned>(v); }
-    void setVerticalAlign(VerticalAlign v) { m_nonInheritedFlags.verticalAlign = static_cast<unsigned>(v); }
+    void setVerticalAlign(VerticalAlign);
     void setVerticalAlignLength(Length&&);
 
     inline void setHasClip(bool = true);
@@ -2164,7 +2164,6 @@ private:
         unsigned originalDisplay : 5; // DisplayType
         unsigned overflowX : 3; // Overflow
         unsigned overflowY : 3; // Overflow
-        unsigned verticalAlign : 4; // VerticalAlign
         unsigned clear : 3; // Clear
         unsigned position : 3; // PositionType
         unsigned unicodeBidi : 3; // UnicodeBidi

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -707,7 +707,8 @@ inline int RenderStyle::usedZIndex() const { return m_nonInheritedData->boxData-
 inline UserDrag RenderStyle::userDrag() const { return static_cast<UserDrag>(m_nonInheritedData->miscData->userDrag); }
 inline UserModify RenderStyle::userModify() const { return static_cast<UserModify>(m_rareInheritedData->userModify); }
 inline UserSelect RenderStyle::userSelect() const { return static_cast<UserSelect>(m_rareInheritedData->userSelect); }
-inline const Length& RenderStyle::verticalAlignLength() const { return m_nonInheritedData->boxData->verticalAlign(); }
+inline VerticalAlign RenderStyle::verticalAlign() const { return m_nonInheritedData->boxData->verticalAlign(); }
+inline const Length& RenderStyle::verticalAlignLength() const { return m_nonInheritedData->boxData->verticalAlignLength(); }
 inline const std::optional<Style::ScopedName>& RenderStyle::viewTransitionName() const { return m_nonInheritedData->rareData->viewTransitionName; }
 inline const StyleColor& RenderStyle::visitedLinkBackgroundColor() const { return m_nonInheritedData->miscData->visitedLinkColor->background; }
 inline const StyleColor& RenderStyle::visitedLinkBorderBottomColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderBottom; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -557,10 +557,15 @@ inline bool RenderStyle::setTextOrientation(TextOrientation textOrientation)
     return true;
 }
 
+inline void RenderStyle::setVerticalAlign(VerticalAlign align)
+{
+    SET_NESTED(m_nonInheritedData, boxData, m_verticalAlign, static_cast<unsigned>(align));
+}
+
 inline void RenderStyle::setVerticalAlignLength(Length&& length)
 {
     setVerticalAlign(VerticalAlign::Length);
-    SET_NESTED(m_nonInheritedData, boxData, m_verticalAlign, WTFMove(length));
+    SET_NESTED(m_nonInheritedData, boxData, m_verticalAlignLength, WTFMove(length));
 }
 
 inline void RenderStyle::setWidows(unsigned short count)

--- a/Source/WebCore/rendering/style/StyleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleBoxData.cpp
@@ -50,6 +50,7 @@ StyleBoxData::StyleBoxData()
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
     , m_boxDecorationBreak(static_cast<unsigned>(BoxDecorationBreak::Slice))
 #endif
+    , m_verticalAlign(static_cast<unsigned>(RenderStyle::initialVerticalAlign()))
 {
 }
 
@@ -61,7 +62,7 @@ inline StyleBoxData::StyleBoxData(const StyleBoxData& o)
     , m_maxWidth(o.m_maxWidth)
     , m_minHeight(o.m_minHeight)
     , m_maxHeight(o.m_maxHeight)
-    , m_verticalAlign(o.m_verticalAlign)
+    , m_verticalAlignLength(o.m_verticalAlignLength)
     , m_specifiedZIndex(o.m_specifiedZIndex)
     , m_usedZIndex(o.m_usedZIndex)
     , m_hasAutoSpecifiedZIndex(o.m_hasAutoSpecifiedZIndex)
@@ -70,6 +71,7 @@ inline StyleBoxData::StyleBoxData(const StyleBoxData& o)
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
     , m_boxDecorationBreak(o.m_boxDecorationBreak)
 #endif
+    , m_verticalAlign(o.m_verticalAlign)
 {
 }
 
@@ -86,7 +88,7 @@ bool StyleBoxData::operator==(const StyleBoxData& o) const
         && m_maxWidth == o.m_maxWidth
         && m_minHeight == o.m_minHeight
         && m_maxHeight == o.m_maxHeight
-        && m_verticalAlign == o.m_verticalAlign
+        && m_verticalAlignLength == o.m_verticalAlignLength
         && m_specifiedZIndex == o.m_specifiedZIndex
         && m_hasAutoSpecifiedZIndex == o.m_hasAutoSpecifiedZIndex
         && m_usedZIndex == o.m_usedZIndex
@@ -95,7 +97,7 @@ bool StyleBoxData::operator==(const StyleBoxData& o) const
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
         && m_boxDecorationBreak == o.m_boxDecorationBreak
 #endif
-        ;
+        && m_verticalAlign == o.m_verticalAlign;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleBoxData.h
@@ -49,7 +49,7 @@ public:
     const Length& maxWidth() const { return m_maxWidth; }
     const Length& maxHeight() const { return m_maxHeight; }
     
-    const Length& verticalAlign() const { return m_verticalAlign; }
+    const Length& verticalAlignLength() const { return m_verticalAlignLength; }
     
     int specifiedZIndex() const { return m_specifiedZIndex; }
     bool hasAutoSpecifiedZIndex() const { return m_hasAutoSpecifiedZIndex; }
@@ -61,6 +61,7 @@ public:
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
     BoxDecorationBreak boxDecorationBreak() const { return static_cast<BoxDecorationBreak>(m_boxDecorationBreak); }
 #endif
+    VerticalAlign verticalAlign() const { return static_cast<VerticalAlign>(m_verticalAlign); }
 
 private:
     friend class RenderStyle;
@@ -77,7 +78,7 @@ private:
     Length m_minHeight;
     Length m_maxHeight;
 
-    Length m_verticalAlign;
+    Length m_verticalAlignLength;
 
     int m_specifiedZIndex;
     int m_usedZIndex;
@@ -87,6 +88,7 @@ private:
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
     unsigned m_boxDecorationBreak : 1; // BoxDecorationBreak
 #endif
+    unsigned m_verticalAlign : 4; // VerticalAlign
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 86db6a29cf795a8a63cb052a2bd0be9d577ea109
<pre>
Move `verticalAlign` from `NonInheritedFlags` to `StyleBoxData`
<a href="https://bugs.webkit.org/show_bug.cgi?id=265210">https://bugs.webkit.org/show_bug.cgi?id=265210</a>
<a href="https://rdar.apple.com/118694983">rdar://118694983</a>

Reviewed by Cameron McCormack.

`verticalAlignLength` is already stored in `StyleBoxData`. Also move `verticalAlign` there to make room for view transition pseudo elements in `NonInheritedFlags`.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
(WebCore::RenderStyle::NonInheritedFlags::copyNonInheritedFrom):
(WebCore::RenderStyle::changeRequiresLayout const):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::verticalAlign const): Deleted.
(WebCore::RenderStyle::setVerticalAlign): Deleted.
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::verticalAlign const):
(WebCore::RenderStyle::verticalAlignLength const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setVerticalAlign):
(WebCore::RenderStyle::setVerticalAlignLength):
* Source/WebCore/rendering/style/StyleBoxData.cpp:
(WebCore::StyleBoxData::StyleBoxData):
(WebCore::StyleBoxData::operator== const):
* Source/WebCore/rendering/style/StyleBoxData.h:
(WebCore::StyleBoxData::verticalAlignLength const):
(WebCore::StyleBoxData::verticalAlign const):

Canonical link: <a href="https://commits.webkit.org/271028@main">https://commits.webkit.org/271028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d52201f56a5fd4df6885424bb0c37f1f321d9a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24649 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24769 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28192 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5558 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4557 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3506 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->