### PR TITLE
RemoteRealtimeMediaSourceProxy::whenReady should support more than one callback

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -169,6 +169,13 @@ void RemoteRealtimeMediaSourceProxy::whenReady(CompletionHandler<void(WebCore::C
     if (m_isReady)
         return callback(WebCore::CaptureSourceError(m_failureReason));
 
+    if (m_callback) {
+        callback = [previousCallbacks = std::exchange(m_callback, { }), newCallback = WTFMove(callback)] (auto&& error) mutable {
+            previousCallbacks(WebCore::CaptureSourceError { error });
+            newCallback(WTFMove(error));
+        };
+    }
+
     m_callback = WTFMove(callback);
 }
 


### PR DESCRIPTION
#### e7ce0121a9b2d114eba06e49044ae54861b807af
<pre>
RemoteRealtimeMediaSourceProxy::whenReady should support more than one callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=265236">https://bugs.webkit.org/show_bug.cgi?id=265236</a>
<a href="https://rdar.apple.com/118709394">rdar://118709394</a>

Reviewed by Jean-Yves Avenard.

CoreAudioCaptureSource::whenReady can support being called more than once.
Given this and given the name (whenReady), we should also have RemoteRealtimeMediaSourceProxy::whenReady handle this.

* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::whenReady):

Canonical link: <a href="https://commits.webkit.org/271073@main">https://commits.webkit.org/271073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8158b1f50891910dbb575046c0c8e72794a31ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24881 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24720 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4148 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30333 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28254 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5650 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6568 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->