### PR TITLE
Worker IDL Interace is not exposed to 'SharedWorker'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL postMessaging to a dedicated sub-worker allows them to see each others' modifications Can't find variable: Worker
-FAIL Bonus: self.crossOriginIsolated assert_true: expected true got false
+Harness Error (TIMEOUT), message = null
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=workers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=workers-expected.txt
@@ -5,6 +5,6 @@ PASS importScripts() in a dedicated worker
 PASS Worker() in a dedicated worker
 FAIL SharedWorker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 FAIL importScripts() in a shared worker assert_equals: expected "%C3%A5" but got "importScripts failed to run"
-FAIL Worker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+PASS Worker() in a shared worker
 FAIL SharedWorker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=workers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=workers-expected.txt
@@ -5,6 +5,6 @@ PASS importScripts() in a dedicated worker
 PASS Worker() in a dedicated worker
 FAIL SharedWorker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 FAIL importScripts() in a shared worker assert_equals: expected "%C3%A5" but got "importScripts failed to run"
-FAIL Worker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+PASS Worker() in a shared worker
 FAIL SharedWorker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=workers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=workers-expected.txt
@@ -5,6 +5,6 @@ PASS importScripts() in a dedicated worker
 PASS Worker() in a dedicated worker
 FAIL SharedWorker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 FAIL importScripts() in a shared worker assert_equals: expected "%C3%A5" but got "importScripts failed to run"
-FAIL Worker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+PASS Worker() in a shared worker
 FAIL SharedWorker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
@@ -13,6 +13,6 @@ PASS Register a service worker for worker subresource interception tests.
 PASS Requests on a dedicated worker controlled by a service worker.
 PASS Requests on a shared worker controlled by a service worker.
 FAIL Requests on a dedicated worker nested in a dedicated worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
-FAIL Requests on a dedicated worker nested in a shared worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "Unexpected error! Can't find variable: Worker"
+FAIL Requests on a dedicated worker nested in a shared worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "Unexpected message! "
 PASS Unregister a service worker for subresource interception tests.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.sharedworker-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL postMessaging to a dedicated sub-worker allows them to see each others' modifications Can't find variable: Worker
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT postMessaging to a dedicated sub-worker allows them to see each others' modifications Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/interface-objects-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/interface-objects-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test if interface objects exist in a shared worker assert_equals: expected "These were missing: " but got "These were missing: Worker"
+PASS Test if interface objects exist in a shared worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/interface-objects/003.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/interface-objects/003.any.sharedworker-expected.txt
@@ -1,7 +1,7 @@
 
 PASS The WorkerGlobalScope interface object should be exposed
 PASS The SharedWorkerGlobalScope interface object should be exposed
-FAIL The Worker interface object should be exposed assert_true: expected true got false
+PASS The Worker interface object should be exposed
 PASS The MessagePort interface object should be exposed
 PASS The MessageEvent interface object should be exposed
 PASS The WorkerNavigator interface object should be exposed

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/exposure.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/exposure.any.sharedworker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Worker exposure assert_not_equals: got disallowed value undefined
+PASS Worker exposure
 PASS SharedWorker exposure
 

--- a/Source/WebCore/workers/Worker.idl
+++ b/Source/WebCore/workers/Worker.idl
@@ -24,16 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface
+
 [
     ActiveDOMObject,
-    Exposed=(Window,DedicatedWorker)
+    Exposed=(Window,DedicatedWorker,SharedWorker)
 ] interface Worker : EventTarget {
-    [CallWith=CurrentScriptExecutionContext&RuntimeFlags] constructor(USVString scriptUrl, optional WorkerOptions options);
+    [CallWith=CurrentScriptExecutionContext&RuntimeFlags] constructor(USVString scriptUrl, optional WorkerOptions options = {});
 
     undefined terminate();
 
     [CallWith=CurrentGlobalObject] undefined postMessage(any message, sequence<object> transfer);
-    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options);
+    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options = {});
     attribute EventHandler onmessage;
     attribute EventHandler onmessageerror;
 };


### PR DESCRIPTION
<pre>
Worker IDL Interace is not exposed to 'SharedWorker'
<a href="https://bugs.webkit.org/show_bug.cgi?id=265263">https://bugs.webkit.org/show_bug.cgi?id=265263</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Web-Specification [1] by exposing 'Worker' to 'SharedWorker'.

[1] <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface">https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface</a>

* Source/WebCore/workers/Worker.idl:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/interface-objects/003.any.sharedworker-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/exposure.any.sharedworker-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-sharedworker-success.https-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=workers-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=workers-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=workers-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/interface-objects-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.sharedworker-expected.txt: Rebaselined
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e035bd8d60ffd520eda949bf9e1f675ca4487902

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24947 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4274 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30339 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4451 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5644 "An unexpected error occured. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28532 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->