### PR TITLE
[CSS] Scoped style rules accept relative selector list

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-cssom.html
@@ -25,7 +25,7 @@ test(() => {
 }, 'CSSScopeRule.cssText, root only');
 
 test(() => {
-  assert_equals(style.sheet.rules[2].cssText, '@scope (.a) to (.b) {\n  div { display: block; }\n}');
+  assert_equals(style.sheet.rules[2].cssText, '@scope (.a) to (.b) {\n  :scope div { display: block; }\n}');
 }, 'CSSScopeRule.cssText, root and limit');
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL @scope (#main) { .b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
-FAIL @scope (#main) to (.b) { .a {  } } assert_equals: scoped + unscoped expected "1" but got "2"
-FAIL @scope (#main, .foo, .bar) { #a {  } } assert_equals: scoped + unscoped expected "1" but got "2"
-FAIL @scope (#main) { div.b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
+FAIL @scope (#main) { .b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
+FAIL @scope (#main) to (.b) { .a {  } } assert_equals: unscoped + scoped expected "2" but got "1"
+FAIL @scope (#main, .foo, .bar) { #a {  } } assert_equals: unscoped + scoped expected "2" but got "1"
+FAIL @scope (#main) { div.b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
 FAIL @scope (#main) { :scope .b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
 FAIL @scope (#main) { & .b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
-FAIL @scope (#main) { div .b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
-FAIL @scope (#main) { @scope (.a) { .b {  } } } assert_equals: scoped + unscoped expected "1" but got "2"
+FAIL @scope (#main) { div .b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
+FAIL @scope (#main) { @scope (.a) { .b {  } } } assert_equals: unscoped + scoped expected "2" but got "1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
@@ -11,8 +11,8 @@ FAIL :link as scoping root, :scope assert_equals: expected "rgb(0, 128, 0)" but 
 PASS :visited as scoping root, :scope
 FAIL :not(:visited) as scoping root, :scope assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
 PASS :not(:link) as scoping root, :scope
-PASS :link as scoping limit
-FAIL :visited as scoping limit assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
-FAIL :not(:link) as scoping limit assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
-PASS :not(:visited) as scoping limit
+FAIL :link as scoping limit assert_equals: expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
+PASS :visited as scoping limit
+PASS :not(:link) as scoping limit
+FAIL :not(:visited) as scoping limit assert_equals: expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -1102,4 +1102,16 @@ bool CSSSelector::hasExplicitNestingParent() const
     return visitAllSimpleSelectors(checkForExplicitParent);
 }
 
+bool CSSSelector::hasExplicitPseudoClassScope() const
+{
+    auto check = [] (const CSSSelector& selector) {
+        if (selector.match() == Match::PseudoClass && selector.pseudoClassType() == PseudoClassType::Scope)
+            return true;
+
+        return false;
+    };
+
+    return visitAllSimpleSelectors(check);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -66,6 +66,7 @@ struct PossiblyQuotedIdentifier {
         bool visitAllSimpleSelectors(auto& apply) const;
 
         bool hasExplicitNestingParent() const;
+        bool hasExplicitPseudoClassScope() const;
         void resolveNestingParentSelectors(const CSSSelectorList& parent);
         void replaceNestingParentByPseudoClassScope();
 

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -68,7 +68,7 @@ public:
     bool isPageRule() const { return type() == StyleRuleType::Page; }
     bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
-    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container; }
+    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
     bool isImportRule() const { return type() == StyleRuleType::Import; }
     bool isLayerRule() const { return type() == StyleRuleType::LayerBlock || type() == StyleRuleType::LayerStatement; }

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -180,14 +180,29 @@ private:
         ASSERT(!m_nestingContextStack.isEmpty());
         return m_nestingContextStack.last();
     }
-    bool isNestedContext()
+
+    bool isStyleNestedContext()
     {
         return (m_isAlwaysNestedContext == CSSParserEnum::IsNestedContext::Yes || m_styleRuleNestingLevel) && context().cssNestingEnabled;
     }
 
+    bool isNestedContext()
+    {
+        return m_scopeRuleNestingLevel || isStyleNestedContext();
+    }
+
     CSSParserEnum::IsNestedContext m_isAlwaysNestedContext { CSSParserEnum::IsNestedContext::No }; // Do we directly start in a nested context (for CSSOM)
+
+    // FIXME: we could unify all those into a single stack data structure.
+    // https://bugs.webkit.org/show_bug.cgi?id=265566
     unsigned m_styleRuleNestingLevel { 0 };
+    unsigned m_scopeRuleNestingLevel { 0 };
     unsigned m_ruleListNestingLevel { 0 };
+    enum class AncestorRuleType : bool {
+        Style,
+        Scope,
+    };
+    Vector<AncestorRuleType, 16> m_ancestorRuleTypeStack;
 
     Vector<NestingContext> m_nestingContextStack { NestingContext { } };
     const CSSParserContext& m_context;

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -164,6 +164,18 @@ bool CSSParserSelector::hasExplicitNestingParent() const
     return false;
 }
 
+bool CSSParserSelector::hasExplicitPseudoClassScope() const
+{
+    auto selector = this;
+    while (selector) {
+        if (selector->selector()->hasExplicitPseudoClassScope())
+            return true;
+
+        selector = selector->tagHistory();
+    }
+    return false;
+}
+
 static bool selectorListMatchesPseudoElement(const CSSSelectorList* selectorList)
 {
     if (!selectorList)
@@ -204,6 +216,19 @@ void CSSParserSelector::appendTagHistory(CSSSelector::RelationType relation, std
 
     end->setRelation(relation);
     end->setTagHistory(WTFMove(selector));
+}
+
+void CSSParserSelector::appendTagHistoryAsRelative(std::unique_ptr<CSSParserSelector> selector)
+{
+    auto lastSelector = leftmostSimpleSelector()->selector();
+    ASSERT(lastSelector);
+
+    // Relation is Descendant by default.
+    auto relation = lastSelector->relation();
+    if (relation == CSSSelector::RelationType::Subselector)
+        relation = CSSSelector::RelationType::DescendantSpace;
+
+    appendTagHistory(relation, WTFMove(selector));
 }
 
 void CSSParserSelector::appendTagHistory(CSSParserSelectorCombinator relation, std::unique_ptr<CSSParserSelector> selector)

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -85,6 +85,7 @@ public:
     bool isHostPseudoSelector() const;
 
     bool hasExplicitNestingParent() const;
+    bool hasExplicitPseudoClassScope() const;
 
     // FIXME-NEWPARSER: "slotted" was removed here for now, since it leads to a combinator
     // connection of ShadowDescendant, and the current shadow DOM code doesn't expect this. When
@@ -99,6 +100,7 @@ public:
     void insertTagHistory(CSSSelector::RelationType before, std::unique_ptr<CSSParserSelector>, CSSSelector::RelationType after);
     void appendTagHistory(CSSSelector::RelationType, std::unique_ptr<CSSParserSelector>);
     void appendTagHistory(CSSParserSelectorCombinator, std::unique_ptr<CSSParserSelector>);
+    void appendTagHistoryAsRelative(std::unique_ptr<CSSParserSelector>);
     void prependTagSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
     std::unique_ptr<CSSParserSelector> releaseTagHistory();
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -300,39 +300,13 @@ static bool isDescendantCombinator(CSSSelector::RelationType relation)
 
 std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeNestedComplexSelector(CSSParserTokenRange& range)
 {
-    auto appendNestingSelector = [] (auto& parserSelector) {
-        // https://drafts.csswg.org/css-nesting/#cssom
-        // Relative selector should be absolutized (only when not "nest-containing" for the descendant one),
-        // with the implied nesting selector inserted.
-
-        auto lastSelector = parserSelector->leftmostSimpleSelector()->selector();
-        ASSERT(lastSelector);
-
-        // Relation is Descendant by default.
-        auto relation = lastSelector->relation();
-        if (relation == CSSSelector::RelationType::Subselector)
-            relation = CSSSelector::RelationType::DescendantSpace;
-
-        auto nestingSelector = makeUnique<CSSParserSelector>();
-        nestingSelector->setMatch(CSSSelector::Match::NestingParent);
-        // We add the implicit parent selector at the beginning of the selector.
-        parserSelector->appendTagHistory(relation, WTFMove(nestingSelector));
-    };
-
     auto selector = consumeComplexSelector(range);
-    if (selector) {
-        if (selector->hasExplicitNestingParent())
-            return selector;
-
-        appendNestingSelector(selector);
+    if (selector)
         return selector;
-    }
 
     selector = consumeRelativeNestedSelector(range);
-    if (selector) {
-        appendNestingSelector(selector);
+    if (selector)
         return selector;
-    }
 
     return nullptr;
 }
@@ -1280,7 +1254,7 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
             // FIXME: We should build a new CSSParserSelector from this selector and resolve it
             const_cast<CSSSelector*>(selector)->resolveNestingParentSelectors(*parentResolvedSelectorList);
         } else {
-            // It's top-level, the nesting parent selector should be replace by :scope
+            // It's top-level, the nesting parent selector should be replaced by :scope
             const_cast<CSSSelector*>(selector)->replaceNestingParentByPseudoClassScope();
         }
         auto parserSelector = makeUnique<CSSParserSelector>(*selector);


### PR DESCRIPTION
#### f658dff67d19b38c9e0ddff921d51fd7d8f722fb
<pre>
[CSS] Scoped style rules accept relative selector list
<a href="https://bugs.webkit.org/show_bug.cgi?id=265289">https://bugs.webkit.org/show_bug.cgi?id=265289</a>
<a href="https://rdar.apple.com/118749004">rdar://118749004</a>

Reviewed by Antti Koivisto.

Like nested style rule, scoped style rules accept a relative selector
list as the prelude for their rule list.
The implicit &quot;:scope&quot; or &quot;&amp;&quot; in their prelude has to be added explicitely when necessary.

<a href="https://drafts.csswg.org/css-cascade-6/#scoped-style-rules">https://drafts.csswg.org/css-cascade-6/#scoped-style-rules</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-cssom.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt:

For the moment, until the @scope feature is more complete, those tests passing or failing don&apos;t mean anything.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::hasExplicitPseudoClassScope const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isGroupRule const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeRegularRuleList):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::CSSParserImpl::consumeStyleRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
(WebCore::CSSParserImpl::isStyleNestedContext):
(WebCore::CSSParserImpl::isNestedContext):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::hasExplicitPseudoClassScope const):
(WebCore::CSSParserSelector::appendTagHistoryAsRelative):
* Source/WebCore/css/parser/CSSParserSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeNestedComplexSelector):

We move the code to add the prepend the implicit selector from CSSSelectorParser
to CSSParserImpl where we know the type of the parent rule
(because we need to preprend either &amp; or :scope)

(WebCore::CSSSelectorParser::resolveNestingParent):

Canonical link: <a href="https://commits.webkit.org/271336@main">https://commits.webkit.org/271336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/181365044b9e0c3c70047d5f5ea7f3f78c7ac604

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25336 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4693 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31278 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31174 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28943 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6725 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->