### PR TITLE
Use faster alternatives to Vector::resize() when possible

### DIFF
--- a/Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp
@@ -97,7 +97,7 @@ bool eliminateDeadCodeImpl(Procedure& proc)
                 changed = true;
             }
         }
-        block->values().resize(targetIndex);
+        block->values().shrink(targetIndex);
     }
 
     for (Variable* variable : proc.variables()) {

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3099,7 +3099,7 @@ private:
         cloneValue(m_value);
 
         // Remove the values from the predecessor.
-        predecessor->values().resize(startIndex);
+        predecessor->values().shrink(startIndex);
         
         predecessor->appendNew<Value>(m_proc, Branch, source->origin(), predicate);
         predecessor->setSuccessors(FrequentedBlock(cases[0]), FrequentedBlock(cases[1]));

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -75,8 +75,8 @@ public:
             dataLogLn("]");
         }
 
-        m_adjacencyList.resize(tmpArraySize);
-        m_moveList.resize(tmpArraySize);
+        m_adjacencyList.grow(tmpArraySize);
+        m_moveList.grow(tmpArraySize);
         m_isOnSelectStack.ensureSize(tmpArraySize);
         m_spillWorklist.ensureSize(tmpArraySize);
     }

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -279,8 +279,7 @@ void CodeBlockBytecodeDumper<Block>::dumpGraph(Block* block, const JSInstruction
 
     out.printf("\n");
 
-    Vector<Vector<unsigned>> predecessors;
-    predecessors.resize(graph.size());
+    Vector<Vector<unsigned>> predecessors(graph.size());
     for (auto& block : graph) {
         if (block.isEntryBlock() || block.isExitBlock())
             continue;

--- a/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
@@ -78,7 +78,7 @@ public:
                 auto bytecode = instruction->as<OpYield>();
                 unsigned liveCalleeLocalsIndex = bytecode.m_yieldPoint;
                 if (liveCalleeLocalsIndex >= m_yields.size())
-                    m_yields.resize(liveCalleeLocalsIndex + 1);
+                    m_yields.grow(liveCalleeLocalsIndex + 1);
                 YieldData& data = m_yields[liveCalleeLocalsIndex];
                 data.point = instruction.offset();
                 data.argument = bytecode.m_argument;
@@ -147,7 +147,7 @@ private:
         // It means that, the register can be retrieved even if the immediate previous op_save does not save it.
 
         if (m_storages.size() <= index)
-            m_storages.resize(index + 1);
+            m_storages.grow(index + 1);
         if (std::optional<Storage> storage = m_storages[index])
             return *storage;
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -3682,7 +3682,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         if (isGenerated)
             poly.m_list[dstIndex++] = WTFMove(someCase);
     }
-    poly.m_list.resize(dstIndex);
+    poly.m_list.shrink(dstIndex);
 
     bool generatedMegamorphicCode = false;
 

--- a/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
@@ -117,7 +117,7 @@ private:
             
             for (unsigned phiIndex = block->phis.size(); phiIndex--;)
                 m_graph.deleteNode(block->phis[phiIndex]);
-            block->phis.resize(0);
+            block->phis.shrink(0);
         }
     }
     

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1562,8 +1562,7 @@ private:
         // Nodes without remaining unmaterialized fields will be
         // materialized first - amongst the remaining unmaterialized
         // nodes
-        Vector<Allocation> toMaterialize;
-        toMaterialize.resize(escapees.size());
+        Vector<Allocation> toMaterialize(escapees.size());
         size_t firstIndex = 0;
         size_t lastIndex = toMaterialize.size();
         auto materializeFirst = [&] (Allocation&& allocation) {

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
@@ -213,7 +213,7 @@ void ShadowChicken::update(VM& vm, CallFrame* callFrame)
             }
             break;
         }
-        m_stack.resize(shadowIndex);
+        m_stack.shrink(shadowIndex);
         
         if (ShadowChickenInternal::verbose)
             dataLog("    Revised stack: ", listDump(m_stack), "\n");

--- a/Source/JavaScriptCore/jit/CallFrameShuffleData.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffleData.cpp
@@ -93,7 +93,7 @@ CallFrameShuffleData CallFrameShuffleData::createForBaselineOrLLIntTailCall(cons
     shuffleData.numberTagRegister = GPRInfo::numberTagRegister;
 #endif
     shuffleData.numLocals = bytecode.m_argv - sizeof(CallerFrameAndPC) / sizeof(Register);
-    shuffleData.args.resize(bytecode.m_argc);
+    shuffleData.args.grow(bytecode.m_argc);
     for (unsigned i = 0; i < bytecode.m_argc; ++i) {
         shuffleData.args[i] =
             ValueRecovery::displacedInJSStack(

--- a/Source/JavaScriptCore/jit/CallFrameShuffler.h
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler.h
@@ -110,7 +110,7 @@ public:
         data.numPassedArgs = m_numPassedArgs;
         data.numParameters = m_numParameters;
         data.callee = getNew(VirtualRegister { CallFrameSlot::callee })->recovery();
-        data.args.resize(argCount());
+        data.args.grow(argCount());
         for (size_t i = 0; i < argCount(); ++i)
             data.args[i] = getNew(virtualRegisterForArgumentIncludingThis(i))->recovery();
         for (Reg reg = Reg::first(); reg <= Reg::last(); reg = reg.next()) {

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1311,7 +1311,7 @@ String formatTimeZoneOffsetString(int64_t offset)
             }
         }
         if (validLength)
-            fraction.resize(validLength.value());
+            fraction.shrink(validLength.value());
         else
             fraction.clear();
         return makeString(negative ? '-' : '+', pad('0', 2, hours), ':', pad('0', 2, minutes), ':', pad('0', 2, seconds), '.', pad('0', paddingLength, emptyString()), fraction);
@@ -1346,7 +1346,7 @@ String temporalTimeToString(PlainTime plainTime, std::tuple<Precision, unsigned>
             }
         }
         if (validLength)
-            fraction.resize(validLength.value());
+            fraction.shrink(validLength.value());
         else
             fraction.clear();
         return makeString(pad('0', 2, plainTime.hour()), ':', pad('0', 2, plainTime.minute()), ':', pad('0', 2, plainTime.second()), '.', pad('0', paddingLength, emptyString()), fraction);

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1726,7 +1726,7 @@ static JSArray* availableCollations(JSGlobalObject* globalObject)
             return WTF::codePointCompare(a, b) < 0;
         });
     auto end = std::unique(elements.begin(), elements.end());
-    elements.resize(elements.size() - (elements.end() - end));
+    elements.shrink(elements.size() - (elements.end() - end));
 
     RELEASE_AND_RETURN(scope, createArrayFromStringVector(globalObject, WTFMove(elements)));
 }
@@ -1782,7 +1782,7 @@ static JSArray* availableCurrencies(JSGlobalObject* globalObject)
             return WTF::codePointCompare(a, b) < 0;
         });
     auto end = std::unique(elements.begin(), elements.end());
-    elements.resize(elements.size() - (elements.end() - end));
+    elements.shrink(elements.size() - (elements.end() - end));
 
     RELEASE_AND_RETURN(scope, createArrayFromStringVector(globalObject, WTFMove(elements)));
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -870,7 +870,7 @@ template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::sort()
     ElementType* originalArray = typedVector();
     ElementType* array = originalArray;
     if (isShared()) {
-        forShared.resize(length);
+        forShared.grow(length);
         WTF::copyElements(forShared.data(), originalArray, length);
         array = forShared.data();
     }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -779,10 +779,8 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
 
     auto* originalArray = thisObject->typedVector();
 
-    Vector<typename ViewClass::ElementType, 16> src;
-    Vector<typename ViewClass::ElementType, 16> dst;
-    src.resize(length);
-    dst.resize(length);
+    Vector<typename ViewClass::ElementType, 16> src(length);
+    Vector<typename ViewClass::ElementType, 16> dst(length);
     WTF::copyElements(src.data(), originalArray, length);
 
     typename ViewClass::ElementType* result = nullptr;

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -81,7 +81,7 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSObject* targ
     // Do not clear since Vector::clear shrinks the backing store.
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    properties.resize(0);
+    properties.shrink(0);
     values.clear();
 
     if (source->canHaveExistingOwnIndexedGetterSetterProperties())

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -373,8 +373,7 @@ void RegExp::deleteCode()
 void RegExp::matchCompareWithInterpreter(const String& s, int startOffset, int* offsetVector, int jitResult)
 {
     int offsetVectorSize = (m_numSubpatterns + 1) * 2;
-    Vector<int> interpreterOvector;
-    interpreterOvector.resize(offsetVectorSize);
+    Vector<int> interpreterOvector(offsetVectorSize);
     int* interpreterOffsetVector = interpreterOvector.data();
     int interpreterResult = 0;
     int differences = 0;

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1278,7 +1278,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
     }
 
     auto& result = vm.stringSplitIndice;
-    result.resize(0);
+    result.shrink(0);
 
     auto cacheAndCreateArray = [&]() -> JSArray* {
         if (result.isEmpty())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -9884,7 +9884,7 @@ private:
             m_locals[value.asLocal()] = loc;
         else if (value.isTemp()) {
             if (m_temps.size() <= value.asTemp())
-                m_temps.resize(value.asTemp() + 1);
+                m_temps.grow(value.asTemp() + 1);
             m_temps[value.asTemp()] = loc;
         }
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -44,27 +44,27 @@ unsigned FunctionIPIntMetadataGenerator::addSignature(const TypeDefinition& sign
 
 void FunctionIPIntMetadataGenerator::addBlankSpace(uint32_t size)
 {
-    m_metadata.resize(m_metadata.size() + size);
+    m_metadata.grow(m_metadata.size() + size);
 }
 
 void FunctionIPIntMetadataGenerator::addRawValue(uint64_t value)
 {
     auto size = m_metadata.size();
-    m_metadata.resize(m_metadata.size() + 8);
+    m_metadata.grow(m_metadata.size() + 8);
     WRITE_TO_METADATA(m_metadata.data() + size, value, uint64_t);
 }
 
 void FunctionIPIntMetadataGenerator::addLength(uint32_t length)
 {
     size_t size = m_metadata.size();
-    m_metadata.resize(size + 1);
+    m_metadata.grow(size + 1);
     WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
 }
 
 void FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length)
 {
     size_t size = m_metadata.size();
-    m_metadata.resize(size + 5);
+    m_metadata.grow(size + 5);
     WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
     WRITE_TO_METADATA(m_metadata.data() + size + 1, value, uint32_t);
 }
@@ -73,10 +73,10 @@ void FunctionIPIntMetadataGenerator::addCondensedLocalIndexAndLength(uint32_t in
 {
     size_t size = m_metadata.size();
     if (length == 2) {
-        m_metadata.resize(size + 1);
+        m_metadata.grow(size + 1);
         WRITE_TO_METADATA(m_metadata.data() + size, 0, uint8_t);
     } else {
-        m_metadata.resize(size + 5);
+        m_metadata.grow(size + 5);
         WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
         WRITE_TO_METADATA(m_metadata.data() + size + 1, index, uint32_t);
     }
@@ -87,21 +87,21 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
     if (type.isI32()) {
         size_t size = m_metadata.size();
         if (length == 2) {
-            m_metadata.resize(size + 1);
+            m_metadata.grow(size + 1);
             WRITE_TO_METADATA(m_metadata.data() + size, (value >> 7) & 1, uint8_t);
         } else {
-            m_metadata.resize(size + 5);
+            m_metadata.grow(size + 5);
             WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
             WRITE_TO_METADATA(m_metadata.data() + size + 1, static_cast<uint32_t>(value), uint32_t);
         }
     } else if (type.isI64()) {
         size_t size = m_metadata.size();
-        m_metadata.resize(size + 9);
+        m_metadata.grow(size + 9);
         WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
         WRITE_TO_METADATA(m_metadata.data() + size + 1, static_cast<uint64_t>(value), uint64_t);
     }  else if (type.isFuncref()) {
         size_t size = m_metadata.size();
-        m_metadata.resize(size + 5);
+        m_metadata.grow(size + 5);
         WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
         WRITE_TO_METADATA(m_metadata.data() + size + 1, static_cast<uint32_t>(value), uint32_t);
     } else if (!type.isF32() && !type.isF64())
@@ -111,7 +111,7 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
 void FunctionIPIntMetadataGenerator::addLEB128V128Constant(v128_t value, uint32_t length)
 {
     size_t size = m_metadata.size();
-    m_metadata.resize(size + 17);
+    m_metadata.grow(size + 17);
     WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
     WRITE_TO_METADATA(m_metadata.data() + size + 1, value, v128_t);
 }

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -2086,7 +2086,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             Vector<ExpressionType> args;
             size_t firstArgumentIndex = m_expressionStack.size() - argc;
             WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argc), "can't allocate enough memory for array.new_fixed ", argc, " values");
-            args.resize(argc);
+            args.grow(argc);
 
             // Start parsing arguments; the expected type for each one is the unpacked version of the array element type
             for (size_t i = 0; i < argc; ++i) {
@@ -2293,7 +2293,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             Vector<ExpressionType> args;
             size_t firstArgumentIndex = m_expressionStack.size() - structType->fieldCount();
             WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(structType->fieldCount()), "can't allocate enough memory for struct.new ", structType->fieldCount(), " values");
-            args.resize(structType->fieldCount());
+            args.grow(structType->fieldCount());
 
             for (size_t i = 0; i < structType->fieldCount(); ++i) {
                 TypedExpression arg = m_expressionStack.at(m_expressionStack.size() - i - 1);
@@ -2659,7 +2659,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         size_t firstArgumentIndex = m_expressionStack.size() - calleeSignature.argumentCount();
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(calleeSignature.argumentCount()), "can't allocate enough memory for call's ", calleeSignature.argumentCount(), " arguments");
-        args.resize(calleeSignature.argumentCount());
+        args.grow(calleeSignature.argumentCount());
         for (size_t i = 0; i < calleeSignature.argumentCount(); ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
             TypedExpression arg = m_expressionStack.at(stackIndex);
@@ -2728,7 +2728,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for ", argumentCount, " call_indirect arguments");
-        args.resize(argumentCount);
+        args.grow(argumentCount);
         size_t firstArgumentIndex = m_expressionStack.size() - argumentCount;
         for (size_t i = 0; i < argumentCount; ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
@@ -2793,7 +2793,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for ", argumentCount, " call_indirect arguments");
-        args.resize(argumentCount);
+        args.grow(argumentCount);
         size_t firstArgumentIndex = m_expressionStack.size() - argumentCount;
         for (size_t i = 0; i < argumentCount; ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
@@ -3008,7 +3008,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         unsigned offset = m_expressionStack.size() - exceptionSignature.argumentCount();
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(exceptionSignature.argumentCount()), "can't allocate enough memory for throw's ", exceptionSignature.argumentCount(), " arguments");
-        args.resize(exceptionSignature.argumentCount());
+        args.grow(exceptionSignature.argumentCount());
         for (unsigned i = 0; i < exceptionSignature.argumentCount(); ++i) {
             TypedExpression arg = m_expressionStack.at(m_expressionStack.size() - i - 1);
             WASM_VALIDATOR_FAIL_IF(arg.type() != exceptionSignature.argumentType(exceptionSignature.argumentCount() - i - 1), "The exception being thrown expects the argument at index ", i, " to be ", exceptionSignature.argumentType(exceptionSignature.argumentCount() - i - 1), " but argument has type ", arg.type());

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -626,7 +626,7 @@ std::unique_ptr<FunctionCodeBlockGenerator> LLIntGenerator::finalize()
     Buffer usedBuffer;
     m_codeBlock->setInstructions(m_writer.finalize(usedBuffer));
     size_t oldCapacity = usedBuffer.capacity();
-    usedBuffer.resize(0);
+    usedBuffer.shrink(0);
     RELEASE_ASSERT(usedBuffer.capacity() == oldCapacity);
     *threadSpecific = WTFMove(usedBuffer);
 

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -338,7 +338,7 @@ protected:
                             liveAtTail.begin(), liveAtTail.end(),
                             m_workset.begin(), m_workset.end(),
                             mergeBuffer.begin());
-                        mergeBuffer.resize(iter - mergeBuffer.begin());
+                        mergeBuffer.shrink(iter - mergeBuffer.begin());
                         
                         if (mergeBuffer.size() == liveAtTail.size())
                             continue;

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -546,7 +546,7 @@ private:
         {
             ASSERT(dependentPromisesCount);
             if constexpr (!std::is_void_v<ResolveValueT>)
-                m_resolveValues.resize(dependentPromisesCount);
+                m_resolveValues.grow(dependentPromisesCount);
         }
 
         template<typename ResolveValueType_>
@@ -609,7 +609,7 @@ private:
             , m_outstandingPromises(dependentPromisesCount)
         {
             ASSERT(dependentPromisesCount);
-            m_results.resize(dependentPromisesCount);
+            m_results.grow(dependentPromisesCount);
         }
 
         void settle(size_t index, ResultParam result)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -624,7 +624,7 @@ inline StringView::UpconvertedCharacters::UpconvertedCharacters(StringView strin
     }
     const LChar* characters8 = string.characters8();
     unsigned length = string.m_length;
-    m_upconvertedCharacters.resize(length);
+    m_upconvertedCharacters.grow(length);
     StringImpl::copyCharacters(m_upconvertedCharacters.data(), characters8, length);
     m_characters = m_upconvertedCharacters.data();
 }

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
@@ -130,7 +130,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(const u
     }
 
     while (shouldCompress) {
-        auto output = Vector<uint8_t>();
+        Vector<uint8_t> output;
         if (!output.tryReserveInitialCapacity(allocateSize)) {
             allocateSize /= 4;
 
@@ -140,7 +140,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(const u
             continue;
         }
 
-        output.resize(allocateSize);
+        output.grow(allocateSize);
 
         m_zstream.next_out = output.data();
         m_zstream.avail_out = output.size();
@@ -152,7 +152,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(const u
 
         if (didDeflateFinish(result)) {
             shouldCompress = false;
-            output.resize(allocateSize - m_zstream.avail_out);
+            output.shrink(allocateSize - m_zstream.avail_out);
         }
         else {
             if (allocateSize < maxAllocationSize)

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
@@ -135,7 +135,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressZlib
     }
 
     while (shouldDecompress) {
-        auto output = Vector<uint8_t>();
+        Vector<uint8_t> output;
         if (!output.tryReserveInitialCapacity(allocateSize)) {
             allocateSize /= 4;
 
@@ -145,7 +145,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressZlib
             continue;
         }
 
-        output.resize(allocateSize);
+        output.grow(allocateSize);
 
         m_zstream.next_out = output.data();
         m_zstream.avail_out = output.size();
@@ -160,7 +160,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressZlib
 
         if (didInflateFinish(result)) {
             shouldDecompress = false;
-            output.resize(allocateSize - m_zstream.avail_out);
+            output.shrink(allocateSize - m_zstream.avail_out);
         } else {
             if (allocateSize < maxAllocationSize)
                 allocateSize *= 2;
@@ -206,7 +206,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressAppl
     m_stream.src_size = inputLength;
     
     while (shouldDecompress) {
-        auto output = Vector<uint8_t>();
+        Vector<uint8_t> output;
         if (!output.tryReserveInitialCapacity(allocateSize)) {
             allocateSize /= 4;
 
@@ -216,7 +216,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressAppl
             continue;
         }
 
-        output.resize(allocateSize);
+        output.grow(allocateSize);
 
         m_stream.dst_ptr = output.data();
         m_stream.dst_size = output.size();
@@ -232,7 +232,7 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressAppl
 
         if (!m_stream.src_size) {
             shouldDecompress = false;
-            output.resize(allocateSize - m_stream.dst_size);
+            output.shrink(allocateSize - m_stream.dst_size);
         } else {
             if (allocateSize < maxAllocationSize)
                 allocateSize *= 2;

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -287,7 +287,7 @@ std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
 {
     if (m_keys.isEmpty() || m_updateCounter != m_headers->m_updateCounter) {
         bool hasSetCookie = !m_headers->m_setCookieValues.isEmpty();
-        m_keys.resize(0);
+        m_keys.shrink(0);
         m_keys.reserveCapacity(m_headers->m_headers.size() + (hasSetCookie ? 1 : 0));
         m_keys.appendContainerWithMapping(m_headers->m_headers, [](auto& header) {
             ASSERT(!header.key.isNull());

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
@@ -134,8 +134,7 @@ SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(const uint8_t* frameData
         return true;
     });
 
-    Vector<uint8_t> buffer;
-    buffer.resize(spsPpsLength + 2);
+    Vector<uint8_t> buffer(spsPpsLength + 2);
 IGNORE_GCC_WARNINGS_BEGIN("restrict")
     // https://bugs.webkit.org/show_bug.cgi?id=246862
     std::memcpy(buffer.data(), frameData, spsPpsLength);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -127,6 +127,8 @@ AudioWorkletNode::AudioWorkletNode(BaseAudioContext& context, const String& name
     , m_name(name)
     , m_parameters(AudioParamMap::create())
     , m_port(WTFMove(port))
+    , m_inputs(options.numberOfInputs)
+    , m_outputs(options.numberOfOutputs)
     , m_wasOutputChannelCountGiven(!!options.outputChannelCount)
 {
     ASSERT(isMainThread());
@@ -134,9 +136,6 @@ AudioWorkletNode::AudioWorkletNode(BaseAudioContext& context, const String& name
         addInput();
     for (unsigned i = 0; i < options.numberOfOutputs; ++i)
         addOutput(options.outputChannelCount ? options.outputChannelCount->at(i): 1);
-
-    m_inputs.resize(options.numberOfInputs);
-    m_outputs.resize(options.numberOfOutputs);
 
     initialize();
 }

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -157,25 +157,25 @@ Vector<uint8_t> CryptoDigest::computeHash()
     Vector<uint8_t> result;
     switch (m_context->algorithm) {
     case CryptoDigest::Algorithm::SHA_1:
-        result.resize(CC_SHA1_DIGEST_LENGTH);
+        result.grow(CC_SHA1_DIGEST_LENGTH);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         CC_SHA1_Final(result.data(), toSHA1Context(m_context.get()));
 ALLOW_DEPRECATED_DECLARATIONS_END
         break;
     case CryptoDigest::Algorithm::SHA_224:
-        result.resize(CC_SHA224_DIGEST_LENGTH);
+        result.grow(CC_SHA224_DIGEST_LENGTH);
         CC_SHA224_Final(result.data(), toSHA224Context(m_context.get()));
         break;
     case CryptoDigest::Algorithm::SHA_256:
-        result.resize(CC_SHA256_DIGEST_LENGTH);
+        result.grow(CC_SHA256_DIGEST_LENGTH);
         CC_SHA256_Final(result.data(), toSHA256Context(m_context.get()));
         break;
     case CryptoDigest::Algorithm::SHA_384:
-        result.resize(CC_SHA384_DIGEST_LENGTH);
+        result.grow(CC_SHA384_DIGEST_LENGTH);
         CC_SHA384_Final(result.data(), toSHA384Context(m_context.get()));
         break;
     case CryptoDigest::Algorithm::SHA_512:
-        result.resize(CC_SHA512_DIGEST_LENGTH);
+        result.grow(CC_SHA512_DIGEST_LENGTH);
         CC_SHA512_Final(result.data(), toSHA512Context(m_context.get()));
         break;
     }

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -510,7 +510,6 @@ void DFABytecodeCompiler::compile()
     // Populate m_maxNodeStartOffsets with a worst-case index of where the node would be with no branch compaction.
     // Compacting the branches using 1-4 byte signed jump distances should only make nodes closer together than this.
     ASSERT(m_maxNodeStartOffsets.isEmpty());
-    m_maxNodeStartOffsets.clear();
     m_maxNodeStartOffsets.resize(m_dfa.nodes.size());
     unsigned rootActionsSize = 0;
     for (uint64_t action : m_dfa.nodes[m_dfa.root].actions(m_dfa))

--- a/Source/WebCore/contentextensions/NFAToDFA.cpp
+++ b/Source/WebCore/contentextensions/NFAToDFA.cpp
@@ -75,9 +75,8 @@ static inline void epsilonClosureExcludingSelf(const SerializedNFA& nfa, unsigne
 
 static NFANodeClosures resolveEpsilonClosures(const SerializedNFA& nfa)
 {
-    NFANodeClosures nfaNodeClosures;
     unsigned nfaGraphSize = nfa.nodes().size();
-    nfaNodeClosures.resize(nfaGraphSize);
+    NFANodeClosures nfaNodeClosures(nfaGraphSize);
 
     for (unsigned nodeId = 0; nodeId < nfaGraphSize; ++nodeId)
         epsilonClosureExcludingSelf(nfa, nodeId, nfaNodeClosures[nodeId]);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -548,11 +548,11 @@ void WebGLRenderingContextBase::initializeContextState()
 
     GCGLint numCombinedTextureImageUnits = m_context->getInteger(GraphicsContextGL::MAX_COMBINED_TEXTURE_IMAGE_UNITS);
     m_textureUnits.clear();
-    m_textureUnits.resize(numCombinedTextureImageUnits);
+    m_textureUnits.grow(numCombinedTextureImageUnits);
 
     GCGLint numVertexAttribs = m_context->getInteger(GraphicsContextGL::MAX_VERTEX_ATTRIBS);
     m_vertexAttribValue.clear();
-    m_vertexAttribValue.resize(numVertexAttribs);
+    m_vertexAttribValue.grow(numVertexAttribs);
 
     m_maxTextureSize = m_context->getInteger(GraphicsContextGL::MAX_TEXTURE_SIZE);
     m_maxTextureLevel = WebGLTexture::computeLevelCount(m_maxTextureSize, m_maxTextureSize);

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
@@ -56,7 +56,7 @@ WebGLTransformFeedback::~WebGLTransformFeedback()
 WebGLTransformFeedback::WebGLTransformFeedback(WebGL2RenderingContext& context, PlatformGLObject object)
     : WebGLObject(context, object)
 {
-    m_boundIndexedTransformFeedbackBuffers.resize(context.maxTransformFeedbackSeparateAttribs());
+    m_boundIndexedTransformFeedbackBuffers.grow(context.maxTransformFeedbackSeparateAttribs());
 }
 
 void WebGLTransformFeedback::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
@@ -39,7 +39,7 @@ WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase(WebGLRenderingContextBase
     : WebGLObject(context, object)
     , m_type(type)
 {
-    m_vertexAttribState.resize(context.maxVertexAttribs());
+    m_vertexAttribState.grow(context.maxVertexAttribs());
 }
 
 void WebGLVertexArrayObjectBase::setElementArrayBuffer(const AbstractLocker& locker, WebGLBuffer* buffer)

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -498,7 +498,7 @@ private:
     // separate buffer.
     String scanEscapedText()
     {
-        m_ucharBuffer.resize(0);
+        m_ucharBuffer.shrink(0);
         while (m_parsingBuffer.hasCharactersRemaining() && *m_parsingBuffer != '<') {
             if (*m_parsingBuffer == '&') {
                 scanHTMLCharacterReference(m_ucharBuffer);
@@ -528,7 +528,7 @@ private:
 
         if (m_parsingBuffer.atEnd() || !isCharAfterTagNameOrAttribute(*m_parsingBuffer)) {
             // Try parsing a case-insensitive tagName.
-            m_charBuffer.resize(0);
+            m_charBuffer.shrink(0);
             m_parsingBuffer.setPosition(start);
             while (m_parsingBuffer.hasCharactersRemaining()) {
                 auto c = *m_parsingBuffer;
@@ -564,7 +564,7 @@ private:
             // At this point name does not contain lowercase. It may contain upper-case,
             // which requires mapping. Assume it does.
             m_parsingBuffer.setPosition(start);
-            m_charBuffer.resize(0);
+            m_charBuffer.shrink(0);
             // isValidAttributeNameChar() returns false if end of input is reached.
             do {
                 auto c = m_parsingBuffer.consume();
@@ -623,7 +623,7 @@ private:
     AtomString scanEscapedAttributeValue()
     {
         skipWhile<isASCIIWhitespace>(m_parsingBuffer);
-        m_ucharBuffer.resize(0);
+        m_ucharBuffer.shrink(0);
         if (UNLIKELY(!m_parsingBuffer.hasCharactersRemaining() || !isQuoteCharacter(*m_parsingBuffer)))
             return didFail(HTMLFastPathResult::FailedParsingUnquotedEscapedAttributeValue, emptyAtom());
 
@@ -710,8 +710,8 @@ private:
 
     void parseAttributes(HTMLElement& parent)
     {
-        m_attributeBuffer.resize(0);
-        m_attributeNames.resize(0);
+        m_attributeBuffer.shrink(0);
+        m_attributeNames.shrink(0);
 
         bool hasDuplicateAttributes = false;
         while (true) {

--- a/Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp
@@ -387,8 +387,8 @@ FlexLayout::SizeList FlexLayout::computeMainSizeForFlexItems(const LogicalFlexIt
             //    its content-box size at zero. If the item's target main size was made smaller by this, it's a max violation.
             //    If the item's target main size was made larger by this, it's a min violation.
             auto totalViolation = LayoutUnit { };
-            minimumViolationList.resize(0);
-            maximumViolationList.resize(0);
+            minimumViolationList.shrink(0);
+            maximumViolationList.shrink(0);
             for (auto nonFrozenIndex : nonFrozenSet) {
                 auto unclampedMainSize = mainSizeList[nonFrozenIndex];
                 auto& flexItem = flexItems[nonFrozenIndex];

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -51,21 +51,18 @@ constexpr int kBufferSize = 1024;
 #endif
 
 Biquad::Biquad()
-{
-#if USE(ACCELERATE)
-    // Allocate two samples more for filter history
-    m_inputBuffer.resize(kBufferSize + 2);
-    m_outputBuffer.resize(kBufferSize + 2);
-#endif
-
     // Allocate enough space for the a-rate filter coefficients to handle a
     // rendering quantum of 128 frames.
-    m_b0.resize(AudioUtilities::renderQuantumSize);
-    m_b1.resize(AudioUtilities::renderQuantumSize);
-    m_b2.resize(AudioUtilities::renderQuantumSize);
-    m_a1.resize(AudioUtilities::renderQuantumSize);
-    m_a2.resize(AudioUtilities::renderQuantumSize);
-
+    : m_b0(AudioUtilities::renderQuantumSize)
+    , m_b1(AudioUtilities::renderQuantumSize)
+    , m_b2(AudioUtilities::renderQuantumSize)
+    , m_a1(AudioUtilities::renderQuantumSize)
+    , m_a2(AudioUtilities::renderQuantumSize)
+#if USE(ACCELERATE)
+    , m_inputBuffer(kBufferSize + 2) // Allocate two samples more for filter history
+    , m_outputBuffer(kBufferSize + 2) // Allocate two samples more for filter history
+#endif
+{
     // Initialize as pass-thru (straight-wire, no filter effect)
     setNormalizedCoefficients(0, 1, 0, 0, 1, 0, 0);
 

--- a/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
@@ -45,6 +45,7 @@ namespace WebCore {
 ReverbConvolverStage::ReverbConvolverStage(const float* impulseResponse, size_t, size_t reverbTotalLatency, size_t stageOffset, size_t stageLength,
     size_t fftSize, size_t renderPhase, size_t renderSliceSize, ReverbAccumulationBuffer* accumulationBuffer, float scale, bool directMode)
     : m_accumulationBuffer(accumulationBuffer)
+    , m_temporaryBuffer(renderSliceSize)
     , m_directMode(directMode)
 {
     ASSERT(impulseResponse);
@@ -71,7 +72,6 @@ ReverbConvolverStage::ReverbConvolverStage(const float* impulseResponse, size_t,
             VectorMath::multiplyByScalar(m_directKernel->data(), scale, m_directKernel->data(), stageLength);
         m_directConvolver = makeUnique<DirectConvolver>(renderSliceSize);
     }
-    m_temporaryBuffer.resize(renderSliceSize);
 
     // The convolution stage at offset stageOffset needs to have a corresponding delay to cancel out the offset.
     size_t totalDelay = stageOffset + reverbTotalLatency;

--- a/Source/WebCore/platform/graphics/FloatPolygon.cpp
+++ b/Source/WebCore/platform/graphics/FloatPolygon.cpp
@@ -86,11 +86,10 @@ static unsigned findNextEdgeVertexIndex(const FloatPolygon& polygon, unsigned ve
 FloatPolygon::FloatPolygon(Vector<FloatPoint>&& vertices, WindRule fillRule)
     : m_vertices(WTFMove(vertices))
     , m_fillRule(fillRule)
+    , m_empty(m_vertices.size() < 3)
+    , m_edges(m_vertices.size())
 {
     unsigned nVertices = numberOfVertices();
-    m_edges.resize(nVertices);
-    m_empty = nVertices < 3;
-
     if (nVertices)
         m_boundingBox.setLocation(vertexAt(0));
 
@@ -129,7 +128,7 @@ FloatPolygon::FloatPolygon(Vector<FloatPoint>&& vertices, WindRule fillRule)
         }
     }
 
-    m_edges.resize(edgeIndex);
+    m_edges.shrink(edgeIndex);
     m_empty = m_edges.size() < 3;
 
     if (m_empty)

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -359,11 +359,11 @@ public:
                 Vector<uint8_t> buffer;
                 if (!buffer.tryReserveInitialCapacity(numToRead))
                     return Status(Status::kNotEnoughMemory);
-                buffer.resize(numToRead);
+                buffer.grow(numToRead);
                 auto readResult = currentSegment.read(m_positionWithinSegment, numToRead, buffer.data());
                 if (!readResult.has_value())
                     return segmentReadErrorToWebmStatus(readResult.error());
-                buffer.resize(readResult.value());
+                buffer.shrink(readResult.value());
                 rawBlockBuffer = SharedBuffer::create(WTFMove(buffer));
             } else
                 rawBlockBuffer = sharedBuffer->getContiguousData(m_positionWithinSegment, numToRead);

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
@@ -164,8 +164,8 @@ struct nameTable {
 #pragma pack()
 
 EOTHeader::EOTHeader()
+    : m_buffer(sizeof(EOTPrefix))
 {
-    m_buffer.resize(sizeof(EOTPrefix));
 }
 
 void EOTHeader::updateEOTSize(size_t fontDataSize)
@@ -176,7 +176,7 @@ void EOTHeader::updateEOTSize(size_t fontDataSize)
 void EOTHeader::appendBigEndianString(const BigEndianUShort* string, unsigned short length)
 {
     size_t oldSize = m_buffer.size();
-    m_buffer.resize(oldSize + length + 2 * sizeof(unsigned short));
+    m_buffer.grow(oldSize + length + 2 * sizeof(unsigned short));
     UChar* dst = reinterpret_cast<UChar*>(m_buffer.data() + oldSize);
     unsigned i = 0;
     dst[i++] = length;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -480,15 +480,17 @@ bool BMPImageReader::processColorTable()
     // Read color table.
     if ((m_decodedOffset > m_data->size()) || ((m_data->size() - m_decodedOffset) < tableSizeInBytes))
         return false;
-    m_colorTable.resize(m_infoHeader.biClrUsed);
-    for (size_t i = 0; i < m_infoHeader.biClrUsed; ++i) {
-        m_colorTable[i].rgbBlue = m_data->data()[m_decodedOffset++];
-        m_colorTable[i].rgbGreen = m_data->data()[m_decodedOffset++];
-        m_colorTable[i].rgbRed = m_data->data()[m_decodedOffset++];
+    m_colorTable = Vector<RGBTriple>(m_infoHeader.biClrUsed, [&](size_t) {
+        RGBTriple triple {
+            .rgbBlue = m_data->data()[m_decodedOffset++],
+            .rgbGreen = m_data->data()[m_decodedOffset++],
+            .rgbRed = m_data->data()[m_decodedOffset++]
+        };
         // Skip padding byte (not present on OS/2 1.x).
         if (!m_isOS21x)
             ++m_decodedOffset;
-    }
+        return triple;
+    });
 
     // We've now decoded all the non-image data we care about.  Skip anything
     // else before the actual raster data.

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -329,7 +329,7 @@ JxlDecoderStatus JPEGXLImageDecoder::processInput(Query query)
             }
 
             if (m_currentFrame >= m_frameBufferCache.size())
-                m_frameBufferCache.resize(m_frameCount + 1);
+                m_frameBufferCache.grow(m_frameCount + 1);
 
             auto& buffer = m_frameBufferCache[m_currentFrame];
             if (buffer.isInvalid() && buffer.initialize(size(), m_premultiplyAlpha)) {

--- a/Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
@@ -206,7 +206,7 @@ bool AudioSampleBufferCompressor::initAudioConverterForSourceFormatDescription(C
 
     auto destinationBufferSize = computeBufferSizeForAudioFormat(m_destinationFormat, m_maxOutputPacketSize, LOW_WATER_TIME_IN_SECONDS);
     if (m_destinationBuffer.size() < destinationBufferSize)
-        m_destinationBuffer.resize(destinationBufferSize);
+        m_destinationBuffer.grow(destinationBufferSize);
     if (!m_destinationFormat.mBytesPerPacket)
         m_destinationPacketDescriptions.resize(m_destinationBuffer.capacity() / m_maxOutputPacketSize);
 
@@ -284,7 +284,7 @@ RetainPtr<CMSampleBufferRef> AudioSampleBufferCompressor::sampleBufferWithNumPac
 
         auto error = PAL::AudioConverterGetPropertyInfo(m_converter, kAudioConverterCompressionMagicCookie, &cookieSize, NULL);
         if ((error == noErr) && !!cookieSize) {
-            cookie.resize(cookieSize);
+            cookie.grow(cookieSize);
 
             if (auto error = PAL::AudioConverterGetProperty(m_converter, kAudioConverterCompressionMagicCookie, &cookieSize, cookie.data())) {
                 RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferCompressor getting kAudioConverterCompressionMagicCookie failed with %d", error);
@@ -349,7 +349,7 @@ OSStatus AudioSampleBufferCompressor::provideSourceDataNumOutputPackets(UInt32* 
         size_t currentOffsetInSourceBuffer = 0;
 
         if (m_sourceBuffer.size() < numBytesToCopy)
-            m_sourceBuffer.resize(numBytesToCopy);
+            m_sourceBuffer.grow(numBytesToCopy);
 
         while (numBytesToCopy) {
             if (m_sampleBlockBufferSize <= m_currentOffsetInSampleBlockBuffer) {
@@ -398,7 +398,7 @@ OSStatus AudioSampleBufferCompressor::provideSourceDataNumOutputPackets(UInt32* 
     ASSERT(m_sourceFormat.mFormatFlags & kAudioFormatFlagIsNonInterleaved);
 
     if (m_sourceBuffer.size() < 2 * numBytesToCopy)
-        m_sourceBuffer.resize(2 * numBytesToCopy);
+        m_sourceBuffer.grow(2 * numBytesToCopy);
     auto* firstChannel = m_sourceBuffer.data();
     auto* secondChannel = m_sourceBuffer.data() + numBytesToCopy;
 

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -76,8 +76,8 @@ void GridMasonryLayout::collectMasonryItems()
 {
     ASSERT(m_gridAxisTracksCount);
     m_firstTrackItems.clear();
-    m_itemsWithDefiniteGridAxisPosition.resize(0);
-    m_itemsWithIndefiniteGridAxisPosition.resize(0);
+    m_itemsWithDefiniteGridAxisPosition.shrink(0);
+    m_itemsWithIndefiniteGridAxisPosition.shrink(0);
 
     auto& grid = m_renderGrid.currentGrid();
     for (auto* child = grid.orderIterator().first(); child; child = grid.orderIterator().next()) {

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1374,7 +1374,7 @@ void RenderTableSection::removeRedundantColumns()
     for (auto& rowItem : m_grid) {
         if (rowItem.row.size() <= maximumNumberOfColumns)
             continue;
-        rowItem.row.resize(maximumNumberOfColumns);
+        rowItem.row.shrink(maximumNumberOfColumns);
     }
 }
 

--- a/Source/WebCore/rendering/shapes/RasterShape.cpp
+++ b/Source/WebCore/rendering/shapes/RasterShape.cpp
@@ -48,11 +48,11 @@ private:
 };
 
 MarginIntervalGenerator::MarginIntervalGenerator(unsigned radius)
-    : m_y(0)
+    : m_xIntercepts(radius + 1)
+    , m_y(0)
     , m_x1(0)
     , m_x2(0)
 {
-    m_xIntercepts.resize(radius + 1);
     unsigned radiusSquared = radius * radius;
     for (unsigned y = 0; y <= radius; y++)
         m_xIntercepts[y] = sqrt(static_cast<double>(radiusSquared - y * y));

--- a/Source/WebCore/rendering/shapes/RasterShape.h
+++ b/Source/WebCore/rendering/shapes/RasterShape.h
@@ -41,9 +41,9 @@ class RasterShapeIntervals {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit RasterShapeIntervals(unsigned size, int offset = 0)
-        : m_offset(offset)
+        : m_intervals(clampTo<int>(size))
+        , m_offset(offset)
     {
-        m_intervals.resize(clampTo<int>(size));
     }
 
     void initializeBounds();

--- a/Source/WebDriver/socket/HTTPParser.cpp
+++ b/Source/WebDriver/socket/HTTPParser.cpp
@@ -105,8 +105,7 @@ HTTPParser::Process HTTPParser::abortProcess(const char* message)
 
     m_phase = Phase::Error;
 
-    if (!m_buffer.isEmpty())
-        m_buffer.resize(0);
+    m_buffer.shrink(0);
 
     return Process::Suspend;
 }

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -47,8 +47,7 @@ NetworkNotificationManager::NetworkNotificationManager(NetworkSession& networkSe
 #if PLATFORM(COCOA)
         auto token = m_networkSession.networkProcess().parentProcessConnection()->getAuditToken();
         if (token) {
-            Vector<uint8_t> auditTokenData;
-            auditTokenData.resize(sizeof(*token));
+            Vector<uint8_t> auditTokenData(sizeof(*token));
             memcpy(auditTokenData.data(), &(*token), sizeof(*token));
             configuration.hostAppAuditTokenData = WTFMove(auditTokenData);
         }

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -210,14 +210,11 @@ static std::optional<Vector<char>> fileContents(const String& path, bool shouldL
 
     char chunk[4096];
     constexpr size_t chunkSize = std::size(chunk);
-    size_t contentSize = 0;
     Vector<char> contents;
     contents.reserveInitialCapacity(chunkSize);
-    while (size_t bytesRead = file.read(chunk, chunkSize)) {
+    while (size_t bytesRead = file.read(chunk, chunkSize))
         contents.append(chunk, bytesRead);
-        contentSize += bytesRead;
-    }
-    contents.resize(contentSize);
+    contents.shrinkToFit();
 
     return contents;
 }

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
@@ -38,12 +38,11 @@ UIGamepad::UIGamepad(WebCore::PlatformGamepad& platformGamepad)
     : m_index(platformGamepad.index())
     , m_id(platformGamepad.id())
     , m_mapping(platformGamepad.mapping())
+    , m_axisValues(platformGamepad.axisValues().size())
+    , m_buttonValues(platformGamepad.buttonValues().size())
     , m_lastUpdateTime(platformGamepad.lastUpdateTime())
     , m_supportedEffectTypes(platformGamepad.supportedEffectTypes())
 {
-    m_axisValues.resize(platformGamepad.axisValues().size());
-    m_buttonValues.resize(platformGamepad.buttonValues().size());
-
     updateFromPlatformGamepad(platformGamepad);
 }
 

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
@@ -108,7 +108,7 @@ bool UserMediaProcessManager::willCreateMediaStream(UserMediaPermissionRequestMa
         SandboxExtension::Handle machBootstrapExtension;
 
         if (!proxy.page().preferences().mockCaptureDevicesEnabled()) {
-            handles.resize(extensionCount);
+            handles.grow(extensionCount);
             ids.reserveInitialCapacity(extensionCount);
 
             if (needsAudioSandboxExtension) {

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -87,7 +87,7 @@ private:
             // filling in the actual rects for the one that we received.
             // The rest will remain empty, but it's important to NSTextFinder
             // that they at least exist.
-            allMatches.resize(matchCount);
+            allMatches.grow(matchCount);
             // FIXME: Clean this up and figure out why we are getting a -1 index
             if (matchIndex >= 0 && static_cast<uint32_t>(matchIndex) < matchCount)
                 allMatches[matchIndex].appendVector(matchRects);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -363,7 +363,7 @@ auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPre
         // GPU Process crashed. Set the output data to all null buffers, requiring a full display.
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::prepareBuffersForDisplay - prepareBuffersForDisplay returned error: %" PUBLIC_LOG_STRING,
             m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::errorAsString(sendResult.error));
-        outputData.resize(inputData.size());
+        outputData.grow(inputData.size());
         for (auto& perLayerOutputData : outputData)
             perLayerOutputData.displayRequirement = SwapBuffersDisplayRequirement::NeedsFullDisplay;
     } else

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
@@ -37,13 +37,13 @@ namespace WebKit {
 
 WebGamepad::WebGamepad(const GamepadData& gamepadData)
     : PlatformGamepad(gamepadData.index())
+    , m_axisValues(gamepadData.axisValues().size())
+    , m_buttonValues(gamepadData.buttonValues().size())
 {
     LOG(Gamepad, "Connecting WebGamepad %u", gamepadData.index());
 
     m_id = gamepadData.id();
     m_mapping = gamepadData.mapping();
-    m_axisValues.resize(gamepadData.axisValues().size());
-    m_buttonValues.resize(gamepadData.buttonValues().size());
     m_supportedEffectTypes = gamepadData.supportedEffectTypes();
 
     updateValues(gamepadData);

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -82,8 +82,8 @@ void WebGamepadProvider::gamepadConnected(const GamepadData& gamepadData, EventM
 
     auto oldGamepadsSize = m_gamepads.size();
     if (m_gamepads.size() <= gamepadData.index()) {
-        m_gamepads.resize(gamepadData.index() + 1);
-        m_rawGamepads.resize(gamepadData.index() + 1);
+        m_gamepads.grow(gamepadData.index() + 1);
+        m_rawGamepads.grow(gamepadData.index() + 1);
     }
     WP_MESSAGE_CHECK((!m_gamepads[gamepadData.index()]), oldGamepadsSize, gamepadData.index(), m_gamepads.size());
 


### PR DESCRIPTION
#### a544a2189b62dab2a7b73034a3f298508619c448
<pre>
Use faster alternatives to Vector::resize() when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=265423">https://bugs.webkit.org/show_bug.cgi?id=265423</a>

Reviewed by Darin Adler.

Use faster alternatives to Vector::resize() when possible. It involves calling
directly Vector::shrink(), Vector::grow() or a Vector constructor.

* Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp:
(JSC::B3::eliminateDeadCodeImpl):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/bytecode/BytecodeDumper.cpp:
(JSC::CodeBlockBytecodeDumper&lt;Block&gt;::dumpGraph):
* Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp:
(JSC::BytecodeGeneratorification::BytecodeGeneratorification):
(JSC::BytecodeGeneratorification::storageForGeneratorLocal):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp:
(JSC::DFG::CPSRethreadingPhase::freeUnnecessaryNodes):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/interpreter/ShadowChicken.cpp:
(JSC::ShadowChicken::update):
* Source/JavaScriptCore/jit/CallFrameShuffleData.cpp:
(JSC::CallFrameShuffleData::createForBaselineOrLLIntTailCall):
* Source/JavaScriptCore/jit/CallFrameShuffler.h:
(JSC::CallFrameShuffler::snapshot const):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::formatTimeZoneOffsetString):
(JSC::ISO8601::temporalTimeToString):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::availableCollations):
(JSC::availableCurrencies):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sort):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncSortImpl):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignFast):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::matchCompareWithInterpreter):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::bind):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addBlankSpace):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addRawValue):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addCondensedLocalIndexAndLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128V128Constant):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::finalize):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::compute):
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::UpconvertedCharacters::UpconvertedCharacters):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp:
(WebCore::CompressionStreamEncoder::compress):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decompressZlib):
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::FetchHeaders::Iterator::next):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(WebCore::RTCRtpSFrameTransformer::encryptFrame):
* Source/WebCore/Modules/mediastream/SFrameUtils.cpp:
(WebCore::computeH264PrefixBuffer):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::AudioWorkletNode):
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
(PAL::CryptoDigest::computeHash):
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
(WebCore::ContentExtensions::DFABytecodeCompiler::compile):
* Source/WebCore/contentextensions/NFAToDFA.cpp:
(WebCore::ContentExtensions::resolveEpsilonClosures):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
* Source/WebCore/html/canvas/WebGLTransformFeedback.cpp:
(WebCore::WebGLTransformFeedback::WebGLTransformFeedback):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanEscapedText):
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::scanAttributeName):
(WebCore::HTMLFastPathParser::scanEscapedAttributeValue):
(WebCore::HTMLFastPathParser::parseAttributes):
* Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp:
(WebCore::Layout::FlexLayout::computeMainSizeForFlexItems const):
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::Biquad):
* Source/WebCore/platform/audio/ReverbConvolverStage.cpp:
(WebCore::ReverbConvolverStage::ReverbConvolverStage):
* Source/WebCore/platform/graphics/FloatPolygon.cpp:
(WebCore::FloatPolygon::FloatPolygon):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
* Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp:
(WebCore::EOTHeader::EOTHeader):
(WebCore::EOTHeader::appendBigEndianString):
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
(WebCore::BMPImageReader::processColorTable):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::processInput):
* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm:
(WebCore::AudioSampleBufferCompressor::initAudioConverterForSourceFormatDescription):
(WebCore::AudioSampleBufferCompressor::sampleBufferWithNumPackets):
(WebCore::AudioSampleBufferCompressor::provideSourceDataNumOutputPackets):
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::collectMasonryItems):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::removeRedundantColumns):
* Source/WebCore/rendering/shapes/RasterShape.cpp:
(WebCore::MarginIntervalGenerator::MarginIntervalGenerator):
* Source/WebCore/rendering/shapes/RasterShape.h:
(WebCore::RasterShapeIntervals::RasterShapeIntervals):
* Source/WebDriver/socket/HTTPParser.cpp:
(WebDriver::HTTPParser::abortProcess):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::NetworkNotificationManager):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::fileContents):
* Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp:
(WebKit::UIGamepad::UIGamepad):
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::willCreateMediaStream):
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp:
(WebKit::WebGamepad::WebGamepad):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::gamepadConnected):

Canonical link: <a href="https://commits.webkit.org/271370@main">https://commits.webkit.org/271370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26626e84d8b3a6247cf57bc28be26d0ff4750291

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28181 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4205 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4850 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31399 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24380 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25678 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27292 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3147 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6517 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34802 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6747 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5406 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7535 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->