### PR TITLE
Correct <input type=checkbox switch> animation corner case and add tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4966,6 +4966,9 @@ media/media-session/mock-coordinator.html [ Skip ]
 media/track/track-description-cue.html [ Skip ]
 media/track/track-extended-descriptions.html [ Skip ]
 
+# Soon Cocoa-only (currently only macOS)
+fast/forms/switch/ [ Skip ]
+
 # These tests rely on webkit-test-runner flags that aren't implemented for DumpRenderTree, so they will fail under legacy WebKit.
 
 # These tests are for iOS port.

--- a/LayoutTests/fast/forms/switch/click-animation-disabled-expected.html
+++ b/LayoutTests/fast/forms/switch/click-animation-disabled-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch checked disabled>

--- a/LayoutTests/fast/forms/switch/click-animation-disabled.html
+++ b/LayoutTests/fast/forms/switch/click-animation-disabled.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    setTimeout(() => {
+        document.querySelector("input").disabled = true;
+        document.documentElement.removeAttribute("class");
+    }, 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-expected-mismatch.html
+++ b/LayoutTests/fast/forms/switch/click-animation-expected-mismatch.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch checked>

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted-document-removed-expected.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted-document-removed-expected.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html>

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted-document-removed.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted-document-removed.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="reftest-wait">
+<iframe srcdoc="<input type=checkbox switch onclick=parent.end()>"></iframe>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(20, 20);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    setTimeout(() => {
+        document.querySelector("iframe").remove();
+        document.documentElement.removeAttribute("class");
+    }, 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted-expected.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch>

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted-type-change-expected.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted-type-change-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=radio checked>

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted-type-change.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted-type-change.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    setTimeout(() => {
+        document.querySelector("input").type = "radio";
+        document.documentElement.removeAttribute("class");
+    }, 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    setTimeout(() => {
+        document.querySelector("input").checked = false;
+        document.documentElement.removeAttribute("class");
+    }, 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-preventdefault-expected.html
+++ b/LayoutTests/fast/forms/switch/click-animation-preventdefault-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch>

--- a/LayoutTests/fast/forms/switch/click-animation-preventdefault.html
+++ b/LayoutTests/fast/forms/switch/click-animation-preventdefault.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    event.preventDefault();
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-redundant-checked-expected-mismatch.html
+++ b/LayoutTests/fast/forms/switch/click-animation-redundant-checked-expected-mismatch.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch checked>

--- a/LayoutTests/fast/forms/switch/click-animation-redundant-checked.html
+++ b/LayoutTests/fast/forms/switch/click-animation-redundant-checked.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    setTimeout(() => {
+        document.querySelector("input").checked = true;
+        document.documentElement.removeAttribute("class");
+    }, 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-redundant-disabled-expected-mismatch.html
+++ b/LayoutTests/fast/forms/switch/click-animation-redundant-disabled-expected-mismatch.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch checked>

--- a/LayoutTests/fast/forms/switch/click-animation-redundant-disabled.html
+++ b/LayoutTests/fast/forms/switch/click-animation-redundant-disabled.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    setTimeout(() => {
+        document.querySelector("input").disabled = false;
+        document.documentElement.removeAttribute("class");
+    }, 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-twice-expected.html
+++ b/LayoutTests/fast/forms/switch/click-animation-twice-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch>

--- a/LayoutTests/fast/forms/switch/click-animation-twice-fast-expected.html
+++ b/LayoutTests/fast/forms/switch/click-animation-twice-fast-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch>

--- a/LayoutTests/fast/forms/switch/click-animation-twice-fast.html
+++ b/LayoutTests/fast/forms/switch/click-animation-twice-fast.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=each()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+    window.eventSender.scheduleAsynchronousClick();
+}
+let count = 0;
+function each() {
+    if (count === 0)
+        count += 1;
+    else if (count === 1)
+        setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation-twice.html
+++ b/LayoutTests/fast/forms/switch/click-animation-twice.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=each()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+let count = 0;
+function each() {
+    if (count === 0) {
+        setTimeout(() => window.eventSender.scheduleAsynchronousClick(), 25);
+        count += 1;
+    } else if (count === 1)
+        setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/click-animation.html
+++ b/LayoutTests/fast/forms/switch/click-animation.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.scheduleAsynchronousClick();
+}
+function end() {
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+</script>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -63,6 +63,8 @@ fast/forms/search/search-padding-cancel-results-buttons.html [ Pass ]
 fast/forms/search/search-results-hidden-crash.html [ Pass ]
 fast/forms/search/search-recent-searches.html [ Pass ]
 
+fast/forms/switch/ [ Pass ]
+
 fast/url/user-visible [ Pass ]
 fast/images/eps-as-image.html [ Skip ]
 

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -127,6 +127,11 @@ bool CheckboxInputType::shouldAppearIndeterminate() const
     return element()->indeterminate() && !isSwitch();
 }
 
+void CheckboxInputType::disabledStateChanged()
+{
+    stopSwitchCheckedChangeAnimation();
+}
+
 // FIXME: ideally CheckboxInputType would not be responsible for the timer specifics and instead
 // ask a more knowledgable system for a refresh callback (perhaps passing a desired FPS).
 static Seconds switchCheckedChangeAnimationUpdateInterval(HTMLInputElement* element)
@@ -144,7 +149,7 @@ void CheckboxInputType::performSwitchCheckedChangeAnimation(WasSetByJavaScript w
     ASSERT(element()->renderer()->style().hasEffectiveAppearance());
 
     if (wasCheckedByJavaScript == WasSetByJavaScript::Yes) {
-        m_switchCheckedChangeAnimationStartTime = 0_s;
+        stopSwitchCheckedChangeAnimation();
         return;
     }
 
@@ -169,6 +174,11 @@ void CheckboxInputType::performSwitchCheckedChangeAnimation(WasSetByJavaScript w
 
     m_switchCheckedChangeAnimationStartTime = MonotonicTime::now().secondsSinceEpoch() - startTimeOffset;
     m_switchCheckedChangeAnimationTimer->startOneShot(updateInterval);
+}
+
+void CheckboxInputType::stopSwitchCheckedChangeAnimation()
+{
+    m_switchCheckedChangeAnimationStartTime = 0_s;
 }
 
 float CheckboxInputType::switchCheckedChangeAnimationProgress() const
@@ -197,7 +207,7 @@ void CheckboxInputType::switchCheckedChangeAnimationTimerFired()
     if (currentTime - m_switchCheckedChangeAnimationStartTime < duration)
         m_switchCheckedChangeAnimationTimer->startOneShot(updateInterval);
     else
-        m_switchCheckedChangeAnimationStartTime = 0_s;
+        stopSwitchCheckedChangeAnimation();
 
     element()->renderer()->repaint();
 }

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -44,7 +44,6 @@ public:
     }
 
     bool valueMissing(const String&) const final;
-
     void performSwitchCheckedChangeAnimation(WasSetByJavaScript);
     float switchCheckedChangeAnimationProgress() const;
 
@@ -62,7 +61,8 @@ private:
     void didDispatchClick(Event&, const InputElementClickState&) final;
     bool matchesIndeterminatePseudoClass() const final;
     bool shouldAppearIndeterminate() const final;
-
+    void disabledStateChanged() final;
+    void stopSwitchCheckedChangeAnimation();
     void switchCheckedChangeAnimationTimerFired();
 
     Seconds m_switchCheckedChangeAnimationStartTime { 0_s };


### PR DESCRIPTION
#### c2e7027de483cb5d51dd8a79965e10a4851ebc52
<pre>
Correct &lt;input type=checkbox switch&gt; animation corner case and add tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=265356">https://bugs.webkit.org/show_bug.cgi?id=265356</a>

Reviewed by Aditya Keerthi.

I&apos;ve decided on the following things:

* When an animation is running and setChecked() is called with the same
  value the animation is running for, the animation continues to run.
  As such we do not modify the early return in setChecked() for when
  the state does not change unlike an earlier iteration of this change.
* When an animation is running and the checked or disabled state
  changes underneath, the animation is stopped.

Stopping the animation is abstracted into a method for clarity.

Test coverage is added for these scenarios and a couple more to reduce
the chances of regressions when refactoring in the future.

I also want to mention here that I strongly considered an alternative
approach whereby CheckboxInputType would be solely responsible for
calling performSwitchCheckedChangeAnimation() right after it calls
setChecked(), but setChecked() can invalidate or reverse an animation
and I could not find a good way to integrate that behavior.

Canonical link: <a href="https://commits.webkit.org/271327@main">https://commits.webkit.org/271327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f193fa4718b7cc7753252facf37f7d9bfcf022d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25233 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28820 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24732 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6722 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->