### PR TITLE
Include arch-specific headers in BiquadDSPKernel

### DIFF
--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
@@ -36,6 +36,14 @@
 #include <limits.h>
 #include <wtf/Vector.h>
 
+#if CPU(X86_SSE2)
+#include <immintrin.h>
+#endif
+
+#if HAVE(ARM_NEON_INTRINSICS)
+#include <arm_neon.h>
+#endif
+
 namespace WebCore {
 
 static bool hasConstantValue(float* values, int framesToProcess)
@@ -49,7 +57,7 @@ static bool hasConstantValue(float* values, int framesToProcess)
     // during the loop execution.
     int processedFrames = 1;
 
-#if defined(__SSE2__)
+#if CPU(X86_SSE2)
     // Process 4 floats at a time using SIMD.
     __m128 valueVec = _mm_set1_ps(value);
     // Start at 0 for byte alignment
@@ -62,7 +70,7 @@ static bool hasConstantValue(float* values, int framesToProcess)
         if (_mm_movemask_ps(cmpVec))
             return false;
     }
-#elif defined(__ARM_NEON__)
+#elif HAVE(ARM_NEON_INTRINSICS)
     // Process 4 floats at a time using SIMD.
     float32x4_t valueVec = vdupq_n_f32(value);
     // Start at 0 for byte alignment.


### PR DESCRIPTION
#### 920ba07bf75fc5f066853531d29bcd7ecac8062d
<pre>
Include arch-specific headers in BiquadDSPKernel
<a href="https://bugs.webkit.org/show_bug.cgi?id=265372">https://bugs.webkit.org/show_bug.cgi?id=265372</a>

Reviewed by Darin Adler.

Commit 270669@main for bug 264488 added usage of arch-specific
intrinsics, by backporting a Chromium patch, but it did not include
the matching headers. Build could fail on some ARM platforms.

* Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp:
(WebCore::hasConstantValue):

Include arch-specific headers, and use WebKit-style macros.

Canonical link: <a href="https://commits.webkit.org/271372@main">https://commits.webkit.org/271372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/293c1f3b41b7c40602797f1d465ad69019a079fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4112 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4901 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25158 "Found 1 new test failure: fast/ruby/ruby-overhang-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31208 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28967 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6437 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6748 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->