### PR TITLE
Fixing build error for Bug 265222

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
+#include "JSDOMConvertEnumeration.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/text/StringParsingBuffer.h>
 

--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.h
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.h
@@ -30,6 +30,7 @@
 #include "ExceptionOr.h"
 #include "NotificationOptionsPayload.h"
 #include "NotificationPayload.h"
+#include <wtf/JSONValues.h>
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/notifications/NotificationPayload.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "NotificationPayload.h"
 
+#include "NotificationData.h"
+#include "NotificationJSONParser.h"
+
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
 #include "Logging.h"


### PR DESCRIPTION
#### 81bd08cb63587b47f556d07e9d377b3d60624369
<pre>
Fixing build error for Bug 265222
<a href="https://bugs.webkit.org/show_bug.cgi?id=265255">https://bugs.webkit.org/show_bug.cgi?id=265255</a>

Reviewed by Mark Lam.

Adding a new stub definition for the keyboard-lock, NotificationPayload.cpp build started failing.
So I expect the bugs was already there before and just revealed with new definition.

See more details on the following link:
<a href="https://ews-build.webkit.org/#/builders/51/builds/3246/steps/14/logs/errors">https://ews-build.webkit.org/#/builders/51/builds/3246/steps/14/logs/errors</a>

* Source/WebCore/Modules/notifications/NotificationJSONParser.cpp:
* Source/WebCore/Modules/notifications/NotificationJSONParser.h:
* Source/WebCore/Modules/notifications/NotificationPayload.cpp:

Canonical link: <a href="https://commits.webkit.org/271344@main">https://commits.webkit.org/271344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef283eab5af5aff28529fa2a788af43f5359ef1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30562 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25317 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28915 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5292 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3631 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->