### PR TITLE
Adopt dynamicDowncast<>() further in css/

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -527,14 +527,14 @@ static RefPtr<CSSValue> positionOffsetValue(const RenderStyle& style, CSSPropert
     auto offset = getOffsetComputedLength(style, propertyID);
 
     // If the element is not displayed; return the "computed value".
-    if (!renderer || !renderer->isRenderBox())
+    CheckedPtr box = dynamicDowncast<RenderBox>(renderer);
+    if (!box)
         return zoomAdjustedPixelValueForLength(offset, style);
 
-    auto& box = downcast<RenderBox>(*renderer);
-    auto* containingBlock = box.containingBlock();
+    auto* containingBlock = box->containingBlock();
 
     // Resolve a "computed value" percentage if the element is positioned.
-    if (containingBlock && offset.isPercentOrCalculated() && box.isPositioned()) {
+    if (containingBlock && offset.isPercentOrCalculated() && box->isPositioned()) {
         bool isVerticalProperty;
         if (propertyID == CSSPropertyTop || propertyID == CSSPropertyBottom)
             isVerticalProperty = true;
@@ -543,21 +543,21 @@ static RefPtr<CSSValue> positionOffsetValue(const RenderStyle& style, CSSPropert
             isVerticalProperty = false;
         }
         LayoutUnit containingBlockSize;
-        if (box.isStickilyPositioned()) {
-            auto& enclosingClippingBox = box.enclosingClippingBoxForStickyPosition().first;
+        if (box->isStickilyPositioned()) {
+            auto& enclosingClippingBox = box->enclosingClippingBoxForStickyPosition().first;
             if (isVerticalProperty == enclosingClippingBox.isHorizontalWritingMode())
                 containingBlockSize = enclosingClippingBox.contentLogicalHeight();
             else
                 containingBlockSize = enclosingClippingBox.contentLogicalWidth();
         } else {
             if (isVerticalProperty == containingBlock->isHorizontalWritingMode()) {
-                containingBlockSize = box.isOutOfFlowPositioned()
-                    ? box.containingBlockLogicalHeightForPositioned(*containingBlock, false)
-                    : box.containingBlockLogicalHeightForContent(ExcludeMarginBorderPadding);
+                containingBlockSize = box->isOutOfFlowPositioned()
+                    ? box->containingBlockLogicalHeightForPositioned(*containingBlock, false)
+                    : box->containingBlockLogicalHeightForContent(ExcludeMarginBorderPadding);
             } else {
-                containingBlockSize = box.isOutOfFlowPositioned()
-                    ? box.containingBlockLogicalWidthForPositioned(*containingBlock, nullptr, false)
-                    : box.containingBlockLogicalWidthForContent();
+                containingBlockSize = box->isOutOfFlowPositioned()
+                    ? box->containingBlockLogicalWidthForPositioned(*containingBlock, nullptr, false)
+                    : box->containingBlockLogicalWidthForContent();
             }
         }
         return zoomAdjustedPixelValue(floatValueForLength(offset, containingBlockSize), style);
@@ -568,11 +568,11 @@ static RefPtr<CSSValue> positionOffsetValue(const RenderStyle& style, CSSPropert
         return zoomAdjustedPixelValueForLength(offset, style);
 
     // The property won't be overconstrained if its computed value is "auto", so the "used value" can be returned.
-    if (box.isRelativelyPositioned())
-        return zoomAdjustedPixelValue(getOffsetUsedStyleRelative(box, propertyID), style);
+    if (box->isRelativelyPositioned())
+        return zoomAdjustedPixelValue(getOffsetUsedStyleRelative(*box, propertyID), style);
 
-    if (containingBlock && box.isOutOfFlowPositioned())
-        return zoomAdjustedPixelValue(getOffsetUsedStyleOutOfFlowPositioned(*containingBlock, box, propertyID), style);
+    if (containingBlock && box->isOutOfFlowPositioned())
+        return zoomAdjustedPixelValue(getOffsetUsedStyleOutOfFlowPositioned(*containingBlock, *box, propertyID), style);
 
     return CSSPrimitiveValue::create(CSSValueAuto);
 }

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -74,8 +74,8 @@ static Vector<Ref<CSSCalcExpressionNode>> createCSS(const Vector<std::unique_ptr
 
 static RefPtr<CSSCalcExpressionNode> createCSSIgnoringZeroLength(const CalcExpressionNode& node, const RenderStyle& style)
 {
-    if (node.type() == CalcExpressionNodeType::Length) {
-        auto& length = downcast<CalcExpressionLength>(node).length();
+    if (auto* lengthNode = dynamicDowncast<CalcExpressionLength>(node)) {
+        auto& length = lengthNode->length();
         if (!length.isPercent() && length.isZero())
             return nullptr;
     }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1980,7 +1980,8 @@ bool CSSPropertyParser::consumeOverflowShorthand(bool important)
 
 static bool isCustomIdentValue(const CSSValue& value)
 {
-    return is<CSSPrimitiveValue>(value) && downcast<CSSPrimitiveValue>(value).isCustomIdent();
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    return primitiveValue && primitiveValue->isCustomIdent();
 }
 
 bool CSSPropertyParser::consumeGridItemPositionShorthand(CSSPropertyID shorthandId, bool important)

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -86,7 +86,8 @@ Color CSSPropertyParserWorkerSafe::parseColor(const String& string)
 
 static CSSParserMode parserMode(ScriptExecutionContext& context)
 {
-    return (is<Document>(context) && downcast<Document>(context).inQuirksMode()) ? HTMLQuirksMode : HTMLStandardMode;
+    auto* document = dynamicDowncast<Document>(context);
+    return (document && document->inQuirksMode()) ? HTMLQuirksMode : HTMLStandardMode;
 }
 
 RefPtr<CSSValueList> CSSPropertyParserWorkerSafe::parseFontFaceSrc(const String& string, const CSSParserContext& context)

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3428,9 +3428,9 @@ class GenerateStyleBuilderGenerated:
     def _generate_fill_layer_property_value_setter(self, to, property):
         to.write(f"auto* child = &builderState.style().{property.method_name_for_ensure_layers}();")
         to.write(f"FillLayer* previousChild = nullptr;")
-        to.write(f"if (is<CSSValueList>(value)) {{")
+        to.write(f"if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {{")
         to.write(f"    // Walk each value and put it into a layer, creating new layers as needed.")
-        to.write(f"    for (auto& item : downcast<CSSValueList>(value)) {{")
+        to.write(f"    for (auto& item : *valueList) {{")
         to.write(f"        if (!child) {{")
         to.write(f"            previousChild->setNext(FillLayer::create({property.enum_name_for_layers_type}));")
         to.write(f"            child = previousChild->next();")

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -45,15 +45,14 @@ struct SizeFeatureSchema : public FeatureSchema {
         // or the query container does not support container size queries on the relevant axes, then the result of
         // evaluating the size feature is unknown."
         // https://drafts.csswg.org/css-contain-3/#size-container
-        if (!is<RenderBox>(context.renderer))
+        CheckedPtr renderer = dynamicDowncast<RenderBox>(context.renderer);
+        if (!renderer)
             return MQ::EvaluationResult::Unknown;
 
-        auto& renderer = downcast<RenderBox>(*context.renderer);
-
-        if (!renderer.hasEligibleContainmentForSizeQuery())
+        if (!renderer->hasEligibleContainmentForSizeQuery())
             return MQ::EvaluationResult::Unknown;
 
-        return evaluate(feature, renderer, context.conversionData);
+        return evaluate(feature, *renderer, context.conversionData);
     }
 
     virtual EvaluationResult evaluate(const MQ::Feature&, const RenderBox&, const CSSToLengthConversionData&) const = 0;

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
@@ -34,19 +34,19 @@ namespace MQ {
 
 static std::optional<LayoutUnit> computeLength(const CSSValue* value, const CSSToLengthConversionData& conversionData)
 {
-    if (!is<CSSPrimitiveValue>(value))
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
         return { };
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(*value);
 
-    if (primitiveValue.isNumberOrInteger()) {
-        if (primitiveValue.doubleValue())
+    if (primitiveValue->isNumberOrInteger()) {
+        if (primitiveValue->doubleValue())
             return { };
         return 0_lu;
     }
 
-    if (!primitiveValue.isLength())
+    if (!primitiveValue->isLength())
         return { };
-    return primitiveValue.computeLength<LayoutUnit>(conversionData);
+    return primitiveValue->computeLength<LayoutUnit>(conversionData);
 }
 
 template<typename T>
@@ -138,15 +138,14 @@ static EvaluationResult evaluateRatioComparison(FloatSize size, const std::optio
     if (!comparison)
         return EvaluationResult::True;
 
-    if (!is<CSSAspectRatioValue>(comparison->value))
+    auto* ratioValue = dynamicDowncast<CSSAspectRatioValue>(comparison->value.get());
+    if (!ratioValue)
         return EvaluationResult::Unknown;
 
-    auto& ratioValue = downcast<CSSAspectRatioValue>(*comparison->value);
-
     // Ratio with zero denominator is infinite and compares greater to any value.
-    auto denominator = ratioValue.denominatorValue();
+    auto denominator = ratioValue->denominatorValue();
 
-    auto comparisonA = denominator ? size.height() * ratioValue.numeratorValue() : 1.f;
+    auto comparisonA = denominator ? size.height() * ratioValue->numeratorValue() : 1.f;
     auto comparisonB = denominator ? size.width() * denominator : 0.f;
 
     auto left = side == Side::Left ? comparisonA : comparisonB;


### PR DESCRIPTION
#### cb498fbf6ed17620706a2c2c8551daf502a84051
<pre>
Adopt dynamicDowncast&lt;&gt;() further in css/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265359">https://bugs.webkit.org/show_bug.cgi?id=265359</a>

Reviewed by Darin Adler.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::positionOffsetValue):
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::createCSSIgnoringZeroLength):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::isCustomIdentValue):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFilterFunction):
(WebCore::CSSPropertyParserHelpers::consumeTransformFunction):
(WebCore::CSSPropertyParserHelpers::isGridTrackFixedSized):
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::parserMode):
* Source/WebCore/css/process-css-properties.py:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
* Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp:
(WebCore::MQ::computeLength):
(WebCore::MQ::evaluateRatioComparison):

Canonical link: <a href="https://commits.webkit.org/271141@main">https://commits.webkit.org/271141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7b525cbccfcd2d8e0ca04f7b7531f8efd1d9d6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29680 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24929 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4256 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30544 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28511 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4887 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3550 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->