### PR TITLE
suspendRedraw should return '1' rather than '0'

### DIFF
--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -77,7 +77,7 @@ public: // DOM
     float getCurrentTime() const;
     void setCurrentTime(float);
     
-    unsigned suspendRedraw(unsigned) { return 0; }
+    unsigned suspendRedraw(unsigned) { return 1; }
     void unsuspendRedraw(unsigned) { }
     void unsuspendRedrawAll() { }
     void forceRedraw() { }


### PR DESCRIPTION
#### 3469748f1862069b78a90ff06f23c9a857a92e78
<pre>
suspendRedraw should return &apos;1&apos; rather than &apos;0&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=265266">https://bugs.webkit.org/show_bug.cgi?id=265266</a>

Reviewed by Simon Fraser.

This patch is to align WebKit with Web-Specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/struct.html#InterfaceSVGSVGElement">https://svgwg.org/svg2-draft/struct.html#InterfaceSVGSVGElement</a>

&quot;When the suspendRedraw method is called, it must return 1.&quot;

* Source/WebCore/svg/SVGSVGElement.h:

Canonical link: <a href="https://commits.webkit.org/271168@main">https://commits.webkit.org/271168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/def4d31f8f75ba526516d60950945d4ec49555ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2362 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28350 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5678 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6625 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->