### PR TITLE
Make <progress> use Page's preferredRenderingUpdateInterval()

### DIFF
--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -81,27 +81,28 @@ bool RenderProgress::isDeterminate() const
 
 void RenderProgress::animationTimerFired()
 {
-    // FIXME: Progress bar animation should be performed as part of the rendering update
-    // lifecycle, to match the display's refresh rate.
+    // FIXME: Ideally obtaining the repeat interval from Page is not RenderTheme-specific, but it
+    // currently is as it also determines whether we animate at all.
+    auto repeatInterval = theme().animationRepeatIntervalForProgressBar(*this);
 
     repaint();
     if (!m_animationTimer.isActive() && m_animating)
-        m_animationTimer.startOneShot(m_animationRepeatInterval);
+        m_animationTimer.startOneShot(repeatInterval);
 }
 
 void RenderProgress::updateAnimationState()
 {
-    m_animationDuration = theme().animationDurationForProgressBar(*this);
-    m_animationRepeatInterval = theme().animationRepeatIntervalForProgressBar(*this);
+    m_animationDuration = theme().animationDurationForProgressBar();
+    auto repeatInterval = theme().animationRepeatIntervalForProgressBar(*this);
 
-    bool animating = style().hasEffectiveAppearance() && m_animationRepeatInterval > 0_s && !isDeterminate();
+    bool animating = style().hasEffectiveAppearance() && repeatInterval > 0_s && !isDeterminate();
     if (animating == m_animating)
         return;
 
     m_animating = animating;
     if (m_animating) {
         m_animationStartTime = MonotonicTime::now();
-        m_animationTimer.startOneShot(m_animationRepeatInterval);
+        m_animationTimer.startOneShot(repeatInterval);
     } else
         m_animationTimer.stop();
 }

--- a/Source/WebCore/rendering/RenderProgress.h
+++ b/Source/WebCore/rendering/RenderProgress.h
@@ -50,7 +50,6 @@ private:
 
     double m_position;
     MonotonicTime m_animationStartTime;
-    Seconds m_animationRepeatInterval { 0_s };
     Seconds m_animationDuration { 0_s };
     bool m_animating { false };
     Timer m_animationTimer;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1568,21 +1568,6 @@ void RenderTheme::paintSliderTicks(const RenderObject& renderer, const PaintInfo
 
 #endif // ENABLE(DATALIST_ELEMENT)
 
-Seconds RenderTheme::animationRepeatIntervalForProgressBar(const RenderProgress&) const
-{
-    return 0_s;
-}
-
-Seconds RenderTheme::animationDurationForProgressBar(const RenderProgress&) const
-{
-    return 0_s;
-}
-
-IntRect RenderTheme::progressBarRectForBounds(const RenderProgress&, const IntRect& bounds) const
-{
-    return bounds;
-}
-
 bool RenderTheme::shouldHaveSpinButton(const HTMLInputElement& inputElement) const
 {
     return inputElement.isSteppable() && !inputElement.isRangeControl();

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -215,11 +215,9 @@ public:
 
     virtual ScrollbarWidth scrollbarWidthStyleForPart(StyleAppearance) { return ScrollbarWidth::Auto; }
 
-    // Returns the repeat interval of the animation for the progress bar.
-    virtual Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const;
-    // Returns the duration of the animation for the progress bar.
-    virtual Seconds animationDurationForProgressBar(const RenderProgress&) const;
-    virtual IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const;
+    virtual Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const { return 0_s; }
+    virtual Seconds animationDurationForProgressBar() const { return 0_s; }
+    virtual IntRect progressBarRectForBounds(const RenderProgress&, const IntRect& bounds) const { return bounds; }
 
     virtual FloatSize meterSizeForBounds(const RenderMeter&, const FloatRect&) const;
     virtual bool supportsMeter(StyleAppearance) const { return false; }

--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -34,6 +34,7 @@
 #include "HTMLInputElement.h"
 #include "HTMLMediaElement.h"
 #include "MediaControlTextTrackContainerElement.h"
+#include "Page.h"
 #include "PaintInfo.h"
 #include "RenderBox.h"
 #include "RenderObject.h"
@@ -73,8 +74,7 @@ static const int menuListButtonFocusOffset = -2;
 static const unsigned menuListButtonPadding = 5;
 static const int menuListButtonBorderSize = 1; // Keep in sync with buttonBorderSize in ThemeAdwaita.
 static const unsigned progressActivityBlocks = 5;
-static const unsigned progressAnimationFrameCount = 75;
-static const Seconds progressAnimationFrameRate = 33_ms; // 30fps.
+static const Seconds progressAnimationDuration = 2475_ms;
 static const unsigned progressBarSize = 6;
 static constexpr auto progressBarBackgroundColorLight = SRGBA<uint8_t> { 0, 0, 0, 40 };
 static constexpr auto progressBarBackgroundColorDark = SRGBA<uint8_t> { 255, 255, 255, 30 };
@@ -440,14 +440,14 @@ void RenderThemeAdwaita::paintMenuListButtonDecorations(const RenderBox& renderO
     paintMenuList(renderObject, paintInfo, rect);
 }
 
-Seconds RenderThemeAdwaita::animationRepeatIntervalForProgressBar(const RenderProgress&) const
+Seconds RenderThemeAdwaita::animationRepeatIntervalForProgressBar(const RenderProgress& renderer) const
 {
-    return progressAnimationFrameRate;
+    return renderer.page().preferredRenderingUpdateInterval();
 }
 
-Seconds RenderThemeAdwaita::animationDurationForProgressBar(const RenderProgress&) const
+Seconds RenderThemeAdwaita::animationDurationForProgressBar() const
 {
-    return progressAnimationFrameRate * progressAnimationFrameCount;
+    return progressAnimationDuration;
 }
 
 IntRect RenderThemeAdwaita::progressBarRectForBounds(const RenderProgress&, const IntRect& bounds) const

--- a/Source/WebCore/rendering/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.h
@@ -86,7 +86,7 @@ private:
     void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) final;
 
     Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
-    Seconds animationDurationForProgressBar(const RenderProgress&) const final;
+    Seconds animationDurationForProgressBar() const final;
     IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const final;
     bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) final;
 

--- a/Source/WebCore/rendering/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/RenderThemeCocoa.h
@@ -56,6 +56,8 @@ private:
 
     void paintFileUploadIconDecorations(const RenderObject& inputRenderer, const RenderObject& buttonRenderer, const PaintInfo&, const IntRect&, Icon*, FileUploadDecorations) override;
 
+    Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
+
 #if ENABLE(APPLE_PAY)
     void adjustApplePayButtonStyle(RenderStyle&, const Element*) const override;
 #endif

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -34,6 +34,8 @@
 #import "GraphicsContextCG.h"
 #import "HTMLInputElement.h"
 #import "ImageBuffer.h"
+#import "Page.h"
+#import "RenderProgress.h"
 #import "RenderText.h"
 #import "UserAgentScripts.h"
 #import "UserAgentStyleSheets.h"
@@ -145,6 +147,11 @@ void RenderThemeCocoa::paintFileUploadIconDecorations(const RenderObject&, const
     // Foreground picture frame and icon.
     paintInfo.context().fillRoundedRect(FloatRoundedRect(thumbnailPictureFrameRect, cornerSize, cornerSize, cornerSize, cornerSize), pictureFrameColor);
     icon->paint(paintInfo.context(), thumbnailRect);
+}
+
+Seconds RenderThemeCocoa::animationRepeatIntervalForProgressBar(const RenderProgress& renderer) const
+{
+    return renderer.page().preferredRenderingUpdateInterval();
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -119,8 +119,6 @@ private:
 
     void paintCheckboxRadioInnerShadow(const PaintInfo&, const FloatRoundedRect&, OptionSet<ControlStates::States>);
 
-    Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
-
     bool supportsMeter(StyleAppearance) const final;
     bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) final;
 

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -65,7 +65,6 @@
 #import "LocalFrameView.h"
 #import "LocalizedDateCache.h"
 #import "NodeRenderStyle.h"
-#import "Page.h"
 #import "PaintInfo.h"
 #import "PathUtilities.h"
 #import "PlatformLocale.h"
@@ -75,7 +74,6 @@
 #import "RenderMenuList.h"
 #import "RenderMeter.h"
 #import "RenderObject.h"
-#import "RenderProgress.h"
 #import "RenderSlider.h"
 #import "RenderStyleSetters.h"
 #import "RenderView.h"
@@ -1601,13 +1599,6 @@ bool RenderThemeIOS::paintRadio(const RenderObject& box, const PaintInfo& paintI
     }
 
     return false;
-}
-
-constexpr Seconds progressAnimationRepeatInterval = 16_ms;
-
-Seconds RenderThemeIOS::animationRepeatIntervalForProgressBar(const RenderProgress&) const
-{
-    return progressAnimationRepeatInterval;
 }
 
 bool RenderThemeIOS::supportsMeter(StyleAppearance appearance) const

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -28,7 +28,6 @@ OBJC_CLASS WebCoreRenderThemeNotificationObserver;
 
 namespace WebCore {
 
-class RenderProgress;
 class RenderStyle;
 
 struct AttachmentLayout;
@@ -83,8 +82,6 @@ public:
     FloatSize meterSizeForBounds(const RenderMeter&, const FloatRect&) const final;
     bool supportsMeter(StyleAppearance) const final;
 
-    // Returns the repeat interval of the animation for the progress bar.
-    Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
     IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const final;
 
     // Controls color values returned from platformFocusRingColor(). systemColor() will be used when false.

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -47,13 +47,11 @@
 #import "LocalFrame.h"
 #import "LocalFrameView.h"
 #import "LocalizedStrings.h"
-#import "Page.h"
 #import "PaintInfo.h"
 #import "PathUtilities.h"
 #import "RenderAttachment.h"
 #import "RenderMedia.h"
 #import "RenderMeter.h"
-#import "RenderProgress.h"
 #import "RenderSlider.h"
 #import "RenderStyleSetters.h"
 #import "RenderView.h"
@@ -81,8 +79,6 @@
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"
 #endif
-
-constexpr Seconds progressAnimationRepeatInterval = 33_ms; // 30 fps
 
 @interface WebCoreRenderThemeNotificationObserver : NSObject
 @end
@@ -1063,11 +1059,6 @@ IntRect RenderThemeMac::progressBarRectForBounds(const RenderProgress& renderPro
 
     auto controlStyle = extractControlStyleForRenderer(renderProgress);
     return IntRect(control->rectForBounds(bounds, controlStyle));
-}
-
-Seconds RenderThemeMac::animationRepeatIntervalForProgressBar(const RenderProgress&) const
-{
-    return progressAnimationRepeatInterval;
 }
 
 void RenderThemeMac::adjustProgressBarStyle(RenderStyle&, const Element*) const


### PR DESCRIPTION
#### ae044324e12b0f44593288217af847856a8405b1
<pre>
Make &lt;progress&gt; use Page&apos;s preferredRenderingUpdateInterval()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265277">https://bugs.webkit.org/show_bug.cgi?id=265277</a>

Reviewed by Darin Adler.

This ensures that we take various other considerations into account
when animating and not just call repaint() at a fixed repeat interval.

This has the side effect of making the animation on macOS run at 60FPS
and on visionOS at 90FPS, under normal circumstances.

For now we don&apos;t change where the repeat interval is obtained from, as
it&apos;s not immediately clear to me that a separate RenderTheme bool
method as to whether &lt;progress&gt; animates is preferable to the existing
setup.

* Source/WebCore/rendering/RenderProgress.cpp:
(WebCore::RenderProgress::animationTimerFired):
(WebCore::RenderProgress::updateAnimationState):
* Source/WebCore/rendering/RenderProgress.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::animationRepeatIntervalForProgressBar const): Deleted.
(WebCore::RenderTheme::animationDurationForProgressBar const): Deleted.
(WebCore::RenderTheme::progressBarRectForBounds const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::animationRepeatIntervalForProgressBar const):
(WebCore::RenderTheme::animationDurationForProgressBar const):
(WebCore::RenderTheme::progressBarRectForBounds const):
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::animationRepeatIntervalForProgressBar const):
(WebCore::RenderThemeAdwaita::animationDurationForProgressBar const):
* Source/WebCore/rendering/RenderThemeAdwaita.h:
* Source/WebCore/rendering/RenderThemeCocoa.h:
* Source/WebCore/rendering/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::animationRepeatIntervalForProgressBar const):
* Source/WebCore/rendering/RenderThemeIOS.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::animationRepeatIntervalForProgressBar const): Deleted.
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::animationRepeatIntervalForProgressBar const): Deleted.

Canonical link: <a href="https://commits.webkit.org/271431@main">https://commits.webkit.org/271431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e341b72e73927812259cad83e035146126e6fa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31453 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29209 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6714 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6800 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5570 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->