### PR TITLE
Check MDM for administrator-specified bundle IDs to grant access to managed domains

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h
@@ -35,6 +35,7 @@ WTF_EXTERN_C_BEGIN
 #import <ManagedConfiguration/ManagedConfiguration.h>
 @interface MCProfileConnection ()
 - (NSArray<NSString *> *)crossSiteTrackingPreventionRelaxedDomains;
+- (NSArray<NSString *> *)crossSiteTrackingPreventionRelaxedApps;
 @end
 
 #else


### PR DESCRIPTION
#### d25dff5c21517511af1894f7002c26a2db4702fc
<pre>
Check MDM for administrator-specified bundle IDs to grant access to managed domains
<a href="https://bugs.webkit.org/show_bug.cgi?id=265390">https://bugs.webkit.org/show_bug.cgi?id=265390</a>
&lt;<a href="https://rdar.apple.com/118906173">rdar://118906173</a>&gt;

Reviewed by John Wilander.

This patch checks MDM to see if the current application is one of a small set
of apps specified by the organization administrator. If so, the app will be
treated the same way as Safari with respect to managed domains (see Bug 246290).

* Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h:
Add missing forward declaration.
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::initializeManagedDomains): Ask MCProfileConnection for
the list of allowed bundleIDs to include in the relaxed handling.

Canonical link: <a href="https://commits.webkit.org/277090@main">https://commits.webkit.org/277090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96f9c502ee5bcc388a7e5f115ed0125b2c13d106

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42542 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37937 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41202 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51018 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45187 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22798 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44128 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10315 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->