### PR TITLE
PathElement duplicates PathSegment definitions

### DIFF
--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -51,6 +51,7 @@
 #import "LayoutRect.h"
 #import "LocalizedStrings.h"
 #import "Page.h"
+#import "PathElement.h"
 #import "RenderTextControl.h"
 #import "RenderView.h"
 #import "RenderWidget.h"
@@ -429,70 +430,43 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     return self.axBackingObject->helpTextAttributeValue();
 }
 
-struct PathConversionInfo {
-    WebAccessibilityObjectWrapperBase *wrapper;
-    CGMutablePathRef path;
-};
-
-static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, const PathElement& element)
-{
-    WebAccessibilityObjectWrapperBase *wrapper = conversion.wrapper;
-    CGMutablePathRef newPath = conversion.path;
-    FloatRect rect;
-    switch (element.type) {
-    case PathElement::Type::MoveToPoint:
-    {
-        rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathMoveToPoint(newPath, nil, newPoint.x, newPoint.y);
-        break;
-    }
-    case PathElement::Type::AddLineToPoint:
-    {
-        rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathAddLineToPoint(newPath, nil, newPoint.x, newPoint.y);
-        break;
-    }
-    case PathElement::Type::AddQuadCurveToPoint:
-    {
-        rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint1 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-
-        rect = FloatRect(element.points[1], FloatSize());
-        CGPoint newPoint2 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathAddQuadCurveToPoint(newPath, nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y);
-        break;
-    }
-    case PathElement::Type::AddCurveToPoint:
-    {
-        rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint1 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-
-        rect = FloatRect(element.points[1], FloatSize());
-        CGPoint newPoint2 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-
-        rect = FloatRect(element.points[2], FloatSize());
-        CGPoint newPoint3 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathAddCurveToPoint(newPath, nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y, newPoint3.x, newPoint3.y);
-        break;
-    }
-    case PathElement::Type::CloseSubpath:
-    {
-        CGPathCloseSubpath(newPath);
-        break;
-    }
-    }
-}
-
 - (CGPathRef)convertPathToScreenSpace:(const Path&)path
 {
-    auto convertedPath = adoptCF(CGPathCreateMutable());
-    PathConversionInfo conversion = { self, convertedPath.get() };
-    path.applyElements([&conversion](const PathElement& pathElement) {
-        convertPathToScreenSpaceFunction(conversion, pathElement);
-    });
-    return convertedPath.autorelease();
+    RetainPtr newPath = adoptCF(CGPathCreateMutable());
+    path.applyElements(
+        [&](const PathMoveTo& moveTo) {
+            FloatRect rect { moveTo.point, FloatSize { } };
+            CGPoint newPoint = [self convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+            CGPathMoveToPoint(newPath.get(), nil, newPoint.x, newPoint.y);
+        },
+        [&](const PathLineTo& lineTo) {
+            FloatRect rect { lineTo.point, FloatSize { } };
+            CGPoint newPoint = [self convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+            CGPathAddLineToPoint(newPath.get(), nil, newPoint.x, newPoint.y);
+        },
+        [&](const PathQuadCurveTo& quadTo) {
+            FloatRect rect1 { quadTo.controlPoint, FloatSize { } };
+            CGPoint newPoint1 = [self convertRectToSpace:rect1 space:AccessibilityConversionSpace::Screen].origin;
+
+            FloatRect rect2 { quadTo.endPoint, FloatSize { } };
+            CGPoint newPoint2 = [self convertRectToSpace:rect2 space:AccessibilityConversionSpace::Screen].origin;
+            CGPathAddQuadCurveToPoint(newPath.get(), nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y);
+        },
+        [&](const PathBezierCurveTo& bezierTo) {
+            FloatRect rect1 { bezierTo.controlPoint1, FloatSize { } };
+            CGPoint newPoint1 = [self convertRectToSpace:rect1 space:AccessibilityConversionSpace::Screen].origin;
+
+            FloatRect rect2 { bezierTo.controlPoint2, FloatSize { } };
+            CGPoint newPoint2 = [self convertRectToSpace:rect2 space:AccessibilityConversionSpace::Screen].origin;
+
+            FloatRect rect3 { bezierTo.endPoint, FloatSize { } };
+            CGPoint newPoint3 = [self convertRectToSpace:rect3 space:AccessibilityConversionSpace::Screen].origin;
+            CGPathAddCurveToPoint(newPath.get(), nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y, newPoint3.x, newPoint3.y);
+        },
+        [&](const PathCloseSubpath&) {
+            CGPathCloseSubpath(newPath.get());
+        });
+    return newPath.autorelease();
 }
 
 // Determine the visible range by checking intersection of unobscuredContentRect and a range of text by

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -337,34 +337,25 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
 
     const auto mapPoints = [&] (const Path& path) {
         Path newPath;
-        path.applyElements([&] (const PathElement& pathElement) {
-            const auto localToRoot = [&] (size_t index) {
-                const FloatPoint& point = pathElement.points[index];
-                return localPointToRootPoint(containingView, renderer->localToAbsolute(shapeOutsideInfo->shapeToRendererPoint(point)));
-            };
-
-            switch (pathElement.type) {
-            case PathElement::Type::MoveToPoint:
-                newPath.moveTo(localToRoot(0));
-                break;
-
-            case PathElement::Type::AddLineToPoint:
-                newPath.addLineTo(localToRoot(0));
-                break;
-
-            case PathElement::Type::AddCurveToPoint:
-                newPath.addBezierCurveTo(localToRoot(0), localToRoot(1), localToRoot(2));
-                break;
-
-            case PathElement::Type::AddQuadCurveToPoint:
-                newPath.addQuadCurveTo(localToRoot(0), localToRoot(1));
-                break;
-
-            case PathElement::Type::CloseSubpath:
+        const auto localToRoot = [&] (FloatPoint point) {
+            return localPointToRootPoint(containingView, renderer->localToAbsolute(shapeOutsideInfo->shapeToRendererPoint(point)));
+        };
+        path.applyElements(
+            [&](const PathMoveTo& moveTo) {
+                newPath.moveTo(localToRoot(moveTo.point));
+            },
+            [&](const PathLineTo& lineTo) {
+                newPath.addLineTo(localToRoot(lineTo.point));
+            },
+            [&](const PathBezierCurveTo& bezierTo) {
+                newPath.addBezierCurveTo(localToRoot(bezierTo.controlPoint1), localToRoot(bezierTo.controlPoint2), localToRoot(bezierTo.endPoint));
+            },
+            [&](const PathQuadCurveTo& quadTo) {
+                newPath.addQuadCurveTo(localToRoot(quadTo.controlPoint), localToRoot(quadTo.endPoint));
+            },
+            [&](const PathCloseSubpath&) {
                 newPath.closeSubpath();
-                break;
-            }
-        });
+            });
         return newPath;
     };
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1569,65 +1569,59 @@ struct GlyphIterationState {
     float y2;
     float minX;
     float maxX;
-};
 
-static std::optional<float> findIntersectionPoint(float y, FloatPoint p1, FloatPoint p2)
-{
-    if ((p1.y() < y && p2.y() > y) || (p1.y() > y && p2.y() < y))
-        return p1.x() + (y - p1.y()) * (p2.x() - p1.x()) / (p2.y() - p1.y());
-    return std::nullopt;
-}
-
-static void updateX(GlyphIterationState& state, float x)
-{
-    state.minX = std::min(state.minX, x);
-    state.maxX = std::max(state.maxX, x);
-}
-
-// This function is called by CGPathApply and is therefore invoked for each
-// contour in a glyph. This function models each contours as a straight line
-// and calculates the intersections between each pseudo-contour and
-// two horizontal lines (the upper and lower bounds of an underline) found in
-// GlyphIterationState::y1 and GlyphIterationState::y2. It keeps track of the
-// leftmost and rightmost intersection in GlyphIterationState::minX and
-// GlyphIterationState::maxX.
-static void findPathIntersections(GlyphIterationState& state, const PathElement& element)
-{
-    bool doIntersection = false;
-    FloatPoint point = FloatPoint();
-    switch (element.type) {
-    case PathElement::Type::MoveToPoint:
-        state.startingPoint = element.points[0];
-        state.currentPoint = element.points[0];
-        break;
-    case PathElement::Type::AddLineToPoint:
-        doIntersection = true;
-        point = element.points[0];
-        break;
-    case PathElement::Type::AddQuadCurveToPoint:
-        doIntersection = true;
-        point = element.points[1];
-        break;
-    case PathElement::Type::AddCurveToPoint:
-        doIntersection = true;
-        point = element.points[2];
-        break;
-    case PathElement::Type::CloseSubpath:
-        doIntersection = true;
-        point = state.startingPoint;
-        break;
+    static std::optional<float> findIntersectionPoint(float y, FloatPoint p1, FloatPoint p2)
+    {
+        if ((p1.y() < y && p2.y() > y) || (p1.y() > y && p2.y() < y))
+            return p1.x() + (y - p1.y()) * (p2.x() - p1.x()) / (p2.y() - p1.y());
+        return std::nullopt;
     }
-    if (!doIntersection)
-        return;
-    if (auto intersectionPoint = findIntersectionPoint(state.y1, state.currentPoint, point))
-        updateX(state, *intersectionPoint);
-    if (auto intersectionPoint = findIntersectionPoint(state.y2, state.currentPoint, point))
-        updateX(state, *intersectionPoint);
-    if ((state.currentPoint.y() >= state.y1 && state.currentPoint.y() <= state.y2)
-        || (state.currentPoint.y() <= state.y1 && state.currentPoint.y() >= state.y2))
-        updateX(state, state.currentPoint.x());
-    state.currentPoint = point;
-}
+
+    void updateX(float x)
+    {
+        minX = std::min(minX, x);
+        maxX = std::max(maxX, x);
+    }
+
+    void updateIntersections(FloatPoint point)
+    {
+        if (auto intersectionPoint = findIntersectionPoint(y1, currentPoint, point))
+            updateX(*intersectionPoint);
+        if (auto intersectionPoint = findIntersectionPoint(y2, currentPoint, point))
+            updateX(*intersectionPoint);
+        if ((currentPoint.y() >= y1 && currentPoint.y() <= y2)
+            || (currentPoint.y() <= y1 && currentPoint.y() >= y2))
+            updateX(currentPoint.x());
+        currentPoint = point;
+    }
+
+    // This function models each contour as a straight line
+    // and calculates the intersections between each pseudo-contour and
+    // two horizontal lines (the upper and lower bounds of an underline) found in
+    // GlyphIterationState::y1 and GlyphIterationState::y2. It keeps track of the
+    // leftmost and rightmost intersection in GlyphIterationState::minX and
+    // GlyphIterationState::maxX.
+    void findPathIntersections(const Path& path)
+    {
+        path.applyElements(
+            [&](const PathMoveTo& moveTo) {
+                startingPoint = moveTo.point;
+                currentPoint = moveTo.point;
+            },
+            [&](const PathLineTo& lineTo) {
+                updateIntersections(lineTo.point);
+            },
+            [&](const PathQuadCurveTo& quadTo) {
+                updateIntersections(quadTo.endPoint);
+            },
+            [&](const PathBezierCurveTo& bezierTo) {
+                updateIntersections(bezierTo.endPoint);
+            },
+            [&](const PathCloseSubpath&) {
+                updateIntersections(startingPoint);
+            });
+    }
+};
 
 class GlyphToPathTranslator {
 public:
@@ -1703,10 +1697,7 @@ DashArray FontCascade::dashesForIntersectionsWithRect(const TextRun& run, const 
         GlyphIterationState info = { FloatPoint(0, 0), FloatPoint(0, 0), lineExtents.y(), lineExtents.y() + lineExtents.height(), lineExtents.x() + lineExtents.width(), lineExtents.x() };
         switch (translator.underlineType()) {
         case GlyphUnderlineType::SkipDescenders: {
-            Path path = translator.path();
-            path.applyElements([&](const PathElement& element) {
-                findPathIntersections(info, element);
-            });
+            info.findPathIntersections(translator.path());
             if (info.minX < info.maxX) {
                 result.append(info.minX - lineExtents.x());
                 result.append(info.maxX - lineExtents.x());

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -76,6 +76,8 @@ public:
 
     void applySegments(const PathSegmentApplier&) const;
     WEBCORE_EXPORT void applyElements(const PathElementApplier&) const;
+    template<class F0, class F1, class F2, class F3, class F4>
+    void applyElements(F0, F1, F2, F3, F4) const;
     void clear();
 
     void translate(const FloatSize& delta);
@@ -126,6 +128,14 @@ private:
 
     std::variant<std::monostate, PathSegment, DataRef<PathImpl>> m_data;
 };
+
+template<class F0, class F1, class F2, class F3, class F4>
+void Path::applyElements(F0 f0, F1 f1, F2 f2, F3 f3, F4 f4) const
+{
+    applyElements([&](const PathElement& element) {
+        WTF::switchOn(element, f0, f1, f2, f3, f4);
+    });
+}
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Path&);
 

--- a/Source/WebCore/platform/graphics/PathElement.h
+++ b/Source/WebCore/platform/graphics/PathElement.h
@@ -25,23 +25,137 @@
 
 #pragma once
 
+#include "AffineTransform.h"
 #include "FloatPoint.h"
+#include "FloatRect.h"
+#include <optional>
+#include <variant>
+#include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
-struct PathElement {
-    enum class Type : uint8_t {
-        MoveToPoint,
-        AddLineToPoint,
-        AddQuadCurveToPoint,
-        AddCurveToPoint,
-        CloseSubpath
-    };
-    Type type;
-    FloatPoint points[3];
-};
+struct PathMoveTo;
+struct PathLineTo;
+struct PathQuadCurveTo;
+struct PathBezierCurveTo;
+struct PathCloseSubpath;
+
+using PathElement = std::variant<
+    PathMoveTo,
+    PathLineTo,
+    PathQuadCurveTo,
+    PathBezierCurveTo,
+    PathCloseSubpath
+>;
 
 using PathElementApplier = Function<void(const PathElement&)>;
+
+struct PathMoveTo {
+    FloatPoint point;
+
+    static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
+
+    bool operator==(const PathMoveTo&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathMoveTo&);
+
+struct PathLineTo {
+    FloatPoint point;
+
+    static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
+
+    bool operator==(const PathLineTo&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathLineTo&);
+
+struct PathQuadCurveTo {
+    FloatPoint controlPoint;
+    FloatPoint endPoint;
+
+    static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
+
+    bool operator==(const PathQuadCurveTo&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathQuadCurveTo&);
+
+struct PathBezierCurveTo {
+    FloatPoint controlPoint1;
+    FloatPoint controlPoint2;
+    FloatPoint endPoint;
+
+    static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
+
+    bool operator==(const PathBezierCurveTo&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathBezierCurveTo&);
+
+struct PathCloseSubpath {
+    static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
+
+    bool operator==(const PathCloseSubpath&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathCloseSubpath&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathImpl.cpp
+++ b/Source/WebCore/platform/graphics/PathImpl.cpp
@@ -94,7 +94,7 @@ bool PathImpl::isClosed() const
     // FIXME: find a more efficient way to implement this, that does not require iterating
     // through all PathElements.
     applyElements([&lastElementIsClosed](const PathElement& element) {
-        lastElementIsClosed = (element.type == PathElement::Type::CloseSubpath);
+        lastElementIsClosed = std::holds_alternative<PathCloseSubpath>(element);
     });
 
     return lastElementIsClosed;

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -28,6 +28,7 @@
 #include "FloatRoundedRect.h"
 #include "PathElement.h"
 #include "PathSegment.h"
+#include "RotationDirection.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/UniqueRef.h>

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -30,14 +30,16 @@
 
 namespace WebCore {
 
+// Represents PathElements or complex shapes that are source for Path data.
 class PathSegment {
 public:
     using Data = std::variant<
         PathMoveTo,
-
         PathLineTo,
         PathQuadCurveTo,
         PathBezierCurveTo,
+        PathCloseSubpath,
+
         PathArcTo,
 
         PathArc,
@@ -49,9 +51,7 @@ public:
         PathDataLine,
         PathDataQuadCurve,
         PathDataBezierCurve,
-        PathDataArc,
-
-        PathCloseSubpath
+        PathDataArc
     >;
 
     WEBCORE_EXPORT PathSegment(Data&&);

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -53,7 +53,7 @@ void PathMoveTo::extendBoundingRect(const FloatPoint&, const FloatPoint&, FloatR
 
 void PathMoveTo::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::MoveToPoint, { point } });
+    applier(*this);
 }
 
 void PathMoveTo::transform(const AffineTransform& transform)
@@ -91,7 +91,7 @@ void PathLineTo::extendBoundingRect(const FloatPoint& currentPoint, const FloatP
 
 void PathLineTo::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::AddLineToPoint, { point } });
+    applier(*this);
 }
 
 void PathLineTo::transform(const AffineTransform& transform)
@@ -167,7 +167,7 @@ void PathQuadCurveTo::extendBoundingRect(const FloatPoint& currentPoint, const F
 
 void PathQuadCurveTo::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::AddQuadCurveToPoint, { controlPoint, endPoint } });
+    applier(*this);
 }
 
 void PathQuadCurveTo::transform(const AffineTransform& transform)
@@ -281,7 +281,7 @@ void PathBezierCurveTo::extendBoundingRect(const FloatPoint& currentPoint, const
 
 void PathBezierCurveTo::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::AddCurveToPoint, { controlPoint1, controlPoint2, endPoint } });
+    applier(*this);
 }
 
 void PathBezierCurveTo::transform(const AffineTransform& transform)
@@ -588,8 +588,8 @@ void PathDataLine::extendBoundingRect(const FloatPoint&, const FloatPoint&, Floa
 
 void PathDataLine::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::MoveToPoint, { start } });
-    applier({ PathElement::Type::AddLineToPoint, { end } });
+    applier(PathMoveTo { start });
+    applier(PathLineTo { end });
 }
 
 void PathDataLine::transform(const AffineTransform& transform)
@@ -635,8 +635,8 @@ void PathDataQuadCurve::extendBoundingRect(const FloatPoint&, const FloatPoint&,
 
 void PathDataQuadCurve::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::MoveToPoint, { start } });
-    applier({ PathElement::Type::AddQuadCurveToPoint, { controlPoint, endPoint } });
+    applier(PathMoveTo { start });
+    applier(PathQuadCurveTo { controlPoint, endPoint });
 }
 
 void PathDataQuadCurve::transform(const AffineTransform& transform)
@@ -685,8 +685,8 @@ void PathDataBezierCurve::extendBoundingRect(const FloatPoint&, const FloatPoint
 
 void PathDataBezierCurve::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::MoveToPoint, { start } });
-    applier({ PathElement::Type::AddCurveToPoint, { controlPoint1, controlPoint2, endPoint } });
+    applier(PathMoveTo { start });
+    applier(PathBezierCurveTo { controlPoint1, controlPoint2, endPoint });
 }
 
 void PathDataBezierCurve::transform(const AffineTransform& transform)
@@ -761,7 +761,7 @@ void PathCloseSubpath::extendBoundingRect(const FloatPoint&, const FloatPoint& l
 
 void PathCloseSubpath::applyElements(const PathElementApplier& applier) const
 {
-    applier({ PathElement::Type::CloseSubpath, { } });
+    applier(*this);
 }
 
 void PathCloseSubpath::transform(const AffineTransform&)

--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -36,93 +36,6 @@ class TextStream;
 
 namespace WebCore {
 
-struct PathMoveTo {
-    FloatPoint point;
-
-    static constexpr bool canApplyElements = true;
-    static constexpr bool canTransform = true;
-
-    bool operator==(const PathMoveTo&) const = default;
-
-    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
-    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
-
-    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
-    void applyElements(const PathElementApplier&) const;
-
-    void transform(const AffineTransform&);
-};
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathMoveTo&);
-
-struct PathLineTo {
-    FloatPoint point;
-
-    static constexpr bool canApplyElements = true;
-    static constexpr bool canTransform = true;
-
-    bool operator==(const PathLineTo&) const = default;
-
-    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
-    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
-
-    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
-    void applyElements(const PathElementApplier&) const;
-
-    void transform(const AffineTransform&);
-};
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathLineTo&);
-
-struct PathQuadCurveTo {
-    FloatPoint controlPoint;
-    FloatPoint endPoint;
-
-    static constexpr bool canApplyElements = true;
-    static constexpr bool canTransform = true;
-
-    bool operator==(const PathQuadCurveTo&) const = default;
-
-    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
-    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
-
-    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
-    void applyElements(const PathElementApplier&) const;
-
-    void transform(const AffineTransform&);
-};
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathQuadCurveTo&);
-
-struct PathBezierCurveTo {
-    FloatPoint controlPoint1;
-    FloatPoint controlPoint2;
-    FloatPoint endPoint;
-
-    static constexpr bool canApplyElements = true;
-    static constexpr bool canTransform = true;
-
-    bool operator==(const PathBezierCurveTo&) const = default;
-
-    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
-    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
-
-    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
-    void applyElements(const PathElementApplier&) const;
-
-    void transform(const AffineTransform&);
-};
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathBezierCurveTo&);
-
 struct PathArcTo {
     FloatPoint controlPoint1;
     FloatPoint controlPoint2;
@@ -138,7 +51,6 @@ struct PathArcTo {
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathArcTo&);
@@ -160,7 +72,6 @@ struct PathArc {
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathArc&);
@@ -184,7 +95,6 @@ struct PathEllipse {
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathEllipse&);
@@ -338,24 +248,5 @@ struct PathDataArc {
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataArc&);
-
-struct PathCloseSubpath {
-    static constexpr bool canApplyElements = true;
-    static constexpr bool canTransform = true;
-
-    bool operator==(const PathCloseSubpath&) const = default;
-
-    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
-    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
-
-    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
-
-    void applyElements(const PathElementApplier&) const;
-
-    void transform(const AffineTransform&);
-};
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathCloseSubpath&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathTraversalState.h
+++ b/Source/WebCore/platform/graphics/PathTraversalState.h
@@ -43,8 +43,7 @@ public:
     PathTraversalState(Action, float desiredLength = 0);
 
 public:
-    bool processPathElement(PathElement::Type, const FloatPoint*);
-    bool processPathElement(const PathElement& element) { return processPathElement(element.type, element.points); }
+    bool processPathElement(const PathElement&);
 
     Action action() const { return m_action; }
     void setAction(Action action) { m_action = action; }
@@ -65,7 +64,7 @@ private:
     void cubicBezierTo(const FloatPoint&, const FloatPoint&, const FloatPoint&);
 
     bool finalizeAppendPathElement();
-    bool appendPathElement(PathElement::Type, const FloatPoint*);
+    bool appendPathElement(const PathElement&);
 
 private:
     Action m_action;

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -226,11 +226,10 @@ void PathCG::addPath(const PathCG& path, const AffineTransform& transform)
     CGPathAddPath(ensureMutablePlatformPath(), &transformCG, pathCopy.get());
 }
 
-static void pathSegmentApplierCallback(void* info, const CGPathElement* element)
+template <typename F>
+static void applyCGPathElement(F& applier, const CGPathElement* element)
 {
-    const auto& applier = *(PathSegmentApplier*)info;
     auto* cgPoints = element->points;
-
     switch (element->type) {
     case kCGPathElementMoveToPoint:
         applier({ PathMoveTo { cgPoints[0] } });
@@ -254,37 +253,19 @@ static void pathSegmentApplierCallback(void* info, const CGPathElement* element)
     }
 }
 
-void PathCG::applySegments(const PathSegmentApplier& applier) const
-{
-    CGPathApply(platformPath(), (void*)&applier, pathSegmentApplierCallback);
-}
-
 static void pathElementApplierCallback(void* info, const CGPathElement* element)
 {
-    const auto& applier = *(PathElementApplier*)info;
-    auto* cgPoints = element->points;
+    applyCGPathElement(*static_cast<PathElementApplier*>(info), element);
+}
 
-    switch (element->type) {
-    case kCGPathElementMoveToPoint:
-        applier({ PathElement::Type::MoveToPoint, { cgPoints[0] } });
-        break;
+static void pathSegmentsApplierCallback(void* info, const CGPathElement* element)
+{
+    applyCGPathElement(*static_cast<PathSegmentApplier*>(info), element);
+}
 
-    case kCGPathElementAddLineToPoint:
-        applier({ PathElement::Type::AddLineToPoint, { cgPoints[0] } });
-        break;
-
-    case kCGPathElementAddQuadCurveToPoint:
-        applier({ PathElement::Type::AddQuadCurveToPoint, { cgPoints[0], cgPoints[1] } });
-        break;
-
-    case kCGPathElementAddCurveToPoint:
-        applier({ PathElement::Type::AddCurveToPoint, { cgPoints[0], cgPoints[1], cgPoints[2] } });
-        break;
-
-    case kCGPathElementCloseSubpath:
-        applier({ PathElement::Type::CloseSubpath, { } });
-        break;
-    }
+void PathCG::applySegments(const PathSegmentApplier& applier) const
+{
+    CGPathApply(platformPath(), (void*)&applier, pathSegmentsApplierCallback);
 }
 
 bool PathCG::applyElements(const PathElementApplier& applier) const

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -307,7 +307,7 @@ void RenderSVGPath::processMarkerPositions()
 
     SVGMarkerData markerData(m_markerPositions, markerReverseStart);
     path().applyElements([&markerData](const PathElement& pathElement) {
-        SVGMarkerData::updateFromPathElement(markerData, pathElement);
+        markerData.updateFromPathElement(pathElement);
     });
     markerData.pathIsDone();
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -284,7 +284,7 @@ void LegacyRenderSVGPath::processMarkerPositions()
 
     SVGMarkerData markerData(m_markerPositions, SVGResourcesCache::cachedResourcesForRenderer(*this)->markerReverseStart());
     path().applyElements([&markerData](const PathElement& pathElement) {
-        SVGMarkerData::updateFromPathElement(markerData, pathElement);
+        markerData.updateFromPathElement(pathElement);
     });
     markerData.pathIsDone();
 }

--- a/Source/WebCore/svg/SVGPathTraversalStateBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathTraversalStateBuilder.cpp
@@ -36,24 +36,22 @@ SVGPathTraversalStateBuilder::SVGPathTraversalStateBuilder(PathTraversalState& s
 
 void SVGPathTraversalStateBuilder::moveTo(const FloatPoint& targetPoint, bool, PathCoordinateMode)
 {
-    m_traversalState.processPathElement(PathElement::Type::MoveToPoint, &targetPoint);
+    m_traversalState.processPathElement(PathMoveTo { targetPoint });
 }
 
 void SVGPathTraversalStateBuilder::lineTo(const FloatPoint& targetPoint, PathCoordinateMode)
 {
-    m_traversalState.processPathElement(PathElement::Type::AddLineToPoint, &targetPoint);
+    m_traversalState.processPathElement(PathLineTo { targetPoint });
 }
 
 void SVGPathTraversalStateBuilder::curveToCubic(const FloatPoint& point1, const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode)
 {
-    FloatPoint points[] = { point1, point2, targetPoint };
-
-    m_traversalState.processPathElement(PathElement::Type::AddCurveToPoint, points);
+    m_traversalState.processPathElement(PathBezierCurveTo { point1, point2, targetPoint });
 }
 
 void SVGPathTraversalStateBuilder::closePath()
 {
-    m_traversalState.processPathElement(PathElement::Type::CloseSubpath, nullptr);
+    m_traversalState.processPathElement(PathCloseSubpath { });
 }
 
 bool SVGPathTraversalStateBuilder::continueConsuming()

--- a/Source/WebCore/svg/SVGPathUtilities.cpp
+++ b/Source/WebCore/svg/SVGPathUtilities.cpp
@@ -57,25 +57,22 @@ String buildStringFromPath(const Path& path)
     StringBuilder builder;
 
     if (!path.isEmpty()) {
-        path.applyElements([&builder] (const PathElement& element) {
-            switch (element.type) {
-            case PathElement::Type::MoveToPoint:
-                builder.append('M', element.points[0].x(), ' ', element.points[0].y());
-                break;
-            case PathElement::Type::AddLineToPoint:
-                builder.append('L', element.points[0].x(), ' ', element.points[0].y());
-                break;
-            case PathElement::Type::AddQuadCurveToPoint:
-                builder.append('Q', element.points[0].x(), ' ', element.points[0].y(), ',', element.points[1].x(), ' ', element.points[1].y());
-                break;
-            case PathElement::Type::AddCurveToPoint:
-                builder.append('C', element.points[0].x(), ' ', element.points[0].y(), ',', element.points[1].x(), ' ', element.points[1].y(), ',', element.points[2].x(), ' ', element.points[2].y());
-                break;
-            case PathElement::Type::CloseSubpath:
+        path.applyElements(
+            [&](const PathMoveTo& moveTo) {
+                builder.append('M', moveTo.point.x(), ' ', moveTo.point.y());
+            },
+            [&](const PathLineTo& lineTo) {
+                builder.append('L', lineTo.point.x(), ' ', lineTo.point.y());
+            },
+            [&](const PathQuadCurveTo& quadTo) {
+                builder.append('Q', quadTo.controlPoint.x(), ' ', quadTo.controlPoint.y(), ',', quadTo.endPoint.x(), ' ', quadTo.endPoint.y());
+            },
+            [&](const PathBezierCurveTo& bezierTo) {
+                builder.append('C', bezierTo.controlPoint1.x(), ' ', bezierTo.controlPoint1.y(), ',', bezierTo.controlPoint2.x(), ' ', bezierTo.controlPoint2.y(), ',', bezierTo.endPoint.x(), ' ', bezierTo.endPoint.y());
+            },
+            [&](const PathCloseSubpath&) {
                 builder.append('Z');
-                break;
-            }
-        });
+            });
     }
 
     return builder.toString();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5314,26 +5314,22 @@ ExceptionOr<String> Internals::pathStringWithShrinkWrappedRects(const Vector<dou
         rects.append(FloatRect(rectComponents[i], rectComponents[i + 1], rectComponents[i + 2], rectComponents[i + 3]));
 
     SVGPathStringBuilder builder;
-    PathUtilities::pathWithShrinkWrappedRects(rects, radius).applyElements([&builder](const PathElement& element) {
-        switch (element.type) {
-        case PathElement::Type::MoveToPoint:
-            builder.moveTo(element.points[0], false, AbsoluteCoordinates);
-            return;
-        case PathElement::Type::AddLineToPoint:
-            builder.lineTo(element.points[0], AbsoluteCoordinates);
-            return;
-        case PathElement::Type::AddQuadCurveToPoint:
-            builder.curveToQuadratic(element.points[0], element.points[1], AbsoluteCoordinates);
-            return;
-        case PathElement::Type::AddCurveToPoint:
-            builder.curveToCubic(element.points[0], element.points[1], element.points[2], AbsoluteCoordinates);
-            return;
-        case PathElement::Type::CloseSubpath:
+    PathUtilities::pathWithShrinkWrappedRects(rects, radius).applyElements(
+        [&](const PathMoveTo& moveTo) {
+            builder.moveTo(moveTo.point, false, AbsoluteCoordinates);
+        },
+        [&](const PathLineTo& lineTo) {
+            builder.lineTo(lineTo.point, AbsoluteCoordinates);
+        },
+        [&](const PathQuadCurveTo& quadTo) {
+            builder.curveToQuadratic(quadTo.controlPoint, quadTo.endPoint, AbsoluteCoordinates);
+        },
+        [&](const PathBezierCurveTo& bezierTo) {
+            builder.curveToCubic(bezierTo.controlPoint1, bezierTo.controlPoint2, bezierTo.endPoint, AbsoluteCoordinates);
+        },
+        [&](const PathCloseSubpath&) {
             builder.closePath();
-            return;
-        }
-        ASSERT_NOT_REACHED();
-    });
+        });
     return builder.result();
 }
 


### PR DESCRIPTION
#### a4bc2a7e65ef6fe1d782f8f55fd871dc4ac89089
<pre>
PathElement duplicates PathSegment definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=265281">https://bugs.webkit.org/show_bug.cgi?id=265281</a>
<a href="https://rdar.apple.com/problem/118743258">rdar://problem/118743258</a>

Reviewed by NOBODY (OOPS!).

PathSegment had type safe data variants PathMoveTo, PathLineTo,
PathQuadCurveTo, PathBezierCurveTo, PathCloseSubpath in addition to
other shape-related data types.

Make PathElement be a variant of PathMoveTo, PathLineTo,
PathQuadCurveTo, PathBezierCurveTo, PathCloseSubpath, too. This
makes the code simpler to work with, when the relationship between
PathSegment and PathElement is clearer.

Move the Element related Path* classes to PathElement.h.

* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase convertPathToScreenSpace:]):
(convertPathToScreenSpaceFunction): Deleted.
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::drawShapeHighlight):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::GlyphIterationState::findIntersectionPoint):
(WebCore::GlyphIterationState::updateX):
(WebCore::GlyphIterationState::updateIntersections):
(WebCore::GlyphIterationState::findPathIntersections):
(WebCore::FontCascade::dashesForIntersectionsWithRect const):
(WebCore::findIntersectionPoint): Deleted.
(WebCore::updateX): Deleted.
(WebCore::findPathIntersections): Deleted.
* Source/WebCore/platform/graphics/Path.h:
(WebCore::Path::applyElements const):
* Source/WebCore/platform/graphics/PathElement.h:
* Source/WebCore/platform/graphics/PathImpl.cpp:
(WebCore::PathImpl::isClosed const):
* Source/WebCore/platform/graphics/PathImpl.h:
* Source/WebCore/platform/graphics/PathSegment.h:
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::PathMoveTo::applyElements const):
(WebCore::PathLineTo::applyElements const):
(WebCore::PathQuadCurveTo::applyElements const):
(WebCore::PathBezierCurveTo::applyElements const):
(WebCore::PathDataLine::applyElements const):
(WebCore::PathDataQuadCurve::applyElements const):
(WebCore::PathDataBezierCurve::applyElements const):
(WebCore::PathCloseSubpath::applyElements const):
* Source/WebCore/platform/graphics/PathSegmentData.h:
* Source/WebCore/platform/graphics/PathTraversalState.cpp:
(WebCore::QuadraticBezier::split const):
(WebCore::CubicBezier::split const):
(WebCore::PathTraversalState::appendPathElement):
(WebCore::PathTraversalState::processPathElement):
* Source/WebCore/platform/graphics/PathTraversalState.h:
(WebCore::PathTraversalState::processPathElement): Deleted.
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::applySegments const):
(WebCore::PathCairo::applyElements const):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::applyCGPathElement):
(WebCore::applyElementsCallback):
(WebCore::applySegmentsCallback):
(WebCore::PathCG::applySegments const):
(WebCore::PathCG::applyElements const):
(WebCore::pathSegmentApplierCallback): Deleted.
(WebCore::pathElementApplierCallback): Deleted.
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::processMarkerPositions):
* Source/WebCore/rendering/svg/SVGMarkerData.h:
(WebCore::SVGMarkerData::updateFromPathElement):
(WebCore::SVGMarkerData::updateMarkerDataForPathElement):
(WebCore::SVGMarkerData::updateOutslope): Deleted.
(WebCore::SVGMarkerData::updateInslope): Deleted.
* Source/WebCore/rendering/svg/SVGSubpathData.h:
(WebCore::SVGSubpathData::updateFromPathElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::processMarkerPositions):
* Source/WebCore/svg/SVGPathTraversalStateBuilder.cpp:
(WebCore::SVGPathTraversalStateBuilder::moveTo):
(WebCore::SVGPathTraversalStateBuilder::lineTo):
(WebCore::SVGPathTraversalStateBuilder::curveToCubic):
(WebCore::SVGPathTraversalStateBuilder::closePath):
* Source/WebCore/svg/SVGPathUtilities.cpp:
(WebCore::buildStringFromPath):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::pathStringWithShrinkWrappedRects):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4bc2a7e65ef6fe1d782f8f55fd871dc4ac89089

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29919 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25318 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25082 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23768 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4422 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30767 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28684 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->