### PR TITLE
[Buildstream SDK] Include a gst-libav deadlock fix

### DIFF
--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.7.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.7.patch
@@ -1,17 +1,20 @@
-From 4d1f7f3d481476ce5a7ffc4980cc94536fee6588 Mon Sep 17 00:00:00 2001
+From 297d68b30e6feeda0a399d697f112d31f5d75006 Mon Sep 17 00:00:00 2001
 From: Philippe Normand <philn@igalia.com>
-Date: Wed, 15 Nov 2023 09:08:00 +0000
+Date: Thu, 23 Nov 2023 17:29:44 +0000
 Subject: [PATCH] GStreamer: Bump to 1.22.7
 
+Also include an avviddec deadlock fix scheduled to ship in 1.22.8.
 ---
- elements/components/gstreamer-plugins-good.bst | 1 +
- elements/include/gstreamer-source.yml          | 2 +-
- 2 files changed, 2 insertions(+), 1 deletion(-)
+ .../components/gstreamer-plugins-good.bst     |  1 +
+ elements/include/gstreamer-source.yml         |  2 +-
+ ...stream-lock-while-waiting-for-decode.patch | 33 +++++++++++++++++
  .../gstreamer/graceful-error-noopenh264.patch | 35 -------------------
+ 4 files changed, 35 insertions(+), 36 deletions(-)
+ create mode 100644 patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch
  delete mode 100644 patches/gstreamer/graceful-error-noopenh264.patch
 
 diff --git a/elements/components/gstreamer-plugins-good.bst b/elements/components/gstreamer-plugins-good.bst
-index cea2a324..5d5224a7 100644
+index cea2a32..5d5224a 100644
 --- a/elements/components/gstreamer-plugins-good.bst
 +++ b/elements/components/gstreamer-plugins-good.bst
 @@ -45,6 +45,7 @@ variables:
@@ -34,6 +37,45 @@ index f36b91e..a5050cc 100644
 +  ref: 1.22.7-0-g4d13eddc8b6d3f42ba44682ba42048acf170547f
  - kind: patch_queue
    path: patches/gstreamer
+diff --git a/patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch b/patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch
+new file mode 100644
+index 0000000..40ae478
+--- /dev/null
++++ b/patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch
+@@ -0,0 +1,33 @@
++From f96d05bf52d2e7b97241ed29b019fc5ad573592a Mon Sep 17 00:00:00 2001
++From: Seungha Yang <seungha@centricular.com>
++Date: Fri, 17 Nov 2023 01:01:36 +0900
++Subject: [PATCH] avviddec: Unlock stream lock while waiting for decoded frame
++
++FFmpeg might request buffer from other threads, it will result
++in deadlock
++
++Fixes: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/2558
++Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5683>
++---
++ subprojects/gst-libav/ext/libav/gstavviddec.c | 4 ++++
++ 1 file changed, 4 insertions(+)
++
++diff --git a/subprojects/gst-libav/ext/libav/gstavviddec.c b/subprojects/gst-libav/ext/libav/gstavviddec.c
++index 1c10bb28ce..060b2f7dbe 100644
++--- a/subprojects/gst-libav/ext/libav/gstavviddec.c
+++++ b/subprojects/gst-libav/ext/libav/gstavviddec.c
++@@ -1779,7 +1779,11 @@ gst_ffmpegviddec_video_frame (GstFFMpegVidDec * ffmpegdec,
++    * else we might skip a reference frame */
++   gst_ffmpegviddec_do_qos (ffmpegdec, frame, &mode_switch);
++ 
+++  /* FFmpeg might request new buffer from other threads.
+++   * Release lock here */
+++  GST_VIDEO_DECODER_STREAM_UNLOCK (ffmpegdec);
++   res = avcodec_receive_frame (ffmpegdec->context, ffmpegdec->picture);
+++  GST_VIDEO_DECODER_STREAM_LOCK (ffmpegdec);
++ 
++   /* No frames available at this time */
++   if (res == AVERROR (EAGAIN)) {
++-- 
++2.42.0
++
 diff --git a/patches/gstreamer/graceful-error-noopenh264.patch b/patches/gstreamer/graceful-error-noopenh264.patch
 deleted file mode 100644
 index 8fbe833..0000000
@@ -76,5 +118,5 @@ index 8fbe833..0000000
 -   openh264enc->encoder->SetOption (ENCODER_OPTION_TRACE_LEVEL, &uiTraceLevel);
 - 
 -- 
-2.41.0
+2.42.0
 


### PR DESCRIPTION
#### 9a7be8162f6c9a7372abf927e5fd22fae849ef87
<pre>
[Buildstream SDK] Include a gst-libav deadlock fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=265291">https://bugs.webkit.org/show_bug.cgi?id=265291</a>

Reviewed by Carlos Alberto Lopez Perez.

This avviddec deadlock might be happening when running the webgl tests and causing FD leaks. The
patch will ship in 1.22.8, so for the time being, vendor it in our SDK.

* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.7.patch:

Canonical link: <a href="https://commits.webkit.org/271084@main">https://commits.webkit.org/271084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aad4ab102f1154dd1c545f3d4c12990ebedcc342

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29499 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3314 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24823 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2408 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4720 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3526 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->