### PR TITLE
Use dynamicDowncast<T> more in css/

### DIFF
--- a/Source/WebCore/css/BasicShapeFunctions.cpp
+++ b/Source/WebCore/css/BasicShapeFunctions.cpp
@@ -225,78 +225,71 @@ static BasicShapeRadius cssValueToBasicShapeRadius(const CSSToLengthConversionDa
 
 Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData& conversionData, const CSSValue& value, float zoom)
 {
-    if (value.isCircle()) {
-        auto& circleValue = downcast<CSSCircleValue>(value);
+    if (auto* circleValue = dynamicDowncast<CSSCircleValue>(value)) {
         auto circle = BasicShapeCircle::create();
-        circle->setRadius(cssValueToBasicShapeRadius(conversionData, circleValue.radius()));
-        circle->setCenterX(convertToCenterCoordinate(conversionData, circleValue.centerX()));
-        circle->setCenterY(convertToCenterCoordinate(conversionData, circleValue.centerY()));
-        circle->setPositionWasOmitted(!circleValue.centerX() && !circleValue.centerY());
+        circle->setRadius(cssValueToBasicShapeRadius(conversionData, circleValue->radius()));
+        circle->setCenterX(convertToCenterCoordinate(conversionData, circleValue->centerX()));
+        circle->setCenterY(convertToCenterCoordinate(conversionData, circleValue->centerY()));
+        circle->setPositionWasOmitted(!circleValue->centerX() && !circleValue->centerY());
         return circle;
     }
-    if (value.isEllipse()) {
-        auto& ellipseValue = downcast<CSSEllipseValue>(value);
+    if (auto* ellipseValue = dynamicDowncast<CSSEllipseValue>(value)) {
         auto ellipse = BasicShapeEllipse::create();
-        ellipse->setRadiusX(cssValueToBasicShapeRadius(conversionData, ellipseValue.radiusX()));
-        ellipse->setRadiusY(cssValueToBasicShapeRadius(conversionData, ellipseValue.radiusY()));
-        ellipse->setCenterX(convertToCenterCoordinate(conversionData, ellipseValue.centerX()));
-        ellipse->setCenterY(convertToCenterCoordinate(conversionData, ellipseValue.centerY()));
-        ellipse->setPositionWasOmitted(!ellipseValue.centerX() && !ellipseValue.centerY());
+        ellipse->setRadiusX(cssValueToBasicShapeRadius(conversionData, ellipseValue->radiusX()));
+        ellipse->setRadiusY(cssValueToBasicShapeRadius(conversionData, ellipseValue->radiusY()));
+        ellipse->setCenterX(convertToCenterCoordinate(conversionData, ellipseValue->centerX()));
+        ellipse->setCenterY(convertToCenterCoordinate(conversionData, ellipseValue->centerY()));
+        ellipse->setPositionWasOmitted(!ellipseValue->centerX() && !ellipseValue->centerY());
         return ellipse;
     }
-    if (value.isPolygon()) {
-        auto& polygonValue = downcast<CSSPolygonValue>(value);
+    if (auto* polygonValue = dynamicDowncast<CSSPolygonValue>(value)) {
         auto polygon = BasicShapePolygon::create();
-        polygon->setWindRule(polygonValue.windRule());
-        for (unsigned i = 0; i < polygonValue.size(); i += 2)
-            polygon->appendPoint(convertToLength(conversionData, *polygonValue.item(i)), convertToLength(conversionData, *polygonValue.item(i + 1)));
+        polygon->setWindRule(polygonValue->windRule());
+        for (unsigned i = 0; i < polygonValue->size(); i += 2)
+            polygon->appendPoint(convertToLength(conversionData, *polygonValue->item(i)), convertToLength(conversionData, *polygonValue->item(i + 1)));
         return polygon;
     }
-    if (value.isInsetShape()) {
-        auto& rectValue = downcast<CSSInsetShapeValue>(value);
+    if (auto* rectValue = dynamicDowncast<CSSInsetShapeValue>(value)) {
         auto rect = BasicShapeInset::create();
-        rect->setTop(convertToLength(conversionData, rectValue.top()));
-        rect->setRight(convertToLength(conversionData, rectValue.right()));
-        rect->setBottom(convertToLength(conversionData, rectValue.bottom()));
-        rect->setLeft(convertToLength(conversionData, rectValue.left()));
-        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue.topLeftRadius()));
-        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue.topRightRadius()));
-        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue.bottomRightRadius()));
-        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue.bottomLeftRadius()));
+        rect->setTop(convertToLength(conversionData, rectValue->top()));
+        rect->setRight(convertToLength(conversionData, rectValue->right()));
+        rect->setBottom(convertToLength(conversionData, rectValue->bottom()));
+        rect->setLeft(convertToLength(conversionData, rectValue->left()));
+        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->topLeftRadius()));
+        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->topRightRadius()));
+        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->bottomRightRadius()));
+        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->bottomLeftRadius()));
         return rect;
     }
-    if (value.isXywhShape()) {
-        auto& rectValue = downcast<CSSXywhValue>(value);
+    if (auto* rectValue = dynamicDowncast<CSSXywhValue>(value)) {
         auto rect = BasicShapeXywh::create();
-        rect->setInsetX(convertToLength(conversionData, rectValue.insetX()));
-        rect->setInsetY(convertToLength(conversionData, rectValue.insetY()));
-        rect->setWidth(convertToLength(conversionData, rectValue.width()));
-        rect->setHeight(convertToLength(conversionData, rectValue.height()));
+        rect->setInsetX(convertToLength(conversionData, rectValue->insetX()));
+        rect->setInsetY(convertToLength(conversionData, rectValue->insetY()));
+        rect->setWidth(convertToLength(conversionData, rectValue->width()));
+        rect->setHeight(convertToLength(conversionData, rectValue->height()));
 
-        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue.topLeftRadius()));
-        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue.topRightRadius()));
-        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue.bottomRightRadius()));
-        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue.bottomLeftRadius()));
+        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->topLeftRadius()));
+        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->topRightRadius()));
+        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->bottomRightRadius()));
+        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->bottomLeftRadius()));
         return rect;
     }
-    if (value.isRectShape()) {
-        auto& rectValue = downcast<CSSRectShapeValue>(value);
+    if (auto* rectValue = dynamicDowncast<CSSRectShapeValue>(value)) {
         auto rect = BasicShapeRect::create();
-        rect->setTop(convertToLengthOrAuto(conversionData, rectValue.top()));
-        rect->setRight(convertToLengthOrAuto(conversionData, rectValue.right()));
-        rect->setBottom(convertToLengthOrAuto(conversionData, rectValue.bottom()));
-        rect->setLeft(convertToLengthOrAuto(conversionData, rectValue.left()));
+        rect->setTop(convertToLengthOrAuto(conversionData, rectValue->top()));
+        rect->setRight(convertToLengthOrAuto(conversionData, rectValue->right()));
+        rect->setBottom(convertToLengthOrAuto(conversionData, rectValue->bottom()));
+        rect->setLeft(convertToLengthOrAuto(conversionData, rectValue->left()));
 
-        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue.topLeftRadius()));
-        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue.topRightRadius()));
-        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue.bottomRightRadius()));
-        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue.bottomLeftRadius()));
+        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->topLeftRadius()));
+        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->topRightRadius()));
+        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->bottomRightRadius()));
+        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->bottomLeftRadius()));
         return rect;
     }
-    if (value.isPath()) {
-        auto& pathValue = downcast<CSSPathValue>(value);
-        auto path = BasicShapePath::create(pathValue.pathData().copy());
-        path->setWindRule(pathValue.windRule());
+    if (auto* pathValue = dynamicDowncast<CSSPathValue>(value)) {
+        auto path = BasicShapePath::create(pathValue->pathData().copy());
+        path->setWindRule(pathValue->windRule());
         path->setZoom(zoom);
         return path;
     }

--- a/Source/WebCore/css/CSSBasicShapes.cpp
+++ b/Source/WebCore/css/CSSBasicShapes.cpp
@@ -91,9 +91,9 @@ static SerializablePositionOffset buildSerializablePositionOffset(CSSValue* offs
     
     if (side == CSSValueCenter)
         side = defaultSide;
-    else if ((side == CSSValueRight || side == CSSValueBottom) && is<CSSPrimitiveValue>(*amount) && downcast<CSSPrimitiveValue>(*amount).isPercentage()) {
+    else if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*amount); (side == CSSValueRight || side == CSSValueBottom) && primitiveValue && primitiveValue->isPercentage()) {
         side = defaultSide;
-        amount = CSSPrimitiveValue::create(Length(100 - downcast<CSSPrimitiveValue>(*amount).floatValue(), LengthType::Percent));
+        amount = CSSPrimitiveValue::create(Length(100 - primitiveValue->floatValue(), LengthType::Percent));
     } else if (isZeroLength(*amount)) {
         if (side == CSSValueRight || side == CSSValueBottom)
             amount = CSSPrimitiveValue::create(Length(100, LengthType::Percent));

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -70,11 +70,11 @@ CSSCounterStyleDescriptors::Ranges rangeFromCSSValue(Ref<CSSValue> value)
 
 static CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(const CSSValue* value)
 {
-    if (!value || !value->isPrimitiveValue())
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
         return { };
 
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(*value);
-    return { primitiveValue.isCustomIdent(), primitiveValue.stringValue() };
+    return { primitiveValue->isCustomIdent(), primitiveValue->stringValue() };
 }
 
 CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(RefPtr<CSSValue> value)
@@ -84,10 +84,11 @@ CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(RefPtr<CSSValue> value)
 
 static CSSCounterStyleDescriptors::Name nameFromCSSValue(Ref<CSSValue> value)
 {
-    if (!value->isPrimitiveValue())
+    RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(WTFMove(value));
+    if (!primitiveValue)
         return { };
 
-    return makeAtomString(downcast<CSSPrimitiveValue>(WTFMove(value))->stringValue());
+    return makeAtomString(primitiveValue->stringValue());
 }
 
 static CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbolsFromStyleProperties(const StyleProperties& properties)

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -35,10 +35,11 @@
 
 namespace WebCore {
 
-Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& imageValue, const std::optional<IntPoint>& hotSpot, LoadedFromOpaqueSource loadedFromOpaqueSource)
+Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& value, const std::optional<IntPoint>& hotSpot, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
-    auto originalURL = is<CSSImageValue>(imageValue) ? downcast<CSSImageValue>(imageValue.get()).imageURL() : URL();
-    return adoptRef(*new CSSCursorImageValue(WTFMove(imageValue), hotSpot, WTFMove(originalURL), loadedFromOpaqueSource));
+    auto* imageValue = dynamicDowncast<CSSImageValue>(value.get());
+    auto originalURL = imageValue ? imageValue->imageURL() : URL();
+    return adoptRef(*new CSSCursorImageValue(WTFMove(value), hotSpot, WTFMove(originalURL), loadedFromOpaqueSource));
 }
 
 Ref<CSSCursorImageValue> CSSCursorImageValue::create(Ref<CSSValue>&& imageValue, const std::optional<IntPoint>& hotSpot, URL originalURL, LoadedFromOpaqueSource loadedFromOpaqueSource)

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -164,21 +164,19 @@ FontFace* CSSFontFace::existingWrapper()
 
 static FontSelectionRange calculateWeightRange(CSSValue& value)
 {
-    if (value.isValueList()) {
-        auto& valueList = downcast<CSSValueList>(value);
-        ASSERT(valueList.length() == 2);
-        if (valueList.length() != 2)
+    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
+        ASSERT(valueList->length() == 2);
+        if (valueList->length() != 2)
             return { normalWeightValue(), normalWeightValue() };
-        ASSERT(valueList.item(0)->isPrimitiveValue());
-        ASSERT(valueList.item(1)->isPrimitiveValue());
-        auto& value0 = downcast<CSSPrimitiveValue>(*valueList.item(0));
-        auto& value1 = downcast<CSSPrimitiveValue>(*valueList.item(1));
+        ASSERT(valueList->item(0)->isPrimitiveValue());
+        ASSERT(valueList->item(1)->isPrimitiveValue());
+        auto& value0 = downcast<CSSPrimitiveValue>(*valueList->item(0));
+        auto& value1 = downcast<CSSPrimitiveValue>(*valueList->item(1));
         auto result0 = Style::BuilderConverter::convertFontWeightFromValue(value0);
         auto result1 = Style::BuilderConverter::convertFontWeightFromValue(value1);
         return { result0, result1 };
     }
 
-    ASSERT(is<CSSPrimitiveValue>(value));
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     FontSelectionValue result = Style::BuilderConverter::convertFontWeightFromValue(primitiveValue);
     return { result, result };
@@ -201,21 +199,19 @@ void CSSFontFace::setWeight(CSSValue& weight)
 
 static FontSelectionRange calculateStretchRange(CSSValue& value)
 {
-    if (value.isValueList()) {
-        auto& valueList = downcast<CSSValueList>(value);
-        ASSERT(valueList.length() == 2);
-        if (valueList.length() != 2)
+    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
+        ASSERT(valueList->length() == 2);
+        if (valueList->length() != 2)
             return { normalStretchValue(), normalStretchValue() };
-        ASSERT(valueList.item(0)->isPrimitiveValue());
-        ASSERT(valueList.item(1)->isPrimitiveValue());
-        auto& value0 = downcast<CSSPrimitiveValue>(*valueList.item(0));
-        auto& value1 = downcast<CSSPrimitiveValue>(*valueList.item(1));
+        ASSERT(valueList->item(0)->isPrimitiveValue());
+        ASSERT(valueList->item(1)->isPrimitiveValue());
+        auto& value0 = downcast<CSSPrimitiveValue>(*valueList->item(0));
+        auto& value1 = downcast<CSSPrimitiveValue>(*valueList->item(1));
         auto result0 = Style::BuilderConverter::convertFontStretchFromValue(value0);
         auto result1 = Style::BuilderConverter::convertFontStretchFromValue(value1);
         return { result0, result1 };
     }
 
-    ASSERT(is<CSSPrimitiveValue>(value));
     const auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     FontSelectionValue result = Style::BuilderConverter::convertFontStretchFromValue(primitiveValue);
     return { result, result };
@@ -238,22 +234,22 @@ void CSSFontFace::setStretch(CSSValue& style)
 
 static FontSelectionRange calculateItalicRange(CSSValue& value)
 {
-    if (!is<CSSFontStyleRangeValue>(value))
+    auto* rangeValue = dynamicDowncast<CSSFontStyleRangeValue>(value);
+    if (!rangeValue)
         return FontSelectionRange { Style::BuilderConverter::convertFontStyleFromValue(value).value_or(normalItalicValue()) };
 
-    auto& rangeValue = downcast<CSSFontStyleRangeValue>(value);
-    auto keyword = rangeValue.fontStyleValue->valueID();
-    if (!rangeValue.obliqueValues) {
+    auto keyword = rangeValue->fontStyleValue->valueID();
+    if (!rangeValue->obliqueValues) {
         if (keyword == CSSValueNormal)
             return FontSelectionRange { normalItalicValue() };
         ASSERT(keyword == CSSValueItalic || keyword == CSSValueOblique);
         return FontSelectionRange { italicValue() };
     }
     ASSERT(keyword == CSSValueOblique);
-    auto length = rangeValue.obliqueValues->length();
+    auto length = rangeValue->obliqueValues->length();
     ASSERT(length == 1 || length == 2);
     auto angleAtIndex = [&] (size_t index) {
-        return Style::BuilderConverter::convertFontStyleAngle(*rangeValue.obliqueValues->itemWithoutBoundsCheck(index));
+        return Style::BuilderConverter::convertFontStyleAngle(*rangeValue->obliqueValues->itemWithoutBoundsCheck(index));
     };
     if (length == 1)
         return FontSelectionRange { angleAtIndex(0) };
@@ -303,9 +299,8 @@ void CSSFontFace::setFeatureSettings(CSSValue& featureSettings)
 
     FontFeatureSettings settings;
 
-    if (is<CSSValueList>(featureSettings)) {
-        auto& list = downcast<CSSValueList>(featureSettings);
-        for (auto& rangeValue : list) {
+    if (auto* list = dynamicDowncast<CSSValueList>(featureSettings)) {
+        for (auto& rangeValue : *list) {
             auto& feature = downcast<CSSFontFeatureValue>(rangeValue);
             settings.insert({ feature.tag(), feature.value() });
         }
@@ -461,8 +456,8 @@ void CSSFontFace::timeoutFired()
 
 Document* CSSFontFace::document()
 {
-    if (m_wrapper && is<Document>(m_wrapper->scriptExecutionContext()))
-        return &downcast<Document>(*m_wrapper->scriptExecutionContext());
+    if (m_wrapper)
+        return dynamicDowncast<Document>(m_wrapper->scriptExecutionContext());
     return nullptr;
 }
 

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -65,7 +65,6 @@ RefPtr<StyleImage> CSSImageSetValue::createStyleImage(Style::BuilderState& state
     size_t length = this->length();
 
     Vector<ImageWithScale> images(length, [&](size_t i) {
-        ASSERT(is<CSSImageSetOptionValue>(item(i)));
         auto option = downcast<CSSImageSetOptionValue>(item(i));
         return ImageWithScale { state.createStyleImage(option->image()), option->resolution()->floatValue(CSSUnitType::CSS_DPPX), option->type() };
     });

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -63,9 +63,12 @@ StyleRuleKeyframe::~StyleRuleKeyframe() = default;
 
 MutableStyleProperties& StyleRuleKeyframe::mutableProperties()
 {
-    if (!is<MutableStyleProperties>(m_properties))
-        m_properties = m_properties->mutableCopy();
-    return downcast<MutableStyleProperties>(m_properties.get());
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
+        return *mutableProperties;
+    Ref mutableProperties = m_properties->mutableCopy();
+    auto& mutablePropertiesRef = mutableProperties.get();
+    m_properties = WTFMove(mutableProperties);
+    return mutablePropertiesRef;
 }
 
 String StyleRuleKeyframe::keyText() const

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -345,7 +345,8 @@ inline CSSValueID valueID(const CSSPrimitiveValue* value)
 
 inline CSSValueID valueID(const CSSValue& value)
 {
-    return value.isPrimitiveValue() ? valueID(downcast<CSSPrimitiveValue>(value)) : CSSValueInvalid;
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    return primitiveValue ? valueID(*primitiveValue) : CSSValueInvalid;
 }
 
 inline CSSValueID valueID(const CSSValue* value)

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -576,7 +576,10 @@ CSSStyleSheet::RuleMutationScope::RuleMutationScope(CSSRule* rule)
     , m_mutationType(is<CSSKeyframesRule>(rule) ? KeyframesRuleMutation : OtherMutation)
     , m_contentsWereClonedForMutation(ContentsWereNotClonedForMutation)
     , m_insertedKeyframesRule(nullptr)
-    , m_modifiedKeyframesRuleName(is<CSSKeyframesRule>(rule) ? downcast<CSSKeyframesRule>(*rule).name() : emptyAtom())
+    , m_modifiedKeyframesRuleName([rule] {
+        auto* cssKeyframeRule = dynamicDowncast<CSSKeyframesRule>(rule);
+        return cssKeyframeRule ? cssKeyframeRule->name() : emptyAtom();
+    }())
 {
     if (m_styleSheet)
         m_contentsWereClonedForMutation = m_styleSheet->willMutateRules();

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -169,12 +169,12 @@ void CSSToStyleMap::mapFillRepeat(CSSPropertyID propertyID, FillLayer& layer, co
         return;
     }
 
-    if (!is<CSSBackgroundRepeatValue>(value))
+    auto* backgroundRepeatValue = dynamicDowncast<CSSBackgroundRepeatValue>(value);
+    if (!backgroundRepeatValue)
         return;
 
-    auto& backgroundRepeatValue = downcast<CSSBackgroundRepeatValue>(value);
-    auto repeatX = fromCSSValueID<FillRepeat>(backgroundRepeatValue.xValue());
-    auto repeatY = fromCSSValueID<FillRepeat>(backgroundRepeatValue.yValue());
+    auto repeatX = fromCSSValueID<FillRepeat>(backgroundRepeatValue->xValue());
+    auto repeatY = fromCSSValueID<FillRepeat>(backgroundRepeatValue->yValue());
     layer.setRepeat(FillRepeatXY { repeatX, repeatY });
 }
 
@@ -289,10 +289,11 @@ void CSSToStyleMap::mapAnimationDelay(Animation& animation, const CSSValue& valu
         return;
     }
 
-    if (!is<CSSPrimitiveValue>(value))
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
         return;
 
-    animation.setDelay(downcast<CSSPrimitiveValue>(value).computeTime<double, CSSPrimitiveValue::Seconds>());
+    animation.setDelay(primitiveValue->computeTime<double, CSSPrimitiveValue::Seconds>());
 }
 
 void CSSToStyleMap::mapAnimationDirection(Animation& layer, const CSSValue& value)
@@ -330,10 +331,11 @@ void CSSToStyleMap::mapAnimationDuration(Animation& animation, const CSSValue& v
         return;
     }
 
-    if (!is<CSSPrimitiveValue>(value))
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
         return;
 
-    auto duration = std::max<double>(downcast<CSSPrimitiveValue>(value).computeTime<double, CSSPrimitiveValue::Seconds>(), 0);
+    auto duration = std::max<double>(primitiveValue->computeTime<double, CSSPrimitiveValue::Seconds>(), 0);
     animation.setDuration(duration);
 }
 
@@ -372,14 +374,14 @@ void CSSToStyleMap::mapAnimationIterationCount(Animation& animation, const CSSVa
         return;
     }
 
-    if (!is<CSSPrimitiveValue>(value))
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
         return;
 
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.valueID() == CSSValueInfinite)
+    if (primitiveValue->valueID() == CSSValueInfinite)
         animation.setIterationCount(Animation::IterationCountInfinite);
     else
-        animation.setIterationCount(primitiveValue.floatValue());
+        animation.setIterationCount(primitiveValue->floatValue());
 }
 
 void CSSToStyleMap::mapAnimationName(Animation& layer, const CSSValue& value)
@@ -389,14 +391,14 @@ void CSSToStyleMap::mapAnimationName(Animation& layer, const CSSValue& value)
         return;
     }
 
-    if (!is<CSSPrimitiveValue>(value))
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
         return;
 
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.valueID() == CSSValueNone)
+    if (primitiveValue->valueID() == CSSValueNone)
         layer.setIsNoneAnimation(true);
     else
-        layer.setName({ AtomString { primitiveValue.stringValue() }, m_builderState.styleScopeOrdinal(), primitiveValue.isCustomIdent() });
+        layer.setName({ AtomString { primitiveValue->stringValue() }, m_builderState.styleScopeOrdinal(), primitiveValue->isCustomIdent() });
 }
 
 void CSSToStyleMap::mapAnimationPlayState(Animation& layer, const CSSValue& value)
@@ -420,26 +422,26 @@ void CSSToStyleMap::mapAnimationProperty(Animation& animation, const CSSValue& v
         return;
     }
 
-    if (!is<CSSPrimitiveValue>(value))
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
         return;
 
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.valueID() == CSSValueAll) {
+    if (primitiveValue->valueID() == CSSValueAll) {
         animation.setProperty({ Animation::TransitionMode::All, CSSPropertyInvalid });
         return;
     }
-    if (primitiveValue.valueID() == CSSValueNone) {
+    if (primitiveValue->valueID() == CSSValueNone) {
         animation.setProperty({ Animation::TransitionMode::None, CSSPropertyInvalid });
         return;
     }
-    if (primitiveValue.propertyID() == CSSPropertyInvalid) {
-        auto stringValue = primitiveValue.stringValue();
+    if (primitiveValue->propertyID() == CSSPropertyInvalid) {
+        auto stringValue = primitiveValue->stringValue();
         auto transitionMode = isCustomPropertyName(stringValue) ? Animation::TransitionMode::SingleProperty : Animation::TransitionMode::UnknownProperty;
         animation.setProperty({ transitionMode, AtomString { stringValue } });
         return;
     }
 
-    animation.setProperty({ Animation::TransitionMode::SingleProperty, primitiveValue.propertyID() });
+    animation.setProperty({ Animation::TransitionMode::SingleProperty, primitiveValue->propertyID() });
 }
 
 void CSSToStyleMap::mapAnimationTimingFunction(Animation& animation, const CSSValue& value)
@@ -461,13 +463,12 @@ void CSSToStyleMap::mapAnimationCompositeOperation(Animation& animation, const C
 void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& image)
 {
     // If we're not a value list, then we are "none" and don't need to alter the empty image at all.
-    if (!is<CSSValueList>(value))
+    auto* borderImage = dynamicDowncast<CSSValueList>(value);
+    if (!borderImage)
         return;
 
     // Retrieve the border image value.
-    auto& borderImage = downcast<CSSValueList>(*value);
-
-    for (auto& current : borderImage) {
+    for (auto& current : *borderImage) {
         if (current.isImage())
             image.setImage(styleImage(current));
         else if (auto* imageSlice = dynamicDowncast<CSSBorderImageSliceValue>(current))
@@ -493,10 +494,8 @@ void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& ima
 
 void CSSToStyleMap::mapNinePieceImageSlice(const CSSValue& value, NinePieceImage& image)
 {
-    if (!is<CSSBorderImageSliceValue>(value))
-        return;
-
-    mapNinePieceImageSlice(downcast<CSSBorderImageSliceValue>(value), image);
+    if (auto* sliceValue = dynamicDowncast<CSSBorderImageSliceValue>(value))
+        mapNinePieceImageSlice(*sliceValue, image);
 }
 
 void CSSToStyleMap::mapNinePieceImageSlice(const CSSBorderImageSliceValue& value, NinePieceImage& image)
@@ -516,10 +515,8 @@ void CSSToStyleMap::mapNinePieceImageSlice(const CSSBorderImageSliceValue& value
 
 void CSSToStyleMap::mapNinePieceImageWidth(const CSSValue& value, NinePieceImage& image)
 {
-    if (!is<CSSBorderImageWidthValue>(value))
-        return;
-
-    return mapNinePieceImageWidth(downcast<CSSBorderImageWidthValue>(value), image);
+    if (auto* widthValue = dynamicDowncast<CSSBorderImageWidthValue>(value))
+        mapNinePieceImageWidth(*widthValue, image);
 }
 
 void CSSToStyleMap::mapNinePieceImageWidth(const CSSBorderImageWidthValue& value, NinePieceImage& image)
@@ -537,9 +534,10 @@ LengthBox CSSToStyleMap::mapNinePieceImageQuad(const CSSValue& value)
         return mapNinePieceImageQuad(value.quad());
 
     // Values coming from CSS Typed OM may not have been converted to a Quad yet.
-    if (!is<CSSPrimitiveValue>(value))
+    auto* primitive = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitive)
         return LengthBox();
-    if (auto& primitive = downcast<CSSPrimitiveValue>(value); !primitive.isNumber() && !primitive.isLength())
+    if (!primitive->isNumber() && !primitive->isLength())
         return LengthBox();
     auto side = mapNinePieceImageSide(value);
     return { Length { side }, Length { side }, Length { side }, Length { side } };


### PR DESCRIPTION
#### 1540d326ead095e4efd8cf6f46fe6068f84acacd
<pre>
Use dynamicDowncast&lt;T&gt; more in css/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265219">https://bugs.webkit.org/show_bug.cgi?id=265219</a>

Reviewed by Jean-Yves Avenard.

* Source/WebCore/css/BasicShapeFunctions.cpp:
(WebCore::basicShapeForValue):
* Source/WebCore/css/CSSBasicShapes.cpp:
(WebCore::buildSerializablePositionOffset):
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::symbolFromCSSValue):
(WebCore::nameFromCSSValue):
* Source/WebCore/css/CSSCursorImageValue.cpp:
(WebCore::CSSCursorImageValue::create):
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::calculateWeightRange):
(WebCore::calculateStretchRange):
(WebCore::calculateItalicRange):
(WebCore::CSSFontFace::setFeatureSettings):
(WebCore::CSSFontFace::document):
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::load):
(WebCore::CSSFontFaceSource::isSVGFontFaceSource const):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::addFontFaceRule):
(WebCore::CSSFontSelector::updateStyleIfNeeded):
(WebCore::CSSFontSelector::fallbackFontAt):
* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::createStyleImage const):
* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::mutableProperties):
* Source/WebCore/css/CSSPrimitiveValue.h:
(WebCore::valueID):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::generateSelectorText const):
(WebCore::CSSStyleRule::setSelectorText):
(WebCore::CSSStyleRule::nestedRules const):
(WebCore::CSSStyleRule::reattach):
(WebCore::CSSStyleRule::insertRule):
(WebCore::CSSStyleRule::deleteRule):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::modifiedKeyframesRuleName):
(WebCore::CSSStyleSheet::RuleMutationScope::RuleMutationScope):
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapFillRepeat):
(WebCore::CSSToStyleMap::mapAnimationDelay):
(WebCore::CSSToStyleMap::mapAnimationDuration):
(WebCore::CSSToStyleMap::mapAnimationIterationCount):
(WebCore::CSSToStyleMap::mapAnimationName):
(WebCore::CSSToStyleMap::mapAnimationProperty):
(WebCore::CSSToStyleMap::mapNinePieceImage):
(WebCore::CSSToStyleMap::mapNinePieceImageSlice):
(WebCore::CSSToStyleMap::mapNinePieceImageWidth):
(WebCore::CSSToStyleMap::mapNinePieceImageQuad):

Canonical link: <a href="https://commits.webkit.org/271065@main">https://commits.webkit.org/271065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18f6c5ae279233059a30a28a05f3118977020354

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24896 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24732 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30345 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28273 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5665 "Hash 18f6c5ae for PR 20804 does not build (failure)") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6559 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->