### PR TITLE
[Navigation] Implement Navigation::Result binding

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -77,6 +77,11 @@ template<typename T> struct JSConverter<IDLPromise<T>> {
         return promise.promise();
     }
 
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, RefPtr<DOMPromise> promise)
+    {
+        return promise->promise();
+    }
+
     template<template<typename> class U>
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, U<T>& promiseProxy)
     {

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -449,6 +449,9 @@
         "ReturnsOwnPromise": {
             "contextsAllowed": ["operation"]
         },
+        "ReturnsPromisePair": {
+            "contextsAllowed": ["operation"]
+        },
         "ReturnValue": {
             "contextsAllowed": ["argument"]
         },

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -235,5 +235,7 @@ template<> TestObj::ConditionalDictionaryC convertDictionary<TestObj::Conditiona
 
 #endif
 
+template<> TestObj::PromisePair convertDictionary<TestObj::PromisePair>(JSC::JSGlobalObject&, JSC::JSValue);
+
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -78,6 +78,7 @@ enum TestConfidence { "high", "kinda-low" };
     [LegacyLenientSetter] readonly attribute DOMString legacyLenientSetterTestAttr;
     [LegacyLenientThis] attribute TestObj lenientTestObjAttr;
     [LegacyUnforgeable] readonly attribute DOMString unforgeableAttr;
+    [ReturnsPromisePair] PromisePair returnsPromisePair();
     attribute [LegacyNullToEmptyString] DOMString stringAttrTreatingNullAsEmptyString;
     attribute [LegacyNullToEmptyString] USVString usvstringAttrTreatingNullAsEmptyString;
     attribute [LegacyNullToEmptyString] ByteString byteStringAttrTreatingNullAsEmptyString;
@@ -574,4 +575,9 @@ dictionary ChildDictionary : ParentDictionary {
     Conditional=Condition1|Condition2
 ] dictionary TestConditionalDictionaryC {
     DOMString stringWithoutDefault;
+};
+
+dictionary PromisePair {
+    Promise<undefined> promise1;
+    Promise<undefined> promise2;
 };

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "Navigation.h"
 
+#include "JSNavigationHistoryEntry.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -36,11 +37,6 @@ Navigation::Navigation(ScriptExecutionContext* context, LocalDOMWindow& window)
     : ContextDestructionObserver(context)
     , LocalDOMWindowProperty(&window)
 {
-}
-
-static Navigation::Result createNewResult()
-{
-    return { };
 }
 
 Navigation::~Navigation() = default;
@@ -55,29 +51,59 @@ EventTargetInterface Navigation::eventTargetInterface() const
     return NavigationEventTargetInterfaceType;
 }
 
-Navigation::Result Navigation::navigate(const String& /* url */, NavigateOptions&&)
+Navigation::Result Navigation::navigate(const String& /* url */, NavigateOptions&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    return createNewResult();
+    // FIXME: keep track of promises to resolve later.
+    auto entry = NavigationHistoryEntry::create(scriptExecutionContext());
+    auto globalObject = committed->globalObject();
+    Navigation::Result result = { DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(committed->promise())), DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(finished->promise())) };
+    committed->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    finished->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    return result;
 }
 
-Navigation::Result Navigation::reload(ReloadOptions&&)
+Navigation::Result Navigation::reload(ReloadOptions&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    return createNewResult();
+    // FIXME: keep track of promises to resolve later.
+    auto entry = NavigationHistoryEntry::create(scriptExecutionContext());
+    auto globalObject = committed->globalObject();
+    Navigation::Result result = { DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(committed->promise())), DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(finished->promise())) };
+    committed->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    finished->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    return result;
 }
 
-Navigation::Result Navigation::traverseTo(const String& /* key */, Options&&)
+Navigation::Result Navigation::traverseTo(const String& /* key */, Options&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    return createNewResult();
+    // FIXME: keep track of promises to resolve later.
+    auto entry = NavigationHistoryEntry::create(scriptExecutionContext());
+    auto globalObject = committed->globalObject();
+    Navigation::Result result = { DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(committed->promise())), DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(finished->promise())) };
+    committed->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    finished->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    return result;
 }
 
-Navigation::Result Navigation::back(Options&&)
+Navigation::Result Navigation::back(Options&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    return createNewResult();
+    // FIXME: keep track of promises to resolve later.
+    auto entry = NavigationHistoryEntry::create(scriptExecutionContext());
+    auto globalObject = committed->globalObject();
+    Navigation::Result result = { DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(committed->promise())), DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(finished->promise())) };
+    committed->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    finished->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    return result;
 }
 
-Navigation::Result Navigation::forward(Options&&)
+Navigation::Result Navigation::forward(Options&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    return createNewResult();
+    // FIXME: keep track of promises to resolve later.
+    auto entry = NavigationHistoryEntry::create(scriptExecutionContext());
+    auto globalObject = committed->globalObject();
+    Navigation::Result result = { DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(committed->promise())), DOMPromise::create(*globalObject, *JSC::jsCast<JSC::JSPromise*>(finished->promise())) };
+    committed->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    finished->resolve<IDLInterface<NavigationHistoryEntry>>(entry.get());
+    return result;
 }
 
 void Navigation::updateCurrentEntry(UpdateCurrentEntryOptions&&)

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -27,12 +27,15 @@
 
 #include "DOMPromiseProxy.h"
 #include "EventTarget.h"
+#include "JSDOMPromise.h"
 #include "LocalDOMWindowProperty.h"
 #include "NavigationHistoryEntry.h"
 #include "NavigationTransition.h"
 #include <JavaScriptCore/JSCJSValue.h>
 
 namespace WebCore {
+
+template<typename IDLType> class DOMPromiseDeferred;
 
 class Navigation final : public RefCounted<Navigation>, public EventTarget, public ContextDestructionObserver, public LocalDOMWindowProperty {
     WTF_MAKE_ISO_ALLOCATED(Navigation);
@@ -68,9 +71,8 @@ public:
     };
 
     struct Result {
-        bool todo;
-        // NavigationHistoryEntryPromise committed;
-        // NavigationHistoryEntryPromise finished;
+        RefPtr<DOMPromise> committed;
+        RefPtr<DOMPromise> finished;
     };
 
     Vector<Ref<NavigationHistoryEntry>> entries() { return m_entries; };
@@ -80,13 +82,13 @@ public:
     bool canGoBack() const { return m_canGoBack; };
     bool canGoForward() const { return m_canGoForward; };
 
-    Result navigate(const String& url, NavigateOptions&&);
+    Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    Result reload(ReloadOptions&&);
+    Result reload(ReloadOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    Result traverseTo(const String& key, Options&&);
-    Result back(Options&&);
-    Result forward(Options&&);
+    Result traverseTo(const String& key, Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result back(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result forward(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
     void updateCurrentEntry(UpdateCurrentEntryOptions&&);
 

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -11,12 +11,12 @@
   readonly attribute boolean canGoBack;
   readonly attribute boolean canGoForward;
 
-  NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
-  NavigationResult reload(optional NavigationReloadOptions options = {});
+  [ReturnsPromisePair] NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
+  [ReturnsPromisePair] NavigationResult reload(optional NavigationReloadOptions options = {});
 
-  NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});
-  NavigationResult back(optional NavigationOptions options = {});
-  NavigationResult forward(optional NavigationOptions options = {});
+  [ReturnsPromisePair] NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});
+  [ReturnsPromisePair] NavigationResult back(optional NavigationOptions options = {});
+  [ReturnsPromisePair] NavigationResult forward(optional NavigationOptions options = {});
 
   attribute EventHandler onnavigate;
   attribute EventHandler onnavigatesuccess;
@@ -45,9 +45,8 @@ dictionary NavigationReloadOptions : NavigationOptions {
     JSGenerateToJSObject,
 ] 
 dictionary NavigationResult {
-  boolean todo = true;
-  // Promise<NavigationHistoryEntry> committed;
-  // Promise<NavigationHistoryEntry> finished;
+  Promise<NavigationHistoryEntry> committed;
+  Promise<NavigationHistoryEntry> finished;
 };
 
 enum NavigationHistoryBehavior {

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -42,6 +42,8 @@ public:
     using RefCounted<NavigationHistoryEntry>::ref;
     using RefCounted<NavigationHistoryEntry>::deref;
 
+    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context) { return adoptRef(*new NavigationHistoryEntry(context)); }
+
     const String& url() const { return m_url; };
     const String& key() const { return m_key; };
     const String& id() const { return m_id; };


### PR DESCRIPTION
#### eabae2c49b43bc31b66a81b1d8050579730666e2
<pre>
[Navigation] Implement Navigation::Result binding
<a href="https://bugs.webkit.org/show_bug.cgi?id=265325">https://bugs.webkit.org/show_bug.cgi?id=265325</a>

Reviewed by Alex Christensen.

Implement Navigation::Result through extending the code generator, a new attribute &apos;ReturnsPromisePair&apos;
is added, which mostly behaves like existing Promise handling, but in this case an extra DeferredPromise
parameter is passed to form a pair.

* Source/WebCore/bindings/js/JSDOMConvertPromise.h:
(WebCore::JSConverter&lt;IDLPromise&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h:
(WebCore::IDLOperationReturningPromise::callReturningPromisePair):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::callPromisePairFunction):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateHeader):
(GenerateOperationTrampolineDefinition):
(GenerateOperationBodyDefinition):
(GenerateOperationDefinition):
(GenerateParametersCheck):
(NativeToJSValue):
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::convertDictionary&lt;TestObj::PromisePair&gt;):
(WebCore::JSTestObjDOMConstructor::construct):
(WebCore::jsTestObjPrototypeFunction_returnsPromisePairBody):
(WebCore::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.h:
* Source/WebCore/bindings/scripts/test/TestObj.idl:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::navigate):
(WebCore::Navigation::reload):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
(WebCore::createNewResult): Deleted.
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigation.idl:
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/273178@main">https://commits.webkit.org/273178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bea9f2a483f36c1c1c34e01d2d009ddd684f6399

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37242 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31228 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30207 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36030 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33983 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11910 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7944 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->