### PR TITLE
[WebXR] Fullscreen AR immersive mode

### DIFF
--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -41,6 +41,7 @@ namespace WebKit {
 
 class ARKitCoordinator final : public PlatformXRCoordinator {
     WTF_MAKE_FAST_ALLOCATED;
+    struct RenderState;
 public:
     ARKitCoordinator();
     virtual ~ARKitCoordinator() = default;
@@ -56,8 +57,8 @@ public:
 
 protected:
     void createSessionIfNeeded();
-    void currentSessionHasEnded();
-    void renderLoop();
+    void endSessionIfExists(std::optional<WebCore::PageIdentifier>);
+    void renderLoop(Box<RenderState>);
 
 private:
     XRDeviceIdentifier m_deviceIdentifier = XRDeviceIdentifier::generate();
@@ -66,18 +67,13 @@ private:
     struct Idle {
     };
     struct Active {
+        WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
         WebCore::PageIdentifier pageIdentifier;
-        WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
-        PlatformXR::Device::RequestFrameCallback onFrameUpdate;
-        RetainPtr<id<WKARPresentationSession>> presentationSession;
+        Box<RenderState> renderState;
         RefPtr<Thread> renderThread;
-        Box<BinarySemaphore> renderSemaphore;
-    };
-    struct Terminating {
-        WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
     };
 
-    using State = std::variant<Idle, Active, Terminating>;
+    using State = std::variant<Idle, Active>;
     State m_state;
 };
 

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -40,6 +40,13 @@
 
 namespace WebKit {
 
+struct ARKitCoordinator::RenderState {
+    RetainPtr<id<WKARPresentationSession>> presentationSession;
+    PlatformXR::Device::RequestFrameCallback onFrameUpdate;
+    BinarySemaphore presentFrame;
+    std::atomic<bool> terminateRequested;
+};
+
 static std::tuple<MachSendRight, bool> makeMachSendRight(id<MTLTexture> texture)
 {
     RetainPtr<MTLSharedTextureHandle> sharedTextureHandle = adoptNS([texture newSharedTextureHandle]);
@@ -119,23 +126,25 @@ void ARKitCoordinator::startSession(WebPageProxy& page, WeakPtr<SessionEventClie
 
             auto presentationSession = adoptNS(createPresesentationSession(m_session.get(), presentationSessionDesc.get()));
 
+            auto renderState = Box<RenderState>::create();
+            renderState->presentationSession = WTFMove(presentationSession);
+            renderState->terminateRequested = false;
+
             m_state = Active {
-                .pageIdentifier = page.webPageID(),
                 .sessionEventClient = WTFMove(sessionEventClient),
-                .presentationSession = WTFMove(presentationSession),
-                .renderThread = Thread::create("ARKitCoordinator session renderer", [this] { renderLoop(); }),
-                .renderSemaphore = Box<BinarySemaphore>::create(),
+                .pageIdentifier = page.webPageID(),
+                .renderState = renderState,
+                .renderThread = Thread::create("ARKitCoordinator session renderer", [this, renderState] { renderLoop(renderState); }),
             };
         },
         [&](Active&) {
             RELEASE_LOG_ERROR(XR, "ARKitCoordinator: an existing immersive session is active");
             if (sessionEventClient)
                 sessionEventClient->sessionDidEnd(m_deviceIdentifier);
-        },
-        [&](Terminating&) { });
+        });
 }
 
-void ARKitCoordinator::endSessionIfExists(WebPageProxy& page)
+void ARKitCoordinator::endSessionIfExists(std::optional<WebCore::PageIdentifier> pageIdentifier)
 {
     RELEASE_LOG(XR, "ARKitCoordinator::endSessionIfExists");
     ASSERT(RunLoop::isMain());
@@ -143,19 +152,35 @@ void ARKitCoordinator::endSessionIfExists(WebPageProxy& page)
     WTF::switchOn(m_state,
         [&](Idle&) { },
         [&](Active& active) {
-            if (active.pageIdentifier != page.webPageID()) {
+            if (pageIdentifier && active.pageIdentifier != *pageIdentifier) {
                 RELEASE_LOG(XR, "ARKitCoordinator: trying to end an immersive session owned by another page");
                 return;
             }
 
-            if (active.onFrameUpdate)
-                active.onFrameUpdate({ });
+            if (active.renderState->terminateRequested)
+                return;
 
-            active.renderSemaphore->signal();
+            active.renderState->terminateRequested = true;
+            active.renderState->presentFrame.signal();
+            active.renderThread->waitForCompletion();
 
-            m_state = Terminating { WTFMove(active.sessionEventClient) };
-        },
-        [&](Terminating&) { });
+            if (active.renderState->onFrameUpdate)
+                active.renderState->onFrameUpdate({ });
+
+            auto& sessionEventClient = active.sessionEventClient;
+            if (sessionEventClient) {
+                RELEASE_LOG(XR, "... immersive session end sent");
+                sessionEventClient->sessionDidEnd(m_deviceIdentifier);
+            }
+
+            m_state = Idle { };
+        });
+}
+
+
+void ARKitCoordinator::endSessionIfExists(WebPageProxy& page)
+{
+    endSessionIfExists(page.webPageID());
 }
 
 void ARKitCoordinator::scheduleAnimationFrame(WebPageProxy& page, PlatformXR::Device::RequestFrameCallback&& onFrameUpdateCallback)
@@ -172,11 +197,12 @@ void ARKitCoordinator::scheduleAnimationFrame(WebPageProxy& page, PlatformXR::De
                 return;
             }
 
-            active.onFrameUpdate = WTFMove(onFrameUpdateCallback);
-        },
-        [&](Terminating&) {
-            RELEASE_LOG(XR, "ARKitCoordinator: trying to schedule frame for terminating session");
-            onFrameUpdateCallback({ });
+            if (active.renderState->terminateRequested) {
+                RELEASE_LOG(XR, "ARKitCoordinator: trying to schedule frame for terminating session");
+                onFrameUpdateCallback({ });
+            }
+
+            active.renderState->onFrameUpdate = WTFMove(onFrameUpdateCallback);
         });
 }
 
@@ -194,13 +220,15 @@ void ARKitCoordinator::submitFrame(WebPageProxy& page)
                 return;
             }
 
+            if (WTF::atomicLoad(&active.renderState->terminateRequested)) {
+                RELEASE_LOG(XR, "ARKitCoordinator: trying to submit frame update for a terminating session");
+                return;
+            }
+
             // FIXME: rdar://118492973 (Re-enable MTLSharedEvent completion sync)
             // Replace frame presentation to depend on
             // active.presentationSession.completionEvent
-            active.renderSemaphore->signal();
-        },
-        [&](Terminating&) {
-            RELEASE_LOG(XR, "ARKitCoordinator: trying to submit frame update for a terminating session");
+            active.renderState->presentFrame.signal();
         });
 }
 
@@ -215,36 +243,27 @@ void ARKitCoordinator::createSessionIfNeeded()
     m_session = adoptNS([WebKit::allocARSessionInstance() init]);
 }
 
-void ARKitCoordinator::currentSessionHasEnded()
-{
-    ASSERT(RunLoop::isMain());
-    RELEASE_LOG(XR, "ARKitCoordinator::currentSessionHasEnded");
-
-    if (auto* terminating = std::get_if<Terminating>(&m_state)) {
-        auto& sessionEventClient = terminating->sessionEventClient;
-        if (sessionEventClient)
-            sessionEventClient->sessionDidEnd(m_deviceIdentifier);
-    }
-
-    RELEASE_LOG(XR, "... immersive session ended");
-    m_state = Idle { };
-}
-
-void ARKitCoordinator::renderLoop()
+void ARKitCoordinator::renderLoop(Box<RenderState> active)
 {
     for (;;) {
-        auto* maybeActive = std::get_if<Active>(&m_state);
-        if (!maybeActive)
+        if (active->terminateRequested)
             break;
 
-        auto& active = *maybeActive;
-        if (!active.onFrameUpdate)
+        if ([active->presentationSession isSessionEndRequested]) {
+            callOnMainRunLoop([this]() {
+                endSessionIfExists(std::nullopt);
+            });
+            break;
+        }
+
+        if (!active->onFrameUpdate)
             continue;
 
         @autoreleasepool {
-            [active.presentationSession startFrame];
+            id<WKARPresentationSession> presentationSession = active->presentationSession.get();
+            [presentationSession startFrame];
 
-            ARFrame* frame = [active.presentationSession currentFrame];
+            ARFrame* frame = presentationSession.currentFrame;
             ARCamera* camera = frame.camera;
 
             PlatformXR::Device::FrameData frameData = { };
@@ -261,10 +280,10 @@ void ARKitCoordinator::renderLoop()
                     PlatformXRPose(frame.camera.projectionMatrix).toColumnMajorFloatArray()
                 },
             });
-            auto colorTexture = makeMachSendRight([active.presentationSession colorTexture]);
-            auto renderingFrameIndex = [active.presentationSession renderingFrameIndex];
+            auto colorTexture = makeMachSendRight(presentationSession.colorTexture);
+            auto renderingFrameIndex = presentationSession.renderingFrameIndex;
             // FIXME: Send this event once at setup time, not every frame.
-            id<MTLSharedEvent> completionEvent = [active.presentationSession completionEvent];
+            id<MTLSharedEvent> completionEvent = presentationSession.completionEvent;
             RetainPtr<MTLSharedEventHandle> completionHandle = adoptNS([completionEvent newSharedEventHandle]);
             auto completionPort = MachSendRight::create([completionHandle.get() eventPort]);
 
@@ -275,19 +294,17 @@ void ARKitCoordinator::renderLoop()
             });
             frameData.shouldRender = true;
 
-            callOnMainRunLoop([callback = WTFMove(active.onFrameUpdate), frameData = WTFMove(frameData)]() mutable {
+            callOnMainRunLoop([callback = WTFMove(active->onFrameUpdate), frameData = WTFMove(frameData)]() mutable {
                 callback(WTFMove(frameData));
             });
 
-            active.renderSemaphore->wait();
+            active->presentFrame.wait();
 
-            [active.presentationSession present];
+            [presentationSession present];
         }
     }
 
-    callOnMainRunLoop([this]() {
-        currentSessionHasEnded();
-    });
+    RELEASE_LOG(XR, "ARKitCoordinator::renderLoop exiting...");
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nonnull, retain, readonly) id<MTLSharedEvent> completionEvent;
 @property (nonatomic, nullable, retain, readonly) id<MTLTexture> colorTexture;
 @property (nonatomic, readonly) NSUInteger renderingFrameIndex;
+@property (atomic, readonly, getter=isSessionEndRequested) BOOL sessionEndRequested;
 
 - (NSUInteger)startFrame;
 - (void)present;


### PR DESCRIPTION
#### 481f557cdcb267e860b6563809cd6acee3be8126
<pre>
[WebXR] Fullscreen AR immersive mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=265297">https://bugs.webkit.org/show_bug.cgi?id=265297</a>
<a href="https://rdar.apple.com/118759729">rdar://118759729</a>

Reviewed by Dean Jackson.

Implement gesture to exit AR immersive mode and display content fullscreen.

To correctly exit RenderLoop thread with out removing backing state, termination
handling has been re-written to ensure that the thread has shutdown before
switching state. This removes the need for the Terminating state, which has been
removed.

* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
(WebKit::ARKitCoordinator::endSessionIfExists):
(WebKit::ARKitCoordinator::endSession):
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
(WebKit::ARKitCoordinator::submitFrame):
(WebKit::ARKitCoordinator::renderLoop):
(WebKit::ARKitCoordinator::currentSessionHasEnded): Deleted.
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[_WKARPresentationSession initWithSession:descriptor:]):
(-[_WKARPresentationSession viewDidLoad]):
(-[_WKARPresentationSession _cancelAction:]):
(-[_WKARPresentationSession _enterFullscreen]):
(-[_WKARPresentationSession _exitFullscreen]):

Canonical link: <a href="https://commits.webkit.org/271188@main">https://commits.webkit.org/271188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1524a54feb3a9a50b1c3b2478e56eb4bfe01a983

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25275 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3683 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4380 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25152 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2716 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6066 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6636 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->