### PR TITLE
Use dynamicDowncast<T> more in css/

### DIFF
--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -294,10 +294,10 @@ bool CSSValue::equals(const CSSValue& other) const
             return typedThis.equals(downcast<ValueType>(other));
         });
     }
-    if (is<CSSValueList>(*this))
-        return downcast<CSSValueList>(*this).containsSingleEqualItem(other);
-    if (is<CSSValueList>(other))
-        return downcast<CSSValueList>(other).containsSingleEqualItem(*this);
+    if (auto* thisList = dynamicDowncast<CSSValueList>(*this))
+        return thisList->containsSingleEqualItem(other);
+    if (auto* otherList = dynamicDowncast<CSSValueList>(other))
+        return otherList->containsSingleEqualItem(*this);
     return false;
 }
 

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -127,17 +127,16 @@ ExceptionOr<String> DeprecatedCSSOMPrimitiveValue::getStringValue() const
 
 ExceptionOr<Ref<DeprecatedCSSOMCounter>> DeprecatedCSSOMPrimitiveValue::getCounterValue() const
 {
-    if (!m_value->isCounter())
-        return Exception { ExceptionCode::InvalidAccessError };
-    auto& value = downcast<CSSCounterValue>(m_value.get());
-    return DeprecatedCSSOMCounter::create(value.identifier(), value.separator(), value.counterStyleCSSText());
+    if (auto* value = dynamicDowncast<CSSCounterValue>(m_value.get()))
+        return DeprecatedCSSOMCounter::create(value->identifier(), value->separator(), value->counterStyleCSSText());
+    return Exception { ExceptionCode::InvalidAccessError };
 }
     
 ExceptionOr<Ref<DeprecatedCSSOMRect>> DeprecatedCSSOMPrimitiveValue::getRectValue() const
 {
-    if (!m_value->isRect())
-        return Exception { ExceptionCode::InvalidAccessError };
-    return DeprecatedCSSOMRect::create(downcast<CSSRectValue>(m_value.get()).rect(), m_owner);
+    if (auto* rectValue = dynamicDowncast<CSSRectValue>(m_value.get()))
+        return DeprecatedCSSOMRect::create(rectValue->rect(), m_owner);
+    return Exception { ExceptionCode::InvalidAccessError };
 }
 
 ExceptionOr<Ref<DeprecatedCSSOMRGBColor>> DeprecatedCSSOMPrimitiveValue::getRGBColorValue() const

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -72,7 +72,8 @@ Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const String& fa
     auto fontAllowedTypes = context.settingsValues().downloadableBinaryFontAllowedTypes;
     auto sourceConversionResult = WTF::switchOn(source,
         [&] (String& string) -> ExceptionOr<void> {
-            auto value = CSSPropertyParserWorkerSafe::parseFontFaceSrc(string, is<Document>(context) ? CSSParserContext(downcast<Document>(context)) : HTMLStandardMode);
+            auto* document = dynamicDowncast<Document>(context);
+            auto value = CSSPropertyParserWorkerSafe::parseFontFaceSrc(string, document ? CSSParserContext(*document) : HTMLStandardMode);
             if (!value)
                 return Exception { ExceptionCode::SyntaxError };
             CSSFontFace::appendSources(result->backing(), *value, &context, false);

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -73,10 +73,9 @@ FontFaceSet::FontFaceSet(ScriptExecutionContext& context, CSSFontFaceSet& backin
     , m_backing(backing)
     , m_readyPromise(makeUniqueRef<ReadyPromise>(*this, &FontFaceSet::readyPromiseResolve))
 {
-    if (is<Document>(context)) {
-        auto& document = downcast<Document>(context);
-        if (document.frame())
-            m_isDocumentLoaded = document.loadEventFinished() && !document.processingLoadEvent();
+    if (auto* document = dynamicDowncast<Document>(context)) {
+        if (document->frame())
+            m_isDocumentLoaded = document->loadEventFinished() && !document->processingLoadEvent();
     }
 
     if (m_isDocumentLoaded && !backing.hasActiveFontFaces())
@@ -168,7 +167,8 @@ void FontFaceSet::load(const String& font, const String& text, LoadPromise&& pro
     for (auto& face : matchingFaces)
         face.get().load();
 
-    if (is<Document>(scriptExecutionContext()) && downcast<Document>(scriptExecutionContext())->quirks().shouldEnableFontLoadingAPIQuirk()) {
+    auto* document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (document && document->quirks().shouldEnableFontLoadingAPIQuirk()) {
         // HBOMax.com expects that loading fonts will succeed, and will totally break when it doesn't. But when lockdown mode is enabled, fonts
         // fail to load, because that's the whole point of lockdown mode.
         //

--- a/Source/WebCore/css/FontVariantBuilder.cpp
+++ b/Source/WebCore/css/FontVariantBuilder.cpp
@@ -40,8 +40,8 @@ FontVariantLigaturesValues extractFontVariantLigatures(const CSSValue& value)
     FontVariantLigatures historical = FontVariantLigatures::Normal;
     FontVariantLigatures contextualAlternates = FontVariantLigatures::Normal;
 
-    if (is<CSSValueList>(value)) {
-        for (auto& item : downcast<CSSValueList>(value)) {
+    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
+        for (auto& item : *valueList) {
             switch (item.valueID()) {
             case CSSValueNoCommonLigatures:
                 common = FontVariantLigatures::No;
@@ -99,8 +99,8 @@ FontVariantNumericValues extractFontVariantNumeric(const CSSValue& value)
     FontVariantNumericOrdinal ordinal = FontVariantNumericOrdinal::Normal;
     FontVariantNumericSlashedZero slashedZero = FontVariantNumericSlashedZero::Normal;
 
-    if (is<CSSValueList>(value)) {
-        for (auto& item : downcast<CSSValueList>(value)) {
+    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
+        for (auto& item : *valueList) {
             switch (item.valueID()) {
             case CSSValueLiningNums:
                 figure = FontVariantNumericFigure::LiningNumbers;
@@ -143,8 +143,8 @@ FontVariantEastAsianValues extractFontVariantEastAsian(const CSSValue& value)
     FontVariantEastAsianWidth width = FontVariantEastAsianWidth::Normal;
     FontVariantEastAsianRuby ruby = FontVariantEastAsianRuby::Normal;
 
-    if (is<CSSValueList>(value)) {
-        for (auto& item : downcast<CSSValueList>(value)) {
+    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
+        for (auto& item : *valueList) {
             switch (item.valueID()) {
             case CSSValueJis78:
                 variant = FontVariantEastAsianVariant::Jis78;

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -54,8 +54,8 @@ MutableStyleProperties::~MutableStyleProperties() = default;
 MutableStyleProperties::MutableStyleProperties(const StyleProperties& other)
     : StyleProperties(other.cssParserMode())
 {
-    if (is<MutableStyleProperties>(other))
-        m_propertyVector = downcast<MutableStyleProperties>(other).m_propertyVector;
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(other))
+        m_propertyVector = mutableProperties->m_propertyVector;
     else {
         m_propertyVector = WTF::map(downcast<ImmutableStyleProperties>(other), [](auto property) {
             return property.toCSSProperty();

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -64,22 +64,26 @@ namespace WebCore {
 
 ALWAYS_INLINE bool isAutofilled(const Element& element)
 {
-    return is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isAutoFilled();
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    return inputElement && inputElement->isAutoFilled();
 }
 
 ALWAYS_INLINE bool isAutofilledStrongPassword(const Element& element)
 {
-    return is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isAutoFilled() && downcast<HTMLInputElement>(element).hasAutoFillStrongPasswordButton();
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    return inputElement && inputElement->isAutoFilled() && inputElement->hasAutoFillStrongPasswordButton();
 }
 
 ALWAYS_INLINE bool isAutofilledStrongPasswordViewable(const Element& element)
 {
-    return is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isAutoFilledAndViewable();
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    return inputElement && inputElement->isAutoFilledAndViewable();
 }
 
 ALWAYS_INLINE bool isAutofilledAndObscured(const Element& element)
 {
-    return is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isAutoFilledAndObscured();
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    return inputElement && inputElement->isAutoFilledAndObscured();
 }
 
 ALWAYS_INLINE bool matchesDefaultPseudoClass(const Element& element)
@@ -90,13 +94,15 @@ ALWAYS_INLINE bool matchesDefaultPseudoClass(const Element& element)
 // https://html.spec.whatwg.org/multipage/scripting.html#selector-disabled
 ALWAYS_INLINE bool matchesDisabledPseudoClass(const Element& element)
 {
-    return is<HTMLElement>(element) && downcast<HTMLElement>(element).isActuallyDisabled();
+    auto* htmlElement = dynamicDowncast<HTMLElement>(element);
+    return htmlElement && htmlElement->isActuallyDisabled();
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#selector-enabled
 ALWAYS_INLINE bool matchesEnabledPseudoClass(const Element& element)
 {
-    return is<HTMLElement>(element) && downcast<HTMLElement>(element).canBeActuallyDisabled() && !downcast<HTMLElement>(element).isActuallyDisabled();
+    auto* htmlElement = dynamicDowncast<HTMLElement>(element);
+    return htmlElement && htmlElement->canBeActuallyDisabled() && !htmlElement->isActuallyDisabled();
 }
 
 // https://dom.spec.whatwg.org/#concept-element-defined
@@ -115,12 +121,10 @@ ALWAYS_INLINE bool isChecked(const Element& element)
     // Even though WinIE allows checked and indeterminate to co-exist, the CSS selector spec says that
     // you can't be both checked and indeterminate. We will behave like WinIE behind the scenes and just
     // obey the CSS spec here in the test for matching the pseudo.
-    if (is<HTMLInputElement>(element)) {
-        auto& inputElement = downcast<HTMLInputElement>(element);
-        return inputElement.shouldAppearChecked() && !inputElement.shouldAppearIndeterminate();
-    }
-    if (is<HTMLOptionElement>(element))
-        return const_cast<HTMLOptionElement&>(downcast<HTMLOptionElement>(element)).selected(AllowStyleInvalidation::No);
+    if (auto* inputElement = dynamicDowncast<HTMLInputElement>(element))
+        return inputElement->shouldAppearChecked() && !inputElement->shouldAppearIndeterminate();
+    if (auto* option = dynamicDowncast<HTMLOptionElement>(element))
+        return const_cast<HTMLOptionElement&>(*option).selected(AllowStyleInvalidation::No);
 
     return false;
 }
@@ -166,7 +170,8 @@ ALWAYS_INLINE bool isWindowInactive(const Element& element)
 #if ENABLE(ATTACHMENT_ELEMENT)
 ALWAYS_INLINE bool hasAttachment(const Element& element)
 {
-    return is<HTMLImageElement>(element) && downcast<HTMLImageElement>(element).attachmentElement();
+    auto* imageElement = dynamicDowncast<HTMLImageElement>(element);
+    return imageElement && imageElement->attachmentElement();
 }
 #endif
 
@@ -204,12 +209,12 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
 {
     AtomString language;
 #if ENABLE(VIDEO)
-    if (is<WebVTTElement>(element))
-        language = downcast<WebVTTElement>(element).language();
-    else if (is<WebVTTRubyElement>(element))
-        language = downcast<WebVTTRubyElement>(element).language();
-    else if (is<WebVTTRubyTextElement>(element))
-        language = downcast<WebVTTRubyTextElement>(element).language();
+    if (auto* vttElement = dynamicDowncast<WebVTTElement>(element))
+        language = vttElement->language();
+    else if (auto* ruby = dynamicDowncast<WebVTTRubyElement>(element))
+        language = ruby->language();
+    else if (auto* rubyText = dynamicDowncast<WebVTTRubyTextElement>(element))
+        language = rubyText->language();
     else
 #endif
         language = element.effectiveLang();
@@ -481,48 +486,55 @@ ALWAYS_INLINE bool matchesFutureCuePseudoClass(const Element& element)
 
 ALWAYS_INLINE bool matchesPastCuePseudoClass(const Element& element)
 {
-    if (is<WebVTTElement>(element))
-        return downcast<WebVTTElement>(element).isPastNode();
-    if (is<WebVTTRubyElement>(element))
-        return downcast<WebVTTRubyElement>(element).isPastNode();
-    if (is<WebVTTRubyTextElement>(element))
-        return downcast<WebVTTRubyTextElement>(element).isPastNode();
+    if (auto* vttElement = dynamicDowncast<WebVTTElement>(element))
+        return vttElement->isPastNode();
+    if (auto* ruby = dynamicDowncast<WebVTTRubyElement>(element))
+        return ruby->isPastNode();
+    if (auto* rubyText = dynamicDowncast<WebVTTRubyTextElement>(element))
+        return rubyText->isPastNode();
     return false;
 }
 
 ALWAYS_INLINE bool matchesPlayingPseudoClass(const Element& element)
 {
-    return is<HTMLMediaElement>(element) && !downcast<HTMLMediaElement>(element).paused();
+    auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
+    return mediaElement && !mediaElement->paused();
 }
 
 ALWAYS_INLINE bool matchesPausedPseudoClass(const Element& element)
 {
-    return is<HTMLMediaElement>(element) && downcast<HTMLMediaElement>(element).paused();
+    auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
+    return mediaElement && mediaElement->paused();
 }
 
 ALWAYS_INLINE bool matchesSeekingPseudoClass(const Element& element)
 {
-    return is<HTMLMediaElement>(element) && downcast<HTMLMediaElement>(element).seeking();
+    auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
+    return mediaElement && mediaElement->seeking();
 }
 
 ALWAYS_INLINE bool matchesBufferingPseudoClass(const Element& element)
 {
-    return is<HTMLMediaElement>(element) && downcast<HTMLMediaElement>(element).buffering();
+    auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
+    return mediaElement && mediaElement->buffering();
 }
 
 ALWAYS_INLINE bool matchesStalledPseudoClass(const Element& element)
 {
-    return is<HTMLMediaElement>(element) && downcast<HTMLMediaElement>(element).stalled();
+    auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
+    return mediaElement && mediaElement->stalled();
 }
 
 ALWAYS_INLINE bool matchesMutedPseudoClass(const Element& element)
 {
-    return is<HTMLMediaElement>(element) && downcast<HTMLMediaElement>(element).muted();
+    auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
+    return mediaElement && mediaElement->muted();
 }
 
 ALWAYS_INLINE bool matchesVolumeLockedPseudoClass(const Element& element)
 {
-    return is<HTMLMediaElement>(element) && downcast<HTMLMediaElement>(element).volumeLocked();
+    auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
+    return mediaElement && mediaElement->volumeLocked();
 }
 #endif
 
@@ -579,8 +591,8 @@ ALWAYS_INLINE bool matchesHtmlDocumentPseudoClass(const Element& element)
 
 ALWAYS_INLINE bool matchesModalPseudoClass(const Element& element)
 {
-    if (is<HTMLDialogElement>(element))
-        return downcast<HTMLDialogElement>(element).isModal();
+    if (auto* dialog = dynamicDowncast<HTMLDialogElement>(element))
+        return dialog->isModal();
 #if ENABLE(FULLSCREEN_API)
     return element.hasFullscreenFlag();
 #else

--- a/Source/WebCore/css/StylePropertiesInlines.h
+++ b/Source/WebCore/css/StylePropertiesInlines.h
@@ -45,15 +45,15 @@ inline StyleProperties::StyleProperties(CSSParserMode mode, unsigned immutableAr
 
 inline StyleProperties::PropertyReference StyleProperties::propertyAt(unsigned index) const
 {
-    if (is<MutableStyleProperties>(*this))
-        return downcast<MutableStyleProperties>(*this).propertyAt(index);
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
+        return mutableProperties->propertyAt(index);
     return downcast<ImmutableStyleProperties>(*this).propertyAt(index);
 }
 
 inline unsigned StyleProperties::propertyCount() const
 {
-    if (is<MutableStyleProperties>(*this))
-        return downcast<MutableStyleProperties>(*this).propertyCount();
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
+        return mutableProperties->propertyCount();
     return downcast<ImmutableStyleProperties>(*this).propertyCount();
 }
 
@@ -62,25 +62,25 @@ inline void StyleProperties::deref() const
     if (!derefBase())
         return;
 
-    if (is<MutableStyleProperties>(*this))
-        delete downcast<MutableStyleProperties>(this);
-    else if (is<ImmutableStyleProperties>(*this))
-        delete downcast<ImmutableStyleProperties>(this);
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
+        delete mutableProperties;
+    else if (auto* immutableProperties = dynamicDowncast<ImmutableStyleProperties>(*this))
+        delete immutableProperties;
     else
         RELEASE_ASSERT_NOT_REACHED();
 }
 
 inline int StyleProperties::findPropertyIndex(CSSPropertyID propertyID) const
 {
-    if (is<MutableStyleProperties>(*this))
-        return downcast<MutableStyleProperties>(*this).findPropertyIndex(propertyID);
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
+        return mutableProperties->findPropertyIndex(propertyID);
     return downcast<ImmutableStyleProperties>(*this).findPropertyIndex(propertyID);
 }
 
 inline int StyleProperties::findCustomPropertyIndex(StringView propertyName) const
 {
-    if (is<MutableStyleProperties>(*this))
-        return downcast<MutableStyleProperties>(*this).findCustomPropertyIndex(propertyName);
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
+        return mutableProperties->findCustomPropertyIndex(propertyName);
     return downcast<ImmutableStyleProperties>(*this).findCustomPropertyIndex(propertyName);
 }
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -263,9 +263,12 @@ void StyleRule::setProperties(Ref<StyleProperties>&& properties)
 
 MutableStyleProperties& StyleRule::mutableProperties()
 {
-    if (!is<MutableStyleProperties>(m_properties))
-        m_properties = properties().mutableCopy();
-    return downcast<MutableStyleProperties>(m_properties.get());
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
+        return *mutableProperties;
+    Ref mutableProperties = m_properties->mutableCopy();
+    auto& mutablePropertiesRef = mutableProperties.get();
+    m_properties = WTFMove(mutableProperties);
+    return mutablePropertiesRef;
 }
 
 Ref<StyleRule> StyleRule::createForSplitting(const Vector<const CSSSelector*>& selectors, Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin)
@@ -372,9 +375,12 @@ Ref<StyleRulePage> StyleRulePage::create(Ref<StyleProperties>&& properties, CSSS
 
 MutableStyleProperties& StyleRulePage::mutableProperties()
 {
-    if (!is<MutableStyleProperties>(m_properties))
-        m_properties = m_properties->mutableCopy();
-    return downcast<MutableStyleProperties>(m_properties.get());
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
+        return *mutableProperties;
+    Ref mutableProperties = m_properties->mutableCopy();
+    auto& mutablePropertiesRef = mutableProperties.get();
+    m_properties = WTFMove(mutableProperties);
+    return mutablePropertiesRef;
 }
 
 StyleRuleFontFace::StyleRuleFontFace(Ref<StyleProperties>&& properties)
@@ -393,9 +399,12 @@ StyleRuleFontFace::~StyleRuleFontFace() = default;
 
 MutableStyleProperties& StyleRuleFontFace::mutableProperties()
 {
-    if (!is<MutableStyleProperties>(m_properties))
-        m_properties = m_properties->mutableCopy();
-    return downcast<MutableStyleProperties>(m_properties.get());
+    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(m_properties.get()))
+        return *mutableProperties;
+    Ref mutableProperties = m_properties->mutableCopy();
+    auto& mutablePropertiesRef = mutableProperties.get();
+    m_properties = WTFMove(mutableProperties);
+    return mutablePropertiesRef;
 }
 
 StyleRuleFontFeatureValues::StyleRuleFontFeatureValues(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&& value)

--- a/Source/WebCore/css/TransformFunctions.cpp
+++ b/Source/WebCore/css/TransformFunctions.cpp
@@ -106,11 +106,12 @@ Length convertToFloatLength(const CSSPrimitiveValue* primitiveValue, const CSSTo
 
 std::optional<TransformOperations> transformsForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)
 {
-    if (!is<CSSTransformListValue>(value))
+    auto* valueList = dynamicDowncast<CSSTransformListValue>(value);
+    if (!valueList)
         return { };
 
     TransformOperations operations;
-    for (auto& currentValue : downcast<CSSTransformListValue>(value)) {
+    for (auto& currentValue : *valueList) {
         auto transform  = transformForValue(currentValue, conversionData);
         if (!transform)
             return { };
@@ -342,19 +343,19 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
 
 RefPtr<TranslateTransformOperation> translateForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)
 {
-    if (!is<CSSValueList>(value))
+    auto* valueList = dynamicDowncast<CSSValueList>(value);
+    if (!valueList)
         return nullptr;
 
-    auto& valueList = downcast<CSSValueList>(value);
-    if (!valueList.length())
+    if (!valueList->length())
         return nullptr;
 
     auto type = TransformOperation::Type::Translate;
     Length tx = Length(0, LengthType::Fixed);
     Length ty = Length(0, LengthType::Fixed);
     Length tz = Length(0, LengthType::Fixed);
-    for (unsigned i = 0; i < valueList.length(); ++i) {
-        auto* valueItem = dynamicDowncast<CSSPrimitiveValue>(valueList[i]);
+    for (unsigned i = 0; i < valueList->length(); ++i) {
+        auto* valueItem = dynamicDowncast<CSSPrimitiveValue>((*valueList)[i]);
         if (!valueItem)
             return nullptr;
         if (!i)
@@ -375,19 +376,19 @@ RefPtr<TranslateTransformOperation> translateForValue(const CSSValue& value, con
 
 RefPtr<ScaleTransformOperation> scaleForValue(const CSSValue& value)
 {
-    if (!is<CSSValueList>(value))
+    auto* valueList = dynamicDowncast<CSSValueList>(value);
+    if (!valueList)
         return nullptr;
 
-    auto& valueList = downcast<CSSValueList>(value);
-    if (!valueList.length())
+    if (!valueList->length())
         return nullptr;
 
     auto type = TransformOperation::Type::Scale;
     double sx = 1.0;
     double sy = 1.0;
     double sz = 1.0;
-    for (unsigned i = 0; i < valueList.length(); ++i) {
-        auto* valueItem = dynamicDowncast<CSSPrimitiveValue>(valueList[i]);
+    for (unsigned i = 0; i < valueList->length(); ++i) {
+        auto* valueItem = dynamicDowncast<CSSPrimitiveValue>((*valueList)[i]);
         if (!valueItem)
             return nullptr;
         if (!i) {
@@ -406,11 +407,11 @@ RefPtr<ScaleTransformOperation> scaleForValue(const CSSValue& value)
 
 RefPtr<RotateTransformOperation> rotateForValue(const CSSValue& value)
 {
-    if (!is<CSSValueList>(value))
+    auto* valueList = dynamicDowncast<CSSValueList>(value);
+    if (!valueList)
         return nullptr;
 
-    auto& valueList = downcast<CSSValueList>(value);
-    auto numberOfItems = valueList.length();
+    auto numberOfItems = valueList->length();
 
     // There are three scenarios here since the rotation axis is defined either as:
     //     - no value: implicit 2d rotation
@@ -420,10 +421,10 @@ RefPtr<RotateTransformOperation> rotateForValue(const CSSValue& value)
     if (numberOfItems != 1 && numberOfItems != 2 && numberOfItems != 4)
         return nullptr;
 
-    auto* lastValue = valueList.itemWithoutBoundsCheck(numberOfItems - 1);
-    if (!is<CSSPrimitiveValue>(lastValue))
+    auto* lastValue = dynamicDowncast<CSSPrimitiveValue>(valueList->itemWithoutBoundsCheck(numberOfItems - 1));
+    if (!lastValue)
         return nullptr;
-    auto angle = downcast<CSSPrimitiveValue>(*lastValue).computeDegrees();
+    auto angle = lastValue->computeDegrees();
 
     if (numberOfItems == 1)
         return RotateTransformOperation::create(angle, TransformOperation::Type::Rotate);
@@ -435,7 +436,7 @@ RefPtr<RotateTransformOperation> rotateForValue(const CSSValue& value)
 
     if (numberOfItems == 2) {
         // An axis identifier was specified.
-        auto axisIdentifier = valueList[0].valueID();
+        auto axisIdentifier = (*valueList)[0].valueID();
         if (axisIdentifier == CSSValueX) {
             type = TransformOperation::Type::RotateX;
             x = 1.0;
@@ -451,16 +452,16 @@ RefPtr<RotateTransformOperation> rotateForValue(const CSSValue& value)
         // The axis was specified using a vector.
         type = TransformOperation::Type::Rotate;
         for (unsigned i = 0; i < 3; ++i) {
-            auto* valueItem = valueList.itemWithoutBoundsCheck(i);
-            if (!is<CSSPrimitiveValue>(valueItem))
+            auto* valueItem = dynamicDowncast<CSSPrimitiveValue>(valueList->itemWithoutBoundsCheck(i));
+            if (!valueItem)
                 return nullptr;
             if (!i)
-                x = downcast<CSSPrimitiveValue>(*valueItem).doubleValue();
+                x = valueItem->doubleValue();
             else if (i == 1)
-                y = downcast<CSSPrimitiveValue>(*valueItem).doubleValue();
+                y = valueItem->doubleValue();
             else if (i == 2) {
                 type = TransformOperation::Type::Rotate3D;
-                z = downcast<CSSPrimitiveValue>(*valueItem).doubleValue();
+                z = valueItem->doubleValue();
             }
         }
     }

--- a/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp
@@ -63,12 +63,11 @@ static constexpr int maxExpressionDepth = 100;
 RefPtr<CSSCalcExpressionNode> CSSCalcExpressionNodeParser::parseCalc(CSSParserTokenRange tokens, CSSValueID function, bool allowsNegativePercentage)
 {
     std::function<void(CSSCalcExpressionNode&)> setAllowsNegativePercentageReferenceIfNeeded = [&](CSSCalcExpressionNode& expression) {
-        if (is<CSSCalcOperationNode>(expression)) {
-            auto& operationNode = downcast<CSSCalcOperationNode>(expression);
-            if (operationNode.isMinOrMaxNode())
-                operationNode.setAllowsNegativePercentageReference();
+        if (auto* operationNode = dynamicDowncast<CSSCalcOperationNode>(expression)) {
+            if (operationNode->isMinOrMaxNode())
+                operationNode->setAllowsNegativePercentageReference();
 
-            for (auto& child : operationNode.children())
+            for (auto& child : operationNode->children())
                 setAllowsNegativePercentageReferenceIfNeeded(child);
         }
     };


### PR DESCRIPTION
#### 195dfef21b846376c8f467f8e610db4900b9a2f4
<pre>
Use dynamicDowncast&lt;T&gt; more in css/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265269">https://bugs.webkit.org/show_bug.cgi?id=265269</a>

Reviewed by Dan Glastonbury.

* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::equals const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::sizingBox):
(WebCore::ComputedStyleExtractor::valueForFilter):
(WebCore::valueForGridTrackList):
(WebCore::styleElementForNode):
(WebCore::contentToCSSValue):
(WebCore::zoomAdjustedPaddingOrMarginPixelValue):
(WebCore::isLayoutDependent):
(WebCore::isFlexOrGridItem):
(WebCore::ComputedStyleExtractor::propertyValue const):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
(WebCore::ComputedStyleExtractor::propertyMatches const):
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
(WebCore::DeprecatedCSSOMPrimitiveValue::getCounterValue const):
(WebCore::DeprecatedCSSOMPrimitiveValue::getRectValue const):
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::create):
* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::FontFaceSet):
(WebCore::FontFaceSet::load):
* Source/WebCore/css/FontVariantBuilder.cpp:
(WebCore::extractFontVariantLigatures):
(WebCore::extractFontVariantNumeric):
(WebCore::extractFontVariantEastAsian):
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::MutableStyleProperties):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::localContextForParent):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::isAutofilled):
(WebCore::isAutofilledStrongPassword):
(WebCore::isAutofilledStrongPasswordViewable):
(WebCore::isAutofilledAndObscured):
(WebCore::matchesDisabledPseudoClass):
(WebCore::matchesEnabledPseudoClass):
(WebCore::isChecked):
(WebCore::hasAttachment):
(WebCore::matchesLangPseudoClass):
(WebCore::matchesPastCuePseudoClass):
(WebCore::matchesPlayingPseudoClass):
(WebCore::matchesPausedPseudoClass):
(WebCore::matchesSeekingPseudoClass):
(WebCore::matchesBufferingPseudoClass):
(WebCore::matchesStalledPseudoClass):
(WebCore::matchesMutedPseudoClass):
(WebCore::matchesVolumeLockedPseudoClass):
(WebCore::matchesModalPseudoClass):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeLayered const):
(WebCore::isValueIDIncludingList):
(WebCore::gridAutoFlowContains):
(WebCore::isCustomIdentValue):
(WebCore::ShorthandSerializer::serializeGridTemplate const):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::immutableCopyIfNeeded const):
(WebCore::serializeLonghandValue):
(WebCore::StyleProperties::asTextInternal const):
(WebCore::StyleProperties::hasCSSOMWrapper const):
* Source/WebCore/css/StylePropertiesInlines.h:
(WebCore::StyleProperties::propertyAt const):
(WebCore::StyleProperties::propertyCount const):
(WebCore::StyleProperties::deref const):
(WebCore::StyleProperties::findPropertyIndex const):
(WebCore::StyleProperties::findCustomPropertyIndex const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::mutableProperties):
(WebCore::StyleRulePage::mutableProperties):
(WebCore::StyleRuleFontFace::mutableProperties):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::parserAppendRule):
(WebCore::StyleSheetContents::wrapperInsertRule):
(WebCore::traverseRulesInVector):
* Source/WebCore/css/TransformFunctions.cpp:
(WebCore::transformsForValue):
(WebCore::translateForValue):
(WebCore::scaleForValue):
(WebCore::rotateForValue):
* Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp:
(WebCore::CSSCalcExpressionNodeParser::parseCalc):
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::hoistChildrenWithOperator):
(WebCore::CSSCalcOperationNode::simplifyRecursive):
(WebCore::CSSCalcOperationNode::simplifyNode):
(WebCore::CSSCalcOperationNode::buildCSSText):
(WebCore::CSSCalcOperationNode::buildCSSTextRecursive):

Canonical link: <a href="https://commits.webkit.org/271083@main">https://commits.webkit.org/271083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d395a22cf3ddbe01515f686ea01aa687426e8e4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24759 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27506 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4674 "Found 1 new test failure: http/tests/download/area-download.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30106 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28306 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4688 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3525 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->