### PR TITLE
[WGSL] Constant determinant function breaks with f16

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -845,27 +845,27 @@ CONSTANT_FUNCTION(Determinant)
     ASSERT(arguments.size() == 1);
     auto& matrix = std::get<ConstantMatrix>(arguments[0]);
     auto columns = matrix.columns;
-    auto solve2 = [&](
-        auto a, auto b,
-        auto c, auto d
-    ) {
+    auto solve2 = [&]<typename T>(
+        T a, T b,
+        T c, T d
+    ) -> T {
         return a * d - b * c;
     };
 
-    auto solve3 = [&](
-        auto a, auto b, auto c,
-        auto d, auto e, auto f,
-        auto g, auto h, auto i
-    ) {
+    auto solve3 = [&]<typename T>(
+        T a, T b, T c,
+        T d, T e, T f,
+        T g, T h, T i
+    ) -> T {
         return a * e * i + b * f * g + c * d * h - c * e * g - b * d * i - a * f * h;
     };
 
-    auto solve4 = [&](
-        auto a, auto b, auto c, auto d,
-        auto e, auto f, auto g, auto h,
-        auto i, auto j, auto k, auto l,
-        auto m, auto n, auto o, auto p
-    ) {
+    auto solve4 = [&]<typename T>(
+        T a, T b, T c, T d,
+        T e, T f, T g, T h,
+        T i, T j, T k, T l,
+        T m, T n, T o, T p
+    ) -> T {
         return a * solve3(f, g, h, j, k, l, n, o, p) - b * solve3(e, g, h, i, k, l, m, o, p) + c * solve3(e, f, h, i, j, l, m, n, p) - d * solve3(e, f, g, i, j, k, m, n, o);
     };
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1524,6 +1524,14 @@ fn testDeterminant()
     _ = determinant(mat2x2(1, 1, 1, 1));
     _ = determinant(mat3x3(1, 1, 1, 1, 1, 1, 1, 1, 1));
     _ = determinant(mat4x4(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+
+    _ = determinant(mat2x2(1f, 1f, 1f, 1f));
+    _ = determinant(mat3x3(1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f));
+    _ = determinant(mat4x4(1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f));
+
+    _ = determinant(mat2x2(1h, 1h, 1h, 1h));
+    _ = determinant(mat3x3(1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h));
+    _ = determinant(mat4x4(1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h, 1h));
 }
 
 // 16.5.19


### PR DESCRIPTION
#### 921f26d0f7880a3d3a90e1afbd84b3703cb4de02
<pre>
[WGSL] Constant determinant function breaks with f16
<a href="https://bugs.webkit.org/show_bug.cgi?id=265394">https://bugs.webkit.org/show_bug.cgi?id=265394</a>
<a href="https://rdar.apple.com/118843391">rdar://118843391</a>

Reviewed by Mike Wyrzykowski.

The helper lambads in constantDeterminant need to explicitly type the result
as the f16/half values will be implicitly casted to float.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/271206@main">https://commits.webkit.org/271206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7f0b7be0d38495d1a45d9b78c2120c5c065c07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25309 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4415 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4587 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30548 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25192 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30703 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2749 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6099 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6647 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->