### PR TITLE
Resync WPT webcodec tests up to 0808db6

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/META.yml
@@ -3,3 +3,5 @@ suggested_reviewers:
   - Djuffin
   - sandersdan
   - youennf
+  - padenot
+  - ChunMinChang

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.js
@@ -241,7 +241,7 @@ async function checkEncodingError(t, config, good_data, bad_data) {
 
   encoder.encode(bad_data);
   await promise_rejects_dom(t, 'EncodingError', encoder.flush().catch((e) => {
-    assert_equals(errors, 0);
+    assert_equals(errors, 1);
     throw e;
   }));
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_av1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_av1-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_annexb-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_avc-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_annexb-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_hevc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_hevc-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp8-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p0-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_av1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_av1-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_annexb-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_hevc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_hevc-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle with realtime latency mode
 PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
@@ -1,0 +1,11 @@
+
+FAIL Test transfering ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering detached buffer to VideoFrame
+FAIL Test transfering view of an ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering same array buffer twice
+FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to AudioData promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
+FAIL Encoding from AudioData with transferred buffer assert_unreached: Encoder error Reached unreachable code
+FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.js
@@ -1,0 +1,281 @@
+// META: global=window,dedicatedworker
+
+promise_test(async t => {
+  let fmt = 'RGBA';
+  const rgb_plane = [
+    0xBA, 0xDF, 0x00, 0xD0, 0xBA, 0xDF, 0x01, 0xD0, 0xBA, 0xDF, 0x02, 0xD0,
+    0xBA, 0xDF, 0x03, 0xD0
+  ];
+  let data = new Uint8Array(rgb_plane);
+  let unused_buffer = new ArrayBuffer(123);
+  let init = {
+    format: fmt,
+    timestamp: 1234,
+    codedWidth: 2,
+    codedHeight: 2,
+    visibleRect: {x: 0, y: 0, width: 2, height: 2},
+    transfer: [data.buffer, unused_buffer]
+  };
+  assert_equals(data.length, 16, 'data.length');
+  assert_equals(unused_buffer.byteLength, 123, 'unused_buffer.byteLength');
+
+  let frame = new VideoFrame(data, init);
+  assert_equals(frame.format, fmt, 'format');
+  assert_equals(data.length, 0, 'data.length after detach');
+  assert_equals(unused_buffer.byteLength, 0, 'unused_buffer after detach');
+
+  const options = {
+    rect: {x: 0, y: 0, width: init.codedWidth, height: init.codedHeight}
+  };
+  let size = frame.allocationSize(options);
+  let output_data = new Uint8Array(size);
+  let layout = await frame.copyTo(output_data, options);
+  let expected_data = new Uint8Array(rgb_plane);
+  assert_equals(expected_data.length, size, 'expected_data size');
+  for (let i = 0; i < size; i++) {
+    assert_equals(expected_data[i], output_data[i], `expected_data[${i}]`);
+  }
+
+  frame.close();
+}, 'Test transfering ArrayBuffer to VideoFrame');
+
+
+promise_test(async t => {
+  const rgb_plane = [
+    0xBA, 0xDF, 0x00, 0xD0, 0xBA, 0xDF, 0x01, 0xD0, 0xBA, 0xDF, 0x02, 0xD0,
+    0xBA, 0xDF, 0x03, 0xD0
+  ];
+  let data = new Uint8Array(rgb_plane);
+  let detached_buffer = new ArrayBuffer(123);
+
+  // Detach `detached_buffer`
+  structuredClone({x: detached_buffer}, {transfer: [detached_buffer]});
+
+  let init = {
+    format: 'RGBA',
+    timestamp: 1234,
+    codedWidth: 2,
+    codedHeight: 2,
+    visibleRect: {x: 0, y: 0, width: 2, height: 2},
+    transfer: [data.buffer, detached_buffer]
+  };
+
+  try {
+    new VideoFrame(data, init);
+  } catch (error) {
+    assert_equals(error.name, 'DataCloneError', 'error.name');
+  }
+  // `data.buffer` didn't get detached
+  assert_equals(data.length, 16, 'data.length');
+}, 'Test transfering detached buffer to VideoFrame');
+
+
+promise_test(async t => {
+  const rgb_plane = [
+    0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE,
+    0xEE, 0xEE, 0xEE, 0xEE
+  ];
+  const padding_size = 6;
+  let arraybuffer = new ArrayBuffer(padding_size + 16 /* pixels */);
+  let data = new Uint8Array(arraybuffer, padding_size);
+  data.set(rgb_plane);
+
+  let init = {
+    format: 'RGBA',
+    timestamp: 1234,
+    codedWidth: 2,
+    codedHeight: 2,
+    visibleRect: {x: 0, y: 0, width: 2, height: 2},
+    transfer: [arraybuffer]
+  };
+
+  let frame = new VideoFrame(data, init);
+  assert_equals(data.length, 0, 'data.length after detach');
+  assert_equals(arraybuffer.byteLength, 0, 'arraybuffer after detach');
+
+  const options = {
+    rect: {x: 0, y: 0, width: init.codedWidth, height: init.codedHeight}
+  };
+  let size = frame.allocationSize(options);
+  let output_data = new Uint8Array(size);
+  let layout = await frame.copyTo(output_data, options);
+  for (let i = 0; i < size; i++) {
+    assert_equals(output_data[i], 0xEE, `output_data[${i}]`);
+  }
+}, 'Test transfering view of an ArrayBuffer to VideoFrame');
+
+promise_test(async t => {
+  const rgb_plane = [
+    0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE,
+    0xEE, 0xEE, 0xEE, 0xEE
+  ];
+  const padding_size = 6;
+  let arraybuffer = new ArrayBuffer(padding_size + 16 /* pixels */);
+  let data = new Uint8Array(arraybuffer, padding_size);
+  data.set(rgb_plane);
+
+  let init = {
+    format: 'RGBA',
+    timestamp: 1234,
+    codedWidth: 2,
+    codedHeight: 2,
+    visibleRect: {x: 0, y: 0, width: 2, height: 2},
+    transfer: [arraybuffer, arraybuffer]
+  };
+
+  try {
+    new VideoFrame(data, init);
+  } catch (error) {
+    assert_equals(error.name, 'DataCloneError', 'error.name');
+  }
+  // `data.buffer` didn't get detached
+  assert_equals(data.length, 16, 'data.length');
+}, 'Test transfering same array buffer twice');
+
+promise_test(async t => {
+  const bytes = [ 0xBA, 0xDF, 0x00, 0xD0, 0xBA, 0xDF, 0x01, 0xD0, 0xBA, 0xDF ];
+  let data = new Uint8Array(bytes);
+  let unused_buffer = new ArrayBuffer(123);
+  let init = {
+    type: 'key',
+    timestamp: 0,
+    data: data,
+    transfer: [data.buffer, unused_buffer]
+  };
+
+  assert_equals(data.length, 10, 'data.length');
+  assert_equals(unused_buffer.byteLength, 123, 'unused_buffer.byteLength');
+
+  let chunk = new EncodedAudioChunk(init);
+  assert_equals(data.length, 0, 'data.length after detach');
+  assert_equals(unused_buffer.byteLength, 0, 'unused_buffer after detach');
+
+  let output_data = new Uint8Array(chunk.byteLength);
+  chunk.copyTo(output_data);
+  let expected_data = new Uint8Array(bytes);
+  assert_equals(expected_data.length, chunk.byteLength, 'expected_data size');
+  for (let i = 0; i < chunk.byteLength; i++) {
+    assert_equals(expected_data[i], output_data[i], `expected_data[${i}]`);
+  }
+}, 'Test transfering ArrayBuffer to EncodedAudioChunk');
+
+promise_test(async t => {
+  const bytes = [ 0xBA, 0xDF, 0x00, 0xD0, 0xBA, 0xDF, 0x01, 0xD0, 0xBA, 0xDF ];
+  let data = new Uint8Array(bytes);
+  let unused_buffer = new ArrayBuffer(123);
+  let init = {
+    type: 'key',
+    timestamp: 0,
+    data: data,
+    transfer: [data.buffer, unused_buffer]
+  };
+
+  assert_equals(data.length, 10, 'data.length');
+  assert_equals(unused_buffer.byteLength, 123, 'unused_buffer.byteLength');
+
+  let chunk = new EncodedVideoChunk(init);
+  assert_equals(data.length, 0, 'data.length after detach');
+  assert_equals(unused_buffer.byteLength, 0, 'unused_buffer after detach');
+
+  let output_data = new Uint8Array(chunk.byteLength);
+  chunk.copyTo(output_data);
+  let expected_data = new Uint8Array(bytes);
+  assert_equals(expected_data.length, chunk.byteLength, 'expected_data size');
+  for (let i = 0; i < chunk.byteLength; i++) {
+    assert_equals(expected_data[i], output_data[i], `expected_data[${i}]`);
+  }
+}, 'Test transfering ArrayBuffer to EncodedVideoChunk');
+
+promise_test(async t => {
+  const bytes = [0xBA, 0xDF, 0x00, 0xD0, 0xBA, 0xDF, 0x01, 0xD0, 0xBA, 0xDF];
+  let data = new Uint8Array(bytes);
+  let unused_buffer = new ArrayBuffer(123);
+  let init = {
+    type: 'key',
+    timestamp: 0,
+    numberOfFrames: data.length,
+    numberOfChannels: 1,
+    sampleRate: 10000,
+    format: 'u8',
+    data: data,
+    transfer: [data.buffer, unused_buffer]
+  };
+
+  assert_equals(data.length, 10, 'data.length');
+  assert_equals(unused_buffer.byteLength, 123, 'unused_buffer.byteLength');
+
+  let audio_data = new AudioData(init);
+  assert_equals(data.length, 0, 'data.length after detach');
+  assert_equals(unused_buffer.byteLength, 0, 'unused_buffer after detach');
+
+  let readback_data = new Uint8Array(bytes.length);
+  audio_data.copyTo(readback_data, {planeIndex: 0, format: 'u8'});
+  let expected_data = new Uint8Array(bytes);
+  for (let i = 0; i < expected_data.length; i++) {
+    assert_equals(expected_data[i], readback_data[i], `expected_data[${i}]`);
+  }
+}, 'Test transfering ArrayBuffer to AudioData');
+
+promise_test(async t => {
+  let sample_rate = 48000;
+  let total_duration_s = 1;
+  let data_count = 10;
+  let chunks = [];
+
+  let encoder_init = {
+    error: t.unreached_func('Encoder error'),
+    output: (chunk, metadata) => {
+      chunks.push(chunk);
+    }
+  };
+  let encoder = new AudioEncoder(encoder_init);
+  let config = {
+    codec: 'opus',
+    sampleRate: sample_rate,
+    numberOfChannels: 2,
+    bitrate: 256000,  // 256kbit
+  };
+  encoder.configure(config);
+
+  let timestamp_us = 0;
+  const data_duration_s = total_duration_s / data_count;
+  const frames = data_duration_s * config.sampleRate;
+  for (let i = 0; i < data_count; i++) {
+    let buffer = new Float32Array(frames * config.numberOfChannels);
+    let data = new AudioData({
+      timestamp: timestamp_us,
+      data: buffer,
+      numberOfChannels: config.numberOfChannels,
+      numberOfFrames: frames,
+      sampleRate: config.sampleRate,
+      format: 'f32-planar',
+      transfer: [buffer.buffer]
+    });
+    timestamp_us += data_duration_s * 1_000_000;
+    assert_equals(buffer.length, 0, 'buffer.length after detach');
+    encoder.encode(data);
+  }
+  await encoder.flush();
+  encoder.close();
+  assert_greater_than(chunks.length, 0);
+}, 'Encoding from AudioData with transferred buffer');
+
+
+promise_test(async t => {
+  let unused_buffer = new ArrayBuffer(123);
+  let support = await ImageDecoder.isTypeSupported('image/png');
+  assert_implements_optional(
+      support, 'Optional codec image/png not supported.');
+  let buffer = await fetch('four-colors.png').then(response => {
+    return response.arrayBuffer();
+  });
+
+  let decoder = new ImageDecoder(
+      {data: buffer, type: 'image/png', transfer: [buffer, unused_buffer]});
+  assert_equals(buffer.byteLength, 0, 'buffer.byteLength after detach');
+  assert_equals(unused_buffer.byteLength, 0, 'unused_buffer after detach');
+
+  let result = await decoder.decode();
+  assert_equals(result.image.displayWidth, 320);
+  assert_equals(result.image.displayHeight, 240);
+}, 'Test transfering ArrayBuffer to ImageDecoder.');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
@@ -1,0 +1,11 @@
+
+FAIL Test transfering ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering detached buffer to VideoFrame
+FAIL Test transfering view of an ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering same array buffer twice
+FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to AudioData promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
+FAIL Encoding from AudioData with transferred buffer assert_unreached: Encoder error Reached unreachable code
+FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Test that contentHint is recognized by VideoEncoder assert_equals: expected (string) "text" but got (undefined) undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.js
@@ -1,0 +1,21 @@
+// META: global=window,dedicatedworker
+
+promise_test(async t => {
+  const config = {
+    codec: 'vp8',
+    width: 1280,
+    height: 720,
+    bitrate: 5000000,
+    bitrateMode: 'constant',
+    framerate: 25,
+    latencyMode: 'realtime',
+    contentHint: 'text',
+  };
+
+  let support = await VideoEncoder.isConfigSupported(config);
+  assert_equals(support.supported, true);
+
+  let new_config = support.config;
+  assert_equals(new_config.codec, config.codec);
+  assert_equals(new_config.contentHint, 'text');
+}, 'Test that contentHint is recognized by VideoEncoder');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Test that contentHint is recognized by VideoEncoder assert_equals: expected (string) "text" but got (undefined) undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log
@@ -74,11 +74,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/sfx.adts
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/sfx.mp3
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/utils.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.crossOriginIsolated.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.crossOriginIsolated.https.any.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Encoding and decoding cycle
-PASS Encoding and decoding cycle w/ stripped color space
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Encoding and decoding cycle
-PASS Encoding and decoding cycle w/ stripped color space
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
@@ -1,0 +1,11 @@
+
+FAIL Test transfering ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering detached buffer to VideoFrame
+FAIL Test transfering view of an ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering same array buffer twice
+FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to AudioData assert_equals: data.length after detach expected 0 but got 10
+FAIL Encoding from AudioData with transferred buffer assert_equals: buffer.length after detach expected 0 but got 9600
+FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
@@ -1,0 +1,11 @@
+
+FAIL Test transfering ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering detached buffer to VideoFrame
+FAIL Test transfering view of an ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
+PASS Test transfering same array buffer twice
+FAIL Test transfering ArrayBuffer to EncodedAudioChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to EncodedVideoChunk assert_equals: data.length after detach expected 0 but got 10
+FAIL Test transfering ArrayBuffer to AudioData assert_equals: data.length after detach expected 0 but got 10
+FAIL Encoding from AudioData with transferred buffer assert_equals: buffer.length after detach expected 0 but got 9600
+FAIL Test transfering ArrayBuffer to ImageDecoder. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
+


### PR DESCRIPTION
#### b251e58b95dd400646e73fec5947292e6d47c2e9
<pre>
Resync WPT webcodec tests up to 0808db6
<a href="https://bugs.webkit.org/show_bug.cgi?id=265364">https://bugs.webkit.org/show_bug.cgi?id=265364</a>
<a href="https://rdar.apple.com/118823698">rdar://118823698</a>

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.js:
(async checkEncodingError):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js:
(async runFullCycleTest):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_av1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_hevc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_av1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_hevc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.js: Added.
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.js: Added.
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-content-hint.https.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/271378@main">https://commits.webkit.org/271378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63f3c257627e34a3472bcd132ccc1a62420a9fcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25686 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4216 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31307 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29064 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25056 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6753 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->