### PR TITLE
[WGSL] Add support for atomicAnd

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1485,6 +1485,11 @@ static void emitAtomicMin(FunctionDefinitionWriter* writer, AST::CallExpression&
     atomicFunction("atomic_fetch_min_explicit", writer, call);
 }
 
+static void emitAtomicAnd(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_fetch_and_explicit", writer, call);
+}
+
 static void emitAtomicOr(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     atomicFunction("atomic_fetch_or_explicit", writer, call);
@@ -1588,6 +1593,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "__dynamicOffset", emitDynamicOffset },
             { "arrayLength", emitArrayLength },
             { "atomicAdd", emitAtomicAdd },
+            { "atomicAnd", emitAtomicAnd },
             { "atomicExchange", emitAtomicExchange },
             { "atomicLoad", emitAtomicLoad },
             { "atomicMax", emitAtomicMax },

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1361,6 +1361,7 @@ function :atomicStore, {
     :atomicSub,
     :atomicMax,
     :atomicMin,
+    :atomicAnd,
     :atomicOr,
     :atomicXor,
     :atomicExchange,

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -3459,6 +3459,7 @@ fn testAtomicReadWriteModify()
     _ = atomicSub(&x, 42);
     _ = atomicMax(&x, 42);
     _ = atomicMin(&x, 42);
+    _ = atomicAnd(&x, 42);
     _ = atomicOr(&x, 42);
     _ = atomicXor(&x, 42);
     _ = atomicExchange(&x, 42);


### PR DESCRIPTION
#### e841f2403c533d84b0db5c8c79c9614b29f11820
<pre>
[WGSL] Add support for atomicAnd
<a href="https://bugs.webkit.org/show_bug.cgi?id=265393">https://bugs.webkit.org/show_bug.cgi?id=265393</a>
<a href="https://rdar.apple.com/118843093">rdar://118843093</a>

Reviewed by Mike Wyrzykowski.

For some reason we supported all the atomic built-in functions, but missed atomicAnd.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitAtomicAnd):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/271203@main">https://commits.webkit.org/271203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7030a721b2995299783010ecfb73eec56623889

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29759 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25202 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24991 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4479 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28590 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5972 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6644 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->