### PR TITLE
Remove HighlightAPIEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3005,11 +3005,12 @@ HighlightAPIEnabled:
   category: css
   humanReadableName: "Highlight API"
   humanReadableDescription: "Highlight API support"
-  webcoreBinding: DeprecatedGlobalSettings
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
+      default: true
+    WebCore:
       default: true
 
 HyperlinkAuditingEnabled:

--- a/Source/WebCore/Modules/highlight/Highlight.idl
+++ b/Source/WebCore/Modules/highlight/Highlight.idl
@@ -30,7 +30,7 @@ enum HighlightType {
 };
 
 [
-    EnabledByDeprecatedGlobalSetting=HighlightAPIEnabled,
+    EnabledBySetting=HighlightAPIEnabled,
     Exposed=Window
 ] interface Highlight {
     constructor(AbstractRange... initialRanges);

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.idl
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledByDeprecatedGlobalSetting=HighlightAPIEnabled,
+    EnabledBySetting=HighlightAPIEnabled,
     Exposed=Window
 ] interface HighlightRegistry {
     constructor();

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -31,7 +31,6 @@
 #include "CSSSelectorList.h"
 #include "CSSSelectorParserContext.h"
 #include "CommonAtomStrings.h"
-#include "DeprecatedGlobalSettings.h"
 #include "HTMLNames.h"
 #include "SelectorPseudoTypeMap.h"
 #include <memory>
@@ -309,8 +308,7 @@ CSSSelector::PseudoElementType CSSSelector::parsePseudoElementType(StringView na
             return PseudoElementWebKitCustom;
         break;
     case PseudoElementHighlight:
-        // FIXME: Stop using DeprecatedGlobalSettings.
-        if (!DeprecatedGlobalSettings::highlightAPIEnabled())
+        if (!context.highlightAPIEnabled)
             return PseudoElementUnknown;
         break;
     case PseudoElementViewTransition:

--- a/Source/WebCore/css/DOMCSSNamespace.idl
+++ b/Source/WebCore/css/DOMCSSNamespace.idl
@@ -34,5 +34,5 @@
     [CallWith=CurrentDocument] boolean supports(DOMString property, DOMString value);
     [CallWith=CurrentDocument] boolean supports(DOMString conditionText);
     DOMString escape(DOMString ident);
-    [EnabledByDeprecatedGlobalSetting=HighlightAPIEnabled, CallWith=CurrentDocument] readonly attribute HighlightRegistry highlights;
+    [EnabledBySetting=HighlightAPIEnabled, CallWith=CurrentDocument] readonly attribute HighlightRegistry highlights;
 };

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -106,6 +106,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }
     , sidewaysWritingModesEnabled { document.settings().sidewaysWritingModesEnabled() }
     , cssTextWrapPrettyEnabled { document.settings().cssTextWrapPrettyEnabled() }
+    , highlightAPIEnabled { document.settings().highlightAPIEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -141,7 +142,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.popoverAttributeEnabled                   << 24
         | context.sidewaysWritingModesEnabled               << 25
         | context.cssTextWrapPrettyEnabled                  << 26
-        | (uint64_t)context.mode                            << 27; // This is multiple bits, so keep it last.
+        | context.highlightAPIEnabled                       << 27
+        | (uint64_t)context.mode                            << 28; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -98,6 +98,7 @@ struct CSSParserContext {
     bool popoverAttributeEnabled : 1 { false };
     bool sidewaysWritingModesEnabled : 1 { false };
     bool cssTextWrapPrettyEnabled : 1 { false };
+    bool highlightAPIEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -37,6 +37,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , cssNestingEnabled(context.cssNestingEnabled)
     , focusVisibleEnabled(context.focusVisibleEnabled)
     , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
+    , highlightAPIEnabled(context.highlightAPIEnabled)
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
 {
@@ -47,6 +48,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , cssNestingEnabled(document.settings().cssNestingEnabled())
     , focusVisibleEnabled(document.settings().focusVisibleEnabled())
     , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
+    , highlightAPIEnabled(document.settings().highlightAPIEnabled())
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
 {
@@ -59,6 +61,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.cssNestingEnabled,
         context.focusVisibleEnabled,
         context.hasPseudoClassEnabled,
+        context.highlightAPIEnabled,
         context.popoverAttributeEnabled,
         context.viewTransitionsEnabled
     );

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -39,6 +39,7 @@ struct CSSSelectorParserContext {
     bool cssNestingEnabled { false };
     bool focusVisibleEnabled { false };
     bool hasPseudoClassEnabled { false };
+    bool highlightAPIEnabled { false };
     bool popoverAttributeEnabled { false };
     bool viewTransitionsEnabled { false };
 

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -103,9 +103,6 @@ public:
     static void setWebSQLEnabled(bool isEnabled) { shared().m_webSQLEnabled = isEnabled; }
     static bool webSQLEnabled() { return shared().m_webSQLEnabled; }
 
-    static void setHighlightAPIEnabled(bool isEnabled) { shared().m_highlightAPIEnabled = isEnabled; }
-    static bool highlightAPIEnabled() { return shared().m_highlightAPIEnabled; }
-
 #if ENABLE(ATTACHMENT_ELEMENT)
     static void setAttachmentElementEnabled(bool areEnabled) { shared().m_isAttachmentElementEnabled = areEnabled; }
     static bool attachmentElementEnabled() { return shared().m_isAttachmentElementEnabled; }
@@ -209,7 +206,6 @@ private:
     bool m_isServerTimingEnabled { false };
     bool m_attrStyleEnabled { false };
     bool m_webSQLEnabled { false };
-    bool m_highlightAPIEnabled { false };
 
     bool m_inlineFormattingContextIntegrationEnabled { true };
 

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "MarkedText.h"
 
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "DocumentMarkerController.h"
@@ -110,7 +109,7 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
 {
     Vector<MarkedText> markedTexts;
     RenderHighlight renderHighlight;
-    if (DeprecatedGlobalSettings::highlightAPIEnabled()) {
+    if (renderer.document().settings().highlightAPIEnabled()) {
         auto& parentRenderer = *renderer.parent();
         auto& parentStyle = parentRenderer.style();
         if (auto highlightRegistry = renderer.document().highlightRegistryIfExists()) {

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -25,7 +25,6 @@
 #include "RenderReplaced.h"
 
 #include "BackgroundPainter.h"
-#include "DeprecatedGlobalSettings.h"
 #include "DocumentInlines.h"
 #include "DocumentMarkerController.h"
 #include "ElementRuleCollector.h"
@@ -177,7 +176,7 @@ Color RenderReplaced::calculateHighlightColor() const
         }
     }
 #endif
-    if (DeprecatedGlobalSettings::highlightAPIEnabled()) {
+    if (document().settings().highlightAPIEnabled()) {
         if (auto highlightRegistry = document().highlightRegistryIfExists()) {
             for (auto& highlight : highlightRegistry->map()) {
                 for (auto& highlightRange : highlight.value->highlightRanges()) {


### PR DESCRIPTION
#### 7b39c638955c147680d2224da8f9b9c86a289225
<pre>
Remove HighlightAPIEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=265345">https://bugs.webkit.org/show_bug.cgi?id=265345</a>
<a href="https://rdar.apple.com/118799736">rdar://118799736</a>

Reviewed by Aditya Keerthi.

Use Document &amp; CSSParserContext settings instead.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/highlight/Highlight.idl:
* Source/WebCore/Modules/highlight/HighlightRegistry.idl:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElementType):
* Source/WebCore/css/DOMCSSNamespace.idl:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setHighlightAPIEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::highlightAPIEnabled): Deleted.
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::calculateHighlightColor const):

Canonical link: <a href="https://commits.webkit.org/271117@main">https://commits.webkit.org/271117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30885852230694fdfdfd4b7ff293885ca23a9a77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/7967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24898 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30277 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30513 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26593 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28472 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5860 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34049 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4850 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7367 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3539 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->