### PR TITLE
Add `scaleNonUniform` in DOMMatrixReadOnly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-002-expected.txt
@@ -3,7 +3,7 @@ Test DOMMatrixReadOnly methods do not mutate the object
 
 PASS test translate() doesn't mutate
 PASS test scale() doesn't mutate
-FAIL test scaleNonUniform() doesn't mutate matrix.scaleNonUniform is not a function. (In 'matrix.scaleNonUniform(1,5)', 'matrix.scaleNonUniform' is undefined)
+PASS test scaleNonUniform() doesn't mutate
 PASS test scale3d() doesn't mutate
 PASS test rotate() doesn't mutate
 PASS test rotateFromVector() doesn't mutate

--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-003-expected.txt
@@ -5,9 +5,9 @@ PASS test translate()
 PASS test scale() without offsets
 PASS test scale() with offsets
 PASS test scale() with identity scale and nonzero originZ
-FAIL test scaleNonUniform() initialDOMMatrix().scaleNonUniform is not a function. (In 'initialDOMMatrix().scaleNonUniform()', 'initialDOMMatrix().scaleNonUniform' is undefined)
-FAIL test scaleNonUniform() with sx initialDOMMatrix().scaleNonUniform is not a function. (In 'initialDOMMatrix().scaleNonUniform(6)', 'initialDOMMatrix().scaleNonUniform' is undefined)
-FAIL test scaleNonUniform() with sx, sy initialDOMMatrix().scaleNonUniform is not a function. (In 'initialDOMMatrix().scaleNonUniform(5, 7)', 'initialDOMMatrix().scaleNonUniform' is undefined)
+PASS test scaleNonUniform()
+PASS test scaleNonUniform() with sx
+PASS test scaleNonUniform() with sx, sy
 PASS test scale3d()
 PASS test rotate() 2d
 PASS test rotate()

--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/idlharness-expected.txt
@@ -200,7 +200,7 @@ PASS DOMMatrixReadOnly interface: attribute is2D
 PASS DOMMatrixReadOnly interface: attribute isIdentity
 PASS DOMMatrixReadOnly interface: operation translate(optional unrestricted double, optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation scale(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)
-FAIL DOMMatrixReadOnly interface: operation scaleNonUniform(optional unrestricted double, optional unrestricted double) assert_own_property: interface prototype object missing non-static operation expected property "scaleNonUniform" missing
+PASS DOMMatrixReadOnly interface: operation scaleNonUniform(optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation scale3d(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation rotate(optional unrestricted double, optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation rotateFromVector(optional unrestricted double, optional unrestricted double)
@@ -252,8 +252,8 @@ PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property 
 PASS DOMMatrixReadOnly interface: calling translate(optional unrestricted double, optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
 PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scale(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)" with the proper type
 PASS DOMMatrixReadOnly interface: calling scale(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
-FAIL DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scaleNonUniform(optional unrestricted double, optional unrestricted double)" with the proper type assert_inherits: property "scaleNonUniform" not found in prototype chain
-FAIL DOMMatrixReadOnly interface: calling scaleNonUniform(optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError assert_inherits: property "scaleNonUniform" not found in prototype chain
+PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scaleNonUniform(optional unrestricted double, optional unrestricted double)" with the proper type
+PASS DOMMatrixReadOnly interface: calling scaleNonUniform(optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
 PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scale3d(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)" with the proper type
 PASS DOMMatrixReadOnly interface: calling scale3d(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
 PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "rotate(optional unrestricted double, optional unrestricted double, optional unrestricted double)" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/idlharness.worker-expected.txt
@@ -180,7 +180,7 @@ PASS DOMMatrixReadOnly interface: attribute is2D
 PASS DOMMatrixReadOnly interface: attribute isIdentity
 PASS DOMMatrixReadOnly interface: operation translate(optional unrestricted double, optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation scale(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)
-FAIL DOMMatrixReadOnly interface: operation scaleNonUniform(optional unrestricted double, optional unrestricted double) assert_own_property: interface prototype object missing non-static operation expected property "scaleNonUniform" missing
+PASS DOMMatrixReadOnly interface: operation scaleNonUniform(optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation scale3d(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation rotate(optional unrestricted double, optional unrestricted double, optional unrestricted double)
 PASS DOMMatrixReadOnly interface: operation rotateFromVector(optional unrestricted double, optional unrestricted double)
@@ -232,8 +232,8 @@ PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property 
 PASS DOMMatrixReadOnly interface: calling translate(optional unrestricted double, optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
 PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scale(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)" with the proper type
 PASS DOMMatrixReadOnly interface: calling scale(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
-FAIL DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scaleNonUniform(optional unrestricted double, optional unrestricted double)" with the proper type assert_inherits: property "scaleNonUniform" not found in prototype chain
-FAIL DOMMatrixReadOnly interface: calling scaleNonUniform(optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError assert_inherits: property "scaleNonUniform" not found in prototype chain
+PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scaleNonUniform(optional unrestricted double, optional unrestricted double)" with the proper type
+PASS DOMMatrixReadOnly interface: calling scaleNonUniform(optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
 PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "scale3d(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double)" with the proper type
 PASS DOMMatrixReadOnly interface: calling scale3d(optional unrestricted double, optional unrestricted double, optional unrestricted double, optional unrestricted double) on new DOMMatrixReadOnly() with too few arguments must throw TypeError
 PASS DOMMatrixReadOnly interface: new DOMMatrixReadOnly() must inherit property "rotate(optional unrestricted double, optional unrestricted double, optional unrestricted double)" with the proper type

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -304,6 +304,12 @@ Ref<DOMMatrix> DOMMatrixReadOnly::scale3d(double scale, double originX, double o
     return matrix->scale3dSelf(scale, originX, originY, originZ);
 }
 
+Ref<DOMMatrix> DOMMatrixReadOnly::scaleNonUniform(double scaleX, double scaleY)
+{
+    auto matrix = cloneAsDOMMatrix();
+    return matrix->scaleSelf(scaleX, scaleY, 1, 0, 0, 0);
+}
+
 Ref<DOMMatrix> DOMMatrixReadOnly::rotate(double rotX, std::optional<double> rotY, std::optional<double> rotZ)
 {
     auto matrix = cloneAsDOMMatrix();

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -102,6 +102,7 @@ public:
     Ref<DOMMatrix> flipY();
     Ref<DOMMatrix> scale(double scaleX = 1, std::optional<double> scaleY = std::nullopt, double scaleZ = 1, double originX = 0, double originY = 0, double originZ = 0);
     Ref<DOMMatrix> scale3d(double scale = 1, double originX = 0, double originY = 0, double originZ = 0);
+    Ref<DOMMatrix> scaleNonUniform(double scaleX = 1, double scaleY = 1);
     Ref<DOMMatrix> rotate(double rotX = 0, std::optional<double> rotY = std::nullopt, std::optional<double> rotZ = std::nullopt); // Angles are in degrees.
     Ref<DOMMatrix> rotateFromVector(double x = 0, double y = 0);
     Ref<DOMMatrix> rotateAxisAngle(double x = 0, double y = 0, double z = 0, double angle = 0); // Angle is in degrees.

--- a/Source/WebCore/css/DOMMatrixReadOnly.idl
+++ b/Source/WebCore/css/DOMMatrixReadOnly.idl
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://drafts.fxtf.org/geometry/#dommatrixreadonly
+
 [
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,Worker),
@@ -76,6 +78,8 @@
                                   optional unrestricted double originX = 0,
                                   optional unrestricted double originY = 0,
                                   optional unrestricted double originZ = 0);
+    [NewObject] DOMMatrix scaleNonUniform(optional unrestricted double scaleX = 1,
+                                          optional unrestricted double scaleY = 1);
     [NewObject] DOMMatrix rotate(optional unrestricted double rotX = 0,
                                  optional unrestricted double rotY,
                                  optional unrestricted double rotZ); // Angles are in degrees.


### PR DESCRIPTION
#### d0f9805c729a97f2064c8572d921cda961b96eb5
<pre>
Add `scaleNonUniform` in DOMMatrixReadOnly

<a href="https://bugs.webkit.org/show_bug.cgi?id=263748">https://bugs.webkit.org/show_bug.cgi?id=263748</a>
<a href="https://rdar.apple.com/problem/117875678">rdar://problem/117875678</a>

Reviewed by Matt Woodrow.

This patch is to align WebKit with Blink / Chromium, Gecko / Firefox and Web-Specification [1]
by adding &apos;scaleNonUniform&apos; support:

[1] <a href="https://drafts.fxtf.org/geometry/#dommatrixreadonly">https://drafts.fxtf.org/geometry/#dommatrixreadonly</a>

* Source/WebCore/css/DOMMatrixReadOnly.cpp:
(DOMMatrixReadOnly::scaleNonUniform):
* Source/WebCore/css/DOMMatrixReadOnly.h:
* Source/WebCore/css/DOMMatrixReadOnly.idl:
* LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-002-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-003-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/css/geometry/idlharness-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/css/geometry/idlharness.worker-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/271030@main">https://commits.webkit.org/271030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b24c57b185822318ce5f1c5801387b23635b1da7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24819 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27402 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/4583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/23293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/3992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/24290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29983 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/24784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/5569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3508 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/4484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->