### PR TITLE
[WebRTC] Release assertion in webrtc::RtpPacketizerH264::PacketizeStapA on bad input

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
@@ -84,7 +84,11 @@ class RtpPacketizerH264 : public RtpPacketizer {
 
   bool GeneratePackets(H264PacketizationMode packetization_mode);
   bool PacketizeFuA(size_t fragment_index);
+#ifdef WEBRTC_WEBKIT_BUILD
+  std::optional<size_t> PacketizeStapA(size_t fragment_index);
+#else
   size_t PacketizeStapA(size_t fragment_index);
+#endif
   bool PacketizeSingleNalu(size_t fragment_index);
 
   void NextAggregatePacket(RtpPacketToSend* rtp_packet);

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Release-assertion-in-webrtc-RtpPacketizerH264.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Release-assertion-in-webrtc-RtpPacketizerH264.patch
@@ -1,0 +1,64 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
+index cc8d1bff34b0..e26dcb6a1d94 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
+@@ -94,7 +94,15 @@ bool RtpPacketizerH264::GeneratePackets(
+             return false;
+           ++i;
+         } else {
++#ifdef WEBRTC_WEBKIT_BUILD
++          auto newFragmentIndex = PacketizeStapA(i);
++          if (!newFragmentIndex) {
++            return false;
++          }
++          i = *newFragmentIndex;
++#else
+           i = PacketizeStapA(i);
++#endif
+         }
+         break;
+     }
+@@ -150,7 +158,12 @@ bool RtpPacketizerH264::PacketizeFuA(size_t fragment_index) {
+   return true;
+ }
+ 
+-size_t RtpPacketizerH264::PacketizeStapA(size_t fragment_index) {
++#ifdef WEBRTC_WEBKIT_BUILD
++std::optional<size_t> RtpPacketizerH264::PacketizeStapA(size_t fragment_index)
++#else
++size_t RtpPacketizerH264::PacketizeStapA(size_t fragment_index)
++#endif
++{
+   // Aggregate fragments into one packet (STAP-A).
+   size_t payload_size_left = limits_.max_payload_len;
+   if (input_fragments_.size() == 1)
+@@ -178,7 +191,13 @@ size_t RtpPacketizerH264::PacketizeStapA(size_t fragment_index) {
+   };
+ 
+   while (payload_size_left >= payload_size_needed()) {
++#ifdef WEBRTC_WEBKIT_BUILD
++    if (fragment.size() == 0) {
++      return std::nullopt;
++    }
++#else
+     RTC_CHECK_GT(fragment.size(), 0);
++#endif
+     packets_.push(PacketUnit(fragment, aggregated_fragments == 0, false, true,
+                              fragment[0]));
+     payload_size_left -= fragment.size();
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
+index f95c3b6c6b73..80709f1f43aa 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
+@@ -84,7 +84,11 @@ class RtpPacketizerH264 : public RtpPacketizer {
+ 
+   bool GeneratePackets(H264PacketizationMode packetization_mode);
+   bool PacketizeFuA(size_t fragment_index);
++#ifdef WEBRTC_WEBKIT_BUILD
++  std::optional<size_t> PacketizeStapA(size_t fragment_index);
++#else
+   size_t PacketizeStapA(size_t fragment_index);
++#endif
+   bool PacketizeSingleNalu(size_t fragment_index);
+ 
+   void NextAggregatePacket(RtpPacketToSend* rtp_packet);


### PR DESCRIPTION
#### 832866a2a943f5e889ab89d9fd07295e5ad82d8d
<pre>
[WebRTC] Release assertion in webrtc::RtpPacketizerH264::PacketizeStapA on bad input
<a href="https://bugs.webkit.org/show_bug.cgi?id=265422">https://bugs.webkit.org/show_bug.cgi?id=265422</a>
&lt;<a href="https://rdar.apple.com/118859268">rdar://118859268</a>&gt;

Reviewed by Youenn Fablet.

Change release assertion into a runtime check to avoid a crash.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc:
(webrtc::RtpPacketizerH264::GeneratePackets):
- Check return value of PacketizeStapA() and return false if
  std::nullopt was returned.
(webrtc::RtpPacketizerH264::PacketizeStapA):
- Change implementation to return std::optional&lt;size_t&gt;.
- Return std::nullopt instead of crashing if fragment.size() == 0.
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h:
(webrtc::RtpPacketizerH264::PacketizeStapA):
- Change declaration to return std::optional&lt;size_t&gt;.

* Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Release-assertion-in-webrtc-RtpPacketizerH264.patch: Add.

Canonical link: <a href="https://commits.webkit.org/271215@main">https://commits.webkit.org/271215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f9456bdfe6d32a8f40ce8b2d459635b8dbdb532

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29850 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25260 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25025 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28616 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5012 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3579 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->