### PR TITLE
Intruduce concept of render tree rebuild root

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2135,7 +2135,7 @@ bool Document::hasPendingFullStyleRebuild() const
     return hasPendingStyleRecalc() && m_needsFullStyleRebuild;
 }
 
-void Document::updateRenderTree(std::unique_ptr<const Style::Update> styleUpdate)
+void Document::updateRenderTree(std::unique_ptr<Style::Update> styleUpdate)
 {
     ASSERT(!inRenderTreeUpdate());
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -734,7 +734,7 @@ public:
 
     bool renderTreeBeingDestroyed() const { return m_renderTreeBeingDestroyed; }
     bool hasLivingRenderTree() const { return renderView() && !renderTreeBeingDestroyed(); }
-    void updateRenderTree(std::unique_ptr<const Style::Update> styleUpdate);
+    void updateRenderTree(std::unique_ptr<Style::Update> styleUpdate);
 
     bool updateLayoutIfDimensionsOutOfDate(Element&, OptionSet<DimensionsCheck> = { DimensionsCheck::All });
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -147,6 +147,19 @@ RenderTreeBuilder::~RenderTreeBuilder()
     s_current = m_previous;
 }
 
+bool RenderTreeBuilder::isRebuildRootForChildren(const RenderElement& renderer)
+{
+    // If a (non-anonymous) child is added or removed to a rebuild root then we'll rebuild the full
+    // subtree instead of trying to maintain the correct anonymous box structure on per-child basis.
+    // This can greatly simplify the code needed to maintain the correct structure.
+
+    auto display = renderer.style().display();
+    if (display == DisplayType::Ruby || display == DisplayType::RubyBlock)
+        return true;
+
+    return false;
+}
+
 void RenderTreeBuilder::destroy(RenderObject& renderer, CanCollapseAnonymousBlock canCollapseAnonymousBlock)
 {
     RELEASE_ASSERT(RenderTreeMutationDisallowedScope::isMutationAllowed());

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -42,6 +42,8 @@ public:
     // FIXME: Remove.
     static RenderTreeBuilder* current() { return s_current; }
 
+    static bool isRebuildRootForChildren(const RenderElement&);
+
     void attach(RenderElement& parent, RenderPtr<RenderObject>, RenderObject* beforeChild = nullptr);
 
     enum class CanCollapseAnonymousBlock : bool { No, Yes };

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -83,10 +83,8 @@ RenderTreeUpdater::RenderTreeUpdater(Document& document, Style::PostResolutionCa
 
 RenderTreeUpdater::~RenderTreeUpdater() = default;
 
-static ContainerNode* findRenderingRoot(ContainerNode& node)
+static Element* findRenderingAncestor(ContainerNode& node)
 {
-    if (node.renderer())
-        return &node;
     for (auto& ancestor : composedTreeAncestors(node)) {
         if (ancestor.renderer())
             return &ancestor;
@@ -96,7 +94,14 @@ static ContainerNode* findRenderingRoot(ContainerNode& node)
     return nullptr;
 }
 
-void RenderTreeUpdater::commit(std::unique_ptr<const Style::Update> styleUpdate)
+static ContainerNode* findRenderingRoot(ContainerNode& node)
+{
+    if (node.renderer())
+        return &node;
+    return findRenderingAncestor(node);
+}
+
+void RenderTreeUpdater::commit(std::unique_ptr<Style::Update> styleUpdate)
 {
     ASSERT(&m_document == &styleUpdate->document());
 
@@ -106,6 +111,8 @@ void RenderTreeUpdater::commit(std::unique_ptr<const Style::Update> styleUpdate)
     TraceScope scope(RenderTreeBuildStart, RenderTreeBuildEnd);
 
     m_styleUpdate = WTFMove(styleUpdate);
+
+    updateRebuildRoots();
 
     updateRenderViewStyle();
 
@@ -124,6 +131,68 @@ void RenderTreeUpdater::commit(std::unique_ptr<const Style::Update> styleUpdate)
     m_builder.updateAfterDescendants(renderView());
 
     m_styleUpdate = nullptr;
+}
+
+void RenderTreeUpdater::updateRebuildRoots()
+{
+    auto findNewRebuildRoot = [&](auto& root) -> Element* {
+        auto* renderingAncestor = findRenderingAncestor(root);
+        if (!renderingAncestor)
+            return nullptr;
+        if (!RenderTreeBuilder::isRebuildRootForChildren(*renderingAncestor->renderer()))
+            return nullptr;
+        return renderingAncestor;
+    };
+
+    auto addForRebuild = [&](auto& element) {
+        auto* existingUpdate = m_styleUpdate->elementUpdate(element);
+        if (existingUpdate) {
+            if (existingUpdate->change == Style::Change::Renderer)
+                return false;
+            existingUpdate->change = Style::Change::Renderer;
+            return true;
+        }
+
+        if (!element.renderer())
+            return element.hasDisplayContents();
+
+        auto* parent = composedTreeAncestors(element).first();
+        m_styleUpdate->addElement(element, parent, Style::ElementUpdate {
+            RenderStyle::clonePtr(element.renderer()->style()),
+            Style::Change::Renderer
+        });
+        return true;
+    };
+
+    auto addSubtreeForRebuild = [&](auto& root) {
+        if (!addForRebuild(root))
+            return;
+        auto descendants = composedTreeDescendants(root);
+        auto it = descendants.begin();
+        auto end = descendants.end();
+        while (it != end) {
+            auto& descendant = *it;
+            if (!is<Element>(descendant)) {
+                it.traverseNext();
+                continue;
+            }
+            if (!addForRebuild(downcast<Element>(descendant))) {
+                it.traverseNextSkippingChildren();
+                continue;
+            }
+            it.traverseNext();
+        }
+    };
+
+    while (true) {
+        auto rebuildRoots = m_styleUpdate->takeRebuildRoots();
+        if (rebuildRoots.isEmpty())
+            break;
+        for (auto& rebuildRoot : rebuildRoots) {
+            if (auto* newRebuildRoot = findNewRebuildRoot(*rebuildRoot))
+                addSubtreeForRebuild(*newRebuildRoot);
+        }
+    }
 }
 
 static bool shouldCreateRenderer(const Element& element, const RenderElement& parentRenderer)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -46,7 +46,7 @@ public:
     RenderTreeUpdater(Document&, Style::PostResolutionCallbackDisabler&);
     ~RenderTreeUpdater();
 
-    void commit(std::unique_ptr<const Style::Update>);
+    void commit(std::unique_ptr<Style::Update>);
 
     static void tearDownRenderers(Element&);
     static void tearDownRenderersAfterSlotChange(Element& host);
@@ -96,10 +96,12 @@ private:
     static void tearDownLeftoverChildrenOfComposedTree(Element&, RenderTreeBuilder&);
     static void tearDownLeftoverPaginationRenderersIfNeeded(Element&, RenderTreeBuilder&);
 
+    void updateRebuildRoots();
+
     RenderView& renderView();
 
     Document& m_document;
-    std::unique_ptr<const Style::Update> m_styleUpdate;
+    std::unique_ptr<Style::Update> m_styleUpdate;
 
     Vector<Parent> m_parentStack;
 

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -94,6 +94,9 @@ void Update::addElement(Element& element, Element* parent, ElementUpdate&& eleme
     m_roots.remove(&element);
     addPossibleRoot(parent);
 
+    if (elementUpdate.change == Change::Renderer)
+        addPossibleRebuildRoot(element, parent);
+
     m_elements.add(&element, WTFMove(elementUpdate));
 }
 
@@ -140,6 +143,14 @@ void Update::addPossibleRoot(Element* element)
     if (element->needsSVGRendererUpdate() || m_elements.contains(element))
         return;
     m_roots.add(element);
+}
+
+void Update::addPossibleRebuildRoot(Element& element, Element* parent)
+{
+    if (parent && m_rebuildRoots.contains(parent))
+        return;
+
+    m_rebuildRoots.add(&element);
 }
 
 }

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -60,6 +60,7 @@ public:
     Update(Document&);
 
     const ListHashSet<RefPtr<ContainerNode>>& roots() const { return m_roots; }
+    ListHashSet<RefPtr<Element>> takeRebuildRoots() { return WTFMove(m_rebuildRoots); }
 
     const ElementUpdate* elementUpdate(const Element&) const;
     ElementUpdate* elementUpdate(const Element&);
@@ -84,9 +85,11 @@ public:
 
 private:
     void addPossibleRoot(Element*);
+    void addPossibleRebuildRoot(Element&, Element* parent);
 
     Ref<Document> m_document;
     ListHashSet<RefPtr<ContainerNode>> m_roots;
+    ListHashSet<RefPtr<Element>> m_rebuildRoots;
     HashMap<RefPtr<const Element>, ElementUpdate> m_elements;
     HashMap<RefPtr<const Text>, TextUpdate> m_texts;
     std::unique_ptr<RenderStyle> m_initialContainingBlockUpdate;


### PR DESCRIPTION
#### c7578c8aa8bf5e14ebebbc1f531f4001fd7d1327
<pre>
Intruduce concept of render tree rebuild root
<a href="https://bugs.webkit.org/show_bug.cgi?id=265284">https://bugs.webkit.org/show_bug.cgi?id=265284</a>
<a href="https://rdar.apple.com/118744369">rdar://118744369</a>

Reviewed by Alan Baradlay.

Add mechanism to rebuild render subtree starting from an ancestor of the changed element.

We can simplify render tree mutations if some complex cases are handled by tearing
down a larger structure with all the associated anonymous boxes and rebuilding them.

Use the mechanism for &lt;ruby&gt; subtrees when style-based ruby is enabled. This gets tested by

fast/ruby/rubyDOM-insert-rt-block-1.html
fast/ruby/rubyDOM-insert-rt-block-2.html
fast/ruby/rubyDOM-insert-rt-block-3.html
fast/ruby/rubyDOM-remove-rt-block-1.html
fast/ruby/rubyDOM-remove-rt-block-2.html
fast/ruby/rubyDOM-remove-rt-block-3.html

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateRenderTree):
* Source/WebCore/dom/Document.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::isRebuildRootForChildren):

Test if a given renderer is rebuild root for its children. For now this only tests for ruby.

* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::findRenderingAncestor):
(WebCore::findRenderingRoot):
(WebCore::RenderTreeUpdater::commit):
(WebCore::RenderTreeUpdater::updateRebuildRoots):

In the beginning of a commit check if any of the rebuild roots need a wider rebuild.
Add all the new elements that will get rebuild to the style update.

* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
* Source/WebCore/style/StyleUpdate.cpp:
(WebCore::Style::Update::addElement):
(WebCore::Style::Update::addPossibleRebuildRoot):

Keep track of the rebuild roots.

* Source/WebCore/style/StyleUpdate.h:
(WebCore::Style::Update::rebuildRoots const):

Canonical link: <a href="https://commits.webkit.org/271082@main">https://commits.webkit.org/271082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/870d8a97e9369181c0c70a30fe1a5ebb8a60db40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24774 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30389 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28329 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5712 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6572 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->