### PR TITLE
Fix build errors due to unused values and declarations

### DIFF
--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -49,11 +49,11 @@
 
 namespace JSC { namespace B3 {
 
+#if ASSERT_ENABLED
 namespace B3ValueInternal {
 constexpr bool alwaysDumpConstructionSite = false;
 }
 
-#if ASSERT_ENABLED
 String Value::generateCompilerConstructionSite()
 {
     StringPrintStream s;

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -151,12 +151,12 @@ ALWAYS_INLINE JSString* LiteralParser<CharType>::makeJSString(VM& vm, typename L
     return jsString(vm, Identifier::fromString(vm, token->stringStart16, token->stringOrIdentifierLength).string());
 }
 
-static ALWAYS_INLINE bool cannotBeIdentPartOrEscapeStart(LChar)
+[[maybe_unused]] static ALWAYS_INLINE bool cannotBeIdentPartOrEscapeStart(LChar)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static ALWAYS_INLINE bool cannotBeIdentPartOrEscapeStart(UChar)
+[[maybe_unused]] static ALWAYS_INLINE bool cannotBeIdentPartOrEscapeStart(UChar)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -96,8 +96,10 @@ namespace WasmB3IRGeneratorInternal {
 static constexpr bool verbose = false;
 static constexpr bool verboseInlining = false;
 static constexpr bool traceExecution = false;
-static constexpr bool traceExecutionIncludesConstructionSite = false;
 static constexpr bool traceStackValues = false;
+#if ASSERT_ENABLED
+static constexpr bool traceExecutionIncludesConstructionSite = false;
+#endif
 }
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
@@ -33,7 +33,9 @@
 
 namespace WebCore {
 
+#if ASSERT_ENABLED
 static constexpr unsigned AES_CM_128_HMAC_SHA256_NONCE_SIZE = 12;
+#endif
 
 static inline void writeUInt64(uint8_t* data, uint64_t value, uint8_t valueLength)
 {

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSSelectorParser.h"
 
+#include "CSSParserIdioms.h"
 #include "CSSParserSelector.h"
 #include "CSSSelector.h"
 #include "CommonAtomStrings.h"

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -181,7 +181,6 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLRenderingContextBase);
 
 static constexpr Seconds secondsBetweenRestoreAttempts { 1_s };
 static constexpr int maxGLErrorsAllowedToConsole = 256;
-static constexpr Seconds checkContextLossHandlingDelay { 3_s };
 static constexpr size_t maxActiveContexts = 16;
 static constexpr size_t maxActiveWorkerContexts = 4;
 

--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -28,6 +28,7 @@
 
 #include "LayoutBox.h"
 #include "LayoutBoxGeometry.h"
+#include "RenderStyleInlines.h"
 #include "TableFormattingGeometry.h"
 
 namespace WebCore {

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -28,6 +28,7 @@
 #include "RunLoopObserver.h"
 #include <JavaScriptCore/EdenGCActivityCallback.h>
 #include <JavaScriptCore/FullGCActivityCallback.h>
+#include <JavaScriptCore/MarkedSpace.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -45,7 +45,9 @@
 
 namespace WebCore {
 
+#if !USE(GSTREAMER)
 static const Seconds deviceChangeDebounceTimerInterval { 200_ms };
+#endif
 
 RealtimeMediaSourceCenter& RealtimeMediaSourceCenter::singleton()
 {

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -29,6 +29,7 @@
 #include "RenderSVGResourceClipper.h"
 #include "RenderSVGText.h"
 #include "RenderStyleInlines.h"
+#include "SVGElementInlines.h"
 #include "SVGNames.h"
 #include "StyleResolver.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -50,7 +50,9 @@
 namespace WebKit {
 using namespace WebCore;
 
+#if !HAVE(DISPLAY_LINK)
 static constexpr unsigned c_defaultRefreshRate = 60000;
+#endif
 
 #if HAVE(DISPLAY_LINK)
 Ref<ThreadedCompositor> ThreadedCompositor::create(Client& client, PlatformDisplayID displayID, const IntSize& viewportSize, float scaleFactor, bool flipY)

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -41,8 +41,6 @@
 namespace WebKit {
 using namespace WebCore;
 
-static constexpr OptionSet<ActivityState> focusedActiveWindow = { ActivityState::IsFocused, ActivityState::WindowIsActive };
-
 UserMediaPermissionRequestManager::UserMediaPermissionRequestManager(WebPage& page)
     : m_page(page)
 {


### PR DESCRIPTION
#### 5266976a72254295a50a7047be137de500323818
<pre>
Fix build errors due to unused values and declarations

Unreviewed build fixes.

* Source/JavaScriptCore/b3/B3Value.cpp: Guard B3ValueInternal::alwaysDumpConstructionSite
  with ASSERT_ENABLED, as it is used only inside assertions.
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::cannotBeIdentPartOrEscapeStart): Mark as [[maybe_unused]].
  reached by other code.
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp: Guard
  WasmB3IRGeneratorInternal::traceExecutionIncludesConstructionSite with
  ASSERT_ENABLED, as it is used only inside assertions.
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp: Guard
  AES_CM_128_HMAC_SHA256_NONCE_SIZE with ASSERT_ENABLED, as it is used only
  inside assertions.
* Source/WebCore/css/parser/CSSSelectorParser.cpp: Add missing
  CSSParserIdioms.h header.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp: Remove
  variable checkContextLossHandlingDelay, as it it unused in the code.
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp: Add
  missing RenderStyleInlines.h header, to solve a linker error.
* Source/WebCore/page/OpportunisticTaskScheduler.h: Add missing
  JavaScriptCore/MarkedSpace.h header inclusion.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
  Guard deviceChangeDebounceTimerInterval variable with !USE(GSTREAMER),
  as it is unused when using GStreamer for multimedia.
* Source/WebCore/svg/SVGClipPathElement.cpp: Add missing
  SVGElementInlines.h header inclusion, to solve a linker error.
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
  Guard c_defaultRefreshRate with !HAVE(DISPLAY_LINK), as it is unused
  with DisplayLink enabled.
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
  Remove focusedActiveWindow, as it is not used in the code.

Canonical link: <a href="https://commits.webkit.org/271093@main">https://commits.webkit.org/271093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caf2fc5af55b2c02b0b8d52bde3aeb1875274264

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29526 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24806 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30165 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23765 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30420 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26483 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28370 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5753 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33939 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4745 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7344 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->