### PR TITLE
[UIAsyncTextInput] All modifier key events are dispatched with `key` equal to `"Dead"`

### DIFF
--- a/Source/WebCore/platform/ios/WebEvent.mm
+++ b/Source/WebCore/platform/ios/WebEvent.mm
@@ -37,6 +37,7 @@
 #import "KeyEventCodesIOS.h"
 #import "WAKAppKitStubs.h"
 #import "WebEventPrivate.h"
+#import "WindowsKeyboardCodes.h"
 #import <pal/ios/UIKitSoftLink.h>
 #import <pal/spi/cocoa/IOKitSPI.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
@@ -523,6 +524,24 @@ static inline WebEventFlags webEventModifierFlags(UIKeyModifierFlags flags)
     return modifiers;
 }
 
+static inline bool isChangingKeyModifiers(UIKeyEvent *event)
+{
+    switch (event.keyCode) {
+    case VK_LWIN:
+    case VK_APPS:
+    case VK_CAPITAL:
+    case VK_LSHIFT:
+    case VK_RSHIFT:
+    case VK_LMENU:
+    case VK_RMENU:
+    case VK_LCONTROL:
+    case VK_RCONTROL:
+        return true;
+    default:
+        return false;
+    }
+}
+
 - (instancetype)initWithUIKeyEvent:(UIKeyEvent *)event
 {
     if (!(self = [super init]))
@@ -532,7 +551,8 @@ static inline WebEventFlags webEventModifierFlags(UIKeyModifierFlags flags)
     _timestamp = static_cast<CFTimeInterval>(event.timestamp);
     _modifierFlags = webEventModifierFlags(event.modifierFlags);
     _keyboardFlags = 0;
-    // FIXME: Set WebEventKeyboardInputModifierFlagsChanged as needed.
+    if (isChangingKeyModifiers(event))
+        _keyboardFlags |= WebEventKeyboardInputModifierFlagsChanged;
     if (event.keyRepeating)
         _keyboardFlags |= WebEventKeyboardInputRepeat;
 


### PR DESCRIPTION
#### ac24f0695930eebba7ae98f70d9ff431cb970038
<pre>
[UIAsyncTextInput] All modifier key events are dispatched with `key` equal to `&quot;Dead&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=265270">https://bugs.webkit.org/show_bug.cgi?id=265270</a>
<a href="https://rdar.apple.com/118728755">rdar://118728755</a>

Reviewed by Richard Robinson.

Add logic to set the `WebEventKeyboardInputModifierFlagsChanged` flag when converting a `UIKeyEvent`
to `WebEvent`, when async text input is enabled. Without this flag, we currently treat all modifier
keys as Dead key event for the purposes of `KeyEvent.key`, since we skip out on returning the
modifier key names in `keyForKeyEvent` and `keyIdentifierForKeyEvent` when creating the platform key
event.

* Source/WebCore/platform/ios/WebEvent.mm:
(isChangingKeyModifiers):
(-[WebEvent initWithUIKeyEvent:]):

Canonical link: <a href="https://commits.webkit.org/271069@main">https://commits.webkit.org/271069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb54afdbc4a331960ddb621d35f436684343b132

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24917 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24752 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4076 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30365 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28295 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5686 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6564 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4600 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->