### PR TITLE
Sync 'resizeBy' and 'resizeTo' with CSSOM-View WebIDL Specification

### DIFF
--- a/LayoutTests/fast/dom/Window/window-resize-and-move-arguments-expected.txt
+++ b/LayoutTests/fast/dom/Window/window-resize-and-move-arguments-expected.txt
@@ -7,10 +7,12 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 window.resizeTo Tests
 
 Testing - resizeTo with 0 arguments
+PASS window.resizeTo() threw exception TypeError: Not enough arguments.
 PASS window.outerWidth is resetWidth
 PASS window.outerHeight is resetHeight
 Testing - resizeTo with 1 argument
-PASS window.outerWidth is width
+PASS window.resizeTo(width) threw exception TypeError: Not enough arguments.
+PASS window.outerWidth is resetWidth
 PASS window.outerHeight is resetHeight
 Testing - resizeTo with more than 2 arguments
 PASS window.outerWidth is width
@@ -19,10 +21,12 @@ PASS window.outerHeight is height
 window.resizeBy Tests
 
 Testing - resizeBy with 0 arguments
+PASS window.resizeBy() threw exception TypeError: Not enough arguments.
 PASS window.outerWidth is resetWidth
 PASS window.outerHeight is resetHeight
 Testing - resizeBy with 1 argument
-PASS window.outerWidth is resetWidth + x
+PASS window.resizeBy(x) threw exception TypeError: Not enough arguments.
+PASS window.outerWidth is resetWidth
 PASS window.outerHeight is resetHeight
 Testing - resizeBy with more than 2 arguments
 PASS window.outerWidth is resetWidth + x

--- a/LayoutTests/fast/dom/Window/window-resize-and-move-arguments.html
+++ b/LayoutTests/fast/dom/Window/window-resize-and-move-arguments.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
     <script src="../../../resources/js-test.js"></script>
@@ -39,14 +39,14 @@
     debug('');
 
     debug("Testing - resizeTo with 0 arguments");
-    window.resizeTo();
+    shouldThrow('window.resizeTo()');
     shouldBe('window.outerWidth', 'resetWidth');
     shouldBe('window.outerHeight', 'resetHeight');
     reset();
 
     debug("Testing - resizeTo with 1 argument");
-    window.resizeTo(x);
-    shouldBe('window.outerWidth', 'width');
+    shouldThrow('window.resizeTo(width)');
+    shouldBe('window.outerWidth', 'resetWidth');
     shouldBe('window.outerHeight', 'resetHeight');
     reset();
 
@@ -62,14 +62,14 @@
     debug('');
 
     debug("Testing - resizeBy with 0 arguments");
-    window.resizeBy();
+    shouldThrow('window.resizeBy()');
     shouldBe('window.outerWidth', 'resetWidth');
     shouldBe('window.outerHeight', 'resetHeight');
     reset();
 
     debug("Testing - resizeBy with 1 argument");
-    window.resizeBy(x);
-    shouldBe('window.outerWidth', 'resetWidth + x');
+    shouldThrow('window.resizeBy(x)');
+    shouldBe('window.outerWidth', 'resetWidth');
     shouldBe('window.outerHeight', 'resetHeight');
     reset();
 

--- a/LayoutTests/fast/dom/non-numeric-values-numeric-parameters-expected.txt
+++ b/LayoutTests/fast/dom/non-numeric-values-numeric-parameters-expected.txt
@@ -74,9 +74,9 @@ PASS nonNumericPolicy('window.moveBy(0, x)') is 'any type allowed (but not omitt
 PASS nonNumericPolicy('window.moveTo(x, 0)') is 'any type allowed'
 PASS nonNumericPolicy('window.moveTo(0, x)') is 'any type allowed (but not omitted)'
 PASS nonNumericPolicy('window.resizeBy(x, 0)') is 'any type allowed'
-PASS nonNumericPolicy('window.resizeBy(0, x)') is 'any type allowed'
+PASS nonNumericPolicy('window.resizeBy(0, x)') is 'any type allowed (but not omitted)'
 PASS nonNumericPolicy('window.resizeTo(x, 0)') is 'any type allowed'
-PASS nonNumericPolicy('window.resizeTo(0, x)') is 'any type allowed'
+PASS nonNumericPolicy('window.resizeTo(0, x)') is 'any type allowed (but not omitted)'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/non-numeric-values-numeric-parameters.html
+++ b/LayoutTests/fast/dom/non-numeric-values-numeric-parameters.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>
@@ -359,9 +359,9 @@ shouldBe("nonNumericPolicy('window.moveBy(0, x)')", "'any type allowed (but not 
 shouldBe("nonNumericPolicy('window.moveTo(x, 0)')", "'any type allowed'");
 shouldBe("nonNumericPolicy('window.moveTo(0, x)')", "'any type allowed (but not omitted)'");
 shouldBe("nonNumericPolicy('window.resizeBy(x, 0)')", "'any type allowed'");
-shouldBe("nonNumericPolicy('window.resizeBy(0, x)')", "'any type allowed'");
+shouldBe("nonNumericPolicy('window.resizeBy(0, x)')", "'any type allowed (but not omitted)'");
 shouldBe("nonNumericPolicy('window.resizeTo(x, 0)')", "'any type allowed'");
-shouldBe("nonNumericPolicy('window.resizeTo(0, x)')", "'any type allowed'");
+shouldBe("nonNumericPolicy('window.resizeTo(0, x)')", "'any type allowed (but not omitted)'");
 // Not tested: openDatabase.
 
 window.resizeTo(10000, 10000);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
@@ -224,8 +224,8 @@ PASS Window interface: operation matchMedia(CSSOMString)
 PASS Window interface: attribute screen
 PASS Window interface: operation moveTo(long, long)
 PASS Window interface: operation moveBy(long, long)
-FAIL Window interface: operation resizeTo(long, long) assert_equals: property has wrong .length expected 2 but got 0
-FAIL Window interface: operation resizeBy(long, long) assert_equals: property has wrong .length expected 2 but got 0
+PASS Window interface: operation resizeTo(long, long)
+PASS Window interface: operation resizeBy(long, long)
 PASS Window interface: attribute innerWidth
 PASS Window interface: attribute innerHeight
 PASS Window interface: attribute scrollX
@@ -253,13 +253,9 @@ PASS Window interface: calling moveTo(long, long) on window with too few argumen
 PASS Window interface: window must inherit property "moveBy(long, long)" with the proper type
 PASS Window interface: calling moveBy(long, long) on window with too few arguments must throw TypeError
 PASS Window interface: window must inherit property "resizeTo(long, long)" with the proper type
-FAIL Window interface: calling resizeTo(long, long) on window with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
-            fn.apply(obj, args);
-        }" did not throw
+PASS Window interface: calling resizeTo(long, long) on window with too few arguments must throw TypeError
 PASS Window interface: window must inherit property "resizeBy(long, long)" with the proper type
-FAIL Window interface: calling resizeBy(long, long) on window with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function() {
-            fn.apply(obj, args);
-        }" did not throw
+PASS Window interface: calling resizeBy(long, long) on window with too few arguments must throw TypeError
 PASS Window interface: window must inherit property "innerWidth" with the proper type
 PASS Window interface: window must inherit property "innerHeight" with the proper type
 PASS Window interface: window must inherit property "scrollX" with the proper type

--- a/Source/WebCore/page/LocalDOMWindow+CSSOMView.idl
+++ b/Source/WebCore/page/LocalDOMWindow+CSSOMView.idl
@@ -33,8 +33,8 @@ partial interface LocalDOMWindow {
     // browsing context
     undefined moveTo(long x, long y);
     undefined moveBy(long x, long y);
-    undefined resizeTo(optional unrestricted float width = NaN, optional unrestricted float height = NaN); // Parameters should be mandatory and of type long.
-    undefined resizeBy(optional unrestricted float x = NaN, optional unrestricted float y = NaN); // FIXME: Parameters should be mandatory and of type long.
+    undefined resizeTo(long width, long height);
+    undefined resizeBy(long x, long y);
 
     // viewport
     [Replaceable] readonly attribute long innerWidth;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1862,27 +1862,27 @@ void LocalDOMWindow::moveTo(int x, int y) const
     page->chrome().setWindowRect(adjustWindowRect(*page, update));
 }
 
-void LocalDOMWindow::resizeBy(float x, float y) const
+void LocalDOMWindow::resizeBy(int x, int y) const
 {
     if (!allowedToChangeWindowGeometry())
         return;
 
     CheckedPtr page = frame()->page();
-    FloatRect fr = page->chrome().windowRect();
-    FloatSize dest = fr.size() + FloatSize(x, y);
-    FloatRect update(fr.location(), dest);
+    auto fr = page->chrome().windowRect();
+    auto dest = fr.size() + LayoutSize(x, y);
+    LayoutRect update(fr.location(), dest);
     page->chrome().setWindowRect(adjustWindowRect(*page, update));
 }
 
-void LocalDOMWindow::resizeTo(float width, float height) const
+void LocalDOMWindow::resizeTo(int width, int height) const
 {
     if (!allowedToChangeWindowGeometry())
         return;
 
     CheckedPtr page = frame()->page();
-    FloatRect fr = page->chrome().windowRect();
-    FloatSize dest = FloatSize(width, height);
-    FloatRect update(fr.location(), dest);
+    auto fr = page->chrome().windowRect();
+    auto dest = LayoutSize(width, height);
+    LayoutRect update(fr.location(), dest);
     page->chrome().setWindowRect(adjustWindowRect(*page, update));
 }
 

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -281,8 +281,8 @@ public:
     void moveBy(int x, int y) const;
     void moveTo(int x, int y) const;
 
-    void resizeBy(float x, float y) const;
-    void resizeTo(float width, float height) const;
+    void resizeBy(int x, int y) const;
+    void resizeTo(int width, int height) const;
 
     VisualViewport& visualViewport();
 


### PR DESCRIPTION
#### 99f5a390d9b4d5772de495a2fc61c3fe7aef1e6c
<pre>
Sync &apos;resizeBy&apos; and &apos;resizeTo&apos; with CSSOM-View WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=265411">https://bugs.webkit.org/show_bug.cgi?id=265411</a>

Reviewed by Chris Dumez.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification [1]:

[1] <a href="https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface</a>

In this patch, &apos;resizeBy&apos; and &apos;resizeTo&apos; are updated to &apos;int&apos; rather than &apos;float&apos; and
accordingly update related function calls.

* Source/WebCore/page/LocalDOMWindow.cpp:
(LocalDOMWindow::resizeBy):
(LocalDOMWindow::resizeTo):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalDOMWindow+CSSOMView.idl:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt: Rebaselined
* LayoutTests/fast/dom/non-numeric-values-numeric-parameters.html: Rebaselined
* LayoutTests/fast/dom/non-numeric-values-numeric-parameters-expected.txt: Rebaselined
* LayoutTests/fast/dom/Window/window-resize-and-move-arguments.html: Rebaselined
* LayoutTests/fast/dom/Window/window-resize-and-move-arguments-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/271194@main">https://commits.webkit.org/271194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9855bad3fba02d8ad57fd5040a08298774915c65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29825 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25017 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30639 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2680 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28609 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->