### PR TITLE
MediaSample should use integer as track id rather than AtomString

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -701,14 +701,14 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             return MediaPromise::createAndReject(PlatformMediaError::AppendError);
         }
 
-        Vector<std::pair<AtomString, AtomString>> trackIdPairs;
+        Vector<std::pair<TrackID, TrackID>> trackIdPairs;
 
         // 3.2 Add the appropriate track descriptions from this initialization segment to each of the track buffers.
         ASSERT(segment.audioTracks.size() == audioTracks().length());
         for (auto& audioTrackInfo : segment.audioTracks) {
             if (audioTracks().length() == 1) {
                 RefPtr track = audioTracks().item(0);
-                auto oldId = track->id();
+                auto oldId = track->trackId();
                 auto newId = audioTrackInfo.track->id();
                 track->setPrivate(*audioTrackInfo.track);
                 if (newId != oldId)
@@ -725,7 +725,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
         for (auto& videoTrackInfo : segment.videoTracks) {
             if (videoTracks().length() == 1) {
                 RefPtr track = videoTracks().item(0);
-                auto oldId = track->id();
+                auto oldId = track->trackId();
                 auto newId = videoTrackInfo.track->id();
                 track->setPrivate(*videoTrackInfo.track);
                 if (newId != oldId)
@@ -742,7 +742,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
         for (auto& textTrackInfo : segment.textTracks) {
             if (textTracks().length() == 1) {
                 RefPtr track = downcast<InbandTextTrack>(textTracks().item(0));
-                auto oldId = track->id();
+                auto oldId = track->trackId();
                 auto newId = textTrackInfo.track->id();
                 track->setPrivate(*textTrackInfo.track);
                 if (newId != oldId)
@@ -820,7 +820,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             m_audioCodecs.append(audioTrackInfo.description->codec());
 
             // 5.2.8 Create a new track buffer to store coded frames for this track.
-            m_private->addTrackBuffer(newAudioTrack->id(), WTFMove(audioTrackInfo.description));
+            m_private->addTrackBuffer(audioTrackInfo.track->id(), WTFMove(audioTrackInfo.description));
         }
 
         // 5.3 For each video track in the initialization segment, run following steps:
@@ -856,7 +856,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             m_videoCodecs.append(videoTrackInfo.description->codec());
 
             // 5.3.8 Create a new track buffer to store coded frames for this track.
-            m_private->addTrackBuffer(newVideoTrack->id(), WTFMove(videoTrackInfo.description));
+            m_private->addTrackBuffer(videoTrackInfo.track->id(), WTFMove(videoTrackInfo.description));
         }
 
         // 5.4 For each text track in the initialization segment, run following steps:
@@ -889,7 +889,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             m_textCodecs.append(textTrackInfo.description->codec());
 
             // 5.4.7 Create a new track buffer to store coded frames for this track.
-            m_private->addTrackBuffer(newTextTrack->id(), WTFMove(textTrackInfo.description));
+            m_private->addTrackBuffer(textTrackPrivate.id(), WTFMove(textTrackInfo.description));
         }
 
         // 5.5 If active track flag equals true, then run the following steps:
@@ -1232,22 +1232,22 @@ void SourceBuffer::reportExtraMemoryAllocated(uint64_t extraMemory)
     scriptExecutionContext()->vm().heap.deprecatedReportExtraMemory(extraMemoryCostDelta);
 }
 
-Ref<SourceBuffer::SamplesPromise> SourceBuffer::bufferedSamplesForTrackId(const AtomString& trackID)
+Ref<SourceBuffer::SamplesPromise> SourceBuffer::bufferedSamplesForTrackId(TrackID trackID)
 {
     return m_private->bufferedSamplesForTrackId(trackID);
 }
 
-Ref<SourceBuffer::SamplesPromise> SourceBuffer::enqueuedSamplesForTrackID(const AtomString& trackID)
+Ref<SourceBuffer::SamplesPromise> SourceBuffer::enqueuedSamplesForTrackID(TrackID trackID)
 {
     return m_private->enqueuedSamplesForTrackID(trackID);
 }
 
-MediaTime SourceBuffer::minimumUpcomingPresentationTimeForTrackID(const AtomString& trackID)
+MediaTime SourceBuffer::minimumUpcomingPresentationTimeForTrackID(TrackID trackID)
 {
     return m_private->minimumUpcomingPresentationTimeForTrackID(trackID);
 }
 
-void SourceBuffer::setMaximumQueueDepthForTrackID(const AtomString& trackID, uint64_t maxQueueDepth)
+void SourceBuffer::setMaximumQueueDepthForTrackID(TrackID trackID, uint64_t maxQueueDepth)
 {
     m_private->setMaximumQueueDepthForTrackID(trackID, maxQueueDepth);
 }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -216,10 +216,10 @@ private:
 
     friend class Internals;
     using SamplesPromise = NativePromise<Vector<String>, int>;
-    WEBCORE_EXPORT Ref<SamplesPromise> bufferedSamplesForTrackId(const AtomString&);
-    WEBCORE_EXPORT Ref<SamplesPromise> enqueuedSamplesForTrackID(const AtomString&);
-    WEBCORE_EXPORT MediaTime minimumUpcomingPresentationTimeForTrackID(const AtomString&);
-    WEBCORE_EXPORT void setMaximumQueueDepthForTrackID(const AtomString&, uint64_t);
+    WEBCORE_EXPORT Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID);
+    WEBCORE_EXPORT Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID);
+    WEBCORE_EXPORT MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID);
+    WEBCORE_EXPORT void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
 
     Ref<SourceBufferPrivate> m_private;
     MediaSource* m_source;

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -63,7 +63,7 @@ const AtomString& AudioTrack::translationKeyword()
 }
 
 AudioTrack::AudioTrack(ScriptExecutionContext* context, AudioTrackPrivate& trackPrivate)
-    : MediaTrackBase(context, MediaTrackBase::AudioTrack, trackPrivate.id(), trackPrivate.label(), trackPrivate.language())
+    : MediaTrackBase(context, MediaTrackBase::AudioTrack, trackPrivate.trackUID(), trackPrivate.id(), trackPrivate.label(), trackPrivate.language())
     , m_private(trackPrivate)
     , m_enabled(trackPrivate.enabled())
     , m_configuration(AudioTrackConfiguration::create())
@@ -160,7 +160,7 @@ void AudioTrack::configurationChanged(const PlatformAudioTrackConfiguration& con
     m_configuration->setState(configuration);
 }
 
-void AudioTrack::idChanged(const AtomString& id)
+void AudioTrack::idChanged(TrackID id)
 {
     setId(id);
     m_clients.forEach([this] (auto& client) {

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -79,7 +79,7 @@ private:
     void configurationChanged(const PlatformAudioTrackConfiguration&) final;
 
     // TrackPrivateBaseClient
-    void idChanged(const AtomString&) final;
+    void idChanged(TrackID) final;
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;
@@ -95,7 +95,7 @@ private:
     WeakHashSet<AudioTrackClient> m_clients;
     Ref<AudioTrackPrivate> m_private;
     bool m_enabled { false };
-    
+
     Ref<AudioTrackConfiguration> m_configuration;
 };
 

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -84,6 +84,16 @@ AudioTrack* AudioTrackList::getTrackById(const AtomString& id) const
     return nullptr;
 }
 
+AudioTrack* AudioTrackList::getTrackById(TrackID id) const
+{
+    for (auto& inbandTrack : m_inbandTracks) {
+        auto& track = downcast<AudioTrack>(*inbandTrack);
+        if (track.trackId() == id)
+            return &track;
+    }
+    return nullptr;
+}
+
 EventTargetInterface AudioTrackList::eventTargetInterface() const
 {
     return AudioTrackListEventTargetInterfaceType;

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -44,6 +44,7 @@ public:
     virtual ~AudioTrackList();
 
     AudioTrack* getTrackById(const AtomString&) const;
+    AudioTrack* getTrackById(TrackID) const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
     AudioTrack* item(unsigned index) const;

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -148,7 +148,7 @@ AtomString InbandTextTrack::inBandMetadataTrackDispatchType() const
     return m_private->inBandMetadataTrackDispatchType();
 }
 
-void InbandTextTrack::idChanged(const AtomString& id)
+void InbandTextTrack::idChanged(TrackID id)
 {
     setId(id);
 }

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -66,7 +66,7 @@ protected:
 
 private:
     bool isInband() const final { return true; }
-    void idChanged(const AtomString&) override;
+    void idChanged(TrackID) override;
     void labelChanged(const AtomString&) override;
     void languageChanged(const AtomString&) override;
     void willRemove() override;

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -87,21 +87,42 @@ TextTrack& TextTrack::captionMenuAutomaticItem()
     return automatic;
 }
 
-TextTrack::TextTrack(ScriptExecutionContext* context, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language, TextTrackType type)
-    : TrackBase(context, TrackBase::TextTrack, id, label, language)
-    , ActiveDOMObject(context)
-    , m_trackType(type)
+TextTrack::Kind TextTrack::convertKind(const AtomString& kind)
 {
     if (kind == captionsAtom())
-        m_kind = Kind::Captions;
-    else if (kind == chaptersKeyword())
-        m_kind = Kind::Chapters;
-    else if (kind == descriptionsKeyword())
-        m_kind = Kind::Descriptions;
-    else if (kind == forcedKeyword())
-        m_kind = Kind::Forced;
-    else if (kind == metadataKeyword())
-        m_kind = Kind::Metadata;
+        return Kind::Captions;
+    if (kind == chaptersKeyword())
+        return Kind::Chapters;
+    if (kind == descriptionsKeyword())
+        return Kind::Descriptions;
+    if (kind == forcedKeyword())
+        return Kind::Forced;
+    if (kind == metadataKeyword())
+        return Kind::Metadata;
+    return Kind::Subtitles;
+}
+
+TextTrack::TextTrack(ScriptExecutionContext* context, const AtomString& kind, TrackID id, const AtomString& label, const AtomString& language, TextTrackType type)
+    : TrackBase(context, TrackBase::TextTrack, std::nullopt, id, label, language)
+    , ActiveDOMObject(context)
+    , m_kind(convertKind(kind))
+    , m_trackType(type)
+{
+}
+
+TextTrack::TextTrack(ScriptExecutionContext* context, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language, TextTrackType type)
+    : TrackBase(context, TrackBase::TextTrack, id, 0, label, language)
+    , ActiveDOMObject(context)
+    , m_kind(convertKind(kind))
+    , m_trackType(type)
+{
+}
+
+Ref<TextTrack> TextTrack::create(Document* document, const AtomString& kind, TrackID id, const AtomString& label, const AtomString& language)
+{
+    auto textTrack = adoptRef(*new TextTrack(document, kind, id, label, language, AddTrack));
+    textTrack->suspendIfNeeded();
+    return textTrack;
 }
 
 Ref<TextTrack> TextTrack::create(Document* document, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language)
@@ -593,7 +614,7 @@ void TextTrack::setLanguage(const AtomString& language)
     });
 }
 
-void TextTrack::setId(const AtomString& id)
+void TextTrack::setId(TrackID id)
 {
     TrackBase::setId(id);
     m_clients.forEach([this] (auto& client) {

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -46,6 +46,7 @@ class VTTRegionList;
 class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(TextTrack);
 public:
+    static Ref<TextTrack> create(Document*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language);
     static Ref<TextTrack> create(Document*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);
     virtual ~TextTrack();
 
@@ -116,7 +117,7 @@ public:
 
     void setLanguage(const AtomString&) final;
 
-    void setId(const AtomString&) override;
+    void setId(TrackID) override;
     void setLabel(const AtomString&) override;
 
     virtual bool isInband() const { return false; }
@@ -134,6 +135,7 @@ public:
     Document& document() const;
 
 protected:
+    TextTrack(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language, TextTrackType);
     TextTrack(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language, TextTrackType);
 
     RefPtr<TextTrackCue> matchCue(TextTrackCue&, TextTrackCue::CueMatchRules = TextTrackCue::MatchAllFields);
@@ -166,9 +168,10 @@ private:
     RefPtr<VTTRegionList> m_regions;
 
     TextTrackCueList& ensureTextTrackCueList();
+    Kind convertKind(const AtomString&);
 
     Mode m_mode { Mode::Disabled };
-    Kind m_kind { Kind::Subtitles };
+    Kind m_kind;
     TextTrackType m_trackType;
     ReadinessState m_readinessState { NotLoaded };
     std::optional<int> m_trackIndex;

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -123,7 +123,7 @@ TextTrack* TextTrackList::item(unsigned index) const
     return nullptr;
 }
 
-TextTrack* TextTrackList::getTrackById(const AtomString& id)
+TextTrack* TextTrackList::getTrackById(const AtomString& id) const
 {
     // 4.8.10.12.5 Text track API
     // The getTrackById(id) method must return the first TextTrack in the
@@ -136,6 +136,16 @@ TextTrack* TextTrackList::getTrackById(const AtomString& id)
     }
 
     // When no tracks match the given argument, the method must return null.
+    return nullptr;
+}
+
+TextTrack* TextTrackList::getTrackById(TrackID id) const
+{
+    for (unsigned i = 0; i < length(); ++i) {
+        auto& track = *item(i);
+        if (track.trackId() == id)
+            return &track;
+    }
     return nullptr;
 }
 

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -52,7 +52,8 @@ public:
     bool contains(TrackBase&) const override;
 
     TextTrack* item(unsigned index) const;
-    TextTrack* getTrackById(const AtomString&);
+    TextTrack* getTrackById(const AtomString&) const;
+    TextTrack* getTrackById(TrackID) const;
     TextTrack* lastItem() const { return item(length() - 1); }
 
     void append(Ref<TextTrack>&&);

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -31,6 +31,7 @@
 #include "TrackListBase.h"
 #include <wtf/Language.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 #if ENABLE(VIDEO)
 
@@ -48,10 +49,11 @@ static RefPtr<Logger>& nullLogger()
 }
 #endif
 
-TrackBase::TrackBase(ScriptExecutionContext* context, Type type, const AtomString& id, const AtomString& label, const AtomString& language)
+TrackBase::TrackBase(ScriptExecutionContext* context, Type type, const std::optional<AtomString>& id, TrackID trackId, const AtomString& label, const AtomString& language)
     : ContextDestructionObserver(context)
     , m_uniqueId(++s_uniqueId)
-    , m_id(id)
+    , m_id(id ? *id : AtomString::number(trackId))
+    , m_trackId(trackId)
     , m_label(label)
     , m_language(language)
 {
@@ -180,8 +182,8 @@ WTFLogChannel& TrackBase::logChannel() const
 }
 #endif
 
-MediaTrackBase::MediaTrackBase(ScriptExecutionContext* context, Type type, const AtomString& id, const AtomString& label, const AtomString& language)
-    : TrackBase(context, type, id, label, language)
+MediaTrackBase::MediaTrackBase(ScriptExecutionContext* context, Type type, const std::optional<AtomString>& id, TrackID trackId, const AtomString& label, const AtomString& language)
+    : TrackBase(context, type, id, trackId, label, language)
 {
 }
 

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class SourceBuffer;
 class TrackListBase;
+using TrackID = uint64_t;
 
 class TrackBase
     : public RefCounted<TrackBase>
@@ -52,6 +53,7 @@ public:
     Type type() const { return m_type; }
 
     virtual AtomString id() const { return m_id; }
+    TrackID trackId() const { return m_trackId; }
     AtomString label() const { return m_label; }
     AtomString validBCP47Language() const { return m_validBCP47Language; }
     AtomString language() const { return m_language; }
@@ -78,9 +80,13 @@ public:
 #endif
 
 protected:
-    TrackBase(ScriptExecutionContext*, Type, const AtomString& id, const AtomString& label, const AtomString& language);
+    TrackBase(ScriptExecutionContext*, Type, const std::optional<AtomString>& id, TrackID, const AtomString& label, const AtomString& language);
 
-    virtual void setId(const AtomString& id) { m_id = id; }
+    virtual void setId(TrackID id)
+    {
+        m_id = AtomString::number(id);
+        m_trackId = id;
+    }
     virtual void setLabel(const AtomString& label) { m_label = label; }
     virtual void setLanguage(const AtomString&);
 
@@ -92,6 +98,7 @@ private:
     Type m_type;
     int m_uniqueId;
     AtomString m_id;
+    TrackID m_trackId { 0 };
     AtomString m_label;
     AtomString m_language;
     AtomString m_validBCP47Language;
@@ -108,7 +115,7 @@ public:
     virtual void setKind(const AtomString&);
 
 protected:
-    MediaTrackBase(ScriptExecutionContext*, Type, const AtomString& id, const AtomString& label, const AtomString& language);
+    MediaTrackBase(ScriptExecutionContext*, Type, const std::optional<AtomString>& id, TrackID, const AtomString& label, const AtomString& language);
 
     void setKindInternal(const AtomString&);
 

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class TrackBase;
+using TrackID = uint64_t;
 
 class TrackListBase : public RefCounted<TrackListBase>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(TrackListBase);

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -55,7 +55,7 @@ const AtomString& VideoTrack::signKeyword()
 }
 
 VideoTrack::VideoTrack(ScriptExecutionContext* context, VideoTrackPrivate& trackPrivate)
-    : MediaTrackBase(context, MediaTrackBase::VideoTrack, trackPrivate.id(), trackPrivate.label(), trackPrivate.language())
+    : MediaTrackBase(context, MediaTrackBase::VideoTrack, trackPrivate.trackUID(), trackPrivate.id(), trackPrivate.label(), trackPrivate.language())
     , m_private(trackPrivate)
     , m_configuration(VideoTrackConfiguration::create())
     , m_selected(trackPrivate.selected())
@@ -141,7 +141,7 @@ void VideoTrack::configurationChanged(const PlatformVideoTrackConfiguration& con
     m_configuration->setState(configuration);
 }
 
-void VideoTrack::idChanged(const AtomString& id)
+void VideoTrack::idChanged(TrackID id)
 {
     setId(id);
     m_clients.forEach([this] (auto& client) {

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -81,7 +81,7 @@ private:
     void configurationChanged(const PlatformVideoTrackConfiguration&) final;
 
     // TrackPrivateBaseClient
-    void idChanged(const AtomString&) final;
+    void idChanged(TrackID) final;
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -75,6 +75,16 @@ VideoTrack* VideoTrackList::getTrackById(const AtomString& id) const
     return nullptr;
 }
 
+VideoTrack* VideoTrackList::getTrackById(TrackID id) const
+{
+    for (auto& inbandTracks : m_inbandTracks) {
+        auto& track = downcast<VideoTrack>(*inbandTracks);
+        if (track.trackId() == id)
+            return &track;
+    }
+    return nullptr;
+}
+
 int VideoTrackList::selectedIndex() const
 {
     // 4.8.10.10.1 AudioTrackList and VideoTrackList objects

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -44,6 +44,7 @@ public:
     virtual ~VideoTrackList();
 
     VideoTrack* getTrackById(const AtomString&) const;
+    VideoTrack* getTrackById(TrackID) const;
     int selectedIndex() const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -50,6 +50,8 @@ class ProcessIdentity;
 class SharedBuffer;
 struct TrackInfo;
 
+using TrackID = uint64_t;
+
 struct PlatformSample {
     enum Type {
         None,
@@ -73,7 +75,7 @@ public:
     virtual MediaTime presentationTime() const = 0;
     virtual MediaTime decodeTime() const = 0;
     virtual MediaTime duration() const = 0;
-    virtual AtomString trackID() const = 0;
+    virtual TrackID trackID() const = 0;
     virtual size_t sizeInBytes() const = 0;
     virtual FloatSize presentationSize() const = 0;
     virtual void offsetTimestampsBy(const MediaTime&) = 0;

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -195,9 +195,9 @@ std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(const ui
     parser->setLogger(m_logger, m_logIdentifier);
     parser->setDidParseInitializationDataCallback([&](SourceBufferParserWebM::InitializationSegment&& init) {
         for (auto& audioTrack : init.audioTracks) {
-            if (audioTrack.track && audioTrack.track->trackUID()) {
+            if (audioTrack.track) {
                 duration = init.duration;
-                audioTrackId = audioTrack.track->trackUID();
+                audioTrackId = audioTrack.track->id();
                 track = static_pointer_cast<AudioTrackPrivateWebM>(audioTrack.track);
                 return;
             }

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -74,7 +74,7 @@ public:
     virtual bool isDefault() const { return false; }
     AtomString label() const override { return emptyAtom(); }
     AtomString language() const override { return emptyAtom(); }
-    AtomString id() const override { return emptyAtom(); }
+    std::optional<AtomString> trackUID() const override { return emptyAtom(); }
     virtual AtomString inBandMetadataTrackDispatchType() const { return emptyAtom(); }
 
     CueFormat cueFormat() const { return m_format; }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -143,6 +143,8 @@ enum class MediaPlatformType {
     Remote
 };
 
+using TrackID = uint64_t;
+
 class MediaPlayerClient : public CanMakeWeakPtr<MediaPlayerClient> {
 public:
     virtual ~MediaPlayerClient() = default;
@@ -825,6 +827,8 @@ inline bool MediaPlayer::hasMediaEngine() const
 }
 
 } // namespace WebCore
+
+using WebCore::TrackID;
 
 namespace WTF {
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -41,10 +41,10 @@
 #include "TrackBuffer.h"
 #include "VideoTrackPrivate.h"
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/IteratorRange.h>
 #include <wtf/MainThread.h>
 #include <wtf/MediaTime.h>
 #include <wtf/StringPrintStream.h>
-#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
@@ -92,25 +92,26 @@ MediaTime SourceBufferPrivate::duration() const
 
 void SourceBufferPrivate::resetTimestampOffsetInTrackBuffers()
 {
-    for (auto& trackBuffer : m_trackBufferMap.values())
-        trackBuffer->resetTimestampOffset();
+    iterateTrackBuffers([&](auto& trackBuffer) {
+        trackBuffer.resetTimestampOffset();
+    });
 }
 
 void SourceBufferPrivate::resetTrackBuffers()
 {
-    for (auto& trackBuffer : m_trackBufferMap.values())
-        trackBuffer->reset();
+    iterateTrackBuffers([&](auto& trackBuffer) {
+        trackBuffer.reset();
+    });
 }
 
 void SourceBufferPrivate::updateHighestPresentationTimestamp()
 {
     MediaTime highestTime;
-    for (auto& trackBuffer : m_trackBufferMap.values()) {
-        auto lastSampleIter = trackBuffer->samples().presentationOrder().rbegin();
-        if (lastSampleIter == trackBuffer->samples().presentationOrder().rend())
-            continue;
-        highestTime = std::max(highestTime, lastSampleIter->first);
-    }
+    iterateTrackBuffers([&](auto& trackBuffer) {
+        auto lastSampleIter = trackBuffer.samples().presentationOrder().rbegin();
+        if (lastSampleIter != trackBuffer.samples().presentationOrder().rend())
+            highestTime = std::max(highestTime, lastSampleIter->first);
+    });
 
     if (m_highestPresentationTimestamp == highestTime)
         return;
@@ -132,8 +133,9 @@ Ref<MediaPromise> SourceBufferPrivate::setBufferedRanges(PlatformTimeRanges&& ti
 
 Vector<PlatformTimeRanges> SourceBufferPrivate::trackBuffersRanges() const
 {
-    return WTF::map(m_trackBufferMap.values(), [](auto& trackBuffer) {
-        return trackBuffer->buffered();
+    auto iteratorRange = makeSizedIteratorRange(m_trackBufferMap, m_trackBufferMap.begin(), m_trackBufferMap.end());
+    return WTF::map(iteratorRange, [](auto& trackBuffer) {
+        return trackBuffer.second->buffered();
     });
 }
 
@@ -180,17 +182,17 @@ Ref<MediaPromise> SourceBufferPrivate::updateBufferedFromTrackBuffers(const Vect
     return setBufferedRanges(WTFMove(intersectionRanges));
 }
 
-void SourceBufferPrivate::reenqueSamples(const AtomString& trackID)
+void SourceBufferPrivate::reenqueSamples(TrackID trackID)
 {
     RefPtr client = this->client();
     if (!client)
         return;
 
-    auto* trackBuffer = m_trackBufferMap.get(trackID);
-    if (!trackBuffer)
+    auto trackBuffer = m_trackBufferMap.find(trackID);
+    if (trackBuffer == m_trackBufferMap.end())
         return;
-    trackBuffer->setNeedsReenqueueing(true);
-    reenqueueMediaForTime(*trackBuffer, trackID, currentMediaTime());
+    trackBuffer->second->setNeedsReenqueueing(true);
+    reenqueueMediaForTime(trackBuffer->second, trackID, currentMediaTime());
 }
 
 Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivate::computeSeekTime(const SeekTarget& target)
@@ -202,13 +204,13 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivate::computeSeekTim
     auto seekTime = target.time;
 
     if (target.negativeThreshold || target.positiveThreshold) {
-        for (auto& trackBuffer : m_trackBufferMap.values()) {
+        iterateTrackBuffers([&](auto& trackBuffer) {
             // Find the sample which contains the target time.
-            auto trackSeekTime = trackBuffer->findSeekTimeForTargetTime(target.time, target.negativeThreshold, target.positiveThreshold);
+            auto trackSeekTime = trackBuffer.findSeekTimeForTargetTime(target.time, target.negativeThreshold, target.positiveThreshold);
 
             if (trackSeekTime.isValid() && abs(target.time - trackSeekTime) > abs(target.time - seekTime))
                 seekTime = trackSeekTime;
-        }
+        });
     }
     // When converting from a double-precision float to a MediaTime, a certain amount of precision is lost. If that
     // results in a round-trip between `float in -> MediaTime -> float out` where in != out, we will wait forever for
@@ -222,8 +224,8 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivate::computeSeekTim
 void SourceBufferPrivate::seekToTime(const MediaTime& time)
 {
     for (auto& trackBufferPair : m_trackBufferMap) {
-        TrackBuffer& trackBuffer = trackBufferPair.value;
-        const AtomString& trackID = trackBufferPair.key;
+        TrackBuffer& trackBuffer = trackBufferPair.second;
+        TrackID trackID = trackBufferPair.first;
 
         trackBuffer.setNeedsReenqueueing(true);
         reenqueueMediaForTime(trackBuffer, trackID, time);
@@ -232,9 +234,9 @@ void SourceBufferPrivate::seekToTime(const MediaTime& time)
 
 void SourceBufferPrivate::clearTrackBuffers(bool shouldReportToClient)
 {
-    for (auto& trackBuffer : m_trackBufferMap.values())
-        trackBuffer->clearSamples();
-
+    iterateTrackBuffers([&](auto& trackBuffer) {
+        trackBuffer.clearSamples();
+    });
     if (!shouldReportToClient)
         return;
 
@@ -247,23 +249,23 @@ void SourceBufferPrivate::clearTrackBuffers(bool shouldReportToClient)
     updateBufferedFromTrackBuffers({ });
 }
 
-Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivate::bufferedSamplesForTrackId(const AtomString& trackId)
+Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivate::bufferedSamplesForTrackId(TrackID trackId)
 {
-    auto* trackBuffer = m_trackBufferMap.get(trackId);
-    if (!trackBuffer)
+    auto trackBuffer = m_trackBufferMap.find(trackId);
+    if (trackBuffer == m_trackBufferMap.end())
         return SamplesPromise::createAndResolve(Vector<String> { });
 
-    return SamplesPromise::createAndResolve(WTF::map(trackBuffer->samples().decodeOrder(), [](auto& entry) {
+    return SamplesPromise::createAndResolve(WTF::map(trackBuffer->second->samples().decodeOrder(), [](auto& entry) {
         return toString(entry.second.get());
     }));
 }
 
-Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivate::enqueuedSamplesForTrackID(const AtomString&)
+Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivate::enqueuedSamplesForTrackID(TrackID)
 {
     return SamplesPromise::createAndResolve(Vector<String> { });
 }
 
-void SourceBufferPrivate::updateMinimumUpcomingPresentationTime(TrackBuffer& trackBuffer, const AtomString& trackID)
+void SourceBufferPrivate::updateMinimumUpcomingPresentationTime(TrackBuffer& trackBuffer, TrackID trackID)
 {
     if (!canSetMinimumUpcomingPresentationTime(trackID))
         return;
@@ -283,15 +285,15 @@ void SourceBufferPrivate::setMediaSourceEnded(bool isEnded)
 
     if (m_isMediaSourceEnded) {
         for (auto& trackBufferPair : m_trackBufferMap) {
-            TrackBuffer& trackBuffer = trackBufferPair.value;
-            const AtomString& trackID = trackBufferPair.key;
+            TrackBuffer& trackBuffer = trackBufferPair.second;
+            TrackID trackID = trackBufferPair.first;
 
             trySignalAllSamplesInTrackEnqueued(trackBuffer, trackID);
         }
     }
 }
 
-void SourceBufferPrivate::trySignalAllSamplesInTrackEnqueued(TrackBuffer& trackBuffer, const AtomString& trackID)
+void SourceBufferPrivate::trySignalAllSamplesInTrackEnqueued(TrackBuffer& trackBuffer, TrackID trackID)
 {
     if (m_isMediaSourceEnded && trackBuffer.decodeQueue().empty()) {
         DEBUG_LOG(LOGIDENTIFIER, "All samples in track \"", trackID, "\" enqueued.");
@@ -299,16 +301,16 @@ void SourceBufferPrivate::trySignalAllSamplesInTrackEnqueued(TrackBuffer& trackB
     }
 }
 
-void SourceBufferPrivate::provideMediaData(const AtomString& trackID)
+void SourceBufferPrivate::provideMediaData(TrackID trackID)
 {
     auto it = m_trackBufferMap.find(trackID);
     if (it == m_trackBufferMap.end())
         return;
 
-    provideMediaData(it->value, trackID);
+    provideMediaData(it->second, trackID);
 }
 
-void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, const AtomString& trackID)
+void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, TrackID trackID)
 {
     if (isSeeking())
         return;
@@ -367,7 +369,7 @@ void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, const AtomS
     trySignalAllSamplesInTrackEnqueued(trackBuffer, trackID);
 }
 
-void SourceBufferPrivate::reenqueueMediaForTime(TrackBuffer& trackBuffer, const AtomString& trackID, const MediaTime& time)
+void SourceBufferPrivate::reenqueueMediaForTime(TrackBuffer& trackBuffer, TrackID trackID, const MediaTime& time)
 {
     flush(trackID);
     if (trackBuffer.reenqueueMediaForTime(time, timeFudgeFactor()))
@@ -377,8 +379,8 @@ void SourceBufferPrivate::reenqueueMediaForTime(TrackBuffer& trackBuffer, const 
 void SourceBufferPrivate::reenqueueMediaIfNeeded(const MediaTime& currentTime)
 {
     for (auto& trackBufferPair : m_trackBufferMap) {
-        TrackBuffer& trackBuffer = trackBufferPair.value;
-        const AtomString& trackID = trackBufferPair.key;
+        TrackBuffer& trackBuffer = trackBufferPair.second;
+        TrackID trackID = trackBufferPair.first;
 
         if (trackBuffer.needsReenqueueing()) {
             DEBUG_LOG(LOGIDENTIFIER, "reenqueuing at time ", currentTime);
@@ -396,15 +398,14 @@ static PlatformTimeRanges removeSamplesFromTrackBuffer(const DecodeOrderSampleMa
 MediaTime SourceBufferPrivate::findPreviousSyncSamplePresentationTime(const MediaTime& time)
 {
     MediaTime previousSyncSamplePresentationTime = time;
-    for (auto& trackBufferKeyValue : m_trackBufferMap) {
-        TrackBuffer& trackBuffer = trackBufferKeyValue.value;
+    iterateTrackBuffers([&](auto& trackBuffer) {
         auto sampleIterator = trackBuffer.samples().decodeOrder().findSyncSamplePriorToPresentationTime(time);
         if (sampleIterator == trackBuffer.samples().decodeOrder().rend())
-            continue;
+            return;
         const MediaTime& samplePresentationTime = sampleIterator->first.second;
         if (samplePresentationTime < time)
             previousSyncSamplePresentationTime = samplePresentationTime;
-    }
+    });
     return previousSyncSamplePresentationTime;
 }
 
@@ -432,17 +433,14 @@ Ref<MediaPromise> SourceBufferPrivate::removeCodedFramesInternal(const MediaTime
     // 2. Let end be the end presentation timestamp for the removal range.
     // 3. For each track buffer in this source buffer, run the following steps:
 
-    for (auto& trackBufferKeyValue : m_trackBufferMap) {
-        TrackBuffer& trackBuffer = trackBufferKeyValue.value;
-        AtomString trackID = trackBufferKeyValue.key;
-
+    iterateTrackBuffers([&](auto& trackBuffer) {
         trackBuffer.removeCodedFrames(start, end, currentTime);
 
         // 3.4 If this object is in activeSourceBuffers, the current playback position is greater than or equal to start
         // and less than the remove end timestamp, and HTMLMediaElement.readyState is greater than HAVE_METADATA, then set
         // the HTMLMediaElement.readyState attribute to HAVE_METADATA and stall playback.
         // This step will be performed in SourceBuffer::sourceBufferPrivateBufferedChanged
-    }
+    });
 
     reenqueueMediaIfNeeded(currentTime);
 
@@ -474,8 +472,9 @@ bool SourceBufferPrivate::hasTooManySamples() const
     if (!evictionThreshold)
         return false;
     size_t currentSize = 0;
-    for (const auto& trackBuffer : m_trackBufferMap.values())
-        currentSize += trackBuffer->samples().size();
+    iterateTrackBuffers([&](auto& trackBuffer) {
+        currentSize += trackBuffer.samples().size();
+    });
     return currentSize > evictionThreshold;
 }
 
@@ -532,13 +531,14 @@ bool SourceBufferPrivate::isBufferFullFor(uint64_t requiredSize, uint64_t maximu
 uint64_t SourceBufferPrivate::totalTrackBufferSizeInBytes() const
 {
     uint64_t totalSizeInBytes = 0;
-    for (auto& trackBuffer : m_trackBufferMap.values())
-        totalSizeInBytes += trackBuffer->samples().sizeInBytes();
+    iterateTrackBuffers([&](auto& trackBuffer) {
+        totalSizeInBytes += trackBuffer.samples().sizeInBytes();
+    });
 
     return totalSizeInBytes;
 }
 
-void SourceBufferPrivate::addTrackBuffer(const AtomString& trackId, RefPtr<MediaDescription>&& description)
+void SourceBufferPrivate::addTrackBuffer(TrackID trackId, RefPtr<MediaDescription>&& description)
 {
     ASSERT(!m_trackBufferMap.contains(trackId));
 
@@ -550,20 +550,21 @@ void SourceBufferPrivate::addTrackBuffer(const AtomString& trackId, RefPtr<Media
 #if !RELEASE_LOG_DISABLED
     trackBuffer->setLogger(logger(), logIdentifier());
 #endif
-    m_trackBufferMap.add(trackId, WTFMove(trackBuffer));
+    m_trackBufferMap.try_emplace(trackId, WTFMove(trackBuffer));
 }
 
-void SourceBufferPrivate::updateTrackIds(Vector<std::pair<AtomString, AtomString>>&& trackIdPairs)
+void SourceBufferPrivate::updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIdPairs)
 {
     auto trackBufferMap = std::exchange(m_trackBufferMap, { });
     for (auto& trackIdPair : trackIdPairs) {
         auto oldId = trackIdPair.first;
         auto newId = trackIdPair.second;
         ASSERT(oldId != newId);
-        auto trackBuffer = trackBufferMap.take(oldId);
-        if (!trackBuffer)
+        auto trackBufferNode = trackBufferMap.extract(oldId);
+        if (!trackBufferNode)
             continue;
-        m_trackBufferMap.add(newId, makeUniqueRefFromNonNullUniquePtr(WTFMove(trackBuffer)));
+        trackBufferNode.key() = newId;
+        m_trackBufferMap.insert(WTFMove(trackBufferNode));
     }
 }
 
@@ -581,8 +582,9 @@ void SourceBufferPrivate::detach()
 
 void SourceBufferPrivate::setAllTrackBuffersNeedRandomAccess()
 {
-    for (auto& trackBuffer : m_trackBufferMap.values())
-        trackBuffer->setNeedRandomAccessFlag(true);
+    iterateTrackBuffers([&](auto& trackBuffer) {
+        trackBuffer.setNeedRandomAccessFlag(true);
+    });
 }
 
 void SourceBufferPrivate::didReceiveInitializationSegment(InitializationSegment&& segment)
@@ -813,15 +815,17 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             // 1.3.1 Set timestampOffset equal to group start timestamp - presentation timestamp.
             m_timestampOffset = m_groupStartTimestamp - presentationTimestamp;
 
-            for (auto& trackBuffer : m_trackBufferMap.values())
-                trackBuffer->resetTimestampOffset();
+            iterateTrackBuffers([&](auto& trackBuffer) {
+                trackBuffer.resetTimestampOffset();
+            });
 
             // 1.3.2 Set group end timestamp equal to group start timestamp.
             m_groupEndTimestamp = m_groupStartTimestamp;
 
             // 1.3.3 Set the need random access point flag on all track buffers to true.
-            for (auto& trackBuffer : m_trackBufferMap.values())
-                trackBuffer->setNeedRandomAccessFlag(true);
+            iterateTrackBuffers([&](auto& trackBuffer) {
+                trackBuffer.setNeedRandomAccessFlag(true);
+            });
 
             // 1.3.4 Unset group start timestamp.
             m_groupStartTimestamp = MediaTime::invalidTime();
@@ -829,7 +833,7 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
 
         // NOTE: this is out-of-order, but we need TrackBuffer to be able to cache the results of timestamp offset rounding
         // 1.5 Let track buffer equal the track buffer that the coded frame will be added to.
-        AtomString trackID = sample->trackID();
+        auto trackID = sample->trackID();
         auto it = m_trackBufferMap.find(trackID);
         if (it == m_trackBufferMap.end()) {
             // The client managed to append a sample with a trackID not present in the initialization
@@ -837,7 +841,7 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             client.sourceBufferPrivateDidDropSample();
             return true;
         }
-        TrackBuffer& trackBuffer = it->value;
+        TrackBuffer& trackBuffer = it->second;
 
         MediaTime microsecond(1, 1000000);
 
@@ -1292,6 +1296,18 @@ void SourceBufferPrivate::setActive(bool isActive)
     m_isActive = isActive;
     if (RefPtr mediaSource = m_mediaSource.get())
         mediaSource->sourceBufferPrivateDidChangeActiveState(*this, isActive);
+}
+
+void SourceBufferPrivate::iterateTrackBuffers(Function<void(TrackBuffer&)>&& func)
+{
+    for (auto& pair : m_trackBufferMap)
+        func(pair.second);
+}
+
+void SourceBufferPrivate::iterateTrackBuffers(Function<void(const TrackBuffer&)>&& func) const
+{
+    for (auto& pair : m_trackBufferMap)
+        func(pair.second);
 }
 
 RefPtr<SourceBufferPrivateClient> SourceBufferPrivate::client() const

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-std::optional<uint64_t> TrackPrivateBase::trackUID() const
+std::optional<AtomString> TrackPrivateBase::trackUID() const
 {
     return std::nullopt;
 }

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -37,6 +37,8 @@
 
 namespace WebCore {
 
+using TrackID = uint64_t;
+
 class WEBCORE_EXPORT TrackPrivateBase
     : public ThreadSafeRefCounted<TrackPrivateBase, WTF::DestructionThread::Main>
 #if !RELEASE_LOG_DISABLED
@@ -50,12 +52,12 @@ public:
 
     virtual TrackPrivateBaseClient* client() const = 0;
 
-    virtual AtomString id() const { return emptyAtom(); }
+    virtual TrackID id() const { return 0; }
     virtual AtomString label() const { return emptyAtom(); }
     virtual AtomString language() const { return emptyAtom(); }
 
     virtual int trackIndex() const { return 0; }
-    virtual std::optional<uint64_t> trackUID() const;
+    virtual std::optional<AtomString> trackUID() const;
     virtual std::optional<bool> defaultEnabled() const;
 
     virtual MediaTime startTimeVariance() const { return MediaTime::zeroTime(); }
@@ -65,7 +67,7 @@ public:
         if (auto* client = this->client())
             client->willRemove();
     }
-    
+
     bool operator==(const TrackPrivateBase&) const;
 
     enum class Type { Video, Audio, Text };

--- a/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
@@ -32,10 +32,12 @@
 
 namespace WebCore {
 
+using TrackID = uint64_t;
+
 class TrackPrivateBaseClient : public CanMakeWeakPtr<TrackPrivateBaseClient> {
 public:
     virtual ~TrackPrivateBaseClient() = default;
-    virtual void idChanged(const AtomString&) = 0;
+    virtual void idChanged(TrackID) = 0;
     virtual void labelChanged(const AtomString&) = 0;
     virtual void languageChanged(const AtomString&) = 0;
     virtual void willRemove() = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
@@ -68,11 +68,9 @@ public:
     VideoTrackPrivate::Kind videoKind() const;
 
     int index() const;
-    AtomString id() const;
+    TrackID id() const;
     AtomString label() const;
     AtomString language() const;
-
-    int trackID() const;
 
     static String languageForAVAssetTrack(AVAssetTrack*);
     static String languageForAVMediaSelectionOption(AVMediaSelectionOption *);

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -184,14 +184,14 @@ int AVTrackPrivateAVFObjCImpl::index() const
     return 0;
 }
 
-AtomString AVTrackPrivateAVFObjCImpl::id() const
+TrackID AVTrackPrivateAVFObjCImpl::id() const
 {
     if (m_assetTrack)
-        return AtomString::number([m_assetTrack trackID]);
+        return [m_assetTrack trackID];
     if (m_mediaSelectionOption)
-        return [[m_mediaSelectionOption->avMediaSelectionOption() optionID] stringValue];
+        return [[m_mediaSelectionOption->avMediaSelectionOption() optionID] unsignedLongLongValue];
     ASSERT_NOT_REACHED();
-    return emptyAtom();
+    return 0;
 }
 
 AtomString AVTrackPrivateAVFObjCImpl::label() const
@@ -280,16 +280,6 @@ PlatformAudioTrackConfiguration AVTrackPrivateAVFObjCImpl::audioTrackConfigurati
         numberOfChannels(),
         bitrate(),
     };
-}
-
-int AVTrackPrivateAVFObjCImpl::trackID() const
-{
-    if (m_assetTrack)
-        return [m_assetTrack trackID];
-    if (m_mediaSelectionOption)
-        return [[m_mediaSelectionOption->avMediaSelectionOption() optionID] intValue];
-    ASSERT_NOT_REACHED();
-    return 0;
 }
 
 static AVAssetTrack* assetTrackFor(const AVTrackPrivateAVFObjCImpl& impl)

--- a/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
@@ -35,20 +35,20 @@ class AudioTrackPrivateAVF : public AudioTrackPrivate {
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateAVF)
 public:
     Kind kind() const override { return m_kind; }
-    AtomString id() const override { return m_id; }
+    TrackID id() const override { return m_id; }
     AtomString label() const override { return m_label; }
     AtomString language() const override { return m_language; }
     int trackIndex() const override { return m_index; }
 
 protected:
     void setKind(Kind kind) { m_kind = kind; }
-    void setId(const AtomString& newId) { m_id = newId; }
+    void setId(TrackID newId) { m_id = newId; }
     void setLabel(const AtomString& label) { m_label = label; }
     void setLanguage(const AtomString& language) { m_language = language; }
     void setTrackIndex(int index) { m_index = index; }
     
     Kind m_kind { None };
-    AtomString m_id;
+    TrackID m_id;
     AtomString m_label;
     AtomString m_language;
     int m_index { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
@@ -38,12 +38,12 @@
 
 namespace WebCore {
 
-Ref<InbandMetadataTextTrackPrivateAVF> InbandMetadataTextTrackPrivateAVF::create(InbandTextTrackPrivate::Kind kind, InbandTextTrackPrivate::CueFormat cueFormat, const AtomString& id)
+Ref<InbandMetadataTextTrackPrivateAVF> InbandMetadataTextTrackPrivateAVF::create(InbandTextTrackPrivate::Kind kind, InbandTextTrackPrivate::CueFormat cueFormat, TrackID id)
 {
     return adoptRef(*new InbandMetadataTextTrackPrivateAVF(kind, cueFormat, id));
 }
 
-InbandMetadataTextTrackPrivateAVF::InbandMetadataTextTrackPrivateAVF(InbandTextTrackPrivate::Kind kind, InbandTextTrackPrivate::CueFormat cueFormat, const AtomString& id)
+InbandMetadataTextTrackPrivateAVF::InbandMetadataTextTrackPrivateAVF(InbandTextTrackPrivate::Kind kind, InbandTextTrackPrivate::CueFormat cueFormat, TrackID id)
     : InbandTextTrackPrivate(cueFormat)
     , m_kind(kind)
     , m_id(id)

--- a/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h
@@ -41,12 +41,12 @@ struct IncompleteMetaDataCue {
 
 class InbandMetadataTextTrackPrivateAVF : public InbandTextTrackPrivate {
 public:
-    static Ref<InbandMetadataTextTrackPrivateAVF> create(Kind, CueFormat, const AtomString& id = emptyAtom());
+    static Ref<InbandMetadataTextTrackPrivateAVF> create(Kind, CueFormat, TrackID = 0);
 
     ~InbandMetadataTextTrackPrivateAVF();
 
     Kind kind() const override { return m_kind; }
-    AtomString id() const override { return m_id; }
+    TrackID id() const override { return m_id; }
     AtomString inBandMetadataTrackDispatchType() const override { return m_inBandMetadataTrackDispatchType; }
     void setInBandMetadataTrackDispatchType(const AtomString& value) { m_inBandMetadataTrackDispatchType = value; }
 
@@ -58,14 +58,14 @@ public:
     void flushPartialCues();
 
 private:
-    InbandMetadataTextTrackPrivateAVF(Kind, CueFormat, const AtomString&);
+    InbandMetadataTextTrackPrivateAVF(Kind, CueFormat, TrackID);
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "InbandMetadataTextTrackPrivateAVF"; }
 #endif
 
     Kind m_kind;
-    AtomString m_id;
+    TrackID m_id;
     AtomString m_inBandMetadataTrackDispatchType;
     MediaTime m_currentCueStartTime;
 #if ENABLE(DATACUE_VALUE)

--- a/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
@@ -36,20 +36,20 @@ class VideoTrackPrivateAVF : public VideoTrackPrivate {
 public:
     int trackIndex() const override { return m_index; }
     Kind kind() const override { return m_kind; }
-    AtomString id() const override { return m_id; }
+    TrackID id() const override { return m_id; }
     AtomString label() const override { return m_label; }
     AtomString language() const override { return m_language; }
 
 protected:
     void setKind(Kind kind) { m_kind = kind; }
-    void setId(const AtomString& newId) { m_id = newId; }
+    void setId(TrackID newId) { m_id = newId; }
     void setLabel(const AtomString& label) { m_label = label; }
     void setLanguage(const AtomString& language) { m_language = language; }
     void setTrackIndex(int index) { m_index = index; }
 
 
     Kind m_kind { None };
-    AtomString m_id;
+    TrackID m_id;
     AtomString m_label;
     AtomString m_language;
     int m_index { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
@@ -41,8 +41,6 @@ AudioTrackPrivateMediaSourceAVFObjC::AudioTrackPrivateMediaSourceAVFObjC(AVAsset
 
 void AudioTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
 {
-    m_trackID = m_impl->trackID();
-
     setKind(m_impl->audioKind());
     setId(m_impl->id());
     setLabel(m_impl->label());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
@@ -49,15 +49,12 @@ public:
     void setAssetTrack(AVAssetTrack*);
     AVAssetTrack* assetTrack();
 
-    int trackID() { return m_trackID; }
-
 private:
     explicit AudioTrackPrivateMediaSourceAVFObjC(AVAssetTrack*);
     
     void resetPropertiesFromTrack();
 
     std::unique_ptr<AVTrackPrivateAVFObjCImpl> m_impl;
-    int m_trackID;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -274,7 +274,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
         // data.
         RefPtr<SourceBufferPrivateAVFObjC> protectedSourceBuffer;
         for (auto& sourceBuffer : m_sourceBuffers) {
-            if (sourceBuffer->protectedTrackID() != notFound) {
+            if (sourceBuffer->protectedTrackID()) {
                 protectedSourceBuffer = sourceBuffer;
                 break;
             }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -41,14 +41,13 @@ class VideoFrameCV;
 
 class MediaSampleAVFObjC : public MediaSample {
 public:
-    static Ref<MediaSampleAVFObjC> create(CMSampleBufferRef sample, uint64_t trackID) { return adoptRef(*new MediaSampleAVFObjC(sample, trackID)); }
-    static Ref<MediaSampleAVFObjC> create(CMSampleBufferRef sample, AtomString trackID) { return adoptRef(*new MediaSampleAVFObjC(sample, trackID)); }
+    static Ref<MediaSampleAVFObjC> create(CMSampleBufferRef sample, TrackID trackID) { return adoptRef(*new MediaSampleAVFObjC(sample, trackID)); }
 
     MediaTime presentationTime() const override;
     MediaTime decodeTime() const override;
     MediaTime duration() const override;
 
-    AtomString trackID() const override { return m_id; }
+    TrackID trackID() const override { return m_id; }
 
     size_t sizeInBytes() const override;
     FloatSize presentationSize() const override;
@@ -77,14 +76,13 @@ public:
 protected:
     WEBCORE_EXPORT MediaSampleAVFObjC(RetainPtr<CMSampleBufferRef>&&);
     WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef);
-    WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef, AtomString trackID);
-    WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef, uint64_t trackID);
+    WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef, TrackID);
     WEBCORE_EXPORT virtual ~MediaSampleAVFObjC();
     
     void commonInit();
 
     RetainPtr<CMSampleBufferRef> m_sample;
-    AtomString m_id;
+    TrackID m_id;
     
     MediaTime m_presentationTime;
     MediaTime m_decodeTime;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -61,16 +61,9 @@ MediaSampleAVFObjC::MediaSampleAVFObjC(CMSampleBufferRef sample)
     commonInit();
 }
 
-MediaSampleAVFObjC::MediaSampleAVFObjC(CMSampleBufferRef sample, AtomString trackID)
+MediaSampleAVFObjC::MediaSampleAVFObjC(CMSampleBufferRef sample, TrackID trackID)
     : m_sample(sample)
     , m_id(trackID)
-{
-    commonInit();
-}
-
-MediaSampleAVFObjC::MediaSampleAVFObjC(CMSampleBufferRef sample, uint64_t trackID)
-    : m_sample(sample)
-    , m_id(AtomString::number(trackID))
 {
     commonInit();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -336,7 +336,7 @@ void SourceBufferParserAVFObjC::didFailToParseStreamDataWithError(NSError* error
     m_lastErrorCode.emplace([error code]);
 }
 
-void SourceBufferParserAVFObjC::didProvideMediaDataForTrackID(uint64_t trackID, CMSampleBufferRef sampleBuffer, const String& mediaType, unsigned flags)
+void SourceBufferParserAVFObjC::didProvideMediaDataForTrackID(TrackID trackID, CMSampleBufferRef sampleBuffer, const String& mediaType, unsigned flags)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "trackID = ", trackID, ", mediaType = ", mediaType);
     UNUSED_PARAM(flags);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
@@ -63,7 +63,7 @@ void VideoTrackPrivateAVFObjC::resetPropertiesFromTrack()
     // AVPlayerItemTrack
     VideoTrackPrivateAVF::setSelected(m_impl->enabled());
 
-    setTrackIndex(m_impl->trackID());
+    setTrackIndex(m_impl->id());
     setKind(m_impl->videoKind());
     setId(m_impl->id());
     setLabel(m_impl->label());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
@@ -50,8 +50,6 @@ public:
     void setAssetTrack(AVAssetTrack*);
     AVAssetTrack* assetTrack() const;
 
-    int trackID() { return m_trackID; }
-
     FloatSize naturalSize() const;
 
 private:
@@ -60,7 +58,6 @@ private:
     void resetPropertiesFromTrack();
 
     std::unique_ptr<AVTrackPrivateAVFObjCImpl> m_impl;
-    int m_trackID;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
@@ -36,15 +36,12 @@ namespace WebCore {
 
 VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track)
     : m_impl(makeUnique<AVTrackPrivateAVFObjCImpl>(track))
-    , m_trackID(-1)
 {
     resetPropertiesFromTrack();
 }
 
 void VideoTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
 {
-    m_trackID = m_impl->trackID();
-
     setTrackIndex(m_impl->index());
     setKind(m_impl->videoKind());
     setId(m_impl->id());

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -44,20 +44,14 @@ AudioTrackPrivateWebM::AudioTrackPrivateWebM(webm::TrackEntry&& trackEntry)
         setEnabled(m_track.is_enabled.value());
 }
 
-AtomString AudioTrackPrivateWebM::id() const
-{
-    if (m_trackID.isNull()) {
-        auto uid = trackUID();
-        m_trackID = uid ? AtomString::number(*uid) : emptyAtom();
-    }
-    return m_trackID;
-}
-
-std::optional<uint64_t> AudioTrackPrivateWebM::trackUID() const
+TrackID AudioTrackPrivateWebM::id() const
 {
     if (m_track.track_uid.is_present())
         return m_track.track_uid.value();
-    return std::nullopt;
+    if (m_track.track_number.is_present())
+        return m_track.track_number.value();
+    ASSERT_NOT_REACHED();
+    return 0;
 }
 
 std::optional<bool> AudioTrackPrivateWebM::defaultEnabled() const

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h
@@ -39,11 +39,10 @@ public:
     static Ref<AudioTrackPrivateWebM> create(webm::TrackEntry&&);
     virtual ~AudioTrackPrivateWebM() = default;
 
-    AtomString id() const final;
+    TrackID id() const final;
     AtomString label() const final;
     AtomString language() const final;
     int trackIndex() const final;
-    std::optional<uint64_t> trackUID() const final;
     std::optional<bool> defaultEnabled() const final;
     std::optional<MediaTime> codecDelay() const;
     void setDiscardPadding(const MediaTime&);
@@ -61,7 +60,6 @@ private:
     webm::TrackEntry m_track;
     RefPtr<AudioInfo> m_formatDescription;
     MediaTime m_discardPadding { MediaTime::invalidTime() };
-    mutable AtomString m_trackID;
     mutable AtomString m_label;
     mutable AtomString m_language;
 };

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -34,9 +34,8 @@
 #include "VideoFrameMetadata.h"
 #include "WebMResourceClient.h"
 #include <wtf/HashFunctions.h>
-#include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
-#include <wtf/RobinHoodHashMap.h>
+#include <wtf/StdUnorderedMap.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/threads/BinarySemaphore.h>
@@ -192,28 +191,28 @@ private:
     bool wirelessVideoPlaybackDisabled() const final { return false; }
 #endif
 
-    void enqueueSample(Ref<MediaSample>&&, uint64_t);
-    void reenqueSamples(uint64_t);
-    void reenqueueMediaForTime(TrackBuffer&, uint64_t, const MediaTime&);
-    void notifyClientWhenReadyForMoreSamples(uint64_t);
+    void enqueueSample(Ref<MediaSample>&&, TrackID);
+    void reenqueSamples(TrackID);
+    void reenqueueMediaForTime(TrackBuffer&, TrackID, const MediaTime&);
+    void notifyClientWhenReadyForMoreSamples(TrackID);
 
-    bool canSetMinimumUpcomingPresentationTime(uint64_t) const;
-    void setMinimumUpcomingPresentationTime(uint64_t, const MediaTime&);
-    void clearMinimumUpcomingPresentationTime(uint64_t);
+    bool canSetMinimumUpcomingPresentationTime(TrackID) const;
+    void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&);
+    void clearMinimumUpcomingPresentationTime(TrackID);
 
-    bool isReadyForMoreSamples(uint64_t);
-    void didBecomeReadyForMoreSamples(uint64_t);
+    bool isReadyForMoreSamples(TrackID);
+    void didBecomeReadyForMoreSamples(TrackID);
     void appendCompleted(bool);
-    void provideMediaData(uint64_t);
-    void provideMediaData(TrackBuffer&, uint64_t);
+    void provideMediaData(TrackID);
+    void provideMediaData(TrackBuffer&, TrackID);
 
     void trackDidChangeSelected(VideoTrackPrivate&, bool);
     void trackDidChangeEnabled(AudioTrackPrivate&, bool);
 
     using InitializationSegment = SourceBufferParserWebM::InitializationSegment;
     void didParseInitializationData(InitializationSegment&&);
-    void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, uint64_t trackId, const String& mediaType);
-    void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, uint64_t);
+    void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, TrackID, const String& mediaType);
+    void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, TrackID);
 
     void append(SharedBuffer&);
 
@@ -221,16 +220,16 @@ private:
 #if PLATFORM(IOS_FAMILY)
     void flushIfNeeded();
 #endif
-    void flushTrack(uint64_t);
+    void flushTrack(TrackID);
     void flushVideo();
     void flushAudio(AVSampleBufferAudioRenderer*);
 
-    void addTrackBuffer(uint64_t, RefPtr<MediaDescription>&&);
+    void addTrackBuffer(TrackID, RefPtr<MediaDescription>&&);
 
     void ensureLayer();
     void ensureDecompressionSession();
-    void addAudioRenderer(uint64_t);
-    void removeAudioRenderer(uint64_t);
+    void addAudioRenderer(TrackID);
+    void removeAudioRenderer(TrackID);
 
     void destroyLayer();
     void destroyDecompressionSession();
@@ -268,11 +267,11 @@ private:
 
     Vector<RefPtr<VideoTrackPrivateWebM>> m_videoTracks;
     Vector<RefPtr<AudioTrackPrivateWebM>> m_audioTracks;
-    HashMap<uint64_t, UniqueRef<TrackBuffer>, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_trackBufferMap;
+    StdUnorderedMap<TrackID, UniqueRef<TrackBuffer>> m_trackBufferMap;
     PlatformTimeRanges m_buffered;
 
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
-    HashMap<uint64_t, RetainPtr<AVSampleBufferAudioRenderer>, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_audioRenderers;
+    StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
     Ref<SourceBufferParserWebM> m_parser;
     const Ref<WTF::WorkQueue> m_appendQueue;
 
@@ -302,7 +301,8 @@ private:
     MediaTime m_duration;
     double m_rate { 1 };
 
-    uint64_t m_enabledVideoTrackID { notFound };
+    bool isEnabledVideoTrackID(TrackID) const;
+    std::optional<TrackID> m_enabledVideoTrackID;
     std::atomic<uint32_t> m_abortCalled { 0 };
     uint32_t m_pendingAppends { 0 };
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -54,20 +54,14 @@ void VideoTrackPrivateWebM::setFormatDescription(Ref<VideoInfo>&& formatDescript
     updateConfiguration();
 }
 
-AtomString VideoTrackPrivateWebM::id() const
-{
-    if (m_trackID.isNull()) {
-        auto uid = trackUID();
-        m_trackID = uid ? AtomString::number(*uid) : emptyAtom();
-    }
-    return m_trackID;
-}
-
-std::optional<uint64_t> VideoTrackPrivateWebM::trackUID() const
+TrackID VideoTrackPrivateWebM::id() const
 {
     if (m_track.track_uid.is_present())
         return m_track.track_uid.value();
-    return std::nullopt;
+    if (m_track.track_number.is_present())
+        return m_track.track_number.value();
+    ASSERT_NOT_REACHED();
+    return 0;
 }
 
 std::optional<bool> VideoTrackPrivateWebM::defaultEnabled() const

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
@@ -39,11 +39,10 @@ public:
     static Ref<VideoTrackPrivateWebM> create(webm::TrackEntry&&);
     virtual ~VideoTrackPrivateWebM() = default;
 
-    AtomString id() const final;
+    TrackID id() const final;
     AtomString label() const final;
     AtomString language() const final;
     int trackIndex() const final;
-    std::optional<uint64_t> trackUID() const final;
     std::optional<bool> defaultEnabled() const final;
 
 private:
@@ -59,7 +58,6 @@ private:
     void updateConfiguration();
 
     webm::TrackEntry m_track;
-    mutable AtomString m_trackID;
     mutable AtomString m_label;
     mutable AtomString m_language;
     RefPtr<VideoInfo> m_formatDescription;

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -56,7 +56,8 @@ public:
 
     int trackIndex() const final { return m_index; }
 
-    AtomString id() const final { return m_id; }
+    TrackID id() const final { return m_index; }
+    std::optional<AtomString> trackUID() const final { return m_stringId; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
@@ -41,7 +41,7 @@ public:
     ~InbandMetadataTextTrackPrivateGStreamer() = default;
 
     Kind kind() const override { return m_kind; }
-    AtomString id() const override { return m_id; }
+    std::optional<AtomString> trackUID() const override { return m_stringId; }
     AtomString inBandMetadataTrackDispatchType() const override { return m_inBandMetadataTrackDispatchType; }
     void setInBandMetadataTrackDispatchType(const AtomString& value) { m_inBandMetadataTrackDispatchType = value; }
 
@@ -61,13 +61,13 @@ private:
     InbandMetadataTextTrackPrivateGStreamer(Kind kind, CueFormat cueFormat, const AtomString& id)
         : InbandTextTrackPrivate(cueFormat)
         , m_kind(kind)
-        , m_id(id)
+        , m_stringId(id)
     {
 
     }
 
     Kind m_kind;
-    AtomString m_id;
+    AtomString m_stringId;
     AtomString m_inBandMetadataTrackDispatchType;
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -47,8 +47,7 @@ InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index,
     : InbandTextTrackPrivate(CueFormat::WebVTT)
     , TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Text, this, index, stream)
 {
-    m_id = AtomString::fromLatin1(gst_stream_get_stream_id(m_stream.get()));
-    GST_INFO("Track %d got stream start for stream %s.", m_index, m_id.string().utf8().data());
+    GST_INFO("Track %d got stream start for stream %s.", m_index, m_stringId.string().utf8().data());
 
     GST_DEBUG("Stream %" GST_PTR_FORMAT, m_stream.get());
     auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
@@ -53,7 +53,8 @@ public:
     }
 
     Kind kind() const final { return m_kind; }
-    AtomString id() const final { return m_id; }
+    TrackID id() const final { return m_index; }
+    std::optional<AtomString> trackUID() const final { return m_stringId; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
     int trackIndex() const final { return m_index; }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-MediaSampleGStreamer::MediaSampleGStreamer(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize, const AtomString& trackId)
+MediaSampleGStreamer::MediaSampleGStreamer(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize, TrackID trackId)
     : m_pts(MediaTime::zeroTime())
     , m_dts(MediaTime::zeroTime())
     , m_duration(MediaTime::zeroTime())
@@ -72,7 +72,7 @@ MediaSampleGStreamer::MediaSampleGStreamer(GRefPtr<GstSample>&& sample, const Fl
         m_flags = static_cast<MediaSample::SampleFlags>(m_flags | MediaSample::IsNonDisplaying);
 }
 
-MediaSampleGStreamer::MediaSampleGStreamer(const FloatSize& presentationSize, const AtomString& trackId)
+MediaSampleGStreamer::MediaSampleGStreamer(const FloatSize& presentationSize, TrackID trackId)
     : m_pts(MediaTime::zeroTime())
     , m_dts(MediaTime::zeroTime())
     , m_duration(MediaTime::zeroTime())
@@ -81,7 +81,7 @@ MediaSampleGStreamer::MediaSampleGStreamer(const FloatSize& presentationSize, co
 {
 }
 
-Ref<MediaSampleGStreamer> MediaSampleGStreamer::createFakeSample(GstCaps*, const MediaTime& pts, const MediaTime& dts, const MediaTime& duration, const FloatSize& presentationSize, const AtomString& trackId)
+Ref<MediaSampleGStreamer> MediaSampleGStreamer::createFakeSample(GstCaps*, const MediaTime& pts, const MediaTime& dts, const MediaTime& duration, const FloatSize& presentationSize, TrackID trackId)
 {
     MediaSampleGStreamer* gstreamerMediaSample = new MediaSampleGStreamer(presentationSize, trackId);
     gstreamerMediaSample->m_pts = pts;
@@ -166,7 +166,7 @@ void MediaSampleGStreamer::dump(PrintStream& out) const
     if (flags() & ~(MediaSample::IsSync | MediaSample::IsNonDisplaying | MediaSample::HasAlpha))
         appendFlag("unknown-flag");
 
-    out.print("), trackId(", trackID().string(), "), presentationSize(", presentationSize().width(), "x", presentationSize().height(), ")}");
+    out.print("), trackId(", trackID(), "), presentationSize(", presentationSize().width(), "x", presentationSize().height(), ")}");
 }
 
 } // namespace WebCore.

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -27,24 +27,23 @@
 #include "GStreamerCommon.h"
 #include "MediaSample.h"
 #include "VideoFrameTimeMetadata.h"
-#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
 class MediaSampleGStreamer : public MediaSample {
 public:
-    static Ref<MediaSampleGStreamer> create(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize, const AtomString& trackId)
+    static Ref<MediaSampleGStreamer> create(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize, TrackID id)
     {
-        return adoptRef(*new MediaSampleGStreamer(WTFMove(sample), presentationSize, trackId));
+        return adoptRef(*new MediaSampleGStreamer(WTFMove(sample), presentationSize, id));
     }
 
-    static Ref<MediaSampleGStreamer> createFakeSample(GstCaps*, const MediaTime& pts, const MediaTime& dts, const MediaTime& duration, const FloatSize& presentationSize, const AtomString& trackId);
+    static Ref<MediaSampleGStreamer> createFakeSample(GstCaps*, const MediaTime& pts, const MediaTime& dts, const MediaTime& duration, const FloatSize& presentationSize, TrackID);
 
     void extendToTheBeginning();
     MediaTime presentationTime() const override { return m_pts; }
     MediaTime decodeTime() const override { return m_dts; }
     MediaTime duration() const override { return m_duration; }
-    AtomString trackID() const override { return m_trackId; }
+    TrackID trackID() const override { return m_trackId; }
     size_t sizeInBytes() const override { return m_size; }
     FloatSize presentationSize() const override { return m_presentationSize; }
     void offsetTimestampsBy(const MediaTime&) override;
@@ -56,16 +55,16 @@ public:
     void dump(PrintStream&) const override;
 
 protected:
-    MediaSampleGStreamer(GRefPtr<GstSample>&&, const FloatSize& presentationSize, const AtomString& trackId);
+    MediaSampleGStreamer(GRefPtr<GstSample>&&, const FloatSize& presentationSize, TrackID);
     virtual ~MediaSampleGStreamer() = default;
 
 private:
-    MediaSampleGStreamer(const FloatSize& presentationSize, const AtomString& trackId);
+    MediaSampleGStreamer(const FloatSize& presentationSize, TrackID);
 
     MediaTime m_pts;
     MediaTime m_dts;
     MediaTime m_duration;
-    AtomString m_trackId;
+    TrackID m_trackId;
     size_t m_size { 0 };
     GRefPtr<GstSample> m_sample;
     FloatSize m_presentationSize;

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -37,6 +37,7 @@
 namespace WebCore {
 
 class TrackPrivateBase;
+using TrackID = uint64_t;
 
 class TrackPrivateBaseGStreamer {
 public:
@@ -49,8 +50,6 @@ public:
         Unknown
     };
 
-    WEBCORE_EXPORT static AtomString generateUniquePlaybin2StreamID(TrackType, unsigned index);
-
     GstPad* pad() const { return m_pad.get(); }
     void setPad(GRefPtr<GstPad>&&);
 
@@ -58,6 +57,7 @@ public:
 
     virtual void setActive(bool) { }
 
+    unsigned index() { return m_index; };
     void setIndex(unsigned index) { m_index =  index; }
 
     GstStream* stream() const { return m_stream.get(); }
@@ -68,6 +68,7 @@ public:
     const GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
 
     static String trackIdFromPadStreamStartOrUniqueID(TrackType, unsigned index, const GRefPtr<GstPad>&);
+    const AtomString& stringId() const { return m_stringId; };
 
     virtual void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) { }
 
@@ -97,7 +98,8 @@ protected:
     unsigned m_index;
     AtomString m_label;
     AtomString m_language;
-    AtomString m_id;
+    AtomString m_stringId;
+    TrackID m_id;
     GRefPtr<GstPad> m_pad;
     GRefPtr<GstPad> m_bestUpstreamPad;
     GRefPtr<GstStream> m_stream;
@@ -107,7 +109,9 @@ protected:
 
 private:
     bool getLanguageCode(GstTagList* tags, AtomString& value);
-
+    static AtomString generateUniquePlaybin2StreamID(TrackType, unsigned index);
+    static TrackID trackIdFromStringIdOrIndex(TrackType, const AtomString&, unsigned);
+    static char prefixForType(TrackType);
     template<class StringType>
     bool getTag(GstTagList* tags, const gchar* tagName, StringType& value);
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -57,7 +57,8 @@ public:
 
     int trackIndex() const final { return m_index; }
 
-    AtomString id() const final { return m_id; }
+    TrackID id() const final { return m_index; }
+    std::optional<AtomString> trackUID() const final { return m_stringId; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -70,14 +70,16 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
 
-        Track(const AtomString& trackId, StreamType streamType, const GRefPtr<GstCaps>& caps, const FloatSize& presentationSize)
+        Track(TrackID trackId, const AtomString& trackSringId, StreamType streamType, const GRefPtr<GstCaps>& caps, const FloatSize& presentationSize)
             : trackId(trackId)
+            , trackSringId(trackSringId)
             , streamType(streamType)
             , caps(caps)
             , presentationSize(presentationSize)
         { }
 
-        AtomString trackId;
+        TrackID trackId;
+        const AtomString trackSringId;
         StreamType streamType;
         GRefPtr<GstCaps> caps;
         FloatSize presentationSize;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
@@ -39,11 +39,12 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_mse_debug);
 
 namespace WebCore {
 
-MediaSourceTrackGStreamer::MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType type, AtomString trackId, GRefPtr<GstCaps>&& initialCaps)
+MediaSourceTrackGStreamer::MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, const AtomString& trackStringId, GRefPtr<GstCaps>&& initialCaps)
     : m_type(type)
-    , m_trackId(trackId)
+    , m_id(trackId)
+    , m_stringId(trackStringId)
     , m_initialCaps(WTFMove(initialCaps))
-    , m_queueDataMutex(trackId)
+    , m_queueDataMutex(trackStringId)
 { }
 
 MediaSourceTrackGStreamer::~MediaSourceTrackGStreamer()
@@ -51,9 +52,9 @@ MediaSourceTrackGStreamer::~MediaSourceTrackGStreamer()
     ASSERT(m_isRemoved);
 }
 
-Ref<MediaSourceTrackGStreamer> MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType type, AtomString trackId, GRefPtr<GstCaps>&& initialCaps)
+Ref<MediaSourceTrackGStreamer> MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, const AtomString& trackStringId, GRefPtr<GstCaps>&& initialCaps)
 {
-    return adoptRef(*new MediaSourceTrackGStreamer(type, trackId, WTFMove(initialCaps)));
+    return adoptRef(*new MediaSourceTrackGStreamer(type, trackId, trackStringId, WTFMove(initialCaps)));
 }
 
 bool MediaSourceTrackGStreamer::isReadyForMoreSamples()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
@@ -41,11 +41,12 @@ namespace WebCore {
 
 class MediaSourceTrackGStreamer final: public ThreadSafeRefCounted<MediaSourceTrackGStreamer> {
 public:
-    static Ref<MediaSourceTrackGStreamer> create(TrackPrivateBaseGStreamer::TrackType, AtomString trackId, GRefPtr<GstCaps>&& initialCaps);
+    static Ref<MediaSourceTrackGStreamer> create(TrackPrivateBaseGStreamer::TrackType, TrackID, const AtomString&, GRefPtr<GstCaps>&& initialCaps);
     virtual ~MediaSourceTrackGStreamer();
 
     TrackPrivateBaseGStreamer::TrackType type() const { return m_type; }
-    AtomString trackId() const { return m_trackId; }
+    TrackID id() const { return m_id; }
+    const AtomString& stringId() const { return m_stringId; }
     GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
     DataMutex<TrackQueue>& queueDataMutex() { return m_queueDataMutex; }
 
@@ -64,10 +65,11 @@ public:
     void remove();
 
 private:
-    explicit MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType, AtomString trackId, GRefPtr<GstCaps>&& initialCaps);
+    explicit MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType, TrackID, const AtomString&, GRefPtr<GstCaps>&& initialCaps);
 
     TrackPrivateBaseGStreamer::TrackType m_type;
-    AtomString m_trackId;
+    TrackID m_id;
+    const AtomString m_stringId;
     GRefPtr<GstCaps> m_initialCaps;
     DataMutex<TrackQueue> m_queueDataMutex;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -43,6 +43,7 @@
 #include "TrackPrivateBaseGStreamer.h"
 #include "WebKitMediaSourceGStreamer.h"
 #include <optional>
+#include <ranges>
 #include <wtf/LoggerHelper.h>
 
 namespace WebCore {
@@ -65,10 +66,10 @@ public:
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;
 
-    void flush(const AtomString&) final;
-    void enqueueSample(Ref<MediaSample>&&, const AtomString&) final;
-    void allSamplesInTrackEnqueued(const AtomString&) final;
-    bool isReadyForMoreSamples(const AtomString&) final;
+    void flush(TrackID) final;
+    void enqueueSample(Ref<MediaSample>&&, TrackID) final;
+    void allSamplesInTrackEnqueued(TrackID) final;
+    bool isReadyForMoreSamples(TrackID) final;
 
     bool precheckInitialisationSegment(const InitializationSegment&) final;
     void processInitialisationSegment(std::optional<InitializationSegment>&&) final;
@@ -76,7 +77,7 @@ public:
     void didReceiveAllPendingSamples();
     void appendParsingFailed();
 
-    HashMap<AtomString, RefPtr<MediaSourceTrackGStreamer>>::ValuesIteratorRange tracks() { return m_tracks.values(); }
+    auto tracks() { return std::views::values(m_tracks); }
 
     ContentType type() const { return m_type; }
 
@@ -97,14 +98,13 @@ private:
 
     SourceBufferPrivateGStreamer(MediaSourcePrivateGStreamer&, const ContentType&, MediaPlayerPrivateGStreamerMSE&);
 
-    void notifyClientWhenReadyForMoreSamples(const AtomString&) override;
+    void notifyClientWhenReadyForMoreSamples(TrackID) override;
 
     bool m_hasBeenRemovedFromMediaSource { false };
     ContentType m_type;
     MediaPlayerPrivateGStreamerMSE& m_playerPrivate;
     UniqueRef<AppendPipeline> m_appendPipeline;
-    AtomString m_trackId;
-    HashMap<AtomString, RefPtr<MediaSourceTrackGStreamer>> m_tracks;
+    StdUnorderedMap<TrackID, RefPtr<MediaSourceTrackGStreamer>> m_tracks;
     std::optional<MediaPromise::Producer> m_appendPromise;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -305,18 +305,18 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
 
     source->priv->collection = adoptGRef(gst_stream_collection_new("WebKitMediaSrc"));
     for (const auto& track : tracks) {
-        GST_DEBUG_OBJECT(source, "Adding stream with trackId '%s' of type %s with caps %" GST_PTR_FORMAT, track->trackId().string().utf8().data(), streamTypeToString(track->type()), track->initialCaps().get());
+        GST_DEBUG_OBJECT(source, "Adding stream with trackId '%s' of type %s with caps %" GST_PTR_FORMAT, track->stringId().string().utf8().data(), streamTypeToString(track->type()), track->initialCaps().get());
 
-        GRefPtr<WebKitMediaSrcPad> pad = WEBKIT_MEDIA_SRC_PAD(g_object_new(webkit_media_src_pad_get_type(), "name", makeString("src_", track->trackId()).utf8().data(), "direction", GST_PAD_SRC, NULL));
+        GRefPtr<WebKitMediaSrcPad> pad = WEBKIT_MEDIA_SRC_PAD(g_object_new(webkit_media_src_pad_get_type(), "name", makeString("src_", track->stringId()).utf8().data(), "direction", GST_PAD_SRC, NULL));
         gst_pad_set_activatemode_function(GST_PAD(pad.get()), webKitMediaSrcActivateMode);
 
         ASSERT(track->initialCaps());
         auto stream = adoptRef(new Stream(source, GRefPtr<GstPad>(GST_PAD(pad.get())), *track,
-            adoptGRef(gst_stream_new(track->trackId().string().utf8().data(), track->initialCaps().get(), gstStreamType(track->type()), GST_STREAM_FLAG_SELECT))));
+            adoptGRef(gst_stream_new(track->stringId().string().utf8().data(), track->initialCaps().get(), gstStreamType(track->type()), GST_STREAM_FLAG_SELECT))));
         pad->priv->stream = stream;
 
         gst_stream_collection_add_stream(source->priv->collection.get(), GRefPtr<GstStream>(stream->streamInfo.get()).leakRef());
-        source->priv->streams.set(track->trackId(), WTFMove(stream));
+        source->priv->streams.set(track->stringId(), WTFMove(stream));
     }
 
     gst_element_post_message(GST_ELEMENT(source), gst_message_new_stream_collection(GST_OBJECT(source), source->priv->collection.get()));
@@ -333,7 +333,7 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
             if (state > GST_STATE_READY)
                 gst_pad_set_active(GST_PAD(stream->pad.get()), true);
         }
-        GST_DEBUG_OBJECT(source, "Adding pad '%s' for stream with name '%s'", GST_OBJECT_NAME(stream->pad.get()), stream->track->trackId().string().utf8().data());
+        GST_DEBUG_OBJECT(source, "Adding pad '%s' for stream with name '%s'", GST_OBJECT_NAME(stream->pad.get()), stream->track->stringId().string().utf8().data());
         gst_element_add_pad(GST_ELEMENT(source), GST_PAD(stream->pad.get()));
     }
     GST_DEBUG_OBJECT(source, "All pads added");
@@ -460,7 +460,7 @@ static void webKitMediaSrcLoop(void* userData)
     }
 
     if (!streamingMembers->wasStreamStartSent) {
-        GUniquePtr<char> streamId { g_strdup_printf("mse/%s", stream->track->trackId().string().utf8().data()) };
+        GUniquePtr<char> streamId { g_strdup_printf("mse/%s", stream->track->stringId().string().utf8().data()) };
         GRefPtr<GstEvent> event = adoptGRef(gst_event_new_stream_start(streamId.get()));
         gst_event_set_group_id(event.get(), stream->source->priv->groupId);
         gst_event_set_stream(event.get(), stream->streamInfo.get());
@@ -554,7 +554,7 @@ static void webKitMediaSrcLoop(void* userData)
         bool pushingFirstBuffer = !streamingMembers->hasPushedFirstBuffer;
         if (pushingFirstBuffer) {
             GST_DEBUG_OBJECT(pad, "Sending first buffer on this pad.");
-            GUniquePtr<char> fileName { g_strdup_printf("playback-pipeline-before-playback-%s", stream->track->trackId().string().utf8().data()) };
+            GUniquePtr<char> fileName { g_strdup_printf("playback-pipeline-before-playback-%s", stream->track->stringId().string().utf8().data()) };
             GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(findPipeline(GRefPtr<GstElement>(GST_ELEMENT(stream->source))).get()),
                 GST_DEBUG_GRAPH_SHOW_ALL, fileName.get());
             streamingMembers->hasPushedFirstBuffer = true;
@@ -568,7 +568,7 @@ static void webKitMediaSrcLoop(void* userData)
         GstFlowReturn result = gst_pad_push(pad, buffer.leakRef());
         if (result != GST_FLOW_OK && result != GST_FLOW_FLUSHING) {
             GST_ERROR_OBJECT(pad, "Pushing buffer returned %s", gst_flow_get_name(result));
-            GUniquePtr<char> fileName { g_strdup_printf("playback-pipeline-pushing-buffer-failed-%s", stream->track->trackId().string().utf8().data()) };
+            GUniquePtr<char> fileName { g_strdup_printf("playback-pipeline-pushing-buffer-failed-%s", stream->track->stringId().string().utf8().data()) };
             GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(findPipeline(GRefPtr<GstElement>(GST_ELEMENT(stream->source))).get()),
                 GST_DEBUG_GRAPH_SHOW_ALL, fileName.get());
             gst_pad_pause_task(pad);
@@ -591,13 +591,13 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
     ASSERT(isMainThread());
     bool skipFlush = false;
     GST_DEBUG_OBJECT(stream->source, "Flush requested for stream '%s'. isSeekingFlush = %s",
-        stream->track->trackId().string().utf8().data(), boolForPrinting(isSeekingFlush));
+        stream->track->stringId().string().utf8().data(), boolForPrinting(isSeekingFlush));
 
     {
         DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
 
         if (!streamingMembers->hasPoppedFirstObject) {
-            GST_DEBUG_OBJECT(stream->source, "Flush request for stream '%s' occurred before hasPoppedFirstObject, just clearing the queue and readjusting the segment.", stream->track->trackId().string().utf8().data());
+            GST_DEBUG_OBJECT(stream->source, "Flush request for stream '%s' occurred before hasPoppedFirstObject, just clearing the queue and readjusting the segment.", stream->track->stringId().string().utf8().data());
             DataMutexLocker queue { stream->track->queueDataMutex() };
             // We use clear() instead of flush() because the WebKitMediaSrc streaming thread could be waiting
             // for the queue. flush() would cancel the notEmptyCallback therefore leaving the streaming thread
@@ -697,7 +697,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
     }
 
     GST_DEBUG_OBJECT(stream->source, "Flush request for stream '%s' (isSeekingFlush = %s) satisfied.",
-        stream->track->trackId().string().utf8().data(), boolForPrinting(isSeekingFlush));
+        stream->track->stringId().string().utf8().data(), boolForPrinting(isSeekingFlush));
 }
 
 void webKitMediaSrcFlush(WebKitMediaSrc* source, const AtomString& streamName)

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
@@ -41,8 +41,6 @@ namespace WebCore {
 AudioTrackPrivateMediaStream::AudioTrackPrivateMediaStream(MediaStreamTrackPrivate& track)
     : m_streamTrack(track)
     , m_audioSource(track.source())
-    , m_id(track.id())
-    , m_label(track.label())
     , m_renderer(createRenderer(*this))
 {
     track.addObserver(*this);

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -75,8 +75,8 @@ private:
 
     // AudioTrackPrivate
     Kind kind() const final { return Kind::Main; }
-    AtomString id() const final { return m_id; }
-    AtomString label() const final { return m_label; }
+    std::optional<AtomString> trackUID() const { return AtomString { m_streamTrack->id() }; }
+    AtomString label() const final { return AtomString { m_streamTrack->label() }; }
     int trackIndex() const final { return m_index; }
     bool isBackedByMediaStreamTrack() const final { return true; }
 
@@ -102,8 +102,6 @@ private:
 
     Ref<MediaStreamTrackPrivate> m_streamTrack;
     Ref<RealtimeMediaSource> m_audioSource;
-    AtomString m_id;
-    AtomString m_label;
     int m_index { 0 };
 
     // Audio thread members

--- a/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
@@ -29,6 +29,7 @@
 
 #include "MediaStreamTrackPrivate.h"
 #include "VideoTrackPrivate.h"
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
@@ -47,20 +48,16 @@ public:
 private:
     VideoTrackPrivateMediaStream(MediaStreamTrackPrivate& track)
         : m_streamTrack(track)
-        , m_id(track.id())
-        , m_label(track.label())
     {
     }
 
     Kind kind() const final { return Kind::Main; }
-    AtomString id() const final { return m_id; }
-    AtomString label() const final { return m_label; }
+    std::optional<AtomString> trackUID() const { return AtomString { m_streamTrack->id() }; }
+    AtomString label() const final { return AtomString { m_streamTrack->label() }; }
     AtomString language() const final { return emptyAtom(); }
     int trackIndex() const final { return m_index; }
 
     Ref<MediaStreamTrackPrivate> m_streamTrack;
-    AtomString m_id;
-    AtomString m_label;
     int m_index { 0 };
 };
 

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -51,14 +51,14 @@ public:
 private:
     MockMediaSample(const MockSampleBox& box)
         : m_box(box)
-        , m_id(AtomString::number(box.trackID()))
+        , m_id(box.trackID())
     {
     }
 
     MediaTime presentationTime() const override { return m_box.presentationTimestamp(); }
     MediaTime decodeTime() const override { return m_box.decodeTimestamp(); }
     MediaTime duration() const override { return m_box.duration(); }
-    AtomString trackID() const override { return m_id; }
+    TrackID trackID() const override { return m_id; }
     size_t sizeInBytes() const override { return sizeof(m_box); }
     SampleFlags flags() const override;
     PlatformSample platformSample() const override;
@@ -72,7 +72,7 @@ private:
     unsigned generation() const { return m_box.generation(); }
 
     MockSampleBox m_box;
-    AtomString m_id;
+    TrackID m_id;
 };
 
 MediaSample::SampleFlags MockMediaSample::flags() const
@@ -216,32 +216,32 @@ void MockSourceBufferPrivate::setReadyState(MediaPlayer::ReadyState readyState)
         mediaSource->player().setReadyState(readyState);
 }
 
-Ref<SourceBufferPrivate::SamplesPromise> MockSourceBufferPrivate::enqueuedSamplesForTrackID(const AtomString&)
+Ref<SourceBufferPrivate::SamplesPromise> MockSourceBufferPrivate::enqueuedSamplesForTrackID(TrackID)
 {
     return SamplesPromise::createAndResolve(copyToVector(m_enqueuedSamples));
 }
 
-MediaTime MockSourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID(const AtomString&)
+MediaTime MockSourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID(TrackID)
 {
     return m_minimumUpcomingPresentationTime;
 }
 
-void MockSourceBufferPrivate::setMaximumQueueDepthForTrackID(const AtomString&, uint64_t maxQueueDepth)
+void MockSourceBufferPrivate::setMaximumQueueDepthForTrackID(TrackID, uint64_t maxQueueDepth)
 {
     m_maxQueueDepth = maxQueueDepth;
 }
 
-bool MockSourceBufferPrivate::canSetMinimumUpcomingPresentationTime(const AtomString&) const
+bool MockSourceBufferPrivate::canSetMinimumUpcomingPresentationTime(TrackID) const
 {
     return true;
 }
 
-void MockSourceBufferPrivate::setMinimumUpcomingPresentationTime(const AtomString&, const MediaTime& presentationTime)
+void MockSourceBufferPrivate::setMinimumUpcomingPresentationTime(TrackID, const MediaTime& presentationTime)
 {
     m_minimumUpcomingPresentationTime = presentationTime;
 }
 
-void MockSourceBufferPrivate::clearMinimumUpcomingPresentationTime(const AtomString&)
+void MockSourceBufferPrivate::clearMinimumUpcomingPresentationTime(TrackID)
 {
     m_minimumUpcomingPresentationTime = MediaTime::invalidTime();
 }
@@ -254,7 +254,7 @@ bool MockSourceBufferPrivate::canSwitchToType(const ContentType& contentType)
     return MockMediaPlayerMediaSource::supportsType(parameters) != MediaPlayer::SupportsType::IsNotSupported;
 }
 
-void MockSourceBufferPrivate::enqueueSample(Ref<MediaSample>&& sample, const AtomString&)
+void MockSourceBufferPrivate::enqueueSample(Ref<MediaSample>&& sample, TrackID)
 {
     RefPtr mediaSource = mediaSourcePrivate();
     if (!mediaSource)

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -54,18 +54,18 @@ private:
     void resetParserStateInternal() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;
-    bool canSetMinimumUpcomingPresentationTime(const AtomString&) const final;
-    void setMinimumUpcomingPresentationTime(const AtomString&, const MediaTime&) final;
-    void clearMinimumUpcomingPresentationTime(const AtomString&) final;
+    bool canSetMinimumUpcomingPresentationTime(TrackID) const final;
+    void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&) final;
+    void clearMinimumUpcomingPresentationTime(TrackID) final;
     bool canSwitchToType(const ContentType&) final;
 
-    void flush(const AtomString&) final { m_enqueuedSamples.clear(); m_minimumUpcomingPresentationTime = MediaTime::invalidTime(); }
-    void enqueueSample(Ref<MediaSample>&&, const AtomString&) final;
-    bool isReadyForMoreSamples(const AtomString&) final { return !m_maxQueueDepth || m_enqueuedSamples.size() < m_maxQueueDepth.value(); }
+    void flush(TrackID) final { m_enqueuedSamples.clear(); m_minimumUpcomingPresentationTime = MediaTime::invalidTime(); }
+    void enqueueSample(Ref<MediaSample>&&, TrackID) final;
+    bool isReadyForMoreSamples(TrackID) final { return !m_maxQueueDepth || m_enqueuedSamples.size() < m_maxQueueDepth.value(); }
 
-    Ref<SamplesPromise> enqueuedSamplesForTrackID(const AtomString&) final;
-    MediaTime minimumUpcomingPresentationTimeForTrackID(const AtomString&) final;
-    void setMaximumQueueDepthForTrackID(const AtomString&, uint64_t) final;
+    Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID) final;
+    MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) final;
+    void setMaximumQueueDepthForTrackID(TrackID, uint64_t) final;
 
     void didReceiveInitializationSegment(const MockInitializationBox&);
     void didReceiveSample(const MockSampleBox&);

--- a/Source/WebCore/platform/mock/mediasource/MockTracks.h
+++ b/Source/WebCore/platform/mock/mediasource/MockTracks.h
@@ -39,16 +39,16 @@ public:
     static Ref<MockAudioTrackPrivate> create(const MockTrackBox& box) { return adoptRef(*new MockAudioTrackPrivate(box)); }
     virtual ~MockAudioTrackPrivate() = default;
 
-    virtual AtomString id() const { return m_id; }
+    TrackID id() const override { return m_id; }
 
 protected:
     MockAudioTrackPrivate(const MockTrackBox& box)
         : m_box(box)
-        , m_id(AtomString::number(box.trackID()))
+        , m_id(box.trackID())
     {
     }
     MockTrackBox m_box;
-    AtomString m_id;
+    TrackID m_id;
 };
 
 class MockTextTrackPrivate : public InbandTextTrackPrivate {
@@ -56,17 +56,17 @@ public:
     static Ref<MockTextTrackPrivate> create(const MockTrackBox& box) { return adoptRef(*new MockTextTrackPrivate(box)); }
     virtual ~MockTextTrackPrivate() = default;
 
-    virtual AtomString id() const { return m_id; }
+    TrackID id() const override { return m_id; }
 
 protected:
     MockTextTrackPrivate(const MockTrackBox& box)
         : InbandTextTrackPrivate(InbandTextTrackPrivate::CueFormat::Generic)
         , m_box(box)
-        , m_id(AtomString::number(box.trackID()))
+        , m_id(box.trackID())
     {
     }
     MockTrackBox m_box;
-    AtomString m_id;
+    TrackID m_id;
 };
 
 
@@ -75,16 +75,16 @@ public:
     static Ref<MockVideoTrackPrivate> create(const MockTrackBox& box) { return adoptRef(*new MockVideoTrackPrivate(box)); }
     virtual ~MockVideoTrackPrivate() = default;
 
-    virtual AtomString id() const { return m_id; }
+    TrackID id() const override { return m_id; }
 
 protected:
     MockVideoTrackPrivate(const MockTrackBox& box)
         : m_box(box)
-        , m_id(AtomString::number(box.trackID()))
+        , m_id(box.trackID())
     {
     }
     MockTrackBox m_box;
-    AtomString m_id;
+    TrackID m_id;
 };
 
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4530,21 +4530,21 @@ void Internals::initializeMockMediaSource()
 
 void Internals::bufferedSamplesForTrackId(SourceBuffer& buffer, const AtomString& trackId, BufferedSamplesPromise&& promise)
 {
-    buffer.bufferedSamplesForTrackId(trackId)->whenSettled(RunLoop::current(), [promise = WTFMove(promise)](auto&& samples) mutable {
+    buffer.bufferedSamplesForTrackId(parseInteger<uint64_t>(trackId).value_or(0))->whenSettled(RunLoop::current(), [promise = WTFMove(promise)](auto&& samples) mutable {
         promise.resolve(WTFMove(*samples));
     });
 }
 
 void Internals::enqueuedSamplesForTrackID(SourceBuffer& buffer, const AtomString& trackID, BufferedSamplesPromise&& promise)
 {
-    buffer.enqueuedSamplesForTrackID(trackID)->whenSettled(RunLoop::current(), [promise = WTFMove(promise)](auto&& samples) mutable {
+    buffer.enqueuedSamplesForTrackID(parseInteger<uint64_t>(trackID).value_or(0))->whenSettled(RunLoop::current(), [promise = WTFMove(promise)](auto&& samples) mutable {
         promise.resolve(WTFMove(*samples));
     });
 }
 
 double Internals::minimumUpcomingPresentationTimeForTrackID(SourceBuffer& buffer, const AtomString& trackID)
 {
-    return buffer.minimumUpcomingPresentationTimeForTrackID(trackID).toDouble();
+    return buffer.minimumUpcomingPresentationTimeForTrackID(parseInteger<TrackID>(trackID).value_or(0)).toDouble();
 }
 
 void Internals::setShouldGenerateTimestamps(SourceBuffer& buffer, bool flag)
@@ -4554,7 +4554,7 @@ void Internals::setShouldGenerateTimestamps(SourceBuffer& buffer, bool flag)
 
 void Internals::setMaximumQueueDepthForTrackID(SourceBuffer& buffer, const AtomString& trackID, size_t maxQueueDepth)
 {
-    buffer.setMaximumQueueDepthForTrackID(trackID, maxQueueDepth);
+    buffer.setMaximumQueueDepthForTrackID(parseInteger<TrackID>(trackID).value_or(0), maxQueueDepth);
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
@@ -96,7 +96,7 @@ void RemoteAudioTrackProxy::configurationChanged(const PlatformAudioTrackConfigu
     configurationChanged();
 }
 
-void RemoteAudioTrackProxy::idChanged(const AtomString&)
+void RemoteAudioTrackProxy::idChanged(TrackID)
 {
     configurationChanged();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -72,7 +72,7 @@ private:
     void configurationChanged(const WebCore::PlatformAudioTrackConfiguration&) final;
 
     // TrackPrivateBaseClient
-    void idChanged(const AtomString&) final;
+    void idChanged(WebCore::TrackID) final;
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -366,12 +366,12 @@ void RemoteSourceBufferProxy::memoryPressure(uint64_t maximumBufferSize, const M
     completionHandler(WTFMove(buffered), m_sourceBufferPrivate->totalTrackBufferSizeInBytes());
 }
 
-void RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID(const AtomString& trackID, CompletionHandler<void(MediaTime)>&& completionHandler)
+void RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID(TrackID trackID, CompletionHandler<void(MediaTime)>&& completionHandler)
 {
     completionHandler(m_sourceBufferPrivate->minimumUpcomingPresentationTimeForTrackID(trackID));
 }
 
-void RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID(const AtomString& trackID, uint64_t depth)
+void RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID(TrackID trackID, uint64_t depth)
 {
     m_sourceBufferPrivate->setMaximumQueueDepthForTrackID(trackID, depth);
 }

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -37,7 +37,6 @@
 #include <WebCore/SourceBufferPrivate.h>
 #include <WebCore/SourceBufferPrivateClient.h>
 #include <wtf/Ref.h>
-#include <wtf/text/AtomString.h>
 
 namespace IPC {
 class Connection;
@@ -114,15 +113,15 @@ private:
     void bufferedSamplesForTrackId(TrackPrivateRemoteIdentifier, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&&);
     void enqueuedSamplesForTrackID(TrackPrivateRemoteIdentifier, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&&);
     void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&&);
-    void minimumUpcomingPresentationTimeForTrackID(const AtomString&, CompletionHandler<void(MediaTime)>&&);
-    void setMaximumQueueDepthForTrackID(const AtomString&, uint64_t);
+    void minimumUpcomingPresentationTimeForTrackID(TrackID, CompletionHandler<void(MediaTime)>&&);
+    void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
 
     WeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
     RemoteSourceBufferIdentifier m_identifier;
     Ref<WebCore::SourceBufferPrivate> m_sourceBufferPrivate;
     WeakPtr<RemoteMediaPlayerProxy> m_remoteMediaPlayerProxy;
 
-    HashMap<TrackPrivateRemoteIdentifier, AtomString> m_trackIds;
+    HashMap<TrackPrivateRemoteIdentifier, TrackID> m_trackIds;
     HashMap<TrackPrivateRemoteIdentifier, Ref<WebCore::MediaDescription>> m_mediaDescriptions;
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -56,8 +56,8 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     BufferedSamplesForTrackId(WebKit::TrackPrivateRemoteIdentifier remoteIdentifier) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     EnqueuedSamplesForTrackID(WebKit::TrackPrivateRemoteIdentifier remoteIdentifier) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     MemoryPressure(uint64_t maximumBufferSize, MediaTime currentTime) -> (WebCore::PlatformTimeRanges buffered, uint64_t totalTrackBufferSizeInBytes)
-    SetMaximumQueueDepthForTrackID(AtomString trackID, uint64_t depth)
-    MinimumUpcomingPresentationTimeForTrackID(AtomString trackID) -> (MediaTime time) Synchronous
+    SetMaximumQueueDepthForTrackID(uint64_t trackID, uint64_t depth)
+    MinimumUpcomingPresentationTimeForTrackID(uint64_t trackID) -> (MediaTime time) Synchronous
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -94,7 +94,7 @@ void RemoteTextTrackProxy::willRemove()
     ASSERT_NOT_REACHED();
 }
 
-void RemoteTextTrackProxy::idChanged(const AtomString&)
+void RemoteTextTrackProxy::idChanged(TrackID)
 {
     configurationChanged();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -81,7 +81,7 @@ private:
     virtual void parseWebVTTCueData(WebCore::ISOWebVTTCue&&);
 
     // TrackPrivateBaseClient
-    void idChanged(const AtomString&) final;
+    void idChanged(WebCore::TrackID) final;
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
@@ -91,7 +91,7 @@ void RemoteVideoTrackProxy::selectedChanged(bool selected)
     updateConfiguration();
 }
 
-void RemoteVideoTrackProxy::idChanged(const AtomString&)
+void RemoteVideoTrackProxy::idChanged(TrackID)
 {
     updateConfiguration();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -72,7 +72,7 @@ private:
     void configurationChanged(const WebCore::PlatformVideoTrackConfiguration&) final { updateConfiguration(); }
 
     // TrackPrivateBaseClient
-    void idChanged(const AtomString&) final;
+    void idChanged(WebCore::TrackID) final;
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;

--- a/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h
@@ -34,7 +34,7 @@
 namespace WebKit {
 
 struct TextTrackPrivateRemoteConfiguration {
-    AtomString trackId;
+    WebCore::TrackID trackId;
     AtomString label;
     AtomString language;
     AtomString inBandMetadataTrackDispatchType;

--- a/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
 struct WebKit::TextTrackPrivateRemoteConfiguration {
-    AtomString trackId;
+    uint64_t trackId;
     AtomString label;
     AtomString language;
     AtomString inBandMetadataTrackDispatchType;

--- a/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 struct TrackPrivateRemoteConfiguration {
-    AtomString trackId;
+    uint64_t trackId;
     AtomString label;
     AtomString language;
     MediaTime startTimeVariance { MediaTime::zeroTime() };

--- a/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
 struct WebKit::TrackPrivateRemoteConfiguration {
-    AtomString trackId;
+    uint64_t trackId;
     AtomString label;
     AtomString language;
     MediaTime startTimeVariance;

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
@@ -179,10 +179,9 @@ void MediaFormatReader::didParseTracks(SourceBufferPrivateClient::Initialization
     m_parseTracksStatus = errorCode ? static_cast<OSStatus>(kMTPluginFormatReaderError_ParsingFailure) : noErr;
     m_duration = WTFMove(segment.duration);
 
-    uint64_t nextUnknownTrackID = 0;
     for (auto& videoTrack : segment.videoTracks) {
         auto track = videoTrack.track.get();
-        auto trackID = track->trackUID().value_or(nextUnknownTrackID++);
+        auto trackID = track->id();
         auto trackReader = MediaTrackReader::create(allocator(), *this, kCMMediaType_Video, trackID, track->defaultEnabled());
         if (!trackReader)
             continue;
@@ -192,7 +191,7 @@ void MediaFormatReader::didParseTracks(SourceBufferPrivateClient::Initialization
 
     for (auto& audioTrack : segment.audioTracks) {
         auto track = audioTrack.track.get();
-        auto trackID = track->trackUID().value_or(nextUnknownTrackID++);
+        auto trackID = track->id();
         auto trackReader = MediaTrackReader::create(allocator(), *this, kCMMediaType_Audio, trackID, track->defaultEnabled());
         if (!trackReader)
             continue;
@@ -202,7 +201,7 @@ void MediaFormatReader::didParseTracks(SourceBufferPrivateClient::Initialization
 
     for (auto& textTrack : segment.textTracks) {
         auto track = textTrack.track.get();
-        auto trackID = track->trackUID().value_or(nextUnknownTrackID++);
+        auto trackID = track->id();
         if (auto trackReader = MediaTrackReader::create(allocator(), *this, kCMMediaType_Text, trackID, track->defaultEnabled()))
             m_trackReaders.append(trackReader.releaseNonNull());
     }

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.cpp
@@ -41,9 +41,9 @@ MediaSampleByteRange::MediaSampleByteRange(MediaSamplesBlock&& sample, MTPluginB
     ASSERT(std::holds_alternative<MediaSample::ByteRange>(m_block.last().data));
 }
 
-AtomString MediaSampleByteRange::trackID() const
+TrackID MediaSampleByteRange::trackID() const
 {
-    return AtomString::number(m_block.info()->trackID);
+    return m_block.info()->trackID;
 }
 
 PlatformSample MediaSampleByteRange::platformSample() const

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.h
@@ -46,7 +46,7 @@ public:
     SampleFlags flags() const final;
     std::optional<ByteRange> byteRange() const final;
 
-    AtomString trackID() const final;
+    TrackID trackID() const final;
     WebCore::PlatformSample platformSample() const final;
     WebCore::PlatformSample::Type platformSampleType() const final { return WebCore::PlatformSample::ByteRangeSampleType; }
     void offsetTimestampsBy(const MediaTime&) final;

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
@@ -59,9 +59,8 @@ void AudioTrackPrivateRemote::setEnabled(bool enabled)
 void AudioTrackPrivateRemote::updateConfiguration(AudioTrackPrivateRemoteConfiguration&& configuration)
 {
     if (configuration.trackId != m_id) {
-        auto changed = !m_id.isEmpty();
         m_id = configuration.trackId;
-        if (changed && client())
+        if (client())
             client()->idChanged(m_id);
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
@@ -46,7 +46,7 @@ public:
         return adoptRef(*new AudioTrackPrivateRemote(gpuProcessConnection, playerIdentifier, identifier, WTFMove(configuration)));
     }
 
-    AtomString id() const final { return m_id; }
+    WebCore::TrackID id() const final { return m_id; }
     void updateConfiguration(AudioTrackPrivateRemoteConfiguration&&);
 
 private:
@@ -62,7 +62,7 @@ private:
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     AudioTrackKind m_kind { None };
-    AtomString m_id;
+    WebCore::TrackID m_id;
     AtomString m_label;
     AtomString m_language;
     int m_trackIndex { -1 };

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -35,12 +35,12 @@
 #include <WebCore/MediaSample.h>
 #include <WebCore/SourceBufferPrivate.h>
 #include <WebCore/SourceBufferPrivateClient.h>
+#include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
-#include <wtf/text/AtomString.h>
 
 namespace IPC {
 class Connection;
@@ -86,7 +86,7 @@ private:
     void setMediaSourceEnded(bool) final;
     void setMode(WebCore::SourceBufferAppendMode) final;
     void reenqueueMediaIfNeeded(const MediaTime& currentMediaTime) final;
-    void addTrackBuffer(const AtomString& trackId, RefPtr<WebCore::MediaDescription>&&) final;
+    void addTrackBuffer(TrackID, RefPtr<WebCore::MediaDescription>&&) final;
     void resetTrackBuffers() final;
     void clearTrackBuffers(bool) final;
     void setAllTrackBuffersNeedRandomAccess() final;
@@ -105,14 +105,14 @@ private:
     Ref<ComputeSeekPromise> computeSeekTime(const WebCore::SeekTarget&) final;
     void seekToTime(const MediaTime&) final;
 
-    void updateTrackIds(Vector<std::pair<AtomString, AtomString>>&&) final;
+    void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&) final;
     uint64_t totalTrackBufferSizeInBytes() const final;
 
     void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime) final;
 
     // Internals Utility methods
-    Ref<SamplesPromise> bufferedSamplesForTrackId(const AtomString&) final;
-    Ref<SamplesPromise> enqueuedSamplesForTrackID(const AtomString&) final;
+    Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID) final;
+    Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID) final;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
@@ -125,15 +125,15 @@ private:
     void sourceBufferPrivateDidDropSample();
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
     void sourceBufferPrivateReportExtraMemoryCost(uint64_t extraMemory);
-    MediaTime minimumUpcomingPresentationTimeForTrackID(const AtomString&) override;
-    void setMaximumQueueDepthForTrackID(const AtomString&, uint64_t) override;
+    MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) override;
+    void setMaximumQueueDepthForTrackID(TrackID, uint64_t) override;
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
 
-    HashMap<AtomString, TrackPrivateRemoteIdentifier> m_trackIdentifierMap;
-    HashMap<AtomString, TrackPrivateRemoteIdentifier> m_prevTrackIdentifierMap;
+    StdUnorderedMap<TrackID, TrackPrivateRemoteIdentifier> m_trackIdentifierMap;
+    StdUnorderedMap<TrackID, TrackPrivateRemoteIdentifier> m_prevTrackIdentifierMap;
     Vector<WebCore::PlatformTimeRanges> m_trackBufferRanges;
 
     uint64_t m_totalTrackBufferSizeInBytes = { 0 };

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -62,9 +62,8 @@ void TextTrackPrivateRemote::setMode(TextTrackMode mode)
 void TextTrackPrivateRemote::updateConfiguration(TextTrackPrivateRemoteConfiguration&& configuration)
 {
     if (configuration.trackId != m_id) {
-        auto changed = !m_id.isEmpty();
         m_id = configuration.trackId;
-        if (changed && client())
+        if (client())
             client()->idChanged(m_id);
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
@@ -74,7 +74,7 @@ public:
 
     void updateConfiguration(TextTrackPrivateRemoteConfiguration&&);
 
-    AtomString id() const final { return m_id; }
+    WebCore::TrackID id() const final { return m_id; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
     int trackIndex() const final { return m_trackIndex; }
@@ -98,7 +98,7 @@ private:
     TextTrackPrivateRemote(GPUProcessConnection&, WebCore::MediaPlayerIdentifier, TrackPrivateRemoteIdentifier, TextTrackPrivateRemoteConfiguration&&);
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
-    AtomString m_id;
+    WebCore::TrackID m_id;
     AtomString m_label;
     AtomString m_language;
     int m_trackIndex { -1 };

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
@@ -59,9 +59,8 @@ void VideoTrackPrivateRemote::setSelected(bool selected)
 void VideoTrackPrivateRemote::updateConfiguration(VideoTrackPrivateRemoteConfiguration&& configuration)
 {
     if (configuration.trackId != m_id) {
-        auto changed = !m_id.isEmpty();
         m_id = configuration.trackId;
-        if (changed && client())
+        if (client())
             client()->idChanged(m_id);
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
@@ -51,7 +51,7 @@ public:
 
     using VideoTrackKind = WebCore::VideoTrackPrivate::Kind;
     VideoTrackKind kind() const final { return m_kind; }
-    AtomString id() const final { return m_id; }
+    WebCore::TrackID id() const final { return m_id; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
     int trackIndex() const final { return m_trackIndex; }
@@ -65,7 +65,7 @@ private:
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     WebCore::MediaPlayerIdentifier m_playerIdentifier;
     VideoTrackKind m_kind { None };
-    AtomString m_id;
+    WebCore::TrackID m_id;
     AtomString m_label;
     AtomString m_language;
     int m_trackIndex { -1 };

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -56,7 +56,7 @@ public:
     MediaTime presentationTime() const final { return m_presentationTime; }
     MediaTime decodeTime() const final { return m_decodeTime; }
     MediaTime duration() const final { return m_duration; }
-    AtomString trackID() const final { return m_trackID; }
+    TrackID trackID() const final { return m_trackID; }
     size_t sizeInBytes() const final { return m_sizeInBytes; }
     FloatSize presentationSize() const final { return m_presentationSize; }
     void offsetTimestampsBy(const MediaTime& offset) final { m_presentationTime += offset; m_decodeTime += offset; }
@@ -86,7 +86,7 @@ private:
     MediaTime m_decodeTime;
     MediaTime m_duration;
     FloatSize m_presentationSize;
-    AtomString m_trackID;
+    TrackID m_trackID;
     size_t m_sizeInBytes { 0 };
     SampleFlags m_flags { None };
 };


### PR DESCRIPTION
#### b3ffcc0a9df7ef521eebfd10f5da302fbbb2180c
<pre>
MediaSample should use integer as track id rather than AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=254099">https://bugs.webkit.org/show_bug.cgi?id=254099</a>
<a href="https://rdar.apple.com/106884653">rdar://106884653</a>

Reviewed by Eric Carlson and Philippe Normand.

In all the containers we support, a track id can only ever be an int, never a string.
While the HTML specs for media tracks require the id to be a string, it
serves no purpose to keep a string internally. And once we move the media private
element outside the main thread, using AtomString become problematic anyway.

So we change the internal storage type to an uint64_t, it allows to simplify the code,
remove the need for conversion back and forth between integers and AtomString.
We can no longer use HashMap objects for storing our TrackID as it prevents
using all ID ranges, so we move to StdUnorderedMap instead.

No observable change, covered by existing tests.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::bufferedSamplesForTrackId):
(WebCore::SourceBuffer::enqueuedSamplesForTrackID):
(WebCore::SourceBuffer::minimumUpcomingPresentationTimeForTrackID):
(WebCore::SourceBuffer::setMaximumQueueDepthForTrackID):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::AudioTrack):
(WebCore::AudioTrack::idChanged):
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/AudioTrackList.cpp:
(WebCore::AudioTrackList::getTrackById const):
* Source/WebCore/html/track/AudioTrackList.h:
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::idChanged):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::convertKind):
(WebCore::TextTrack::TextTrack):
(WebCore::TextTrack::create):
(WebCore::TextTrack::setId):
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackList.cpp:
(WebCore::TextTrackList::getTrackById const): Make method const.
(WebCore::TextTrackList::getTrackById): Deleted.
* Source/WebCore/html/track/TextTrackList.h:
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::TrackBase):
(WebCore::MediaTrackBase::MediaTrackBase):
* Source/WebCore/html/track/TrackBase.h:
(WebCore::TrackBase::trackId const):
(WebCore::TrackBase::setId):
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::VideoTrack):
(WebCore::VideoTrack::idChanged):
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/html/track/VideoTrackList.cpp:
(WebCore::VideoTrackList::getTrackById const):
* Source/WebCore/html/track/VideoTrackList.h:
* Source/WebCore/platform/MediaSample.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::resetTimestampOffsetInTrackBuffers):
(WebCore::SourceBufferPrivate::resetTrackBuffers):
(WebCore::SourceBufferPrivate::updateHighestPresentationTimestamp):
(WebCore::SourceBufferPrivate::trackBuffersRanges const):
(WebCore::SourceBufferPrivate::reenqueSamples):
(WebCore::SourceBufferPrivate::computeSeekTime):
(WebCore::SourceBufferPrivate::seekToTime):
(WebCore::SourceBufferPrivate::clearTrackBuffers):
(WebCore::SourceBufferPrivate::bufferedSamplesForTrackId):
(WebCore::SourceBufferPrivate::enqueuedSamplesForTrackID):
(WebCore::SourceBufferPrivate::updateMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivate::setMediaSourceEnded):
(WebCore::SourceBufferPrivate::trySignalAllSamplesInTrackEnqueued):
(WebCore::SourceBufferPrivate::provideMediaData):
(WebCore::SourceBufferPrivate::reenqueueMediaForTime):
(WebCore::SourceBufferPrivate::reenqueueMediaIfNeeded):
(WebCore::SourceBufferPrivate::findPreviousSyncSamplePresentationTime):
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):
(WebCore::SourceBufferPrivate::hasTooManySamples const):
(WebCore::SourceBufferPrivate::totalTrackBufferSizeInBytes const):
(WebCore::SourceBufferPrivate::addTrackBuffer):
(WebCore::SourceBufferPrivate::updateTrackIds):
(WebCore::SourceBufferPrivate::setAllTrackBuffersNeedRandomAccess):
(WebCore::SourceBufferPrivate::processMediaSample):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID):
(WebCore::SourceBufferPrivate::setMaximumQueueDepthForTrackID):
(WebCore::SourceBufferPrivate::flush):
(WebCore::SourceBufferPrivate::enqueueSample):
(WebCore::SourceBufferPrivate::allSamplesInTrackEnqueued):
(WebCore::SourceBufferPrivate::isReadyForMoreSamples):
(WebCore::SourceBufferPrivate::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivate::canSetMinimumUpcomingPresentationTime const):
(WebCore::SourceBufferPrivate::setMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivate::clearMinimumUpcomingPresentationTime):
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WebCore::TrackPrivateBase::trackUID const):
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/TrackPrivateBaseClient.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::id const):
(WebCore::AVTrackPrivateAVFObjCImpl::trackID const): Deleted. Redundant method with id() returning the same value.
* Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h:
(WebCore::AudioTrackPrivateAVF::setId):
* Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp:
(WebCore::InbandMetadataTextTrackPrivateAVF::create):
(WebCore::InbandMetadataTextTrackPrivateAVF::InbandMetadataTextTrackPrivateAVF):
* Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h:
(WebCore::VideoTrackPrivateAVF::setId):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp:
(WebCore::AudioTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::update):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h:
(WebCore::MediaSampleAVFObjC::create):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::MediaSampleAVFObjC):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::didProvideMediaDataForTrackID):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::isMediaSampleAllowed const):
(WebCore::SourceBufferPrivateAVFObjC::processFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::needsVideoLayer const):
(WebCore::SourceBufferPrivateAVFObjC::hasSelectedVideo const):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::flushIfNeeded):
(WebCore::SourceBufferPrivateAVFObjC::rendererWasAutomaticallyFlushed):
(WebCore::SourceBufferPrivateAVFObjC::flush):
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::canSetMinimumUpcomingPresentationTime const):
(WebCore::SourceBufferPrivateAVFObjC::setMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivateAVFObjC::clearMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivateAVFObjC::setVideoLayer):
(WebCore::SourceBufferPrivateAVFObjC::setDecompressionSession):
(WebCore::SourceBufferPrivateAVFObjC::isEnabledVideoTrackID const): Add utility method to check if the current trackID is the currently selected video track.
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
(WebCore::VideoTrackPrivateAVFObjC::resetPropertiesFromTrack):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm:
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC):
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::id const):
(WebCore::AudioTrackPrivateWebM::trackUID const): Deleted.
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::seekToTarget):
(WebCore::MediaPlayerPrivateWebM::setVolume):
(WebCore::MediaPlayerPrivateWebM::setMuted):
(WebCore::MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers):
(WebCore::MediaPlayerPrivateWebM::updateDurationFromTrackBuffers):
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::reenqueSamples):
(WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime):
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::canSetMinimumUpcomingPresentationTime const):
(WebCore::MediaPlayerPrivateWebM::setMinimumUpcomingPresentationTime):
(WebCore::MediaPlayerPrivateWebM::clearMinimumUpcomingPresentationTime):
(WebCore::MediaPlayerPrivateWebM::isReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::provideMediaData):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeEnabled):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
(WebCore::MediaPlayerPrivateWebM::didProvideMediaDataForTrackId):
(WebCore::MediaPlayerPrivateWebM::append):
(WebCore::MediaPlayerPrivateWebM::flush):
(WebCore::MediaPlayerPrivateWebM::flushIfNeeded):
(WebCore::MediaPlayerPrivateWebM::flushTrack):
(WebCore::MediaPlayerPrivateWebM::addTrackBuffer):
(WebCore::MediaPlayerPrivateWebM::ensureLayer):
(WebCore::MediaPlayerPrivateWebM::ensureDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::addAudioRenderer):
(WebCore::MediaPlayerPrivateWebM::removeAudioRenderer):
(WebCore::MediaPlayerPrivateWebM::destroyAudioRenderers):
(WebCore::MediaPlayerPrivateWebM::isEnabledVideoTrackID const):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::id const):
(WebCore::VideoTrackPrivateWebM::trackUID const): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h:
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h:
(WebCore::InbandMetadataTextTrackPrivateGStreamer::InbandMetadataTextTrackPrivateGStreamer):
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
(WebCore::InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer): m_id was set twice to the same value, first in the base constructor.
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfTrack):
(WebCore::MediaPlayerPrivateGStreamer::handleTextSample):
(WebCore::MediaPlayerPrivateGStreamer::updateEnabledVideoTrack):
(WebCore::MediaPlayerPrivateGStreamer::updateEnabledAudioTrack):
(WebCore::MediaPlayerPrivateGStreamer::updateTracks):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp:
(WebCore::MediaSampleGStreamer::MediaSampleGStreamer):
(WebCore::MediaSampleGStreamer::createFakeSample):
(WebCore::MediaSampleGStreamer::dump const):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h:
(WebCore::MediaSampleGStreamer::create):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::prefixForType):
(WebCore::TrackPrivateBaseGStreamer::generateUniquePlaybin2StreamID):
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer): m_id was calculated twice, once in the constructor, and once in setPad.
(WebCore::TrackPrivateBaseGStreamer::setPad):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged):
(WebCore::TrackPrivateBaseGStreamer::trackIdFromStringIdOrIndex):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
(WebCore::TrackPrivateBaseGStreamer::index):
(WebCore::TrackPrivateBaseGStreamer::stringId const):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkNewSample):
(WebCore::AppendPipeline::didReceiveInitializationSegment):
(WebCore::createOptionalParserForFormat):
(WebCore::AppendPipeline::recycleTrackForPad):
(WebCore::AppendPipeline::linkPadWithTrack):
(WebCore::AppendPipeline::Track::emplaceOptionalParserForFormat):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
(WebCore::AppendPipeline::Track::Track):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp:
(WebCore::MediaSourceTrackGStreamer::MediaSourceTrackGStreamer):
(WebCore::MediaSourceTrackGStreamer::create):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::removedFromMediaSource):
(WebCore::SourceBufferPrivateGStreamer::flush):
(WebCore::SourceBufferPrivateGStreamer::enqueueSample):
(WebCore::SourceBufferPrivateGStreamer::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateGStreamer::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued):
(WebCore::SourceBufferPrivateGStreamer::precheckInitialisationSegment):
(WebCore::SourceBufferPrivateGStreamer::platformMaximumBufferSize const):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcEmitStreams):
(webKitMediaSrcLoop):
(webKitMediaSrcStreamFlush):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp:
(WebCore::AudioTrackPrivateMediaStream::AudioTrackPrivateMediaStream):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::enqueuedSamplesForTrackID):
(WebCore::MockSourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID):
(WebCore::MockSourceBufferPrivate::setMaximumQueueDepthForTrackID):
(WebCore::MockSourceBufferPrivate::canSetMinimumUpcomingPresentationTime const):
(WebCore::MockSourceBufferPrivate::setMinimumUpcomingPresentationTime):
(WebCore::MockSourceBufferPrivate::clearMinimumUpcomingPresentationTime):
(WebCore::MockSourceBufferPrivate::enqueueSample):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebCore/platform/mock/mediasource/MockTracks.h:
(WebCore::MockAudioTrackPrivate::MockAudioTrackPrivate):
(WebCore::MockTextTrackPrivate::MockTextTrackPrivate):
(WebCore::MockVideoTrackPrivate::MockVideoTrackPrivate):
(WebCore::MockAudioTrackPrivate::id const): Deleted. Mark method override as it&apos;s virtual
(WebCore::MockTextTrackPrivate::id const): Deleted. Mark method override as it&apos;s virtual
(WebCore::MockVideoTrackPrivate::id const): Deleted. Mark method override as it&apos;s virtual
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::bufferedSamplesForTrackId):
(WebCore::Internals::enqueuedSamplesForTrackID):
(WebCore::Internals::minimumUpcomingPresentationTimeForTrackID):
(WebCore::Internals::setMaximumQueueDepthForTrackID):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp:
(WebKit::RemoteAudioTrackProxy::idChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID):
(WebKit::RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::idChanged):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp:
(WebKit::RemoteVideoTrackProxy::idChanged):
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h:
* Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in:
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h:
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in:
* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp:
(WebKit::MediaFormatReader::didParseTracks):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.cpp:
(WebKit::MediaSampleByteRange::trackID const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.h:
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp:
(WebKit::AudioTrackPrivateRemote::updateConfiguration):
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::addTrackBuffer):
(WebKit::SourceBufferPrivateRemote::updateTrackIds):
(WebKit::SourceBufferPrivateRemote::bufferedSamplesForTrackId):
(WebKit::SourceBufferPrivateRemote::enqueuedSamplesForTrackID):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID):
(WebKit::SourceBufferPrivateRemote::setMaximumQueueDepthForTrackID):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp:
(WebKit::TextTrackPrivateRemote::updateConfiguration):
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp:
(WebKit::VideoTrackPrivateRemote::updateConfiguration):
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h:
* Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:

Canonical link: <a href="https://commits.webkit.org/271419@main">https://commits.webkit.org/271419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/290632ba25e516ef4ed0996c4d0ad6f3cdb1ddca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28349 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30876 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4364 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5030 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31436 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29193 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6786 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->