### PR TITLE
[WPE][GTK] API test `TestCookieManager` `/webkit/WebKitCookieManager/long-expires` is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
@@ -839,7 +839,7 @@ static void testCookieManagerLongExpires(CookieManagerTest* test, gconstpointer)
 
     GRefPtr<GDateTime> now = adoptGRef(g_date_time_new_now_utc());
     GRefPtr<GDateTime> expires = adoptGRef(g_date_time_add_years(now.get(), 35));
-    GUniquePtr<char> line(g_strdup_printf("#HttpOnly_localhost\tFALSE\t/\tFALSE\t%ld\tprov\t123\tNone", g_date_time_to_unix(expires.get())));
+    GUniquePtr<char> line(g_strdup_printf("#HttpOnly_localhost\tFALSE\t/\tFALSE\t%ld\tprov\t123", g_date_time_to_unix(expires.get())));
     test->m_cookiesTextFile.reset(g_build_filename(Test::dataDirectory(), "cookies.txt", nullptr));
     g_file_set_contents(test->m_cookiesTextFile.get(), line.get(), -1, nullptr);
     test->setPersistentStorage(WEBKIT_COOKIE_PERSISTENT_STORAGE_TEXT);


### PR DESCRIPTION
#### 1c1eb7d0182bcb398ccf101e2bfd27013b7b010e
<pre>
[WPE][GTK] API test `TestCookieManager` `/webkit/WebKitCookieManager/long-expires` is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=265379">https://bugs.webkit.org/show_bug.cgi?id=265379</a>

Reviewed by Michael Catanzaro.

Since <a href="https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/348">https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/348</a>,
libsoup rejects SameSite=None cookies by default.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp:
(testCookieManagerLongExpires):

Canonical link: <a href="https://commits.webkit.org/271198@main">https://commits.webkit.org/271198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d124694dc436c51d2f58fce5fd5e3c45f7862af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30585 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28646 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5937 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6640 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4927 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->