### PR TITLE
Move renderer invalidity into a separate bit, out from Style::Validity enum

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2421,8 +2421,7 @@ void Element::invalidateStyleForSubtree()
 
 void Element::invalidateStyleAndRenderersForSubtree()
 {
-    Node::invalidateStyle(Style::Validity::SubtreeAndRenderersInvalid);
-    invalidateSiblingsIfNeeded(*this);
+    Node::invalidateStyle(Style::Validity::SubtreeInvalid, Style::InvalidationMode::RebuildRenderer);
 }
 
 void Element::invalidateStyleInternal()

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -199,7 +199,7 @@ void Text::updateRendererAfterContentChange(unsigned offsetOfReplacedData, unsig
     if (!isConnected())
         return;
 
-    if (styleValidity() >= Style::Validity::SubtreeAndRenderersInvalid)
+    if (hasInvalidRenderer())
         return;
 
     protectedDocument()->updateTextRenderer(*this, offsetOfReplacedData, lengthOfReplacedData);

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -176,7 +176,6 @@ Invalidator::CheckDescendants Invalidator::invalidateIfNeeded(Element& element, 
     case Validity::ElementInvalid:
         return CheckDescendants::Yes;
     case Validity::SubtreeInvalid:
-    case Validity::SubtreeAndRenderersInvalid:
         return CheckDescendants::No;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -650,8 +650,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
 
     auto change = oldStyle ? determineChange(*oldStyle, *newStyle) : Change::Renderer;
 
-    auto validity = element.styleValidity();
-    if (validity >= Validity::SubtreeAndRenderersInvalid || parentChange == Change::Renderer)
+    if (element.hasInvalidRenderer() || parentChange == Change::Renderer)
         change = Change::Renderer;
 
     bool shouldRecompositeLayer = animationImpact.contains(AnimationImpact::RequiresRecomposite) || element.styleResolutionShouldRecompositeLayer();
@@ -843,7 +842,7 @@ void TreeResolver::resolveComposedTree()
         if (is<Text>(node)) {
             auto& text = downcast<Text>(node);
             
-            if ((text.styleValidity() >= Validity::SubtreeAndRenderersInvalid && parent.change != Change::Renderer) || parent.style.display() == DisplayType::Contents) {
+            if ((text.hasInvalidRenderer() && parent.change != Change::Renderer) || parent.style.display() == DisplayType::Contents) {
                 TextUpdate textUpdate;
                 textUpdate.inheritedDisplayContentsStyle = createInheritedDisplayContentsStyleIfNeeded(parent.style, parentBoxStyle());
 

--- a/Source/WebCore/style/StyleValidity.h
+++ b/Source/WebCore/style/StyleValidity.h
@@ -33,12 +33,13 @@ enum class Validity : uint8_t {
     AnimationInvalid,
     ElementInvalid,
     SubtreeInvalid,
-    SubtreeAndRenderersInvalid
 };
 
 enum class InvalidationMode : uint8_t {
     Normal,
-    RecompositeLayer
+    RecompositeLayer,
+    RebuildRenderer,
+    InsertedIntoAncestor
 };
 
 enum class InvalidationScope : uint8_t {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -832,8 +832,6 @@ static String styleValidityToToString(Style::Validity validity)
         return "InlineStyleChange"_s;
     case Style::Validity::SubtreeInvalid:
         return "FullStyleChange"_s;
-    case Style::Validity::SubtreeAndRenderersInvalid:
-        return "ReconstructRenderTree"_s;
     }
     ASSERT_NOT_REACHED();
     return emptyString();


### PR DESCRIPTION
#### e3d93fff672a15f0117befd91a416acae9681d57
<pre>
Move renderer invalidity into a separate bit, out from Style::Validity enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=265311">https://bugs.webkit.org/show_bug.cgi?id=265311</a>
<a href="https://rdar.apple.com/problem/118772735">rdar://problem/118772735</a>

Reviewed by Alan Baradlay.

Make it possible to mark a render subtree for rebuild without needing to recompute the style.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateStyleAndRenderersForSubtree):

Also remove unncesssary sibling invalidation. It is a leftover from old pseudo-class invalidation code.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::adjustStyleValidity):

Make renderer invalidity a style flag.

(WebCore::Node::invalidateStyle):

Also add an invalidation mode for newly inserted nodes. Those will always need to invalidate the renderer and the ancestor chain.

(WebCore::Node::insertedIntoAncestor):
* Source/WebCore/dom/Node.h:
(WebCore::Node::needsStyleRecalc const):
(WebCore::Node::hasInvalidRenderer const):
(WebCore::Node::setHasValidStyle):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::updateRendererAfterContentChange):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateIfNeeded):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::resolveComposedTree):
* Source/WebCore/style/StyleValidity.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::styleValidityToToString):

Canonical link: <a href="https://commits.webkit.org/271144@main">https://commits.webkit.org/271144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e1b600b418e1b5810ed1dc49625be1f572b4a06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29716 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3524 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4284 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25118 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/25024 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2602 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5930 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6608 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->