### PR TITLE
Add stubs for Keyboard Lock API

### DIFF
--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -1017,3 +1017,7 @@
     || PLATFORM(VISION))
 #define ENABLE_AV1 1
 #endif
+
+#if !defined(ENABLE_KEYBOARD_LOCK)
+#define ENABLE_KEYBOARD_LOCK 1
+#endif

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -43,6 +43,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/Modules/indexeddb/client"
     "${WEBCORE_DIR}/Modules/indexeddb/server"
     "${WEBCORE_DIR}/Modules/indexeddb/shared"
+    "${WEBCORE_DIR}/Modules/keyboard-lock"
     "${WEBCORE_DIR}/Modules/mediacapabilities"
     "${WEBCORE_DIR}/Modules/mediacontrols"
     "${WEBCORE_DIR}/Modules/mediarecorder"
@@ -224,6 +225,7 @@ set(WebCore_IDL_INCLUDES
     Modules/geolocation
     Modules/highlight
     Modules/indexeddb
+    Modules/keyboard-lock
     Modules/mediacapabilities
     Modules/mediarecorder
     Modules/mediastream
@@ -383,6 +385,9 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/indexeddb/IDBTransactionMode.idl
     Modules/indexeddb/IDBVersionChangeEvent.idl
     Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl
+
+    Modules/keyboard-lock/Keyboard.idl
+    Modules/keyboard-lock/Navigator+Keyboard.idl
 
     Modules/mediacapabilities/AudioConfiguration.idl
     Modules/mediacapabilities/ColorGamut.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -514,6 +514,8 @@ $(PROJECT_DIR)/Modules/indexeddb/IDBTransactionDurability.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBTransactionMode.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBVersionChangeEvent.idl
 $(PROJECT_DIR)/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl
+$(PROJECT_DIR)/Modules/keyboard-lock/Keyboard.idl
+$(PROJECT_DIR)/Modules/keyboard-lock/Navigator+Keyboard.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/AudioConfiguration.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/ColorGamut.idl
 $(PROJECT_DIR)/Modules/mediacapabilities/HdrMetadataType.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1687,6 +1687,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSJsonWebKey.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSJsonWebKey.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKHRParallelShaderCompile.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKHRParallelShaderCompile.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyboard.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyboard.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyboardEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyboardEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyframeAnimationOptions.cpp
@@ -1952,6 +1954,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Geolocation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Geolocation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+IsLoggedIn.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+IsLoggedIn.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Keyboard.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Keyboard.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaCapabilities.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaCapabilities.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaDevices.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -385,6 +385,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/indexeddb/IDBTransactionMode.idl \
     $(WebCore)/Modules/indexeddb/IDBVersionChangeEvent.idl \
     $(WebCore)/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl \
+    $(WebCore)/Modules/keyboard-lock/Keyboard.idl \
+    $(WebCore)/Modules/keyboard-lock/Navigator+Keyboard.idl \
     $(WebCore)/Modules/mediacapabilities/AudioConfiguration.idl \
     $(WebCore)/Modules/mediacapabilities/ColorGamut.idl \
     $(WebCore)/Modules/mediacapabilities/HdrMetadataType.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -447,6 +447,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/indexeddb/shared/IDBResultData.h
     Modules/indexeddb/shared/IDBTransactionInfo.h
 
+    Modules/keyboard-lock/Keyboard.h
+    Modules/keyboard-lock/KeyboardLockController.h
+    Modules/keyboard-lock/NavigatorKeyboard.h
+
     Modules/mediarecorder/MediaRecorderProvider.h
 
     Modules/mediasession/NavigatorMediaSession.h

--- a/Source/WebCore/Modules/keyboard-lock/Keyboard.cpp
+++ b/Source/WebCore/Modules/keyboard-lock/Keyboard.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(KEYBOARD_LOCK)
+
+#include "config.h"
+#include "Keyboard.h"
+
+#include "Document.h"
+#include "Exception.h"
+#include "JSDOMPromiseDeferred.h"
+#include "KeyboardLockController.h"
+#include "NavigatorBase.h"
+#include "Page.h"
+#include "ScriptExecutionContext.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(Keyboard);
+
+Ref<Keyboard> Keyboard::create(NavigatorBase& navigator)
+{
+    return adoptRef(*new Keyboard(navigator));
+}
+
+Keyboard::Keyboard(NavigatorBase& navigator)
+    : m_navigator(navigator)
+{
+}
+
+NavigatorBase* Keyboard::navigator()
+{
+    return m_navigator.get();
+}
+
+Keyboard::~Keyboard() = default;
+
+void Keyboard::lock(const std::optional<Vector<String>>& keyCodes, DOMPromiseDeferred<void>&& promise)
+{
+    RefPtr context = m_navigator ? m_navigator->scriptExecutionContext() : nullptr;
+    if (!context || !context->globalObject()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The context is invalid"_s });
+        return;
+    }
+
+    RefPtr document = dynamicDowncast<Document>(*context);
+    if (document && !document->isFullyActive()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active"_s });
+        return;
+    }
+
+    if (document) {
+        WeakPtr page = document->page();
+        if (!page) {
+            promise.reject(Exception { ExceptionCode::InvalidStateError, "The page does not exist"_s });
+            return;
+        }
+        KeyboardLockController::shared().lock(*page, keyCodes.value(), WTFMove(promise));
+    }
+    return;
+}
+
+void Keyboard::unlock()
+{
+    RefPtr context = m_navigator ? m_navigator->scriptExecutionContext() : nullptr;
+    if (!context || !context->globalObject())
+        return;
+
+    RefPtr document = dynamicDowncast<Document>(*context);
+    if (document && !document->isFullyActive())
+        return;
+
+    if (document) {
+        WeakPtr page = document->page();
+        if (!page)
+            return;
+
+        KeyboardLockController::shared().unlock(*page);
+    }
+    return;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(KEYBOARD_LOCK)

--- a/Source/WebCore/Modules/keyboard-lock/Keyboard.h
+++ b/Source/WebCore/Modules/keyboard-lock/Keyboard.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(KEYBOARD_LOCK)
+
+#include "IDLTypes.h"
+
+#include <wtf/IsoMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WTF {
+class String;
+}
+
+namespace WebCore {
+
+class NavigatorBase;
+
+template<typename IDLType> class DOMPromiseDeferred;
+
+class Keyboard : public RefCounted<Keyboard> {
+    WTF_MAKE_ISO_ALLOCATED(Keyboard);
+public:
+    static Ref<Keyboard> create(NavigatorBase&);
+    ~Keyboard();
+
+    NavigatorBase* navigator();
+    void lock(const std::optional<Vector<String>>&, DOMPromiseDeferred<void>&&);
+    void unlock();
+
+private:
+    explicit Keyboard(NavigatorBase&);
+
+    WeakPtr<NavigatorBase> m_navigator;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(KEYBOARD_LOCK)

--- a/Source/WebCore/Modules/keyboard-lock/Keyboard.idl
+++ b/Source/WebCore/Modules/keyboard-lock/Keyboard.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://wicg.github.io/keyboard-lock/#keyboard-interface
+
+[
+    EnabledBySetting=PermissionsAPIEnabled,
+    GenerateIsReachable=ReachableFromNavigator,
+    Exposed=Window
+] interface Keyboard {
+    Promise<undefined> lock(optional sequence<DOMString> keyCodes = []);
+    undefined unlock();
+};

--- a/Source/WebCore/Modules/keyboard-lock/KeyboardLockController.cpp
+++ b/Source/WebCore/Modules/keyboard-lock/KeyboardLockController.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "KeyboardLockController.h"
+
+#if ENABLE(KEYBOARD_LOCK)
+
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+static RefPtr<KeyboardLockController>& sharedController()
+{
+    static MainThreadNeverDestroyed<RefPtr<KeyboardLockController>> controller;
+    return controller;
+}
+
+KeyboardLockController& KeyboardLockController::shared()
+{
+    auto& controller = sharedController();
+    if (!controller)
+        controller = DummyKeyboardLockController::create();
+    return *controller;
+}
+
+void KeyboardLockController::setSharedController(Ref<KeyboardLockController>&& controller)
+{
+    ASSERT(!sharedController());
+    sharedController() = WTFMove(controller);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(KEYBOARD_LOCK)

--- a/Source/WebCore/Modules/keyboard-lock/KeyboardLockController.h
+++ b/Source/WebCore/Modules/keyboard-lock/KeyboardLockController.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(KEYBOARD_LOCK)
+
+#include <wtf/CompletionHandler.h>
+#include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class Page;
+
+class KeyboardLockController : public ThreadSafeRefCounted<KeyboardLockController> {
+public:
+    static KeyboardLockController& shared();
+    WEBCORE_EXPORT static void setSharedController(Ref<KeyboardLockController>&&);
+
+    virtual ~KeyboardLockController() = default;
+    virtual void lock(const WeakPtr<Page>&, const Vector<String>&, DOMPromiseDeferred<void>&&) = 0;
+    virtual void unlock(const WeakPtr<Page>&) = 0;
+protected:
+    KeyboardLockController() = default;
+};
+
+class DummyKeyboardLockController final : public KeyboardLockController {
+public:
+    static Ref<DummyKeyboardLockController> create() { return adoptRef(*new DummyKeyboardLockController); }
+private:
+    DummyKeyboardLockController() = default;
+    void lock(const WeakPtr<Page>&, const Vector<String>&, DOMPromiseDeferred<void>&& promise) final { promise.resolve(); }
+    void unlock(const WeakPtr<Page>&) final { }
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(KEYBOARD_LOCK)

--- a/Source/WebCore/Modules/keyboard-lock/Navigator+Keyboard.idl
+++ b/Source/WebCore/Modules/keyboard-lock/Navigator+Keyboard.idl
@@ -1,0 +1,8 @@
+
+// https://wicg.github.io/keyboard-lock/#navigator-interface
+
+[
+    ImplementedBy=NavigatorKeyboard
+] partial interface Navigator {
+    [SecureContext, SameObject] readonly attribute Keyboard keyboard;
+};

--- a/Source/WebCore/Modules/keyboard-lock/NavigatorKeyboard.cpp
+++ b/Source/WebCore/Modules/keyboard-lock/NavigatorKeyboard.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(KEYBOARD_LOCK)
+
+#include "config.h"
+#include "NavigatorKeyboard.h"
+
+#include "Keyboard.h"
+#include "Navigator.h"
+
+namespace WebCore {
+
+NavigatorKeyboard::NavigatorKeyboard(Navigator& navigator)
+    : m_navigator(navigator)
+{
+}
+
+Keyboard& NavigatorKeyboard::keyboard(Navigator& navigator)
+{
+    return NavigatorKeyboard::from(navigator).keyboard();
+}
+
+Keyboard& NavigatorKeyboard::keyboard()
+{
+    if (!m_keyboard)
+        m_keyboard = Keyboard::create(m_navigator);
+
+    return *m_keyboard;
+}
+
+NavigatorKeyboard& NavigatorKeyboard::from(Navigator& navigator)
+{
+    auto* supplement = static_cast<NavigatorKeyboard*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    if (!supplement) {
+        auto newSupplement = makeUnique<NavigatorKeyboard>(navigator);
+        supplement = newSupplement.get();
+        provideTo(&navigator, supplementName(), WTFMove(newSupplement));
+    }
+
+    return *supplement;
+}
+
+const char* NavigatorKeyboard::supplementName()
+{
+    return "NavigatorKeyboard";
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(KEYBOARD_LOCK)

--- a/Source/WebCore/Modules/keyboard-lock/NavigatorKeyboard.h
+++ b/Source/WebCore/Modules/keyboard-lock/NavigatorKeyboard.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(KEYBOARD_LOCK)
+
+#include "Supplementable.h"
+
+namespace WebCore {
+
+class Navigator;
+class Keyboard;
+
+class NavigatorKeyboard final : public Supplement<Navigator> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit NavigatorKeyboard(Navigator&);
+
+    static Keyboard& keyboard(Navigator&);
+    Keyboard& keyboard();
+
+private:
+    static NavigatorKeyboard& from(Navigator&);
+    static const char* supplementName();
+
+    RefPtr<Keyboard> m_keyboard;
+    Navigator& m_navigator;
+};
+
+}
+
+#endif // ENABLE(KEYBOARD_LOCK)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -202,6 +202,9 @@ Modules/indexeddb/shared/IDBResourceIdentifier.cpp
 Modules/indexeddb/shared/IDBResultData.cpp
 Modules/indexeddb/shared/IDBTransactionInfo.cpp
 Modules/indexeddb/shared/IndexKey.cpp
+Modules/keyboard-lock/Keyboard.cpp
+Modules/keyboard-lock/KeyboardLockController.cpp
+Modules/keyboard-lock/NavigatorKeyboard.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
 Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
@@ -3797,6 +3800,7 @@ JSIntersectionObserverEntry.cpp
 JSIterationCompositeOperation.cpp
 JSJsonWebKey.cpp
 JSKeyboardEvent.cpp
+JSKeyboard.cpp
 JSKeyframeAnimationOptions.cpp
 JSKeyframeEffect.cpp
 JSKeyframeEffectOptions.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -272,6 +272,7 @@ namespace WebCore {
     macro(InputEvent) \
     macro(IntersectionObserver) \
     macro(IntersectionObserverEntry) \
+    macro(Keyboard) \
     macro(KeyframeEffect) \
     macro(Lock) \
     macro(LockManager) \
@@ -308,6 +309,7 @@ namespace WebCore {
     macro(NavigationPreloadManager) \
     macro(NavigationTransition) \
     macro(NavigatorCredentials) \
+    macro(NavigatorKeyboard) \
     macro(NavigatorMediaDevices) \
     macro(NavigatorPermissions) \
     macro(NavigatorUserMedia) \


### PR DESCRIPTION
#### c1634333112e11d682186c93ed1c4d9972148678
<pre>
Add stubs for Keyboard Lock API
<a href="https://bugs.webkit.org/show_bug.cgi?id=265222">https://bugs.webkit.org/show_bug.cgi?id=265222</a>

Reviewed by NOBODY (OOPS!).

This patch is extracted from following WebPlatformForEmbedded WPEWebKit code changes:
&lt;<a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/0d7f83d8d30cf0561ebb5de57642d2a8372b91da">https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/0d7f83d8d30cf0561ebb5de57642d2a8372b91da</a>&gt;

co-authoured by:
Philippe Normand &lt;philn@webkit.org&gt;

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/keyboard-lock/Keyboard.cpp: Added.
(WebCore::Keyboard::create):
(WebCore::Keyboard::Keyboard):
(WebCore::Keyboard::navigator):
(WebCore::Keyboard::lock):
(WebCore::Keyboard::unlock):
* Source/WebCore/Modules/keyboard-lock/Keyboard.h: Added.
* Source/WebCore/Modules/keyboard-lock/Keyboard.idl: Added.
* Source/WebCore/Modules/keyboard-lock/KeyboardLockController.cpp: Added.
(WebCore::sharedController):
(WebCore::KeyboardLockController::shared):
(WebCore::KeyboardLockController::setSharedController):
* Source/WebCore/Modules/keyboard-lock/KeyboardLockController.h: Added.
* Source/WebCore/Modules/keyboard-lock/Navigator+Keyboard.idl: Added.
* Source/WebCore/Modules/keyboard-lock/NavigatorKeyboard.cpp: Added.
(WebCore::NavigatorKeyboard::NavigatorKeyboard):
(WebCore::NavigatorKeyboard::keyboard):
(WebCore::NavigatorKeyboard::from):
(WebCore::NavigatorKeyboard::supplementName):
* Source/WebCore/Modules/keyboard-lock/NavigatorKeyboard.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1634333112e11d682186c93ed1c4d9972148678

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29442 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30623 "Hash c1634333 for PR 20823 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25611 "Hash c1634333 for PR 20823 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4119 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/30623 "Hash c1634333 for PR 20823 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24172 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/30623 "Hash c1634333 for PR 20823 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4908 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25169 "Found 2 new test failures: fast/dom/navigator-detached-no-crash.html, fast/ruby/ruby-overhang-crash.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31312 "Hash c1634333 for PR 20823 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24318 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25699 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25610 "Found 1 new test failure: fast/dom/navigator-detached-no-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/31312 "Hash c1634333 for PR 20823 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27216 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4904 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3126 "Found 1 new test failure: fast/dom/navigator-detached-no-crash.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/31312 "Hash c1634333 for PR 20823 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6444 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34714 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5342 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7512 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->