### PR TITLE
Remove TextTrackCue constructor

### DIFF
--- a/Source/WebCore/html/track/TextTrackCue.idl
+++ b/Source/WebCore/html/track/TextTrackCue.idl
@@ -46,7 +46,5 @@
     attribute EventHandler onenter;
     attribute EventHandler onexit;
 
-    // FIXME: Add 'unrestricted' to 'endTime' to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260765
-    [CallWith=CurrentDocument] constructor(double startTime, double endTime, DocumentFragment cueNode);
     [EnabledBySetting=GenericCueAPIEnabled] DocumentFragment getCueAsHTML();
 };


### PR DESCRIPTION
<pre>
Remove TextTrackCue constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=129615">https://bugs.webkit.org/show_bug.cgi?id=129615</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Blink / Chromium, Geck / Firefox and Web-Specification [1]:

[1] <a href="https://html.spec.whatwg.org/#texttrackcue">https://html.spec.whatwg.org/#texttrackcue</a>

This constructor was removed from Blink in 2014 and from Web-Specification as well.

* Source/WebCore/html/track/TextTrackCue.idl:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b970a61e33b07adca5e2d8d248cd72db8c50b4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24805 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27583 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/7643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3136 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24647 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/constructor.html, media/track/texttrackcue/texttrackcue-addcue.html, media/track/texttrackcue/texttrackcue-constructor.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27387 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4569 "Found 2 new test failures: media/track/texttrackcue/texttrackcue-addcue.html, media/track/texttrackcue/texttrackcue-constructor.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3982 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4088 "Unexpected infrastructure issue, retrying build") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24280 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/constructor.html, media/track/texttrackcue/texttrackcue-addcue.html, media/track/texttrackcue/texttrackcue-constructor.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24771 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24691 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/constructor.html, media/track/texttrackcue/texttrackcue-addcue.html, media/track/texttrackcue/texttrackcue-constructor.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30270 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/constructor.html, media/track/texttrackcue/texttrackcue-addcue.html, media/track/texttrackcue/texttrackcue-constructor.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4093 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2281 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/interfaces/TextTrackCue/constructor.html, media/track/texttrackcue/texttrackcue-addcue.html, media/track/texttrackcue/texttrackcue-constructor.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28191 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5557 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->