### PR TITLE
Fix keyboard scrolling after 269941@main

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -61,6 +61,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     MouseLocationState&& mouseLocationState,
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
+    RequestedKeyboardScrollData&& keyboardScrollData,
     float frameScaleFactor,
     EventTrackingRegions&& eventTrackingRegions,
     std::optional<PlatformLayerIdentifier> rootContentsLayer,
@@ -80,8 +81,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     FloatPoint minLayoutViewportOrigin,
     FloatPoint maxLayoutViewportOrigin,
     std::optional<FloatSize> overrideVisualViewportSize,
-    bool overlayScrollbarsEnabled,
-    RequestedKeyboardScrollData&& keyboardScrollData
+    bool overlayScrollbarsEnabled
 ) : ScrollingStateScrollingNode(
     isMainFrame ? ScrollingNodeType::MainFrame : ScrollingNodeType::Subframe,
     scrollingNodeID,
@@ -111,17 +111,17 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
     WTFMove(keyboardScrollData))
-, m_rootContentsLayer(rootContentsLayer.value_or(PlatformLayerIdentifier()))
-, m_counterScrollingLayer(counterScrollingLayer.value_or(PlatformLayerIdentifier()))
-, m_insetClipLayer(insetClipLayer.value_or(PlatformLayerIdentifier()))
-, m_contentShadowLayer(contentShadowLayer.value_or(PlatformLayerIdentifier()))
-, m_eventTrackingRegions(WTFMove(eventTrackingRegions))
-, m_layoutViewport(layoutViewport)
-, m_minLayoutViewportOrigin(minLayoutViewportOrigin)
-, m_maxLayoutViewportOrigin(maxLayoutViewportOrigin)
-, m_overrideVisualViewportSize(overrideVisualViewportSize)
-, m_frameScaleFactor(frameScaleFactor)
-, m_topContentInset(topContentInset)
+    , m_rootContentsLayer(rootContentsLayer.value_or(PlatformLayerIdentifier()))
+    , m_counterScrollingLayer(counterScrollingLayer.value_or(PlatformLayerIdentifier()))
+    , m_insetClipLayer(insetClipLayer.value_or(PlatformLayerIdentifier()))
+    , m_contentShadowLayer(contentShadowLayer.value_or(PlatformLayerIdentifier()))
+    , m_eventTrackingRegions(WTFMove(eventTrackingRegions))
+    , m_layoutViewport(layoutViewport)
+    , m_minLayoutViewportOrigin(minLayoutViewportOrigin)
+    , m_maxLayoutViewportOrigin(maxLayoutViewportOrigin)
+    , m_overrideVisualViewportSize(overrideVisualViewportSize)
+    , m_frameScaleFactor(frameScaleFactor)
+    , m_topContentInset(topContentInset)
     , m_headerHeight(headerHeight)
     , m_footerHeight(footerHeight)
     , m_behaviorForFixed(WTFMove(scrollBehaviorForFixedElements))

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -153,6 +153,7 @@ private:
         MouseLocationState&&,
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
+        RequestedKeyboardScrollData&&,
         float frameScaleFactor,
         EventTrackingRegions&&,
         std::optional<PlatformLayerIdentifier> rootContentsLayer,
@@ -172,8 +173,7 @@ private:
         FloatPoint minLayoutViewportOrigin,
         FloatPoint maxLayoutViewportOrigin,
         std::optional<FloatSize> overrideVisualViewportSize,
-        bool overlayScrollbarsEnabled,
-        RequestedKeyboardScrollData&&
+        bool overlayScrollbarsEnabled
     );
 
     ScrollingStateFrameScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -235,7 +235,8 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ScrollbarHoverState                         = MouseActivityState << 1,
     ScrollbarEnabledState                       = ScrollbarHoverState << 1,
     // ScrollingStateFrameScrollingNode
-    FrameScaleFactor                            = ScrollbarEnabledState << 1,
+    KeyboardScrollData                          = ScrollbarEnabledState << 1,
+    FrameScaleFactor                            = KeyboardScrollData << 1,
     EventTrackingRegion                         = FrameScaleFactor << 1,
     RootContentsLayer                           = EventTrackingRegion << 1,
     CounterScrollingLayer                       = RootContentsLayer << 1,
@@ -257,7 +258,6 @@ enum class ScrollingStateNodeProperty : uint64_t {
     MaxLayoutViewportOrigin                     = MinLayoutViewportOrigin << 1,
     OverrideVisualViewportSize                  = MaxLayoutViewportOrigin << 1,
     OverlayScrollbarsEnabled                    = OverrideVisualViewportSize << 1,
-    KeyboardScrollData                          = OverlayScrollbarsEnabled << 1,
     // ScrollingStatePositionedNode
     RelatedOverflowScrollingNodes               = 1LLU << 1, // Same value as ScrollableAreaSize, ViewportConstraints and OverflowScrollingNode
     LayoutConstraintData                        = 1LLU << 2, // Same value as TotalContentsSize

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
@@ -59,7 +59,8 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     bool mouseIsOverContentArea,
     MouseLocationState&& mouseLocationState,
     ScrollbarHoverState&& scrollbarHoverState,
-    ScrollbarEnabledState&& scrollbarEnabledState
+    ScrollbarEnabledState&& scrollbarEnabledState,
+    RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::Overflow,
     scrollingNodeID,
@@ -88,7 +89,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     WTFMove(mouseLocationState),
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
-    RequestedKeyboardScrollData { } // FIXME: This probably needs to be refactored so that this is a member of ScrollingStateFrameScrollingNode instead of ScrollingStateScrollingNode.
+    WTFMove(scrollData)
 ) { }
 
 ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(ScrollingStateTree& stateTree, ScrollingNodeID nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
@@ -68,7 +68,8 @@ private:
         bool mouseIsOverContentArea,
         MouseLocationState&&,
         ScrollbarHoverState&&,
-        ScrollbarEnabledState&&
+        ScrollbarEnabledState&&,
+        RequestedKeyboardScrollData&&
     );
     ScrollingStateOverflowScrollingNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateOverflowScrollingNode(const ScrollingStateOverflowScrollingNode&, ScrollingStateTree&);

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
@@ -59,7 +59,8 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     bool mouseIsOverContentArea,
     MouseLocationState&& mouseLocationState,
     ScrollbarHoverState&& scrollbarHoverState,
-    ScrollbarEnabledState&& scrollbarEnabledState
+    ScrollbarEnabledState&& scrollbarEnabledState,
+    RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::PluginScrolling,
     scrollingNodeID,
@@ -88,7 +89,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     WTFMove(mouseLocationState),
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
-    RequestedKeyboardScrollData { } // FIXME: This probably needs to be refactored so that this is a member of ScrollingStateFrameScrollingNode instead of ScrollingStateScrollingNode.
+    WTFMove(scrollData)
 )
 {
     ASSERT(isPluginScrollingNode());

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
@@ -74,7 +74,8 @@ private:
         bool mouseIsOverContentArea,
         MouseLocationState&&,
         ScrollbarHoverState&&,
-        ScrollbarEnabledState&&
+        ScrollbarEnabledState&&,
+        RequestedKeyboardScrollData&&
     );
 
     ScrollingStatePluginScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -90,6 +90,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MouseActivityState] WebCore::MouseLocationState mouseLocationState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::FrameScaleFactor] float frameScaleFactor()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::EventTrackingRegion] WebCore::EventTrackingRegions eventTrackingRegions()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::RootContentsLayer] std::optional<WebCore::PlatformLayerIdentifier> rootContentsLayer().layerIDForEncoding();
@@ -110,7 +111,6 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MaxLayoutViewportOrigin] WebCore::FloatPoint maxLayoutViewportOrigin();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::OverrideVisualViewportSize] std::optional<WebCore::FloatSize> overrideVisualViewportSize();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::OverlayScrollbarsEnabled] bool overlayScrollbarsEnabled();
-    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
 }
 
 [RefCounted] class WebCore::ScrollingStateOverflowScrollingNode {
@@ -141,6 +141,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MouseActivityState] WebCore::MouseLocationState mouseLocationState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
 };
 
 [RefCounted] class WebCore::ScrollingStatePluginHostingNode {
@@ -178,6 +179,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MouseActivityState] WebCore::MouseLocationState mouseLocationState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
 }
 
 [CustomHeader] struct WebCore::ScrollbarHoverState {


### PR DESCRIPTION
#### 07f2e6aa57a55fc278f11a9d562b12fd371cf5ae
<pre>
Fix keyboard scrolling after 269941@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=265396">https://bugs.webkit.org/show_bug.cgi?id=265396</a>
<a href="https://rdar.apple.com/118453548">rdar://118453548</a>

Reviewed by Simon Fraser.

I didn&apos;t quite get the KeyboardScrollData hooked up correctly in that PR.
I thought it might need a structural refactoring, but I was wrong.
This restores behavior to how it was before that PR.

* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp:
(WebCore::ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp:
(WebCore::ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271160@main">https://commits.webkit.org/271160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d925679bc4c94fe5d996903f0714cf51eb1b992d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3555 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->