### PR TITLE
Draft: trying to re-implement kerning for Text fast path

### DIFF
--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -111,6 +111,15 @@ public:
         m_offsetsInString.append(offsetInString);
     }
 
+    void add(const GlyphBuffer& glyphBuffer, unsigned from, unsigned len)
+    {
+        m_fonts.append(glyphBuffer.fonts(from), len);
+        m_glyphs.append(glyphBuffer.glyphs(from), len);
+        m_advances.append(glyphBuffer.advances(from), len);
+        m_origins.append(glyphBuffer.origins(from), len);
+        m_offsetsInString.append(glyphBuffer.offsetsInString(from), len);
+    }
+
     void remove(unsigned location, unsigned length)
     {
         m_fonts.remove(location, length);

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -60,6 +60,7 @@ WidthIterator::WidthIterator(const FontCascade& font, const TextRun& run, WeakHa
         else
             m_expansionPerOpportunity = m_expansion / expansionOpportunityCount;
     }
+    m_characterIndexOfGlyph.reserveInitialCapacity(m_run->length());
 }
 
 struct OriginalAdvancesForCharacterTreatedAsSpace {
@@ -431,6 +432,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
             commitCurrentFontRange(advanceInternalState);
 
             addToGlyphBuffer(advanceInternalState.glyphBuffer, deletedGlyph, primaryFont, 0, advanceInternalState.currentCharacterIndex, characterToWrite);
+            m_characterIndexOfGlyph.append(advanceInternalState.currentCharacterIndex);
 
             textIterator.advance(advanceLength);
             advanceInternalState.currentCharacterIndex = textIterator.currentIndex();
@@ -454,6 +456,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
             glyph = deletedGlyph;
 
         addToGlyphBuffer(glyphBuffer, glyph, *advanceInternalState.nextRangeFont, width, advanceInternalState.currentCharacterIndex, characterToWrite);
+        m_characterIndexOfGlyph.append(advanceInternalState.currentCharacterIndex);
 
         // Advance past the character we just dealt with.
         textIterator.advance(advanceLength);
@@ -813,17 +816,4 @@ void WidthIterator::advance(unsigned offset, GlyphBuffer& glyphBuffer)
 
     applyCSSVisibilityRules(glyphBuffer, glyphBufferStartIndex);
 }
-
-// FIXME: It's pretty much never right to advance just one character.
-bool WidthIterator::advanceOneCharacter(float& width, GlyphBuffer& glyphBuffer)
-{
-    unsigned oldSize = glyphBuffer.size();
-    advance(m_currentCharacterIndex + 1, glyphBuffer);
-    float w = 0;
-    for (unsigned i = oldSize; i < glyphBuffer.size(); ++i)
-        w += WebCore::width(glyphBuffer.advanceAt(i));
-    width = w;
-    return glyphBuffer.size() > oldSize;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/WidthIterator.h
+++ b/Source/WebCore/platform/graphics/WidthIterator.h
@@ -48,7 +48,6 @@ public:
     WidthIterator(const FontCascade&, const TextRun&, WeakHashSet<const Font>* fallbackFonts = 0, bool accountForGlyphBounds = false, bool forTextEmphasis = false);
 
     void advance(unsigned to, GlyphBuffer&);
-    bool advanceOneCharacter(float& width, GlyphBuffer&);
     void finalize(GlyphBuffer&);
 
     float maxGlyphBoundingBoxY() const { ASSERT(m_accountForGlyphBounds); return m_maxGlyphBoundingBoxY; }
@@ -61,6 +60,7 @@ public:
     unsigned currentCharacterIndex() const { return m_currentCharacterIndex; }
 
     static bool characterCanUseSimplifiedTextMeasuring(UChar32, bool whitespaceIsCollapsed);
+    Vector<unsigned, 10> m_characterIndexOfGlyph;
 
 private:
     GlyphData glyphDataForCharacter(UChar32, bool mirror);


### PR DESCRIPTION
#### 7200231ce0875bdc39bb4c9c520eaf44725794cf
<pre>
Draft: trying to re-implement kerning for Text fast path
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

The following patches by Allan Sandfeld Jensen were reverted
because they broke text selection for ligatures.
We are trying to re-implement it but enable the fast path
just for kerning and not for ligatures.

In the future we will try to optmize this patch, for now
we just want to see if it correct (from our tests perspective)
and if it does not regress perfromance.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthOfTextRange const):
(WebCore::FontCascade::codePath const):
(WebCore::FontCascade::layoutSimpleText const):
(WebCore::FontCascade::adjustSelectionRectForSimpleText const):
(WebCore::FontCascade::offsetForPositionForSimpleText const):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::add):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::WidthIterator):
(WebCore::WidthIterator::advanceInternal):
(WebCore::WidthIterator::advance):
(WebCore::WidthIterator::advanceOneCharacter): Deleted.
* Source/WebCore/platform/graphics/WidthIterator.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7200231ce0875bdc39bb4c9c520eaf44725794cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24961 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24785 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27541 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4713 "Found 1 new test failure: fast/text/ruby-justification-flush.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4111 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4232 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24410 "Found 15 new test failures: fast/ruby/ruby-expansion-cjk-2.html, fast/ruby/ruby-expansion-cjk-3.html, fast/ruby/ruby-expansion-cjk-4.html, fast/ruby/ruby-expansion-cjk.html, fast/ruby/ruby-justification.html, fast/text/ruby-justification-flush.html, fast/text/simple-line-layout-hyphen-limit-lines.html, imported/w3c/web-platform-tests/css/cssom-view/getBoundingClientRect-shy.html, svg/text/select-textLength-spacingAndGlyphs-squeeze-1.svg, svg/text/select-textLength-spacingAndGlyphs-squeeze-2.svg ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24912 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24827 "Found 15 new test failures: fast/ruby/ruby-expansion-cjk-2.html, fast/ruby/ruby-expansion-cjk-3.html, fast/ruby/ruby-expansion-cjk-4.html, fast/ruby/ruby-expansion-cjk.html, fast/ruby/ruby-justification.html, fast/text/ruby-justification-flush.html, fast/text/simple-line-layout-hyphen-limit-lines.html, imported/w3c/web-platform-tests/css/cssom-view/getBoundingClientRect-shy.html, svg/text/select-textLength-spacingAndGlyphs-squeeze-1.svg, svg/text/select-textLength-spacingAndGlyphs-squeeze-2.svg ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30400 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4264 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2411 "Found 15 new test failures: fast/ruby/ruby-expansion-cjk-2.html, fast/ruby/ruby-expansion-cjk-3.html, fast/ruby/ruby-expansion-cjk-4.html, fast/ruby/ruby-expansion-cjk.html, fast/ruby/ruby-justification.html, fast/text/ruby-justification-flush.html, fast/text/simple-line-layout-hyphen-limit-lines.html, imported/w3c/web-platform-tests/css/cssom-view/getBoundingClientRect-shy.html, svg/text/select-textLength-spacingAndGlyphs-squeeze-1.svg, svg/text/select-textLength-spacingAndGlyphs-squeeze-2.svg ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28344 "Found 10 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/long-expires, /TestWebCore:GStreamerTest.harnessDecodeMP4Video, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5730 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->