### PR TITLE
Remove fatalErrorHandler()

### DIFF
--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1114,15 +1114,6 @@ static void warningHandler(void* closure, const char* message, ...)
 }
 
 WTF_ATTRIBUTE_PRINTF(2, 3)
-static void fatalErrorHandler(void* closure, const char* message, ...)
-{
-    va_list args;
-    va_start(args, message);
-    getParser(closure)->error(XMLErrors::fatal, message, args);
-    va_end(args);
-}
-
-WTF_ATTRIBUTE_PRINTF(2, 3)
 static void normalErrorHandler(void* closure, const char* message, ...)
 {
     va_list args;
@@ -1284,8 +1275,12 @@ void XMLDocumentParser::initializeParserContext(const CString& chunk)
     xmlSAXHandler sax;
     memset(&sax, 0, sizeof(sax));
 
+    // According to https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-tree.html#xmlSAXHandler
+    // and https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-parser.html#fatalErrorSAXFunc
+    // the SAX fatalError callback is unused; error gets all the errors. Use normalErrorHandler for both
+    // the error and fatalError callbacks.
     sax.error = normalErrorHandler;
-    sax.fatalError = fatalErrorHandler;
+    sax.fatalError = normalErrorHandler;
     sax.characters = charactersHandler;
     sax.processingInstruction = processingInstructionHandler;
     sax.cdataBlock = cdataBlockHandler;


### PR DESCRIPTION
<pre>
Remove fatalErrorHandler()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263565">https://bugs.webkit.org/show_bug.cgi?id=263565</a>
rdar://problem/117710028

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=186338">https://src.chromium.org/viewvc/blink?view=revision&revision=186338</a>

According to libxml2 documentation [1] & [2], the SAX fatalError callback is unused; error gets all the errors.
Use normalErrorHandler for both the error and fatalError callbacks and remove fatalErrorHandler().

[1] <a href="https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-tree.html#xmlSAXHandler">https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-tree.html#xmlSAXHandler</a>
[2] <a href="https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-parser.html#fatalErrorSAXFunc">https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-parser.html#fatalErrorSAXFunc</a>

* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(fatalErrorHandler): Deleted
(XMLDocumentParser::initializeParserContext): Update 'fatalError' to be 'normalErrorHandler'
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7140da5a8348ae40314f4edbdabc79d04f7b8981

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25006 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30629 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28601 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->