### PR TITLE
[UIAsyncTextInput] fast/events/ios/contenteditable-autocapitalize.html fails when using async text input

### DIFF
--- a/LayoutTests/fast/events/ios/contenteditable-autocapitalize-expected.txt
+++ b/LayoutTests/fast/events/ios/contenteditable-autocapitalize-expected.txt
@@ -1,6 +1,12 @@
 To manually test, type 't' into the contenteditable. The 't' should not be autocapitalized.
 
-With autocapitalize: none, the output is: "to"
-With autocapitalize: sentences, the output is: "To"
-With autocapitalize: characters, the output is: "TO"
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS With autocapitalize: none, the output is: "to"
+PASS With autocapitalize: sentences, the output is: "To"
+PASS With autocapitalize: characters, the output is: "TO"
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/events/ios/contenteditable-autocapitalize.html
+++ b/LayoutTests/fast/events/ios/contenteditable-autocapitalize.html
@@ -1,59 +1,38 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
-
 <html>
-
 <head>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
     <script>
-        let write = message => output.innerHTML += message + "<br>";
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
-
-        let remainingInputEventCount = 0;
-        let resolveExpectedInputEvents = null;
-        function handleInput() {
-            remainingInputEventCount--;
-            if (resolveExpectedInputEvents && !remainingInputEventCount)
-                resolveExpectedInputEvents();
-        }
-
-        function runTestWithAutocapitalizeType(autocapitalizeType, inputEventCount)
-        {
-            editable.autocapitalize = autocapitalizeType;
-            remainingInputEventCount = inputEventCount;
-            resolveExpectedInputEvents = () => {
-                write(`With autocapitalize: ${editable.autocapitalize}, the output is: "${editable.textContent}"`);
-                editable.textContent = "";
-                editable.blur();
-            };
-
-            return new Promise(function(resolve) {
-                let rect = editable.getBoundingClientRect();
-                testRunner.runUIScript(`(function() {
-                    uiController.didShowKeyboardCallback = function() {
-                        uiController.typeCharacterUsingHardwareKeyboard("t", function() {
-                            uiController.typeCharacterUsingHardwareKeyboard("o", function() {});
-                        });
-                    }
-                    uiController.didHideKeyboardCallback = function() {
-                        uiController.uiScriptComplete();
-                    }
-                    uiController.singleTapAtPoint(${rect.left + rect.width / 2}, ${rect.top + rect.height / 2}, function() {});
-                })();`, resolve);
-            });
-        }
+        jsTestIsAsync = true;
+        description("To manually test, type 't' into the contenteditable. The 't' should not be autocapitalized.");
 
         async function runTest()
         {
             if (!window.testRunner || !testRunner.runUIScript)
                 return;
 
-            await runTestWithAutocapitalizeType("none", 2);
-            await runTestWithAutocapitalizeType("sentences", 2);
-            await runTestWithAutocapitalizeType("characters", 2);
-            testRunner.notifyDone();
+            for (const [autocapitalizeType, expectedTextContent] of [["none", "to"], ["sentences", "To"], ["characters", "TO"]]) {
+                editable.autocapitalize = autocapitalizeType;
+
+                await UIHelper.activateElementAndWaitForInputSession(editable);
+                await UIHelper.typeCharacter("t");
+                await UIHelper.ensurePresentationUpdate();
+                await UIHelper.typeCharacter("o");
+                await UIHelper.ensurePresentationUpdate();
+
+                if (expectedTextContent === editable.textContent)
+                    testPassed(`With autocapitalize: ${autocapitalizeType}, the output is: "${editable.textContent}"`);
+                else
+                    testFailed(`With autocapitalize: ${autocapitalizeType}, the output is: "${editable.textContent}" (expected "${expectedTextContent}")`);
+
+                editable.textContent = "";
+                editable.blur();
+            }
+
+            await UIHelper.waitForKeyboardToHide();
+            finishJSTest();
         }
     </script>
     <style>
@@ -68,8 +47,7 @@
 </head>
 
 <body onload=runTest()>
-    <div contenteditable id="editable" oninput=handleInput()></div>
-    <p>To manually test, type 't' into the contenteditable. The 't' should not be autocapitalized.</p>
+    <div contenteditable id="editable"></div>
     <div id="output"></div>
 </body>
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5178,7 +5178,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 
 - (void)requestPreferredArrowDirectionForEditMenuWithCompletionHandler:(void(^)(UIEditMenuArrowDirection))completion
 {
-    if ([self _shouldSuppressSelectionCommands]) {
+    if (self.shouldSuppressEditMenu) {
         completion(UIEditMenuArrowDirectionAutomatic);
         return;
     }
@@ -8673,7 +8673,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
         if (!strongSelf)
             return completionHandler(false, { });
 
-        if (shouldPresentMenu && ![strongSelf _shouldSuppressSelectionCommands])
+        if (shouldPresentMenu && ![strongSelf shouldSuppressEditMenu])
             [strongSelf->_textInteractionWrapper activateSelection];
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -63,6 +63,13 @@
 #import <UIKit/UIWindow_Private.h>
 #import <UIKit/_UINavigationInteractiveTransition.h>
 
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+#import <UIKit/UIAsyncTextInput.h>
+#import <UIKit/UIAsyncTextInputClient.h>
+#import <UIKit/UIAsyncTextInteraction.h>
+#import <UIKit/UIKeyEventContext.h>
+#endif
+
 IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 #import <UIKit/UIWebBrowserView.h>
 #import <UIKit/UIWebScrollView.h>
@@ -616,5 +623,11 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 @interface UIApplication (IPI)
 - (UIPressInfo *)_pressInfoForPhysicalKeyboardEvent:(UIPhysicalKeyboardEvent *)physicalKeyboardEvent;
 @end
+
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+@protocol UIAsyncTextInput_Staging <UIAsyncTextInput>
+@property (nonatomic, readonly) CGRect selectionClipRect; // Added in <rdar://118189933>.
+@end
+#endif
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -796,8 +796,6 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (auto view = self.textSelectionDisplayInteraction.cursorView; !view.hidden)
         caretView = view;
-#else
-    caretView = [self.textInputContentView valueForKeyPath:@"interactionAssistant.selectionView.caretView"];
 #endif
 
     return [caretView convertRect:caretView.bounds toView:self.textInputContentView];
@@ -810,8 +808,6 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (auto view = self.textSelectionDisplayInteraction.highlightView; !view.hidden)
         rects = view.selectionRects;
-#else
-    rects = [self.textInputContentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView.rects"];
 #endif
 
     for (UITextSelectionRect *rect in rects)

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -33,6 +33,7 @@
 typedef struct CGRect CGRect;
 OBJC_CLASS UITextSelectionDisplayInteraction;
 
+@protocol UIAsyncTextInput_Staging;
 @protocol UICoordinateSpace;
 
 namespace WebCore {
@@ -192,6 +193,12 @@ private:
     void simulateRotation(DeviceOrientation, JSValueRef callback);
 
     int64_t pasteboardChangeCount() const final;
+
+    void clipSelectionViewRectToContentView(CGRect&) const;
+
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    id<UIAsyncTextInput_Staging> asyncTextInput() const;
+#endif
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     UITextSelectionDisplayInteraction *textSelectionDisplayInteraction() const;


### PR DESCRIPTION
#### 76b8798632ec1c107571bdf2c46d140de68e215a
<pre>
[UIAsyncTextInput] fast/events/ios/contenteditable-autocapitalize.html fails when using async text input
<a href="https://bugs.webkit.org/show_bug.cgi?id=265385">https://bugs.webkit.org/show_bug.cgi?id=265385</a>
<a href="https://rdar.apple.com/118835028">rdar://118835028</a>

Reviewed by Megan Gardner.

Address this test failure (as well as some adjacent issues and cleanup). See below for more details.

* LayoutTests/fast/events/ios/contenteditable-autocapitalize-expected.txt:
* LayoutTests/fast/events/ios/contenteditable-autocapitalize.html:

Rewrite this layout test to be easier to follow by using existing `UIHelper` functions to wait for
the keyboard to show and dismiss, and `js-test.js` helper functions.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestPreferredArrowDirectionForEditMenuWithCompletionHandler:]):

Prevent a self-induced release assertion by replacing an internal call to the legacy
`-_shouldSuppressSelectionCommands` function with the replacment, `-shouldSuppressEditMenu`.

(-[WKContentView _internalSelectTextForContextMenuWithLocationInView:completionHandler:]):
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:

Include all of the `UIAsyncTextInput` and related headers, in this test-runner-only SPI header.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView caretViewRectInContentCoordinates]):
(-[TestWKWebView selectionViewRectsInContentCoordinates]):

Take the opportunity to remove some old codepaths for grabbing selection/caret views that are no
longer relevant to the new selection display interaction codepaths in iOS 17+.

* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::applyAutocorrection):

Prevent another release assertion here by adopting the async text input version,
`-replaceText:withText:options:withCompletionHandler:`.

(WTR::UIScriptControllerIOS::clipSelectionViewRectToContentView const):
(WTR::UIScriptControllerIOS::selectionStartGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionEndGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionEndGrabberViewShapePathDescription const):
(WTR::UIScriptControllerIOS::selectionCaretViewRect const):
(WTR::UIScriptControllerIOS::selectionRangeViewRects const):

Prevent a release assertion by calling `-selectionClipRect` instead of `-_selectionClipRect` when
grabbing the caret or selection view rects for testing.

(WTR::UIScriptControllerIOS::selectionCaretBackgroundColor const):
(WTR::UIScriptControllerIOS::asyncTextInput const):

Add a helper method to return the `WKContentView`, as a `UIAsyncTextInput`.

(WTR::clipSelectionViewRectToContentView): Deleted.

Canonical link: <a href="https://commits.webkit.org/271162@main">https://commits.webkit.org/271162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/746dd4d5e7c64da40070d3374f6ebfec3af5d6eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/27978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3544 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30371 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25039 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2619 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24349 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6623 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->