### PR TITLE
Remove LineHeightUnitsEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3758,21 +3758,6 @@ LegacyOverflowScrollingTouchEnabled:
     WebCore:
       default: true
 
-LineHeightUnitsEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "lh / rlh units"
-  humanReadableDescription: "Enable the lh and rlh units"
-  webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 LinkModulePreloadEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -33,7 +33,6 @@
 #include "CSSMarkup.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParser.h"
-#include "DeprecatedGlobalSettings.h"
 #include <limits.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/StringBuilder.h>
@@ -91,7 +90,7 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
             }
             break;
         case 'l':
-            if (toASCIILower(data[1]) == 'h' && DeprecatedGlobalSettings::lineHeightUnitsEnabled())
+            if (toASCIILower(data[1]) == 'h')
                 return CSSUnitType::CSS_LH;
             break;
         case 'm':
@@ -209,7 +208,7 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
                     return CSSUnitType::CSS_RIC;
                 break;
             case 'l':
-                if (toASCIILower(data[2]) == 'h' && DeprecatedGlobalSettings::lineHeightUnitsEnabled())
+                if (toASCIILower(data[2]) == 'h')
                     return CSSUnitType::CSS_RLH;
                 break;
             }

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -124,9 +124,6 @@ public:
     static void setReadableByteStreamAPIEnabled(bool isEnabled) { shared().m_isReadableByteStreamAPIEnabled = isEnabled; }
     static bool readableByteStreamAPIEnabled() { return shared().m_isReadableByteStreamAPIEnabled; }
 
-    static void setLineHeightUnitsEnabled(bool isEnabled) { shared().m_lineHeightUnitsEnabled = isEnabled; }
-    static bool lineHeightUnitsEnabled() { return shared().m_lineHeightUnitsEnabled; }
-
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     static void setIsAccessibilityIsolatedTreeEnabled(bool isEnabled) { shared().m_accessibilityIsolatedTree = isEnabled; }
     static bool isAccessibilityIsolatedTreeEnabled() { return shared().m_accessibilityIsolatedTree; }
@@ -222,8 +219,6 @@ private:
     bool m_isWebRTCAudioLatencyAdaptationEnabled { true };
 
     bool m_isReadableByteStreamAPIEnabled { false };
-
-    bool m_lineHeightUnitsEnabled { true };
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     bool m_accessibilityIsolatedTree { false };

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -228,7 +228,6 @@
 #define WebKitPictureInPictureAPIEnabledKey @"WebKitPictureInPictureAPIEnabled"
 #define WebKitAllowMediaContentTypesRequiringHardwareSupportAsFallbackKey @"WebKitAllowMediaContentTypesRequiringHardwareSupportAsFallback"
 #define WebKitMediaCapabilitiesEnabledPreferenceKey @"WebKitMediaCapabilitiesEnabled"
-#define WebKitLineHeightUnitsEnabledPreferenceKey @"WebKitLineHeightUnitsEnabled"
 #define WebKitDebugInAppBrowserPrivacyEnabledPreferenceKey @"WebKitDebugInAppBrowserPrivacyEnabled"
 
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -2735,16 +2735,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:flag forKey:WebKitMediaCapabilitiesEnabledPreferenceKey];
 }
 
-- (BOOL)lineHeightUnitsEnabled
-{
-    return [self _boolValueForKey:WebKitLineHeightUnitsEnabledPreferenceKey];
-}
-
-- (void)setLineHeightUnitsEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitLineHeightUnitsEnabledPreferenceKey];
-}
-
 - (BOOL)layoutFormattingContextIntegrationEnabled
 {
     return [self _boolValueForKey:WebKitLayoutFormattingContextIntegrationEnabledPreferenceKey];
@@ -3337,6 +3327,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 }
 
 - (void)setTransformStreamAPIEnabled:(BOOL)flag
+{
+}
+
+- (BOOL)lineHeightUnitsEnabled
+{
+    return YES;
+}
+
+- (void)setLineHeightUnitsEnabled:(BOOL)flag
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -210,7 +210,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL cacheAPIEnabled;
 @property (nonatomic) BOOL downloadAttributeEnabled;
 @property (nonatomic) BOOL directoryUploadEnabled;
-@property (nonatomic) BOOL lineHeightUnitsEnabled;
 @property (nonatomic) BOOL layoutFormattingContextIntegrationEnabled;
 @property (nonatomic, getter=isInAppBrowserPrivacyEnabled) BOOL inAppBrowserPrivacyEnabled;
 @property (nonatomic) BOOL webSQLEnabled;
@@ -356,6 +355,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL loadsSiteIconsIgnoringImageLoadingPreference;
 @property (nonatomic) BOOL displayListDrawingEnabled;
 @property (nonatomic) BOOL transformStreamAPIEnabled;
+@property (nonatomic) BOOL lineHeightUnitsEnabled;
 
 - (void)setDiskImageCacheEnabled:(BOOL)enabled;
 


### PR DESCRIPTION
#### d709a5d8a2090d8a93d8366f8dd79928e25b1ce9
<pre>
Remove LineHeightUnitsEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=265346">https://bugs.webkit.org/show_bug.cgi?id=265346</a>
<a href="https://rdar.apple.com/118799769">rdar://118799769</a>

Reviewed by Darin Adler.

This has been enabled for more than a year now, and there is really no reason to turn this feature off.

Remove it to reduce the uses of DeprecatedGlobalSettings.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::cssPrimitiveValueUnitFromTrie):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setLineHeightUnitsEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::lineHeightUnitsEnabled): Deleted.
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences lineHeightUnitsEnabled]):
(-[WebPreferences setLineHeightUnitsEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/271143@main">https://commits.webkit.org/271143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1062298cd530b2e6b1faf15640752e84d889f403

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24920 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30308 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23875 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30536 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26622 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2560 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28501 "Found 7 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/long-expires, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5888 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34079 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6609 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4879 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7379 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->