### PR TITLE
[WebGPU] GPUQueue.copyExternalImageToTexture fails for some formats

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -350,8 +350,8 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
     case GPUTextureFormat::R16uint:
     case GPUTextureFormat::R16sint: {
         uint16_t* data = (uint16_t*)malloc(sizeInBytes / 2);
-        for (size_t i = 0; i < sizeInBytes; i += 4)
-            data[i] = rgbaBytes[i];
+        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+            data[i0] = rgbaBytes[i];
 
         sizeInBytes = sizeInBytes / 2;
         return data;
@@ -359,8 +359,8 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
 
     case GPUTextureFormat::R16float: {
         __fp16* data = (__fp16*)malloc(sizeInBytes / 2);
-        for (size_t i = 0; i < sizeInBytes; i += 4)
-            data[i] = rgbaBytes[i];
+        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+            data[i0] = rgbaBytes[i] / 255.f;
 
         sizeInBytes = sizeInBytes / 2;
         return data;
@@ -382,11 +382,43 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
 
     // 32-bit formats
     case GPUTextureFormat::R32uint:
-    case GPUTextureFormat::R32sint:
-    case GPUTextureFormat::R32float:
+    case GPUTextureFormat::R32sint: {
+        uint32_t* data = (uint32_t*)malloc(sizeInBytes);
+        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+            data[i0] = rgbaBytes[i];
+
+        return data;
+    }
+
+    case GPUTextureFormat::R32float: {
+        float* data = (float*)malloc(sizeInBytes);
+        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+            data[i0] = rgbaBytes[i] / 255.f;
+
+        return data;
+    }
+
     case GPUTextureFormat::Rg16uint:
-    case GPUTextureFormat::Rg16sint:
-    case GPUTextureFormat::Rg16float:
+    case GPUTextureFormat::Rg16sint: {
+        uint16_t* data = (uint16_t*)malloc(sizeInBytes);
+        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+            data[i0] = rgbaBytes[i];
+            data[i0 + 1] = rgbaBytes[i + 1];
+        }
+
+        return data;
+    }
+
+    case GPUTextureFormat::Rg16float: {
+        __fp16* data = (__fp16*)malloc(sizeInBytes);
+        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+            data[i0] = rgbaBytes[i] / 255.f;
+            data[i0 + 1] = rgbaBytes[i + 1] / 255.f;
+        }
+
+        return data;
+    }
+
     case GPUTextureFormat::Rgba8unorm:
     case GPUTextureFormat::Rgba8unormSRGB:
     case GPUTextureFormat::Rgba8snorm:
@@ -396,9 +428,12 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
     case GPUTextureFormat::Bgra8unormSRGB:
     case GPUTextureFormat::Rgb9e5ufloat:
     case GPUTextureFormat::Rgb10a2uint:
-    case GPUTextureFormat::Rgb10a2unorm:
     case GPUTextureFormat::Rg11b10ufloat:
         return nullptr;
+    case GPUTextureFormat::Rgb10a2unorm: {
+        ASSERT_NOT_REACHED("Remapping to 10 bits per channel is not implemented");
+        return nullptr;
+    }
 
     // 64-bit formats
     case GPUTextureFormat::Rg32uint:


### PR DESCRIPTION
#### 7b2dc45dd08ff963adfd0bd899311361be663e54
<pre>
[WebGPU] GPUQueue.copyExternalImageToTexture fails for some formats
<a href="https://bugs.webkit.org/show_bug.cgi?id=265260">https://bugs.webkit.org/show_bug.cgi?id=265260</a>
radar://118725062

Reviewed by Dan Glastonbury.

RG16f textures were not being properly supported in external image conversion.

Moving this logic to the GPU process is tracked by <a href="https://bugs.webkit.org/show_bug.cgi?id=263692">https://bugs.webkit.org/show_bug.cgi?id=263692</a>

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::copyToDestinationFormat):

Canonical link: <a href="https://commits.webkit.org/271067@main">https://commits.webkit.org/271067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9c8ff9e984d9cdceda394be441072b9ce3594f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3272 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23371 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4075 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30096 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30363 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4219 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28292 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5685 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6561 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->