### PR TITLE
re-import css/cssom WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-002-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Load event doesn't fire on removed link
+PASS Load event doesn't fire for removed sheet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-002.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Link element load event doesn't block the parser.</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<link rel="help" href="https://html.spec.whatwg.org/#link-type-stylesheet">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  let NUM_LOADS = 0;
+
+  function sheetUrl(token) {
+    return "stylesheet-same-origin.css?" + token;
+  }
+
+  function createLink(token) {
+    let link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = sheetUrl(token);
+    return link;
+  }
+
+  function waitForEnoughTimeToLoadSheet(token) {
+    return new Promise(resolve => {
+      let link = createLink(token);
+      link.onload = resolve;
+      document.head.appendChild(link);
+    });
+  }
+
+  promise_test(async function (t) {
+    let link = createLink("removed");
+    link.addEventListener("load", t.unreached_func("got unexpected load event"));
+    link.addEventListener("error", t.unreached_func("got unexpected error event"));
+    document.head.appendChild(link);
+    link.remove();
+
+    await waitForEnoughTimeToLoadSheet("removed-wait");
+  }, "Load event doesn't fire on removed link");
+
+  promise_test(async function (t) {
+    let link = createLink("changed-initial");
+    let sawLoad = false;
+    let load = new Promise(resolve => {
+      link.addEventListener("load", function(e) {
+        assert_false(sawLoad, "Should only see load event once");
+        sawLoad = true;
+        resolve();
+      });
+    });
+    link.addEventListener("error", t.unreached_func("got unexpected error event"));
+    document.head.appendChild(link);
+    link.href = sheetUrl("changed-change");
+
+    await waitForEnoughTimeToLoadSheet("changed-wait");
+    await load;
+
+    assert_true(sawLoad, "Should've seen the load event only once");
+  }, "Load event doesn't fire for removed sheet");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Link element load event doesn't block the parser.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Link element load event doesn't block the parser.</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<link rel="help" href="https://html.spec.whatwg.org/#link-type-stylesheet">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  let NUM_LOADS = 0;
+</script>
+<link rel="stylesheet" href="data:text/css,*{}" onload="++NUM_LOADS">
+<script>
+let t = async_test(document.title);
+window.addEventListener("load", t.step_func_done(() => {
+  assert_equals(NUM_LOADS, 2, "Load event should've fired for all links");
+}));
+t.step(function() {
+  assert_equals(document.styleSheets.length, 1, "Should expose the sheet to the OM before running script");
+  // We can't quite assert that NUM_LOADS is zero (even though it almost-always
+  // should be the case), in case the parser yields just before executing the
+  // script but after parsing the link load.
+  let loadsBefore = NUM_LOADS;
+  // Intentionally the same href as above, to test caching behavior.
+  document.write(`
+    <link rel="stylesheet" href="data:text/css,*{}" onload="++NUM_LOADS">
+  `);
+  assert_equals(document.styleSheets.length, 2, "Should expose both sheets to the OM before running second script");
+  assert_equals(NUM_LOADS, loadsBefore, "Shouldn't fire the load event sync");
+  assert_not_equals(document.styleSheets[0], document.styleSheets[1], "Should be different sheets");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLStyleElement-load-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLStyleElement-load-event-expected.txt
@@ -1,0 +1,3 @@
+
+PASS style elements fire load events properly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLStyleElement-load-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLStyleElement-load-event.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>style elements fire load events properly</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<link rel="help" href="https://html.spec.whatwg.org/#update-a-style-block">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  let NUM_LOADS = 0;
+</script>
+<style onload="++NUM_LOADS"></style>
+<style onload="++NUM_LOADS">:root { background-color: lime }</style>
+<style onload="++NUM_LOADS">:root { background-color: lime }</style> <!-- Intentionally the same -->
+<script>
+async_test(function(t) {
+  assert_equals(document.styleSheets.length, 3, "Should expose the three stylesheets to the OM sync");
+  assert_equals(NUM_LOADS, 0, "Should not fire load event sync");
+  window.addEventListener("load", t.step_func_done(() => {
+    assert_equals(NUM_LOADS, 3, "Load event should've fired for all nodes");
+  }));
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt
@@ -1,0 +1,8 @@
+aaa
+
+PASS document.caretPositionFromPoint() throws when called without the correct parameters
+FAIL document.caretPositionFromPoint() should return null for a document with no viewport doc.caretPositionFromPoint is not a function. (In 'doc.caretPositionFromPoint(0, 0)', 'doc.caretPositionFromPoint' is undefined)
+FAIL document.caretPositionFromPoint() should return null if given coordinates outside of the viewport document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(-5, 5)', 'document.caretPositionFromPoint' is undefined)
+FAIL document.caretPositionFromPoint() should return a CaretPosition at the specified location document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(x, y)', 'document.caretPositionFromPoint' is undefined)
+FAIL CaretRange.getClientRect() should return a DOMRect that matches one obtained from a manually constructed Range document.caretPositionFromPoint is not a function. (In 'document.caretPositionFromPoint(x, y)', 'document.caretPositionFromPoint' is undefined)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html
@@ -25,14 +25,18 @@
       return [rect.x + rect.width / 2, rect.y + rect.height / 2];
     };
 
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       frame.srcdoc = source;
       frame.onload = () => {
-        const frameDoc = frame.contentDocument;
-        const {offset} = frameDoc.caretPositionFromPoint(
-          ...elementCenter(frameDoc.querySelector("h1"))
-        );
-        resolve(offset);
+        try {
+          const frameDoc = frame.contentDocument;
+          const {offset} = frameDoc.caretPositionFromPoint(
+            ...elementCenter(frameDoc.querySelector("h1"))
+          );
+          resolve(offset);
+        } catch (error) {
+          reject(error);
+        }
       };
     });
   };

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>document.caretPositionFromPoint()</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-document-caretpositionfrompoint">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #textDiv {
+    display: inline-block;
+  }
+</style>
+<div id="textDiv">aaa</div>
+<script>
+  test(() => {
+    assert_throws_js(TypeError, () => { document.caretPositionFromPoint(); });
+    assert_throws_js(TypeError, () => { document.caretPositionFromPoint(5); });
+    assert_throws_js(TypeError, () => { document.caretPositionFromPoint("foo", 5); });
+  }, "document.caretPositionFromPoint() throws when called without the correct parameters");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("");
+    assert_equals(doc.caretPositionFromPoint(0, 0), null);
+  }, "document.caretPositionFromPoint() should return null for a document with no viewport");
+
+  test(() => {
+    assert_equals(document.caretPositionFromPoint(-5, 5), null);
+    assert_equals(document.caretPositionFromPoint(5, -5), null);
+    assert_equals(document.caretPositionFromPoint(document.documentElement.clientWidth * 2, 5), null);
+    assert_equals(document.caretPositionFromPoint(5, document.documentElement.clientHeight * 2), null);
+  }, "document.caretPositionFromPoint() should return null if given coordinates outside of the viewport");
+
+  test(() => {
+    const textDiv = document.getElementById("textDiv");
+    const rect = textDiv.getBoundingClientRect();
+    const characterWidth = rect.width / textDiv.textContent.length;
+    const characterIndex = 2
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y);
+    assert_true(caretPosition instanceof CaretPosition);
+    assert_true(caretPosition.offsetNode instanceof Text);
+    assert_equals(typeof(caretPosition.offset), "number");
+    assert_equals(caretPosition.offsetNode, textDiv.firstChild);
+    assert_equals(caretPosition.offset, characterIndex);
+  }, "document.caretPositionFromPoint() should return a CaretPosition at the specified location");
+
+  test(() => {
+    const textDiv = document.getElementById("textDiv");
+    const rect = textDiv.getBoundingClientRect();
+    const characterWidth = rect.width / textDiv.textContent.length;
+    const characterIndex = 2
+    const x = rect.left + characterWidth * characterIndex;
+    const y = rect.top + rect.height / 2;
+    const caretPosition = document.caretPositionFromPoint(x, y);
+    const caretRangeExpected = new Range();
+    caretRangeExpected.setStart(textDiv.firstChild, characterIndex);
+    caretRectExpected = caretRangeExpected.getBoundingClientRect();
+    assert_true(caretPosition.getClientRect instanceof Function);
+    const caretRectActual = caretPosition.getClientRect();
+    assert_true(caretRectActual instanceof DOMRect);
+    assert_not_equals(caretRectActual, caretPosition.getClientRect(), "CaretPosition.getClientRect() should return a new DOMRect every time");
+    assert_equals(caretRectActual.x, caretRectExpected.x);
+    assert_equals(caretRectActual.y, caretRectExpected.y);
+    assert_equals(caretRectActual.width, 0, "Caret range should be collapsed");
+    assert_equals(caretRectActual.height, caretRectExpected.height);
+  }, "CaretRange.getClientRect() should return a DOMRect that matches one obtained from a manually constructed Range");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/change-rule-with-layers-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/change-rule-with-layers-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSSOM Test: Chrome crash when modifying rules with @layer</title>
+<link rel="help" href="https://crbug.com/1499277">
+<link rel="author" title="Steinar H. Gunderson" href="mailto:sesse@chromium.org">
+<style id="s">
+.x {
+  transition: color 0.5s;
+  @layer warning {
+    :first-child { }
+    :last-child { }
+  }
+}
+</style>
+<p>Test passes if it does not crash.</p>
+<script>
+document.body.offsetTop;
+s.sheet.cssRules[0].style.transitionDuration = '1s';
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule.html
@@ -16,6 +16,7 @@
         @import url("support/a-green.css") screen;
         @import url("support/a-green.css") all;
         @import url("support/a-green") supports((display: flex) or (display: block));
+        @import url('quote"quote');
         @page { background-color: red; }
     </style>
 </head>
@@ -23,7 +24,7 @@
     <div id="log"></div>
 
     <script type="text/javascript">
-        var styleSheet, ruleList, rule, ruleWithMedia, ruleWithMediaAll, ruleWithSupports;
+        var styleSheet, ruleList, rule, ruleWithMedia, ruleWithMediaAll, ruleWithSupports, ruleWithQuote;
         setup(function() {
             styleSheet = document.getElementById("styleElement").sheet;
             ruleList = styleSheet.cssRules;
@@ -31,6 +32,7 @@
             ruleWithMedia = ruleList[1];
             ruleWithMediaAll = ruleList[2];
             ruleWithSupports = ruleList[3];
+            ruleWithQuote = ruleList[4];
         });
 
         test(function() {
@@ -71,6 +73,7 @@
             assert_equals(ruleWithMedia.cssText, '@import url("support/a-green.css") screen;');
             assert_equals(ruleWithMediaAll.cssText, '@import url("support/a-green.css") all;');
             assert_equals(ruleWithSupports.cssText, '@import url("support/a-green") supports((display: flex) or (display: block));');
+            assert_equals(ruleWithQuote.cssText, '@import url("quote\\\"quote");');
             assert_equals(rule.parentRule, null);
             assert_true(rule.parentStyleSheet instanceof CSSStyleSheet);
         }, "Values of CSSRule attributes");
@@ -99,7 +102,7 @@
         }, "CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]");
 
         test(function() {
-            var ruleWithPage = ruleList[4];
+            var ruleWithPage = ruleList[5];
             ruleWithPage.style = "margin-top: 10px;"
             assert_equals(ruleWithPage.style.cssText, "margin-top: 10px;");
         }, "CSSStyleDeclaration cssText attribute should be updated due to [PutForwards]");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule-expected.txt
@@ -4,5 +4,11 @@ FAIL Page selector is initially the empty string assert_equals: expected "" but 
 FAIL Set selectorText to :left pseudo page assert_equals: expected ":left" but got "@page"
 FAIL Set selectorText to named page assert_equals: expected "named" but got "@page named"
 FAIL Set selectorText to named page with :first pseudo page assert_equals: expected "named:first" but got "@page named"
+FAIL Set selectorText to named page with case insensitive :first pseudo page assert_equals: expected "named:first" but got "@page named"
+FAIL Set selectorText to named page with two :first pseudo page assert_equals: expected "named:first:first" but got "@page named"
+FAIL Set selectorText to named page with pseudo pages of :first, :left, :right, :first in order. assert_equals: expected "named:first:left:right:first" but got "@page named"
+FAIL Cannot set selectorText to named page with pseudo, whitespace between assert_equals: expected "" but got "@page named"
+FAIL Cannot set selectorText to two pseudos, whitespace between assert_equals: expected "" but got "@page named"
+FAIL Cannot set selectorText to invalid pseudo page assert_equals: expected "" but got "@page named"
 PASS Set selectorText to named page after rule was removed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule.html
@@ -35,6 +35,40 @@
   }, "Set selectorText to named page with :first pseudo page");
 
   test(() => {
+    rule.selectorText = "named:First";
+    assert_equals(rule.selectorText, "named:first");
+  }, "Set selectorText to named page with case insensitive :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:first:first";
+    assert_equals(rule.selectorText, "named:first:first");
+  }, "Set selectorText to named page with two :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:first:left:right:first";
+    assert_equals(rule.selectorText, "named:first:left:right:first");
+  }, "Set selectorText to named page with pseudo pages of " +
+    ":first, :left, :right, :first in order.");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = "named :first";
+    assert_equals(rule.selectorText, "");
+  }, "Cannot set selectorText to named page with pseudo, whitespace between");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = ":first :left";
+    assert_equals(rule.selectorText, "");
+  }, "Cannot set selectorText to two pseudos, whitespace between");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = ":notapagepseudo";
+    assert_equals(rule.selectorText, "");
+  }, "Cannot set selectorText to invalid pseudo page");
+
+  test(() => {
     assert_equals(rule.parentStyleSheet, sheet);
     sheet.deleteRule(0);
     assert_equals(rule.parentStyleSheet, null);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Deleting a @namespace rule when list contains anything other than @import or @namespace rules should throw InvalidStateError. assert_throws_dom: function "() => styleSheet.deleteRule(0)" did not throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Deleting a @namespace rule when list contains anything other than @import or @namespace rules should throw InvalidStateError.</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-1/#remove-a-css-rule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @namespace a url();
+</style>
+<script>
+  test(function () {
+    let styleSheet = document.styleSheets[0];
+    styleSheet.cssRules[0];
+    styleSheet.insertRule(`b {}`, 1);
+    assert_throws_dom("InvalidStateError", () => styleSheet.deleteRule(0));
+  }, "Deleting a @namespace rule when list contains anything other than @import or @namespace rules should throw InvalidStateError.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-crash.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Chromium bug: getComputedStyle() crashes with subtree layout of out-of-flow node</title>
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1458561">
+
+<style>
+.container {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  background: lime;
+}
+
+.oof {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  top: 0;
+  left: 0;
+  overflow: hidden;
+  background: hotpink;
+}
+</style>
+
+<div class="container">
+  <div id="target1" class="oof">hi</div>
+</div>
+<script>
+document.body.offsetTop;
+target1.innerText = 'boom';
+getComputedStyle(target1).top;  // Shouldn't crash
+</script>
+
+<div class="container">
+  <div id="target2" class="oof"><div>hi</div></div>
+</div>
+<script>
+document.body.offsetTop;
+target2.firstChild.innerText = 'boom';
+getComputedStyle(target2).top;  // Shouldn't crash
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-logical-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-logical-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>Chromium bug: getComputedStyle() crashes with logical inset properties</title>
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1478578">
+
+<style>
+.target {
+  position: absolute;
+}
+</style>
+
+<div class="target" id="target1"></div>
+<script>getComputedStyle(target1).insetInlineStart</script>
+
+<div class="target" id="targetr2"></div>
+<script>getComputedStyle(target2).insetInlineEnd</script>
+
+<div class="target" id="target3"></div>
+<script>getComputedStyle(target3).insetBlockStart</script>
+
+<div class="target" id="target4"></div>
+<script>getComputedStyle(target4).insetBlockEnd</script>
+
+<div class="target" id="target5"></div>
+<script>getComputedStyle(target5).insetInline</script>
+
+<div class="target" id="target6"></div>
+<script>getComputedStyle(target6).insetBlock</script>
+
+<div class="target" id="target7"></div>
+<script>getComputedStyle(target7).inset</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-roundtrip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-roundtrip-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL Fixed-length left property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+FAIL Fixed-length right property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+FAIL Fixed-length top property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+FAIL Fixed-length bottom property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-roundtrip.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-roundtrip.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>Chromium bug: getComputedStyle() fixed-length inset values don't roundtrip</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1482703">
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+.target {
+  position: absolute;
+}
+</style>
+
+<div class="target" id="target1" style="left: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target1).left, '20.7px');
+}, 'Fixed-length left property value should roundtrip');
+</script>
+
+<div class="target" id="target2" style="right: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target2).right, '20.7px');
+}, 'Fixed-length right property value should roundtrip');
+</script>
+
+<div class="target" id="target3" style="top: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target3).top, '20.7px');
+}, 'Fixed-length top property value should roundtrip');
+</script>
+
+<div class="target" id="target4" style="bottom: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target4).bottom, '20.7px');
+}, 'Fixed-length bottom property value should roundtrip');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-grid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-grid-expected.txt
@@ -1,0 +1,4 @@
+abcdef
+
+FAIL Position absolute getComputedStyle left (for display: grid) assert_equals: Invalid gCS($("body > span > span"))['left']; expected "0px" but got "100px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-grid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-grid.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>Position absolute getComputedStyle left (for display: grid)</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=867616">
+<link rel="author" href="mailto:francois.remy.dev@outlook.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+
+span { display: grid; grid-template-columns: 100px 100px; }
+span { position: absolute; grid-column: 2; }
+
+</style>
+
+<span>abc<span>def</span></span>
+
+<script>
+var test_description = document.title;
+promise_test(t => {
+  return new Promise(test => addEventListener('load', e=>test()))
+      .then(test => assert_equals(
+          getComputedStyle(document.querySelector("body > span > span"))['left'], "0px",
+          "Invalid gCS($(\"body > span > span\"))['left'];"));
+}, test_description);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-multicol-absolute-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-multicol-absolute-crash.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<title>Chromium bug: getComputedStyle() crashes with inset properties on abspos in multicol</title>
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1473508">
+<style>
+html {
+  column-count:2;
+}
+body {
+  transform: scale(1);
+}
+div#test {
+  column-count:2;
+  position:absolute;
+}
+</style>
+
+<div id="test">
+  <svg xmlns="http://www.w3.org/2000/svg"></svg>
+  <div style="transform: scale(1)">
+    <ruby style="position: absolute">
+      <rt>foo</rt>
+    </ruby>
+  </div>
+</div>
+
+<script>
+getComputedStyle(test).right;
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline-expected.txt
@@ -1,0 +1,8 @@
+Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet
+
+FAIL OOF with left fixed right auto in relpos inline container assert_equals: expected "140px" but got "420px"
+PASS OOF with left auto right fixed in relpos inline container
+FAIL OOF with left fixed right auto in relpos inline container with mixed directions assert_equals: expected "140px" but got "420px"
+PASS OOF with left auto right fixed in relpos inline container with mixed directions
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<title>getComputedStyle OOF inset resolved against relpos inline container</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+.ifc {
+  position: relative;
+  width: max-content;
+  font: 20px/1 Ahem;
+  margin-bottom: 2em;
+}
+
+.relpos {
+  position: relative;
+  background: yellow;
+  color: yellow;
+}
+
+.target {
+  position: absolute;
+  background: green;
+  width: 5em;
+  height: 1em;
+  top: 1em;
+}
+
+.fix-start {
+  inset-inline-start: 0;
+}
+
+.fix-end {
+  inset-inline-end: 0;
+}
+</style>
+
+<div class="ifc">
+  Lorem
+  <span class="relpos">
+    ipsum dolor
+    <div class="target fix-start" id="target1"></div>
+    <div class="target fix-end" id="target2"></div>
+  </span>
+  sit amet
+</div>
+<script>
+test(() => {
+  let style = getComputedStyle(target1);
+  assert_equals(style.left, '0px');
+  assert_equals(style.right, '140px');
+}, 'OOF with left fixed right auto in relpos inline container');
+
+test(() => {
+  let style = getComputedStyle(target2);
+  assert_equals(style.left, '140px');
+  assert_equals(style.right, '0px');
+}, 'OOF with left auto right fixed in relpos inline container');
+</script>
+
+<div class="ifc">
+  Lorem
+  <span class="relpos" dir="rtl">
+    ipsum dolor
+    <div class="target fix-start" id="target3" dir="ltr"></div>
+    <div class="target fix-end" id="target4" dir="ltr"></div>
+  </span>
+  sit amet
+</div>
+<script>
+test(() => {
+  let style = getComputedStyle(target3);
+  assert_equals(style.left, '0px');
+  assert_equals(style.right, '140px');
+}, 'OOF with left fixed right auto in relpos inline container with mixed directions');
+
+test(() => {
+  let style = getComputedStyle(target4);
+  assert_equals(style.left, '140px');
+  assert_equals(style.right, '0px');
+}, 'OOF with left auto right fixed in relpos inline container with mixed directions');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL Fixed-length margin-left property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+FAIL Fixed-length margin-right property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+FAIL Fixed-length margin-top property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+FAIL Fixed-length margin-bottom property value should roundtrip assert_equals: expected "20.7px" but got "20.700001px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>Chromium bug: getComputedStyle() fixed-length inset values don't roundtrip</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1482703">
+<link rel="help" href="mailto:xiaochengh@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="target1" style="margin-left: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target1).marginLeft, '20.7px');
+}, 'Fixed-length margin-left property value should roundtrip');
+</script>
+
+<div id="target2" style="margin-right: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target2).marginRight, '20.7px');
+}, 'Fixed-length margin-right property value should roundtrip');
+</script>
+
+<div id="target3" style="margin-top: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target3).marginTop, '20.7px');
+}, 'Fixed-length margin-top property value should roundtrip');
+</script>
+
+<div id="target4" style="margin-bottom: 20.7px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target4).marginBottom, '20.7px');
+}, 'Fixed-length margin-bottom property value should roundtrip');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
@@ -1,3 +1,4 @@
+Item
 
 PASS Resolution of width is correct for ::before and ::after pseudo-elements
 PASS Resolution of width is correct for ::before and ::after pseudo-elements of display: contents elements
@@ -8,4 +9,5 @@ FAIL Item-based blockification of nonexistent pseudo-elements assert_equals: Pse
 PASS display: contents on pseudo-elements
 PASS Dynamically change to display: contents on pseudo-elements
 FAIL Unknown pseudo-elements assert_true: Should return an empty style for unknown pseudo-elements starting with double-colon expected true got false
+FAIL Unknown pseudo-element with a known string (ex: marker) assert_true: Should return an empty style for :marker expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle">
 <link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values">
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Karl Dubost" href="https://github.com/karlcow">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <style>
@@ -54,6 +55,12 @@
 #contents-pseudos-dynamic.contents::after {
   display: contents;
 }
+#pseudo-invalid::marker {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid {
+  color: rgb(255, 0, 0)
+}
 </style>
 <div id="test">
   <div id="contents"></div>
@@ -62,6 +69,7 @@
   <div id="flex-no-pseudo"></div>
   <div id="contents-pseudos"></div>
   <div id="contents-pseudos-dynamic"></div>
+  <ul><li id="pseudo-invalid">Item</li></ul>
 </div>
 <script>
 test(function() {
@@ -150,4 +158,19 @@ test(function() {
     getComputedStyle(div, ":totallynotapseudo").length == 0,
     "Should return an empty style for unknown pseudo-elements starting with colon");
 }, "Unknown pseudo-elements");
+test(function() {
+  let li = document.querySelector('li');
+  assert_true(
+    getComputedStyle(li, ':marker').length == 0,
+    "Should return an empty style for :marker");
+  assert_true(
+    getComputedStyle(li, 'marker').length != 0,
+    "Should return the element style for marker");
+  assert_equals(
+    getComputedStyle(li, 'marker').color, "rgb(255, 0, 0)",
+    "Should return the element style for marker (ex: color is rgb(255, 0, 0), not rgb(0, 128, 0)");
+  assert_equals(
+  getComputedStyle(li, '::marker').color, "rgb(0, 128, 0)",
+  "Should return the element style for marker (ex: color is rgb(0, 128, 0)");
+}, "Unknown pseudo-element with a known string (ex: marker)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSSOM Test: Chrome crash inserting :dir rule</title>
+<link rel="help" href="https://crbug.com/1486351">
+<p>PASS if no crash.</p>
+<style id="sheet"> </style>
+<div id="host"></div>
+<script>
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = "<slot></slot>";
+  host.offsetTop;
+  host.innerHTML = "<span>Green</span>";
+  sheet.sheet.insertRule("html:dir(ltr) { color: green; }");
+  document.fonts.size();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-in-iframe-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-in-iframe-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSSOM Test: Chrome crash inserting :dir rule in iframe</title>
+<link rel="help" href="https://crbug.com/1486351">
+<p>PASS if no crash.</p>
+<iframe srcdoc='<!DOCTYPE html>
+                <style id="sheet"> </style>
+                <div id="host"></div>
+                <script>
+                  let root = host.attachShadow({mode:"open"});
+                  root.innerHTML = "<slot></slot>";
+                  host.offsetTop;
+                  host.innerHTML = "<span>Green</span>";
+                  sheet.sheet.insertRule("html:dir(ltr) { color: green; }");
+                  getComputedStyle(host).color;
+                </script>
+                '>
+</iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-invalid-where-rule-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-invalid-where-rule-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>CSSOM Test: Chrome crash keeping rule with empty selector list</title>
+<link rel="help" href="https://crbug.com/1499358">
+<link rel="author" title="Steinar H. Gunderson" href="mailto:sesse@chromium.org">
+<p id="elem">PASS if no crash.</p>
+<style id="sheet">.x, :where("something invalid") {} </style>
+<script>
+  elem.offsetTop;
+  sheet.sheet.insertRule("p { color: green; }", 0);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize.html
@@ -130,7 +130,7 @@
               assert_selector_serializes_to("|\\\\", "|\\\\");
             }, "escaped character (\\) in element name with no namespace");
 
-            const element_escaped_ns_rule = "@namespace x\\* 'blah';";            
+            const element_escaped_ns_rule = "@namespace x\\* 'blah';";
             test(() => {
               assert_selector_serializes_to(element_escaped_ns_rule + "x\\*|test", "x\\*|test");
             }, "escaped character (*) in element prefix");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
@@ -324,6 +324,13 @@ PASS content: counter(par-num, decimal)
 PASS content: counter(par-num, upper-roman)
 PASS content: attr(foo-bar)
 PASS content: attr(foo_bar)
+FAIL content: attr(|bar) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
+FAIL content: attr( |bar ) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
+FAIL content: attr(foo-bar, "fallback") assert_equals: content raw inline style declaration expected "attr(foo-bar, \"fallback\")" but got ""
+FAIL content: attr(foo_bar, "fallback") assert_equals: content raw inline style declaration expected "attr(foo_bar, \"fallback\")" but got ""
+FAIL content: attr(|bar, "fallback") assert_equals: content raw inline style declaration expected "attr(bar, \"fallback\")" but got ""
+FAIL content: attr(foo, "") assert_equals: content raw inline style declaration expected "attr(foo)" but got ""
+FAIL content: attr( |foo ,  "" ) assert_equals: content raw inline style declaration expected "attr(foo)" but got ""
 PASS content: inherit
 PASS cursor: auto
 PASS cursor: crosshair

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values.html
@@ -97,7 +97,17 @@
     }
 
     function attr() {
-      var values = ['attr(foo-bar)', 'attr(foo_bar)'];
+      var values = ['attr(foo-bar)', 'attr(foo_bar)',
+                    {actual: "attr(|bar)", serialized: "attr(bar)"},
+                    {actual: "attr( |bar )", serialized: "attr(bar)"}];
+      return iterable(values);
+    }
+
+    function attr_fallback() {
+      var values = ['attr(foo-bar, "fallback")', 'attr(foo_bar, "fallback")',
+                    {actual: 'attr(|bar, "fallback")', serialized: 'attr(bar, "fallback")'},
+                    {actual: 'attr(foo, "")', serialized: 'attr(foo)'},
+                    {actual: 'attr( |foo ,  "" )', serialized: 'attr(foo)'}];
       return iterable(values);
     }
 
@@ -361,7 +371,7 @@
         'initial': 'black', //FIXME depends on user agent
       }],
       ['content', {
-        'values': ['normal', 'none', string, uri, counter, attr, 'inherit'], //FIXME
+        'values': ['normal', 'none', string, uri, counter, attr, attr_fallback, 'inherit'], //FIXME
         'initial': 'normal',
       }],
       //counter-increment

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
@@ -7,7 +7,7 @@ PASS The serialization of border-top: 1px; border-right: 1px; border-bottom: 1px
 PASS The serialization of border-top: 1px; border-right: 1px; border-bottom: 1px; border-left: 1px; should be canonical.
 PASS The serialization of border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px; should be canonical.
 PASS The serialization of border: 1px; border-top: 2px; should be canonical.
-PASS The serialization of border: 1px; border-top: 1px !important; should be canonical.
+FAIL The serialization of border: 1px; border-top: 1px !important; should be canonical. assert_equals: expected "border-right: 1px; border-bottom: 1px; border-left: 1px; border-image: none; border-top: 1px !important;" but got "border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-right-style: none; border-bottom-style: none; border-left-style: none; border-right-color: currentcolor; border-bottom-color: currentcolor; border-left-color: currentcolor; border-image: none; border-top-width: 1px !important; border-top-style: none !important; border-top-color: currentcolor !important;"
 PASS The serialization of border: 1px; border-top-color: red; should be canonical.
 PASS The serialization of border: solid; border-style: dotted should be canonical.
 PASS The serialization of border-width: 1px; should be canonical.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html
@@ -29,7 +29,7 @@
         'border-top: 1px; border-right: 1px; border-bottom: 1px; border-left: 1px;': 'border-width: 1px; border-style: none; border-color: currentcolor;',
         'border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px;': 'border-width: 1px 2px 3px 4px; border-style: none; border-color: currentcolor;',
         'border: 1px; border-top: 2px;': 'border-width: 2px 1px 1px; border-style: none; border-color: currentcolor; border-image: none;',
-        'border: 1px; border-top: 1px !important;': 'border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-right-style: none; border-bottom-style: none; border-left-style: none; border-right-color: currentcolor; border-bottom-color: currentcolor; border-left-color: currentcolor; border-image: none; border-top-width: 1px !important; border-top-style: none !important; border-top-color: currentcolor !important;',
+        'border: 1px; border-top: 1px !important;': 'border-right: 1px; border-bottom: 1px; border-left: 1px; border-image: none; border-top: 1px !important;',
         'border: 1px; border-top-color: red;': 'border-width: 1px; border-style: none; border-color: red currentcolor currentcolor; border-image: none;',
         'border: solid; border-style: dotted': 'border: dotted;',
         'border-width: 1px;': 'border-width: 1px;',

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-dom-mutation-event-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-dom-mutation-event-crash.html
@@ -1,0 +1,13 @@
+<script>
+function go() {
+  b.innerHTML = undefined
+}
+document.addEventListener("DOMContentLoaded", () => {
+  b.appendChild(document.createTextNode(""))
+  a.addEventListener("DOMNodeRemoved", go)
+  go();
+})
+</script>
+<div id="a">
+<style id="b">
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
@@ -51,6 +51,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-002.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLStyleElement-load-event.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/MediaList.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/MediaList2.xhtml
@@ -61,6 +64,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/base-uri.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/border-shorthand-serialization.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/change-rule-with-layers-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/computed-style-003.html
@@ -101,6 +106,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-setter-form-controls.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-setter-logical.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/declaration-block-all-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/escape.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/flex-serialization.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-family-serialization-001.html
@@ -113,10 +119,16 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-display-none-003.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-dynamic-subdoc.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-getter-v-properties.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-logical-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-roundtrip.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-fixed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-grid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-multicol-absolute-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-nobox.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-static.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-sticky-container-for-abspos.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-sticky.html
@@ -124,6 +136,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-layout-dependent-replaced-into-ib-split.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-line-height.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-logical-enumeration.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-property-order.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-resolved-colors.html
@@ -133,6 +146,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/historical.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/inline-style-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-in-iframe-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-invalid-where-rule-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-across-context.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-charset-no-index.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-from-script-expected.html
@@ -142,6 +158,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-no-index.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-no-index.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-syntax-error-01.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-dynamic-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-dynamic-001-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-dynamic-001.html
@@ -174,6 +191,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/style-attr-update-across-documents.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/style-sheet-interfaces-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/style-sheet-interfaces-002.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-dom-mutation-event-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline-expected.txt
@@ -1,0 +1,8 @@
+Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet
+
+FAIL OOF with left fixed right auto in relpos inline container assert_equals: expected "140px" but got "127px"
+FAIL OOF with left auto right fixed in relpos inline container assert_equals: expected "140px" but got "3px"
+FAIL OOF with left fixed right auto in relpos inline container with mixed directions assert_equals: expected "140px" but got "127px"
+FAIL OOF with left auto right fixed in relpos inline container with mixed directions assert_equals: expected "140px" but got "3px"
+


### PR DESCRIPTION
#### dff9be75a492d2ce9d9dcae73413b1d264c29ab0
<pre>
re-import css/cssom WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=265237">https://bugs.webkit.org/show_bug.cgi?id=265237</a>
<a href="https://rdar.apple.com/118710238">rdar://118710238</a>

Reviewed by Tim Nguyen.

This re-imports WPT css/cssom tests.
Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/73d59dc0214b5795c4417c90170682df2bfdf549">https://github.com/web-platform-tests/wpt/commit/73d59dc0214b5795c4417c90170682df2bfdf549</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-load-event.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLStyleElement-load-event-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLStyleElement-load-event.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/change-rule-with-layers-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-logical-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-roundtrip-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-absolute-roundtrip.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-grid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-grid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-multicol-absolute-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-dir-rule-in-iframe-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/insert-invalid-where-rule-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-dom-mutation-event-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-relpos-inline-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/271070@main">https://commits.webkit.org/271070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40c177c8c1f3d8d82c048f47bc3257f5f04ea795

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24918 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27498 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4666 "Found 1 new test failure: fast/forms/datalist/datalist-option-labels.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4078 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30364 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28297 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24104 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6563 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->