### PR TITLE
[WebRTC] Release assertion in webrtc::RtpPacketizerH264::PacketizeSingleNalu on bad input

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
@@ -240,7 +240,13 @@ bool RtpPacketizerH264::PacketizeSingleNalu(size_t fragment_index) {
                       << limits_.max_payload_len;
     return false;
   }
+#ifdef WEBRTC_WEBKIT_BUILD
+  if (fragment.size() == 0u) {
+    return false;
+  }
+#else
   RTC_CHECK_GT(fragment.size(), 0u);
+#endif
   packets_.push(PacketUnit(fragment, true /* first */, true /* last */,
                            false /* aggregated */, fragment[0]));
   ++num_packets_left_;

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Release-assertion-in-webrtc-RtpPacketizerH264-PacketizeSingleNalu.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Release-assertion-in-webrtc-RtpPacketizerH264-PacketizeSingleNalu.patch
@@ -1,0 +1,18 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
+index cc8d1bff34b0..c5f462ec0504 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
+@@ -221,7 +221,13 @@ bool RtpPacketizerH264::PacketizeSingleNalu(size_t fragment_index) {
+                       << limits_.max_payload_len;
+     return false;
+   }
++#ifdef WEBRTC_WEBKIT_BUILD
++  if (fragment.size() == 0u) {
++    return false;
++  }
++#else
+   RTC_CHECK_GT(fragment.size(), 0u);
++#endif
+   packets_.push(PacketUnit(fragment, true /* first */, true /* last */,
+                            false /* aggregated */, fragment[0]));
+   ++num_packets_left_;


### PR DESCRIPTION
#### 5755e4b0e62818d53637554c343585fc19e17a1e
<pre>
[WebRTC] Release assertion in webrtc::RtpPacketizerH264::PacketizeSingleNalu on bad input
<a href="https://bugs.webkit.org/show_bug.cgi?id=265427">https://bugs.webkit.org/show_bug.cgi?id=265427</a>
&lt;<a href="https://rdar.apple.com/118861718">rdar://118861718</a>&gt;

Reviewed by Youenn Fablet.

Change release assertion into a runtime check to avoid a crash.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc:
(webrtc::RtpPacketizerH264::PacketizeSingleNalu):
- Return false instead of crashing if fragment.size() == 0u.

* Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Release-assertion-in-webrtc-RtpPacketizerH264-PacketizeSingleNalu.patch: Add.

Canonical link: <a href="https://commits.webkit.org/271216@main">https://commits.webkit.org/271216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b767e18b59242e2476ba358cddb67298e899371

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29858 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25265 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25030 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23710 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4367 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30663 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28626 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5017 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3580 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->