### PR TITLE
[Cocoa] WebCodecs H265 decoder should reorder frames according presentation time

### DIFF
--- a/LayoutTests/http/tests/webcodecs/hevc-reordering-expected.txt
+++ b/LayoutTests/http/tests/webcodecs/hevc-reordering-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test HEVC reordering
+

--- a/LayoutTests/http/tests/webcodecs/hevc-reordering.html
+++ b/LayoutTests/http/tests/webcodecs/hevc-reordering.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+let decoder;
+promise_test(async () => {
+     const response = await fetch("/media-resources/media-source/content/test-bframes-hevc.mp4");
+     const buffer = await response.arrayBuffer();
+     const hvcCOffset = [705, 130];
+     const frames = [
+         [99, 3973, 46304],
+         [366, 50277, 4531],
+         [233, 54808, 1371],
+         [167, 56179, 379],
+         [133, 56558, 172],
+         [199, 56730, 120],
+         [300, 56850, 313],
+         [266, 57163, 112],
+         [333, 57275, 150],
+         [633, 57425, 6427]
+    ];
+
+    let frameTimestamps = [];
+    decoder =  new VideoDecoder({
+        output(frame) {
+            frameTimestamps.push(frame.timestamp);
+            frame.close();
+        },
+        error(e) {
+            console.log(e);
+        }
+    });
+    decoder.configure({
+        codec: 'hev1.1.6.L120.90',
+        codedWidth: 852,
+        codedHeight: 480,
+        visibleRect: {x: 0, y: 0, width: 852, height: 480},
+        displayWidth: 852,
+        displayHeight: 480,
+        format: 'hevc',
+        description: new Uint8Array(buffer, hvcCOffset[0], hvcCOffset[1])
+    });
+
+    chunks = frames.map((frame, i) => new EncodedVideoChunk({type: i == 0 ? 'key' : 'delta', timestamp: frame[0], duration: 1, data: new Uint8Array(buffer, frame[1], frame[2])}));
+
+    chunks.forEach(chunk => decoder.decode(chunk));
+    await decoder.flush();
+
+    assert_array_equals(frameTimestamps, frames.map(frame => frame[0]).sort((a,b) => a - b), "timestamps are ordered");
+}, "Test HEVC reordering");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1195,6 +1195,7 @@ imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker.
 imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Pass DumpJSConsoleLogInStdErr ]
 
 http/tests/webcodecs/h264-reordering.html [ Failure ]
+http/tests/webcodecs/hevc-reordering.html [ Failure ]
 
 # This test is flaky crashing with the current GStreamer version of the SDK (1.22), raising a
 # critical warning in GStreamer, but the issue is not happening with GStreamer 1.23. So this test is

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
@@ -207,6 +207,9 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
   sps_max_sub_layers_minus1 = reader.ReadBits(3);
   sps.sps_max_sub_layers_minus1 = sps_max_sub_layers_minus1;
   sps.sps_max_dec_pic_buffering_minus1.resize(sps_max_sub_layers_minus1 + 1, 0);
+#if WEBRTC_WEBKIT_BUILD
+  sps.sps_max_num_reorder_pics.resize(sps_max_sub_layers_minus1 + 1, 0);
+#endif
   // sps_temporal_id_nesting_flag: u(1)
   reader.ConsumeBits(1);
   // profile_tier_level(1, sps_max_sub_layers_minus1). We are acutally not
@@ -323,7 +326,9 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsInternal(
     // sps_max_dec_pic_buffering_minus1: ue(v)
     sps.sps_max_dec_pic_buffering_minus1[i] = reader.ReadExponentialGolomb();
     // sps_max_num_reorder_pics: ue(v)
-    reader.ReadExponentialGolomb();
+#if WEBRTC_WEBKIT_BUILD
+    sps.sps_max_num_reorder_pics[i] = reader.ReadExponentialGolomb();
+#endif
     // sps_max_latency_increase_plus1: ue(v)
     reader.ReadExponentialGolomb();
   }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.h
@@ -52,6 +52,9 @@ class H265SpsParser {
     uint32_t pic_height_in_luma_samples = 0;
     uint32_t log2_max_pic_order_cnt_lsb_minus4 = 0;
     std::vector<uint32_t> sps_max_dec_pic_buffering_minus1;
+#if WEBRTC_WEBKIT_BUILD
+    std::vector<uint32_t> sps_max_num_reorder_pics;
+#endif
     uint32_t log2_min_luma_coding_block_size_minus3 = 0;
     uint32_t log2_diff_max_min_luma_coding_block_size = 0;
     uint32_t sample_adaptive_offset_enabled_flag = 0;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitDecoder.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitDecoder.mm
@@ -103,7 +103,7 @@
     if (m_h264Decoder)
         return [m_h264Decoder setAVCFormat:data size:size width:width height:height];
     if (m_h265Decoder)
-        return [m_h265Decoder setAVCFormat:data size:size width:width height:height];
+        return [m_h265Decoder setHVCCFormat:data size:size width:width height:height];
     return 0;
 }
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.h
@@ -16,7 +16,7 @@
 RTC_OBJC_EXPORT
 __attribute__((objc_runtime_name("WK_RTCVideoDecoderH265")))
 @interface RTCVideoDecoderH265 : NSObject <RTCVideoDecoder>
-- (NSInteger)setAVCFormat:(const uint8_t *)data size:(size_t)size width:(uint16_t)width height:(uint16_t)height;
+- (NSInteger)setHVCCFormat:(const uint8_t *)data size:(size_t)size width:(uint16_t)width height:(uint16_t)height;
 - (NSInteger)decodeData:(const uint8_t *)data
     size:(size_t)size
     timeStamp:(int64_t)timeStamp;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -13,29 +13,32 @@
 
 #import <VideoToolbox/VideoToolbox.h>
 
+#import "RTCVideoFrameReorderQueue.h"
 #import "base/RTCVideoFrame.h"
 #import "base/RTCVideoFrameBuffer.h"
+#import "common_video/h265/h265_sps_parser.h"
 #import "components/video_frame_buffer/RTCCVPixelBuffer.h"
 #import "helpers.h"
 #import "helpers/scoped_cftyperef.h"
-
-#include "modules/video_coding/include/video_error_codes.h"
-#include "rtc_base/checks.h"
-#include "rtc_base/logging.h"
-#include "rtc_base/time_utils.h"
-#include "sdk/objc/components/video_codec/nalu_rewriter.h"
+#import "nalu_rewriter.h"
+#import "rtc_base/bitstream_reader.h"
+#import "rtc_base/checks.h"
+#import "rtc_base/logging.h"
+#import "rtc_base/time_utils.h"
+#import <span>
 
 // Struct that we pass to the decoder per frame to decode. We receive it again
 // in the decoder callback.
 struct RTCH265FrameDecodeParams {
-  RTCH265FrameDecodeParams(RTCVideoDecoderCallback cb, int64_t ts)
-      : callback(cb), timestamp(ts) {}
-  RTCVideoDecoderCallback callback;
+  RTCH265FrameDecodeParams(int64_t ts, uint64_t reorderSize)
+      : timestamp(ts), reorderSize(reorderSize) {}
   int64_t timestamp;
+  uint64_t reorderSize { 0 };
 };
 
 @interface RTCVideoDecoderH265 ()
 - (void)setError:(OSStatus)error;
+- (void)processFrame:(RTCVideoFrame*)decodedFrame reorderSize:(uint64_t)reorderSize;
 @end
 
 static void overrideColorSpaceAttachments(CVImageBufferRef imageBuffer) {
@@ -44,6 +47,112 @@ static void overrideColorSpaceAttachments(CVImageBufferRef imageBuffer) {
   CVBufferSetAttachment(imageBuffer, kCVImageBufferTransferFunctionKey, kCVImageBufferTransferFunction_sRGB, kCVAttachmentMode_ShouldPropagate);
   CVBufferSetAttachment(imageBuffer, kCVImageBufferYCbCrMatrixKey, kCVImageBufferYCbCrMatrix_ITU_R_709_2, kCVAttachmentMode_ShouldPropagate);
   CVBufferSetAttachment(imageBuffer, (CFStringRef)@"ColorInfoGuessedBy", (CFStringRef)@"RTCVideoDecoderH265", kCVAttachmentMode_ShouldPropagate);
+}
+
+std::span<const uint8_t> spsDataFromHvcc(const uint8_t* hvccData, size_t hvccDataSize) {
+  std::vector<uint8_t> unpacked_buffer { hvccData, hvccData + hvccDataSize };
+  webrtc::BitstreamReader reader(unpacked_buffer);
+
+  // configuration_version
+  auto version = reader.Read<uint8_t>();
+  if (version > 1) {
+    reader.Ok();
+    return { };
+  }
+  // profile_indication
+  reader.ConsumeBits(8);
+  // general_profile_compatibility_flags
+  reader.ConsumeBits(32);
+  // general_constraint_indicator_flags_hi;
+  reader.ConsumeBits(32);
+  // general_constraint_indicator_flags_lo;
+  reader.ConsumeBits(16);
+  // general_level_idc;
+  reader.ConsumeBits(8);
+  // min_spatial_segmentation_idc
+  reader.ConsumeBits(16);
+  // parallelismType;
+  reader.ConsumeBits(8);
+  // chromaFormat;
+  reader.ConsumeBits(8);
+  // bitDepthLumaMinus8
+  reader.ConsumeBits(8);
+  // bitDepthChromaMinus8
+  reader.ConsumeBits(8);
+  // avgFrameRate
+  reader.ConsumeBits(16);
+  //misc
+  reader.ConsumeBits(8);
+  auto numOfArrays = reader.Read<uint8_t>();
+
+  if (!reader.Ok()) {
+    return { };
+  }
+
+  size_t position = (8 + 8 + 32 + 32 + 16 + 8 + 16 + 8 + 8 + 8 + 8 + 16 + 8 + 8) / 8;
+  for (uint32_t j = 0; j < numOfArrays; j++) {
+    // NAL_unit_type
+    auto nalUnitType = reader.Read<uint8_t>();
+    auto numOfNalus = reader.Read<uint16_t>();
+    position += 3;
+    if (!reader.Ok()) {
+        return { };
+    }
+
+    for (uint32_t k = 0; k < numOfNalus; k++) {
+        auto size = reader.Read<uint16_t>();
+
+        position += 2;
+        reader.ConsumeBits(8 * size);
+
+        static const size_t hevcNalHeaderSize = 2;
+        if (!reader.Ok() || size <= hevcNalHeaderSize) {
+            return { };
+        }
+
+        if (nalUnitType != webrtc::H265::NaluType::kSps) {
+            position += size;
+            continue;
+        }
+
+        return { hvccData + position + hevcNalHeaderSize, size - hevcNalHeaderSize };
+    }
+  }
+  reader.Ok();
+  return { };
+}
+
+uint8_t ComputeH265ReorderSizeFromSPS(const uint8_t* spsData, size_t spsDataSize)
+{
+    auto parsedSps = webrtc::H265SpsParser::ParseSps(spsData, spsDataSize);
+    if (!parsedSps)
+      return 0;
+    auto reorderSize = *std::max_element(std::begin(parsedSps->sps_max_num_reorder_pics), std::end(parsedSps->sps_max_num_reorder_pics));
+    // We use a max value of 16
+    return std::max(reorderSize, 16u);
+}
+
+uint8_t ComputeH265ReorderSizeFromHVCC(const uint8_t* hvccData, size_t hvccDataSize)
+{
+  auto spsData = spsDataFromHvcc(hvccData, hvccDataSize);
+  if (!spsData.size()) {
+    return 0;
+  }
+  return ComputeH265ReorderSizeFromSPS(spsData.data(), spsData.size());
+}
+
+uint8_t ComputeH265ReorderSizeFromAnnexB(const uint8_t* annexb_buffer, size_t annexb_buffer_size)
+{
+    webrtc::AnnexBBufferReader bufferReader(annexb_buffer, annexb_buffer_size);
+    if (bufferReader.SeekToNextNaluOfType(webrtc::H265::kSps)) {
+      const uint8_t* data;
+      size_t data_len;
+      if (!bufferReader.ReadNalu(&data, &data_len)) {
+        return 0;
+      }
+      return ComputeH265ReorderSizeFromSPS(data, data_len);
+    }
+    return 0;
 }
 
 // This is the callback function that VideoToolbox calls when decode is
@@ -56,11 +165,11 @@ void h265DecompressionOutputCallback(void* decoderRef,
                                      CMTime timestamp,
                                      CMTime duration) {
   std::unique_ptr<RTCH265FrameDecodeParams> decodeParams(reinterpret_cast<RTCH265FrameDecodeParams*>(params));
-  if (status != noErr || !imageBuffer) {
     RTCVideoDecoderH265 *decoder = (__bridge RTCVideoDecoderH265 *)decoderRef;
+  if (status != noErr || !imageBuffer) {
     [decoder setError:status != noErr ? status : 1];
     RTC_LOG(LS_ERROR) << "Failed to decode frame. Status: " << status;
-    decodeParams->callback(nil);
+    [decoder processFrame:nil reorderSize:decodeParams->reorderSize];
     return;
   }
 
@@ -69,13 +178,12 @@ void h265DecompressionOutputCallback(void* decoderRef,
   // TODO(tkchin): Handle CVO properly.
   RTCCVPixelBuffer* frameBuffer =
       [[RTCCVPixelBuffer alloc] initWithPixelBuffer:imageBuffer];
-  // FIXME: compute reorderSize.
   RTCVideoFrame* decodedFrame = [[RTCVideoFrame alloc]
       initWithBuffer:frameBuffer
             rotation:RTCVideoRotation_0
          timeStampNs:CMTimeGetSeconds(timestamp) * rtc::kNumNanosecsPerSec];
   decodedFrame.timeStamp = decodeParams->timestamp;
-  decodeParams->callback(decodedFrame);
+  [decoder processFrame:decodedFrame reorderSize:decodeParams->reorderSize];
 }
 
 // Decoder.
@@ -85,6 +193,7 @@ void h265DecompressionOutputCallback(void* decoderRef,
   RTCVideoDecoderCallback _callback;
   OSStatus _error;
   bool _useAVC;
+  webrtc::RTCVideoFrameReorderQueue _reorderQueue;
 }
 
 - (instancetype)init {
@@ -148,6 +257,8 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
       rtc::ScopedCF(webrtc::CreateH265VideoFormatDescription(
           (uint8_t*)data, size));
   if (inputFormat) {
+    _reorderQueue.setReorderSize(ComputeH265ReorderSizeFromHVCC(data, size));
+
     CMVideoDimensions dimensions =
         CMVideoFormatDescriptionGetDimensions(inputFormat.get());
     RTC_LOG(LS_INFO) << "Resolution: " << dimensions.width << " x "
@@ -187,7 +298,7 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
       kVTDecodeFrame_EnableAsynchronousDecompression;
   std::unique_ptr<RTCH265FrameDecodeParams> frameDecodeParams;
   frameDecodeParams.reset(
-      new RTCH265FrameDecodeParams(_callback, timeStamp));
+      new RTCH265FrameDecodeParams(timeStamp, _reorderQueue.reorderSize()));
   OSStatus status = VTDecompressionSessionDecodeFrame(
       _decompressionSession, sampleBuffer, decodeFlags,
       frameDecodeParams.release(), nullptr);
@@ -197,7 +308,7 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
   if (status == kVTInvalidSessionErr &&
       [self resetDecompressionSession] == WEBRTC_VIDEO_CODEC_OK) {
     frameDecodeParams.reset(
-        new RTCH265FrameDecodeParams(_callback, timeStamp));
+        new RTCH265FrameDecodeParams(timeStamp, _reorderQueue.reorderSize()));
     status = VTDecompressionSessionDecodeFrame(
         _decompressionSession, sampleBuffer, decodeFlags,
         frameDecodeParams.release(), nullptr);
@@ -211,7 +322,7 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
   return WEBRTC_VIDEO_CODEC_OK;
 }
 
-- (NSInteger)setAVCFormat:(const uint8_t *)data size:(size_t)size width:(uint16_t)width height:(uint16_t)height {
+- (NSInteger)setHVCCFormat:(const uint8_t *)data size:(size_t)size width:(uint16_t)width height:(uint16_t)height {
   CFStringRef avcCString = (CFStringRef)@"hvcC";
   CFDataRef codecConfig = CFDataCreate(kCFAllocatorDefault, data, size);
   CFDictionaryRef atomsDict = CFDictionaryCreate(NULL,
@@ -240,6 +351,8 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
 
   rtc::ScopedCFTypeRef<CMVideoFormatDescriptionRef> inputFormat = rtc::ScopedCF(videoFormatDescription);
   if (inputFormat) {
+    _reorderQueue.setReorderSize(ComputeH265ReorderSizeFromHVCC(data, size));
+
     // Check if the video format has changed, and reinitialize decoder if
     // needed.
     if (!CMFormatDescriptionEqual(inputFormat.get(), _videoFormat)) {
@@ -317,7 +430,7 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
   }
   VTDecompressionOutputCallbackRecord record = {
       h265DecompressionOutputCallback,
-      nullptr,
+      (__bridge void *)self,
   };
   OSStatus status =
       VTDecompressionSessionCreate(nullptr, _videoFormat, nullptr, attributes,
@@ -353,6 +466,10 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
 - (void)flush {
   if (_decompressionSession)
     VTDecompressionSessionWaitForAsynchronousFrames(_decompressionSession);
+
+  while (auto *frame = _reorderQueue.takeIfAny()) {
+    _callback(frame);
+  }
 }
 
 - (void)setVideoFormat:(CMVideoFormatDescriptionRef)videoFormat {
@@ -370,6 +487,18 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
 
 - (NSString*)implementationName {
   return @"VideoToolbox";
+}
+
+- (void)processFrame:(RTCVideoFrame*)decodedFrame reorderSize:(uint64_t)reorderSize {
+  // FIXME: In case of IDR, we could push out all queued frames.
+  if (!_reorderQueue.isEmpty() || reorderSize) {
+    _reorderQueue.append(decodedFrame, reorderSize);
+    while (auto *frame = _reorderQueue.takeIfAvailable()) {
+      _callback(frame);
+    }
+    return;
+  }
+  _callback(decodedFrame);
 }
 
 @end

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "base/RTCVideoFrame.h"
+#include <deque>
+#include "rtc_base/synchronization/mutex.h"
+
+namespace webrtc {
+
+class RTCVideoFrameReorderQueue {
+public:
+    RTCVideoFrameReorderQueue() = default;
+
+    struct RTCVideoFrameWithOrder {
+        RTCVideoFrameWithOrder(RTCVideoFrame* frame, uint64_t reorderSize)
+            : frame((__bridge_retained void*)frame)
+            , timeStamp(frame.timeStamp)
+            , reorderSize(reorderSize)
+        {
+        }
+
+        ~RTCVideoFrameWithOrder()
+        {
+            if (frame)
+                take();
+        }
+
+        RTCVideoFrame* take()
+        {
+            auto* rtcFrame = (__bridge_transfer RTCVideoFrame *)frame;
+            frame = nullptr;
+            return rtcFrame;
+        }
+
+        void* frame;
+        uint64_t timeStamp;
+        uint64_t reorderSize;
+    };
+
+    bool isEmpty();
+    uint8_t reorderSize() const;
+    void setReorderSize(uint8_t);
+    void append(RTCVideoFrame*, uint8_t);
+    RTCVideoFrame *takeIfAvailable();
+    RTCVideoFrame *takeIfAny();
+
+private:
+    std::deque<std::unique_ptr<RTCVideoFrameWithOrder>> _reorderQueue;
+    uint8_t _reorderSize { 0 };
+    mutable webrtc::Mutex _reorderQueueLock;
+};
+
+}

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.mm
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ */
+
+#import "RTCVideoFrameReorderQueue.h"
+
+namespace webrtc {
+
+bool RTCVideoFrameReorderQueue::isEmpty()
+{
+    return _reorderQueue.empty();
+}
+
+uint8_t RTCVideoFrameReorderQueue::reorderSize() const
+{
+    webrtc::MutexLock lock(&_reorderQueueLock);
+    return _reorderSize;
+}
+
+void RTCVideoFrameReorderQueue::setReorderSize(uint8_t size)
+{
+    webrtc::MutexLock lock(&_reorderQueueLock);
+    _reorderSize = size;
+}
+
+void RTCVideoFrameReorderQueue::append(RTCVideoFrame* frame, uint8_t reorderSize)
+{
+    webrtc::MutexLock lock(&_reorderQueueLock);
+    _reorderQueue.push_back(std::make_unique<RTCVideoFrameWithOrder>(frame, reorderSize));
+    std::sort(_reorderQueue.begin(), _reorderQueue.end(), [](auto& a, auto& b) {
+        return a->timeStamp < b->timeStamp;
+    });
+}
+
+RTCVideoFrame* RTCVideoFrameReorderQueue::takeIfAvailable()
+{
+    webrtc::MutexLock lock(&_reorderQueueLock);
+    if (_reorderQueue.size() && _reorderQueue.size() > _reorderQueue.front()->reorderSize) {
+        auto *frame = _reorderQueue.front()->take();
+        _reorderQueue.pop_front();
+        return frame;
+    }
+    return nil;
+}
+
+RTCVideoFrame* RTCVideoFrameReorderQueue::takeIfAny()
+{
+    webrtc::MutexLock lock(&_reorderQueueLock);
+    if (_reorderQueue.size()) {
+        auto *frame = _reorderQueue.front()->take();
+        _reorderQueue.pop_front();
+        return frame;
+    }
+    return nil;
+}
+
+}

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -2249,6 +2249,8 @@
 		419100E32152ECE700A6F17B /* shortidct4x4llm_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 419100BF2152ECDC00A6F17B /* shortidct4x4llm_neon.c */; };
 		419100E42152ECE700A6F17B /* sixtappredict_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 419100C52152ECDE00A6F17B /* sixtappredict_neon.c */; };
 		419100E52152ECE700A6F17B /* vp8_loopfilter_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 419100B92152ECDB00A6F17B /* vp8_loopfilter_neon.c */; };
+		4191FD472B0E63040067312B /* RTCVideoFrameReorderQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4191FD462B0E63040067312B /* RTCVideoFrameReorderQueue.mm */; };
+		4191FD492B0E631E0067312B /* RTCVideoFrameReorderQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 4191FD482B0E631D0067312B /* RTCVideoFrameReorderQueue.h */; };
 		4192413A2127372400634FCF /* features_extraction.cc in Sources */ = {isa = PBXBuildFile; fileRef = 419241312127372200634FCF /* features_extraction.cc */; };
 		4192413B2127372400634FCF /* features_extraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 419241322127372200634FCF /* features_extraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4192413C2127372400634FCF /* pitch_search.h in Headers */ = {isa = PBXBuildFile; fileRef = 419241332127372300634FCF /* pitch_search.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -8153,6 +8155,8 @@
 		419100F32152ED1800A6F17B /* vpx_convolve8_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vpx_convolve8_neon.c; sourceTree = "<group>"; };
 		419100F42152ED1900A6F17B /* vpx_scaled_convolve8_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vpx_scaled_convolve8_neon.c; sourceTree = "<group>"; };
 		419100F52152ED1900A6F17B /* sad4d_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sad4d_neon.c; sourceTree = "<group>"; };
+		4191FD462B0E63040067312B /* RTCVideoFrameReorderQueue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCVideoFrameReorderQueue.mm; sourceTree = "<group>"; };
+		4191FD482B0E631D0067312B /* RTCVideoFrameReorderQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoFrameReorderQueue.h; sourceTree = "<group>"; };
 		419241312127372200634FCF /* features_extraction.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = features_extraction.cc; sourceTree = "<group>"; };
 		419241322127372200634FCF /* features_extraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = features_extraction.h; sourceTree = "<group>"; };
 		419241332127372300634FCF /* pitch_search.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pitch_search.h; sourceTree = "<group>"; };
@@ -13599,6 +13603,8 @@
 				416225F6216981F400A91C9B /* RTCVideoEncoderH264.mm */,
 				41009204242E3A4500C5EDA2 /* RTCVideoEncoderH265.h */,
 				41009206242E3A4500C5EDA2 /* RTCVideoEncoderH265.mm */,
+				4191FD482B0E631D0067312B /* RTCVideoFrameReorderQueue.h */,
+				4191FD462B0E63040067312B /* RTCVideoFrameReorderQueue.mm */,
 				416225EE216981F200A91C9B /* UIDevice+H264Profile.h */,
 				417953AE2169823F0028266B /* UIDevice+H264Profile.mm */,
 			);
@@ -22218,6 +22224,7 @@
 				413E678F216987DB00EF37ED /* RTCVideoFrame.h in Headers */,
 				413E6791216987DB00EF37ED /* RTCVideoFrameBuffer.h in Headers */,
 				413A24411FE1991A00373E99 /* RTCVideoFrameBuffer.h in Headers */,
+				4191FD492B0E631E0067312B /* RTCVideoFrameReorderQueue.h in Headers */,
 				413A246F1FE1991A00373E99 /* RTCVideoRenderer.h in Headers */,
 				DDF30B8E27C5A3F2006A526F /* RTCVideoRenderer.h in Headers */,
 				DDF30B5C27C5A3C5006A526F /* RTCVideoSource+Private.h in Headers */,
@@ -25588,6 +25595,7 @@
 				413E67652169854600EF37ED /* RTCVideoEncoderVP8.mm in Sources */,
 				414035ED24AA0EBC00BCE9B2 /* RTCVideoEncoderVP9.mm in Sources */,
 				413E6790216987DB00EF37ED /* RTCVideoFrame.mm in Sources */,
+				4191FD472B0E63040067312B /* RTCVideoFrameReorderQueue.mm in Sources */,
 				41CDC66D28F6FC2C00603E59 /* RTCWrappedNativeVideoDecoder.mm in Sources */,
 				413E676D2169854B00EF37ED /* RTCWrappedNativeVideoEncoder.mm in Sources */,
 				41D6B45921273159008F9353 /* rtp_bitrate_configurator.cc in Sources */,


### PR DESCRIPTION
#### ed090e21829dc96a1e4d2127eb5705c859e8b8c1
<pre>
[Cocoa] WebCodecs H265 decoder should reorder frames according presentation time
<a href="https://bugs.webkit.org/show_bug.cgi?id=265389">https://bugs.webkit.org/show_bug.cgi?id=265389</a>
<a href="https://rdar.apple.com/problem/118836800">rdar://problem/118836800</a>

Reviewed by Eric Carlson.

We compute the reorder queue size by parsing SPS.
We reuse the same queue as RTCVideoDecoderH264 and, for that purpose, refactor the code in a RTCVideoFrameWithOrder class.

* LayoutTests/http/tests/webcodecs/hevc-reordering-expected.txt: Added.
* LayoutTests/http/tests/webcodecs/hevc-reordering.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitDecoder.mm:
(-[WK_RTCLocalVideoH264H265VP9Decoder setFormat:size:width:height:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm:
(RTCFrameDecodeParams::RTCFrameDecodeParams):
(decompressionOutputCallback):
(-[RTCVideoDecoderH264 init]):
(-[RTCVideoDecoderH264 decodeData:size:timeStamp:]):
(-[RTCVideoDecoderH264 setAVCFormat:size:width:height:]):
(-[RTCVideoDecoderH264 flush]):
(-[RTCVideoDecoderH264 processFrame:reorderSize:]):
(RTCVideoFrameWithOrder::RTCVideoFrameWithOrder): Deleted.
(RTCVideoFrameWithOrder::~RTCVideoFrameWithOrder): Deleted.
(RTCVideoFrameWithOrder::take): Deleted.
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm:
(RTCH265FrameDecodeParams::RTCH265FrameDecodeParams):
(spsDataFromHvcc):
(ComputeH265ReorderSizeFromSPS):
(ComputeH265ReorderSizeFromHVCC):
(ComputeH265ReorderSizeFromAnnexB):
(h265DecompressionOutputCallback):
(-[RTCVideoDecoderH265 decodeData:size:timeStamp:]):
(-[RTCVideoDecoderH265 setHVCCFormat:size:width:height:]):
(-[RTCVideoDecoderH265 resetDecompressionSession]):
(-[RTCVideoDecoderH265 flush]):
(-[RTCVideoDecoderH265 processFrame:reorderSize:]):
(-[RTCVideoDecoderH265 setAVCFormat:size:width:height:]): Deleted.
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.h: Added.
(webrtc::RTCVideoFrameReorderQueue::RTCVideoFrameWithOrder::RTCVideoFrameWithOrder):
(webrtc::RTCVideoFrameReorderQueue::RTCVideoFrameWithOrder::~RTCVideoFrameWithOrder):
(webrtc::RTCVideoFrameReorderQueue::RTCVideoFrameWithOrder::take):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoFrameReorderQueue.mm: Added.
(webrtc::RTCVideoFrameReorderQueue::isEmpty):
(webrtc::RTCVideoFrameReorderQueue::reorderSize const):
(webrtc::RTCVideoFrameReorderQueue::setReorderSize):
(webrtc::RTCVideoFrameReorderQueue::append):
(webrtc::RTCVideoFrameReorderQueue::takeIfAvailable):
(webrtc::RTCVideoFrameReorderQueue::takeIfAny):
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271242@main">https://commits.webkit.org/271242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a82b014f15de64ad21d6d88ad8bf0b9bb0e94a0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25361 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3791 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30617 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30796 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28721 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6668 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->