### PR TITLE
[WGSL] Constant cross function breaks with f16

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -822,9 +822,9 @@ CONSTANT_FUNCTION(Cross)
         auto v2 = std::get<T>(rhs.elements[2]);
 
         ConstantVector result(3);
-        result.elements[0] = u1 * v2 - u2 * v1;
-        result.elements[1] = u2 * v0 - u0 * v2;
-        result.elements[2] = u0 * v1 - u1 * v0;
+        result.elements[0] = static_cast<T>(u1 * v2 - u2 * v1);
+        result.elements[1] = static_cast<T>(u2 * v0 - u0 * v2);
+        result.elements[2] = static_cast<T>(u0 * v1 - u1 * v0);
         return { { result } };
     };
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1484,6 +1484,10 @@ fn testCross()
     _ = cross(vec3(1, 1, 1), vec3(1f, 2f, 3f));
     _ = cross(vec3(1.0, 1.0, 1.0), vec3(1f, 2f, 3f));
     _ = cross(vec3(1f, 1f, 1f), vec3(1f, 2f, 3f));
+
+    _ = cross(vec3(1, 1, 1), vec3(1h, 2h, 3h));
+    _ = cross(vec3(1.0, 1.0, 1.0), vec3(1h, 2h, 3h));
+    _ = cross(vec3(1h, 1h, 1h), vec3(1h, 2h, 3h));
 }
 
 // 16.5.17


### PR DESCRIPTION
#### 7aa3c2dee61a758fefafb19d2472609d6af3b6ac
<pre>
[WGSL] Constant cross function breaks with f16
<a href="https://bugs.webkit.org/show_bug.cgi?id=265392">https://bugs.webkit.org/show_bug.cgi?id=265392</a>
<a href="https://rdar.apple.com/118842794">rdar://118842794</a>

Reviewed by Mike Wyrzykowski.

We need to explicitly cast the elements of the result vector, as the f16/half
values get implicitly promoted to float.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/271201@main">https://commits.webkit.org/271201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56446e2a01f69bcd3c75db3cc91dd89672b7e67c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25201 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24990 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4506 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30616 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28583 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5971 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->