### PR TITLE
RemoteRealtimeMediaSourceProxy should use latest successful constraints when creating the remote source

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -97,7 +97,7 @@ private:
     bool m_shouldCaptureInGPUProcess { false };
 
     WebCore::MediaConstraints m_constraints;
-    Deque<WebCore::RealtimeMediaSource::ApplyConstraintsHandler> m_pendingApplyConstraintsCallbacks;
+    Deque<std::pair<WebCore::RealtimeMediaSource::ApplyConstraintsHandler, WebCore::MediaConstraints>> m_pendingApplyConstraintsRequests;
     bool m_isReady { false };
     CompletionHandler<void(WebCore::CaptureSourceError&&)> m_callback;
     WebCore::CaptureSourceError m_failureReason;

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -715,6 +715,10 @@ TEST(WebKit2, CrashGPUProcessAfterApplyingConstraints)
     [webView stringByEvaluatingJavaScript:@"changeConstraints()"];
     TestWebKitAPI::Util::run(&done);
 
+    done = false;
+    [webView stringByEvaluatingJavaScript:@"applyBadConstraintsToAudio()"];
+    TestWebKitAPI::Util::run(&done);
+
     auto webViewPID = [webView _webProcessIdentifier];
 
     // The GPU process should get launched.

--- a/Tools/TestWebKitAPI/Tests/WebKit/getUserMedia.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/getUserMedia.html
@@ -222,6 +222,17 @@
                 });
             }
 
+            function applyBadConstraintsToAudio() {
+                async function doApplyBadConstraintsToAudio() {
+                    const audioTrack = stream.getAudioTracks()[0];
+                    await audioTrack.applyConstraints({ echoCancellation: false, sampleRate: { exact: 10 } });
+                }
+                doApplyBadConstraintsToAudio().then(() => {
+                    window.webkit.messageHandlers.gum.postMessage("FAIL applyBadConstraintsToAudio succeeded");
+                }, (e) => {
+                    window.webkit.messageHandlers.gum.postMessage("PASS");
+                });
+            }
 
             function captureOrientation() {
                 let settings = stream.getVideoTracks()[0].getSettings();


### PR DESCRIPTION
#### 6abef0032d2b2b4d390ae4a11ba256d76cd88607
<pre>
RemoteRealtimeMediaSourceProxy should use latest successful constraints when creating the remote source
<a href="https://bugs.webkit.org/show_bug.cgi?id=265232">https://bugs.webkit.org/show_bug.cgi?id=265232</a>
<a href="https://rdar.apple.com/118708700">rdar://118708700</a>

Reviewed by Eric Carlson and Jean-Yves Avenard.

In case of GPUProcess crash, we are recreating a remote source by calling RemoteRealtimeMediaSourceProxy::createRemoteMediaSource.
createRemoteMediaSource is currently using the constraints used initially (via getUserMedia).
But it should in fact use the last successful constraints applied to the previous remote source (via applyConstraints).
Update the code accordingly and update API test to cover that case.

Canonical link: <a href="https://commits.webkit.org/271074@main">https://commits.webkit.org/271074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d833815084bd9ca22b36a4c8c695587ff4e28941

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24687 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30310 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28231 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5631 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6569 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->