### PR TITLE
[scroll-anchoring] Turn of scrollbars for anchoring adjustments on macOS

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -340,7 +340,7 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
         return false;
 
     if (options.originalScrollDelta)
-        stateNode->setRequestedScrollData({ ScrollRequestType::DeltaUpdate, *options.originalScrollDelta, options.type, options.clamping, options.animated });
+        stateNode->setRequestedScrollData({ ScrollRequestType::DeltaUpdate, *options.originalScrollDelta, options.type, options.clamping, options.animated, { }, options.shouldHideScrollbars });
     else
         stateNode->setRequestedScrollData({ ScrollRequestType::PositionUpdate, scrollPosition, options.type, options.clamping, options.animated });
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -324,7 +324,7 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
     if (!adjustment.isZero()) {
         auto newScrollPosition = m_owningScrollableArea.scrollPosition() + IntPoint(adjustment.width(), adjustment.height());
         LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() for frame: " << frameView() << " for scroller: " << m_owningScrollableArea << " adjusting from: " << m_owningScrollableArea.scrollPosition() << " to: " << newScrollPosition);
-        auto options = ScrollPositionChangeOptions::createProgrammatic();
+        auto options = ScrollPositionChangeOptions::createScrollAnchoringAdjustment();
         options.originalScrollDelta = adjustment;
         auto oldScrollType = m_owningScrollableArea.currentScrollType();
         m_owningScrollableArea.setCurrentScrollType(ScrollType::Programmatic);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -114,6 +114,7 @@ struct RequestedScrollData {
     ScrollClamping clamping { ScrollClamping::Clamped };
     ScrollIsAnimated animated { ScrollIsAnimated::No };
     std::optional<std::tuple<ScrollRequestType, std::variant<FloatPoint, FloatSize>, ScrollType, ScrollClamping>> requestedDataBeforeAnimatedScroll { };
+    bool shouldHideScrollbars = false;
 
     void merge(RequestedScrollData&&);
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -88,7 +88,7 @@ public:
     virtual void serviceScrollAnimation(MonotonicTime);
 
     // These are imperative; they adjust the scrolling layers.
-    void scrollTo(const FloatPoint&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped);
+    void scrollTo(const FloatPoint&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped, bool hideScrollbars = false);
     void scrollBy(const FloatSize&, ScrollClamping = ScrollClamping::Clamped);
 
     void handleScrollPositionRequest(const RequestedScrollData&);

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -60,6 +60,8 @@ public:
 
     virtual FloatPoint adjustedScrollPosition(const FloatPoint& scrollPosition) const { return scrollPosition; }
     virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
+    
+    virtual void shouldHideScrollbars(bool) { }
 
 protected:
     WEBCORE_EXPORT ScrollingTree& scrollingTree() const;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -73,7 +73,7 @@ public:
     void updateMinimumKnobLength(int);
     void detach();
     void setEnabled(bool flag) { m_isEnabled = flag; }
-
+    bool enabled() { return m_isEnabled; }
 private:
     int m_minimumKnobLength { 0 };
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -422,6 +422,8 @@ void ScrollerMac::visibilityChanged(bool isVisible)
 {
     if (m_isVisible == isVisible)
         return;
+        
+    ALWAYS_LOG_WITH_STREAM(stream << "ScrollerMac::visibilityChanged: " << isVisible);
     m_isVisible = isVisible;
     m_pair.node().scrollbarVisibilityDidChange(m_orientation, isVisible);
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -111,7 +111,9 @@ public:
     ScrollingTreeScrollingNode& node() const { return m_scrollingNode; }
     
     bool mouseInContentArea() const { return m_mouseInContentArea; }
-
+    void shouldHideScrollbars(bool flag);
+    bool shouldHideScrollbars() { return m_shouldHideScrollbars; }
+    std::pair<bool,bool> oldScrollbarState() { return m_scrollbarEnabledState; }
 private:
     ScrollerPairMac(ScrollingTreeScrollingNode&);
 
@@ -135,6 +137,8 @@ private:
     std::atomic<ScrollbarStyle> m_scrollbarStyle { ScrollbarStyle::AlwaysVisible };
     bool m_inLiveResize { false };
     bool m_mouseInContentArea { false };
+    std::pair<bool,bool> m_scrollbarEnabledState { false, false };
+    bool m_shouldHideScrollbars { false };
 };
 
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -66,6 +66,7 @@ public:
     void viewSizeDidChange() final;
     void initScrollbars() final;
     String scrollbarStateForOrientation(ScrollbarOrientation) const final;
+    void shouldHideScrollbars(bool) final;
 
 private:
     void updateFromStateNode(const ScrollingStateScrollingNode&) final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -353,6 +353,12 @@ String ScrollingTreeScrollingNodeDelegateMac::scrollbarStateForOrientation(Scrol
     return m_scrollerPair->scrollbarStateForOrientation(orientation);
 }
 
+void ScrollingTreeScrollingNodeDelegateMac::shouldHideScrollbars(bool flag)
+{
+    m_scrollerPair->shouldHideScrollbars(flag);
+}
+
+
 } // namespace WebCore
 
 #endif // PLATFORM(MAC) && ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -351,7 +351,16 @@ struct ScrollPositionChangeOptions {
     ScrollIsAnimated animated = ScrollIsAnimated::No;
     ScrollSnapPointSelectionMethod snapPointSelectionMethod = ScrollSnapPointSelectionMethod::Closest;
     std::optional<FloatSize> originalScrollDelta = std::nullopt;
+    bool shouldHideScrollbars = false;
 
+    static ScrollPositionChangeOptions createScrollAnchoringAdjustment()
+    {
+        ScrollPositionChangeOptions options;
+        options.type = ScrollType::Programmatic;
+        options.shouldHideScrollbars = true;
+        return options;
+    }
+    
     static ScrollPositionChangeOptions createProgrammatic()
     {
         return { ScrollType::Programmatic };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3750,6 +3750,7 @@ header: <WebCore/ScrollingStateNode.h>
     WebCore::ScrollClamping clamping;
     WebCore::ScrollIsAnimated animated;
     std::optional<std::tuple<WebCore::ScrollRequestType, std::variant<WebCore::FloatPoint, WebCore::FloatSize>, WebCore::ScrollType, WebCore::ScrollClamping>> requestedDataBeforeAnimatedScroll;
+    bool shouldHideScrollbars;
 }
 
 [Alias=struct ScrollSnapOffsetsInfo<float,WebCore::FloatRect>, CustomHeader] alias WebCore::FloatScrollSnapOffsetsInfo {


### PR DESCRIPTION
#### cea298ed0e1e40868362ca86ed93816d8b14b7ba
<pre>
[scroll-anchoring] Turn of scrollbars for anchoring adjustments on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=265391">https://bugs.webkit.org/show_bug.cgi?id=265391</a>
<a href="https://rdar.apple.com/118842527">rdar://118842527</a>

Reviewed by NOBODY (OOPS!).

Turn of scrollbars for programmatic scrolls triggered by scroll anchoring
adjustments on macOS.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
(WebCore::ScrollingTreeScrollingNode::scrollTo):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::shouldHideScrollbars):
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
(WebCore::ScrollerMac::enabled):
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::visibilityChanged):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::shouldHideScrollbars):
(WebCore::ScrollerPairMac::oldScrollbarState):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::shouldHideScrollbars):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::shouldHideScrollbars):
* Source/WebCore/platform/ScrollTypes.h:
(WebCore::ScrollPositionChangeOptions::createScrollAnchoringAdjustment):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cea298ed0e1e40868362ca86ed93816d8b14b7ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27815 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25159 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30671 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30870 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28771 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6209 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->