### PR TITLE
Add parsing support for grammar and spelling error pseudo-elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt
@@ -3,10 +3,10 @@ PASS getComputedStyle() for ::selection at #target1
 PASS getComputedStyle() for ::selection at #target2
 FAIL getComputedStyle() for ::target-text at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 128, 0)"
 FAIL getComputedStyle() for ::target-text at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::spelling-error at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 128, 0)"
-FAIL getComputedStyle() for ::spelling-error at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::grammar-error at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 128, 0)"
-FAIL getComputedStyle() for ::grammar-error at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+PASS getComputedStyle() for ::spelling-error at #target1
+PASS getComputedStyle() for ::spelling-error at #target2
+PASS getComputedStyle() for ::grammar-error at #target1
+PASS getComputedStyle() for ::grammar-error at #target2
 FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 128, 0)"
 FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-computed-expected.txt
@@ -15,7 +15,7 @@ PASS getComputedStyle() for ::target-text(foo) should be element's default
 PASS getComputedStyle() for ::target-text() should be element's default
 PASS getComputedStyle() for :::target-text should be element's default
 PASS getComputedStyle() for ::target-text. should be element's default
-FAIL getComputedStyle() for ::spelling-error assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+PASS getComputedStyle() for ::spelling-error
 PASS getComputedStyle() for ::spelling-error: should be element's default
 PASS getComputedStyle() for ::spelling-error) should be element's default
 PASS getComputedStyle() for ::spelling-error( should be element's default
@@ -23,7 +23,7 @@ PASS getComputedStyle() for ::spelling-error(foo) should be element's default
 PASS getComputedStyle() for ::spelling-error() should be element's default
 PASS getComputedStyle() for :::spelling-error should be element's default
 PASS getComputedStyle() for ::spelling-error. should be element's default
-FAIL getComputedStyle() for ::grammar-error assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+PASS getComputedStyle() for ::grammar-error
 PASS getComputedStyle() for ::grammar-error: should be element's default
 PASS getComputedStyle() for ::grammar-error) should be element's default
 PASS getComputedStyle() for ::grammar-error( should be element's default

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt
@@ -3,10 +3,10 @@ PASS getComputedStyle() for ::selection at #target1
 PASS getComputedStyle() for ::selection at #target2
 FAIL getComputedStyle() for ::target-text at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
 FAIL getComputedStyle() for ::target-text at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
-FAIL getComputedStyle() for ::spelling-error at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
-FAIL getComputedStyle() for ::spelling-error at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
-FAIL getComputedStyle() for ::grammar-error at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
-FAIL getComputedStyle() for ::grammar-error at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
+PASS getComputedStyle() for ::spelling-error at #target1
+PASS getComputedStyle() for ::spelling-error at #target2
+PASS getComputedStyle() for ::grammar-error at #target1
+PASS getComputedStyle() for ::grammar-error at #target2
 FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
 FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/highlight-pseudos-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/highlight-pseudos-expected.txt
@@ -19,20 +19,20 @@ PASS "::target-text div" should be an invalid selector
 PASS "::target-text::after" should be an invalid selector
 PASS "::target-text:hover" should be an invalid selector
 PASS ":not(::target-text)" should be an invalid selector
-FAIL "::spelling-error" should be a valid selector '::spelling-error' is not a valid selector.
-FAIL ".a::spelling-error" should be a valid selector '.a::spelling-error' is not a valid selector.
-FAIL "div ::spelling-error" should be a valid selector 'div ::spelling-error' is not a valid selector.
-FAIL "::part(my-part)::spelling-error" should be a valid selector '::part(my-part)::spelling-error' is not a valid selector.
+PASS "::spelling-error" should be a valid selector
+PASS ".a::spelling-error" should be a valid selector
+PASS "div ::spelling-error" should be a valid selector
+PASS "::part(my-part)::spelling-error" should be a valid selector
 PASS "::before::spelling-error" should be an invalid selector
 PASS "::spelling-error.a" should be an invalid selector
 PASS "::spelling-error div" should be an invalid selector
 PASS "::spelling-error::after" should be an invalid selector
 PASS "::spelling-error:hover" should be an invalid selector
 PASS ":not(::spelling-error)" should be an invalid selector
-FAIL "::grammar-error" should be a valid selector '::grammar-error' is not a valid selector.
-FAIL ".a::grammar-error" should be a valid selector '.a::grammar-error' is not a valid selector.
-FAIL "div ::grammar-error" should be a valid selector 'div ::grammar-error' is not a valid selector.
-FAIL "::part(my-part)::grammar-error" should be a valid selector '::part(my-part)::grammar-error' is not a valid selector.
+PASS "::grammar-error" should be a valid selector
+PASS ".a::grammar-error" should be a valid selector
+PASS "div ::grammar-error" should be a valid selector
+PASS "::part(my-part)::grammar-error" should be a valid selector
 PASS "::before::grammar-error" should be an invalid selector
 PASS "::grammar-error.a" should be an invalid selector
 PASS "::grammar-error div" should be an invalid selector

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -38,6 +38,7 @@
             "enum": [
                 "first-line",
                 "first-letter",
+                "grammar-error",
                 "highlight",
                 "marker",
                 "before",
@@ -50,6 +51,7 @@
                 "scrollbar-track",
                 "scrollbar-track-piece",
                 "scrollbar-corner",
+                "spelling-error",
                 "resizer",
                 "view-transition",
                 "view-transition-group",

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2872,6 +2872,20 @@ GoogleAntiFlickerOptimizationQuirkEnabled:
     WebCore:
       default: true
 
+GrammarAndSpellingPseudoElementsEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "::grammar-error and ::spelling-error pseudo-elements"
+  humanReadableDescription: "Enable the ::grammar-error and ::spelling-error CSS pseudo-elements"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 GraphicsContextFiltersEnabled:
    type: bool
    status: stable

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -61,7 +61,7 @@ static bool compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder
     //     - any other pseudo-elements not mentioned specifically in this list, sorted in ascending order by the Unicode codepoints that make up each selector
     //     - ::after
     //     - element children
-    enum SortingIndex : uint8_t { NotPseudo, Marker, Before, FirstLetter, FirstLine, Highlight, Scrollbar, Selection, After, Other };
+    enum SortingIndex : uint8_t { NotPseudo, Marker, Before, FirstLetter, FirstLine, GrammarError, Highlight, Scrollbar, Selection, SpellingError, After, Other };
     auto sortingIndex = [](PseudoId pseudoId) -> SortingIndex {
         switch (pseudoId) {
         case PseudoId::None:
@@ -74,12 +74,16 @@ static bool compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder
             return FirstLetter;
         case PseudoId::FirstLine:
             return FirstLine;
+        case PseudoId::GrammarError:
+            return GrammarError;
         case PseudoId::Highlight:
             return Highlight;
         case PseudoId::Scrollbar:
             return Scrollbar;
         case PseudoId::Selection:
             return Selection;
+        case PseudoId::SpellingError:
+            return SpellingError;
         case PseudoId::After:
             return After;
         default:
@@ -287,10 +291,12 @@ String pseudoIdAsString(PseudoId pseudoId)
     static NeverDestroyed<const String> before(MAKE_STATIC_STRING_IMPL("::before"));
     static NeverDestroyed<const String> firstLetter(MAKE_STATIC_STRING_IMPL("::first-letter"));
     static NeverDestroyed<const String> firstLine(MAKE_STATIC_STRING_IMPL("::first-line"));
+    static NeverDestroyed<const String> grammarError(MAKE_STATIC_STRING_IMPL("::grammar-error"));
     static NeverDestroyed<const String> highlight(MAKE_STATIC_STRING_IMPL("::highlight"));
     static NeverDestroyed<const String> marker(MAKE_STATIC_STRING_IMPL("::marker"));
     static NeverDestroyed<const String> selection(MAKE_STATIC_STRING_IMPL("::selection"));
     static NeverDestroyed<const String> scrollbar(MAKE_STATIC_STRING_IMPL("::-webkit-scrollbar"));
+    static NeverDestroyed<const String> spellingError(MAKE_STATIC_STRING_IMPL("::spelling-error"));
     static NeverDestroyed<const String> viewTransition(MAKE_STATIC_STRING_IMPL("::view-transition"));
     static NeverDestroyed<const String> viewTransitionGroup(MAKE_STATIC_STRING_IMPL("::view-transition-group"));
     static NeverDestroyed<const String> viewTransitionImagePair(MAKE_STATIC_STRING_IMPL("::view-transition-image-pair"));
@@ -305,6 +311,8 @@ String pseudoIdAsString(PseudoId pseudoId)
         return firstLetter;
     case PseudoId::FirstLine:
         return firstLine;
+    case PseudoId::GrammarError:
+        return grammarError;
     case PseudoId::Highlight:
         return highlight;
     case PseudoId::Marker:
@@ -313,6 +321,8 @@ String pseudoIdAsString(PseudoId pseudoId)
         return selection;
     case PseudoId::Scrollbar:
         return scrollbar;
+    case PseudoId::SpellingError:
+        return spellingError;
     case PseudoId::ViewTransition:
         return viewTransition;
     case PseudoId::ViewTransitionGroup:

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-enum class PseudoId : uint16_t;
+enum class PseudoId : uint32_t;
 
 class AnimationEventBase;
 class Element;

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -241,6 +241,10 @@ PseudoId CSSSelector::pseudoId(PseudoElementType type)
         return PseudoId::FirstLine;
     case PseudoElementFirstLetter:
         return PseudoId::FirstLetter;
+    case PseudoElementGrammarError:
+        return PseudoId::GrammarError;
+    case PseudoElementSpellingError:
+        return PseudoId::SpellingError;
     case PseudoElementSelection:
         return PseudoId::Selection;
     case PseudoElementHighlight:
@@ -309,6 +313,11 @@ CSSSelector::PseudoElementType CSSSelector::parsePseudoElementType(StringView na
         break;
     case PseudoElementHighlight:
         if (!context.highlightAPIEnabled)
+            return PseudoElementUnknown;
+        break;
+    case PseudoElementGrammarError:
+    case PseudoElementSpellingError:
+        if (!context.grammarAndSpellingPseudoElementsEnabled)
             return PseudoElementUnknown;
         break;
     case PseudoElementViewTransition:

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -210,6 +210,7 @@ struct PossiblyQuotedIdentifier {
 #endif
             PseudoElementFirstLetter,
             PseudoElementFirstLine,
+            PseudoElementGrammarError,
             PseudoElementHighlight,
             PseudoElementMarker,
             PseudoElementPart,
@@ -222,6 +223,7 @@ struct PossiblyQuotedIdentifier {
             PseudoElementScrollbarTrackPiece,
             PseudoElementSelection,
             PseudoElementSlotted,
+            PseudoElementSpellingError,
             PseudoElementViewTransition,
             PseudoElementViewTransitionGroup,
             PseudoElementViewTransitionImagePair,

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -46,7 +46,7 @@ struct PropertyValue;
 enum CSSPropertyID : uint16_t;
 enum CSSValueID : uint16_t;
 
-enum class PseudoId : uint16_t;
+enum class PseudoId : uint32_t;
 enum class SVGPaintType : uint8_t;
 
 using CSSValueListBuilder = Vector<Ref<CSSValue>, 4>;

--- a/Source/WebCore/css/SelectorPseudoElementTypeMap.in
+++ b/Source/WebCore/css/SelectorPseudoElementTypeMap.in
@@ -6,6 +6,7 @@ cue
 #endif
 first-letter
 first-line
+grammar-error
 highlight
 marker
 part
@@ -22,6 +23,7 @@ placeholder, PseudoElementWebKitCustom
 -webkit-scrollbar-track-piece
 selection
 slotted
+spelling-error
 thumb, PseudoElementWebKitCustom
 track, PseudoElementWebKitCustom
 view-transition

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -105,6 +105,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , sidewaysWritingModesEnabled { document.settings().sidewaysWritingModesEnabled() }
     , cssTextWrapPrettyEnabled { document.settings().cssTextWrapPrettyEnabled() }
     , highlightAPIEnabled { document.settings().highlightAPIEnabled() }
+    , grammarAndSpellingPseudoElementsEnabled { document.settings().grammarAndSpellingPseudoElementsEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -140,7 +141,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.sidewaysWritingModesEnabled               << 24
         | context.cssTextWrapPrettyEnabled                  << 25
         | context.highlightAPIEnabled                       << 26
-        | (uint64_t)context.mode                            << 27; // This is multiple bits, so keep it last.
+        | context.grammarAndSpellingPseudoElementsEnabled   << 27
+        | (uint64_t)context.mode                            << 28; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -98,6 +98,7 @@ struct CSSParserContext {
     bool sidewaysWritingModesEnabled : 1 { false };
     bool cssTextWrapPrettyEnabled : 1 { false };
     bool highlightAPIEnabled : 1 { false };
+    bool grammarAndSpellingPseudoElementsEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -36,6 +36,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     : mode(context.mode)
     , cssNestingEnabled(context.cssNestingEnabled)
     , focusVisibleEnabled(context.focusVisibleEnabled)
+    , grammarAndSpellingPseudoElementsEnabled(context.grammarAndSpellingPseudoElementsEnabled)
     , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
     , highlightAPIEnabled(context.highlightAPIEnabled)
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
@@ -47,6 +48,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
     , cssNestingEnabled(document.settings().cssNestingEnabled())
     , focusVisibleEnabled(document.settings().focusVisibleEnabled())
+    , grammarAndSpellingPseudoElementsEnabled(document.settings().grammarAndSpellingPseudoElementsEnabled())
     , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
     , highlightAPIEnabled(document.settings().highlightAPIEnabled())
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
@@ -60,6 +62,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.mode,
         context.cssNestingEnabled,
         context.focusVisibleEnabled,
+        context.grammarAndSpellingPseudoElementsEnabled,
         context.hasPseudoClassEnabled,
         context.highlightAPIEnabled,
         context.popoverAttributeEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -38,6 +38,7 @@ struct CSSSelectorParserContext {
     CSSParserMode mode { CSSParserMode::HTMLStandardMode };
     bool cssNestingEnabled { false };
     bool focusVisibleEnabled { false };
+    bool grammarAndSpellingPseudoElementsEnabled { false };
     bool hasPseudoClassEnabled { false };
     bool highlightAPIEnabled { false };
     bool popoverAttributeEnabled { false };

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1483,6 +1483,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             case CSSSelector::PseudoElementBefore:
             case CSSSelector::PseudoElementFirstLetter:
             case CSSSelector::PseudoElementFirstLine:
+            case CSSSelector::PseudoElementGrammarError:
             case CSSSelector::PseudoElementMarker:
             case CSSSelector::PseudoElementResizer:
             case CSSSelector::PseudoElementScrollbar:
@@ -1492,6 +1493,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             case CSSSelector::PseudoElementScrollbarTrack:
             case CSSSelector::PseudoElementScrollbarTrackPiece:
             case CSSSelector::PseudoElementSelection:
+            case CSSSelector::PseudoElementSpellingError:
             case CSSSelector::PseudoElementViewTransition:
             case CSSSelector::PseudoElementWebKitCustom:
             case CSSSelector::PseudoElementWebKitCustomLegacyPrefixed:

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -402,6 +402,8 @@ std::optional<Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudo
         return Protocol::CSS::PseudoId::FirstLine;
     case PseudoId::FirstLetter:
         return Protocol::CSS::PseudoId::FirstLetter;
+    case PseudoId::GrammarError:
+        return Protocol::CSS::PseudoId::GrammarError;
     case PseudoId::Marker:
         return Protocol::CSS::PseudoId::Marker;
     case PseudoId::Backdrop:
@@ -426,6 +428,8 @@ std::optional<Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudo
         return Protocol::CSS::PseudoId::ScrollbarTrackPiece;
     case PseudoId::ScrollbarCorner:
         return Protocol::CSS::PseudoId::ScrollbarCorner;
+    case PseudoId::SpellingError:
+        return Protocol::CSS::PseudoId::SpellingError;
     case PseudoId::Resizer:
         return Protocol::CSS::PseudoId::Resizer;
     case PseudoId::ViewTransition:

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -182,7 +182,7 @@ enum class PaintType : uint8_t;
 enum class PointerEvents : uint8_t;
 enum class PositionType : uint8_t;
 enum class PrintColorAdjust : bool;
-enum class PseudoId : uint16_t;
+enum class PseudoId : uint32_t;
 enum class QuoteType : uint8_t;
 enum class Resize : uint8_t;
 enum class RubyPosition : uint8_t;
@@ -275,7 +275,7 @@ class CustomPropertyRegistry;
 struct ScopedName;
 }
 
-constexpr auto PublicPseudoIDBits = 14;
+constexpr auto PublicPseudoIDBits = 16;
 constexpr auto TextDecorationLineBits = 4;
 constexpr auto TextTransformBits = 5;
 
@@ -2171,14 +2171,14 @@ private:
         unsigned unicodeBidi : 3; // UnicodeBidi
         unsigned floating : 3; // Float
         unsigned tableLayout : 1; // TableLayoutType
-        unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
 
         unsigned usesViewportUnits : 1;
         unsigned usesContainerUnits : 1;
+        unsigned isUnique : 1; // Style cannot be shared.
+        unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
         unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.
         unsigned disallowsFastPathInheritance : 1;
         unsigned hasContentNone : 1;
-        unsigned isUnique : 1; // Style cannot be shared.
 
         // Non-property related state bits.
         unsigned emptyState : 1;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -841,6 +841,7 @@ TextStream& operator<<(TextStream& ts, PseudoId pseudoId)
     case PseudoId::None: ts << "none"; break;
     case PseudoId::FirstLine: ts << "first-line"; break;
     case PseudoId::FirstLetter: ts << "first-letter"; break;
+    case PseudoId::GrammarError: ts << "grammar-error"; break;
     case PseudoId::Highlight: ts << "highlight"; break;
     case PseudoId::Marker: ts << "marker"; break;
     case PseudoId::Backdrop: ts << "backdrop"; break;
@@ -853,6 +854,7 @@ TextStream& operator<<(TextStream& ts, PseudoId pseudoId)
     case PseudoId::ScrollbarTrack: ts << "scrollbar-track"; break;
     case PseudoId::ScrollbarTrackPiece: ts << "scrollbar-trackpiece"; break;
     case PseudoId::ScrollbarCorner: ts << "scrollbar-corner"; break;
+    case PseudoId::SpellingError: ts << "spelling-error"; break;
     case PseudoId::ViewTransition: ts << "view-transition"; break;
     case PseudoId::ViewTransitionGroup: ts << "view-transition-group"; break;
     case PseudoId::ViewTransitionImagePair: ts << "view-transition-image-pair"; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -80,13 +80,14 @@ enum class StyleDifferenceContextSensitiveProperty : uint8_t {
 };
 
 // Static pseudo styles. Dynamic ones are produced on the fly.
-enum class PseudoId : uint16_t {
+enum class PseudoId : uint32_t {
     // The order must be None, public IDs, and then internal IDs.
     None,
 
     // Public:
     FirstLine,
     FirstLetter,
+    GrammarError,
     Highlight,
     Marker,
     Before,
@@ -94,6 +95,7 @@ enum class PseudoId : uint16_t {
     Selection,
     Backdrop,
     Scrollbar,
+    SpellingError,
     ViewTransition,
     ViewTransitionGroup,
     ViewTransitionImagePair,

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -232,6 +232,8 @@ WI.CSSManager = class CSSManager extends WI.Object
             return WI.unlocalizedString("::first-letter");
         case CSSManager.PseudoSelectorNames.Highlight:
             return WI.unlocalizedString("::highlight");
+        case CSSManager.PseudoSelectorNames.GrammarError:
+            return WI.unlocalizedString("::grammar-error");
         case CSSManager.PseudoSelectorNames.Marker:
             return WI.unlocalizedString("::marker");
         case CSSManager.PseudoSelectorNames.Before:
@@ -254,6 +256,8 @@ WI.CSSManager = class CSSManager extends WI.Object
             return WI.unlocalizedString("::scrollbar-track-piece");
         case CSSManager.PseudoSelectorNames.ScrollbarCorner:
             return WI.unlocalizedString("::scrollbar-corner");
+        case CSSManager.PseudoSelectorNames.SpellingError:
+            return WI.unlocalizedString("::spelling-error");
         case CSSManager.PseudoSelectorNames.Resizer:
             return WI.unlocalizedString("::resizer");
         case CSSManager.PseudoSelectorNames.ViewTransition:
@@ -881,6 +885,7 @@ WI.CSSManager.PseudoSelectorNames = {
     FirstLetter: "first-letter",
     FirstLine: "first-line",
     Highlight: "highlight",
+    GrammarError: "grammar-error",
     Marker: "marker",
     Resizer: "resizer",
     Scrollbar: "scrollbar",
@@ -890,6 +895,7 @@ WI.CSSManager.PseudoSelectorNames = {
     ScrollbarTrack: "scrollbar-track",
     ScrollbarTrackPiece: "scrollbar-track-piece",
     Selection: "selection",
+    SpellingError: "spelling-error",
     ViewTransition: "view-transition",
     ViewTransitionGroup: "view-transition-group",
     ViewTransitionImagePair: "view-transition-image-pair",


### PR DESCRIPTION
#### 56d0d7bd50be02e4b84bdb9f800b2ec17a020e4c
<pre>
Add parsing support for grammar and spelling error pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=265334">https://bugs.webkit.org/show_bug.cgi?id=265334</a>
<a href="https://rdar.apple.com/118785399">rdar://118785399</a>

Reviewed by Tim Nguyen.

Add support for parsing `::grammar-error` and `::spelling-error` behind a
preference.

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/highlight-pseudos-expected.txt:
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder):
(WebCore::pseudoIdAsString):
* Source/WebCore/animation/WebAnimationUtilities.h:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::pseudoId):
(WebCore::CSSSelector::parsePseudoElementType):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/ComputedStyleExtractor.h:
* Source/WebCore/css/SelectorPseudoElementTypeMap.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::protocolValueForPseudoId):
* Source/WebCore/rendering/style/RenderStyle.h:

Move bits around in `NonInheritedFlags` to remove padding. This ensures new
pseudo ID bits can be added without overflowing the existing bitfield size.

* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.displayNameForPseudoId):

Canonical link: <a href="https://commits.webkit.org/271271@main">https://commits.webkit.org/271271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c9e19f4403107680636196c399c3a0cfa8b402b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25191 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31077 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24146 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25356 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27010 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2873 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28789 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6239 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34481 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6691 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5167 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7443 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->