### PR TITLE
[GStreamer] New test media/media-source/media-source-webm-configuration-change.html failing

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2474,8 +2474,7 @@ imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-
 webkit.org/b/256768 fast/mediastream/captureStream/canvas3d.html [ Failure Pass ]
 
 webkit.org/b/249477 media/audioSession/audioSessionType.html [ Skip ]
-webkit.org/b/253832 media/media-source/media-source-webm-configuration-change.html [ Failure ]
-webkit.org/b/253832 media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failure ]
+
 media/media-source/media-source-rendering-update-count.html [ Skip ]
 
 # Tests failing while still having the right values in expected related to the import in webkit.org/b/252516

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1533,8 +1533,6 @@ webkit.org/b/236926 webrtc/vp8-then-h264-gpu-process-crash.html [ Timeout Pass ]
 
 ############ end of test failures related to GPU Process on by default
 
-webkit.org/b/256543 media/media-source/media-source-webm-configuration-change.html [ Failure ]
-webkit.org/b/256543 media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failure ]
 media/media-source/media-source-rendering-update-count.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -31,6 +31,7 @@
 
 #include "GStreamerCommon.h"
 #include "MediaPlayerPrivateGStreamer.h"
+#include <gst/pbutils/pbutils.h>
 #include <wtf/Scope.h>
 
 namespace WebCore {
@@ -86,7 +87,7 @@ void AudioTrackPrivateGStreamer::capsChanged(const String& streamId, GRefPtr<Gst
     setConfiguration(WTFMove(configuration));
 }
 
-void AudioTrackPrivateGStreamer::updateConfigurationFromTags(const GRefPtr<GstTagList>&& tags)
+void AudioTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>&& tags)
 {
     ASSERT(isMainThread());
     GST_DEBUG_OBJECT(objectForLogging(), "Updating audio configuration from %" GST_PTR_FORMAT, tags.get());
@@ -103,7 +104,7 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromTags(const GRefPtr<GstTa
     setConfiguration(WTFMove(configuration));
 }
 
-void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(const GRefPtr<GstCaps>&& caps)
+void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& caps)
 {
     ASSERT(isMainThread());
     if (!caps || !gst_caps_is_fixed(caps.get()))
@@ -114,6 +115,10 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(const GRefPtr<GstCa
     auto scopeExit = makeScopeExit([&] {
         setConfiguration(WTFMove(configuration));
     });
+
+    GUniquePtr<char> mimeCodec(gst_codec_utils_caps_get_mime_codec(caps.get()));
+    if (mimeCodec)
+        configuration.codec = makeString(mimeCodec.get());
 
     if (areEncryptedCaps(caps.get())) {
         int sampleRate, numberOfChannels;

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -60,9 +60,10 @@ public:
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
 
+    void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) final;
+
 protected:
-    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&&) override;
-    void updateConfigurationFromTags(const GRefPtr<GstTagList>&&) override;
+    void updateConfigurationFromTags(GRefPtr<GstTagList>&&) final;
 
     void tagsChanged(GRefPtr<GstTagList>&& tags) final { updateConfigurationFromTags(WTFMove(tags)); }
     void capsChanged(const String& streamId, GRefPtr<GstCaps>&&) final;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -788,7 +788,7 @@ PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo& info)
         colorSpace.matrix = PlatformVideoMatrixCoefficients::Fcc;
         break;
     case GST_VIDEO_COLOR_MATRIX_BT2020:
-        colorSpace.matrix = PlatformVideoMatrixCoefficients::Bt2020ConstantLuminance;
+        colorSpace.matrix = PlatformVideoMatrixCoefficients::Bt2020Ncl;
         break;
     case GST_VIDEO_COLOR_MATRIX_UNKNOWN:
         colorSpace.matrix = PlatformVideoMatrixCoefficients::Unspecified;
@@ -917,7 +917,7 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVi
         case PlatformVideoMatrixCoefficients::Fcc:
             GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_FCC;
             break;
-        case PlatformVideoMatrixCoefficients::Bt2020ConstantLuminance:
+        case PlatformVideoMatrixCoefficients::Bt2020NonconstantLuminance:
             GST_VIDEO_INFO_COLORIMETRY(info).matrix = GST_VIDEO_COLOR_MATRIX_BT2020;
             break;
         case PlatformVideoMatrixCoefficients::Unspecified:

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -69,6 +69,8 @@ public:
 
     static String trackIdFromPadStreamStartOrUniqueID(TrackType, unsigned index, const GRefPtr<GstPad>&);
 
+    virtual void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) { }
+
 protected:
     TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
     TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GstStream*);
@@ -81,8 +83,7 @@ protected:
     virtual void tagsChanged(GRefPtr<GstTagList>&&) { }
     virtual void capsChanged(const String&, GRefPtr<GstCaps>&&) { }
     void installUpdateConfigurationHandlers();
-    virtual void updateConfigurationFromCaps(const GRefPtr<GstCaps>&&) { }
-    virtual void updateConfigurationFromTags(const GRefPtr<GstTagList>&&) { }
+    virtual void updateConfigurationFromTags(GRefPtr<GstTagList>&&) { }
 
     static GRefPtr<GstTagList> getAllTags(const GRefPtr<GstPad>&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -61,9 +61,10 @@ public:
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
 
+    void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) final;
+
 protected:
-    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&&) override;
-    void updateConfigurationFromTags(const GRefPtr<GstTagList>&&) override;
+    void updateConfigurationFromTags(GRefPtr<GstTagList>&&) final;
 
     void tagsChanged(GRefPtr<GstTagList>&& tags) final { updateConfigurationFromTags(WTFMove(tags)); }
     void capsChanged(const String&, GRefPtr<GstCaps>&&) final;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -768,6 +768,10 @@ GRefPtr<GstElement> createOptionalParserForFormat(GstBin* bin, const AtomString&
         default:
             GST_WARNING_OBJECT(bin, "Unsupported audio mpeg caps: %" GST_PTR_FORMAT, caps);
         }
+    } else if (!g_strcmp0(mediaType, "video/x-vp9")) {
+        // Necessary for: metadata filling.
+        // Without this parser the codec string set on the corresponding video track will be incomplete.
+        elementClass = "vp9parse";
     }
 
     GST_DEBUG_OBJECT(bin, "Creating %s parser for stream with caps %" GST_PTR_FORMAT, elementClass, caps);


### PR DESCRIPTION
#### 7734fe565b9151fb97688649bd2a53c14327e55a
<pre>
[GStreamer] New test media/media-source/media-source-webm-configuration-change.html failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253832">https://bugs.webkit.org/show_bug.cgi?id=253832</a>

Reviewed by Xabier Rodriguez-Calvar.

The append pipeline is now parsing VP9, which allows the corresponding video track to advertise a
more accurate codec string. The BT2020 matrix coefficients mapping were also updated to the
Conventional non-constant luminance Y&apos;C&apos;BC&apos;R defined in Rec. ITU-R BT.2020-2, I opened an issue in
GStreamer&apos;s gitlab regarding this, <a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3156.">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3156.</a>

* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::videoColorSpaceFromInfo):
(WebCore::fillVideoInfoColorimetryFromColorSpace):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::updateTracks):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
(WebCore::TrackPrivateBaseGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::createOptionalParserForFormat):

Canonical link: <a href="https://commits.webkit.org/271224@main">https://commits.webkit.org/271224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bec8a02437a9323d41d501e400fc52cc5aa2688

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25061 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30541 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25185 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30693 "Found 1 new test failure: fast/events/monotonic-event-time.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28663 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6092 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6658 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->