### PR TITLE
Stop using SPI: -_scrollView:adjustedOffsetForOffset:translation:startPoint:horizontalVelocity:verticalVelocity:

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -486,6 +486,7 @@ UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm
 UIProcess/ios/WKActionSheet.mm
 UIProcess/ios/WKActionSheetAssistant.mm
 UIProcess/ios/WKApplicationStateTrackingView.mm
+UIProcess/ios/WKAxisLockingScrollView.mm
 UIProcess/ios/WKContentView.mm @no-unify
 UIProcess/ios/WKContentViewInteraction.mm @no-unify
 UIProcess/ios/WKDeferringGestureRecognizer.mm

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "WKAxisLockingScrollView.h"
 #import "WKWebViewInternal.h"
 #import "_WKTapHandlingResult.h"
 
@@ -36,7 +37,7 @@ namespace WebKit {
 enum class TapHandlingResult : uint8_t;
 }
 
-@interface WKWebView (WKViewInternalIOS)
+@interface WKWebView (WKViewInternalIOS) <WKAxisLockingScrollViewDelegate>
 
 - (void)_setupScrollAndContentViews;
 - (void)_registerForNotifications;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -26,6 +26,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
+#import "WKAxisLockingScrollView.h"
 #import <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -68,7 +69,7 @@ class WebPageProxy;
 @interface WKUIRemoteView : _UIRemoteView <WKContentControlled>
 @end
 
-@interface WKChildScrollView : UIScrollView <WKContentControlled>
+@interface WKChildScrollView : WKAxisLockingScrollView <WKContentControlled>
 @end
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.h
@@ -27,13 +27,20 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import "WKAxisLockingScrollView.h"
+#import <UIKit/UIKit.h>
 
-@interface WKVelocityTrackingScrollView : WKAxisLockingScrollView
+@class WKAxisLockingScrollView;
 
-- (void)updateInteractiveScrollVelocity;
+@protocol WKAxisLockingScrollViewDelegate <NSObject>
 
-@property (nonatomic, readonly) CGSize interactiveScrollVelocityInPointsPerSecond;
+- (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKAxisLockingScrollView *)scrollView;
+
+@end
+
+@interface WKAxisLockingScrollView : UIScrollView
+
+@property (nonatomic, weak) id<WKAxisLockingScrollViewDelegate> scrollAxisLockingDelegate;
+@property (nonatomic, readonly) UIAxis axesToPreventMomentumScrolling;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.mm
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKAxisLockingScrollView.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+@interface UIScrollView (GestureRecognizerDelegate) <UIGestureRecognizerDelegate>
+@end
+
+@implementation WKAxisLockingScrollView {
+    RetainPtr<UIPanGestureRecognizer> _axisLockingPanGestureRecognizer;
+    UIAxis _axesToPreventMomentumScrolling;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    if (!(self = [super initWithFrame:frame]))
+        return nil;
+
+    _axesToPreventMomentumScrolling = UIAxisNeither;
+    [self.panGestureRecognizer addTarget:self action:@selector(_updatePanGestureToPreventScrolling)];
+    return self;
+}
+
+- (void)addGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
+    if (self.panGestureRecognizer == gestureRecognizer) {
+        if (!_axisLockingPanGestureRecognizer) {
+            _axisLockingPanGestureRecognizer = adoptNS([[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(_updatePanGestureToPreventScrolling)]);
+            [_axisLockingPanGestureRecognizer setName:@"Scroll axis locking"];
+            [_axisLockingPanGestureRecognizer setDelegate:self];
+        }
+        [self addGestureRecognizer:_axisLockingPanGestureRecognizer.get()];
+    }
+
+    [super addGestureRecognizer:gestureRecognizer];
+}
+
+- (void)removeGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
+    if (self.panGestureRecognizer == gestureRecognizer) {
+        if (auto gesture = std::exchange(_axisLockingPanGestureRecognizer, nil))
+            [self removeGestureRecognizer:gesture.get()];
+    }
+
+    [super removeGestureRecognizer:gestureRecognizer];
+}
+
+- (void)_updatePanGestureToPreventScrolling
+{
+    auto panGesture = self.panGestureRecognizer;
+    switch (self.panGestureRecognizer.state) {
+    case UIGestureRecognizerStatePossible:
+    case UIGestureRecognizerStateEnded:
+    case UIGestureRecognizerStateCancelled:
+    case UIGestureRecognizerStateFailed:
+        return;
+    case UIGestureRecognizerStateBegan:
+    case UIGestureRecognizerStateChanged:
+        break;
+    }
+
+    auto axesToPrevent = self._axesToPreventScrollingFromDelegate;
+    if (axesToPrevent == UIAxisNeither)
+        return;
+
+    auto adjustedTranslation = [panGesture translationInView:nil];
+    bool translationChanged = false;
+    if ((axesToPrevent & UIAxisHorizontal) && std::abs(adjustedTranslation.x) > CGFLOAT_EPSILON) {
+        adjustedTranslation.x = 0;
+        _axesToPreventMomentumScrolling |= UIAxisHorizontal;
+        translationChanged = true;
+    }
+
+    if ((axesToPrevent & UIAxisVertical) && std::abs(adjustedTranslation.y) > CGFLOAT_EPSILON) {
+        adjustedTranslation.y = 0;
+        _axesToPreventMomentumScrolling |= UIAxisVertical;
+        translationChanged = true;
+    }
+
+    if (translationChanged)
+        [panGesture setTranslation:adjustedTranslation inView:nil];
+}
+
+- (UIAxis)_axesToPreventScrollingFromDelegate
+{
+    auto delegate = self.scrollAxisLockingDelegate;
+    return delegate ? [delegate axesToPreventScrollingForPanGestureInScrollView:self] : UIAxisBoth;
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    if (gestureRecognizer == _axisLockingPanGestureRecognizer || otherGestureRecognizer == _axisLockingPanGestureRecognizer)
+        return YES;
+
+    static BOOL callIntoSuperclass = [UIScrollView instancesRespondToSelector:@selector(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)];
+    if (!callIntoSuperclass)
+        return NO;
+
+    return [super gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    if (self.panGestureRecognizer == gestureRecognizer)
+        _axesToPreventMomentumScrolling = UIAxisNeither;
+
+    static BOOL callIntoSuperclass = [UIScrollView instancesRespondToSelector:@selector(gestureRecognizerShouldBegin:)];
+    if (!callIntoSuperclass)
+        return YES;
+
+    return [super gestureRecognizerShouldBegin:gestureRecognizer];
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1242,21 +1242,25 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
     _touchActionLeftSwipeGestureRecognizer = adoptNS([[UISwipeGestureRecognizer alloc] initWithTarget:nil action:nil]);
     [_touchActionLeftSwipeGestureRecognizer setDirection:UISwipeGestureRecognizerDirectionLeft];
     [_touchActionLeftSwipeGestureRecognizer setDelegate:self];
+    [_touchActionLeftSwipeGestureRecognizer setName:@"Touch action swipe left"];
     [self addGestureRecognizer:_touchActionLeftSwipeGestureRecognizer.get()];
 
     _touchActionRightSwipeGestureRecognizer = adoptNS([[UISwipeGestureRecognizer alloc] initWithTarget:nil action:nil]);
     [_touchActionRightSwipeGestureRecognizer setDirection:UISwipeGestureRecognizerDirectionRight];
     [_touchActionRightSwipeGestureRecognizer setDelegate:self];
+    [_touchActionRightSwipeGestureRecognizer setName:@"Touch action swipe right"];
     [self addGestureRecognizer:_touchActionRightSwipeGestureRecognizer.get()];
 
     _touchActionUpSwipeGestureRecognizer = adoptNS([[UISwipeGestureRecognizer alloc] initWithTarget:nil action:nil]);
     [_touchActionUpSwipeGestureRecognizer setDirection:UISwipeGestureRecognizerDirectionUp];
     [_touchActionUpSwipeGestureRecognizer setDelegate:self];
+    [_touchActionUpSwipeGestureRecognizer setName:@"Touch action swipe up"];
     [self addGestureRecognizer:_touchActionUpSwipeGestureRecognizer.get()];
 
     _touchActionDownSwipeGestureRecognizer = adoptNS([[UISwipeGestureRecognizer alloc] initWithTarget:nil action:nil]);
     [_touchActionDownSwipeGestureRecognizer setDirection:UISwipeGestureRecognizerDirectionDown];
     [_touchActionDownSwipeGestureRecognizer setDelegate:self];
+    [_touchActionDownSwipeGestureRecognizer setName:@"Touch action swipe down"];
     [self addGestureRecognizer:_touchActionDownSwipeGestureRecognizer.get()];
 
     _touchStartDeferringGestureRecognizerForImmediatelyResettableGestures = adoptNS([[WKDeferringGestureRecognizer alloc] initWithDeferringGestureDelegate:self]);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2362,6 +2362,7 @@
 		F4DBC0BE276AA6A70001D169 /* _WKModalContainerInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DBC0BC276AA6A70001D169 /* _WKModalContainerInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F4DBC0C1276AA6CA0001D169 /* _WKModalContainerInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DBC0C0276AA6CA0001D169 /* _WKModalContainerInfoInternal.h */; };
 		F4DF71E82B069AC6009A4522 /* WKExtendedTextInputTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */; };
+		F4DF72122B0C3A8C009A4522 /* WKAxisLockingScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF72102B0C324F009A4522 /* WKAxisLockingScrollView.h */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
 		F4EC94E32356CC57000BB614 /* ApplicationServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 29D04E2821F7C73D0076741D /* ApplicationServicesSPI.h */; };
@@ -7655,6 +7656,8 @@
 		F4DD79EF2AD59BA6000C6821 /* WKVelocityTrackingScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKVelocityTrackingScrollView.mm; path = ios/WKVelocityTrackingScrollView.mm; sourceTree = "<group>"; };
 		F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKExtendedTextInputTraits.h; path = ios/WKExtendedTextInputTraits.h; sourceTree = "<group>"; };
 		F4DF71D82B0689A5009A4522 /* WKExtendedTextInputTraits.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKExtendedTextInputTraits.mm; path = ios/WKExtendedTextInputTraits.mm; sourceTree = "<group>"; };
+		F4DF72102B0C324F009A4522 /* WKAxisLockingScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKAxisLockingScrollView.h; path = ios/WKAxisLockingScrollView.h; sourceTree = "<group>"; };
+		F4DF72112B0C324F009A4522 /* WKAxisLockingScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKAxisLockingScrollView.mm; path = ios/WKAxisLockingScrollView.mm; sourceTree = "<group>"; };
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
 		F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTouchEventsGestureRecognizerTypes.h; path = ios/WKTouchEventsGestureRecognizerTypes.h; sourceTree = "<group>"; };
@@ -10206,6 +10209,8 @@
 				0FCB4E3B18BBE044000FCFC9 /* WKActionSheetAssistant.mm */,
 				A13DC680207AA6B20066EF72 /* WKApplicationStateTrackingView.h */,
 				A13DC681207AA6B20066EF72 /* WKApplicationStateTrackingView.mm */,
+				F4DF72102B0C324F009A4522 /* WKAxisLockingScrollView.h */,
+				F4DF72112B0C324F009A4522 /* WKAxisLockingScrollView.mm */,
 				0FCB4E3C18BBE044000FCFC9 /* WKContentView.h */,
 				0FCB4E3D18BBE044000FCFC9 /* WKContentView.mm */,
 				0FCB4E6A18BBF26A000FCFC9 /* WKContentViewInteraction.h */,
@@ -15921,6 +15926,7 @@
 				577739952580388F0059348B /* WKASCAuthorizationPresenterDelegate.h in Headers */,
 				512F58F612A88A5400629530 /* WKAuthenticationChallenge.h in Headers */,
 				512F58F812A88A5400629530 /* WKAuthenticationDecisionListener.h in Headers */,
+				F4DF72122B0C3A8C009A4522 /* WKAxisLockingScrollView.h in Headers */,
 				37C4C08D1814AC5C003688B9 /* WKBackForwardList.h in Headers */,
 				37C4C0951814B9E6003688B9 /* WKBackForwardListInternal.h in Headers */,
 				37C4C08718149C5B003688B9 /* WKBackForwardListItem.h in Headers */,


### PR DESCRIPTION
#### e8b8f75b41b3d873fb5aadda2df4da3f1d744f8d
<pre>
Stop using SPI: -_scrollView:adjustedOffsetForOffset:translation:startPoint:horizontalVelocity:verticalVelocity:
<a href="https://bugs.webkit.org/show_bug.cgi?id=265215">https://bugs.webkit.org/show_bug.cgi?id=265215</a>
<a href="https://rdar.apple.com/118696702">rdar://118696702</a>

Reviewed by Megan Gardner.

Move off of the private `UIScrollViewDelegate` method `-_scrollView:adjustedOffsetForOffset:…:`,
which allows clients to retarget the would-be target content offset right before a pan gesture (or
pan-gesture-induced momentum scrolling). We currently use this to implement `touch-action: pan-x|y`
by retargeting the content offset such that the `x` or `y` offsets are locked to their initial
values at the start of scrolling, which has the effect of locking pan-gesture-based scrolling to a
single axis.

To achieve the same effect without adopting any scroll view SPI, we can instead create and deploy a
new scroll view subclass, `WKAxisLockingScrollView`, which allows clients, in the form of a
`WKAxisLockingScrollViewDelegate`, to choose which axis to prevent scrolling during a pan gesture by
returning `UIAxisHorizontal` and/or `UIAxisVertical` in a new internal delegate method. For example,
we return `UIAxisVertical` to prevent scrolling in the y-axis, when `pan-x` is specified (and vice-
versa for `pan-y`).

To implement this subclass, we:

1.  Add our own pan gesture recognizer (the &quot;axis locking pan gesture&quot;) to the scroll view, right as
    UIKit is about to add the built-in `UIScrollViewPanGestureRecognizer`. The order in which these
    two gestures are added to the scroll view is important, since this guarantees that the gesture
    action for the axis locking pan gesture will always fire right before the scroll view&apos;s default
    scrolling pan gesture.

2.  We build on this by calling out to the axis locking delegate to get the set of axes to prevent
    scrolling and use this information to call `-[UIPanGestureRecognizer setTranslation:inView:]` on
    the scroll view&apos;s built-in pan gesture recognizer, zeroing out either the `x` or `y` component
    of the translation (depending on what the delegate method returned). This allows us to make
    UIKit behave as if the user was scrolling perfectly along the x or y axis upon converting the
    pan gesture translation amount into scroll deltas, using the built-in pan gesture recognizer.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setupScrollAndContentViews]):
(-[WKWebView scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKWebView axesToPreventScrollingForPanGestureInScrollView:]):
(-[WKWebView _scrollView:adjustedOffsetForOffset:translation:startPoint:locationInView:horizontalVelocity:verticalVelocity:]): Deleted.

Delete this SPI delegate method implementation, and instead move the corresponding logic into the
new `-axesToPreventScrollingForPanGestureInScrollView:` delegate method.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:

Make `WKChildScrollView` subclass the new `WKAxisLockingScrollView`.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate scrollViewWillEndDragging:withVelocity:targetContentOffset:]):

Because the new `-axesToPreventScrollingForPanGestureInScrollView:` delegate method isn&apos;t called
after scrolling ends, we need a separate mechanism in order to limit momentum scrolling to the
locked scrolling axis. Achieve this by keeping track of the axes where we prevented scrolling in the
`WKAxisLockingScrollView` during the pan gesutre, and then use public scroll view delegate API to
retarget the default scrolling destination to the current offset value, effectively canceling out
any momentum scrolling in that axis.

(-[WKScrollingNodeScrollViewDelegate axesToPreventScrollingForPanGestureInScrollView:]):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):
(-[WKScrollingNodeScrollViewDelegate _scrollView:adjustedOffsetForOffset:translation:startPoint:locationInView:horizontalVelocity:verticalVelocity:]): Deleted.

Same as above; move this logic into `-axesToPreventScrollingForPanGestureInScrollView:` to service
the overflow scrolling case.

* Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.h: Copied from Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h.
* Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.mm: Added.
(-[WKAxisLockingScrollView initWithFrame:]):
(-[WKAxisLockingScrollView addGestureRecognizer:]):
(-[WKAxisLockingScrollView removeGestureRecognizer:]):
(-[WKAxisLockingScrollView _updatePanGestureToPreventScrolling]):
(-[WKAxisLockingScrollView _axesToPreventScrollingFromDelegate]):
(-[WKAxisLockingScrollView gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKAxisLockingScrollView gestureRecognizerShouldBegin:]):

Add the new internal scroll view subclass; see above for more details.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):

(Drive-by): give these `_touchAction*SwipeGestureRecognizer`s human-readable names, so that they&apos;re
easier to identify and debug.

* Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h:

Make the velocity tracking scroll view subclass `WKAxisLockingScrollView` (`WKScrollView`, in turn,
subclasses this).

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271171@main">https://commits.webkit.org/271171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3236f972200ae922dba8397a8bbe7da0d72d970d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24829 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24669 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4109 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28211 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5582 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->