### PR TITLE
PathSegments cannot be used with anything else than PathImpl

### DIFF
--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -118,7 +118,7 @@ void Path::moveTo(const FloatPoint& point)
     if (isEmpty())
         m_data = PathSegment(PathMoveTo { point });
     else
-        ensureImpl().moveTo(point);
+        ensureImpl().add(PathMoveTo { point });
 }
 
 const PathMoveTo* Path::asSingleMoveTo() const
@@ -135,7 +135,7 @@ void Path::addLineTo(const FloatPoint& point)
     else if (auto moveTo = asSingleMoveTo())
         m_data = PathSegment(PathDataLine { moveTo->point, point });
     else
-        ensureImpl().addLineTo(point);
+        ensureImpl().add(PathLineTo { point });
 }
 
 void Path::addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endPoint)
@@ -145,7 +145,7 @@ void Path::addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endP
     else if (auto moveTo = asSingleMoveTo())
         m_data = PathSegment(PathDataQuadCurve { moveTo->point, controlPoint, endPoint });
     else
-        ensureImpl().addQuadCurveTo(controlPoint, endPoint);
+        ensureImpl().add(PathQuadCurveTo { controlPoint, endPoint });
 }
 
 void Path::addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint)
@@ -155,7 +155,7 @@ void Path::addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& c
     else if (auto moveTo = asSingleMoveTo())
         m_data = PathSegment(PathDataBezierCurve { moveTo->point, controlPoint1, controlPoint2, endPoint });
     else
-        ensureImpl().addBezierCurveTo(controlPoint1, controlPoint2, endPoint);
+        ensureImpl().add(PathBezierCurveTo { controlPoint1, controlPoint2, endPoint });
 }
 
 void Path::addArcTo(const FloatPoint& point1, const FloatPoint& point2, float radius)
@@ -165,7 +165,7 @@ void Path::addArcTo(const FloatPoint& point1, const FloatPoint& point2, float ra
     else if (auto moveTo = asSingleMoveTo())
         m_data = PathSegment(PathDataArc { moveTo->point, point1, point2, radius });
     else
-        ensureImpl().addArcTo(point1, point2, radius);
+        ensureImpl().add(PathArcTo { point1, point2, radius });
 }
 
 void Path::addArc(const FloatPoint& point, float radius, float startAngle, float endAngle, RotationDirection direction)
@@ -179,7 +179,7 @@ void Path::addArc(const FloatPoint& point, float radius, float startAngle, float
     if (isEmpty())
         m_data = PathSegment(PathArc { point, radius, startAngle, endAngle, direction });
     else
-        ensureImpl().addArc(point, radius, startAngle, endAngle, direction);
+        ensureImpl().add(PathArc { point, radius, startAngle, endAngle, direction });
 }
 
 void Path::addEllipse(const FloatPoint& point, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection direction)
@@ -187,7 +187,7 @@ void Path::addEllipse(const FloatPoint& point, float radiusX, float radiusY, flo
     if (isEmpty())
         m_data = PathSegment(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
     else
-        ensureImpl().addEllipse(point, radiusX, radiusY, rotation, startAngle, endAngle, direction);
+        ensureImpl().add(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
 }
 
 void Path::addEllipseInRect(const FloatRect& rect)
@@ -195,7 +195,7 @@ void Path::addEllipseInRect(const FloatRect& rect)
     if (isEmpty())
         m_data = PathSegment(PathEllipseInRect { rect });
     else
-        ensureImpl().addEllipseInRect(rect);
+        ensureImpl().add(PathEllipseInRect { rect });
 }
 
 void Path::addRect(const FloatRect& rect)
@@ -203,7 +203,7 @@ void Path::addRect(const FloatRect& rect)
     if (isEmpty())
         m_data = PathSegment(PathRect { rect });
     else
-        ensureImpl().addRect(rect);
+        ensureImpl().add(PathRect { rect });
 }
 
 static FloatRoundedRect calculateEvenRoundedRect(const FloatRect& rect, const FloatSize& roundingRadii)
@@ -245,7 +245,7 @@ void Path::addRoundedRect(const FloatRoundedRect& roundedRect, PathRoundedRect::
     if (isEmpty())
         m_data = PathSegment(PathRoundedRect { roundedRect, strategy });
     else
-        ensureImpl().addRoundedRect(roundedRect, strategy);
+        ensureImpl().add(PathRoundedRect { roundedRect, strategy });
 }
 
 void Path::addRoundedRect(const FloatRect& rect, const FloatSize& roundingRadii, PathRoundedRect::Strategy strategy)
@@ -256,7 +256,7 @@ void Path::addRoundedRect(const FloatRect& rect, const FloatSize& roundingRadii,
     if (isEmpty())
         m_data = PathSegment(PathRoundedRect { calculateEvenRoundedRect(rect, roundingRadii), strategy });
     else
-        ensureImpl().addRoundedRect(calculateEvenRoundedRect(rect, roundingRadii), strategy);
+        ensureImpl().add(PathRoundedRect { calculateEvenRoundedRect(rect, roundingRadii), strategy });
 }
 
 void Path::addRoundedRect(const RoundedRect& rect)
@@ -269,7 +269,7 @@ void Path::closeSubpath()
     if (isEmpty() || isClosed())
         return;
 
-    ensureImpl().closeSubpath();
+    ensureImpl().add(PathCloseSubpath { });
 }
 
 void Path::addPath(const Path& path, const AffineTransform& transform)

--- a/Source/WebCore/platform/graphics/PathImpl.cpp
+++ b/Source/WebCore/platform/graphics/PathImpl.cpp
@@ -28,18 +28,13 @@
 
 namespace WebCore {
 
-void PathImpl::appendSegment(const PathSegment& segment)
-{
-    segment.addToImpl(*this);
-}
-
 void PathImpl::addLinesForRect(const FloatRect& rect)
 {
-    moveTo(rect.minXMinYCorner());
-    addLineTo(rect.maxXMinYCorner());
-    addLineTo(rect.maxXMaxYCorner());
-    addLineTo(rect.minXMaxYCorner());
-    closeSubpath();
+    add(PathMoveTo { rect.minXMinYCorner() });
+    add(PathLineTo { rect.maxXMinYCorner() });
+    add(PathLineTo { rect.maxXMaxYCorner() });
+    add(PathLineTo { rect.minXMaxYCorner() });
+    add(PathCloseSubpath { });
 }
 
 void PathImpl::addBeziersForRoundedRect(const FloatRoundedRect& roundedRect)
@@ -52,37 +47,37 @@ void PathImpl::addBeziersForRoundedRect(const FloatRoundedRect& roundedRect)
     const auto& bottomLeftRadius = radii.bottomLeft();
     const auto& bottomRightRadius = radii.bottomRight();
 
-    moveTo(FloatPoint(rect.x() + topLeftRadius.width(), rect.y()));
+    add(PathMoveTo { FloatPoint(rect.x() + topLeftRadius.width(), rect.y()) });
 
-    addLineTo(FloatPoint(rect.maxX() - topRightRadius.width(), rect.y()));
+    add(PathLineTo { FloatPoint(rect.maxX() - topRightRadius.width(), rect.y()) });
     if (topRightRadius.width() > 0 || topRightRadius.height() > 0) {
-        addBezierCurveTo(FloatPoint(rect.maxX() - topRightRadius.width() * circleControlPoint(), rect.y()),
+        add(PathBezierCurveTo { FloatPoint(rect.maxX() - topRightRadius.width() * circleControlPoint(), rect.y()),
             FloatPoint(rect.maxX(), rect.y() + topRightRadius.height() * circleControlPoint()),
-            FloatPoint(rect.maxX(), rect.y() + topRightRadius.height()));
+            FloatPoint(rect.maxX(), rect.y() + topRightRadius.height()) });
     }
 
-    addLineTo(FloatPoint(rect.maxX(), rect.maxY() - bottomRightRadius.height()));
+    add(PathLineTo { FloatPoint(rect.maxX(), rect.maxY() - bottomRightRadius.height()) });
     if (bottomRightRadius.width() > 0 || bottomRightRadius.height() > 0) {
-        addBezierCurveTo(FloatPoint(rect.maxX(), rect.maxY() - bottomRightRadius.height() * circleControlPoint()),
+        add(PathBezierCurveTo { FloatPoint(rect.maxX(), rect.maxY() - bottomRightRadius.height() * circleControlPoint()),
             FloatPoint(rect.maxX() - bottomRightRadius.width() * circleControlPoint(), rect.maxY()),
-            FloatPoint(rect.maxX() - bottomRightRadius.width(), rect.maxY()));
+            FloatPoint(rect.maxX() - bottomRightRadius.width(), rect.maxY()) });
     }
 
-    addLineTo(FloatPoint(rect.x() + bottomLeftRadius.width(), rect.maxY()));
+    add(PathLineTo { FloatPoint(rect.x() + bottomLeftRadius.width(), rect.maxY()) });
     if (bottomLeftRadius.width() > 0 || bottomLeftRadius.height() > 0) {
-        addBezierCurveTo(FloatPoint(rect.x() + bottomLeftRadius.width() * circleControlPoint(), rect.maxY()),
+        add(PathBezierCurveTo { FloatPoint(rect.x() + bottomLeftRadius.width() * circleControlPoint(), rect.maxY()),
             FloatPoint(rect.x(), rect.maxY() - bottomLeftRadius.height() * circleControlPoint()),
-            FloatPoint(rect.x(), rect.maxY() - bottomLeftRadius.height()));
+            FloatPoint(rect.x(), rect.maxY() - bottomLeftRadius.height()) });
     }
 
-    addLineTo(FloatPoint(rect.x(), rect.y() + topLeftRadius.height()));
+    add(PathLineTo { FloatPoint(rect.x(), rect.y() + topLeftRadius.height()) });
     if (topLeftRadius.width() > 0 || topLeftRadius.height() > 0) {
-        addBezierCurveTo(FloatPoint(rect.x(), rect.y() + topLeftRadius.height() * circleControlPoint()),
+        add(PathBezierCurveTo { FloatPoint(rect.x(), rect.y() + topLeftRadius.height() * circleControlPoint()),
             FloatPoint(rect.x() + topLeftRadius.width() * circleControlPoint(), rect.y()),
-            FloatPoint(rect.x() + topLeftRadius.width(), rect.y()));
+            FloatPoint(rect.x() + topLeftRadius.width(), rect.y()) });
     }
 
-    closeSubpath();
+    add(PathCloseSubpath { });
 }
 
 bool PathImpl::isClosed() const

--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -65,13 +65,6 @@ void PathSegment::extendBoundingRect(const FloatPoint& currentPoint, const Float
     });
 }
 
-void PathSegment::addToImpl(PathImpl& impl) const
-{
-    WTF::switchOn(m_data, [&](auto& data) {
-        data.addToImpl(impl);
-    });
-}
-
 bool PathSegment::canApplyElements() const
 {
     return WTF::switchOn(m_data, [&](auto& data) {

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -58,15 +58,14 @@ public:
 
     bool operator==(const PathSegment&) const = default;
 
-    const Data& data() const { return m_data; }
+    const Data& data() const & { return m_data; }
+    Data&& data() && { return WTFMove(m_data); }
     bool isCloseSubPath() const { return std::holds_alternative<PathCloseSubpath>(m_data); }
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
     std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
-    void addToImpl(PathImpl&) const;
 
     bool canApplyElements() const;
     bool applyElements(const PathElementApplier&) const;

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -27,7 +27,6 @@
 #include "PathSegmentData.h"
 
 #include "AffineTransform.h"
-#include "PathImpl.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -50,11 +49,6 @@ void PathMoveTo::extendFastBoundingRect(const FloatPoint&, const FloatPoint&, Fl
 
 void PathMoveTo::extendBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect&) const
 {
-}
-
-void PathMoveTo::addToImpl(PathImpl& impl) const
-{
-    impl.moveTo(point);
 }
 
 void PathMoveTo::applyElements(const PathElementApplier& applier) const
@@ -93,11 +87,6 @@ void PathLineTo::extendBoundingRect(const FloatPoint& currentPoint, const FloatP
 {
     boundingRect.extend(currentPoint);
     boundingRect.extend(point);
-}
-
-void PathLineTo::addToImpl(PathImpl& impl) const
-{
-    impl.addLineTo(point);
 }
 
 void PathLineTo::applyElements(const PathElementApplier& applier) const
@@ -174,11 +163,6 @@ void PathQuadCurveTo::extendBoundingRect(const FloatPoint& currentPoint, const F
     boundingRect.extend(currentPoint);
     boundingRect.extend(extremity);
     boundingRect.extend(endPoint);
-}
-
-void PathQuadCurveTo::addToImpl(PathImpl& impl) const
-{
-    impl.addQuadCurveTo(controlPoint, endPoint);
 }
 
 void PathQuadCurveTo::applyElements(const PathElementApplier& applier) const
@@ -295,11 +279,6 @@ void PathBezierCurveTo::extendBoundingRect(const FloatPoint& currentPoint, const
     boundingRect.extend(endPoint);
 }
 
-void PathBezierCurveTo::addToImpl(PathImpl& impl) const
-{
-    impl.addBezierCurveTo(controlPoint1, controlPoint2, endPoint);
-}
-
 void PathBezierCurveTo::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::AddCurveToPoint, { controlPoint1, controlPoint2, endPoint } });
@@ -363,11 +342,6 @@ void PathArcTo::extendBoundingRect(const FloatPoint& currentPoint, const FloatPo
     boundingRect.extend(currentPoint);
     boundingRect.extend(controlPoint1);
     boundingRect.extend(calculateArcToEndPoint(currentPoint, controlPoint1, controlPoint2, radius));
-}
-
-void PathArcTo::addToImpl(PathImpl& impl) const
-{
-    impl.addArcTo(controlPoint1, controlPoint2, radius);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathArcTo& data)
@@ -447,11 +421,6 @@ void PathArc::extendBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect
     boundingRect.extend({ x2, y2 });
 }
 
-void PathArc::addToImpl(PathImpl& impl) const
-{
-    impl.addArc(center, radius, startAngle, endAngle, direction);
-}
-
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathArc& data)
 {
     ts << "add arc " << data.center << " " << data.radius  << " " << data.startAngle  << " " << data.endAngle  << " " << data.direction;
@@ -501,11 +470,6 @@ void PathEllipse::extendBoundingRect(const FloatPoint& currentPoint, const Float
     boundingRect.extend(currentPoint);
 }
 
-void PathEllipse::addToImpl(PathImpl& impl) const
-{
-    impl.addEllipse(center, radiusX, radiusY, rotation, startAngle, endAngle, direction);
-}
-
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathEllipse& data)
 {
     ts << "add ellipse " << data.center << " " << data.radiusX << " " << data.radiusY  << " " << data.rotation << " " << data.startAngle  << " " << data.endAngle  << " " << data.direction;
@@ -533,11 +497,6 @@ void PathEllipseInRect::extendBoundingRect(const FloatPoint&, const FloatPoint&,
 {
     boundingRect.extend(rect.minXMinYCorner());
     boundingRect.extend(rect.maxXMaxYCorner());
-}
-
-void PathEllipseInRect::addToImpl(PathImpl& impl) const
-{
-    impl.addEllipseInRect(rect);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathEllipseInRect& data)
@@ -569,11 +528,6 @@ void PathRect::extendBoundingRect(const FloatPoint&, const FloatPoint&, FloatRec
     boundingRect.extend(rect.maxXMaxYCorner());
 }
 
-void PathRect::addToImpl(PathImpl& impl) const
-{
-    impl.addRect(rect);
-}
-
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathRect& data)
 {
     ts << "add rect " << data.rect;
@@ -603,11 +557,6 @@ void PathRoundedRect::extendBoundingRect(const FloatPoint&, const FloatPoint&, F
     boundingRect.extend(roundedRect.rect().maxXMaxYCorner());
 }
 
-void PathRoundedRect::addToImpl(PathImpl& impl) const
-{
-    impl.addRoundedRect(roundedRect, strategy);
-}
-
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathRoundedRect& data)
 {
     ts << "add rounded rect " << data.roundedRect;
@@ -635,12 +584,6 @@ void PathDataLine::extendBoundingRect(const FloatPoint&, const FloatPoint&, Floa
 {
     boundingRect.extend(start);
     boundingRect.extend(end);
-}
-
-void PathDataLine::addToImpl(PathImpl& impl) const
-{
-    impl.moveTo(start);
-    impl.addLineTo(end);
 }
 
 void PathDataLine::applyElements(const PathElementApplier& applier) const
@@ -688,12 +631,6 @@ void PathDataQuadCurve::extendBoundingRect(const FloatPoint&, const FloatPoint&,
     boundingRect.extend(start);
     boundingRect.extend(extremity);
     boundingRect.extend(endPoint);
-}
-
-void PathDataQuadCurve::addToImpl(PathImpl& impl) const
-{
-    impl.moveTo(start);
-    impl.addQuadCurveTo(controlPoint, endPoint);
 }
 
 void PathDataQuadCurve::applyElements(const PathElementApplier& applier) const
@@ -746,12 +683,6 @@ void PathDataBezierCurve::extendBoundingRect(const FloatPoint&, const FloatPoint
     boundingRect.extend(endPoint);
 }
 
-void PathDataBezierCurve::addToImpl(PathImpl& impl) const
-{
-    impl.moveTo(start);
-    impl.addBezierCurveTo(controlPoint1, controlPoint2, endPoint);
-}
-
 void PathDataBezierCurve::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::MoveToPoint, { start } });
@@ -800,12 +731,6 @@ void PathDataArc::extendBoundingRect(const FloatPoint&, const FloatPoint&, Float
     boundingRect.extend(calculateArcToEndPoint(start, controlPoint1, controlPoint2, radius));
 }
 
-void PathDataArc::addToImpl(PathImpl& impl) const
-{
-    impl.moveTo(start);
-    impl.addArcTo(controlPoint1, controlPoint2, radius);
-}
-
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataArc& data)
 {
     ts << "move to " << data.start;
@@ -832,11 +757,6 @@ void PathCloseSubpath::extendFastBoundingRect(const FloatPoint&, const FloatPoin
 void PathCloseSubpath::extendBoundingRect(const FloatPoint&, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
 {
     boundingRect.extend(lastMoveToPoint);
-}
-
-void PathCloseSubpath::addToImpl(PathImpl& impl) const
-{
-    impl.closeSubpath();
 }
 
 void PathCloseSubpath::applyElements(const PathElementApplier& applier) const

--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -36,8 +36,6 @@ class TextStream;
 
 namespace WebCore {
 
-class PathImpl;
-
 struct PathMoveTo {
     FloatPoint point;
 
@@ -52,7 +50,6 @@ struct PathMoveTo {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
@@ -74,7 +71,6 @@ struct PathLineTo {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
@@ -97,7 +93,6 @@ struct PathQuadCurveTo {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
@@ -121,7 +116,6 @@ struct PathBezierCurveTo {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
@@ -145,7 +139,6 @@ struct PathArcTo {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathArcTo&);
@@ -168,7 +161,6 @@ struct PathArc {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathArc&);
@@ -193,7 +185,6 @@ struct PathEllipse {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathEllipse&);
@@ -212,7 +203,6 @@ struct PathEllipseInRect {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathEllipseInRect&);
@@ -231,7 +221,6 @@ struct PathRect {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathRect&);
@@ -256,7 +245,6 @@ struct PathRoundedRect {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathRoundedRect&);
@@ -276,7 +264,6 @@ struct PathDataLine {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
@@ -300,7 +287,6 @@ struct PathDataQuadCurve {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
@@ -325,7 +311,6 @@ struct PathDataBezierCurve {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);
@@ -350,7 +335,6 @@ struct PathDataArc {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataArc&);
@@ -367,7 +351,6 @@ struct PathCloseSubpath {
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
-    void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
 
     void transform(const AffineTransform&);

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -42,20 +42,17 @@ public:
 
     Ref<PathImpl> copy() const final;
 
-    void moveTo(const FloatPoint&) final;
-
-    void addLineTo(const FloatPoint&) final;
-    void addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endPoint) final;
-    void addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint) final;
-    void addArcTo(const FloatPoint& point1, const FloatPoint& point2, float radius) final;
-
-    void addArc(const FloatPoint&, float radius, float startAngle, float endAngle, RotationDirection) final;
-    void addEllipse(const FloatPoint&, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection) final;
-    void addEllipseInRect(const FloatRect&) final;
-    void addRect(const FloatRect&) final;
-    void addRoundedRect(const FloatRoundedRect&, PathRoundedRect::Strategy) final;
-
-    void closeSubpath() final;
+    void add(PathMoveTo) final;
+    void add(PathLineTo) final;
+    void add(PathQuadCurveTo) final;
+    void add(PathBezierCurveTo) final;
+    void add(PathArcTo) final;
+    void add(PathArc) final;
+    void add(PathEllipse) final;
+    void add(PathEllipseInRect) final;
+    void add(PathRect) final;
+    void add(PathRoundedRect) final;
+    void add(PathCloseSubpath) final;
 
     const Vector<PathSegment>& segments() const { return m_segments; }
 

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.h
@@ -51,6 +51,19 @@ public:
 
     void addPath(const PathCairo&, const AffineTransform&);
 
+    Ref<PathImpl> copy() const final;
+    void add(PathMoveTo) final;
+    void add(PathLineTo) final;
+    void add(PathQuadCurveTo) final;
+    void add(PathBezierCurveTo) final;
+    void add(PathArcTo) final;
+    void add(PathArc) final;
+    void add(PathEllipse) final;
+    void add(PathEllipseInRect) final;
+    void add(PathRect) final;
+    void add(PathRoundedRect) final;
+    void add(PathCloseSubpath) final;
+
     bool applyElements(const PathElementApplier&) const final;
 
     bool transform(const AffineTransform&) final;
@@ -61,23 +74,6 @@ public:
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
 private:
-    Ref<PathImpl> copy() const final;
-
-    void moveTo(const FloatPoint&) final;
-
-    void addLineTo(const FloatPoint&) final;
-    void addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endPoint) final;
-    void addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint) final;
-    void addArcTo(const FloatPoint& point1, const FloatPoint& point2, float radius) final;
-
-    void addArc(const FloatPoint&, float radius, float startAngle, float endAngle, RotationDirection) final;
-    void addEllipse(const FloatPoint&, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection) final;
-    void addEllipseInRect(const FloatRect&) final;
-    void addRect(const FloatRect&) final;
-    void addRoundedRect(const FloatRoundedRect&, PathRoundedRect::Strategy) final;
-
-    void closeSubpath() final;
-
     void applySegments(const PathSegmentApplier&) const final;
 
     bool isEmpty() const final;

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -48,6 +48,19 @@ public:
 
     void addPath(const PathCG&, const AffineTransform&);
 
+    Ref<PathImpl> copy() const final;
+    void add(PathMoveTo) final;
+    void add(PathLineTo) final;
+    void add(PathQuadCurveTo) final;
+    void add(PathBezierCurveTo) final;
+    void add(PathArcTo) final;
+    void add(PathArc) final;
+    void add(PathEllipse) final;
+    void add(PathEllipseInRect) final;
+    void add(PathRect) final;
+    void add(PathRoundedRect) final;
+    void add(PathCloseSubpath) final;
+
     bool applyElements(const PathElementApplier&) const final;
 
     bool transform(const AffineTransform&) final;
@@ -61,24 +74,7 @@ private:
     PathCG();
     PathCG(RetainPtr<CGMutablePathRef>&&);
 
-    Ref<PathImpl> copy() const final;
-
     PlatformPathPtr ensureMutablePlatformPath();
-
-    void moveTo(const FloatPoint&) final;
-
-    void addLineTo(const FloatPoint&) final;
-    void addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endPoint) final;
-    void addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint) final;
-    void addArcTo(const FloatPoint& point1, const FloatPoint& point2, float radius) final;
-
-    void addArc(const FloatPoint& center, float radius, float startAngle, float endAngle, RotationDirection) final;
-    void addEllipse(const FloatPoint& center, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection) final;
-    void addEllipseInRect(const FloatRect&) final;
-    void addRect(const FloatRect&) final;
-    void addRoundedRect(const FloatRoundedRect&, PathRoundedRect::Strategy) final;
-
-    void closeSubpath() final;
 
     void applySegments(const PathSegmentApplier&) const final;
 


### PR DESCRIPTION
#### d132cc11f0bf78cb0752568e1eb5d707c50ace5a
<pre>
PathSegments cannot be used with anything else than PathImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=265247">https://bugs.webkit.org/show_bug.cgi?id=265247</a>
<a href="https://rdar.apple.com/118717060">rdar://118717060</a>

Reviewed by Said Abou-Hallawa.

PathImpl and PathSegment were coupled:
PathImpl::appendSegment would call into PathSegment::addToImpl
PathSegment::addToImpl would call into PathImpl

This would be more complex than needed and also limit the PathSegments
to be only used with PathImpl.

Instead:
  - PathSegment is the data that is being held -- no actions toward any
    class that does actual work on the data.
  - PathImpl knows how to use the path segment types: PathImpl::add()
    for each path segment type.
  - PathImpl knows how to use the PathSegment variant:
    PathImpl::addSegment() for the PathSegment, doing generic add() over
    the variants.
  - Make each member function for adding segments PathImpl::add(). This
    way generic algorithms over the variants are consistent to write.
  - The PathImpl::add() parameters are by-value to avoid introducing
    indirection, the arguments are always used.

Construct PathCG, PathCairo from PathStream without applySegments, as
the PathStream segment list can be just iterated.

This works towards being able to play back a PathSegment list to a
CGContext.

* Source/WebCore/platform/graphics/PathImpl.cpp:
(WebCore::PathImpl::appendSegment): Deleted.
* Source/WebCore/platform/graphics/PathImpl.h:
(WebCore::addPathSegment):
* Source/WebCore/platform/graphics/PathSegment.cpp:
(WebCore::PathSegment::addToImpl const): Deleted.
* Source/WebCore/platform/graphics/PathSegment.h:
(WebCore::PathSegment::addTo const):
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::PathMoveTo::addToImpl const): Deleted.
(WebCore::PathLineTo::addToImpl const): Deleted.
(WebCore::PathQuadCurveTo::addToImpl const): Deleted.
(WebCore::PathBezierCurveTo::addToImpl const): Deleted.
(WebCore::PathArcTo::addToImpl const): Deleted.
(WebCore::PathArc::addToImpl const): Deleted.
(WebCore::PathEllipse::addToImpl const): Deleted.
(WebCore::PathEllipseInRect::addToImpl const): Deleted.
(WebCore::PathRect::addToImpl const): Deleted.
(WebCore::PathRoundedRect::addToImpl const): Deleted.
(WebCore::PathDataLine::addToImpl const): Deleted.
(WebCore::PathDataQuadCurve::addToImpl const): Deleted.
(WebCore::PathDataBezierCurve::addToImpl const): Deleted.
(WebCore::PathDataArc::addToImpl const): Deleted.
(WebCore::PathCloseSubpath::addToImpl const): Deleted.
* Source/WebCore/platform/graphics/PathSegmentData.h:
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::create):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::create):

Canonical link: <a href="https://commits.webkit.org/271199@main">https://commits.webkit.org/271199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b87147434e75a0eebdd6f7012da47bedb4706e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25013 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24823 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30193 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30441 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28395 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5780 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6641 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->