### PR TITLE
Move `hasExplicitlySet{Direction|WritingMode}` from `NonInheritedFlags` into `StyleMiscNonInheritedData`

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -216,8 +216,6 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.floating = static_cast<unsigned>(initialFloating());
     m_nonInheritedFlags.tableLayout = static_cast<unsigned>(initialTableLayout());
     m_nonInheritedFlags.textDecorationLine = initialTextDecorationLine().toRaw();
-    m_nonInheritedFlags.hasExplicitlySetDirection = false;
-    m_nonInheritedFlags.hasExplicitlySetWritingMode = false;
     m_nonInheritedFlags.usesViewportUnits = false;
     m_nonInheritedFlags.usesContainerUnits = false;
     m_nonInheritedFlags.hasExplicitlyInheritedProperties = false;
@@ -398,8 +396,6 @@ inline void RenderStyle::NonInheritedFlags::copyNonInheritedFrom(const NonInheri
     floating = other.floating;
     tableLayout = other.tableLayout;
     textDecorationLine = other.textDecorationLine;
-    hasExplicitlySetDirection = other.hasExplicitlySetDirection;
-    hasExplicitlySetWritingMode = other.hasExplicitlySetWritingMode;
     usesViewportUnits = other.usesViewportUnits;
     usesContainerUnits = other.usesContainerUnits;
     hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
@@ -1555,8 +1551,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // effectiveDisplay
         // originalDisplay
         // unicodeBidi
-        // hasExplicitlySetDirection
-        // hasExplicitlySetWritingMode
         // usesViewportUnits
         // usesContainerUnits
         // hasExplicitlyInheritedProperties
@@ -1803,6 +1797,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // deprecatedFlexibleBox
         // hasAttrContent
         // hasExplicitlySetColorScheme
+        // hasExplicitlySetDirection
+        // hasExplicitlySetWritingMode
         // appearance
         // effectiveAppearance
         // userDrag

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -569,7 +569,7 @@ public:
 
     TextDirection direction() const { return static_cast<TextDirection>(m_inheritedFlags.direction); }
     inline bool isLeftToRightDirection() const;
-    bool hasExplicitlySetDirection() const { return m_nonInheritedFlags.hasExplicitlySetDirection; }
+    inline bool hasExplicitlySetDirection() const;
 
     const Length& specifiedLineHeight() const;
     WEBCORE_EXPORT const Length& lineHeight() const;
@@ -1222,7 +1222,7 @@ public:
     inline void setTextUnderlineOffset(TextUnderlineOffset);
     inline void setTextDecorationThickness(TextDecorationThickness);
     void setDirection(TextDirection v) { m_inheritedFlags.direction = static_cast<unsigned>(v); }
-    void setHasExplicitlySetDirection(bool v) { m_nonInheritedFlags.hasExplicitlySetDirection = v; }
+    inline void setHasExplicitlySetDirection();
     void setLineHeight(Length&&);
     bool setZoom(float);
     void setZoomWithoutReturnValue(float f) { setZoom(f); }
@@ -1740,8 +1740,8 @@ public:
 
     inline bool setWritingMode(WritingMode);
 
-    bool hasExplicitlySetWritingMode() const { return m_nonInheritedFlags.hasExplicitlySetWritingMode; }
-    void setHasExplicitlySetWritingMode(bool v) { m_nonInheritedFlags.hasExplicitlySetWritingMode = v; }
+    inline bool hasExplicitlySetWritingMode() const;
+    inline void setHasExplicitlySetWritingMode();
 
     // A unique style is one that has matches something that makes it impossible to share.
     bool unique() const { return m_nonInheritedFlags.isUnique; }
@@ -2171,8 +2171,6 @@ private:
         unsigned tableLayout : 1; // TableLayoutType
         unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
 
-        unsigned hasExplicitlySetDirection : 1;
-        unsigned hasExplicitlySetWritingMode : 1;
         unsigned usesViewportUnits : 1;
         unsigned usesContainerUnits : 1;
         unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -773,6 +773,9 @@ inline bool RenderStyle::hasBackdropFilter() const { return !backdropFilter().op
 inline FilterOperations RenderStyle::initialBackdropFilter() { return { }; }
 #endif
 
+inline bool RenderStyle::hasExplicitlySetDirection() const { return m_nonInheritedData->miscData->hasExplicitlySetDirection; }
+inline bool RenderStyle::hasExplicitlySetWritingMode() const { return m_nonInheritedData->miscData->hasExplicitlySetWritingMode; }
+
 #if PLATFORM(IOS_FAMILY)
 inline bool RenderStyle::touchCalloutEnabled() const { return m_rareInheritedData->touchCalloutEnabled; }
 #endif

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -476,6 +476,16 @@ inline void RenderStyle::setGridRowList(const GridTrackList& list)
         m_nonInheritedData.access().rareData.access().grid.access().setRows(list);
 }
 
+inline void RenderStyle::setHasExplicitlySetDirection()
+{
+    SET_NESTED(m_nonInheritedData, miscData, hasExplicitlySetDirection, true);
+}
+
+inline void RenderStyle::setHasExplicitlySetWritingMode()
+{
+    SET_NESTED(m_nonInheritedData, miscData, hasExplicitlySetWritingMode, true);
+}
+
 inline void RenderStyle::setLogicalHeight(Length&& height)
 {
     if (isHorizontalWritingMode())

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -101,6 +101,8 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData(const StyleMiscNonInherited
 #if ENABLE(DARK_MODE_CSS)
     , hasExplicitlySetColorScheme(o.hasExplicitlySetColorScheme)
 #endif
+    , hasExplicitlySetDirection(o.hasExplicitlySetDirection)
+    , hasExplicitlySetWritingMode(o.hasExplicitlySetWritingMode)
     , aspectRatioType(o.aspectRatioType)
     , appearance(o.appearance)
     , effectiveAppearance(o.effectiveAppearance)
@@ -147,6 +149,8 @@ bool StyleMiscNonInheritedData::operator==(const StyleMiscNonInheritedData& o) c
 #if ENABLE(DARK_MODE_CSS)
         && hasExplicitlySetColorScheme == o.hasExplicitlySetColorScheme
 #endif
+        && hasExplicitlySetDirection == o.hasExplicitlySetDirection
+        && hasExplicitlySetWritingMode == o.hasExplicitlySetWritingMode
         && aspectRatioType == o.aspectRatioType
         && appearance == o.appearance
         && effectiveAppearance == o.effectiveAppearance

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -94,6 +94,8 @@ public:
 #if ENABLE(DARK_MODE_CSS)
     unsigned hasExplicitlySetColorScheme : 1 { false };
 #endif
+    unsigned hasExplicitlySetDirection : 1 { false };
+    unsigned hasExplicitlySetWritingMode : 1 { false };
     unsigned aspectRatioType : 2; // AspectRatioType
     unsigned appearance : appearanceBitWidth; // EAppearance
     unsigned effectiveAppearance : appearanceBitWidth; // EAppearance

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -185,7 +185,7 @@ private:
 inline void BuilderCustom::applyValueDirection(BuilderState& builderState, CSSValue& value)
 {
     builderState.style().setDirection(fromCSSValue<TextDirection>(value));
-    builderState.style().setHasExplicitlySetDirection(true);
+    builderState.style().setHasExplicitlySetDirection();
 }
 
 inline void BuilderCustom::resetEffectiveZoom(BuilderState& builderState)
@@ -815,7 +815,7 @@ inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CS
 inline void BuilderCustom::applyValueWritingMode(BuilderState& builderState, CSSValue& value)
 {
     builderState.setWritingMode(fromCSSValue<WritingMode>(value));
-    builderState.style().setHasExplicitlySetWritingMode(true);
+    builderState.style().setHasExplicitlySetWritingMode();
 }
 
 inline void BuilderCustom::applyValueTextOrientation(BuilderState& builderState, CSSValue& value)


### PR DESCRIPTION
#### a64ff93835bb7ea77d63c0b36e07ec878f8cefdf
<pre>
Move `hasExplicitlySet{Direction|WritingMode}` from `NonInheritedFlags` into `StyleMiscNonInheritedData`
<a href="https://bugs.webkit.org/show_bug.cgi?id=265217">https://bugs.webkit.org/show_bug.cgi?id=265217</a>
<a href="https://rdar.apple.com/118697101">rdar://118697101</a>

Reviewed by Cameron McCormack and Timothy Hatcher.

Make room for view transitions pseudo elements.

Remove the setter argument to be consistent with `hasExplicitlySetColorScheme`.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
(WebCore::RenderStyle::NonInheritedFlags::copyNonInheritedFrom):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::hasExplicitlySetDirection const): Deleted.
(WebCore::RenderStyle::setHasExplicitlySetDirection): Deleted.
(WebCore::RenderStyle::hasExplicitlySetWritingMode const): Deleted.
(WebCore::RenderStyle::setHasExplicitlySetWritingMode): Deleted.
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasExplicitlySetDirection const):
(WebCore::RenderStyle::hasExplicitlySetWritingMode const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setHasExplicitlySetDirection):
(WebCore::RenderStyle::setHasExplicitlySetWritingMode):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp:
(WebCore::StyleMiscNonInheritedData::StyleMiscNonInheritedData):
(WebCore::StyleMiscNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueDirection):
(WebCore::Style::BuilderCustom::applyValueWritingMode):

Canonical link: <a href="https://commits.webkit.org/271029@main">https://commits.webkit.org/271029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e2e37ce0499fe0c1a88b7542079f960cb2d908c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3140 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3988 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24697 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28197 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5561 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6516 "") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4560 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3507 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->