### PR TITLE
[LBSE] Fix clip-rule in masks

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
@@ -50,7 +50,9 @@ bool LegacyRenderSVGResourceSolidColor::applyResource(RenderElement& renderer, c
         else
             context->setAlpha(1);
         context->setFillColor(style.colorByApplyingColorFilter(m_color));
-        if (!isRenderingMask)
+        if (isRenderingMask)
+            context->setFillRule(svgStyle.clipRule());
+        else
             context->setFillRule(svgStyle.fillRule());
 
         if (resourceMode.contains(RenderSVGResourceMode::ApplyToText))


### PR DESCRIPTION
#### d4e8950c2cd2feec2a3d8dccc53c44d1e1c5a4cc
<pre>
[LBSE] Fix clip-rule in masks
<a href="https://bugs.webkit.org/show_bug.cgi?id=265183">https://bugs.webkit.org/show_bug.cgi?id=265183</a>

Reviewed by Nikolas Zimmermann.

I forgot to include the code change in r271053.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp:
(WebCore::LegacyRenderSVGResourceSolidColor::applyResource):

Canonical link: <a href="https://commits.webkit.org/271058@main">https://commits.webkit.org/271058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76930c7affe2e20e079103b5e7d2c362a086e4f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24722 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30335 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2340 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28255 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5652 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6555 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->