### PR TITLE
Remove m_canCrossOriginRequestsAskUserForCredentials

### DIFF
--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -529,7 +529,7 @@ static void logResourceResponseSource(LocalFrame* frame, ResourceResponse::Sourc
 bool ResourceLoader::shouldAllowResourceToAskForCredentials() const
 {
     auto* topFrame = dynamicDowncast<LocalFrame>(m_frame->tree().top());
-    return m_canCrossOriginRequestsAskUserForCredentials
+    return cachedResource()->type() == CachedResource::Type::MainResource
         || (topFrame && topFrame->document()->securityOrigin().canRequest(m_request.url(), OriginAccessPatternsForWebProcess::singleton()));
 }
 

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -190,7 +190,6 @@ protected:
 #if USE(QUICK_LOOK)
     std::unique_ptr<LegacyPreviewLoader> m_previewLoader;
 #endif
-    bool m_canCrossOriginRequestsAskUserForCredentials { true };
 
 private:
     virtual void willCancel(const ResourceError&) = 0;

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -122,7 +122,6 @@ SubresourceLoader::SubresourceLoader(LocalFrame& frame, CachedResource& resource
 #if ENABLE(CONTENT_EXTENSIONS)
     m_resourceType = ContentExtensions::toResourceType(resource.type(), resource.resourceRequest().requester());
 #endif
-    m_canCrossOriginRequestsAskUserForCredentials = resource.type() == CachedResource::Type::MainResource;
     m_site = CachedResourceLoader::computeFetchMetadataSite(resource.resourceRequest(), resource.type(), options.mode, frame.document()->securityOrigin());
 }
 


### PR DESCRIPTION
#### a195c077beee9f49bd70a4c93b880cc9ac860017
<pre>
Remove m_canCrossOriginRequestsAskUserForCredentials
<a href="https://bugs.webkit.org/show_bug.cgi?id=265367">https://bugs.webkit.org/show_bug.cgi?id=265367</a>

Reviewed by NOBODY (OOPS!).

This addresses a review comment on 271130@main that I wanted to address
separately just in case.

* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::shouldAllowResourceToAskForCredentials const):
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::SubresourceLoader):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a195c077beee9f49bd70a4c93b880cc9ac860017

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24937 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4895 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23580 "Found 1 new API test failure: TestWebKitAPI.WebKit.CookieAccessFromPDFInAboutBlank (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25093 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25000 "Found 6 new test failures: accessibility/mac/basic-embed-pdf-accessibility.html, accessibility/mac/scrolling-in-pdf-crash.html, accessibility/mac/widget-visibility.html, fast/replaced/encrypted-pdf-as-object-and-embed.html, fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html, platform/mac-wk2/plugins/pdf-plugin-initial-scroll-position.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30554 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4444 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2596 "Found 7 new test failures: accessibility/mac/basic-embed-pdf-accessibility.html, accessibility/mac/scrolling-in-pdf-crash.html, accessibility/mac/widget-visibility.html, compositing/plugins/pdf/pdf-in-embed-rounded-border.html, compositing/plugins/pdf/pdf-in-embed.html, compositing/plugins/pdf/pdf-scrolling-tree-dynamic.html, compositing/plugins/pdf/pdf-scrolling-tree.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28522 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->