### PR TITLE
Compile declarativeNetRequest rules and load them into the proper user content controllers

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -86,6 +86,25 @@ WKWebViewConfiguration *WebExtensionControllerConfiguration::webViewConfiguratio
     return m_webViewConfiguration.get();
 }
 
+String WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory()
+{
+    if (!m_declarativeNetRequestStoreDirectory.isEmpty())
+        return m_declarativeNetRequestStoreDirectory;
+
+    if (!storageIsPersistent()) {
+        m_declarativeNetRequestStoreDirectory = FileSystem::createTemporaryDirectory(@"DeclarativeNetRequest");
+        return m_declarativeNetRequestStoreDirectory;
+    }
+
+    m_declarativeNetRequestStoreDirectory = FileSystem::pathByAppendingComponent(m_storageDirectory, "DeclarativeNetRequest"_s);
+    if (!FileSystem::makeAllDirectories(m_declarativeNetRequestStoreDirectory)) {
+        m_declarativeNetRequestStoreDirectory = String();
+        return m_declarativeNetRequestStoreDirectory;
+    }
+
+    return m_declarativeNetRequestStoreDirectory;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
@@ -83,8 +83,10 @@ using namespace WebKit;
     NSMutableArray<NSString *> *errors = [NSMutableArray array];
     for (NSData *jsonData in jsonDataArray) {
         NSError *error;
-        NSArray<NSDictionary *> *json = parseJSON(jsonData, { }, &error);
-        if (json)
+        NSArray<NSDictionary *> *json = parseJSON(jsonData, JSONOptions::FragmentsAllowed, &error);
+
+        // The top level of a declarativeNetRequest ruleset should be an array.
+        if (json && [json isKindOfClass:NSArray.class])
             [allJSONObjects addObject:json];
 
         if (error)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -72,6 +72,7 @@ OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
 OBJC_CLASS NSUUID;
+OBJC_CLASS WKContentRuleListStore;
 OBJC_CLASS WKNavigation;
 OBJC_CLASS WKNavigationAction;
 OBJC_CLASS WKWebView;
@@ -413,6 +414,9 @@ private:
 
     void loadDeclarativeNetRequestRules();
     void compileDeclarativeNetRequestRules(NSArray *);
+    void removeDeclarativeNetRequestRules();
+    void addDeclarativeNetRequestRulesToPrivateUserContentControllers();
+    WKContentRuleListStore *declarativeNetRequestRuleStore();
 
     // Action APIs
     void actionGetTitle(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(std::optional<String>, std::optional<String>)>&&);
@@ -618,6 +622,8 @@ private:
 
     CommandsVector m_commands;
     bool m_populatedCommands { false };
+
+    WKContentRuleListStore *m_declarativeNetRequestRuleStore;
 };
 
 template<typename T>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -58,6 +58,8 @@ public:
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
     String storageDirectory() const { return m_storageDirectory; }
 
+    String declarativeNetRequestStoreDirectory();
+
     WKWebViewConfiguration *webViewConfiguration();
     void setWebViewConfiguration(WKWebViewConfiguration *configuration) { m_webViewConfiguration = configuration; }
 
@@ -72,6 +74,7 @@ private:
 
     Markable<WTF::UUID> m_identifier;
     String m_storageDirectory;
+    String m_declarativeNetRequestStoreDirectory;
     RetainPtr<WKWebViewConfiguration> m_webViewConfiguration;
 };
 


### PR DESCRIPTION
#### f23885142bfbfa43aa5ccecaffd0b094b3bb7611
<pre>
Compile declarativeNetRequest rules and load them into the proper user content controllers
<a href="https://bugs.webkit.org/show_bug.cgi?id=265399">https://bugs.webkit.org/show_bug.cgi?id=265399</a>
&lt;<a href="https://rdar.apple.com/problem/118845373">rdar://problem/118845373</a>&gt;

Reviewed by Timothy Hatcher.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::unload): Remove the compiled rules from all userContentControllers.
(WebKit::WebExtensionContext::setHasAccessInPrivateBrowsing): Add or remove declarativeNetRequest rules from private browsing
user content controllers.
(WebKit::WebExtensionContext::declarativeNetRequestRuleStore): Returns the rule store.
(WebKit::WebExtensionContext::removeDeclarativeNetRequestRules): Removes the compiled rules for this extension from all userContentControllers.
(WebKit::WebExtensionContext::addDeclarativeNetRequestRulesToPrivateUserContentControllers): Adds the compiled rules for this extension to all
private browsing userContentControllers.
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules): Translate the NSData given to us into rules in the WebKit content blocker format
and compile them. When the compilation finishes, add the compiled content rule lists to the needed userContentControllers.
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules): Add a bug number to a FIXME.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory): Generate the directory to store these content blockers in.
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm:
(+[_WKWebExtensionDeclarativeNetRequestTranslator jsonObjectsFromData:errorStrings:]): Allow fragments when parsing the JSON. This is needed
because the top level object of a DNR rule set is an array. We also make sure we were given an array.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST): Add tests that DNR rules are blocking content in both regular and private browsing.

Canonical link: <a href="https://commits.webkit.org/271177@main">https://commits.webkit.org/271177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c1f32c9273ee67ee7b61c4307d74fc8598e1121

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29795 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3607 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4333 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30434 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23961 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25086 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6001 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6630 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->