### PR TITLE
VideoEncoder produces no frames with latencyMode "realtime" when framerate/bitrate are not given

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Realtime encoding without framerate and bitrate
+PASS Realtime encoding without bitrate
+PASS Realtime encoding without framerate
+

--- a/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.html
+++ b/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.js
+++ b/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.js
@@ -1,0 +1,68 @@
+async function encoderTest(testConfig)
+{
+    const width = 200;
+    const height = 100;
+    const img = new ImageData(width, height);
+
+    for (let r = 0; r < height; r++) {
+        for (let c = 0; c < width; c++) {
+            const index = (r * width + c) * 4;
+            img.data[index + 0] = 127;
+            img.data[index + 1] = 127;
+            img.data[index + 2] = 127;
+            img.data[index + 3] = 255;
+        }
+    }
+    const bitmap = await createImageBitmap(img);
+
+    let framesCount = 0;
+    let errorCount = 0;
+    const encoder = new VideoEncoder({
+      output: (chunk, metadata) => {
+          ++framesCount;
+      }, error: (err) => {
+          ++errorCount;
+      }
+    })
+
+    const encoderConfig = {
+        codec: "avc1.42001f", // Baseline profile (42 00) with level 3.1 (1f)
+        width,
+        height,
+        latencyMode: "realtime",
+        avc: { format: "annexb" },
+    }
+    if (testConfig.framerate)
+        encoderConfig.framerate = testConfig.framerate;
+    if (testConfig.bitrate)
+        encoderConfig.bitrate = testConfig.bitrate;
+
+    encoder.configure(encoderConfig);
+
+    for (let i = 0; i < 20; i++) {
+        const frame = new VideoFrame(bitmap, { timestamp: i });
+        encoder.encode(frame, {keyFrame: i === 0});
+        frame.close();
+    }
+
+    bitmap.close();
+
+    await encoder.flush();
+    encoder.close();
+
+    assert_greater_than(framesCount, 0, "frames count");
+    assert_equals(errorCount, 0, "error count");
+}
+
+promise_test(async () => {
+    return encoderTest({ });
+}, "Realtime encoding without framerate and bitrate");
+
+promise_test(async () => {
+    return encoderTest({ frameRate: 10 });
+}, "Realtime encoding without bitrate");
+
+promise_test(async () => {
+    return encoderTest({ bitrate: 1000 });
+}, "Realtime encoding without framerate");
+

--- a/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.worker-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.worker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Realtime encoding without framerate and bitrate
+PASS Realtime encoding without bitrate
+PASS Realtime encoding without framerate
+

--- a/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.worker.html
+++ b/LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1208,6 +1208,8 @@ fast/mediastream/play-newly-added-audio-track.html [ Pass Crash ]
 webkit.org/b/264663 media/media-source/media-source-webm-configuration-framerate.html [ Crash Pass ]
 
 webkit.org/b/264665 http/wpt/webcodecs/videoFrame-webglCanvasImageSource.html [ Failure ]
+webkit.org/b/264894 http/wpt/webcodecs/h264-encoder-default-config.https.any.html [ Failure ]
+webkit.org/b/264894 http/wpt/webcodecs/h264-encoder-default-config.https.any.worker.html [ Failure ]
 
 webkit.org/b/264666 imported/w3c/web-platform-tests/encrypted-media/clearkey-generate-request-disallowed-input.https.html [ Failure ]
 


### PR DESCRIPTION
#### ef16bd3f9b1c89053d0d975a2a8ef4e0fdbafcb4
<pre>
VideoEncoder produces no frames with latencyMode &quot;realtime&quot; when framerate/bitrate are not given
<a href="https://bugs.webkit.org/show_bug.cgi?id=264894">https://bugs.webkit.org/show_bug.cgi?id=264894</a>
<a href="https://rdar.apple.com/118725549">rdar://118725549</a>

Reviewed by Eric Carlson.

When frame rate and/or bitrate is not set, use default values for them.
For frame rate, we use 30 frames.
For bitrate, we use the max bit rate as per H264 table A.1.

* LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.html: Added.
* LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.js: Added.
(async encoderTest):
(promise_test.async return):
(promise_test):
* LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.worker-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/h264-encoder-default-config.https.any.worker.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm:
(-[RTCVideoEncoderH264 startEncodeWithSettings:numberOfCores:]):
(-[RTCVideoEncoderH264 setBitrate:framerate:]):
(-[RTCVideoEncoderH264 setEncoderBitrateBps:frameRate:]):

Canonical link: <a href="https://commits.webkit.org/271087@main">https://commits.webkit.org/271087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73532e8b478590a6077f404b8a4aa5f92789a9bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24938 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30385 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28325 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24123 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6574 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4621 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->