### PR TITLE
[MSE] MSE objects should be using thread-safe refcount

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -56,8 +56,7 @@ class SourceBufferPrivate;
 class TimeRanges;
 
 class MediaSource
-    : public RefCounted<MediaSource>
-    , public MediaSourcePrivateClient
+    : public MediaSourcePrivateClient
     , public ActiveDOMObject
     , public EventTarget
     , public URLRegistrable
@@ -116,8 +115,8 @@ public:
 
     void sourceBufferBufferedChanged();
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    using MediaSourcePrivateClient::ref;
+    using MediaSourcePrivateClient::deref;
 
     static const MediaTime& currentTimeFudgeFactor();
     static bool contentTypeShouldGenerateTimestamps(const ContentType&);

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -58,10 +58,9 @@ class VideoTrackList;
 class WebCoreOpaqueRoot;
 
 class SourceBuffer
-    : public RefCounted<SourceBuffer>
+    : public SourceBufferPrivateClient
     , public ActiveDOMObject
     , public EventTarget
-    , private SourceBufferPrivateClient
     , private AudioTrackClient
     , private VideoTrackClient
     , private TextTrackClient
@@ -118,8 +117,8 @@ public:
     // EventTarget
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    using SourceBufferPrivateClient::ref;
+    using SourceBufferPrivateClient::deref;
 
     Document& document() const;
     enum class AppendMode { Segments, Sequence };

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -563,7 +563,7 @@ const MediaPlayerFactory* MediaPlayer::nextBestMediaEngine(const MediaPlayerFact
     parameters.type = m_contentType;
     parameters.url = m_url;
 #if ENABLE(MEDIA_SOURCE)
-    parameters.isMediaSource = !!m_mediaSource;
+    parameters.isMediaSource = !!m_mediaSource.get();
 #endif
 #if ENABLE(MEDIA_STREAM)
     parameters.isMediaStream = !!m_mediaStream;
@@ -595,8 +595,9 @@ void MediaPlayer::reloadAndResumePlaybackIfNeeded()
 
 void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
 {
-#if ENABLE(MEDIA_SOURCE) 
-#define MEDIASOURCE m_mediaSource
+
+#if ENABLE(MEDIA_SOURCE)
+#define MEDIASOURCE m_mediaSource.get()
 #else
 #define MEDIASOURCE 0
 #endif
@@ -645,8 +646,8 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
 
     if (m_private) {
 #if ENABLE(MEDIA_SOURCE)
-        if (m_mediaSource)
-            m_private->load(m_url, m_contentMIMETypeWasInferredFromExtension ? ContentType() : m_contentType, *m_mediaSource);
+        if (RefPtr mediaSource = m_mediaSource.get())
+            m_private->load(m_url, m_contentMIMETypeWasInferredFromExtension ? ContentType() : m_contentType, *mediaSource);
         else
 #endif
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -136,6 +136,13 @@ struct SeekTarget {
     WEBCORE_EXPORT String toString() const;
 };
 
+enum class MediaPlatformType {
+    Mock,
+    AVFObjC,
+    GStreamer,
+    Remote
+};
+
 class MediaPlayerClient : public CanMakeWeakPtr<MediaPlayerClient> {
 public:
     virtual ~MediaPlayerClient() = default;
@@ -757,7 +764,7 @@ private:
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };
 
 #if ENABLE(MEDIA_SOURCE)
-    WeakPtr<MediaSourcePrivateClient> m_mediaSource;
+    ThreadSafeWeakPtr<MediaSourcePrivateClient> m_mediaSource;
 #endif
 #if ENABLE(MEDIA_STREAM)
     RefPtr<MediaStreamPrivate> m_mediaStream;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -32,13 +32,13 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Logger.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
 class MediaSourcePrivate;
 
-class MediaSourcePrivateClient : public CanMakeWeakPtr<MediaSourcePrivateClient> {
+class MediaSourcePrivateClient : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaSourcePrivateClient> {
 public:
     virtual ~MediaSourcePrivateClient() = default;
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -43,7 +43,6 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MainThread.h>
 #include <wtf/MediaTime.h>
-#include <wtf/RunLoop.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -74,26 +73,24 @@ void SourceBufferPrivate::removedFromMediaSource()
     Ref<SourceBufferPrivate> protectedThis { *this };
 
     // m_mediaSource may hold the last reference to ourselves.
-    if (m_mediaSource)
-        m_mediaSource->removeSourceBuffer(*this);
+    if (RefPtr mediaSource = m_mediaSource.get())
+        mediaSource->removeSourceBuffer(*this);
 
     clearMediaSource();
 }
 
 MediaTime SourceBufferPrivate::currentMediaTime() const
 {
-    if (!m_mediaSource)
-        return { };
-
-    return m_mediaSource->currentMediaTime();
+    if (RefPtr mediaSource = m_mediaSource.get())
+        return mediaSource->currentMediaTime();
+    return { };
 }
 
 MediaTime SourceBufferPrivate::duration() const
 {
-    if (!m_mediaSource)
-        return { };
-
-    return m_mediaSource->duration();
+    if (RefPtr mediaSource = m_mediaSource.get())
+        return mediaSource->duration();
+    return { };
 }
 
 void SourceBufferPrivate::resetTimestampOffsetInTrackBuffers()
@@ -122,8 +119,8 @@ void SourceBufferPrivate::updateHighestPresentationTimestamp()
         return;
 
     m_highestPresentationTimestamp = highestTime;
-    if (isAttached())
-        client().sourceBufferPrivateHighestPresentationTimestampChanged(m_highestPresentationTimestamp);
+    if (RefPtr client = this->client())
+        client->sourceBufferPrivateHighestPresentationTimestampChanged(m_highestPresentationTimestamp);
 }
 
 Ref<MediaPromise> SourceBufferPrivate::setBufferedRanges(PlatformTimeRanges&& timeRanges)
@@ -131,7 +128,9 @@ Ref<MediaPromise> SourceBufferPrivate::setBufferedRanges(PlatformTimeRanges&& ti
     if (m_buffered == timeRanges)
         return MediaPromise::createAndResolve();
     m_buffered = WTFMove(timeRanges);
-    return isAttached() ? client().sourceBufferPrivateBufferedChanged(buffered()) : MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
+    if (RefPtr client = this->client())
+        return client->sourceBufferPrivateBufferedChanged(buffered());
+    return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
 }
 
 Vector<PlatformTimeRanges> SourceBufferPrivate::trackBuffersRanges() const
@@ -186,7 +185,8 @@ Ref<MediaPromise> SourceBufferPrivate::updateBufferedFromTrackBuffers(const Vect
 
 void SourceBufferPrivate::reenqueSamples(const AtomString& trackID)
 {
-    if (!isAttached())
+    RefPtr client = this->client();
+    if (!client)
         return;
 
     auto* trackBuffer = m_trackBufferMap.get(trackID);
@@ -198,7 +198,8 @@ void SourceBufferPrivate::reenqueSamples(const AtomString& trackID)
 
 Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivate::computeSeekTime(const SeekTarget& target)
 {
-    if (!isAttached())
+    RefPtr client = this->client();
+    if (!client)
         return ComputeSeekPromise::createAndReject(PlatformMediaError::BufferRemoved);
 
     auto seekTime = target.time;
@@ -242,9 +243,9 @@ void SourceBufferPrivate::clearTrackBuffers(bool shouldReportToClient)
 
     updateHighestPresentationTimestamp();
 
-    if (isAttached()) {
-        client().sourceBufferPrivateTrackBuffersChanged({ });
-        client().sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
+    if (RefPtr client = this->client()) {
+        client->sourceBufferPrivateTrackBuffersChanged({ });
+        client->sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
     }
     updateBufferedFromTrackBuffers({ });
 }
@@ -312,8 +313,11 @@ void SourceBufferPrivate::provideMediaData(const AtomString& trackID)
 
 void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, const AtomString& trackID)
 {
-    if (!isAttached() || isSeeking())
+    if (isSeeking())
         return;
+    RefPtr client = this->client();
+    if (!client)
+        return; // detached.
 
 #if !RELEASE_LOG_DISABLED
     unsigned enqueuedSamples = 0;
@@ -409,8 +413,9 @@ MediaTime SourceBufferPrivate::findPreviousSyncSamplePresentationTime(const Medi
 
 Ref<MediaPromise> SourceBufferPrivate::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime)
 {
-    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }, this, start, end, currentTime](auto result) mutable -> Ref<OperationPromise> {
-        if (!weakThis || !result)
+    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }, this, start, end, currentTime](auto result) mutable -> Ref<OperationPromise> {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !result)
             return OperationPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
         return removeCodedFramesInternal(start, end, currentTime).get();
     });
@@ -452,9 +457,9 @@ Ref<MediaPromise> SourceBufferPrivate::removeCodedFramesInternal(const MediaTime
     LOG(Media, "SourceBuffer::removeCodedFramesInternal(%p) - buffered = %s", this, toString(m_buffered).utf8().data());
 
     auto trackBuffers = trackBuffersRanges();
-    if (isAttached()) {
-        client().sourceBufferPrivateTrackBuffersChanged(trackBuffers);
-        client().sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
+    if (RefPtr client = this->client()) {
+        client->sourceBufferPrivateTrackBuffersChanged(trackBuffers);
+        client->sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
     }
 
     return updateBufferedFromTrackBuffers(trackBuffers);
@@ -482,7 +487,8 @@ void SourceBufferPrivate::evictCodedFrames(uint64_t newDataSize, uint64_t maximu
     // 3.5.13 Coded Frame Eviction Algorithm
     // http://www.w3.org/TR/media-source/#sourcebuffer-coded-frame-eviction
 
-    if (!isAttached())
+    RefPtr client = this->client();
+    if (!client)
         return;
 
     // This algorithm is run to free up space in this source buffer when new data is appended.
@@ -576,11 +582,6 @@ void SourceBufferPrivate::detach()
     m_client = nullptr;
 }
 
-bool SourceBufferPrivate::isAttached() const
-{
-    return !!m_client;
-}
-
 void SourceBufferPrivate::setAllTrackBuffersNeedRandomAccess()
 {
     for (auto& trackBuffer : m_trackBufferMap.values())
@@ -592,8 +593,12 @@ void SourceBufferPrivate::didReceiveInitializationSegment(InitializationSegment&
     processPendingMediaSamples();
 
     auto segmentCopy = segment;
-    m_currentAppendProcessing = m_currentAppendProcessing->whenSettled(RunLoop::current(), [segment = WTFMove(segment), weakThis = WeakPtr { *this }, this, abortCount = m_abortCount](auto result) mutable {
-        if (!weakThis || !isAttached())
+    m_currentAppendProcessing = m_currentAppendProcessing->whenSettled(RunLoop::current(), [segment = WTFMove(segment), weakThis = ThreadSafeWeakPtr { *this }, this, abortCount = m_abortCount](auto result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
+        RefPtr client = this->client();
+        if (!client)
             return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
 
         if (abortCount != m_abortCount) {
@@ -605,9 +610,10 @@ void SourceBufferPrivate::didReceiveInitializationSegment(InitializationSegment&
             return MediaPromise::createAndReject(!result ? result.error() : PlatformMediaError::ParsingError);
         }
 
-        return client().sourceBufferPrivateDidReceiveInitializationSegment(WTFMove(segment));
-    })->whenSettled(RunLoop::current(), [this, weakThis = WeakPtr { *this }, segment = WTFMove(segmentCopy)] (auto result) mutable {
-        if (!weakThis)
+        return client->sourceBufferPrivateDidReceiveInitializationSegment(WTFMove(segment));
+    })->whenSettled(RunLoop::current(), [this, weakThis = ThreadSafeWeakPtr { *this }, segment = WTFMove(segmentCopy)] (auto result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
 
         // We don't check for abort here as we need to complete the already started initialization segment.
@@ -622,8 +628,9 @@ void SourceBufferPrivate::didReceiveInitializationSegment(InitializationSegment&
 
 void SourceBufferPrivate::didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&& formatDescription, uint64_t trackId)
 {
-    m_currentAppendProcessing = m_currentAppendProcessing->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }, this, formatDescription = WTFMove(formatDescription), trackId] (auto result) mutable {
-        if (!weakThis || !result)
+    m_currentAppendProcessing = m_currentAppendProcessing->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }, this, formatDescription = WTFMove(formatDescription), trackId] (auto result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !result)
             return MediaPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
         processFormatDescriptionForTrackId(WTFMove(formatDescription), trackId);
         return MediaPromise::createAndResolve();
@@ -660,9 +667,6 @@ bool SourceBufferPrivate::validateInitializationSegment(const SourceBufferPrivat
 
 void SourceBufferPrivate::didReceiveSample(Ref<MediaSample>&& sample)
 {
-    if (!isAttached())
-        return;
-
     DEBUG_LOG(LOGIDENTIFIER, sample.get());
 
     m_pendingSamples.append(WTFMove(sample));
@@ -670,8 +674,9 @@ void SourceBufferPrivate::didReceiveSample(Ref<MediaSample>&& sample)
 
 Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
 {
-    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }, this, buffer = WTFMove(buffer), abortCount = m_abortCount](auto result) mutable {
-        if (!weakThis || !result)
+    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }, this, buffer = WTFMove(buffer), abortCount = m_abortCount](auto result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !result)
             return MediaPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
 
         // We have fully completed the previous append operation, we can start a new promise chain.
@@ -685,8 +690,9 @@ Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
 
         // Before the promise returned by appendInternal is resolved, the various callbacks would have been called and populating m_currentAppendProcessing.
         return appendInternal(WTFMove(buffer));
-    })->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }, this](auto result) mutable -> Ref<OperationPromise> {
-        if (!weakThis)
+    })->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }, this](auto result) mutable -> Ref<OperationPromise> {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return OperationPromise::createAndReject(PlatformMediaError::BufferRemoved);
 
         processPendingMediaSamples();
@@ -695,16 +701,21 @@ Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
         return m_currentAppendProcessing->whenSettled(RunLoop::current(), [previousResult = WTFMove(result)](auto result) {
             return (previousResult && result) ? OperationPromise::createAndResolve() : OperationPromise::createAndReject(!result ? result.error() : previousResult.error());
         });
-    })->whenSettled(RunLoop::current(), [weakThis = WeakPtr { * this }, this, abortCount = m_abortCount](auto result) mutable -> Ref<OperationPromise> {
-        if (!weakThis || !result || !isAttached())
+    })->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { * this }, this, abortCount = m_abortCount](auto result) mutable -> Ref<OperationPromise> {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !result)
             return OperationPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
         if (abortCount != m_abortCount)
             return OperationPromise::createAndResolve();
 
+        RefPtr client = this->client();
+        if (!client)
+            return OperationPromise::createAndReject(PlatformMediaError::BufferRemoved);
+
         // Resolve the changes in TrackBuffers' buffered ranges
         // into the SourceBuffer's buffered ranges
         auto trackBuffers = trackBuffersRanges();
-        client().sourceBufferPrivateTrackBuffersChanged(trackBuffers);
+        client->sourceBufferPrivateTrackBuffersChanged(trackBuffers);
 
         Vector<Ref<MediaPromise>> promises;
         promises.append(updateBufferedFromTrackBuffers(trackBuffers));
@@ -712,9 +723,9 @@ Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
             // https://w3c.github.io/media-source/#sourcebuffer-coded-frame-processing
             // 5. If the media segment contains data beyond the current duration, then run the duration change algorithm with new
             // duration set to the maximum of the current duration and the group end timestamp.
-            promises.append(client().sourceBufferPrivateDurationChanged(m_groupEndTimestamp));
+            promises.append(client->sourceBufferPrivateDurationChanged(m_groupEndTimestamp));
         }
-        client().sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
+        client->sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
 
         return MediaPromise::all(promises).get();
     });
@@ -726,23 +737,27 @@ void SourceBufferPrivate::processPendingMediaSamples()
     if (m_pendingSamples.isEmpty())
         return;
     auto samples = std::exchange(m_pendingSamples, { });
-    m_currentAppendProcessing = m_currentAppendProcessing->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }, this, samples = WTFMove(samples), abortCount = m_abortCount](auto result) mutable {
-        if (!weakThis || !result || !isAttached())
+    m_currentAppendProcessing = m_currentAppendProcessing->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }, this, samples = WTFMove(samples), abortCount = m_abortCount](auto result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !result)
             return MediaPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
         if (abortCount != m_abortCount)
             return MediaPromise::createAndResolve();
 
+        RefPtr client = this->client();
+        if (!client)
+            return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
+
         for (auto& sample : samples) {
-            if (!processMediaSample(WTFMove(sample)))
+            if (!processMediaSample(*client, WTFMove(sample)))
                 return MediaPromise::createAndReject(PlatformMediaError::ParsingError);
         }
         return MediaPromise::createAndResolve();
     });
 }
 
-bool SourceBufferPrivate::processMediaSample(Ref<MediaSample>&& sample)
+bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, Ref<MediaSample>&& sample)
 {
-    ASSERT(isAttached());
     // 3.5.1 Segment Parser Loop
     // 6.1 If the first initialization segment received flag is false, (Note: Issue # 155 & changeType()
     // algorithm) or the  pending initialization segment for changeType flag  is true, (End note)
@@ -822,7 +837,7 @@ bool SourceBufferPrivate::processMediaSample(Ref<MediaSample>&& sample)
         if (it == m_trackBufferMap.end()) {
             // The client managed to append a sample with a trackID not present in the initialization
             // segment. This would be a good place to post an message to the developer console.
-            client().sourceBufferPrivateDidDropSample();
+            client.sourceBufferPrivateDidDropSample();
             return true;
         }
         TrackBuffer& trackBuffer = it->value;
@@ -924,7 +939,7 @@ bool SourceBufferPrivate::processMediaSample(Ref<MediaSample>&& sample)
                 }
             }
             trackBuffer.setNeedRandomAccessFlag(true);
-            client().sourceBufferPrivateDidDropSample();
+            client.sourceBufferPrivateDidDropSample();
             return true;
         }
 
@@ -933,7 +948,7 @@ bool SourceBufferPrivate::processMediaSample(Ref<MediaSample>&& sample)
             // 1.11.1 If the coded frame is not a random access point, then drop the coded frame and jump
             // to the top of the loop to start processing the next coded frame.
             if (!sample->isSync()) {
-                client().sourceBufferPrivateDidDropSample();
+                client.sourceBufferPrivateDidDropSample();
                 return true;
             }
 
@@ -1157,7 +1172,7 @@ bool SourceBufferPrivate::processMediaSample(Ref<MediaSample>&& sample)
 
         auto presentationEndTime = presentationTimestamp + frameDuration;
         trackBuffer.addBufferedRange(presentationTimestamp, presentationEndTime, AddTimeRangeOption::EliminateSmallGaps);
-        client().sourceBufferPrivateDidParseSample(frameDuration.toDouble());
+        client.sourceBufferPrivateDidParseSample(frameDuration.toDouble());
 
         break;
     } while (true);
@@ -1176,8 +1191,9 @@ void SourceBufferPrivate::abort()
 
 void SourceBufferPrivate::resetParserState()
 {
-    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }, this](auto result) mutable {
-        if (!weakThis)
+    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }, this](auto result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return OperationPromise::createAndReject(PlatformMediaError::BufferRemoved);
         resetParserStateInternal();
         return OperationPromise::createAndSettle(WTFMove(result));
@@ -1188,7 +1204,10 @@ void SourceBufferPrivate::memoryPressure(uint64_t maximumBufferSize, const Media
 {
     ALWAYS_LOG(LOGIDENTIFIER, "isActive = ", isActive());
 
-    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }, this, maximumBufferSize, currentTime](auto result) mutable {
+    m_currentSourceBufferOperation = m_currentSourceBufferOperation->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }, this, maximumBufferSize, currentTime](auto result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return OperationPromise::createAndReject(PlatformMediaError::BufferRemoved);
         if (isActive())
             evictFrames(maximumBufferSize, maximumBufferSize, currentTime);
         else {
@@ -1274,14 +1293,13 @@ void SourceBufferPrivate::setActive(bool isActive)
     ALWAYS_LOG(LOGIDENTIFIER, isActive);
 
     m_isActive = isActive;
-    if (m_mediaSource)
-        m_mediaSource->sourceBufferPrivateDidChangeActiveState(*this, isActive);
+    if (RefPtr mediaSource = m_mediaSource.get())
+        mediaSource->sourceBufferPrivateDidChangeActiveState(*this, isActive);
 }
 
-SourceBufferPrivateClient& SourceBufferPrivate::client() const
+RefPtr<SourceBufferPrivateClient> SourceBufferPrivate::client() const
 {
-    RELEASE_ASSERT(isAttached());
-    return *m_client;
+    return m_client.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -43,7 +43,7 @@ class MediaDescription;
 class PlatformTimeRanges;
 class VideoTrackPrivate;
 
-class SourceBufferPrivateClient : public CanMakeWeakPtr<SourceBufferPrivateClient> {
+class SourceBufferPrivateClient : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SourceBufferPrivateClient> {
 public:
     virtual ~SourceBufferPrivateClient() = default;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -62,6 +62,8 @@ public:
     static Ref<MediaSourcePrivateAVFObjC> create(MediaPlayerPrivateMediaSourceAVFObjC&, MediaSourcePrivateClient&);
     virtual ~MediaSourcePrivateAVFObjC();
 
+    constexpr MediaPlatformType platformType() const final { return MediaPlatformType::AVFObjC; }
+
     MediaPlayerPrivateMediaSourceAVFObjC* player() const { return m_player.get(); }
 
     AddStatus addSourceBuffer(const ContentType&, bool webMParserEnabled, RefPtr<SourceBufferPrivate>&) final;
@@ -70,12 +72,6 @@ public:
 
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;
-
-    Ref<MediaTimePromise> waitForTarget(const SeekTarget&) final;
-    Ref<MediaPromise> seekToTime(const MediaTime&) final;
-
-    MediaTime duration() const final;
-    const PlatformTimeRanges& buffered();
 
     bool hasSelectedVideo() const;
 
@@ -127,7 +123,6 @@ private:
     friend class SourceBufferPrivateAVFObjC;
 
     WeakPtr<MediaPlayerPrivateMediaSourceAVFObjC> m_player;
-    WeakPtr<MediaSourcePrivateClient> m_client;
     Deque<SourceBufferPrivateAVFObjC*> m_sourceBuffersNeedingSessions;
     SourceBufferPrivateAVFObjC* m_sourceBufferWithSelectedVideo { nullptr };
 #if ENABLE(ENCRYPTED_MEDIA)
@@ -140,6 +135,10 @@ private:
 #endif
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaSourcePrivateAVFObjC)
+static bool isType(const WebCore::MediaSourcePrivate& mediaSource) { return mediaSource.platformType() == WebCore::MediaPlatformType::AVFObjC; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -94,9 +94,8 @@ public:
     static Ref<SourceBufferPrivateAVFObjC> create(MediaSourcePrivateAVFObjC&, Ref<SourceBufferParser>&&);
     virtual ~SourceBufferPrivateAVFObjC();
 
-    constexpr PlatformType platformType() const final { return PlatformType::AVFObjC; }
+    constexpr MediaPlatformType platformType() const final { return MediaPlatformType::AVFObjC; }
 
-    void willProvideContentKeyRequestInitializationDataForTrackID(uint64_t trackID);
     void didProvideContentKeyRequestInitializationDataForTrackID(Ref<SharedBuffer>&&, uint64_t trackID, Box<BinarySemaphore>);
 
     void didProvideContentKeyRequestIdentifierForTrackID(Ref<SharedBuffer>&&, uint64_t trackID);
@@ -265,7 +264,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SourceBufferPrivateAVFObjC)
-static bool isType(const WebCore::SourceBufferPrivate& sourceBuffer) { return sourceBuffer.platformType() == WebCore::SourceBufferPrivate::PlatformType::AVFObjC; }
+static bool isType(const WebCore::SourceBufferPrivate& sourceBuffer) { return sourceBuffer.platformType() == WebCore::MediaPlatformType::AVFObjC; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -97,7 +97,7 @@ static void* errorContext = &errorContext;
 static void* outputObscuredDueToInsufficientExternalProtectionContext = &outputObscuredDueToInsufficientExternalProtectionContext;
 
 @interface WebAVSampleBufferListener : NSObject {
-    WeakPtr<WebCore::SourceBufferPrivateAVFObjC> _parent;
+    ThreadSafeWeakPtr<WebCore::SourceBufferPrivateAVFObjC> _parent;
     Vector<RetainPtr<AVSampleBufferDisplayLayer>> _layers;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     Vector<RetainPtr<AVSampleBufferAudioRenderer>> _renderers;
@@ -136,7 +136,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 - (void)invalidate
 {
     ASSERT(isMainThread());
-    if (!_parent && !_layers.size() && !_renderers.size())
+    auto protectedParent = _parent.get();
+    if (!protectedParent && !_layers.size() && !_renderers.size())
         return;
 
     for (auto& layer : _layers) {
@@ -157,7 +158,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 - (void)beginObservingLayer:(AVSampleBufferDisplayLayer *)layer
 {
     ASSERT(isMainThread());
-    ASSERT(_parent);
     ASSERT(!_layers.contains(layer));
 
     _layers.append(layer);
@@ -175,7 +175,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 - (void)stopObservingLayer:(AVSampleBufferDisplayLayer *)layer
 {
     ASSERT(isMainThread());
-    ASSERT(_parent);
     ASSERT(_layers.contains(layer));
 
     [layer removeObserver:self forKeyPath:errorKeyPath];
@@ -196,7 +195,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 {
     ASSERT(isMainThread());
-    ASSERT(_parent);
     ASSERT(!_renderers.contains(renderer));
 
     _renderers.append(renderer);
@@ -209,7 +207,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 {
     ASSERT(isMainThread());
-    ASSERT(_parent);
     ASSERT(_renderers.contains(renderer));
 
     [renderer removeObserver:self forKeyPath:errorKeyPath];
@@ -220,8 +217,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void*)context
 {
-    ASSERT(_parent);
-
     if (context == errorContext) {
         RetainPtr error = dynamic_objc_cast<NSError>([change valueForKey:NSKeyValueChangeNewKey]);
         if (!error)
@@ -331,18 +326,6 @@ namespace WebCore {
 #pragma mark -
 #pragma mark SourceBufferPrivateAVFObjC
 
-static HashMap<uint64_t, WeakPtr<SourceBufferPrivateAVFObjC>>& sourceBufferMap()
-{
-    static NeverDestroyed<HashMap<uint64_t, WeakPtr<SourceBufferPrivateAVFObjC>>> map;
-    return map;
-}
-
-static uint64_t nextMapID()
-{
-    static uint64_t mapID = 0;
-    return ++mapID;
-}
-
 static bool sampleBufferRenderersSupportKeySession()
 {
     static bool supports = false;
@@ -371,7 +354,6 @@ SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC(MediaSourcePrivateAVFObjC
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
     , m_keyStatusesChangedObserver(makeUniqueRef<Observer<void()>>([this] { keyStatusesChanged(); }))
 #endif
-    , m_mapID(nextMapID())
 #if !RELEASE_LOG_DISABLED
     , m_logger(parent.logger())
     , m_logIdentifier(parent.nextSourceBufferLogIdentifier())
@@ -382,15 +364,12 @@ SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC(MediaSourcePrivateAVFObjC
 #if !RELEASE_LOG_DISABLED
     m_parser->setLogger(m_logger.get(), m_logIdentifier);
 #endif
-
-    sourceBufferMap().add(m_mapID, *this);
 }
 
 SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    sourceBufferMap().remove(m_mapID);
     destroyStreamDataParser();
     destroyRenderers();
     clearTracks();
@@ -401,8 +380,9 @@ SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC()
 void SourceBufferPrivateAVFObjC::setTrackChangeCallbacks(const InitializationSegment& segment, bool initialized)
 {
     for (auto& videoTrackInfo : segment.videoTracks) {
-        videoTrackInfo.track->setSelectedChangedCallback([weakThis = WeakPtr { *this }, this, initialized] (VideoTrackPrivate& track, bool selected) {
-            if (!weakThis)
+        videoTrackInfo.track->setSelectedChangedCallback([weakThis = ThreadSafeWeakPtr { *this }, this, initialized] (VideoTrackPrivate& track, bool selected) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             if (initialized) {
@@ -410,15 +390,16 @@ void SourceBufferPrivateAVFObjC::setTrackChangeCallbacks(const InitializationSeg
                 return;
             }
             m_pendingTrackChangeTasks.append([weakThis, trackRef = Ref { track }, selected] {
-                if (weakThis)
-                    weakThis->trackDidChangeSelected(trackRef, selected);
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->trackDidChangeSelected(trackRef, selected);
             });
         });
     }
 
     for (auto& audioTrackInfo : segment.audioTracks) {
-        audioTrackInfo.track->setEnabledChangedCallback([weakThis = WeakPtr { *this }, this, initialized] (AudioTrackPrivate& track, bool enabled) {
-            if (!weakThis)
+        audioTrackInfo.track->setEnabledChangedCallback([weakThis = ThreadSafeWeakPtr { *this }, this, initialized] (AudioTrackPrivate& track, bool enabled) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             if (initialized) {
@@ -427,8 +408,8 @@ void SourceBufferPrivateAVFObjC::setTrackChangeCallbacks(const InitializationSeg
             }
 
             m_pendingTrackChangeTasks.append([weakThis, trackRef = Ref { track }, enabled] {
-                if (weakThis)
-                    weakThis->trackDidChangeEnabled(trackRef, enabled);
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->trackDidChangeEnabled(trackRef, enabled);
             });
         });
     }
@@ -501,40 +482,34 @@ bool SourceBufferPrivateAVFObjC::isMediaSampleAllowed(const MediaSample& sample)
 
 void SourceBufferPrivateAVFObjC::processFormatDescriptionForTrackId(Ref<TrackInfo>&& formatDescription, uint64_t trackId)
 {
-    if (is<VideoInfo>(formatDescription)) {
+    if (auto videoDescription = dynamicDowncast<VideoInfo>(formatDescription)) {
         auto result = m_videoTracks.find(AtomString::number(trackId));
         if (result != m_videoTracks.end())
-            result->value->setFormatDescription(downcast<VideoInfo>(formatDescription.get()));
+            result->value->setFormatDescription(videoDescription.releaseNonNull());
         return;
     }
 
-    if (is<AudioInfo>(formatDescription)) {
+    if (auto audioDescription = dynamicDowncast<AudioInfo>(formatDescription)) {
         auto result = m_audioTracks.find(AtomString::number(trackId));
         if (result != m_audioTracks.end())
-            result->value->setFormatDescription(downcast<AudioInfo>(formatDescription.get()));
+            result->value->setFormatDescription(audioDescription.releaseNonNull());
     }
-}
-
-void SourceBufferPrivateAVFObjC::willProvideContentKeyRequestInitializationDataForTrackID(uint64_t trackID)
-{
-    if (!m_mediaSource)
-        return;
-
-    UNUSED_PARAM(trackID);
 }
 
 void SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID(Ref<SharedBuffer>&& initData, uint64_t trackID, Box<BinarySemaphore> hasSessionSemaphore)
 {
-    auto player = this->player();
-    if (!player || !m_mediaSource)
+    RefPtr player = this->player();
+    if (!player)
         return;
-
+    RefPtr mediaSource = downcast<MediaSourcePrivateAVFObjC>(m_mediaSource.get());
+    if (!mediaSource)
+        return;
 #if HAVE(AVCONTENTKEYSESSION) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
     ALWAYS_LOG(LOGIDENTIFIER, "track = ", trackID);
 
     m_protectedTrackID = trackID;
     m_initData = WTFMove(initData);
-    static_cast<MediaSourcePrivateAVFObjC*>(m_mediaSource.get())->sourceBufferKeyNeeded(this, *m_initData);
+    mediaSource->sourceBufferKeyNeeded(this, *m_initData);
 
     if (auto session = player->cdmSession()) {
         if (sampleBufferRenderersSupportKeySession()) {
@@ -608,35 +583,30 @@ Ref<MediaPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>&&
     ASSERT(!m_hasSessionSemaphore);
     ASSERT(!m_abortSemaphore);
 
-    m_parser->setDidParseInitializationDataCallback([weakThis = WeakPtr { *this }] (InitializationSegment&& segment) {
+    m_parser->setDidParseInitializationDataCallback([weakThis = ThreadSafeWeakPtr { *this }] (InitializationSegment&& segment) {
         ASSERT(isMainThread());
-        if (!weakThis)
-            return;
-        weakThis->didReceiveInitializationSegment(WTFMove(segment));
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->didReceiveInitializationSegment(WTFMove(segment));
     });
 
-    m_parser->setDidProvideMediaDataCallback([weakThis = WeakPtr { *this }] (Ref<MediaSampleAVFObjC>&& sample, uint64_t trackId, const String& mediaType) {
+    m_parser->setDidProvideMediaDataCallback([weakThis = ThreadSafeWeakPtr { *this }] (Ref<MediaSampleAVFObjC>&& sample, uint64_t trackId, const String& mediaType) {
         ASSERT(isMainThread());
-        if (!weakThis)
-            return;
-        weakThis->didProvideMediaDataForTrackId(WTFMove(sample), trackId, mediaType);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->didProvideMediaDataForTrackId(WTFMove(sample), trackId, mediaType);
     });
 
-    m_parser->setDidUpdateFormatDescriptionForTrackIDCallback([weakThis = WeakPtr { *this }, abortCalled = m_abortCalled] (Ref<TrackInfo>&& formatDescription, uint64_t trackId) {
+    m_parser->setDidUpdateFormatDescriptionForTrackIDCallback([weakThis = ThreadSafeWeakPtr { *this }, this, abortCalled = m_abortCalled] (Ref<TrackInfo>&& formatDescription, uint64_t trackId) {
         ASSERT(isMainThread());
-        if (!weakThis || abortCalled != weakThis->m_abortCalled)
-            return;
-        weakThis->didUpdateFormatDescriptionForTrackId(WTFMove(formatDescription), trackId);
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && abortCalled == m_abortCalled)
+            protectedThis->didUpdateFormatDescriptionForTrackId(WTFMove(formatDescription), trackId);
     });
 
     m_abortSemaphore = Box<Semaphore>::create(0);
-    m_parser->setWillProvideContentKeyRequestInitializationDataForTrackIDCallback([weakThis = WeakPtr { *this }, abortSemaphore = m_abortSemaphore] (uint64_t trackID) mutable {
+    m_parser->setWillProvideContentKeyRequestInitializationDataForTrackIDCallback([abortSemaphore = m_abortSemaphore] (uint64_t) mutable {
         // We must call synchronously to the main thread, as the AVStreamSession must be associated
         // with the streamDataParser before the delegate method returns.
         Box<BinarySemaphore> respondedSemaphore = Box<BinarySemaphore>::create();
-        callOnMainThread([weakThis = WTFMove(weakThis), trackID, respondedSemaphore]() {
-            if (weakThis)
-                weakThis->willProvideContentKeyRequestInitializationDataForTrackID(trackID);
+        callOnMainThread([respondedSemaphore]() {
             respondedSemaphore->signal();
         });
 
@@ -651,13 +621,12 @@ Ref<MediaPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>&&
         }
     });
 
-    m_parser->setDidProvideContentKeyRequestInitializationDataForTrackIDCallback([weakThis = WeakPtr { *this }, abortSemaphore = m_abortSemaphore](Ref<SharedBuffer>&& initData, uint64_t trackID) mutable {
+    m_parser->setDidProvideContentKeyRequestInitializationDataForTrackIDCallback([weakThis = ThreadSafeWeakPtr { *this }, abortSemaphore = m_abortSemaphore](Ref<SharedBuffer>&& initData, uint64_t trackID) mutable {
         // Called on the data parser queue.
         Box<BinarySemaphore> hasSessionSemaphore = Box<BinarySemaphore>::create();
-        callOnMainThread([weakThis = WTFMove(weakThis), initData = WTFMove(initData), trackID, hasSessionSemaphore] () mutable {
-            if (!weakThis)
-                return;
-            weakThis->didProvideContentKeyRequestInitializationDataForTrackID(WTFMove(initData), trackID, hasSessionSemaphore);
+        callOnMainThread([weakThis, initData = WTFMove(initData), trackID, hasSessionSemaphore] () mutable {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->didProvideContentKeyRequestInitializationDataForTrackID(WTFMove(initData), trackID, hasSessionSemaphore);
         });
 
         while (true) {
@@ -671,18 +640,17 @@ Ref<MediaPromise> SourceBufferPrivateAVFObjC::appendInternal(Ref<SharedBuffer>&&
         }
     });
 
-    m_parser->setDidProvideContentKeyRequestIdentifierForTrackIDCallback([weakThis = WeakPtr { *this }] (Ref<SharedBuffer>&& initData, uint64_t trackID) {
+    m_parser->setDidProvideContentKeyRequestIdentifierForTrackIDCallback([weakThis = ThreadSafeWeakPtr { *this }] (Ref<SharedBuffer>&& initData, uint64_t trackID) {
         ASSERT(isMainThread());
-        if (!weakThis)
-            return;
-        weakThis->didProvideContentKeyRequestInitializationDataForTrackID(WTFMove(initData), trackID, nullptr);
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->didProvideContentKeyRequestInitializationDataForTrackID(WTFMove(initData), trackID, nullptr);
     });
 
     return invokeAsync(m_appendQueue, [data = WTFMove(data), parser = m_parser]() mutable {
         return MediaPromise::createAndSettle(parser->appendData(WTFMove(data)));
-    })->whenSettled(RunLoop::current(), [weakThis = WeakPtr { *this }](auto&& result) {
-        if (weakThis)
-            weakThis->appendCompleted(!!result);
+    })->whenSettled(RunLoop::current(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->appendCompleted(!!result);
         return MediaPromise::createAndSettle(WTFMove(result));
     });
 }
@@ -824,9 +792,9 @@ void SourceBufferPrivateAVFObjC::trackDidChangeSelected(VideoTrackPrivate& track
         m_parser->setShouldProvideMediaDataForTrackID(true, trackID);
 
         if (m_decompressionSession) {
-            m_decompressionSession->requestMediaDataWhenReady([weakThis = WeakPtr { *this }, trackID] {
-                if (weakThis)
-                    weakThis->didBecomeReadyForMoreSamples(trackID);
+            m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, trackID] {
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->didBecomeReadyForMoreSamples(trackID);
             });
         }
     }
@@ -834,7 +802,8 @@ void SourceBufferPrivateAVFObjC::trackDidChangeSelected(VideoTrackPrivate& track
     if (RefPtr player = this->player())
         player->needsVideoLayerChanged();
 
-    static_cast<MediaSourcePrivateAVFObjC*>(m_mediaSource.get())->hasSelectedVideoChanged(*this);
+    if (RefPtr mediaSource = downcast<MediaSourcePrivateAVFObjC>(m_mediaSource.get()))
+        mediaSource->hasSelectedVideoChanged(*this);
 }
 
 void SourceBufferPrivateAVFObjC::trackDidChangeEnabled(AudioTrackPrivate& track, bool enabled)
@@ -860,8 +829,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
             if (!renderer) {
                 ERROR_LOG(LOGIDENTIFIER, "-[AVSampleBufferAudioRenderer init] returned nil! bailing!");
-                if (m_mediaSource)
-                    static_cast<MediaSourcePrivateAVFObjC*>(m_mediaSource.get())->failedToCreateRenderer(MediaSourcePrivateAVFObjC::RendererType::Audio);
+                if (RefPtr mediaSourcePrivate = downcast<MediaSourcePrivateAVFObjC>(m_mediaSource.get()))
+                    mediaSourcePrivate->failedToCreateRenderer(MediaSourcePrivateAVFObjC::RendererType::Audio);
                 if (RefPtr player = this->player())
                     player->setNetworkState(MediaPlayer::NetworkState::DecodeError);
                 return;
@@ -872,10 +841,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
             [m_cdmInstance->contentKeySession() addContentKeyRecipient:renderer.get()];
 #endif
 
-            WeakPtr weakThis { *this };
+            ThreadSafeWeakPtr weakThis { *this };
             [renderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
-                if (weakThis)
-                    weakThis->didBecomeReadyForMoreSamples(trackID);
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->didBecomeReadyForMoreSamples(trackID);
             }];
             m_audioRenderers.set(trackID, renderer);
             [m_listener beginObservingRenderer:renderer.get()];
@@ -889,8 +858,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 AVStreamDataParser* SourceBufferPrivateAVFObjC::streamDataParser() const
 {
-    if (is<SourceBufferParserAVFObjC>(m_parser))
-        return downcast<SourceBufferParserAVFObjC>(m_parser.get()).streamDataParser();
+    if (auto avfParser = dynamicDowncast<SourceBufferParserAVFObjC>(m_parser))
+        return avfParser->streamDataParser();
     return nil;
 }
 
@@ -915,12 +884,12 @@ void SourceBufferPrivateAVFObjC::setCDMSession(LegacyCDMSession* session)
         }
 
         if (m_hdcpError) {
-            callOnMainThread([weakThis = WeakPtr { *this }] {
-                if (!weakThis || !weakThis->m_session || !weakThis->m_hdcpError)
-                    return;
+            callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+                if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_session && protectedThis->m_hdcpError) {
 
-                bool ignored = false;
-                weakThis->m_session->layerDidReceiveError(nullptr, weakThis->m_hdcpError.get(), ignored);
+                    bool ignored = false;
+                    protectedThis->m_session->layerDidReceiveError(nullptr, protectedThis->m_hdcpError.get(), ignored);
+                }
             });
         }
     }
@@ -1063,8 +1032,8 @@ void SourceBufferPrivateAVFObjC::layerDidReceiveError(AVSampleBufferDisplayLayer
 
     int errorCode = [[[error userInfo] valueForKey:@"OSStatus"] intValue];
 
-    if (isAttached())
-        client().sourceBufferPrivateDidReceiveRenderingError(errorCode);
+    if (RefPtr client = this->client())
+        client->sourceBufferPrivateDidReceiveRenderingError(errorCode);
 }
 
 void SourceBufferPrivateAVFObjC::rendererWasAutomaticallyFlushed(AVSampleBufferAudioRenderer *renderer, const CMTime& time)
@@ -1088,8 +1057,7 @@ void SourceBufferPrivateAVFObjC::rendererWasAutomaticallyFlushed(AVSampleBufferA
 void SourceBufferPrivateAVFObjC::outputObscuredDueToInsufficientExternalProtectionChanged(bool obscured)
 {
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    auto mediaSource = static_cast<MediaSourcePrivateAVFObjC*>(m_mediaSource.get());
-    if (mediaSource && mediaSource->cdmInstance()) {
+    if (RefPtr mediaSource = downcast<MediaSourcePrivateAVFObjC>(m_mediaSource.get()); mediaSource && mediaSource->cdmInstance()) {
         mediaSource->outputObscuredDueToInsufficientExternalProtectionChanged(obscured);
         return;
     }
@@ -1160,9 +1128,11 @@ void SourceBufferPrivateAVFObjC::flushVideo()
 
     if (m_decompressionSession) {
         m_decompressionSession->flush();
-        m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->player())
-                weakThis->player()->setHasAvailableVideoFrame(true);
+        m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->player())
+                    player->setHasAvailableVideoFrame(true);
+            }
         });
     }
 
@@ -1252,16 +1222,14 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSample>&& sample, const 
         return;
 
     ASSERT(is<MediaSampleAVFObjC>(sample));
-    if (!is<MediaSampleAVFObjC>(sample))
-        return;
+    if (RefPtr sampleAVFObjC = dynamicDowncast<MediaSampleAVFObjC>(WTFMove(sample))) {
+        if (!canEnqueueSample(trackID, *sampleAVFObjC)) {
+            m_blockedSamples.append({ trackID, sampleAVFObjC.releaseNonNull() });
+            return;
+        }
 
-    Ref sampleAVFObjC = downcast<MediaSampleAVFObjC>(WTFMove(sample));
-    if (!canEnqueueSample(trackID, sampleAVFObjC)) {
-        m_blockedSamples.append({ trackID, WTFMove(sampleAVFObjC) });
-        return;
+        enqueueSample(sampleAVFObjC.releaseNonNull(), trackID);
     }
-
-    enqueueSample(WTFMove(sampleAVFObjC), trackID);
 }
 
 void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSampleAVFObjC>&& sample, uint64_t trackID)
@@ -1344,7 +1312,7 @@ void SourceBufferPrivateAVFObjC::enqueueSampleBuffer(MediaSampleAVFObjC& sample)
 
     DEBUG_LOG(LOGIDENTIFIER, "adding buffer attachment");
 
-    [m_displayLayer prerollDecodeWithCompletionHandler:[this, weakThis = WeakPtr { *this }, logSiteIdentifier = LOGIDENTIFIER] (BOOL success) mutable {
+    [m_displayLayer prerollDecodeWithCompletionHandler:[this, weakThis = ThreadSafeWeakPtr { *this }, logSiteIdentifier = LOGIDENTIFIER] (BOOL success) mutable {
         callOnMainThread([this, weakThis = WTFMove(weakThis), logSiteIdentifier, success] () {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
@@ -1381,8 +1349,8 @@ bool SourceBufferPrivateAVFObjC::isReadyForMoreSamples(const AtomString& trackID
 
 MediaTime SourceBufferPrivateAVFObjC::timeFudgeFactor() const
 {
-    if (m_mediaSource)
-        return m_mediaSource->timeFudgeFactor();
+    if (RefPtr mediaSource = m_mediaSource.get())
+        return mediaSource->timeFudgeFactor();
 
     return SourceBufferPrivate::timeFudgeFactor();
 }
@@ -1433,23 +1401,23 @@ void SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples(const AtomS
     auto trackID = parseIntegerAllowingTrailingJunk<uint64_t>(trackIDString).value_or(0);
     if (trackID == m_enabledVideoTrackID) {
         if (m_decompressionSession) {
-            m_decompressionSession->requestMediaDataWhenReady([weakThis = WeakPtr { *this }, trackID] {
-                if (weakThis)
-                    weakThis->didBecomeReadyForMoreSamples(trackID);
+            m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, trackID] {
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->didBecomeReadyForMoreSamples(trackID);
             });
         }
         if (m_displayLayer) {
-            WeakPtr weakThis { *this };
+            ThreadSafeWeakPtr weakThis { *this };
             [m_displayLayer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^ {
-                if (weakThis)
-                    weakThis->didBecomeReadyForMoreSamples(trackID);
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->didBecomeReadyForMoreSamples(trackID);
             }];
         }
     } else if (m_audioRenderers.contains(trackID)) {
-        WeakPtr weakThis { *this };
+        ThreadSafeWeakPtr weakThis { *this };
         [m_audioRenderers.get(trackID) requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^ {
-            if (weakThis)
-                weakThis->didBecomeReadyForMoreSamples(trackID);
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->didBecomeReadyForMoreSamples(trackID);
         }];
     }
 }
@@ -1516,10 +1484,10 @@ void SourceBufferPrivateAVFObjC::setVideoLayer(AVSampleBufferDisplayLayer* layer
             [m_cdmInstance->contentKeySession() addContentKeyRecipient:m_displayLayer.get()];
 #endif
 
-        WeakPtr weakThis { *this };
+        ThreadSafeWeakPtr weakThis { *this };
         [m_displayLayer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^ {
-            if (weakThis)
-                weakThis->didBecomeReadyForMoreSamples(m_enabledVideoTrackID);
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->didBecomeReadyForMoreSamples(m_enabledVideoTrackID);
         }];
         [m_listener beginObservingLayer:m_displayLayer.get()];
         reenqueSamples(AtomString::number(m_enabledVideoTrackID));
@@ -1543,22 +1511,25 @@ void SourceBufferPrivateAVFObjC::setDecompressionSession(WebCoreDecompressionSes
     if (!m_decompressionSession)
         return;
 
-    m_decompressionSession->requestMediaDataWhenReady([weakThis = WeakPtr { *this }] {
-        if (weakThis)
-            weakThis->didBecomeReadyForMoreSamples(weakThis->m_enabledVideoTrackID);
+    m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->didBecomeReadyForMoreSamples(protectedThis->m_enabledVideoTrackID);
     });
-    m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }] {
-        if (weakThis && weakThis->player())
-            weakThis->player()->setHasAvailableVideoFrame(true);
+    m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (auto player = protectedThis->player())
+                player->setHasAvailableVideoFrame(true);
+        }
     });
     reenqueSamples(AtomString::number(m_enabledVideoTrackID));
 }
 
 RefPtr<MediaPlayerPrivateMediaSourceAVFObjC> SourceBufferPrivateAVFObjC::player() const
 {
-    return m_mediaSource ? static_cast<MediaSourcePrivateAVFObjC*>(m_mediaSource.get())->player() : nullptr;
+    if (RefPtr mediaSource = downcast<MediaSourcePrivateAVFObjC>(m_mediaSource.get()))
+        return mediaSource->player();
+    return nullptr;
 }
-
 
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& SourceBufferPrivateAVFObjC::logChannel() const

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -76,7 +76,6 @@ public:
 
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
-    MediaSourcePrivateClient* mediaSourcePrivateClient() { return m_mediaSource.get(); }
 
     void setInitialVideoSize(const FloatSize&);
 
@@ -106,10 +105,11 @@ private:
     bool isTimeBuffered(const MediaTime&) const;
 
     bool isMediaSource() const override { return true; }
+    RefPtr<MediaSourcePrivateClient> mediaSourcePrivateClient() { return m_mediaSource.get(); }
 
     void propagateReadyStateToPlayer();
 
-    WeakPtr<MediaSourcePrivateClient> m_mediaSource;
+    ThreadSafeWeakPtr<MediaSourcePrivateClient> m_mediaSource;
     RefPtr<MediaSourcePrivateGStreamer> m_mediaSourcePrivate;
     MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
     bool m_isPipelinePlaying = true;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -56,6 +56,8 @@ public:
     static Ref<MediaSourcePrivateGStreamer> open(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
     virtual ~MediaSourcePrivateGStreamer();
 
+    constexpr MediaPlatformType platformType() const final { return MediaPlatformType::GStreamer; }
+
     AddStatus addSourceBuffer(const ContentType&, bool, RefPtr<SourceBufferPrivate>&) override;
 
     void durationChanged(const MediaTime&) override;
@@ -64,18 +66,12 @@ public:
     MediaPlayer::ReadyState readyState() const override;
     void setReadyState(MediaPlayer::ReadyState) override;
 
-    Ref<MediaTimePromise> waitForTarget(const SeekTarget&) final;
-    Ref<MediaPromise> seekToTime(const MediaTime&) final;
-
-    MediaTime duration() const final;
     MediaTime currentMediaTime() const final;
 
     void notifyActiveSourceBuffersChanged() final;
 
     void startPlaybackIfHasAllTracks();
     bool hasAllTracks() const { return m_hasAllTracks; }
-
-    const PlatformTimeRanges& buffered();
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
@@ -89,7 +85,6 @@ public:
 private:
     MediaSourcePrivateGStreamer(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
 
-    WeakPtr<MediaSourcePrivateClient> m_mediaSource;
     MediaPlayerPrivateGStreamerMSE& m_playerPrivate;
     bool m_hasAllTracks { false };
 #if !RELEASE_LOG_DISABLED
@@ -99,6 +94,10 @@ private:
 #endif
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaSourcePrivateGStreamer)
+static bool isType(const WebCore::MediaSourcePrivate& mediaSource) { return mediaSource.platformType() == WebCore::MediaPlatformType::GStreamer; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -57,7 +57,7 @@ public:
     static Ref<SourceBufferPrivateGStreamer> create(MediaSourcePrivateGStreamer&, const ContentType&, MediaPlayerPrivateGStreamerMSE&);
     ~SourceBufferPrivateGStreamer();
 
-    constexpr PlatformType platformType() const final { return PlatformType::GStreamer; }
+    constexpr MediaPlatformType platformType() const final { return MediaPlatformType::GStreamer; }
 
     Ref<MediaPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void resetParserStateInternal() final;
@@ -116,7 +116,7 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SourceBufferPrivateGStreamer)
-static bool isType(const WebCore::SourceBufferPrivate& sourceBuffer) { return sourceBuffer.platformType() == WebCore::SourceBufferPrivate::PlatformType::GStreamer; }
+static bool isType(const WebCore::SourceBufferPrivate& sourceBuffer) { return sourceBuffer.platformType() == WebCore::MediaPlatformType::GStreamer; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -44,8 +44,8 @@ Ref<MockMediaSourcePrivate> MockMediaSourcePrivate::create(MockMediaPlayerMediaS
 }
 
 MockMediaSourcePrivate::MockMediaSourcePrivate(MockMediaPlayerMediaSource& parent, MediaSourcePrivateClient& client)
-    : m_player(parent)
-    , m_client(client)
+    : MediaSourcePrivate(client)
+    , m_player(parent)
 #if !RELEASE_LOG_DISABLED
     , m_logger(m_player.mediaPlayerLogger())
     , m_logIdentifier(m_player.mediaPlayerLogIdentifier())
@@ -70,20 +70,6 @@ MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const Cont
     outPrivate = m_sourceBuffers.last();
 
     return AddStatus::Ok;
-}
-
-MediaTime MockMediaSourcePrivate::duration() const
-{
-    if (m_client)
-        return m_client->duration();
-    return MediaTime::invalidTime();
-}
-
-const PlatformTimeRanges& MockMediaSourcePrivate::buffered()
-{
-    if (m_client)
-        return m_client->buffered();
-    return PlatformTimeRanges::emptyRanges();
 }
 
 void MockMediaSourcePrivate::durationChanged(const MediaTime& duration)
@@ -111,20 +97,6 @@ void MockMediaSourcePrivate::setReadyState(MediaPlayer::ReadyState readyState)
 void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
 {
     m_player.notifyActiveSourceBuffersChanged();
-}
-
-Ref<MediaTimePromise> MockMediaSourcePrivate::waitForTarget(const SeekTarget& target)
-{
-    if (!m_client)
-        return MediaTimePromise::createAndReject(PlatformMediaError::ClientDisconnected);
-    return m_client->waitForTarget(target);
-}
-
-Ref<MediaPromise> MockMediaSourcePrivate::seekToTime(const MediaTime& time)
-{
-    if (!m_client)
-        return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
-    return m_client->seekToTime(time);
 }
 
 MediaTime MockMediaSourcePrivate::currentMediaTime() const

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -46,14 +46,11 @@ public:
     static Ref<MockMediaSourcePrivate> create(MockMediaPlayerMediaSource&, MediaSourcePrivateClient&);
     virtual ~MockMediaSourcePrivate();
 
-    const PlatformTimeRanges& buffered();
+    constexpr MediaPlatformType platformType() const final { return MediaPlatformType::Mock; }
 
     MockMediaPlayerMediaSource& player() const { return m_player; }
 
-    Ref<MediaTimePromise> waitForTarget(const SeekTarget&) final;
-    Ref<MediaPromise> seekToTime(const MediaTime&) final;
     MediaTime currentMediaTime() const final;
-    MediaTime duration() const final;
 
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics();
 
@@ -87,7 +84,6 @@ private:
     friend class MockSourceBufferPrivate;
 
     MockMediaPlayerMediaSource& m_player;
-    WeakPtr<MediaSourcePrivateClient> m_client;
 
     unsigned m_totalVideoFrames { 0 };
     unsigned m_droppedVideoFrames { 0 };
@@ -100,6 +96,10 @@ private:
 #endif
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MockMediaSourcePrivate)
+static bool isType(const WebCore::MediaSourcePrivate& mediaSource) { return mediaSource.platformType() == WebCore::MediaPlatformType::Mock; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -44,10 +44,10 @@ public:
     static Ref<MockSourceBufferPrivate> create(MockMediaSourcePrivate&);
     virtual ~MockSourceBufferPrivate();
 
-    constexpr PlatformType platformType() const final { return PlatformType::Mock; }
+    constexpr MediaPlatformType platformType() const final { return MediaPlatformType::Mock; }
 private:
     explicit MockSourceBufferPrivate(MockMediaSourcePrivate&);
-    MockMediaSourcePrivate* mediaSourcePrivate() const;
+    RefPtr<MockMediaSourcePrivate> mediaSourcePrivate() const;
 
     // SourceBufferPrivate overrides
     Ref<MediaPromise> appendInternal(Ref<SharedBuffer>&&) final;
@@ -92,6 +92,6 @@ private:
 #endif
 };
 
-}
+} // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -53,8 +53,7 @@ class GPUConnectionToWebProcess;
 class RemoteMediaPlayerProxy;
 
 class RemoteMediaSourceProxy final
-    : public RefCounted<RemoteMediaSourceProxy>
-    , public WebCore::MediaSourcePrivateClient
+    : public WebCore::MediaSourcePrivateClient
     , private IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -57,8 +57,7 @@ struct MediaDescriptionInfo;
 class RemoteMediaPlayerProxy;
 
 class RemoteSourceBufferProxy final
-    : public RefCounted<RemoteSourceBufferProxy>
-    , public WebCore::SourceBufferPrivateClient
+    : public WebCore::SourceBufferPrivateClient
     , private IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -61,6 +61,7 @@ public:
     virtual ~MediaSourcePrivateRemote();
 
     // MediaSourcePrivate overrides
+    constexpr WebCore::MediaPlatformType platformType() const final { return WebCore::MediaPlatformType::Remote; }
     AddStatus addSourceBuffer(const WebCore::ContentType&, bool webMParserEnabled, RefPtr<WebCore::SourceBufferPrivate>&) final;
     void removeSourceBuffer(WebCore::SourceBufferPrivate&) final { }
     void notifyActiveSourceBuffersChanged() final { };
@@ -71,12 +72,8 @@ public:
     WebCore::MediaPlayer::ReadyState readyState() const final;
     void setReadyState(WebCore::MediaPlayer::ReadyState) final;
 
-    Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
-    Ref<WebCore::MediaPromise> seekToTime(const MediaTime&) final;
-
     void setTimeFudgeFactor(const MediaTime&) final;
 
-    MediaTime duration() const final { return m_client ? m_client->duration() : MediaTime(); }
     MediaTime currentMediaTime() const final
     {
         ASSERT_NOT_REACHED();
@@ -103,7 +100,6 @@ private:
     RemoteMediaSourceIdentifier m_identifier;
     RemoteMediaPlayerMIMETypeCache& m_mimeTypeCache;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
-    WeakPtr<WebCore::MediaSourcePrivateClient> m_client;
     Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
     bool m_shutdown { false };
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -65,7 +65,7 @@ public:
     static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
     virtual ~SourceBufferPrivateRemote();
 
-    constexpr PlatformType platformType() const final { return PlatformType::Remote; }
+    constexpr WebCore::MediaPlatformType platformType() const final { return WebCore::MediaPlatformType::Remote; }
 
     void disconnect() { m_disconnected = true; }
 


### PR DESCRIPTION
#### 3e109296984d430615fc4d881514ca9d7d0e7afa
<pre>
[MSE] MSE objects should be using thread-safe refcount
<a href="https://bugs.webkit.org/show_bug.cgi?id=265274">https://bugs.webkit.org/show_bug.cgi?id=265274</a>
<a href="https://rdar.apple.com/118734205">rdar://118734205</a>

Reviewed by Youenn Fablet.

Make MSE objects support thread-safe refcount and weakptr.
We also move common to all MediaSourcePrivate implementation to the main class.

Fly-by fix: MediaSourcePrivateAVFObjC was keeping an unused HashMap of all SourceBufferPrivate in use, we remove it.
Use dynamicDowncast where useful.

* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::nextBestMediaEngine):
(WebCore::MediaPlayer::loadWithNextMediaEngine):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::MediaSourcePrivate):
(WebCore::MediaSourcePrivate::client const):
(WebCore::MediaSourcePrivate::duration const):
(WebCore::MediaSourcePrivate::buffered const):
(WebCore::MediaSourcePrivate::waitForTarget):
(WebCore::MediaSourcePrivate::seekToTime):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removedFromMediaSource):
(WebCore::SourceBufferPrivate::currentMediaTime const):
(WebCore::SourceBufferPrivate::duration const):
(WebCore::SourceBufferPrivate::updateHighestPresentationTimestamp):
(WebCore::SourceBufferPrivate::setBufferedRanges):
(WebCore::SourceBufferPrivate::reenqueSamples):
(WebCore::SourceBufferPrivate::computeSeekTime):
(WebCore::SourceBufferPrivate::clearTrackBuffers):
(WebCore::SourceBufferPrivate::provideMediaData):
(WebCore::SourceBufferPrivate::removeCodedFrames):
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):
(WebCore::SourceBufferPrivate::evictCodedFrames):
(WebCore::SourceBufferPrivate::setClient):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didUpdateFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::didReceiveSample):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::processPendingMediaSamples):
(WebCore::SourceBufferPrivate::processMediaSample):
(WebCore::SourceBufferPrivate::resetParserState):
(WebCore::SourceBufferPrivate::memoryPressure):
(WebCore::SourceBufferPrivate::setActive):
(WebCore::SourceBufferPrivate::client const):
(WebCore::SourceBufferPrivate::isAttached const): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::queue):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::MediaSourcePrivateAVFObjC):
(WebCore::MediaSourcePrivateAVFObjC::notifyActiveSourceBuffersChanged):
(WebCore::MediaSourcePrivateAVFObjC::durationChanged):
(WebCore::MediaSourcePrivateAVFObjC::markEndOfStream):
(WebCore::MediaSourcePrivateAVFObjC::readyState const):
(WebCore::MediaSourcePrivateAVFObjC::setReadyState):
(WebCore::MediaSourcePrivateAVFObjC::currentMediaTime const):
(WebCore::MediaSourcePrivateAVFObjC::sourceBufferKeyNeeded):
(WebCore::MediaSourcePrivateAVFObjC::setSourceBufferWithSelectedVideo):
(WebCore::MediaSourcePrivateAVFObjC::failedToCreateRenderer):
(WebCore::MediaSourcePrivateAVFObjC::duration const): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::buffered): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::waitForTarget): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::seekToTime): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(-[WebAVSampleBufferListener invalidate]):
(-[WebAVSampleBufferListener beginObservingLayer:]):
(-[WebAVSampleBufferListener stopObservingLayer:]):
(-[WebAVSampleBufferListener beginObservingRenderer:]):
(-[WebAVSampleBufferListener stopObservingRenderer:]):
(-[WebAVSampleBufferListener observeValueForKeyPath:ofObject:change:context:]):
(WebCore::m_logIdentifier):
(WebCore::SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::setTrackChangeCallbacks):
(WebCore::SourceBufferPrivateAVFObjC::processFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::appendInternal):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::streamDataParser const):
(WebCore::SourceBufferPrivateAVFObjC::setCDMSession):
(WebCore::SourceBufferPrivateAVFObjC::layerDidReceiveError):
(WebCore::SourceBufferPrivateAVFObjC::outputObscuredDueToInsufficientExternalProtectionChanged):
(WebCore::SourceBufferPrivateAVFObjC::flushVideo):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSampleBuffer):
(WebCore::SourceBufferPrivateAVFObjC::timeFudgeFactor const):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::setVideoLayer):
(WebCore::SourceBufferPrivateAVFObjC::setDecompressionSession):
(WebCore::SourceBufferPrivateAVFObjC::player const):
(WebCore::sourceBufferMap): Deleted.
(WebCore::nextMapID): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::willProvideContentKeyRequestInitializationDataForTrackID): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::MediaSourcePrivateGStreamer):
(WebCore::MediaSourcePrivateGStreamer::durationChanged):
(WebCore::MediaSourcePrivateGStreamer::waitForTarget): Deleted.
(WebCore::MediaSourcePrivateGStreamer::seekToTime): Deleted.
(WebCore::MediaSourcePrivateGStreamer::duration const): Deleted.
(WebCore::MediaSourcePrivateGStreamer::buffered): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
(isType):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::platformMaximumBufferSize const):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
(isType):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::MockMediaSourcePrivate):
(WebCore::MockMediaSourcePrivate::duration const): Deleted.
(WebCore::MockMediaSourcePrivate::buffered): Deleted.
(WebCore::MockMediaSourcePrivate::waitForTarget): Deleted.
(WebCore::MockMediaSourcePrivate::seekToTime): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
(isType):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::mediaSourcePrivate const):
(WebCore::MockSourceBufferPrivate::readyState const):
(WebCore::MockSourceBufferPrivate::setReadyState):
(WebCore::MockSourceBufferPrivate::enqueueSample):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::MediaSourcePrivateRemote):
(WebKit::MediaSourcePrivateRemote::proxyWaitForTarget):
(WebKit::MediaSourcePrivateRemote::proxySeekToTime):
(WebKit::MediaSourcePrivateRemote::waitForTarget): Deleted.
(WebKit::MediaSourcePrivateRemote::seekToTime): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::append):
(WebKit::SourceBufferPrivateRemote::setReadyState):
(WebKit::SourceBufferPrivateRemote::setActive):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateHighestPresentationTimestampChanged):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDurationChanged):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidParseSample):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidDropSample):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveRenderingError):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateReportExtraMemoryCost):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/271111@main">https://commits.webkit.org/271111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9389ed03f41f6ab7e56454445ce5ea58b5ebce9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24870 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30486 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28442 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5831 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6591 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->