### PR TITLE
Path::operator== is incorrect and unused

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -429,7 +429,7 @@ void AXIsolatedObject::setProperty(AXPropertyName propertyName, AXPropertyValueV
         [](Vector<AXID>& typedValue) { return typedValue.isEmpty(); },
         [](Vector<std::pair<AXID, AXID>>& typedValue) { return typedValue.isEmpty(); },
         [](Vector<String>& typedValue) { return typedValue.isEmpty(); },
-        [](Path& typedValue) { return typedValue == Path(); },
+        [](Path& typedValue) { return typedValue.isEmpty(); },
         [](OptionSet<AXAncestorFlag>& typedValue) { return typedValue.isEmpty(); },
 #if PLATFORM(COCOA)
         [](RetainPtr<NSAttributedString>& typedValue) { return !typedValue; },

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -67,23 +67,6 @@ Path::Path(PathSegment&& segment)
     m_data = WTFMove(segment);
 }
 
-bool Path::operator==(const Path& other) const
-{
-    if (auto segment = asSingle()) {
-        if (auto otherSegment = other.asSingle())
-            return *segment == *otherSegment;
-        return false;
-    }
-
-    if (auto impl = asImpl()) {
-        if (auto otherImpl = other.asImpl())
-            return impl == otherImpl;
-        return false;
-    }
-
-    return true;
-}
-
 PathImpl& Path::setImpl(Ref<PathImpl>&& impl)
 {
     auto& platformPathImpl = impl.get();

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -55,8 +55,6 @@ public:
     Path& operator=(const Path&) = default;
     Path& operator=(Path&&) = default;
 
-    WEBCORE_EXPORT bool operator==(const Path&) const;
-
     WEBCORE_EXPORT void moveTo(const FloatPoint&);
 
     WEBCORE_EXPORT void addLineTo(const FloatPoint&);

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
@@ -29,11 +29,19 @@
 #include <WebCore/DisplayListItems.h>
 #include <WebCore/Filter.h>
 #include <WebCore/Gradient.h>
+#include <wtf/text/TextStream.h>
 
 namespace TestWebKitAPI {
 using namespace WebCore;
 using DisplayList::DisplayList;
 using namespace DisplayList;
+
+static String convertToString(const Path& path)
+{
+    TextStream stream(TextStream::LineMode::SingleLine);
+    stream << path;
+    return stream.release();
+}
 
 static Ref<Gradient> createGradient()
 {
@@ -81,7 +89,7 @@ TEST(DisplayListTests, AppendItems)
         [&](const SetInlineStroke& item) {
             EXPECT_EQ(item.thickness(), 1.5);
         }, [&](const FillPath& item) {
-            EXPECT_EQ(item.path(), path);
+            EXPECT_EQ(convertToString(item.path()), convertToString(path));
         }, [&](const FillRectWithGradient& item) {
             EXPECT_EQ(item.rect(), FloatRect(1., 1., 10., 10.));
             EXPECT_EQ(item.gradient().ptr(), gradient.ptr());


### PR DESCRIPTION
#### 2502481c805f5c8a62af86eeef6794d85dc08098
<pre>
Path::operator== is incorrect and unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=265333">https://bugs.webkit.org/show_bug.cgi?id=265333</a>
<a href="https://rdar.apple.com/problem/118823083">rdar://problem/118823083</a>

Reviewed by Tim Nguyen.

It is not entirely trivial to compare paths for equality. The
current implementation is confusing since it returns false for equal
Paths. Remove the implementation instead of fixing since it&apos;s not used.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::operator== const): Deleted.
* Source/WebCore/platform/graphics/Path.h:
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp:
(TestWebKitAPI::convertToString):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271136@main">https://commits.webkit.org/271136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f07b37dd249ec862b23685b1afbe49ce46294ed5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3500 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27728 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4419 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/24575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30328 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24998 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2577 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5907 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6604 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->