### PR TITLE
Use dynamicDowncast<T> more in RenderTheme

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -292,31 +292,31 @@ inline bool is(const Ref<ArgType, PtrTraits>& source)
 }
 
 template<typename Target, typename Source, typename PtrTraits>
-inline Ref<Target> checkedDowncast(Ref<Source, PtrTraits> source)
+inline Ref<match_constness_t<Source, Target>> checkedDowncast(Ref<Source, PtrTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     RELEASE_ASSERT(is<Target>(source));
-    return static_reference_cast<Target>(WTFMove(source));
+    return static_reference_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 
 template<typename Target, typename Source, typename PtrTraits>
-inline Ref<Target> downcast(Ref<Source, PtrTraits> source)
+inline Ref<match_constness_t<Source, Target>> downcast(Ref<Source, PtrTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
-    return static_reference_cast<Target>(WTFMove(source));
+    return static_reference_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 
 template<typename Target, typename Source, typename PtrTraits>
-inline RefPtr<Target> dynamicDowncast(Ref<Source, PtrTraits> source)
+inline RefPtr<match_constness_t<Source, Target>> dynamicDowncast(Ref<Source, PtrTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     if (!is<Target>(source))
         return nullptr;
-    return static_reference_cast<Target>(WTFMove(source));
+    return static_reference_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -259,32 +259,32 @@ inline bool is(const RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
 }
 
 template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
-inline RefPtr<Target> checkedDowncast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
+inline RefPtr<match_constness_t<Source, Target>> checkedDowncast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     RELEASE_ASSERT(!source || is<Target>(*source));
-    return static_pointer_cast<Target>(WTFMove(source));
+    return static_pointer_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 
 template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
-inline RefPtr<Target> downcast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
+inline RefPtr<match_constness_t<Source, Target>> downcast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
-    return static_pointer_cast<Target>(WTFMove(source));
+    return static_pointer_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 
 template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename TargetRefDerefTraits = DefaultRefDerefTraits<Target>,
     typename SourcePtrTraits, typename SourceRefDerefTraits>
-inline RefPtr<Target, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits> source)
+inline RefPtr<match_constness_t<Source, Target>, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     if (!is<Target>(source))
         return nullptr;
-    return static_pointer_cast<Target, TargetPtrTraits, TargetRefDerefTraits>(WTFMove(source));
+    return static_pointer_cast<match_constness_t<Source, Target>, TargetPtrTraits, TargetRefDerefTraits>(WTFMove(source));
 }
 
 } // namespace WTF

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -251,11 +251,10 @@ void RenderThemeIOS::adjustTextFieldStyle(RenderStyle& style, const Element* ele
     bool hasTextfieldAppearance = false;
     // Do not force a background color for elements that have a textfield
     // appearance by default, so that their background color can be styled.
-    if (is<HTMLInputElement>(*element)) {
-        auto& input = downcast<HTMLInputElement>(*element);
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element)) {
         // <input type=search> is the only TextFieldInputType that has a
         // non-textfield appearance value.
-        hasTextfieldAppearance = input.isTextField() && !input.isSearchField();
+        hasTextfieldAppearance = input->isTextField() && !input->isSearchField();
     }
 
     auto adjustBackgroundColor = [&] {
@@ -316,9 +315,8 @@ void RenderThemeIOS::paintTextFieldDecorations(const RenderBox& box, const Paint
 
     auto shouldPaintFillAndInnerShadow = false;
     auto element = box.element();
-    if (is<HTMLInputElement>(*element)) {
-        auto& input = downcast<HTMLInputElement>(*element);
-        if (input.isTextField() && !input.isSearchField())
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element)) {
+        if (input->isTextField() && !input->isSearchField())
             shouldPaintFillAndInnerShadow = true;
     } else if (is<HTMLTextAreaElement>(*element))
         shouldPaintFillAndInnerShadow = true;
@@ -503,8 +501,8 @@ void RenderThemeIOS::adjustMenuListButtonStyle(RenderStyle& style, const Element
     // "-webkit-appearance: menulist-button".
     if (is<HTMLSelectElement>(*element) && !element->hasAttributeWithoutSynchronization(HTMLNames::multipleAttr))
         adjustSelectListButtonStyle(style, *element);
-    else if (is<HTMLInputElement>(*element))
-        adjustInputElementButtonStyle(style, downcast<HTMLInputElement>(*element));
+    else if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element))
+        adjustInputElementButtonStyle(style, *input);
 }
 
 void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
@@ -614,9 +612,9 @@ constexpr auto nativeControlBorderInlineSize = 1.0f;
 
 bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
 {
-    if (!is<RenderSlider>(box))
+    auto* renderSlider = dynamicDowncast<RenderSlider>(box);
+    if (!renderSlider)
         return true;
-    auto& renderSlider = downcast<RenderSlider>(box);
 
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
@@ -666,7 +664,7 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
     paintSliderTicks(box, paintInfo, trackClip);
 #endif
 
-    double valueRatio = renderSlider.valueRatio();
+    double valueRatio = renderSlider->valueRatio();
     if (isHorizontal) {
         double newWidth = trackClip.width() * valueRatio;
 
@@ -708,9 +706,9 @@ constexpr auto reducedMotionProgressAnimationMaxOpacity = 0.6f;
 
 bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
 {
-    if (!is<RenderProgress>(renderer))
+    auto* renderProgress = dynamicDowncast<RenderProgress>(renderer);
+    if (!renderProgress)
         return true;
-    auto& renderProgress = downcast<RenderProgress>(renderer);
 
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
@@ -759,13 +757,13 @@ bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintI
     float barBlockStart = trackBlockStart;
     float alpha = 1.0f;
 
-    if (renderProgress.isDeterminate()) {
-        barInlineSize = clampTo<float>(renderProgress.position(), 0.0f, 1.0f) * trackInlineSize;
+    if (renderProgress->isDeterminate()) {
+        barInlineSize = clampTo<float>(renderProgress->position(), 0.0f, 1.0f) * trackInlineSize;
 
-        if (!renderProgress.style().isLeftToRightDirection())
+        if (!renderProgress->style().isLeftToRightDirection())
             barInlineStart = trackInlineStart + trackInlineSize - barInlineSize;
     } else {
-        Seconds elapsed = MonotonicTime::now() - renderProgress.animationStartTime();
+        Seconds elapsed = MonotonicTime::now() - renderProgress->animationStartTime();
         float position = fmodf(elapsed.value(), 1.0f);
         bool reverseDirection = static_cast<int>(elapsed.value()) % 2;
 
@@ -837,11 +835,11 @@ constexpr auto pressedStateOpacity = 0.75f;
 
 bool RenderThemeIOS::isSubmitStyleButton(const Element& element) const
 {
-    if (is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isSubmitButton())
-        return true;
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(element))
+        return input->isSubmitButton();
 
-    if (is<HTMLButtonElement>(element) && downcast<HTMLButtonElement>(element).isExplicitlySetSubmitButton())
-        return true;
+    if (RefPtr button = dynamicDowncast<HTMLButtonElement>(element))
+        return button->isExplicitlySetSubmitButton();
 
     return false;
 }
@@ -1299,22 +1297,21 @@ static void paintAttachmentBorder(GraphicsContext& context, Path& borderPath)
 
 bool RenderThemeIOS::paintAttachment(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& paintRect)
 {
-    if (!is<RenderAttachment>(renderer))
+    auto* attachment = dynamicDowncast<RenderAttachment>(renderer);
+    if (!attachment)
         return false;
 
-    const RenderAttachment& attachment = downcast<RenderAttachment>(renderer);
-
-    if (attachment.paintWideLayoutAttachmentOnly(paintInfo, paintRect.location()))
+    if (attachment->paintWideLayoutAttachmentOnly(paintInfo, paintRect.location()))
         return true;
 
-    AttachmentLayout info(attachment);
+    AttachmentLayout info(*attachment);
 
     GraphicsContext& context = paintInfo.context();
     GraphicsContextStateSaver saver(context);
 
     context.translate(toFloatSize(paintRect.location()));
 
-    if (attachment.shouldDrawBorder()) {
+    if (attachment->shouldDrawBorder()) {
         auto borderPath = attachmentBorderPath(info);
         paintAttachmentBorder(context, borderPath);
         context.clipPath(borderPath);
@@ -1615,11 +1612,11 @@ bool RenderThemeIOS::supportsMeter(StyleAppearance appearance) const
 
 bool RenderThemeIOS::paintMeter(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
 {
-    if (!is<RenderMeter>(renderer))
+    auto* renderMeter = dynamicDowncast<RenderMeter>(renderer);
+    if (!renderMeter)
         return true;
 
-    auto& renderMeter = downcast<RenderMeter>(renderer);
-    RefPtr element = renderMeter.meterElement();
+    RefPtr element = renderMeter->meterElement();
 
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
@@ -1714,19 +1711,16 @@ bool RenderThemeIOS::paintListButton(const RenderObject& box, const PaintInfo& p
 
 void RenderThemeIOS::paintSliderTicks(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
-    if (!is<HTMLInputElement>(box.node()))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(box.node());
+    if (!input || !input->isRangeControl())
         return;
 
-    auto& input = downcast<HTMLInputElement>(*box.node());
-    if (!input.isRangeControl())
-        return;
-
-    auto dataList = input.dataList();
+    auto dataList = input->dataList();
     if (!dataList)
         return;
 
-    double min = input.minimum();
-    double max = input.maximum();
+    double min = input->minimum();
+    double max = input->maximum();
     if (min >= max)
         return;
 
@@ -1751,13 +1745,13 @@ void RenderThemeIOS::paintSliderTicks(const RenderObject& box, const PaintInfo& 
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
-    auto value = input.valueAsNumber();
+    auto value = input->valueAsNumber();
     auto deviceScaleFactor = box.document().deviceScaleFactor();
     auto styleColorOptions = box.styleColorOptions();
 
     bool isReversedInlineDirection = (!isHorizontal && box.style().isHorizontalWritingMode()) || !box.style().isLeftToRightDirection();
     for (auto& optionElement : dataList->suggestions()) {
-        if (auto optionValue = input.listOptionValueAsDouble(optionElement)) {
+        if (auto optionValue = input->listOptionValueAsDouble(optionElement)) {
             auto tickFraction = (*optionValue - min) / (max - min);
             auto tickRatio = isReversedInlineDirection ? 1.0 - tickFraction : tickFraction;
             if (isHorizontal)

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1609,21 +1609,20 @@ static void paintAttachmentPlaceholderBorder(const RenderAttachment& attachment,
 
 bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& paintRect)
 {
-    if (!is<RenderAttachment>(renderer))
+    auto* attachment = dynamicDowncast<RenderAttachment>(renderer);
+    if (!attachment)
         return false;
 
-    const RenderAttachment& attachment = downcast<RenderAttachment>(renderer);
-
-    if (attachment.paintWideLayoutAttachmentOnly(paintInfo, paintRect.location()))
+    if (attachment->paintWideLayoutAttachmentOnly(paintInfo, paintRect.location()))
         return true;
 
-    HTMLAttachmentElement& element = attachment.attachmentElement();
+    HTMLAttachmentElement& element = attachment->attachmentElement();
 
     auto layoutStyle = AttachmentLayoutStyle::NonSelected;
-    if (attachment.selectionState() != RenderObject::HighlightState::None && paintInfo.phase != PaintPhase::Selection)
+    if (attachment->selectionState() != RenderObject::HighlightState::None && paintInfo.phase != PaintPhase::Selection)
         layoutStyle = AttachmentLayoutStyle::Selected;
 
-    AttachmentLayout layout(attachment, layoutStyle);
+    AttachmentLayout layout(*attachment, layoutStyle);
 
     auto& progressString = element.attributeWithoutSynchronization(progressAttr);
     bool validProgress = false;
@@ -1639,21 +1638,21 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
 
     bool usePlaceholder = validProgress && !progress;
 
-    paintAttachmentIconBackground(attachment, context, layout);
+    paintAttachmentIconBackground(*attachment, context, layout);
 
     if (usePlaceholder)
-        paintAttachmentIconPlaceholder(attachment, context, layout);
+        paintAttachmentIconPlaceholder(*attachment, context, layout);
     else
-        paintAttachmentIcon(attachment, context, layout);
+        paintAttachmentIcon(*attachment, context, layout);
 
-    paintAttachmentTitleBackground(attachment, context, layout);
+    paintAttachmentTitleBackground(*attachment, context, layout);
     paintAttachmentText(context, &layout);
 
     if (validProgress && progress)
-        paintAttachmentProgress(attachment, context, layout, progress);
+        paintAttachmentProgress(*attachment, context, layout, progress);
 
     if (usePlaceholder)
-        paintAttachmentPlaceholderBorder(attachment, context, layout);
+        paintAttachmentPlaceholderBorder(*attachment, context, layout);
 
     return true;
 }


### PR DESCRIPTION
#### b6d576d54824560544da2e793ca9625b54d1989b
<pre>
Use dynamicDowncast&lt;T&gt; more in RenderTheme
<a href="https://bugs.webkit.org/show_bug.cgi?id=265299">https://bugs.webkit.org/show_bug.cgi?id=265299</a>

Reviewed by Chris Dumez and Darin Adler.

A few instances of downcast&lt;T&gt; remain due to asserts or not being
preceded by an equivalent is&lt;T&gt; check.

Also use RefPtr where possible and use clearer variable names for
impacted methods.

This includes a change by cdumez to Ref and RefPtr that makes the
various downcast methods work with const.

* Source/WTF/wtf/Ref.h:
(WTF::checkedDowncast):
(WTF::downcast):
(WTF::dynamicDowncast):
* Source/WTF/wtf/RefPtr.h:
(WTF::checkedDowncast):
(WTF::downcast):
(WTF::dynamicDowncast):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::extractControlStyleForRenderer const):
(WebCore::RenderTheme::isChecked const):
(WebCore::RenderTheme::isIndeterminate const):
(WebCore::RenderTheme::isEnabled const):
(WebCore::RenderTheme::isFocused const):
(WebCore::RenderTheme::isPresenting const):
(WebCore::RenderTheme::hasListButton const):
(WebCore::RenderTheme::hasListButtonPressed const):
(WebCore::RenderTheme::paintSliderTicks):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustTextFieldStyle const):
(WebCore::RenderThemeIOS::paintTextFieldDecorations):
(WebCore::RenderThemeIOS::adjustMenuListButtonStyle const):
(WebCore::RenderThemeIOS::paintSliderTrack):
(WebCore::RenderThemeIOS::paintProgressBar):
(WebCore::RenderThemeIOS::isSubmitStyleButton const):
(WebCore::RenderThemeIOS::paintAttachment):
(WebCore::RenderThemeIOS::paintMeter):
(WebCore::RenderThemeIOS::paintSliderTicks):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::paintAttachment):

Canonical link: <a href="https://commits.webkit.org/271170@main">https://commits.webkit.org/271170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de2f8a7c4769940f8c86016f3ea3a37d9d530f5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24970 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30369 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23921 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30596 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26682 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2618 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5947 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34140 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4936 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7394 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3557 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->