### PR TITLE
[CMake][WPE] Add WPE-specific CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,6 +76,39 @@
             "name": "gtk-dev-debug",
             "displayName": "GTK Development Debug",
             "inherits": ["gtk-debug", "dev"]
+        },
+        {
+            "name": "wpe",
+            "hidden": true,
+            "generator": "Ninja",
+            "cacheVariables": {
+                "PORT": {
+                    "type": "STRING",
+                    "value": "WPE"
+                }
+            }
+        },
+        {
+            "name": "wpe-release",
+            "displayName": "WPE Release",
+            "inherits": ["wpe", "release"],
+            "binaryDir": "WebKitBuild/WPE/Release"
+        },
+        {
+            "name": "wpe-debug",
+            "displayName": "WPE Debug",
+            "inherits": ["wpe", "debug"],
+            "binaryDir": "WebKitBuild/WPE/Debug"
+        },
+        {
+            "name": "wpe-dev-release",
+            "displayName": "WPE Development Release",
+            "inherits": ["wpe-release", "dev"]
+        },
+        {
+            "name": "wpe-dev-debug",
+            "displayName": "WPE Development Debug",
+            "inherits": ["wpe-debug", "dev"]
         }
     ],
     "buildPresets": [
@@ -98,6 +131,26 @@
             "name": "gtk-dev-debug",
             "displayName": "GTK Development Debug",
             "configurePreset": "gtk-dev-debug"
+        },
+        {
+            "name": "wpe-release",
+            "displayName": "WPE Release",
+            "configurePreset": "wpe-release"
+        },
+        {
+            "name": "wpe-debug",
+            "displayName": "WPE Debug",
+            "configurePreset": "wpe-debug"
+        },
+        {
+            "name": "wpe-dev-release",
+            "displayName": "WPE Development Release",
+            "configurePreset": "wpe-dev-release"
+        },
+        {
+            "name": "wpe-dev-debug",
+            "displayName": "WPE Development Debug",
+            "configurePreset": "wpe-dev-debug"
         }
     ]
 }


### PR DESCRIPTION
#### 5ad0c5b53b0169911dfc98cf20ff60ed71c2cd0b
<pre>
[CMake][WPE] Add WPE-specific CMake presets
<a href="https://bugs.webkit.org/show_bug.cgi?id=265370">https://bugs.webkit.org/show_bug.cgi?id=265370</a>

Reviewed by Carlos Garcia Campos.

We already have GTK-specific presets in `CMakePresets.json`.
They work pretty well both with `cmake` command line tool and
&quot;Visual Studio Code&quot; with &quot;CMake Tools&quot; extension.

* CMakePresets.json:

Canonical link: <a href="https://commits.webkit.org/271137@main">https://commits.webkit.org/271137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d5055138f062ea8b431ed47ad44d193231a0cf2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25147 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3505 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4424 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25004 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30556 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2582 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28524 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hyperlink/basic (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5912 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4903 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3548 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->