### PR TITLE
Move CSSSelectorParserContext to its own file

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -875,6 +875,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/parser/CSSParserToken.h
     css/parser/CSSParserTokenRange.h
     css/parser/CSSSelectorParser.h
+    css/parser/CSSSelectorParserContext.h
 
     css/query/GenericMediaQueryTypes.h
     css/query/MediaQuery.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -961,6 +961,7 @@ css/parser/CSSPropertyParser.cpp
 css/parser/CSSPropertyParserHelpers.cpp
 css/parser/CSSPropertyParserWorkerSafe.cpp
 css/parser/CSSSelectorParser.cpp
+css/parser/CSSSelectorParserContext.cpp
 css/parser/CSSSupportsParser.cpp
 css/parser/CSSTokenizer.cpp
 css/parser/CSSTokenizerInputStream.cpp

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -48,34 +48,6 @@ namespace WebCore {
 static AtomString serializeANPlusB(const std::pair<int, int>&);
 static bool consumeANPlusB(CSSParserTokenRange&, std::pair<int, int>&);
 
-CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& context)
-    : mode(context.mode)
-    , cssNestingEnabled(context.cssNestingEnabled)
-    , focusVisibleEnabled(context.focusVisibleEnabled)
-    , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
-    , popoverAttributeEnabled(context.popoverAttributeEnabled)
-{
-}
-
-CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
-    : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
-    , cssNestingEnabled(document.settings().cssNestingEnabled())
-    , focusVisibleEnabled(document.settings().focusVisibleEnabled())
-    , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
-    , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
-{
-}
-
-void add(Hasher& hasher, const CSSSelectorParserContext& context)
-{
-    add(hasher,
-        context.mode,
-        context.cssNestingEnabled,
-        context.focusVisibleEnabled,
-        context.hasPseudoClassEnabled
-    );
-}
-
 std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange range, const CSSSelectorParserContext& context, StyleSheetContents* styleSheet, CSSParserEnum::IsNestedContext isNestedContext, CSSParserEnum::IsForgiving isForgiving)
 {
     CSSSelectorParser parser(context, styleSheet, isNestedContext);

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -34,9 +34,8 @@
 #include "CSSParserSelector.h"
 #include "CSSParserTokenRange.h"
 #include "CSSSelectorList.h"
+#include "CSSSelectorParserContext.h"
 #include "StyleSheetContents.h"
-#include <wtf/HashFunctions.h>
-#include <wtf/Hasher.h>
 
 namespace WebCore {
 
@@ -44,22 +43,6 @@ class CSSParserTokenRange;
 class CSSSelectorList;
 class StyleSheetContents;
 class StyleRule;
-
-struct CSSSelectorParserContext {
-    CSSParserMode mode { CSSParserMode::HTMLStandardMode };
-    bool cssNestingEnabled { false };
-    bool focusVisibleEnabled { false };
-    bool hasPseudoClassEnabled { false };
-    bool popoverAttributeEnabled { false };
-
-    bool isHashTableDeletedValue { false };
-
-    CSSSelectorParserContext() = default;
-    CSSSelectorParserContext(const CSSParserContext&);
-    explicit CSSSelectorParserContext(const Document&);
-
-    friend bool operator==(const CSSSelectorParserContext&, const CSSSelectorParserContext&) = default;
-};
 
 class CSSSelectorParser {
 public:
@@ -127,24 +110,4 @@ private:
 
 std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving = CSSParserEnum::IsForgiving::No);
 
-void add(Hasher&, const CSSSelectorParserContext&);
-
-struct CSSSelectorParserContextHash {
-    static unsigned hash(const CSSSelectorParserContext& context) { return computeHash(context); }
-    static bool equal(const CSSSelectorParserContext& a, const CSSSelectorParserContext& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = false;
-};
-
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct HashTraits<WebCore::CSSSelectorParserContext> : GenericHashTraits<WebCore::CSSSelectorParserContext> {
-    static void constructDeletedValue(WebCore::CSSSelectorParserContext& slot) { slot.isHashTableDeletedValue = true; }
-    static bool isDeletedValue(const WebCore::CSSSelectorParserContext& value) { return value.isHashTableDeletedValue; }
-    static WebCore::CSSSelectorParserContext emptyValue() { return { }; }
-};
-
-template<> struct DefaultHash<WebCore::CSSSelectorParserContext> : WebCore::CSSSelectorParserContextHash { };
-
-} // namespace WTF

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSSelectorParserContext.h"
+
+#include "CSSParserContext.h"
+#include "Document.h"
+#include <wtf/Hasher.h>
+
+namespace WebCore {
+
+CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& context)
+    : mode(context.mode)
+    , cssNestingEnabled(context.cssNestingEnabled)
+    , focusVisibleEnabled(context.focusVisibleEnabled)
+    , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
+    , popoverAttributeEnabled(context.popoverAttributeEnabled)
+{
+}
+
+CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
+    : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
+    , cssNestingEnabled(document.settings().cssNestingEnabled())
+    , focusVisibleEnabled(document.settings().focusVisibleEnabled())
+    , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
+    , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
+{
+}
+
+void add(Hasher& hasher, const CSSSelectorParserContext& context)
+{
+    add(hasher,
+        context.mode,
+        context.cssNestingEnabled,
+        context.focusVisibleEnabled,
+        context.hasPseudoClassEnabled
+    );
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSParserMode.h"
+#include <wtf/HashFunctions.h>
+#include <wtf/Hasher.h>
+
+namespace WebCore {
+
+struct CSSParserContext;
+class Document;
+
+struct CSSSelectorParserContext {
+    CSSParserMode mode { CSSParserMode::HTMLStandardMode };
+    bool cssNestingEnabled { false };
+    bool focusVisibleEnabled { false };
+    bool hasPseudoClassEnabled { false };
+    bool popoverAttributeEnabled { false };
+
+    bool isHashTableDeletedValue { false };
+
+    CSSSelectorParserContext() = default;
+    CSSSelectorParserContext(const CSSParserContext&);
+    explicit CSSSelectorParserContext(const Document&);
+
+    bool operator==(const CSSSelectorParserContext&, const CSSSelectorParserContext&) = default;
+};
+
+void add(Hasher&, const CSSSelectorParserContext&);
+
+struct CSSSelectorParserContextHash {
+    static unsigned hash(const CSSSelectorParserContext& context) { return computeHash(context); }
+    static bool equal(const CSSSelectorParserContext& a, const CSSSelectorParserContext& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = false;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct HashTraits<WebCore::CSSSelectorParserContext> : GenericHashTraits<WebCore::CSSSelectorParserContext> {
+    static void constructDeletedValue(WebCore::CSSSelectorParserContext& slot) { slot.isHashTableDeletedValue = true; }
+    static bool isDeletedValue(const WebCore::CSSSelectorParserContext& value) { return value.isHashTableDeletedValue; }
+    static WebCore::CSSSelectorParserContext emptyValue() { return { }; }
+};
+
+template<> struct DefaultHash<WebCore::CSSSelectorParserContext> : WebCore::CSSSelectorParserContextHash { };
+
+} // namespace WTF


### PR DESCRIPTION
#### b7c822739450db84fb5f89f0969112db84a9c934
<pre>
Move CSSSelectorParserContext to its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=265220">https://bugs.webkit.org/show_bug.cgi?id=265220</a>
<a href="https://rdar.apple.com/118700294">rdar://118700294</a>

Reviewed by Jean-Yves Avenard.

Allow constructing CSSSelectorParserContext outside of CSSSelectorParser without including the entirety of CSSSelectorParser.h

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext): Deleted.
(WebCore::add): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.h:
(WebCore::CSSSelectorParserContextHash::hash): Deleted.
(WebCore::CSSSelectorParserContextHash::equal): Deleted.
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::constructDeletedValue): Deleted.
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::isDeletedValue): Deleted.
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::emptyValue): Deleted.
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp: Added.
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h: Added.
(WebCore::CSSSelectorParserContextHash::hash):
(WebCore::CSSSelectorParserContextHash::equal):
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::isDeletedValue):
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::emptyValue):

Canonical link: <a href="https://commits.webkit.org/271035@main">https://commits.webkit.org/271035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dd71ca8d6e8bb237aebcaa44147c9fc56d334d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27171 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5787 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28407 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/29378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24843 "Hash 3dd71ca8 for PR 20807 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27629 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7677 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3182 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/29378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27433 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/7677 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/28407 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/29378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/7677 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/28407 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/30013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/7677 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/28407 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/30013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/3182 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/30013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5597 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/28407 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4592 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3511 "Built successfully and passed tests") | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4511 "Hash 3dd71ca8 for PR 20807 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->