### PR TITLE
[Win][Clang] WTF_CrossThreadTask.Basic is failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/CrossThreadTask.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CrossThreadTask.cpp
@@ -123,11 +123,11 @@ TEST(WTF_CrossThreadTask, Basic)
     ASSERT_EQ(2u, copyConstructorSet.count("<default>-1-0"_s));
     ASSERT_EQ(1u, copyConstructorSet.count("<default>-2-0"_s));
 
-#if !COMPILER(MSVC)
+#if !COMPILER(MSVC) || COMPILER(CLANG)
     ASSERT_EQ(6u, moveConstructorSet.size());
 #else
-    // The number of times the move constructor is called is different on Windows in this test.
-    // This seems to be caused by differences in MSVC's implementation of lambdas or std functions like std::make_tuple.
+    // The number of times the move constructor is called is different with MSVC in this test.
+    // This seems to be caused by differences in MSVC's implementation of lambdas.
     ASSERT_EQ(9u, moveConstructorSet.size());
 #endif
     ASSERT_EQ(1u, moveConstructorSet.count("logger-1-1"_s));
@@ -137,10 +137,10 @@ TEST(WTF_CrossThreadTask, Basic)
     ASSERT_EQ(1u, moveConstructorSet.count("<default>-1-1"_s));
     ASSERT_EQ(1u, moveConstructorSet.count("<default>-1-2"_s));
 
-#if !COMPILER(MSVC)
+#if !COMPILER(MSVC) || COMPILER(CLANG)
     ASSERT_EQ(12u, totalDestructorCalls);
 #else
-    // Since the move constructor is called 3 more times on Windows (see above), we will have 3 more destructor calls.
+    // Since the move constructor is called 3 more times with MSVC (see above), we will have 3 more destructor calls.
     ASSERT_EQ(15u, totalDestructorCalls);
 #endif
     ASSERT_EQ(3u, totalIsolatedCopyCalls);


### PR DESCRIPTION
#### e1b3b6883b8cea1667aaf74efa832e430b82879c
<pre>
[Win][Clang] WTF_CrossThreadTask.Basic is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=265417">https://bugs.webkit.org/show_bug.cgi?id=265417</a>

Reviewed by Ross Kirsling.

&lt;<a href="https://webkit.org/b/161140">https://webkit.org/b/161140</a>&gt; added a workaround to the test case for
MSVC. However, clang-cl doesn&apos;t need it. Becuase Windows port is still
supporting both MSVC and clang-cl, clang-cl builds are enableing
WTF_COMPILER_MSVC macro at the moment.

* Tools/TestWebKitAPI/Tests/WTF/CrossThreadTask.cpp:
clang-cl should take the code path of non-MSVC compiler.

Canonical link: <a href="https://commits.webkit.org/271186@main">https://commits.webkit.org/271186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/824078e660724633dd37ae404a926c8fd1e8a971

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25248 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25018 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30642 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2686 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6031 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3567 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->