### PR TITLE
Use dynamicDowncast<T> even more in JS bindings code

### DIFF
--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -238,10 +238,8 @@ void JSCustomElementInterface::upgradeElement(Element& element)
         return;
     }
 
-    if (m_isFormAssociated) {
-        ASSERT(is<HTMLMaybeFormAssociatedCustomElement>(element));
+    if (m_isFormAssociated)
         downcast<HTMLMaybeFormAssociatedCustomElement>(element).willUpgradeFormAssociated();
-    }
 
     MarkedArgumentBuffer args;
     ASSERT(!args.hasOverflowed());

--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -50,8 +50,8 @@ template<typename T> struct Converter<IDLPromise<T>> : DefaultConverter<IDLPromi
         auto* promise = JSC::JSPromise::resolvedPromise(globalObject, value);
         if (scope.exception()) {
             auto* scriptExecutionContext = globalObject->scriptExecutionContext();
-            if (is<WorkerGlobalScope>(scriptExecutionContext)) {
-                auto* scriptController = downcast<WorkerGlobalScope>(*scriptExecutionContext).script();
+            if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext)) {
+                auto* scriptController = globalScope->script();
                 bool terminatorCausedException = vm.isTerminationException(scope.exception());
                 if (terminatorCausedException || (scriptController && scriptController->isTerminatingExecution())) {
                     scriptController->forbidExecution();

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -669,7 +669,7 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
 
     auto domGlobalObject = jsCast<JSDOMGlobalObject*>(globalObject);
     auto context = domGlobalObject->scriptExecutionContext();
-    if (is<Document>(context)) {
+    if (auto* document = dynamicDowncast<Document>(context)) {
         // Same-origin iframes present a difficult circumstance because the
         // shadow realm global object cannot retain the incubating realm's
         // global object (that would be a refcount loop); but, same-origin
@@ -681,7 +681,6 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
         // origin while avoiding any lifetime issues (since the topmost document
         // with a given wrapper world should outlive other objects in that
         // world)
-        auto document = &downcast<Document>(*context);
         const auto& originalOrigin = document->securityOrigin();
         auto& originalWorld = domGlobalObject->world();
 
@@ -729,11 +728,11 @@ String JSDOMGlobalObject::agentClusterID() const
 
 JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& context, DOMWrapperWorld& world)
 {
-    if (is<Document>(context))
-        return toJSLocalDOMWindow(downcast<Document>(context).frame(), world);
+    if (auto* document = dynamicDowncast<Document>(context))
+        return toJSLocalDOMWindow(document->frame(), world);
 
-    if (is<WorkerOrWorkletGlobalScope>(context))
-        return downcast<WorkerOrWorkletGlobalScope>(context).script()->globalScopeWrapper();
+    if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(context))
+        return globalScope->script()->globalScopeWrapper();
 
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -298,8 +298,8 @@ bool DeferredPromise::handleTerminationExceptionIfNeeded(CatchScope& scope, JSDO
     VM& vm = scope.vm();
 
     auto& scriptExecutionContext = *lexicalGlobalObject.scriptExecutionContext();
-    if (is<WorkerGlobalScope>(scriptExecutionContext)) {
-        auto* scriptController = downcast<WorkerGlobalScope>(scriptExecutionContext).script();
+    if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext)) {
+        auto* scriptController = globalScope->script();
         bool terminatorCausedException = vm.isTerminationException(exception);
         if (terminatorCausedException || (scriptController && scriptController->isTerminatingExecution())) {
             scriptController->forbidExecution();

--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -57,17 +57,16 @@ static bool jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter(JSDOMWindowPr
 
     // Allow shortcuts like 'Image1' instead of document.images.Image1
     auto* document = window.document();
-    if (is<HTMLDocument>(document)) {
-        auto& htmlDocument = downcast<HTMLDocument>(*document);
+    if (auto* htmlDocument = dynamicDowncast<HTMLDocument>(document)) {
         AtomString atomPropertyName = propertyName.publicName();
-        if (!atomPropertyName.isEmpty() && htmlDocument.hasWindowNamedItem(atomPropertyName)) {
+        if (!atomPropertyName.isEmpty() && htmlDocument->hasWindowNamedItem(atomPropertyName)) {
             JSValue namedItem;
-            if (UNLIKELY(htmlDocument.windowNamedItemContainsMultipleElements(atomPropertyName))) {
+            if (UNLIKELY(htmlDocument->windowNamedItemContainsMultipleElements(atomPropertyName))) {
                 Ref<HTMLCollection> collection = document->windowNamedItems(atomPropertyName);
                 ASSERT(collection->length() > 1);
                 namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), collection);
             } else
-                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), htmlDocument.windowNamedItem(atomPropertyName).get());
+                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), htmlDocument->windowNamedItem(atomPropertyName).get());
             slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::DontEnum), namedItem);
             return true;
         }

--- a/Source/WebCore/bindings/js/JSDeprecatedCSSOMValueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDeprecatedCSSOMValueCustom.cpp
@@ -52,7 +52,7 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<D
     if (value->isValueList())
         return createWrapper<DeprecatedCSSOMValueList>(globalObject, WTFMove(value));
     // Expose CSS-wide keywords as plain CSSValues to keep the existing behavior.
-    if (value->isPrimitiveValue() && !downcast<DeprecatedCSSOMPrimitiveValue>(value.get()).isCSSWideKeyword())
+    if (auto* primitiveValue = dynamicDowncast<DeprecatedCSSOMPrimitiveValue>(value.get()); primitiveValue && !primitiveValue->isCSSWideKeyword())
         return createWrapper<DeprecatedCSSOMPrimitiveValue>(globalObject, WTFMove(value));
     return createWrapper<DeprecatedCSSOMValue>(globalObject, WTFMove(value));
 }

--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -55,13 +55,13 @@ using namespace HTMLNames;
 
 static JSValue createNewElementWrapper(JSDOMGlobalObject* globalObject, Ref<Element>&& element)
 {
-    if (is<HTMLElement>(element))
-        return createJSHTMLWrapper(globalObject, downcast<HTMLElement>(WTFMove(element)));
-    if (is<SVGElement>(element))
-        return createJSSVGWrapper(globalObject, downcast<SVGElement>(WTFMove(element)));
+    if (auto* htmlElement = dynamicDowncast<HTMLElement>(element.get()))
+        return createJSHTMLWrapper(globalObject, *htmlElement);
+    if (auto* svgElement = dynamicDowncast<SVGElement>(element.get()))
+        return createJSSVGWrapper(globalObject, *svgElement);
 #if ENABLE(MATHML)
-    if (is<MathMLElement>(element))
-        return createJSMathMLWrapper(globalObject, downcast<MathMLElement>(WTFMove(element)));
+    if (auto* mathmlElement = dynamicDowncast<MathMLElement>(element.get()))
+        return createJSMathMLWrapper(globalObject, *mathmlElement);
 #endif
     return createWrapper<Element>(globalObject, WTFMove(element));
 }

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -62,7 +62,8 @@ public:
     void replaceJSFunctionForAttributeListener(JSC::JSObject* function, JSC::JSObject* wrapper);
     static bool wasCreatedFromMarkup(const EventListener& listener)
     {
-        return is<JSEventListener>(listener) && downcast<JSEventListener>(listener).wasCreatedFromMarkup();
+        auto* jsEventListener = dynamicDowncast<JSEventListener>(listener);
+        return jsEventListener && jsEventListener->wasCreatedFromMarkup();
     }
 
 private:

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -114,8 +114,6 @@ JSLazyEventListener::~JSLazyEventListener()
 
 JSObject* JSLazyEventListener::initializeJSFunction(ScriptExecutionContext& executionContext) const
 {
-    ASSERT(is<Document>(executionContext));
-
     Ref executionContextDocument = downcast<Document>(executionContext);
 
     // As per the HTML specification [1], if this is an element's event handler, then document should be the

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -157,8 +157,8 @@ bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject* thisO
     // the Moz way.
     // FIXME: Add support to named attributes on RemoteFrames.
     auto* frame = window.frame();
-    if (frame && is<LocalFrame>(*frame)) {
-        if (auto* scopedChild = dynamicDowncast<LocalFrame>(downcast<LocalFrame>(*frame).tree().scopedChildBySpecifiedName(propertyNameToAtomString(propertyName)))) {
+    if (auto* localFrame = dynamicDowncast<LocalFrame>(frame)) {
+        if (auto* scopedChild = dynamicDowncast<LocalFrame>(localFrame->tree().scopedChildBySpecifiedName(propertyNameToAtomString(propertyName)))) {
             slot.setValue(thisObject, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum, toJS(&lexicalGlobalObject, scopedChild->document()->domWindow()));
             return true;
         }

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -106,13 +106,13 @@ static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalOb
     JSDOMObject* wrapper;    
     switch (node->nodeType()) {
         case Node::ELEMENT_NODE:
-            if (is<HTMLElement>(node))
-                wrapper = createJSHTMLWrapper(globalObject, downcast<HTMLElement>(WTFMove(node)));
-            else if (is<SVGElement>(node))
-                wrapper = createJSSVGWrapper(globalObject, downcast<SVGElement>(WTFMove(node)));
+            if (auto* htmlElement = dynamicDowncast<HTMLElement>(node.get()))
+                wrapper = createJSHTMLWrapper(globalObject, *htmlElement);
+            else if (auto* svgElement = dynamicDowncast<SVGElement>(node.get()))
+                wrapper = createJSSVGWrapper(globalObject, *svgElement);
 #if ENABLE(MATHML)
-            else if (is<MathMLElement>(node))
-                wrapper = createJSMathMLWrapper(globalObject, downcast<MathMLElement>(WTFMove(node)));
+            else if (auto* mathmlElement = dynamicDowncast<MathMLElement>(node.get()))
+                wrapper = createJSMathMLWrapper(globalObject, *mathmlElement);
 #endif
             else
                 wrapper = createWrapper<Element>(globalObject, WTFMove(node));

--- a/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
+++ b/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
@@ -39,9 +39,10 @@ static JSC_DECLARE_CUSTOM_GETTER(pluginElementPropertyGetter);
 Instance* pluginInstance(HTMLElement& element)
 {
     // The plugin element holds an owning reference, so we don't have to.
-    if (!is<HTMLPlugInElement>(element))
+    auto* pluginElement = dynamicDowncast<HTMLPlugInElement>(element);
+    if (!pluginElement)
         return nullptr;
-    auto* instance = downcast<HTMLPlugInElement>(element).bindingsInstance();
+    auto* instance = pluginElement->bindingsInstance();
     if (!instance || !instance->rootObject())
         return nullptr;
     return instance;

--- a/Source/WebCore/bindings/js/JSWebXRSpaceCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRSpaceCustom.cpp
@@ -36,8 +36,8 @@ using namespace JSC;
 
 JSValue toJSNewlyCreated(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebXRSpace>&& space)
 {
-    if (is<WebXRReferenceSpace>(space))
-        return toJSNewlyCreated(lexicalGlobalObject, globalObject, downcast<WebXRReferenceSpace>(WTFMove(space)));
+    if (auto* xrReferenceSpace = dynamicDowncast<WebXRReferenceSpace>(space.get()))
+        return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { *xrReferenceSpace });
     return createWrapper<WebXRSpace>(globalObject, WTFMove(space));
 }
 

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -86,8 +86,8 @@ auto ScheduledAction::type() const -> Type
 
 void ScheduledAction::execute(ScriptExecutionContext& context)
 {
-    if (is<Document>(context))
-        execute(downcast<Document>(context));
+    if (auto* document = dynamicDowncast<Document>(context))
+        execute(*document);
     else
         execute(downcast<WorkerGlobalScope>(context));
 }

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -345,8 +345,9 @@ JSC::JSInternalPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* js
         parameters = ModuleFetchParameters::create(type, emptyString(), /* isTopLevelModule */ true);
 
         if (m_ownerType == OwnerType::Document) {
-            baseURL = downcast<Document>(*m_context).baseURL();
-            scriptFetcher = CachedScriptFetcher::create(downcast<Document>(*m_context).charset());
+            auto& document = downcast<Document>(*m_context);
+            baseURL = document.baseURL();
+            scriptFetcher = CachedScriptFetcher::create(document.charset());
         } else {
             // https://html.spec.whatwg.org/multipage/webappapis.html#default-classic-script-fetch-options
             baseURL = m_context->url();
@@ -571,8 +572,8 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
                     static_cast<WorkerScriptFetcher&>(loader.scriptFetcher()).setReferrerPolicy(loader.referrerPolicy());
             }
             responseURL = canonicalizeAndRegisterResponseURL(responseURL, workerScriptLoader.isRedirected(), workerScriptLoader.responseSource());
-            if (is<ServiceWorkerGlobalScope>(*m_context))
-                downcast<ServiceWorkerGlobalScope>(*m_context).setScriptResource(sourceURL, ServiceWorkerContextData::ImportedScript { loader.script(), responseURL, loader.responseMIMEType() });
+            if (auto* globalScope = dynamicDowncast<ServiceWorkerGlobalScope>(*m_context))
+                globalScope->setScriptResource(sourceURL, ServiceWorkerContextData::ImportedScript { loader.script(), responseURL, loader.responseMIMEType() });
         }
         m_requestURLToResponseURLMap.add(sourceURL.string(), responseURL);
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1347,13 +1347,13 @@ private:
         // FIXME: We should try to avoid converting pixel format.
         PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, buffer->colorSpace() };
         const IntSize& logicalSize = buffer->truncatedLogicalSize();
-        auto pixelBuffer = buffer->getPixelBuffer(format, { IntPoint::zero(), logicalSize });
-        if (!is<ByteArrayPixelBuffer>(pixelBuffer)) {
+        auto pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, { IntPoint::zero(), logicalSize }));
+        if (!pixelBuffer) {
             code = SerializationReturnCode::ValidationError;
             return;
         }
 
-        auto arrayBuffer = downcast<ByteArrayPixelBuffer>(*pixelBuffer).data().possiblySharedBuffer();
+        auto arrayBuffer = pixelBuffer->data().possiblySharedBuffer();
         if (!arrayBuffer) {
             code = SerializationReturnCode::ValidationError;
             return;

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -132,8 +132,8 @@ JSWindowProxy& WindowProxy::createJSWindowProxyWithInitializedScript(DOMWrapperW
 
     JSLockHolder lock(world.vm());
     auto& windowProxy = createJSWindowProxy(world);
-    if (is<LocalFrame>(*m_frame))
-        downcast<LocalFrame>(*m_frame).script().initScriptForWindowProxy(windowProxy);
+    if (auto* localFrame = dynamicDowncast<LocalFrame>(*m_frame))
+        localFrame->script().initScriptForWindowProxy(windowProxy);
     return windowProxy;
 }
 
@@ -180,10 +180,9 @@ void WindowProxy::setDOMWindow(DOMWindow* newDOMWindow)
 
         ScriptController* scriptController = nullptr;
         Page* page = nullptr;
-        if (is<LocalFrame>(*m_frame)) {
-            auto& frame = downcast<LocalFrame>(*m_frame);
-            scriptController = &frame.script();
-            page = frame.page();
+        if (auto* localFrame = dynamicDowncast<LocalFrame>(*m_frame)) {
+            scriptController = &localFrame->script();
+            page = localFrame->page();
         }
 
         // ScriptController's m_cacheableBindingRootObject persists between page navigations

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -63,8 +63,8 @@ void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
 {
     m_sourceURL = WTFMove(sourceURL);
 
-    if (is<ServiceWorkerGlobalScope>(context)) {
-        if (auto* scriptResource = downcast<ServiceWorkerGlobalScope>(context).scriptResource(m_sourceURL)) {
+    if (auto* globalScope = dynamicDowncast<ServiceWorkerGlobalScope>(context)) {
+        if (auto* scriptResource = globalScope->scriptResource(m_sourceURL)) {
             m_script = scriptResource->script;
             m_responseURL = scriptResource->responseURL;
             m_responseMIMEType = scriptResource->mimeType;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6240,7 +6240,6 @@ sub GenerateCallWith
         push(@$outputArray, $indent . "auto* context = ${scriptExecutionContextAccessor}->scriptExecutionContext();\n");
         push(@$outputArray, $indent . "if (UNLIKELY(!context))\n");
         push(@$outputArray, $indent . "    return" . ($contextMissing ? " " . $contextMissing : "") . ";\n");
-        push(@$outputArray, $indent . "ASSERT(context->isDocument());\n");
         push(@$outputArray, $indent . "auto& document = downcast<Document>(*context);\n");
         push(@callWithArgs, "document");
     }
@@ -6250,7 +6249,6 @@ sub GenerateCallWith
         push(@$outputArray, $indent . "auto* context = ${relevantGlobalObjectPointer}->scriptExecutionContext();\n");
         push(@$outputArray, $indent . "if (UNLIKELY(!context))\n");
         push(@$outputArray, $indent . "    return" . ($contextMissing ? " " . $contextMissing : "") . ";\n");
-        push(@$outputArray, $indent . "ASSERT(context->isDocument());\n");
         push(@$outputArray, $indent . "auto& document = downcast<Document>(*context);\n");
         push(@callWithArgs, "document");
     }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
@@ -116,7 +116,6 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTestLegacyFactoryFunctionLe
     auto* context = castedThis->scriptExecutionContext();
     if (UNLIKELY(!context))
         return throwConstructorScriptExecutionContextUnavailableError(*lexicalGlobalObject, throwScope, "TestLegacyFactoryFunction");
-    ASSERT(context->isDocument());
     auto& document = downcast<Document>(*context);
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto str1 = convert<IDLDOMString>(*lexicalGlobalObject, argument0.value());

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2146,7 +2146,6 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTestObjDOMConstructor::cons
     auto* context = castedThis->scriptExecutionContext();
     if (UNLIKELY(!context))
         return throwConstructorScriptExecutionContextUnavailableError(*lexicalGlobalObject, throwScope, "TestObject");
-    ASSERT(context->isDocument());
     auto& document = downcast<Document>(*context);
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto testCallback = convert<IDLCallbackInterface<JSTestCallbackInterface>>(*lexicalGlobalObject, argument0.value(), *castedThis->globalObject(), [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentMustBeObjectError(lexicalGlobalObject, scope, 0, "testCallback", "TestObject", nullptr); });
@@ -2940,7 +2939,6 @@ static inline JSValue jsTestObjConstructor_testStaticReadonlyObjGetter(JSGlobalO
     auto* context = jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->scriptExecutionContext();
     if (UNLIKELY(!context))
         return jsUndefined();
-    ASSERT(context->isDocument());
     auto& document = downcast<Document>(*context);
     RELEASE_AND_RETURN(throwScope, (toJS<IDLInterface<TestObj>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, TestObj::testStaticReadonlyObj(document))));
 }
@@ -6796,7 +6794,6 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_withCurrentDocument
     auto* context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
     if (UNLIKELY(!context))
         return JSValue::encode(jsUndefined());
-    ASSERT(context->isDocument());
     auto& document = downcast<Document>(*context);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.withCurrentDocumentArgument(document); })));
 }
@@ -6816,7 +6813,6 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_withRelevantDocumen
     auto* context = (*castedThis).globalObject()->scriptExecutionContext();
     if (UNLIKELY(!context))
         return JSValue::encode(jsUndefined());
-    ASSERT(context->isDocument());
     auto& document = downcast<Document>(*context);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.withRelevantDocumentArgument(document); })));
 }


### PR DESCRIPTION
#### 58140e2cf813d401bf421b7ec8c04e355097459e
<pre>
Use dynamicDowncast&lt;T&gt; even more in JS bindings code
<a href="https://bugs.webkit.org/show_bug.cgi?id=265360">https://bugs.webkit.org/show_bug.cgi?id=265360</a>

Reviewed by Dan Glastonbury.

* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::upgradeElement):
* Source/WebCore/bindings/js/JSDOMConvertPromise.h:
(WebCore::Converter&lt;IDLPromise&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::deriveShadowRealmGlobalObject):
(WebCore::toJSDOMGlobalObject):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::handleTerminationExceptionIfNeeded):
* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
(WebCore::jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter):
* Source/WebCore/bindings/js/JSDeprecatedCSSOMValueCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::createNewElementWrapper):
* Source/WebCore/bindings/js/JSErrorHandler.cpp:
(WebCore::JSErrorHandler::handleEvent):
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::handleEvent):
(WebCore::JSEventListener::operator== const):
* Source/WebCore/bindings/js/JSEventListener.h:
(WebCore::JSEventListener::wasCreatedFromMarkup):
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::initializeJSFunction const):
* Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp:
(WebCore::jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess):
* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::createWrapperInline):
* Source/WebCore/bindings/js/JSPluginElementFunctions.cpp:
(WebCore::pluginInstance):
* Source/WebCore/bindings/js/JSWebXRSpaceCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/JSWindowProxy.cpp:
(WebCore::JSWindowProxy::setWindow):
* Source/WebCore/bindings/js/ScheduledAction.cpp:
(WebCore::ScheduledAction::execute):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::importModule):
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpImageBitmap):
* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::createJSWindowProxyWithInitializedScript):
(WebCore::WindowProxy::setDOMWindow):
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::load):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallWith):
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp:
(WebCore::JSTestLegacyFactoryFunctionLegacyFactoryFunction::construct):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::JSTestObjDOMConstructor::construct):
(WebCore::jsTestObjConstructor_testStaticReadonlyObjGetter):
(WebCore::jsTestObjPrototypeFunction_withCurrentDocumentArgumentBody):
(WebCore::jsTestObjPrototypeFunction_withRelevantDocumentArgumentBody):

Canonical link: <a href="https://commits.webkit.org/271217@main">https://commits.webkit.org/271217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1051f851f8faa4a42cb8c83052c327b8be57e44a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29767 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24995 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30406 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23946 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25158 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30613 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26799 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28580 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5980 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34177 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4963 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7398 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3581 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->