### PR TITLE
[JSC] Make CodeBlock destruction lazy

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.h
@@ -35,19 +35,19 @@ class CodeBlockJettisoningWatchpoint final : public Watchpoint {
 public:
     CodeBlockJettisoningWatchpoint(CodeBlock* codeBlock = nullptr)
         : Watchpoint(Watchpoint::Type::CodeBlockJettisoning)
-        , m_codeBlock(codeBlock)
+        , m_owner(codeBlock)
     {
     }
 
     void initialize(CodeBlock* codeBlock)
     {
-        m_codeBlock = codeBlock;
+        m_owner = codeBlock;
     }
     
     void fireInternal(VM&, const FireDetail&);
 
 private:
-    PackedCellPtr<CodeBlock> m_codeBlock;
+    PackedCellPtr<CodeBlock> m_owner;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4244,7 +4244,15 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         codeBlock, linkBuffer, JITStubRoutinePtrTag,
         "%s", toCString("Access stub for ", *codeBlock, " ", m_stubInfo->codeOrigin, "with start: ", m_stubInfo->startLocation, " with return point ", successLabel, ": ", listDump(cases)).data());
 
-    stub = createICJITStubRoutine(code, WTFMove(keys), WTFMove(weakStructures), vm(), codeBlock, doesCalls, cellsToMark, WTFMove(m_callLinkInfos), codeBlockThatOwnsExceptionHandlers, callSiteIndexForExceptionHandling);
+    CodeBlock* owner = codeBlock;
+    if (generatedMegamorphicCode && useHandlerIC()) {
+        ASSERT(codeBlock->useDataIC());
+        ASSERT(!doesCalls);
+        ASSERT(cellsToMark.isEmpty());
+        owner = nullptr;
+    }
+
+    stub = createICJITStubRoutine(code, WTFMove(keys), WTFMove(weakStructures), vm(), owner, doesCalls, cellsToMark, WTFMove(m_callLinkInfos), codeBlockThatOwnsExceptionHandlers, callSiteIndexForExceptionHandling);
 
     if (generatedMegamorphicCode && useHandlerIC()) {
         ASSERT(codeBlock->useDataIC());

--- a/Source/JavaScriptCore/bytecode/MetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/MetadataTable.cpp
@@ -70,7 +70,7 @@ void MetadataTable::destroy(MetadataTable* table)
 
 size_t MetadataTable::sizeInBytesForGC()
 {
-    return linkingData().unlinkedMetadata->sizeInBytesForGC(*this);
+    return unlinkedMetadata().sizeInBytesForGC(*this);
 }
 
 void MetadataTable::validate() const

--- a/Source/JavaScriptCore/bytecode/MetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/MetadataTable.h
@@ -70,7 +70,7 @@ public:
     ALWAYS_INLINE void forEachValueProfile(const Functor& func)
     {
         // We could do a checked multiply here but if it overflows we'd just not look at any value profiles so it's probably not worth it.
-        int lastValueProfileOffset = -linkingData().unlinkedMetadata->m_numValueProfiles;
+        int lastValueProfileOffset = -unlinkedMetadata().m_numValueProfiles;
         for (int i = -1; i >= lastValueProfileOffset; --i)
             func(valueProfilesEnd()[i]);
     }
@@ -82,7 +82,7 @@ public:
 
     ValueProfile& valueProfileForOffset(unsigned profileOffset)
     {
-        ASSERT(profileOffset <= linkingData().unlinkedMetadata->m_numValueProfiles);
+        ASSERT(profileOffset <= unlinkedMetadata().m_numValueProfiles);
         return valueProfilesEnd()[-static_cast<ptrdiff_t>(profileOffset)];
     }
 
@@ -123,6 +123,8 @@ public:
 
     void validate() const;
 
+    UnlinkedMetadataTable& unlinkedMetadata() const { return linkingData().unlinkedMetadata.get(); }
+
 private:
     MetadataTable(UnlinkedMetadataTable&);
 
@@ -131,7 +133,7 @@ private:
 
     size_t totalSize() const
     {
-        return linkingData().unlinkedMetadata->m_numValueProfiles * sizeof(ValueProfile) + sizeof(UnlinkedMetadataTable::LinkingData) + getOffset(UnlinkedMetadataTable::s_offsetTableEntries - 1);
+        return unlinkedMetadata().m_numValueProfiles * sizeof(ValueProfile) + sizeof(UnlinkedMetadataTable::LinkingData) + getOffset(UnlinkedMetadataTable::s_offsetTableEntries - 1);
     }
 
     UnlinkedMetadataTable::LinkingData& linkingData() const

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -60,7 +60,6 @@ UnlinkedCodeBlock::UnlinkedCodeBlock(VM& vm, Structure* structure, CodeType code
     , m_derivedContextType(static_cast<unsigned>(info.derivedContextType()))
     , m_evalContextType(static_cast<unsigned>(info.evalContextType()))
     , m_codeType(static_cast<unsigned>(codeType))
-    , m_didOptimize(static_cast<unsigned>(TriState::Indeterminate))
     , m_age(0)
     , m_hasCheckpoints(false)
     , m_parseMode(info.parseMode())
@@ -69,7 +68,6 @@ UnlinkedCodeBlock::UnlinkedCodeBlock(VM& vm, Structure* structure, CodeType code
 {
     ASSERT(m_constructorKind == static_cast<unsigned>(info.constructorKind()));
     ASSERT(m_codeType == static_cast<unsigned>(codeType));
-    ASSERT(m_didOptimize == static_cast<unsigned>(TriState::Indeterminate));
     if (info.needsClassFieldInitializer() == NeedsClassFieldInitializer::Yes) {
         Locker locker { cellLock() };
         createRareDataIfNecessary(locker);

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -295,8 +295,8 @@ public:
     bool wasCompiledWithControlFlowProfilerOpcodes() const { return m_codeGenerationMode.contains(CodeGenerationMode::ControlFlowProfiler); }
     OptionSet<CodeGenerationMode> codeGenerationMode() const { return m_codeGenerationMode; }
 
-    TriState didOptimize() const { return static_cast<TriState>(m_didOptimize); }
-    void setDidOptimize(TriState didOptimize) { m_didOptimize = static_cast<unsigned>(didOptimize); }
+    TriState didOptimize() const { return m_metadata->didOptimize(); }
+    void setDidOptimize(TriState didOptimize) { m_metadata->setDidOptimize(didOptimize); }
 
     static constexpr unsigned maxAge = 7;
 
@@ -413,7 +413,6 @@ private:
     unsigned m_derivedContextType : 2;
     unsigned m_evalContextType : 2;
     unsigned m_codeType : 2;
-    unsigned m_didOptimize : 2;
     unsigned m_age : 3;
     static_assert(((1U << 3) - 1) >= maxAge);
     bool m_hasCheckpoints : 1;

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
@@ -96,6 +96,9 @@ public:
 
     unsigned numValueProfiles() const { return m_numValueProfiles; }
 
+    TriState didOptimize() const { return m_didOptimize; }
+    void setDidOptimize(TriState didOptimize) { m_didOptimize = didOptimize; }
+
 private:
     enum EmptyTag { Empty };
 
@@ -164,6 +167,7 @@ private:
     bool m_isFinalized : 1;
     bool m_isLinked : 1;
     bool m_is32Bit : 1;
+    TriState m_didOptimize : 2 { TriState::Indeterminate };
     unsigned m_numValueProfiles { 0 };
     uint8_t* m_rawBuffer;
 };

--- a/Source/JavaScriptCore/heap/CodeBlockSet.cpp
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.cpp
@@ -48,9 +48,13 @@ bool CodeBlockSet::contains(const AbstractLocker&, void* candidateCodeBlock)
     return m_codeBlocks.contains(codeBlock);
 }
 
-void CodeBlockSet::clearCurrentlyExecuting()
+void CodeBlockSet::clearCurrentlyExecutingAndRemoveDeadCodeBlocks(VM& vm)
 {
+    ASSERT(vm.heap.isInPhase(CollectorPhase::End));
     m_currentlyExecuting.clear();
+    m_codeBlocks.removeIf([&](CodeBlock* codeBlock) {
+        return !vm.heap.isMarked(codeBlock);
+    });
 }
 
 bool CodeBlockSet::isCurrentlyExecuting(CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/heap/CodeBlockSet.h
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.h
@@ -51,7 +51,7 @@ public:
 
     void mark(const AbstractLocker&, CodeBlock* candidateCodeBlock);
     
-    void clearCurrentlyExecuting();
+    void clearCurrentlyExecutingAndRemoveDeadCodeBlocks(VM&);
 
     bool contains(const AbstractLocker&, void* candidateCodeBlock);
     Lock& getLock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -572,6 +572,8 @@ public:
         m_possiblyAccessedStringsFromConcurrentThreads.append(WTFMove(string));
     }
 
+    bool isInPhase(CollectorPhase phase) const { return m_currentPhase == phase; }
+
 private:
     friend class AllocatingScope;
     friend class CodeBlock;

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.h
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.h
@@ -61,7 +61,7 @@ public:
 
     void prepareForConservativeScan();
     
-    void deleteUnmarkedJettisonedStubRoutines();
+    void deleteUnmarkedJettisonedStubRoutines(VM&);
 
     template<typename Visitor> void traceMarkedStubRoutines(Visitor&);
     
@@ -90,7 +90,7 @@ public:
     void clearMarks() { }
     void mark(void*) { }
     void prepareForConservativeScan() { }
-    void deleteUnmarkedJettisonedStubRoutines() { }
+    void deleteUnmarkedJettisonedStubRoutines(VM&) { }
     template<typename Visitor> void traceMarkedStubRoutines(Visitor&) { }
 };
 

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -39,8 +39,9 @@
 
 namespace JSC {
 
-GCAwareJITStubRoutine::GCAwareJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code)
+GCAwareJITStubRoutine::GCAwareJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, JSCell* owner)
     : JITStubRoutine(type, code)
+    , m_owner(owner)
 {
 }
 
@@ -80,8 +81,8 @@ IGNORE_GCC_WARNINGS_BEGIN("sequence-point")
 IGNORE_GCC_WARNINGS_END
 }
 
-PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures)
-    : GCAwareJITStubRoutine(type, code)
+PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner)
+    : GCAwareJITStubRoutine(type, code, owner)
     , m_vm(vm)
     , m_cases(WTFMove(cases))
     , m_weakStructures(WTFMove(weakStructures))
@@ -106,9 +107,9 @@ unsigned PolymorphicAccessJITStubRoutine::computeHash(const FixedVector<RefPtr<A
 }
 
 MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine(
-    Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, const JSCell* owner,
+    Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner,
     const Vector<JSCell*>& cells, Bag<OptimizingCallLinkInfo>&& callLinkInfos)
-    : PolymorphicAccessJITStubRoutine(type, code, vm, WTFMove(cases), WTFMove(weakStructures))
+    : PolymorphicAccessJITStubRoutine(type, code, vm, WTFMove(cases), WTFMove(weakStructures), owner)
     , m_cells(cells.size())
     , m_callLinkInfos(WTFMove(callLinkInfos))
 {
@@ -132,7 +133,7 @@ void MarkingGCAwareJITStubRoutine::markRequiredObjectsImpl(SlotVisitor& visitor)
     markRequiredObjectsInternalImpl(visitor);
 }
 
-GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, const JSCell* owner, const Vector<JSCell*>& cells, Bag<OptimizingCallLinkInfo>&& callLinkInfos,
+GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner, const Vector<JSCell*>& cells, Bag<OptimizingCallLinkInfo>&& callLinkInfos,
     CodeBlock* codeBlockForExceptionHandlers, DisposableCallSiteIndex exceptionHandlerCallSiteIndex)
     : MarkingGCAwareJITStubRoutine(JITStubRoutine::Type::GCAwareJITStubRoutineWithExceptionHandlerType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos))
     , m_codeBlockWithExceptionHandler(codeBlockForExceptionHandlers)
@@ -175,7 +176,7 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     FixedVector<RefPtr<AccessCase>>&& cases,
     FixedVector<StructureID>&& weakStructures,
     VM& vm,
-    const JSCell* owner,
+    JSCell* owner,
     bool makesCalls,
     const Vector<JSCell*>& cells,
     Bag<OptimizingCallLinkInfo>&& callLinkInfos,
@@ -185,7 +186,7 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     if (!makesCalls) {
         // Allocating CallLinkInfos means we should have calls.
         ASSERT(callLinkInfos.isEmpty());
-        return adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures)));
+        return adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
     }
     
     if (codeBlockForExceptionHandlers) {
@@ -196,7 +197,7 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     }
 
     if (cells.isEmpty() && callLinkInfos.isEmpty()) {
-        auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures)));
+        auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
         stub->makeGCAware(vm);
         return stub;
     }

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -60,10 +60,10 @@ void PolymorphicCallCase::dump(PrintStream& out) const
 }
 
 PolymorphicCallStubRoutine::PolymorphicCallStubRoutine(
-    const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& codeRef, VM& vm, const JSCell* owner, CallFrame* callerFrame,
+    const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& codeRef, VM& vm, JSCell* owner, CallFrame* callerFrame,
     CallLinkInfo& info, const Vector<PolymorphicCallCase>& cases,
     UniqueArray<uint32_t>&& fastCounts)
-    : GCAwareJITStubRoutine(Type::PolymorphicCallStubRoutineType, codeRef)
+    : GCAwareJITStubRoutine(Type::PolymorphicCallStubRoutineType, codeRef, owner)
     , m_variants(cases.size())
     , m_fastCounts(WTFMove(fastCounts))
 {

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -85,7 +85,7 @@ public:
     friend class JITStubRoutine;
 
     PolymorphicCallStubRoutine(
-        const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, const JSCell* owner,
+        const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, JSCell* owner,
         CallFrame* callerFrame, CallLinkInfo&, const Vector<PolymorphicCallCase>&,
         UniqueArray<uint32_t>&& fastCounts);
     

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2138,7 +2138,6 @@ ALWAYS_INLINE UnlinkedCodeBlock::UnlinkedCodeBlock(Decoder& decoder, Structure* 
     , m_evalContextType(cachedCodeBlock.evalContextType())
     , m_codeType(cachedCodeBlock.codeType())
 
-    , m_didOptimize(static_cast<unsigned>(TriState::Indeterminate))
     , m_age(0)
     , m_hasCheckpoints(cachedCodeBlock.hasCheckpoints())
 


### PR DESCRIPTION
#### bebb1488bc66c7d4a4b5b2837a3e8e163659b623
<pre>
[JSC] Make CodeBlock destruction lazy
<a href="https://bugs.webkit.org/show_bug.cgi?id=265361">https://bugs.webkit.org/show_bug.cgi?id=265361</a>
<a href="https://rdar.apple.com/118818460">rdar://118818460</a>

Reviewed by Mark Lam.

This patch makes CodeBlock destruction lazy.

1. CodeBlockSet is relying on the fact that CodeBlock&apos;s destructor is called as soon as it gets dead.
   We wipe dead CodeBlocks instead in CodeBlockSet::clearCurrentlyExecutingAndRemoveDeadCodeBlocks.
2. JITStubRoutine has a possibility that, (1) now CodeBlock is dead but destructor is not called, (2) JITStubRoutine
   was not executed, but (3) because of conservativeness, once it is determined as non-executed but now it is conservatively
   seen as executed. In this case, we may mark already dead cells and cause the problem. In this patch, GCAwareJITStubRoutine
   now has owner cell (we already had this concept), and we maintain the liveness information of this owner cell.
   As a result, we can know that whether this JITStubRoutine is dead or not based on this owner cell&apos;s liveness and avoid the
   above race conditions.
3. CodeBlockJettisoningWatchpoint should check whether CodeBlock is still alive (via isLive), since it is possible that CodeBlock
   may be dead now but destructor is not called yet. This is well aligned to the other Watchpoint.
4. CodeBlock destructor should not touch UnlinkedCodeBlock since it may be already dead at this point. Previously it was OK since
   we are always sweeping CodeBlocks first before UnlinkedCodeBlock. But now this is not guaranteed. But only usage is didOptimize
   bit propagation. So we put this in UnlinkedMetadataTable instead. We may miss this propagation when MetadataTable is empty, but
   this is very rare and it happens only for super small functions, so it does not matter for the real world code.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::~CodeBlock):
* Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.cpp:
(JSC::CodeBlockJettisoningWatchpoint::fireInternal):
* Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/MetadataTable.cpp:
(JSC::MetadataTable::sizeInBytesForGC):
* Source/JavaScriptCore/bytecode/MetadataTable.h:
(JSC::MetadataTable::forEachValueProfile):
(JSC::MetadataTable::valueProfileForOffset):
(JSC::MetadataTable::unlinkedMetadata const):
(JSC::MetadataTable::totalSize const):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::UnlinkedCodeBlock):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::didOptimize const):
(JSC::UnlinkedCodeBlock::setDidOptimize):
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h:
(JSC::UnlinkedMetadataTable::didOptimize const):
(JSC::UnlinkedMetadataTable::setDidOptimize):
* Source/JavaScriptCore/heap/CodeBlockSet.cpp:
(JSC::CodeBlockSet::clearCurrentlyExecutingAndRemoveDeadCodeBlocks):
(JSC::CodeBlockSet::clearCurrentlyExecuting): Deleted.
* Source/JavaScriptCore/heap/CodeBlockSet.h:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::deleteUnmarkedCompiledCode):
(JSC::Heap::runEndPhase):
(JSC::Heap::finalize):
* Source/JavaScriptCore/heap/JITStubRoutineSet.cpp:
(JSC::JITStubRoutineSet::~JITStubRoutineSet):
(JSC::JITStubRoutineSet::deleteUnmarkedJettisonedStubRoutines):
* Source/JavaScriptCore/heap/JITStubRoutineSet.h:
(JSC::JITStubRoutineSet::deleteUnmarkedJettisonedStubRoutines):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::GCAwareJITStubRoutine::GCAwareJITStubRoutine):
(JSC::PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine):
(JSC::MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine):
(JSC::GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler):
(JSC::createICJITStubRoutine):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::GCAwareJITStubRoutine::create):
(JSC::GCAwareJITStubRoutine::owner const):
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp:
(JSC::PolymorphicCallStubRoutine::PolymorphicCallStubRoutine):
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::UnlinkedCodeBlock::UnlinkedCodeBlock):

Canonical link: <a href="https://commits.webkit.org/271184@main">https://commits.webkit.org/271184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b768ac3b9a44db2ed1d18d332a119797427ca1a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27614 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6253 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/28860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29834 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/8179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/3646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27880 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/8179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/28860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/4356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/8179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/28860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30474 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/23984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/8179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/28860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/26780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/6033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/28860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34248 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/7408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3565 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/4960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->