### PR TITLE
[WGSL] Constant function for abs is wrong for u32 and f16

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -783,9 +783,9 @@ CONSTANT_TRIGONOMETRIC(Cosh, cosh);
 CONSTANT_TRIGONOMETRIC(Sinh, sinh);
 CONSTANT_TRIGONOMETRIC(Tanh, tanh);
 
-UNARY_OPERATION(Abs, Number, [&](auto n) {
+UNARY_OPERATION(Abs, Number, [&]<typename T>(T n) -> T {
     if constexpr (std::is_same_v<decltype(n), uint32_t>)
-        return static_cast<uint32_t>(std::abs(static_cast<int32_t>(n)));
+        return n;
     else
         return std::abs(n);
 });


### PR DESCRIPTION
#### 25af3c24b4b9d4439099c2e5642a61e1a96108c1
<pre>
[WGSL] Constant function for abs is wrong for u32 and f16
<a href="https://bugs.webkit.org/show_bug.cgi?id=265257">https://bugs.webkit.org/show_bug.cgi?id=265257</a>
<a href="https://rdar.apple.com/118724534">rdar://118724534</a>

Reviewed by Mike Wyrzykowski.

For some reason it was casting u32 to int, when the result should be the identity.
The result type also needs to be explicit, otherwise we return f32 for f16 inputs.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::UNARY_OPERATION):

Canonical link: <a href="https://commits.webkit.org/271072@main">https://commits.webkit.org/271072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24813ea8479b10d2d2eb11143d401e8e38177bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24736 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4166 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30349 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28275 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5669 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6566 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->