### PR TITLE
[UIAsyncTextInput] Edit menu doesn't appear after choosing "Select" in editable content

### DIFF
--- a/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word-expected.txt
+++ b/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS Showed menu by tapping
 PASS Selected word using menu action
 PASS Callout bar contains 'Copy' action
-PASS selectAllItemRect is null
+PASS Callout bar no longer contains 'Select All'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word.html
+++ b/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word.html
@@ -56,8 +56,11 @@ addEventListener("load", async () => {
     await waitUntilMenuContains("Copy");
     testPassed("Callout bar contains 'Copy' action");
 
-    selectAllItemRect = await UIHelper.rectForMenuAction("Select All");
-    shouldBeNull("selectAllItemRect");
+    var selectAllItemRect;
+    do {
+        selectAllItemRect = await UIHelper.rectForMenuAction("Select All");
+    } while (selectAllItemRect);
+    testPassed("Callout bar no longer contains 'Select All'");
 
     editor.remove();
     finishJSTest();


### PR DESCRIPTION
#### 457b73ca23e9f18da1d4f827b8aa6dcf7ac7565c
<pre>
[UIAsyncTextInput] Edit menu doesn&apos;t appear after choosing &quot;Select&quot; in editable content
<a href="https://bugs.webkit.org/show_bug.cgi?id=265265">https://bugs.webkit.org/show_bug.cgi?id=265265</a>
<a href="https://rdar.apple.com/118726761">rdar://118726761</a>

Reviewed by Aditya Keerthi.

Previously, `UIWKTextInteractionAssistant` would automatically present the edit menu after a 200 ms
delay, when invoking `-selectAll:` or `-selectWord`. These SPIs are no longer exposed on
`UIAsyncTextInteraction`, but we instead have the ability to directly request edit menu presentation
via `-presentEditMenuForSelection`.

This causes the layout test `editing/selection/ios/show-callout-bar-after-selecting-word.html` to
fail when using the async text input/interaction codepath. To fix this, we add logic to schedule
edit menu presentation 200 ms after the next selection change, after triggering `-selectWord` or
`-selectAll:`.

* LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word-expected.txt:
* LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word.html:

Also adjust this test to be more robust, by waiting for the edit menu to no longer contain &quot;Select
All&quot;. This is because it&apos;s possible for the last step of the test:

```
await UIHelper.rectForMenuAction(&quot;Select All&quot;);
```

...to check the contents of the edit menu, before the internal collection view for the edit menu has
been reloaded since being shown for the caret selection. This currently causes the test to be flaky,
with or without `--use-async-uikit-interactions`, on some versions of iOS 17.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper dealloc]):
(-[WKTextInteractionWrapper deactivateSelection]):
(-[WKTextInteractionWrapper selectionChanged]):

Schedule a timer to present the edit menu after 200 ms, after the next selection change after
calling `-selectWord` or `-selectAll:`. See above for more details.

(-[WKTextInteractionWrapper selectWord]):
(-[WKTextInteractionWrapper selectAll:]):
(-[WKTextInteractionWrapper showEditMenuTimerFired]):
(-[WKTextInteractionWrapper stopShowEditMenuTimer]):

Canonical link: <a href="https://commits.webkit.org/271114@main">https://commits.webkit.org/271114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c237a978bab6733d3fdede1bab6cf4d8944aec2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24910 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24744 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23364 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4067 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30356 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28282 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6592 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->