### PR TITLE
[WinCairo] Read GITHUB_TOKEN from env when updating WebKitRequirements

### DIFF
--- a/Tools/Scripts/update-webkit-wincairo-libs.py
+++ b/Tools/Scripts/update-webkit-wincairo-libs.py
@@ -36,6 +36,9 @@ file = 'WebKitRequirementsWin64.zip'
 output = os.getenv('WEBKIT_LIBRARIES', 'WebKitLibraries/win')
 options = [repo, file, '-o', output]
 
+if os.getenv('GITHUB_TOKEN'):
+    options += ['-t', os.getenv('GITHUB_TOKEN')]
+
 # Check if there's a specific version to request
 config_path = os.path.join(output, file) + '.config'
 if os.path.exists(config_path):


### PR DESCRIPTION
#### 46ea518570fd5522d27506779a7b06446cbde515
<pre>
[WinCairo] Read GITHUB_TOKEN from env when updating WebKitRequirements
<a href="https://bugs.webkit.org/show_bug.cgi?id=265373">https://bugs.webkit.org/show_bug.cgi?id=265373</a>

Reviewed by Don Olmstead.

Read the API token from env and add it accordingly if set.

* Tools/Scripts/update-webkit-wincairo-libs.py:

Canonical link: <a href="https://commits.webkit.org/271154@main">https://commits.webkit.org/271154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddff7b172ca32d158c7492461024265404d1cfc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25160 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4280 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30571 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28541 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5925 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6618 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4915 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4846 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->