### PR TITLE
Use dynamicDowncast<T> even more in html/

### DIFF
--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -186,10 +186,12 @@ void HTMLFrameSetElement::willAttachRenderers()
 
 void HTMLFrameSetElement::defaultEventHandler(Event& event)
 {
-    if (is<MouseEvent>(event) && !m_noresize && is<RenderFrameSet>(renderer())) {
-        if (downcast<RenderFrameSet>(*renderer()).userResize(downcast<MouseEvent>(event))) {
-            event.setDefaultHandled();
-            return;
+    if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && !m_noresize) {
+        if (CheckedPtr renderFrameSet = dynamicDowncast<RenderFrameSet>(renderer())) {
+            if (renderFrameSet->userResize(*mouseEvent)) {
+                event.setDefaultHandled();
+                return;
+            }
         }
     }
     HTMLElement::defaultEventHandler(event);

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -214,8 +214,8 @@ bool HTMLObjectElement::hasFallbackContent() const
 {
     for (RefPtr<Node> child = firstChild(); child; child = child->nextSibling()) {
         // Ignore whitespace-only text, and <param> tags, any other content is fallback content.
-        if (is<Text>(*child)) {
-            if (!downcast<Text>(*child).data().containsOnly<isASCIIWhitespace>())
+        if (auto* textChild = dynamicDowncast<Text>(*child)) {
+            if (!textChild->data().containsOnly<isASCIIWhitespace>())
                 return true;
         } else if (!is<HTMLParamElement>(*child))
             return true;

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -118,8 +118,8 @@ static void flattenAssignedNodes(Vector<Ref<Node>>& nodes, const HTMLSlotElement
     auto* assignedNodes = slot.assignedNodes();
     if (!assignedNodes) {
         for (RefPtr<Node> child = slot.firstChild(); child; child = child->nextSibling()) {
-            if (is<HTMLSlotElement>(*child))
-                flattenAssignedNodes(nodes, downcast<HTMLSlotElement>(*child));
+            if (auto* slot = dynamicDowncast<HTMLSlotElement>(*child))
+                flattenAssignedNodes(nodes, *slot);
             else if (is<Text>(*child) || is<Element>(*child))
                 nodes.append(*child);
         }
@@ -131,8 +131,8 @@ static void flattenAssignedNodes(Vector<Ref<Node>>& nodes, const HTMLSlotElement
             ASSERT_NOT_REACHED();
             continue;
         }
-        if (is<HTMLSlotElement>(*node) && downcast<HTMLSlotElement>(*node).containingShadowRoot())
-            flattenAssignedNodes(nodes, downcast<HTMLSlotElement>(*node));
+        if (auto* slot = dynamicDowncast<HTMLSlotElement>(*node); slot && slot->containingShadowRoot())
+            flattenAssignedNodes(nodes, *slot);
         else
             nodes.append(*node);
     }

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -79,16 +79,16 @@ Node::InsertedIntoAncestorResult HTMLSourceElement::insertedIntoAncestor(Inserti
     RefPtr<Element> parent = parentElement();
     if (parent == &parentOfInsertedTree) {
 #if ENABLE(VIDEO)
-        if (is<HTMLMediaElement>(*parent))
-            downcast<HTMLMediaElement>(*parent).sourceWasAdded(*this);
+        if (auto* mediaElement = dynamicDowncast<HTMLMediaElement>(*parent))
+            mediaElement->sourceWasAdded(*this);
         else
 #endif
 #if ENABLE(MODEL_ELEMENT)
-        if (is<HTMLModelElement>(*parent))
-            downcast<HTMLModelElement>(*parent).sourcesChanged();
+        if (auto* modelElement = dynamicDowncast<HTMLModelElement>(*parent))
+            modelElement->sourcesChanged();
         else
 #endif
-        if (is<HTMLPictureElement>(*parent)) {
+        if (auto* pictureElement = dynamicDowncast<HTMLPictureElement>(*parent)) {
             // The new source element only is a relevant mutation if it precedes any img element.
             m_shouldCallSourcesChanged = true;
             for (const Node* node = previousSibling(); node; node = node->previousSibling()) {
@@ -96,7 +96,7 @@ Node::InsertedIntoAncestorResult HTMLSourceElement::insertedIntoAncestor(Inserti
                     m_shouldCallSourcesChanged = false;
             }
             if (m_shouldCallSourcesChanged)
-                downcast<HTMLPictureElement>(*parent).sourcesChanged();
+                pictureElement->sourcesChanged();
         }
     }
     return InsertedIntoAncestorResult::Done;
@@ -107,13 +107,13 @@ void HTMLSourceElement::removedFromAncestor(RemovalType removalType, ContainerNo
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
     if (!parentNode() && is<Element>(oldParentOfRemovedTree)) {
 #if ENABLE(VIDEO)
-        if (is<HTMLMediaElement>(oldParentOfRemovedTree))
-            downcast<HTMLMediaElement>(oldParentOfRemovedTree).sourceWasRemoved(*this);
+        if (auto* medialElement = dynamicDowncast<HTMLMediaElement>(oldParentOfRemovedTree))
+            medialElement->sourceWasRemoved(*this);
         else
 #endif
 #if ENABLE(MODEL_ELEMENT)
-        if (is<HTMLModelElement>(oldParentOfRemovedTree))
-            downcast<HTMLModelElement>(oldParentOfRemovedTree).sourcesChanged();
+        if (auto* model = dynamicDowncast<HTMLModelElement>(oldParentOfRemovedTree))
+            model->sourcesChanged();
         else
 #endif
         if (m_shouldCallSourcesChanged) {

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -131,8 +131,8 @@ void HTMLTableCellElement::attributeChanged(const QualifiedName& name, const Ato
     HTMLTablePartElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
     if (name == rowspanAttr || name == colspanAttr) {
-        if (is<RenderTableCell>(renderer()))
-            downcast<RenderTableCell>(*renderer()).colSpanOrRowSpanChanged();
+        if (CheckedPtr tableCell = dynamicDowncast<RenderTableCell>(renderer()))
+            tableCell->colSpanOrRowSpanChanged();
     }
 }
 
@@ -208,12 +208,11 @@ void HTMLTableCellElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) c
 
 HTMLTableCellElement* HTMLTableCellElement::cellAbove() const
 {
-    auto* cellRenderer = renderer();
-    if (!is<RenderTableCell>(cellRenderer))
+    auto* tableCellRenderer = dynamicDowncast<RenderTableCell>(renderer());
+    if (!tableCellRenderer)
         return nullptr;
 
-    auto& tableCellRenderer = downcast<RenderTableCell>(*cellRenderer);
-    auto* cellAboveRenderer = tableCellRenderer.table()->cellAbove(&tableCellRenderer);
+    auto* cellAboveRenderer = tableCellRenderer->table()->cellAbove(tableCellRenderer);
     if (!cellAboveRenderer)
         return nullptr;
 

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -68,5 +68,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLTableCellElement)
     static bool isType(const WebCore::HTMLElement& element) { return element.hasTagName(WebCore::HTMLNames::tdTag) || element.hasTagName(WebCore::HTMLNames::thTag); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLElement>(node) && isType(downcast<WebCore::HTMLElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* htmlElement = dynamicDowncast<WebCore::HTMLElement>(node);
+        return htmlElement && isType(*htmlElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLTableColElement.cpp
+++ b/Source/WebCore/html/HTMLTableColElement.cpp
@@ -78,15 +78,14 @@ void HTMLTableColElement::attributeChanged(const QualifiedName& name, const Atom
 
     if (name == spanAttr) {
         m_span = clampHTMLNonNegativeIntegerToRange(newValue, minSpan, maxSpan, defaultSpan);
-        if (is<RenderTableCol>(renderer()))
-            downcast<RenderTableCol>(*renderer()).updateFromElement();
+        if (CheckedPtr col = dynamicDowncast<RenderTableCol>(renderer()))
+            col->updateFromElement();
     } else if (name == widthAttr) {
         if (!newValue.isEmpty()) {
-            if (is<RenderTableCol>(renderer())) {
-                auto& col = downcast<RenderTableCol>(*renderer());
+            if (CheckedPtr col = dynamicDowncast<RenderTableCol>(renderer())) {
                 int newWidth = parseHTMLInteger(newValue).value_or(0);
-                if (newWidth != col.width())
-                    col.setNeedsLayoutAndPrefWidthsRecalc();
+                if (newWidth != col->width())
+                    col->setNeedsLayoutAndPrefWidthsRecalc();
             }
         }
     }

--- a/Source/WebCore/html/HTMLTablePartElement.h
+++ b/Source/WebCore/html/HTMLTablePartElement.h
@@ -51,5 +51,9 @@ protected:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLTablePartElement)
     static bool isType(const WebCore::Element& element) { return element.isHTMLTablePartElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -61,12 +61,12 @@ Ref<HTMLTableRowElement> HTMLTableRowElement::create(const QualifiedName& tagNam
 static inline RefPtr<HTMLTableElement> findTable(const HTMLTableRowElement& row)
 {
     auto* parent = row.parentNode();
-    if (is<HTMLTableElement>(parent))
-        return downcast<HTMLTableElement>(parent);
+    if (auto* table = dynamicDowncast<HTMLTableElement>(parent))
+        return table;
     if (is<HTMLTableSectionElement>(parent)) {
         auto* grandparent = parent->parentNode();
-        if (is<HTMLTableElement>(grandparent))
-            return downcast<HTMLTableElement>(grandparent);
+        if (auto* table = dynamicDowncast<HTMLTableElement>(grandparent))
+            return table;
     }
     return nullptr;
 }
@@ -90,10 +90,10 @@ int HTMLTableRowElement::rowIndex() const
 static inline RefPtr<HTMLCollection> findRows(const HTMLTableRowElement& row)
 {
     RefPtr parent = row.parentNode();
-    if (is<HTMLTableSectionElement>(parent))
-        return downcast<HTMLTableSectionElement>(*parent).rows();
-    if (is<HTMLTableElement>(parent))
-        return downcast<HTMLTableElement>(*parent).rows();
+    if (auto* section = dynamicDowncast<HTMLTableSectionElement>(parent.get()))
+        return section->rows();
+    if (auto* table = dynamicDowncast<HTMLTableElement>(parent.get()))
+        return table->rows();
     return nullptr;
 }
 

--- a/Source/WebCore/html/HTMLTableRowsCollection.cpp
+++ b/Source/WebCore/html/HTMLTableRowsCollection.cpp
@@ -102,8 +102,8 @@ HTMLTableRowElement* HTMLTableRowsCollection::rowAfter(HTMLTableElement& table, 
     else if (isInSection(*previous, tbodyTag))
         child = ElementTraversal::nextSibling(*previous->parentNode());
     for (; child; child = ElementTraversal::nextSibling(*child)) {
-        if (is<HTMLTableRowElement>(*child))
-            return downcast<HTMLTableRowElement>(child.get());
+        if (auto* row = dynamicDowncast<HTMLTableRowElement>(*child))
+            return row;
         if (child->hasTagName(tbodyTag)) {
             if (auto row = childrenOfType<HTMLTableRowElement>(*child).first())
                 return row;
@@ -135,8 +135,8 @@ HTMLTableRowElement* HTMLTableRowsCollection::lastRow(HTMLTableElement& table)
     }
 
     for (auto* child = ElementTraversal::lastChild(table); child; child = ElementTraversal::previousSibling(*child)) {
-        if (is<HTMLTableRowElement>(*child))
-            return downcast<HTMLTableRowElement>(child);
+        if (auto* row = dynamicDowncast<HTMLTableRowElement>(*child))
+            return row;
         if (child->hasTagName(tbodyTag)) {
             if (auto* row = childrenOfType<HTMLTableRowElement>(*child).last())
                 return row;

--- a/Source/WebCore/html/HTMLTableSectionElement.h
+++ b/Source/WebCore/html/HTMLTableSectionElement.h
@@ -52,5 +52,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLTableSectionElement)
     static bool isType(const WebCore::HTMLElement& element) { return element.hasTagName(WebCore::HTMLNames::theadTag) || element.hasTagName(WebCore::HTMLNames::tfootTag) || element.hasTagName(WebCore::HTMLNames::tbodyTag); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::HTMLElement>(node) && isType(downcast<WebCore::HTMLElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* htmlElement = dynamicDowncast<WebCore::HTMLElement>(node);
+        return htmlElement && isType(*htmlElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -163,10 +163,10 @@ void HTMLTemplateElement::attachAsDeclarativeShadowRootIfNeeded(Element& host)
     auto importedContent = document().importNode(content(), /* deep */ true).releaseReturnValue();
     for (RefPtr<Node> node = NodeTraversal::next(importedContent), next; node; node = next) {
         next = NodeTraversal::next(*node);
-        if (!is<HTMLTemplateElement>(*node))
-            continue;
-        if (RefPtr parentElement = node->parentElement())
-            downcast<HTMLTemplateElement>(*node).attachAsDeclarativeShadowRootIfNeeded(*parentElement);
+        if (auto* templateElement = dynamicDowncast<HTMLTemplateElement>(*node)) {
+            if (RefPtr parentElement = node->parentElement())
+                templateElement->attachAsDeclarativeShadowRootIfNeeded(*parentElement);
+        }
     }
 
     Ref shadowRoot = exceptionOrShadowRoot.releaseReturnValue();

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -238,10 +238,12 @@ void HTMLTextAreaElement::updateFocusAppearance(SelectionRestorationMode restora
 
 void HTMLTextAreaElement::defaultEventHandler(Event& event)
 {
-    if (renderer() && (event.isMouseEvent() || event.type() == eventNames().blurEvent))
-        forwardEvent(event);
-    else if (renderer() && is<BeforeTextInsertedEvent>(event))
-        handleBeforeTextInsertedEvent(downcast<BeforeTextInsertedEvent>(event));
+    if (renderer()) {
+        if (event.isMouseEvent() || event.type() == eventNames().blurEvent)
+            forwardEvent(event);
+        else if (auto* insertedEvent = dynamicDowncast<BeforeTextInsertedEvent>(event))
+            handleBeforeTextInsertedEvent(*insertedEvent);
+    }
 
     HTMLTextFormControlElement::defaultEventHandler(event);
 }

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -191,6 +191,14 @@ WEBCORE_EXPORT HTMLTextFormControlElement* enclosingTextFormControl(const Positi
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLTextFormControlElement)
     static bool isType(const WebCore::Element& element) { return element.isTextFormControlElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
-    static bool isType(const WebCore::EventTarget& target) { return is<WebCore::Node>(target) && isType(downcast<WebCore::Node>(target)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
+    static bool isType(const WebCore::EventTarget& target)
+    {
+        auto* node = dynamicDowncast<WebCore::Node>(target);
+        return node && isType(*node);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -650,7 +650,8 @@ void InputType::forwardEvent(Event&)
 
 bool InputType::shouldSubmitImplicitly(Event& event)
 {
-    return is<KeyboardEvent>(event) && event.type() == eventNames().keypressEvent && downcast<KeyboardEvent>(event).charCode() == '\r';
+    auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event);
+    return keyboardEvent && event.type() == eventNames().keypressEvent && keyboardEvent->charCode() == '\r';
 }
 
 RenderPtr<RenderElement> InputType::createInputRenderer(RenderStyle&& style)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -4540,8 +4540,8 @@ void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
 
     // Extend the base useProgram method instead of overriding it in
     // WebGL2RenderingContext to keep the preceding validations in the same order.
-    if (isWebGL2()) {
-        if (downcast<WebGL2RenderingContext>(*this).isTransformFeedbackActiveAndNotPaused()) {
+    if (auto* context = dynamicDowncast<WebGL2RenderingContext>(*this)) {
+        if (context->isTransformFeedbackActiveAndNotPaused()) {
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "useProgram", "transform feedback is active and not paused");
             return;
         }


### PR DESCRIPTION
#### 9381085dab32d8a8f6ebe23c5ce0ec2ca8f15845
<pre>
Use dynamicDowncast&lt;T&gt; even more in html/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265226">https://bugs.webkit.org/show_bug.cgi?id=265226</a>

Reviewed by Dan Glastonbury.

* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::defaultEventHandler):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::hasFallbackContent const):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::flattenAssignedNodes):
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::insertedIntoAncestor):
(WebCore::HTMLSourceElement::removedFromAncestor):
* Source/WebCore/html/HTMLSummaryElement.cpp:
(WebCore::HTMLSummaryElement::detailsElement const):
(WebCore::isInSummaryInteractiveContent):
(WebCore::HTMLSummaryElement::defaultEventHandler):
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::attributeChanged):
(WebCore::HTMLTableCellElement::cellAbove const):
* Source/WebCore/html/HTMLTableCellElement.h:
(isType):
* Source/WebCore/html/HTMLTableColElement.cpp:
(WebCore::HTMLTableColElement::attributeChanged):
* Source/WebCore/html/HTMLTablePartElement.h:
(isType):
* Source/WebCore/html/HTMLTableRowElement.cpp:
(WebCore::findTable):
(WebCore::findRows):
* Source/WebCore/html/HTMLTableRowsCollection.cpp:
(WebCore::HTMLTableRowsCollection::rowAfter):
(WebCore::HTMLTableRowsCollection::lastRow):
* Source/WebCore/html/HTMLTableSectionElement.h:
(isType):
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::attachAsDeclarativeShadowRootIfNeeded):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::defaultEventHandler):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::selection const):
(WebCore::innerTextValueFrom):
(WebCore::HTMLTextFormControlElement::setInnerTextValue):
(WebCore::positionForIndex):
(WebCore::HTMLTextFormControlElement::indexForPosition const):
(WebCore::HTMLTextFormControlElement::valueWithHardLineBreaks const):
* Source/WebCore/html/HTMLTextFormControlElement.h:
(isType):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::shouldSubmitImplicitly):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::useProgram):

Canonical link: <a href="https://commits.webkit.org/271060@main">https://commits.webkit.org/271060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c5cd0d560caae1f4ed22e83a2ee416fe704509

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24676 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30009 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30300 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28221 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4588 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3520 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4507 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->