### PR TITLE
Generate serialization of webrtc::WebKitEncodedFrameInfo

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.h
@@ -55,6 +55,14 @@ using VideoEncoderSetRatesCallback = void(*)(WebKitVideoEncoder, const VideoEnco
 void setVideoEncoderCallbacks(VideoEncoderCreateCallback, VideoEncoderReleaseCallback, VideoEncoderInitializeCallback, VideoEncoderEncodeCallback, VideoEncoderRegisterEncodeCompleteCallback, VideoEncoderSetRatesCallback);
 
 using WebKitEncodedFrameTiming = EncodedImage::Timing;
+
+enum class WebKitEncodedVideoRotation : uint8_t {
+    kVideoRotation_0,
+    kVideoRotation_90,
+    kVideoRotation_180,
+    kVideoRotation_270
+};
+
 struct WebKitEncodedFrameInfo {
     uint32_t width { 0 };
     uint32_t height { 0 };
@@ -63,15 +71,12 @@ struct WebKitEncodedFrameInfo {
     int64_t ntpTimeMS { 0 };
     int64_t captureTimeMS { 0 };
     VideoFrameType frameType { VideoFrameType::kVideoFrameDelta };
-    VideoRotation rotation { kVideoRotation_0 };
+    WebKitEncodedVideoRotation rotation { WebKitEncodedVideoRotation::kVideoRotation_0 };
     VideoContentType contentType { VideoContentType::UNSPECIFIED };
     bool completeFrame = false;
     int qp { -1 };
     int temporalIndex { -1 };
     WebKitEncodedFrameTiming timing;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static bool decode(Decoder&, WebKitEncodedFrameInfo&);
 };
 
 enum class LocalEncoderScalabilityMode : uint8_t { L1T1, L1T2 };
@@ -87,82 +92,5 @@ void setLocalEncoderRates(LocalEncoder, uint32_t bitRate, uint32_t frameRate);
 void setLocalEncoderLowLatency(LocalEncoder, bool isLowLatencyEnabled);
 void encoderVideoTaskComplete(void*, webrtc::VideoCodecType, const uint8_t* buffer, size_t length, const WebKitEncodedFrameInfo&);
 void flushLocalEncoder(LocalEncoder);
-
-template<class Decoder>
-bool WebKitEncodedFrameInfo::decode(Decoder& decoder, WebKitEncodedFrameInfo& info)
-{
-    if (!decoder.decode(info.width))
-        return false;
-    if (!decoder.decode(info.height))
-        return false;
-    if (!decoder.decode(info.timeStamp))
-        return false;
-    if (!decoder.decode(info.duration))
-        return false;
-    if (!decoder.decode(info.ntpTimeMS))
-        return false;
-    if (!decoder.decode(info.captureTimeMS))
-        return false;
-    if (!decoder.decode(info.frameType))
-        return false;
-    if (!decoder.decode(info.rotation))
-        return false;
-    if (!decoder.decode(info.contentType))
-        return false;
-    if (!decoder.decode(info.completeFrame))
-        return false;
-    if (!decoder.decode(info.qp))
-        return false;
-    if (!decoder.decode(info.temporalIndex))
-        return false;
-
-    if (!decoder.decode(info.timing.flags))
-        return false;
-    if (!decoder.decode(info.timing.encode_start_ms))
-        return false;
-    if (!decoder.decode(info.timing.encode_finish_ms))
-        return false;
-    if (!decoder.decode(info.timing.packetization_finish_ms))
-        return false;
-    if (!decoder.decode(info.timing.pacer_exit_ms))
-        return false;
-    if (!decoder.decode(info.timing.network_timestamp_ms))
-        return false;
-    if (!decoder.decode(info.timing.network2_timestamp_ms))
-        return false;
-    if (!decoder.decode(info.timing.receive_start_ms))
-        return false;
-    if (!decoder.decode(info.timing.receive_finish_ms))
-        return false;
-
-    return true;
-}
-
-template<class Encoder>
-void WebKitEncodedFrameInfo::encode(Encoder& encoder) const
-{
-    encoder << width;
-    encoder << height;
-    encoder << timeStamp;
-    encoder << duration;
-    encoder << ntpTimeMS;
-    encoder << captureTimeMS;
-    encoder << frameType;
-    encoder << rotation;
-    encoder << contentType;
-    encoder << completeFrame;
-    encoder << qp;
-    encoder << temporalIndex;
-
-    encoder << timing.flags;
-    encoder << timing.encode_start_ms;
-    encoder << timing.encode_finish_ms;
-    encoder << timing.packetization_finish_ms;
-    encoder << timing.pacer_exit_ms;
-    encoder << timing.network_timestamp_ms;
-    encoder << timing.network2_timestamp_ms;
-    encoder << timing.receive_start_ms;
-    encoder << timing.receive_finish_ms;
-}
 
 }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm
@@ -311,6 +311,34 @@ int32_t RemoteVideoEncoder::RegisterEncodeCompleteCallback(EncodedImageCallback*
     return videoEncoderCallbacks().registerEncodeCompleteCallback(m_internalEncoder, callback);
 }
 
+static inline VideoRotation fromEncoded(WebKitEncodedVideoRotation encoded)
+{
+    switch (encoded) {
+    case WebKitEncodedVideoRotation::kVideoRotation_0:
+        return VideoRotation::kVideoRotation_0;
+    case WebKitEncodedVideoRotation::kVideoRotation_90:
+        return VideoRotation::kVideoRotation_90;
+    case WebKitEncodedVideoRotation::kVideoRotation_180:
+        return VideoRotation::kVideoRotation_180;
+    case WebKitEncodedVideoRotation::kVideoRotation_270:
+        return VideoRotation::kVideoRotation_270;
+    }
+}
+
+static inline WebKitEncodedVideoRotation toEncoded(VideoRotation rotation)
+{
+    switch (rotation) {
+    case VideoRotation::kVideoRotation_0:
+        return WebKitEncodedVideoRotation::kVideoRotation_0;
+    case VideoRotation::kVideoRotation_90:
+        return WebKitEncodedVideoRotation::kVideoRotation_90;
+    case VideoRotation::kVideoRotation_180:
+        return WebKitEncodedVideoRotation::kVideoRotation_180;
+    case VideoRotation::kVideoRotation_270:
+        return WebKitEncodedVideoRotation::kVideoRotation_270;
+    }
+}
+
 void encoderVideoTaskComplete(void* callback, webrtc::VideoCodecType codecType, const uint8_t* buffer, size_t length, const WebKitEncodedFrameInfo& info)
 {
     webrtc::EncodedImage encodedImage;
@@ -323,7 +351,7 @@ void encoderVideoTaskComplete(void* callback, webrtc::VideoCodecType codecType, 
     encodedImage.ntp_time_ms_ = info.ntpTimeMS;
     encodedImage.timing_ = info.timing;
     encodedImage._frameType = info.frameType;
-    encodedImage.rotation_ = info.rotation;
+    encodedImage.rotation_ = fromEncoded(info.rotation);
     encodedImage.qp_ = info.qp;
     encodedImage.content_type_ = info.contentType;
 
@@ -357,7 +385,7 @@ void* createLocalEncoder(const webrtc::SdpVideoFormat& format, bool useAnnexB, w
         info.ntpTimeMS = encodedImage.ntp_time_ms_;
         info.captureTimeMS = encodedImage.capture_time_ms_;
         info.frameType = encodedImage._frameType;
-        info.rotation = encodedImage.rotation_;
+        info.rotation = toEncoded(encodedImage.rotation_);
         info.contentType = encodedImage.content_type_;
         info.qp = encodedImage.qp_;
         info.timing = encodedImage.timing_;

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -54,4 +54,54 @@ struct WebKit::RTCNetwork {
     int scopeID;
     Vector<WebKit::RTC::Network::InterfaceAddress> ips;
 };
+
+header: "RTCWebKitEncodedFrameInfo.h"
+[CustomHeader] struct webrtc::WebKitEncodedFrameInfo {
+    uint32_t width
+    uint32_t height
+    int64_t timeStamp
+    std::optional<uint64_t> duration
+    int64_t ntpTimeMS
+    int64_t captureTimeMS
+    webrtc::VideoFrameType frameType
+    webrtc::WebKitEncodedVideoRotation rotation
+    webrtc::VideoContentType contentType
+    bool completeFrame
+    int qp
+    int temporalIndex
+    webrtc::WebKitEncodedFrameTiming timing;
+};
+
+enum class webrtc::WebKitEncodedVideoRotation : uint8_t {
+    kVideoRotation_0,
+    kVideoRotation_90,
+    kVideoRotation_180,
+    kVideoRotation_270
+};
+
+using WebKitEncodedFrameTiming = webrtc::EncodedImage::Timing
+
+[Nested] struct webrtc::EncodedImage::Timing {
+    uint8_t flags
+    int64_t encode_start_ms
+    int64_t encode_finish_ms
+    int64_t packetization_finish_ms
+    int64_t pacer_exit_ms
+    int64_t network_timestamp_ms
+    int64_t network2_timestamp_ms
+    int64_t receive_start_ms
+    int64_t receive_finish_ms
+};
+
+enum class webrtc::VideoFrameType : int {
+  kEmptyFrame,
+  kVideoFrameKey,
+  kVideoFrameDelta,
+};
+
+enum class webrtc::VideoContentType : uint8_t {
+  UNSPECIFIED,
+  SCREENSHARE,
+};
+
 #endif


### PR DESCRIPTION
#### c68f7caf5b378de2ea3e9b95e9745ada7df61203
<pre>
Generate serialization of webrtc::WebKitEncodedFrameInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=265398">https://bugs.webkit.org/show_bug.cgi?id=265398</a>
<a href="https://rdar.apple.com/118845948">rdar://118845948</a>

Reviewed by Chris Dumez.

* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.h:
(webrtc::WebKitEncodedFrameInfo::decode): Deleted.
(webrtc::WebKitEncodedFrameInfo::encode const): Deleted.
* Source/WebKit/Shared/RTCNetwork.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271173@main">https://commits.webkit.org/271173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/976731d300ff1c69f210a12ca80499b1362b8cfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29769 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3580 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4319 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25069 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5982 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3559 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->