### PR TITLE
Add a "Media" WebInspector Element details panel

### DIFF
--- a/LayoutTests/inspector/dom/getMediaStats-expected.txt
+++ b/LayoutTests/inspector/dom/getMediaStats-expected.txt
@@ -1,0 +1,18 @@
+
+
+== Running test suite: DOM.getMediaStats
+-- Running test case: GetMediaStats-InvalidElement
+PASS: Should produce an exception.
+Error: Node for given nodeId is not a media element
+
+-- Running test case: GetMediaStats-EmptyVideo
+PASS: Did not throw when calling getMediaStats on video#emptyVideo
+PASS: Empty Video elements should not provide a stats.video
+PASS: Empty Video elements should not provide a stats.audio
+
+-- Running test case: GetMediaStats-ValidVideo
+PASS: Did not throw when calling getMediaStats on video#validVideo
+PASS: Empty Audio elements should not have empty stats.video
+PASS: Empty Audio elements should not have empty stats.video.codec
+PASS: Empty Audio elements should not have empty stats.video.humanReadableCodecString
+

--- a/LayoutTests/inspector/dom/getMediaStats.html
+++ b/LayoutTests/inspector/dom/getMediaStats.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("DOM.getMediaStats");
+
+    suite.addTestCase({
+        name: "GetMediaStats-InvalidElement",
+        description: "Call GetMediaStats on an invalid element.",
+        async test() {
+            let documentNode = await WI.domManager.requestDocument();
+            let nodeId = await documentNode.querySelector("#notAVideo");
+            let domNode = WI.domManager.nodeForId(nodeId);
+            InspectorTest.assert(domNode, "DOMNode exists");
+            await InspectorTest.expectException(async () => {
+                let stats = await domNode.getMediaStats();
+            });
+        }
+    });
+
+    suite.addTestCase({
+        name: "GetMediaStats-EmptyVideo",
+        description: "Call GetMediaStats on an empty Video element.",
+        async test() {
+            let documentNode = await WI.domManager.requestDocument();
+            let nodeId = await documentNode.querySelector("#emptyVideo");
+            let domNode = WI.domManager.nodeForId(nodeId);
+            InspectorTest.assert(domNode, "DOMNode exists");
+            let stats = await domNode.getMediaStats();
+            InspectorTest.log("PASS: Did not throw when calling getMediaStats on video#emptyVideo");
+            InspectorTest.expectFalse("video" in stats, "Empty Video elements should not provide a stats.video");
+            InspectorTest.expectFalse("audio" in stats, "Empty Video elements should not provide a stats.audio");
+        }
+    });
+
+    suite.addTestCase({
+        name: "GetMediaStats-ValidVideo",
+        description: "Call GetMediaStats on an loaded Video element.",
+        test: async () => {
+            let documentNode = await WI.domManager.requestDocument();
+            let nodeId = await documentNode.querySelector("#validVideo");
+            let domNode = WI.domManager.nodeForId(nodeId);
+            InspectorTest.assert(domNode, "DOMNode exists");
+            let stats = await domNode.getMediaStats();
+            InspectorTest.log("PASS: Did not throw when calling getMediaStats on video#validVideo");
+            InspectorTest.expectNotEqual(stats.video, undefined, "Empty Audio elements should not have empty stats.video");
+            InspectorTest.expectNotEqual(stats.video.codec, "", "Empty Audio elements should not have empty stats.video.codec");
+            InspectorTest.expectNotEqual(stats.video.humanReadableCodecString, "", "Empty Audio elements should not have empty stats.video.humanReadableCodecString");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <div id=notAVideo></div>
+    <video controls id=emptyVideo></video>
+    <video controls id=validVideo>
+        <source src="../../media/content/test.mp4" type="video/mp4">
+        <source src="../../media/content/test.webm" type="video/webm">
+    </video>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -199,6 +199,74 @@
                 { "name": "pseudoId", "$ref": "CSS.PseudoId", "optional": true }
             ],
             "description": "An object referencing a node and a pseudo-element, primarily used to identify an animation effect target."
+        },
+        {
+            "id": "MediaStats",
+            "type": "object",
+            "description": "A structure holding media element statistics and configurations.",
+            "properties": [
+                { "name": "audio", "$ref": "AudioMediaStats", "optional": true },
+                { "name": "video", "$ref": "VideoMediaStats", "optional": true },
+                { "name": "devicePixelRatio", "type": "number", "optional": true, "description": "The ratio between physical screen pixels and CSS pixels." },
+                { "name": "viewport", "$ref": "ViewportSize", "optional": true, "description": "The viewport size occupied by the media element." },
+                { "name": "quality", "$ref": "VideoPlaybackQuality", "optional": true },
+                { "name": "source", "type": "string", "optional": true, "description": "The source type of the media element." }
+            ]
+        },
+        {
+            "id": "AudioMediaStats",
+            "type": "object",
+            "description": "A structure holding media element's audio-specific statistics and configurations.",
+            "properties": [
+                { "name": "bitrate", "type": "integer", "description": "The data rate of the primary audio track in bits/s." },
+                { "name": "codec", "type": "string", "description": "The codec string of the primary audio track. (E.g., \"hvc1.1.6.L123.B0\")" },
+                { "name": "humanReadableCodecString", "type": "string", "description": "A human readable version of the `codec` parameter."},
+                { "name": "numberOfChannels", "type": "integer", "description": "The number of audio channels in the primary audio track." },
+                { "name": "sampleRate", "type": "number", "description": "The sample rate of the primary audio track in hertz." }
+            ]
+        },
+        {
+            "id": "VideoMediaStats",
+            "type": "object",
+            "description": "A structure holding media element's audio-specific statistics and configurations.",
+            "properties": [
+                { "name": "bitrate", "type": "integer", "description": "The data rate of the video track in bits/s." },
+                { "name": "codec", "type": "string", "description": "The codec string of the video track. (E.g., \"hvc1.1.6.L123.B0\")" },
+                { "name": "humanReadableCodecString", "type": "string", "description": "A human readable version of the `codec` parameter."},
+                { "name": "colorSpace", "$ref": "VideoColorSpace" },
+                { "name": "framerate", "type": "number", "description": "The nominal frame rate of video track in frames per second." },
+                { "name": "height", "type": "integer", "description": "The native height of the video track in CSS pixels" },
+                { "name": "width", "type": "integer", "description": "The native width of the video track in CSS pixels" }
+            ]
+        },
+        {
+            "id": "VideoColorSpace",
+            "type": "object",
+            "description": "WebCodecs VideoColorSpace",
+            "properties": [
+                { "name": "fullRange", "type": "boolean", "optional": true, "description": "A flag indicating whether the colorspace is Full range (true) or Video range (false)" },
+                { "name": "matrix", "type": "string", "optional": true, "description": "The matrix specification of the colorspace" },
+                { "name": "primaries", "type": "string", "optional": true, "description": "The color primaries specification of the colorspace" },
+                { "name": "transfer", "type": "string", "optional": true, "description": "The transfer function specification of the colorspace" }
+            ]
+        },
+        {
+            "id": "VideoPlaybackQuality",
+            "type": "object",
+            "description": "A count of frames enqueued for display by the media element, and a subset count of dropped and display composited frames.",
+            "properties": [
+                { "name": "displayCompositedVideoFrames", "type": "integer", "description": "The number of frames of the total which were composited by the display." },
+                { "name": "droppedVideoFrames", "type": "integer", "description": "The number of frames of the total which were dropped without being displayed." },
+                { "name": "totalVideoFrames", "type": "integer", "description": "The total number of frames enqueued for display by the media element." }
+            ]
+        },
+        {
+            "id": "ViewportSize",
+            "type": "object",
+            "properties": [
+                { "name": "width", "type": "number" },
+                { "name": "height", "type": "number" }
+            ]
         }
     ],
     "commands": [
@@ -694,6 +762,16 @@
             "targetTypes": ["page"],
             "parameters": [
                 { "name": "allow", "type": "boolean" }
+            ]
+        },
+        {
+            "name": "getMediaStats",
+            "description": "Returns media stats for the selected node.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve mediastats for." }
+            ],
+            "returns": [
+                { "name": "mediaStats", "$ref": "MediaStats", "description": "An interleaved array of node attribute names and values." }
             ]
         }
     ],

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -61,6 +61,12 @@ struct MainThreadAccessTraits;
 struct ObjectIdentifierMainThreadAccessTraits;
 struct ObjectIdentifierThreadSafeAccessTraits;
 
+namespace JSONImpl {
+class Array;
+class Object;
+template<typename> class ArrayOf;
+}
+
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 struct VectorBufferMalloc;
 #else
@@ -127,6 +133,10 @@ template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> cl
 using GenericPromise = NativePromise<void, void>;
 using GenericNonExclusivePromise = NativePromise<void, void, 1>;
 template<typename T> class NativePromiseRequest;
+}
+
+namespace JSON {
+using namespace WTF::JSONImpl;
 }
 
 namespace std {

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -756,29 +756,8 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 
 auto MediaControlsHost::sourceType() const -> std::optional<SourceType>
 {
-    if (!m_mediaElement)
-        return std::nullopt;
-
-    if (m_mediaElement->hasMediaStreamSource())
-        return SourceType::MediaStream;
-
-#if ENABLE(MEDIA_SOURCE)
-    if (m_mediaElement->hasManagedMediaSource())
-        return SourceType::ManagedMediaSource;
-
-    if (m_mediaElement->hasMediaSource())
-        return SourceType::MediaSource;
-#endif
-
-    switch (m_mediaElement->movieLoadType()) {
-    case HTMLMediaElement::MovieLoadType::Unknown: return std::nullopt;
-    case HTMLMediaElement::MovieLoadType::Download: return SourceType::File;
-    case HTMLMediaElement::MovieLoadType::StoredStream: return SourceType::LiveStream;
-    case HTMLMediaElement::MovieLoadType::LiveStream: return SourceType::StoredStream;
-    case HTMLMediaElement::MovieLoadType::HttpLiveStream: return SourceType::HLS;
-    }
-
-    ASSERT_NOT_REACHED();
+    if (m_mediaElement)
+        return m_mediaElement->sourceType();
     return std::nullopt;
 }
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "HTMLMediaElement.h"
 #include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -104,16 +105,7 @@ public:
     bool showMediaControlsContextMenu(HTMLElement&, String&& optionsJSONString, Ref<VoidCallback>&&);
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 
-    enum class SourceType : uint8_t {
-        File,
-        HLS,
-        MediaSource,
-        ManagedMediaSource,
-        MediaStream,
-        LiveStream,
-        StoredStream,
-    };
-
+    using SourceType = HTMLMediaElement::SourceType;
     std::optional<SourceType> sourceType() const;
 #endif // ENABLE(MODERN_MEDIA_CONTROLS)
 

--- a/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp
+++ b/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(VIDEO)
 
 #include "MediaPlayer.h"
+#include <wtf/JSONValues.h>
 
 namespace WebCore {
 
@@ -45,6 +46,20 @@ VideoPlaybackQuality::VideoPlaybackQuality(double creationTime, const VideoPlayb
     , m_displayCompositedVideoFrames(metrics.displayCompositedVideoFrames)
     , m_totalFrameDelay(metrics.totalFrameDelay)
 {
+}
+
+Ref<JSON::Object> VideoPlaybackQuality::toJSONObject() const
+{
+    Ref json = JSON::Object::create();
+
+    json->setDouble("creationTime"_s, m_creationTime);
+    json->setInteger("totalVideoFrames"_s, m_totalVideoFrames);
+    json->setInteger("droppedVideoFrames"_s, m_droppedVideoFrames);
+    json->setInteger("corruptedVideoFrames"_s, m_corruptedVideoFrames);
+    json->setInteger("displayCompositedVideoFrames"_s, m_displayCompositedVideoFrames);
+    json->setDouble("totalFrameDelay"_s, m_totalFrameDelay);
+
+    return json;
 }
 
 }

--- a/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.h
+++ b/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.h
@@ -46,6 +46,8 @@ public:
     unsigned displayCompositedVideoFrames() const { return m_displayCompositedVideoFrames; }
     double totalFrameDelay() const { return m_totalFrameDelay; }
 
+    Ref<JSON::Object> toJSONObject() const;
+
 private:
     VideoPlaybackQuality(double creationTime, const VideoPlaybackQualityMetrics&);
 

--- a/Source/WebCore/Modules/webcodecs/VideoColorSpace.cpp
+++ b/Source/WebCore/Modules/webcodecs/VideoColorSpace.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VideoColorSpace.h"
+
+#if ENABLE(VIDEO)
+
+#include "JSVideoColorPrimaries.h"
+#include "JSVideoMatrixCoefficients.h"
+#include "JSVideoTransferCharacteristics.h"
+#include <wtf/JSONValues.h>
+
+namespace WebCore {
+
+Ref<JSON::Object> VideoColorSpace::toJSON() const
+{
+    Ref json = JSON::Object::create();
+
+    if (auto& primaries = this->primaries())
+        json->setString("primaries"_s, convertEnumerationToString(*primaries));
+    if (auto& transfer = this->transfer())
+        json->setString("transfer"_s, convertEnumerationToString(*transfer));
+    if (auto& matrix = this->matrix())
+        json->setString("matrix"_s, convertEnumerationToString(*matrix));
+    if (auto& fullRange = this->fullRange())
+        json->setBoolean("fullRange"_s, *fullRange);
+
+    return json;
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/VideoColorSpace.h
+++ b/Source/WebCore/Modules/webcodecs/VideoColorSpace.h
@@ -32,6 +32,7 @@
 #include "VideoMatrixCoefficients.h"
 #include "VideoTransferCharacteristics.h"
 #include <wtf/FastMalloc.h>
+#include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -58,6 +59,8 @@ public:
     void setfFullRange(std::optional<bool>&& fullRange) { m_state.fullRange = WTFMove(fullRange); }
 
     VideoColorSpaceInit state() const { return m_state; }
+
+    Ref<JSON::Object> toJSON() const;
 
 private:
     VideoColorSpace() = default;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -439,6 +439,7 @@ Modules/webauthn/fido/FidoParsingUtils.cpp
 Modules/webauthn/fido/Pin.cpp
 Modules/webauthn/fido/U2fCommandConstructor.cpp
 Modules/webauthn/fido/U2fResponseConverter.cpp
+Modules/webcodecs/VideoColorSpace.cpp
 Modules/webcodecs/WebCodecsAudioDecoder.cpp
 Modules/webcodecs/WebCodecsAudioData.cpp
 Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
@@ -1610,6 +1611,7 @@ html/shadow/SpinButtonElement.cpp
 html/shadow/TextControlInnerElements.cpp
 html/shadow/TextPlaceholderElement.cpp
 html/track/AudioTrack.cpp
+html/track/AudioTrackConfiguration.cpp
 html/track/AudioTrackList.cpp
 html/track/BufferedLineReader.cpp
 html/track/DataCue.cpp
@@ -1631,6 +1633,7 @@ html/track/VTTRegion.cpp
 html/track/VTTRegionList.cpp
 html/track/VTTScanner.cpp
 html/track/VideoTrack.cpp
+html/track/VideoTrackConfiguration.cpp
 html/track/VideoTrackList.cpp
 html/track/WebVTTElement.cpp
 html/track/WebVTTParser.cpp
@@ -2224,6 +2227,7 @@ platform/graphics/BifurcatedGraphicsContext.cpp
 platform/graphics/BitmapImage.cpp
 platform/graphics/ByteArrayPixelBuffer.cpp
 platform/graphics/CachedSubimage.cpp
+platform/graphics/CodecUtilities.cpp
 platform/graphics/Color.cpp
 platform/graphics/ColorBlending.cpp
 platform/graphics/ColorConversion.cpp

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -85,6 +85,9 @@
 /* Label to describe the number of files selected in a file upload control that allows multiple files */
 "%d files" = "%d files";
 
+/* Codec Level (Codec Strings) */
+"%d.%d" = "%d.%d";
+
 /* label next to file upload control; parameters are the number of photos and the number of videos */
 "%lu photo(s) and %lu video(s)" = "%lu photo(s) and %lu video(s)";
 
@@ -129,6 +132,15 @@
 
 /* WKErrorJavaScriptExceptionOccurred description */
 "A JavaScript exception occurred" = "A JavaScript exception occurred";
+
+/* Codec Strings */
+"AAC-LC Codec String" = "AAC-LC";
+
+/* Codec Strings */
+"AV1 (Codec String)" = "AV1";
+
+/* Codec Strings */
+"AVC (Codec String)" = "AVC";
 
 /* Actual Size context menu item */
 "Actual Size" = "Actual Size";
@@ -202,6 +214,9 @@
 /* Message for user microphone access prompt */
 "Allow “%@” to use your microphone?" = "Allow “%@” to use your microphone?";
 
+/* Informative text for requesting cross-site cookie and website data access. */
+"Allowing access to website data is necessary for the website to work correctly." = "Allowing access to website data is necessary for the website to work correctly.";
+
 /* WKWebExtensionErrorUnknown description */
 "An unknown error has occurred." = "An unknown error has occurred.";
 
@@ -219,6 +234,9 @@
 
 /* Label for the plain Apple Pay button. */
 "Apple Pay" = "Apple Pay";
+
+/* Message for requesting cross-site cookie and website data access. */
+"Are you logging in to this website, and do you want to allow other %@ sites access to your website data while browsing the websites listed below?" = "Are you logging in to this website, and do you want to allow other %@ sites access to your website data while browsing the websites listed below?";
 
 /* Malware confirmation dialog title */
 "Are you sure you wish to go to this site?" = "Are you sure you wish to go to this site?";
@@ -240,6 +258,9 @@
 
 /* Back context menu item */
 "Back" = "Back";
+
+/* Codec Strings */
+"Baseline Profile (AVC Codec Profile)" = "Baseline Profile";
 
 /* Label text to be used if plugin is blocked by a page's Content Security Policy */
 "Blocked Plug-In (Blocked by page's Content Security Policy)" = "Blocked Plug-in";
@@ -424,14 +445,8 @@
 /* Message for requesting cross-site cookie and website data access. */
 "Do you want to allow “%@” to use cookies and website data while browsing “%@”?" = "Do you want to allow “%@” to use cookies and website data while browsing “%@”?";
 
-/* Message for requesting cross-site cookie and website data access. */
-"Are you logging in to this website, and do you want to allow other %@ sites access to your website data while browsing the websites listed below?" = "Are you logging in to this website, and do you want to allow other %@ sites access to your website data while browsing the websites listed below?";
-
-/* Informative text for requesting cross-site cookie and website data access. */
-"Allowing access to website data is necessary for the website to work correctly." = "Allowing access to website data is necessary for the website to work correctly.";
-
-/* Accessory text for requesting cross-site cookie and website data access. */
-"While you are visiting %@, the following related websites will gain access to their cookies:\n  - %@" = "While you are visiting %@, the following related websites will gain access to their cookies:\n  - %@";
+/* Codec Strings */
+"Dolby Vision Codec String" = "Dolby Vision";
 
 /* Label for the donate with Apple Pay button. */
 "Donate with Apple Pay" = "Donate with Apple Pay";
@@ -565,6 +580,9 @@
 /* menu item */
 "Exit Picture in Picture" = "Exit Picture in Picture";
 
+/* Codec Strings */
+"Extended Profile (AVC Codec Profile)" = "Extended Profile";
+
 /* WKWebExtensionContextErrorAlreadyLoaded description */
 "Extension context is already loaded." = "Extension context is already loaded.";
 
@@ -585,6 +603,9 @@
 
 /* WKWebExtensionErrorInvalidIcon description for failing to load images */
 "Failed to load images in `icons` manifest entry." = "Failed to load images in `icons` manifest entry.";
+
+/* Media Element Source Type */
+"File (Media Element Source Type)" = "File";
 
 /* The requested file doesn't exist */
 "File does not exist" = "File does not exist";
@@ -634,6 +655,12 @@
 /* Inspector element selection tooltip text for items inside a Grid Container. */
 "Grid Item (Inspector Element Selection)" = "Grid Item";
 
+/* Codec Strings */
+"HEVC (Codec String)" = "HEVC";
+
+/* Media Element Source Type */
+"HLS (Media Element Source Type)" = "HLS";
+
 /* accessibility role description for web area */
 "HTML content" = "HTML content";
 
@@ -651,6 +678,24 @@
 
 /* menu item title */
 "Hide Substitutions" = "Hide Substitutions";
+
+/* Codec Strings */
+"High 10 Profile (AVC Codec Profile)" = "High 10 Profile";
+
+/* Codec Strings */
+"High 422 Profile (AVC Codec Profile)" = "High 422 Profile";
+
+/* Codec Strings */
+"High 444 Predictive Profile (AVC Codec Profile)" = "High 444 Predictive Profile";
+
+/* Codec Strings */
+"High Profile (AV1 Codec Profile)" = "High Profile, ";
+
+/* Codec Strings */
+"High Profile (AVC Codec Profile)" = "High Profile";
+
+/* Codec Strings */
+"High Tier (HEVC Codec Tier" = "High Tier";
 
 /* Phishing warning description */
 "If you believe this website is safe, you can %report-an-error%. Or, if you understand the risks involved, you can %bypass-link%." = "If you believe this website is safe, you can %report-an-error%. Or, if you understand the risks involved, you can %bypass-link%.";
@@ -739,8 +784,92 @@
 /* Left to Right context menu item */
 "Left to Right" = "Left to Right";
 
+/* Level %d (AVC Codec Level) */
+"Level %d" = "Level %d";
+
+/* Level %d.%d (AVC Codec Level) */
+"Level %d.%d" = "Level %d.%d";
+
+/* Codec Strings */
+"Level 1b (AVC Codec Level)" = "Level 1b";
+
+/* Codec Strings */
+"Level 2.0 (AV1 Codec Level)" = "Level 2.0";
+
+/* Codec Strings */
+"Level 2.1 (AV1 Codec Level)" = "Level 2.1";
+
+/* Codec Strings */
+"Level 2.2 (AV1 Codec Level)" = "Level 2.2";
+
+/* Codec Strings */
+"Level 2.3 (AV1 Codec Level)" = "Level 2.3";
+
+/* Codec Strings */
+"Level 3.0 (AV1 Codec Level)" = "Level 3.0";
+
+/* Codec Strings */
+"Level 3.1 (AV1 Codec Level)" = "Level 3.1";
+
+/* Codec Strings */
+"Level 3.2 (AV1 Codec Level)" = "Level 3.2";
+
+/* Codec Strings */
+"Level 3.3 (AV1 Codec Level)" = "Level 3.3";
+
+/* Codec Strings */
+"Level 4.0 (AV1 Codec Level)" = "Level 4.0";
+
+/* Codec Strings */
+"Level 4.1 (AV1 Codec Level)" = "Level 4.1";
+
+/* Codec Strings */
+"Level 4.2 (AV1 Codec Level)" = "Level 4.2";
+
+/* Codec Strings */
+"Level 4.3 (AV1 Codec Level)" = "Level 4.3";
+
+/* Codec Strings */
+"Level 5.0 (AV1 Codec Level)" = "Level 5.0";
+
+/* Codec Strings */
+"Level 5.1 (AV1 Codec Level)" = "Level 5.1";
+
+/* Codec Strings */
+"Level 5.2 (AV1 Codec Level)" = "Level 5.2";
+
+/* Codec Strings */
+"Level 5.3 (AV1 Codec Level)" = "Level 5.3";
+
+/* Codec Strings */
+"Level 6.0 (AV1 Codec Level)" = "Level 6.0";
+
+/* Codec Strings */
+"Level 6.1 (AV1 Codec Level)" = "Level 6.1";
+
+/* Codec Strings */
+"Level 6.2 (AV1 Codec Level)" = "Level 6.2";
+
+/* Codec Strings */
+"Level 6.3 (AV1 Codec Level)" = "Level 6.3";
+
+/* Codec Strings */
+"Level 7.0 (AV1 Codec Level)" = "Level 7.0";
+
+/* Codec Strings */
+"Level 7.1 (AV1 Codec Level)" = "Level 7.1";
+
+/* Codec Strings */
+"Level 7.2 (AV1 Codec Level)" = "Level 7.2";
+
+/* Codec Strings */
+"Level 7.3 (AV1 Codec Level)" = "Level 7.3";
+
 /* Media controller status message when watching a live broadcast */
 "Live Broadcast" = "Live Broadcast";
+
+/* Media Element Source Type */
+"LiveStream (Media Element Source Type)" = "Live Stream";
 
 /* Load request cancelled */
 "Load request cancelled" = "Load request cancelled";
@@ -781,6 +910,27 @@
 /* Month label in date picker */
 "MONTH (Date picker for extra zoom mode)" = "MONTH";
 
+/* Codec Strings */
+"MP3 Codec String" = "MP3";
+
+/* Codec Strings */
+"MPEG-4 AAC Codec String" = "MPEG-4 AAC";
+
+/* Codec Strings */
+"Main 10 Profile (HEVC Codec Profile)" = "Main 10 Profile";
+
+/* Codec Strings */
+"Main Profile (AV1 Codec Profile)" = "Main Profile, ";
+
+/* Codec Strings */
+"Main Profile (AVC Codec Profile)" = "Main Profile";
+
+/* Codec Strings */
+"Main Profile (HEVC Codec Profile)" = "Main Profile";
+
+/* Codec Strings */
+"Main Tier (HEVC Codec Tier" = "Main Tier";
+
 /* Make Lower Case context menu item */
 "Make Lower Case" = "Make Lower Case";
 
@@ -789,6 +939,9 @@
 
 /* Malware warning title */
 "Malware Website Warning" = "Malware Website Warning";
+
+/* Media Element Source Type */
+"ManagedMediaSource (Media Element Source Type)" = "Managed Media Source";
 
 /* WKWebExtensionErrorInvalidBackgroundContent description for missing background required keys */
 "Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`." = "Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`.";
@@ -813,6 +966,12 @@
 
 /* Validation message for input form controls requiring a constrained value according to pattern followed by a website-provided description of the pattern */
 "Match the requested format: %s" = "Match the requested format: %s";
+
+/* Media Element Source Type */
+"MediaSource (Media Element Source Type)" = "Media Source";
+
+/* Media Element Source Type */
+"MediaStream (Media Element Source Type)" = "Media Stream";
 
 /* Malware confirmation dialog */
 "Merely visiting a site is sufficient for malware to install itself and harm your computer." = "Merely visiting a site is sufficient for malware to install itself and harm your computer.";
@@ -919,6 +1078,9 @@
 /* Open with Preview context menu item */
 "Open with Preview" = "Open with Preview";
 
+/* Codec Strings */
+"Opus Codec String" = "Opus";
+
 /* Label for the order with Apple Pay button. */
 "Order with Apple Pay" = "Order with Apple Pay";
 
@@ -1002,6 +1164,12 @@
 
 /* Title for the webarea while the accessibility tree is being built. */
 "Processing page" = "Processing page";
+
+/* Codec Strings */
+"Professional Profile (AV1 Codec Profile)" = "Professional Profile, ";
+
+/* VP8/9 Codec Level & Profile (Codec Strings) */
+"Profile %d, Level %s" = "Profile %d, Level %s";
 
 /* Undo action name */
 "Raise Baseline (Undo action name)" = "Raise Baseline";
@@ -1176,6 +1344,9 @@
 
 /* Stop speaking context menu item */
 "Stop Speaking" = "Stop Speaking";
+
+/* Media Element Source Type */
+"StoredStream (Media Element Source Type)" = "Stored Stream";
 
 /* Undo action name */
 "StrikeThrough (Undo action name)" = "StrikeThrough";
@@ -1426,6 +1597,12 @@
 /* The download was cancelled by the user */
 "User cancelled the download" = "User cancelled the download";
 
+/* Codec Strings */
+"VP8 (Codec String)" = "VP8";
+
+/* Codec Strings */
+"VP9 (Codec String)" = "VP9";
+
 /* Validation message for input form controls with value lower than allowed minimum */
 "Value must be greater than or equal to %@" = "Value must be greater than or equal to %@";
 
@@ -1437,6 +1614,9 @@
 
 /* Validation message for input form controls with value higher than allowed maximum */
 "Value must be less than or equal to %s" = "Value must be less than or equal to %s";
+
+/* Codec Strings */
+"Vorbis Codec String" = "Vorbis";
 
 /* Phishing warning description */
 "Warnings are shown for websites that have been reported as deceptive. Deceptive websites try to trick you into believing they are legitimate websites you trust." = "Warnings are shown for websites that have been reported as deceptive. Deceptive websites try to trick you into believing they are legitimate websites you trust.";
@@ -1458,6 +1638,9 @@
 
 /* Unwanted software warning title */
 "Website With Harmful Software Warning" = "Website With Harmful Software Warning";
+
+/* Accessory text for requesting cross-site cookie and website data access. */
+"While you are visiting %@, the following related websites will gain access to their cookies:\n  - %@" = "While you are visiting %@, the following related websites will gain access to their cookies:\n  - %@";
 
 /* Year label in date picker */
 "YEAR (Date picker for extra zoom mode)" = "YEAR";

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -526,7 +526,7 @@ public:
     void mediaLoadingFailed(MediaPlayer::NetworkState);
     void mediaLoadingFailedFatally(MediaPlayer::NetworkState);
 
-    RefPtr<VideoPlaybackQuality> getVideoPlaybackQuality();
+    RefPtr<VideoPlaybackQuality> getVideoPlaybackQuality() const;
 
     MediaPlayer::Preload preloadValue() const { return m_preload; }
     MediaElementSession* mediaSessionIfExists() const { return m_mediaSession.get(); }
@@ -646,6 +646,20 @@ public:
     WEBCORE_EXPORT WebCore::FloatSize videoLayerSize() const;
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRight&&);
     void updateMediaState();
+
+    enum class SourceType : uint8_t {
+        File,
+        HLS,
+        MediaSource,
+        ManagedMediaSource,
+        MediaStream,
+        LiveStream,
+        StoredStream,
+    };
+    std::optional<SourceType> sourceType() const;
+    String localizedSourceType() const;
+
+    LayoutRect contentBoxRect() const { return mediaPlayerContentBoxRect(); }
 
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);

--- a/Source/WebCore/html/track/AudioTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AudioTrackConfiguration.h"
+
+#if ENABLE(VIDEO)
+
+#include <wtf/JSONValues.h>
+
+namespace WebCore {
+
+Ref<JSON::Object> AudioTrackConfiguration::toJSON() const
+{
+    Ref json = JSON::Object::create();
+    json->setString("codec"_s, codec());
+    json->setInteger("sampleRate"_s, sampleRate());
+    json->setInteger("numberOfChannels"_s, numberOfChannels());
+    json->setInteger("bitrate"_s, bitrate());
+    return json;
+}
+
+}
+
+#endif

--- a/Source/WebCore/html/track/AudioTrackConfiguration.h
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.h
@@ -54,6 +54,8 @@ public:
     uint64_t bitrate() const { return m_state.bitrate; }
     void setBitrate(uint64_t bitrate) { m_state.bitrate = bitrate; }
 
+    Ref<JSON::Object> toJSON() const;
+
 private:
     AudioTrackConfiguration(AudioTrackConfigurationInit&& init)
         : m_state(init)

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -74,6 +74,15 @@ AudioTrack* AudioTrackList::item(unsigned index) const
     return nullptr;
 }
 
+AudioTrack* AudioTrackList::firstEnabled() const
+{
+    for (auto& item : m_inbandTracks) {
+        if (item && item->enabled())
+            return downcast<AudioTrack>(item.get());
+    }
+    return nullptr;
+}
+
 AudioTrack* AudioTrackList::getTrackById(const AtomString& id) const
 {
     for (auto& inbandTrack : m_inbandTracks) {

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -49,6 +49,7 @@ public:
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
     AudioTrack* item(unsigned index) const;
     AudioTrack* lastItem() const { return item(length() - 1); }
+    AudioTrack* firstEnabled() const;
     void append(Ref<AudioTrack>&&);
     void remove(TrackBase&, bool scheduleEvent = true) final;
 

--- a/Source/WebCore/html/track/VideoTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VideoTrackConfiguration.h"
+
+#if ENABLE(VIDEO)
+
+#include <wtf/JSONValues.h>
+
+namespace WebCore {
+
+Ref<JSON::Object> VideoTrackConfiguration::toJSON() const
+{
+    Ref json = JSON::Object::create();
+    json->setString("codec"_s, codec());
+    json->setInteger("width"_s, width());
+    json->setInteger("height"_s, height());
+    json->setObject("colorSpace"_s, colorSpace()->toJSON());
+    json->setDouble("framerate"_s, framerate());
+    json->setInteger("bitrate"_s, bitrate());
+    return json;
+}
+
+}
+
+#endif

--- a/Source/WebCore/html/track/VideoTrackConfiguration.h
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.h
@@ -65,6 +65,8 @@ public:
     uint64_t bitrate() const { return m_state.bitrate; }
     void setBitrate(uint64_t bitrate) { m_state.bitrate = bitrate; }
 
+    Ref<JSON::Object> toJSON() const;
+
 private:
     VideoTrackConfiguration(VideoTrackConfigurationInit&& init)
         : m_state(init)

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -99,6 +99,15 @@ int VideoTrackList::selectedIndex() const
     return -1;
 }
 
+VideoTrack* VideoTrackList::selectedItem() const
+{
+    auto selectedIndex = this->selectedIndex();
+    if (selectedIndex < 0)
+        return nullptr;
+
+    return item(selectedIndex);
+}
+
 EventTargetInterface VideoTrackList::eventTargetInterface() const
 {
     return VideoTrackListEventTargetInterfaceType;

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -50,6 +50,7 @@ public:
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
     VideoTrack* item(unsigned) const;
     VideoTrack* lastItem() const { return item(length() - 1); }
+    VideoTrack* selectedItem() const;
     void append(Ref<VideoTrack>&&);
 
     // EventTarget

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -170,6 +170,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> focus(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<void> setInspectedNode(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<void> setAllowEditingUserAgentShadowTrees(bool);
+    Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> getMediaStats(Inspector::Protocol::DOM::NodeId);
 
     // InspectorInstrumentation
     Inspector::Protocol::DOM::NodeId identifierForNode(Node&);

--- a/Source/WebCore/platform/graphics/CodecUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CodecUtilities.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CodecUtilities.h"
+
+#include "AV1Utilities.h"
+#include "HEVCUtilities.h"
+#include "LocalizedStrings.h"
+#include "VP9Utilities.h"
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+String humanReadableStringFromCodecString(const String& codecString)
+{
+    if (auto parameters = parseVPCodecParameters(codecString)) {
+        StringBuilder builder;
+        if (parameters->codecName == "vp08"_s)
+            builder.append(WEB_UI_STRING_KEY("VP8", "VP8 (Codec String)", "Codec Strings"));
+        else if (parameters->codecName == "vp09"_s)
+            builder.append(WEB_UI_STRING_KEY("VP9", "VP9 (Codec String)", "Codec Strings"));
+        builder.append(" (");
+
+        uint8_t levelMajor = parameters->level / 10;
+        uint8_t levelMinor = parameters->level % 10;
+        auto levelString = levelMinor ? WEB_UI_FORMAT_STRING("%d.%d", "Codec Level (Codec Strings)", levelMajor, levelMinor) : String::number(levelMajor);
+        builder.append(WEB_UI_FORMAT_STRING("Profile %d, Level %s", "VP8/9 Codec Level & Profile (Codec Strings)", parameters->profile, levelString.utf8().data()));
+        builder.append(")");
+
+        return builder.toString();
+    }
+
+    if (auto parameters = parseAVCCodecParameters(codecString)) {
+        StringBuilder builder;
+        builder.append(WEB_UI_STRING_KEY("AVC", "AVC (Codec String)", "Codec Strings"));
+        builder.append(" (");
+        switch (parameters->profileIDC) {
+        case 66:
+            builder.append(WEB_UI_STRING_KEY("Baseline Profile", "Baseline Profile (AVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case 77:
+            builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (AVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case 88:
+            builder.append(WEB_UI_STRING_KEY("Extended Profile", "Extended Profile (AVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case 100:
+            builder.append(WEB_UI_STRING_KEY("High Profile", "High Profile (AVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case 110:
+            builder.append(WEB_UI_STRING_KEY("High 10 Profile", "High 10 Profile (AVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case 122:
+            builder.append(WEB_UI_STRING_KEY("High 422 Profile", "High 422 Profile (AVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case 244:
+            builder.append(WEB_UI_STRING_KEY("High 444 Predictive Profile", "High 444 Predictive Profile (AVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        }
+        if (parameters->levelIDC == 11)
+            builder.append(WEB_UI_STRING_KEY("Level 1b", "Level 1b (AVC Codec Level)", "Codec Strings"));
+        else {
+            uint8_t levelMajor = parameters->levelIDC / 10;
+            uint8_t levelMinor = parameters->levelIDC % 10;
+            auto levelString = levelMinor ? WEB_UI_FORMAT_STRING("Level %d.%d", "Level %d.%d (AVC Codec Level)", levelMajor, levelMinor) : WEB_UI_FORMAT_STRING("Level %d", "Level %d (AVC Codec Level)", levelMajor);
+            builder.append(levelString);
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+
+    if (auto parameters = parseHEVCCodecParameters(codecString)) {
+        StringBuilder builder;
+        builder.append(WEB_UI_STRING_KEY("HEVC", "HEVC (Codec String)", "Codec Strings"));
+        builder.append(" (");
+        switch (parameters->generalProfileIDC) {
+        case 1:
+            builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (HEVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case 2:
+            builder.append(WEB_UI_STRING_KEY("Main 10 Profile", "Main 10 Profile (HEVC Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        }
+        if (parameters->generalTierFlag)
+            builder.append(WEB_UI_STRING_KEY("High Tier", "High Tier (HEVC Codec Tier", "Codec Strings"));
+        else
+            builder.append(WEB_UI_STRING_KEY("Main Tier", "Main Tier (HEVC Codec Tier", "Codec Strings"));
+        builder.append(")");
+        return builder.toString();
+    }
+
+    if (auto parameters = parseAV1CodecParameters(codecString)) {
+        StringBuilder builder;
+        builder.append(WEB_UI_STRING_KEY("AV1", "AV1 (Codec String)", "Codec Strings"));
+        builder.append(" (");
+        switch (parameters->profile) {
+        case AV1ConfigurationProfile::Main:
+            builder.append(WEB_UI_STRING_KEY("Main Profile, ", "Main Profile (AV1 Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case AV1ConfigurationProfile::High:
+            builder.append(WEB_UI_STRING_KEY("High Profile, ", "High Profile (AV1 Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        case AV1ConfigurationProfile::Professional:
+            builder.append(WEB_UI_STRING_KEY("Professional Profile, ", "Professional Profile (AV1 Codec Profile)", "Codec Strings"));
+            builder.append(", ");
+            break;
+        };
+
+        switch (parameters->level) {
+        case AV1ConfigurationLevel::Level_2_0:
+            builder.append(WEB_UI_STRING_KEY("Level 2.0", "Level 2.0 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_2_1:
+            builder.append(WEB_UI_STRING_KEY("Level 2.1", "Level 2.1 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_2_2:
+            builder.append(WEB_UI_STRING_KEY("Level 2.2", "Level 2.2 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_2_3:
+            builder.append(WEB_UI_STRING_KEY("Level 2.3", "Level 2.3 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_3_0:
+            builder.append(WEB_UI_STRING_KEY("Level 3.0", "Level 3.0 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_3_1:
+            builder.append(WEB_UI_STRING_KEY("Level 3.1", "Level 3.1 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_3_2:
+            builder.append(WEB_UI_STRING_KEY("Level 3.2", "Level 3.2 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_3_3:
+            builder.append(WEB_UI_STRING_KEY("Level 3.3", "Level 3.3 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_4_0:
+            builder.append(WEB_UI_STRING_KEY("Level 4.0", "Level 4.0 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_4_1:
+            builder.append(WEB_UI_STRING_KEY("Level 4.1", "Level 4.1 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_4_2:
+            builder.append(WEB_UI_STRING_KEY("Level 4.2", "Level 4.2 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_4_3:
+            builder.append(WEB_UI_STRING_KEY("Level 4.3", "Level 4.3 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_5_0:
+            builder.append(WEB_UI_STRING_KEY("Level 5.0", "Level 5.0 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_5_1:
+            builder.append(WEB_UI_STRING_KEY("Level 5.1", "Level 5.1 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_5_2:
+            builder.append(WEB_UI_STRING_KEY("Level 5.2", "Level 5.2 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_5_3:
+            builder.append(WEB_UI_STRING_KEY("Level 5.3", "Level 5.3 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_6_0:
+            builder.append(WEB_UI_STRING_KEY("Level 6.0", "Level 6.0 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_6_1:
+            builder.append(WEB_UI_STRING_KEY("Level 6.1", "Level 6.1 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_6_2:
+            builder.append(WEB_UI_STRING_KEY("Level 6.2", "Level 6.2 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_6_3:
+            builder.append(WEB_UI_STRING_KEY("Level 6.3", "Level 6.3 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_7_0:
+            builder.append(WEB_UI_STRING_KEY("Level 7.0", "Level 7.0 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_7_1:
+            builder.append(WEB_UI_STRING_KEY("Level 7.1", "Level 7.1 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_7_2:
+            builder.append(WEB_UI_STRING_KEY("Level 7.2", "Level 7.2 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        case AV1ConfigurationLevel::Level_7_3:
+            builder.append(WEB_UI_STRING_KEY("Level 7.3", "Level 7.3 (AV1 Codec Level)", "Codec Strings"));
+            break;
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+
+    if (auto parameters = parseDoViCodecParameters(codecString))
+        return WEB_UI_STRING_KEY("Dolby Vision", "Dolby Vision Codec String", "Codec Strings");
+
+    if (codecString.startsWith("opus"_s))
+        return WEB_UI_STRING_KEY("Opus", "Opus Codec String", "Codec Strings");
+
+    if (codecString.startsWith("vorbis"_s))
+        return WEB_UI_STRING_KEY("Vorbis", "Vorbis Codec String", "Codec Strings");
+
+    if (codecString.startsWith("mp4a.40."_s)) {
+        auto objectType = codecString.substring(8);
+        auto objectValue = parseInteger<uint8_t>(objectType, 10);
+
+        switch (objectValue.value_or(0)) {
+        case 1:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 29:
+            return WEB_UI_STRING_KEY("MPEG-4 AAC", "MPEG-4 AAC Codec String", "Codec Strings");
+        case 2:
+            return WEB_UI_STRING_KEY("AAC-LC", "AAC-LC Codec String", "Codec Strings");
+        case 34:
+            return WEB_UI_STRING_KEY("MP3", "MP3 Codec String", "Codec Strings");
+        }
+
+        return WEB_UI_STRING_KEY("MPEG-4 AAC", "MPEG-4 AAC Codec String", "Codec Strings");
+    }
+
+    auto dotIndex = codecString.find('.');
+    return codecString.substring(0, dotIndex == notFound ? String::MaxLength : dotIndex);
+}
+
+}

--- a/Source/WebCore/platform/graphics/CodecUtilities.h
+++ b/Source/WebCore/platform/graphics/CodecUtilities.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+WEBCORE_EXPORT String humanReadableStringFromCodecString(const String&);
+
+}

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -31,6 +31,7 @@ localizedStrings["%d Failed (plural)"] = "%d Failed";
 localizedStrings["%d Failed (singular)"] = "%d Failed";
 localizedStrings["%d Frame"] = "%d Frame";
 localizedStrings["%d Frames"] = "%d Frames";
+localizedStrings["%d Hz"] = "%d Hz";
 localizedStrings["%d More\u2026"] = "%d More\u2026";
 localizedStrings["%d Passed (plural)"] = "%d Passed";
 localizedStrings["%d Passed (singular)"] = "%d Passed";
@@ -51,6 +52,8 @@ localizedStrings["%d resource"] = "%d resource";
 localizedStrings["%d resources"] = "%d resources";
 localizedStrings["%dpx"] = "%dpx";
 localizedStrings["%dpx\u00B2"] = "%dpx\u00B2";
+localizedStrings["%dx%d (%dfps)"] = "%dx%d (%dfps)";
+localizedStrings["%dx%d (%dx)"] = "%dx%d (%dx)";
 localizedStrings["%s (%s)"] = "%s (%s)";
 localizedStrings["%s (%s, %s)"] = "%s (%s, %s)";
 /* Label for case-insensitive match pattern of an event breakpoint. */
@@ -219,6 +222,12 @@ localizedStrings["Attribute"] = "Attribute";
 /* A submenu item of 'Break On' that breaks (pauses) before DOM attribute is modified */
 localizedStrings["Attribute Modified @ DOM Breakpoint"] = "Attribute Modified";
 localizedStrings["Attributes"] = "Attributes";
+/* Title for Audio Codec row in Media Sidebar */
+localizedStrings["Audio Codec @ Media Sidebar"] = "Audio Codec";
+/* Title for Audio Details section in Media Sidebar */
+localizedStrings["Audio Details @ Media Sidebar"] = "Audio Details";
+/* Title for Audio Format row in Media Sidebar */
+localizedStrings["Audio Format @ Media Sidebar"] = "Audio Format";
 localizedStrings["Audit"] = "Audit";
 localizedStrings["Audit Error: %s"] = "Audit Error: %s";
 /* Name of Audit Tab */
@@ -325,6 +334,8 @@ localizedStrings["Catch Variables"] = "Catch Variables";
 localizedStrings["Categories"] = "Categories";
 localizedStrings["Certificate"] = "Certificate";
 localizedStrings["Changes"] = "Changes";
+/* Title for Channels row in Media Sidebar */
+localizedStrings["Channels @ Media Sidebar"] = "Channels";
 localizedStrings["Character Data"] = "Character Data";
 localizedStrings["Charge \u201C%s\u201D to Callers"] = "Charge \u201C%s\u201D to Callers";
 localizedStrings["Checked"] = "Checked";
@@ -385,6 +396,10 @@ localizedStrings["Code"] = "Code";
 localizedStrings["Collapse All"] = "Collapse All";
 localizedStrings["Collapse columns"] = "Collapse columns";
 localizedStrings["Collect garbage"] = "Collect garbage";
+/* Title for Color Primaries row in Media Sidebar */
+localizedStrings["Color Primaries @ Media Sidebar"] = "Color Primaries";
+/* Title for Color Range row in Media Sidebar */
+localizedStrings["Color Range @ Media Sidebar"] = "Color Range";
 /* Label for input to override the preference for color scheme. */
 localizedStrings["Color scheme @ User Preferences Overrides"] = "Color scheme";
 /* Section header for the group of CSS variables with colors as values */
@@ -590,6 +605,8 @@ localizedStrings["Done"] = "Done";
 localizedStrings["Download"] = "Download";
 localizedStrings["Download Web Archive"] = "Download Web Archive";
 localizedStrings["Dropped Element"] = "Dropped Element";
+/* Format string for Dropped Frame count in Media Sidebar */
+localizedStrings["Dropped Frame Format @ Media Sidebar"] = "%d dropped of %d";
 localizedStrings["Dropped Node"] = "Dropped Node";
 localizedStrings["Duplicate Audit"] = "Duplicate Audit";
 localizedStrings["Duplicate Selector"] = "Duplicate Selector";
@@ -801,8 +818,12 @@ localizedStrings["Frames"] = "Frames";
 localizedStrings["Frames %d \u2013 %d"] = "Frames %d \u2013 %d";
 /* Title for list of HTML subframe JavaScript execution contexts */
 localizedStrings["Frames @ Execution Context Picker"] = "Frames";
+/* Title for Frames row in Media Sidebar */
+localizedStrings["Frames @ Media Sidebar Frame Count"] = "Frames";
 localizedStrings["Full Garbage Collection"] = "Full Garbage Collection";
 localizedStrings["Full URL"] = "Full URL";
+/* Value string for Full Range color in the Media Sidebar */
+localizedStrings["Full range @ Media Sidebar"] = "Full range";
 localizedStrings["Full-Screen"] = "Full-Screen";
 localizedStrings["Full-Screen from \u201C%s\u201D"] = "Full-Screen from \u201C%s\u201D";
 /* Property value for `font-variant-alternates: full-width`. */
@@ -814,6 +835,8 @@ localizedStrings["Garbage Collection"] = "Garbage Collection";
 localizedStrings["General"] = "General";
 /* Text indicating that the local override will block the network activity with a general error. */
 localizedStrings["General @ Local Override Type"] = "General";
+/* Title for General Section in Media Sidebar */
+localizedStrings["General @ Media Sidebar"] = "General";
 localizedStrings["Getter"] = "Getter";
 localizedStrings["Global Code"] = "Global Code";
 localizedStrings["Global Lexical Environment"] = "Global Lexical Environment";
@@ -1030,6 +1053,8 @@ localizedStrings["Map to File @ Resource Preview"] = "Map to File";
 localizedStrings["Mapped to \u201C%s\u201D"] = "Mapped to \u201C%s\u201D";
 localizedStrings["Mass"] = "Mass";
 localizedStrings["Matching"] = "Matching";
+/* Title for Matrix Coefficients row in Media Sidebar */
+localizedStrings["Matrix Coefficients @ Media Sidebar"] = "Matrix Coefficients";
 localizedStrings["Max Comparison"] = "Max Comparison";
 localizedStrings["Maximum"] = "Maximum";
 localizedStrings["Maximum CPU Usage: %s"] = "Maximum CPU Usage: %s";
@@ -1062,6 +1087,7 @@ localizedStrings["Mixed"] = "Mixed";
 localizedStrings["Modifications are saved automatically and will apply the next time the Console Snippet is run."] = "Modifications are saved automatically and will apply the next time the Console Snippet is run.";
 localizedStrings["Modifications made here will take effect on the next load of any page or sub-frame."] = "Modifications made here will take effect on the next load of any page or sub-frame.";
 localizedStrings["Module Code"] = "Module Code";
+localizedStrings["Mono"] = "Mono";
 localizedStrings["More information is available at <https://webkit.org/web-inspector/console-snippets/>."] = "More information is available at <https://webkit.org/web-inspector/console-snippets/>.";
 localizedStrings["More information is available at <https://webkit.org/web-inspector/inspector-bootstrap-script/>."] = "More information is available at <https://webkit.org/web-inspector/inspector-bootstrap-script/>.";
 localizedStrings["Multi-Entry"] = "Multi-Entry";
@@ -1372,6 +1398,8 @@ localizedStrings["Requesting \u201C%s\u201D"] = "Requesting \u201C%s\u201D";
 localizedStrings["Required"] = "Required";
 /* Context menu action for resetting the breakpoint to its initial configuration. */
 localizedStrings["Reset Breakpoint @ Breakpoint Context Menu"] = "Reset Breakpoint";
+/* Title for Resolution row in Media Sidebar */
+localizedStrings["Resolution @ Media Sidebar"] = "Resolution";
 localizedStrings["Resource"] = "Resource";
 localizedStrings["Resource Size"] = "Resource Size";
 localizedStrings["Resource Type"] = "Resource Type";
@@ -1433,6 +1461,8 @@ localizedStrings["Run Console Snippet\u2026"] = "Run Console Snippet\u2026";
 localizedStrings["Run console commands as if inside a user gesture"] = "Run console commands as if inside a user gesture";
 localizedStrings["Running the \u201C%s\u201D audit"] = "Running the \u201C%s\u201D audit";
 localizedStrings["SVG"] = "SVG";
+/* Title for Sample Rate row in Media Sidebar */
+localizedStrings["Sample Rate @ Media Sidebar"] = "Sample Rate";
 localizedStrings["Samples"] = "Samples";
 localizedStrings["Save %d"] = "Save %d";
 localizedStrings["Save File"] = "Save File";
@@ -1578,6 +1608,8 @@ localizedStrings["Some examples of ways to use this script include (but are not 
 localizedStrings["Sort Ascending"] = "Sort Ascending";
 localizedStrings["Sort Descending"] = "Sort Descending";
 localizedStrings["Source"] = "Source";
+/* Title for Source row in Media Sidebar */
+localizedStrings["Source @ Media Sidebar"] = "Source";
 localizedStrings["Source Map loading errors"] = "Source Map loading errors";
 localizedStrings["Source Maps:"] = "Source Maps:";
 localizedStrings["Sources"] = "Sources";
@@ -1612,6 +1644,7 @@ localizedStrings["Step (%s or %s)"] = "Step (%s or %s)";
 localizedStrings["Step into (%s or %s)"] = "Step into (%s or %s)";
 localizedStrings["Step out (%s or %s)"] = "Step out (%s or %s)";
 localizedStrings["Step over (%s or %s)"] = "Step over (%s or %s)";
+localizedStrings["Stereo"] = "Stereo";
 localizedStrings["Stiffness"] = "Stiffness";
 localizedStrings["Stop"] = "Stop";
 localizedStrings["Stop Audit"] = "Stop Audit";
@@ -1781,6 +1814,8 @@ localizedStrings["Traces:"] = "Traces:";
 localizedStrings["Track sizes @ Layout Panel Overlay Options"] = "Track Sizes";
 /* Property value for `font-variant-alternates: traditional`. */
 localizedStrings["Traditional Forms @ Font Details Sidebar Property Value"] = "Traditional Forms";
+/* Title for Transfer Function row in Media Sidebar */
+localizedStrings["Transfer Function @ Media Sidebar"] = "Transfer Function";
 /* Amount of data sent over the network for a single resource */
 localizedStrings["Transfer Size"] = "Transfer Size";
 localizedStrings["Transferred"] = "Transferred";
@@ -1804,6 +1839,7 @@ localizedStrings["Ungrouped @ Computed Style variables grouping mode"] = "Ungrou
 /* Property value for `font-variant-capitals: unicase`. */
 localizedStrings["Unicase @ Font Details Sidebar Property Value"] = "Unicase";
 localizedStrings["Unique"] = "Unique";
+localizedStrings["Unknown"] = "Unknown";
 localizedStrings["Unknown Location"] = "Unknown Location";
 localizedStrings["Unknown error"] = "Unknown error";
 localizedStrings["Unknown node"] = "Unknown node";
@@ -1837,10 +1873,20 @@ localizedStrings["Vertex Shader"] = "Vertex Shader";
 localizedStrings["Vertex/Fragment Shader"] = "Vertex/Fragment Shader";
 /* Energy Impact: Very High */
 localizedStrings["Very High @ Timeline Energy Impact"] = "Very High";
+/* Title for Video Codec row in Media Sidebar */
+localizedStrings["Video Codec @ Media Sidebar"] = "Video Codec";
+/* Title for Video Details section in Media Sidebar */
+localizedStrings["Video Details @ Media Sidebar"] = "Video Details";
+/* Title for Video Format row in Media Sidebar */
+localizedStrings["Video Format @ Media Sidebar"] = "Video Format";
+/* Value string for Video Range color in the Media Sidebar */
+localizedStrings["Video range @ Media Sidebar"] = "Video range";
 localizedStrings["View Image"] = "View Image";
 localizedStrings["View Recording"] = "View Recording";
 localizedStrings["View Shader"] = "View Shader";
 localizedStrings["Viewport"] = "Viewport";
+/* Title for Viewport row in Media Sidebar */
+localizedStrings["Viewport @ Media Sidebar"] = "Viewport";
 localizedStrings["Visible"] = "Visible";
 localizedStrings["Waiting"] = "Waiting";
 localizedStrings["Waiting for animations created by CSS."] = "Waiting for animations created by CSS.";

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -159,6 +159,7 @@
     <link rel="stylesheet" href="Views/LocalResourceOverrideWarningView.css">
     <link rel="stylesheet" href="Views/LogContentView.css">
     <link rel="stylesheet" href="Views/LogIcon.css">
+    <link rel="stylesheet" href="Views/MediaDetailsSidebarPanel.css">
     <link rel="stylesheet" href="Views/MediaTimelineOverviewGraph.css">
     <link rel="stylesheet" href="Views/MediaTimelineView.css">
     <link rel="stylesheet" href="Views/MemoryCategoryView.css">
@@ -582,6 +583,12 @@
     <script src="Views/TreeOutline.js"></script>
     <script src="Views/TreeOutlineGroup.js"></script>
 
+    <script src="Views/DetailsSection.js"></script>
+    <script src="Views/DetailsSectionDataGridRow.js"></script>
+    <script src="Views/DetailsSectionGroup.js"></script>
+    <script src="Views/DetailsSectionSimpleRow.js"></script>
+    <script src="Views/DetailsSectionTextRow.js"></script>
+
     <script src="Views/ButtonNavigationItem.js"></script>
     <script src="Views/DatabaseUserQueryViewBase.js"></script>
     <script src="Views/DatabaseUserQueryErrorView.js"></script>
@@ -617,6 +624,7 @@
     <script src="Views/RulesStyleDetailsSidebarPanel.js"></script>
     <script src="Views/ComputedStyleDetailsSidebarPanel.js"></script>
     <script src="Views/StyleDetailsPanel.js"></script>
+    <script src="Views/MediaDetailsSidebarPanel.js"></script>
 
     <script src="Views/AuditTabContentView.js"></script>
     <script src="Views/ConsoleTabContentView.js"></script>
@@ -631,12 +639,6 @@
     <script src="Views/StorageTabContentView.js"></script>
     <script src="Views/TimelineTabContentView.js"></script>
     <script src="Views/WebInspectorExtensionTabContentView.js"></script>
-
-    <script src="Views/DetailsSection.js"></script>
-    <script src="Views/DetailsSectionDataGridRow.js"></script>
-    <script src="Views/DetailsSectionGroup.js"></script>
-    <script src="Views/DetailsSectionSimpleRow.js"></script>
-    <script src="Views/DetailsSectionTextRow.js"></script>
 
     <script src="Views/NodeOverlayListSection.js"></script>
 

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -1321,6 +1321,13 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this._layoutOverlayShowing)
             this.showLayoutOverlay();
     }
+
+    async getMediaStats()
+    {
+        let target = WI.assumingMainTarget();
+        let {mediaStats} = await target.DOMAgent.getMediaStats(this.id);
+        return mediaStats;
+    }
 };
 
 WI.DOMNode._defaultLayoutOverlayConfiguration = {

--- a/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
@@ -39,6 +39,10 @@ WI.ElementsTabContentView = class ElementsTabContentView extends WI.ContentBrows
         // COMPATIBILITY (iOS 14.0): `CSS.getFontDataForNode` did not exist yet.
         if (InspectorBackend.hasCommand("CSS.getFontDataForNode"))
             detailsSidebarPanelConstructors.push(WI.FontDetailsSidebarPanel);
+
+        if (InspectorBackend.hasCommand("DOM.getMediaStats"))
+            detailsSidebarPanelConstructors.push(WI.MediaDetailsSidebarPanel)
+
         detailsSidebarPanelConstructors.push(WI.ChangesDetailsSidebarPanel, WI.DOMNodeDetailsSidebarPanel);
         if (InspectorBackend.hasDomain("LayerTree"))
             detailsSidebarPanelConstructors.push(WI.LayerTreeDetailsSidebarPanel);

--- a/Source/WebInspectorUI/UserInterface/Views/FontDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontDetailsSidebarPanel.js
@@ -29,4 +29,11 @@ WI.FontDetailsSidebarPanel = class FontDetailsSidebarPanel extends WI.GeneralSty
     {
         super("style-font", WI.UIString("Font"), WI.FontDetailsPanel);
     }
+
+    supportsDOMNode(nodeToInspect)
+    {
+        if (nodeToInspect.isMediaElement())
+            return false;
+        return super.supportsDOMNode(nodeToInspect);
+    }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.css
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.sidebar > .panel.details.media-details > .details-section > .content > .group > .row.simple > .label {
+    min-width: 101px; /* Width of `Matrix Coefficients` in English. */
+}

--- a/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
@@ -1,0 +1,323 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetailsSidebarPanel
+{
+    // Static
+
+    static StyleClassName = "media";
+
+    // Public
+
+    constructor(delegate)
+    {
+        super("media-details", WI.UIString("Media"));
+
+        this.#ui.sourceRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Source", "Source @ Media Sidebar", "Title for Source row in Media Sidebar"));
+        this.#ui.viewportRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Viewport", "Viewport @ Media Sidebar", "Title for Viewport row in Media Sidebar"));
+        this.#ui.framesRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Frames", "Frames @ Media Sidebar Frame Count", "Title for Frames row in Media Sidebar"));
+        this.#ui.resolutionRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Resolution", "Resolution @ Media Sidebar", "Title for Resolution row in Media Sidebar"));
+        this.#ui.videoFormatRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Video Format", "Video Format @ Media Sidebar", "Title for Video Format row in Media Sidebar"));
+        this.#ui.audioFormatRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Audio Format", "Audio Format @ Media Sidebar", "Title for Audio Format row in Media Sidebar"));
+
+        let generalGroup = new WI.DetailsSectionGroup([this.#ui.sourceRow, this.#ui.viewportRow, this.#ui.framesRow, this.#ui.resolutionRow, this.#ui.videoFormatRow, this.#ui.audioFormatRow]);
+        this.#ui.generalSection = new WI.DetailsSection("media-details-general", WI.UIString("General", "General @ Media Sidebar", "Title for General Section in Media Sidebar"), [generalGroup]);
+
+        this.#ui.videoCodecRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Video Codec", "Video Codec @ Media Sidebar", "Title for Video Codec row in Media Sidebar"));
+        this.#ui.transferRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Transfer Function", "Transfer Function @ Media Sidebar", "Title for Transfer Function row in Media Sidebar"));
+        this.#ui.primariesRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Color Primaries", "Color Primaries @ Media Sidebar", "Title for Color Primaries row in Media Sidebar"));
+        this.#ui.matrixRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Matrix Coefficients", "Matrix Coefficients @ Media Sidebar", "Title for Matrix Coefficients row in Media Sidebar"));
+        this.#ui.fullRangeRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Color Range", "Color Range @ Media Sidebar", "Title for Color Range row in Media Sidebar"));
+
+        let videoGroup = new WI.DetailsSectionGroup([this.#ui.videoCodecRow, this.#ui.primariesRow, this.#ui.transferRow, this.#ui.matrixRow, this.#ui.fullRangeRow]);
+        this.#ui.videoSection = new WI.DetailsSection("media-video-details", WI.UIString("Video Details", "Video Details @ Media Sidebar", "Title for Video Details section in Media Sidebar"), [videoGroup]);
+        this.#ui.audioCodecRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Audio Codec", "Audio Codec @ Media Sidebar", "Title for Audio Codec row in Media Sidebar"));
+        this.#ui.sampleRateRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Sample Rate", "Sample Rate @ Media Sidebar", "Title for Sample Rate row in Media Sidebar"));
+        this.#ui.channelsRow = new WI.MediaDetailsSidebarPanel.#Row(WI.UIString("Channels", "Channels @ Media Sidebar", "Title for Channels row in Media Sidebar"));
+
+        let audioGroup = new WI.DetailsSectionGroup([this.#ui.audioCodecRow, this.#ui.sampleRateRow, this.#ui.channelsRow]);
+        this.#ui.audioSection = new WI.DetailsSection("media-audio-details", WI.UIString("Audio Details", "Audio Details @ Media Sidebar", "Title for Audio Details section in Media Sidebar"), [audioGroup]);
+    }
+
+    layout()
+    {
+        this.#ui.sourceRow.updateValue();
+        this.#ui.viewportRow.updateValue();
+        this.#ui.framesRow.updateValue();
+        this.#ui.resolutionRow.updateValue();
+        this.#ui.videoFormatRow.updateValue();
+        this.#ui.audioFormatRow.updateValue();
+        this.#ui.videoCodecRow.updateValue();
+        this.#ui.transferRow.updateValue();
+        this.#ui.primariesRow.updateValue();
+        this.#ui.matrixRow.updateValue();
+        this.#ui.fullRangeRow.updateValue();
+        this.#ui.audioCodecRow.updateValue();
+        this.#ui.sampleRateRow.updateValue();
+        this.#ui.channelsRow.updateValue();
+    }
+
+    // Protected
+
+    // DOMDetailsSidebarPanel Overrides
+
+    supportsDOMNode(nodeToInspect)
+    {
+        return nodeToInspect.isMediaElement();
+    }
+
+    attached()
+    {
+        super.attached();
+        this.#startUpdateTimer();
+    }
+
+    detached()
+    {
+        super.detached();
+        this.#cancelUpdateTimer();
+    }
+
+    // View Overrides
+
+    initialLayout()
+    {
+        super.initialLayout();
+
+        this.element.appendChild(this.#ui.generalSection.element);
+        this.element.appendChild(this.#ui.videoSection.element);
+        this.element.appendChild(this.#ui.audioSection.element);
+    }
+
+    // Private
+
+    static #Row = class MediaDetailsSectionSimpleRow extends WI.DetailsSectionSimpleRow
+    {
+        // Public
+
+        set pendingValue(value)
+        {
+            this.#pendingValue = value;
+            this.#dirty = true;
+        }
+
+        updateValue()
+        {
+            if (!this.#dirty)
+                return;
+            this.value = this.#pendingValue;
+            this.#pendingValue = null;
+            this.#dirty = false;
+        }
+
+        // Private
+
+        #pendingValue = null;
+        #dirty = null;
+    };
+
+    #values = {
+        source: null,
+        viewport: null,
+        devicePixelRatio: null,
+        quality: null,
+        videoFormat: null,
+        audioFormat: null,
+        video: null,
+        audio: null,
+    };
+
+    #ui = {
+        sourceRow: null,
+        viewportRow: null,
+        framesRow: null,
+        resolutionRow: null,
+        videoFormatRow: null,
+        audioFormatRow: null,
+        generalSection: null,
+        videoCodecRow: null,
+        transferRow: null,
+        primariesRow: null,
+        matrixRow: null,
+        fullRangeRow: null,
+        videoSection: null,
+        audioCodecRow: null,
+        sampleRateRow: null,
+        channelsRow: null,
+        audioSection: null,
+    };
+
+    #updateTimer = null;
+    #updateTimerInterval = 250;
+
+    #startUpdateTimer()
+    {
+        this.#cancelUpdateTimer();
+        this.#updateTimerFired();
+    }
+
+    #cancelUpdateTimer()
+    {
+        if (this.#updateTimer)
+            clearTimeout(this.#updateTimer);
+    }
+
+    async #updateTimerFired()
+    {
+        if (!this.domNode)
+            return;
+
+        let stats = await this.domNode.getMediaStats();
+        this.#setSource(stats.source);
+        this.#setViewport(stats.viewport);
+        this.#setDevicePixelRatio(stats.devicePixelRatio);
+        this.#setQuality(stats.quality);
+        this.#setVideoFormat(stats.video?.humanReadableCodecString);
+        this.#setAudioFormat(stats.audio?.humanReadableCodecString);
+        this.#setVideo(stats.video);
+        this.#setAudio(stats.audio);
+
+        if (this.isAttached)
+            this.#updateTimer = setTimeout(() => this.#updateTimerFired(), this.#updateTimerInterval);
+    }
+
+    #setSource(source)
+    {
+        if (this.#values.source === source)
+            return;
+
+        this.#values.source = source;
+        this.#ui.sourceRow.pendingValue = this.#values.source;
+        this.needsLayout();
+    }
+
+    #setViewport(viewport)
+    {
+        if (Object.shallowEqual(this.#values.viewport, viewport))
+            return;
+
+        this.#values.viewport = viewport;
+        this.#updateViewportRow();
+    }
+
+    #setDevicePixelRatio(devicePixelRatio)
+    {
+        if (this.#values.devicePixelRatio === devicePixelRatio)
+            return;
+
+        this.#values.devicePixelRatio = devicePixelRatio;
+        this.#updateViewportRow();
+    }
+
+    #updateViewportRow()
+    {
+        this.#ui.viewportRow.pendingValue = WI.UIString("%dx%d (%dx)").format(this.#values.viewport?.width ?? 0, this.#values.viewport?.height ?? 0, this.#values.devicePixelRatio ?? 1);
+        this.needsLayout();
+    }
+
+    #setQuality(quality)
+    {
+        if (Object.shallowEqual(this.#values.quality, quality))
+            return;
+
+        this.#values.quality = quality;
+        let formatString = WI.UIString("%d dropped of %d", "Dropped Frame Format @ Media Sidebar", "Format string for Dropped Frame count in Media Sidebar");
+        this.#ui.framesRow.pendingValue = formatString.format(quality?.droppedVideoFrames ?? 0, quality?.totalVideoFrames ?? 0);
+        this.needsLayout();
+    }
+
+    #setVideoFormat(videoFormat)
+    {
+        if (this.#values.videoFormat === videoFormat)
+            return;
+
+        this.#values.videoFormat = videoFormat;
+        this.#ui.videoFormatRow.pendingValue = videoFormat;
+        this.needsLayout();
+    }
+
+    #setAudioFormat(audioFormat)
+    {
+        if (this.#values.audioFormat === audioFormat)
+            return;
+
+        this.#values.audioFormat = audioFormat;
+        this.#ui.audioFormatRow.pendingValue = audioFormat;
+        this.needsLayout();
+    }
+
+    #setVideo(video)
+    {
+        if (this.#values.video === video)
+            return;
+
+        if (this.#values.video?.width === video?.width
+            && this.#values.video?.height === video?.height
+            && this.#values.video?.framerate === video?.framerate
+            && this.#values.video?.codec === video?.codec
+            && Object.shallowEqual(this.#values.video?.colorSpace, video?.colorSpace)
+            && this.#values.video?.colorSpace?.primaries === video?.colorSpace?.primaries
+            && this.#values.video?.colorSpace?.matrix === video?.colorSpace?.matrix
+            && this.#values.video?.fullRange === video?.fullRange)
+            return;
+
+        this.#values.video = video;
+        this.#ui.videoSection.element.classList.toggle("hidden", !video);
+        this.#ui.resolutionRow.pendingValue = WI.UIString("%dx%d (%dfps)").format(video?.width ?? 0, video?.height ?? 0, video?.framerate ?? 0);
+        this.#ui.resolutionRow.element.classList.toggle("hidden", !video);
+        this.#ui.videoCodecRow.pendingValue = video?.codec;
+        this.#ui.transferRow.pendingValue = video?.colorSpace?.transfer;
+        this.#ui.primariesRow.pendingValue = video?.colorSpace?.primaries;
+        this.#ui.matrixRow.pendingValue = video?.colorSpace?.matrix;
+        if (video?.fullRange)
+            this.#ui.fullRangeRow.pendingValue = WI.UIString("Full range", "Full range @ Media Sidebar", "Value string for Full Range color in the Media Sidebar");
+        else
+            this.#ui.fullRangeRow.pendingValue = WI.UIString("Video range", "Video range @ Media Sidebar", "Value string for Video Range color in the Media Sidebar");
+        this.needsLayout();
+    }
+
+    #setAudio(audio)
+    {
+        if (Object.shallowEqual(this.#values.audio, audio))
+            return;
+
+        this.#values.audio = audio;
+        this.#ui.audioSection.element.classList.toggle("hidden", !audio);
+        this.#ui.audioCodecRow.pendingValue = audio?.codec;
+        this.#ui.sampleRateRow.pendingValue = WI.UIString("%d Hz").format(audio?.sampleRate);
+        switch (audio?.numberOfChannels) {
+        case 1:
+            this.#ui.channelsRow.pendingValue = WI.UIString("Mono");
+            break;
+        case 2:
+            this.#ui.channelsRow.pendingValue = WI.UIString("Stereo");
+            break;
+        default:
+            this.#ui.channelsRow.pendingValue = audio?.numberOfChannels;
+            break;
+        }
+        this.needsLayout();
+    }
+};


### PR DESCRIPTION
#### ddfb1a4a5608af37f95f99d837b43db85f48e435
<pre>
Add a &quot;Media&quot; WebInspector Element details panel
<a href="https://bugs.webkit.org/show_bug.cgi?id=265429">https://bugs.webkit.org/show_bug.cgi?id=265429</a>
<a href="https://rdar.apple.com/118865793">rdar://118865793</a>

Reviewed by Devin Rousso and Antoine Quint.

Add a &quot;Media&quot; details panel to the Web Inspector when selecting a &lt;video&gt; or &lt;audio&gt; element.

The contents of the details panel should be broadly similar to the contents of the &quot;Show Media Stats&quot;
panel in desktop WebKit. These contents are collected within HTMLMediaElement::getStatsAsJSON(), put
into a JSON object, and passed to the WebInspector via InspectorDOMAgent. In order to facilitate
crating this JSON stats object, add toJSON/toJSONObject() methods to VideoPlaybackQuality,
AudioTrackConfiguration, and VideoTrackConfiguration. Add a new utility method to create a human
readable string from an extended codec string. And create and populate a new panel within the
WebInspectorUI to display these stats.

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WTF/wtf/Forward.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::sourceType const):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp:
(WebCore::VideoPlaybackQuality::toJSONObject const):
* Source/WebCore/Modules/mediasource/VideoPlaybackQuality.h:
* Source/WebCore/Modules/webcodecs/VideoColorSpace.cpp: Copied from Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp.
(WebCore::VideoColorSpace::toJSON const):
* Source/WebCore/Modules/webcodecs/VideoColorSpace.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::getVideoPlaybackQuality const):
(WebCore::HTMLMediaElement::getStatsAsJSON const):
(WebCore::HTMLMediaElement::sourceType const):
(WebCore::HTMLMediaElement::getVideoPlaybackQuality): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/track/AudioTrackConfiguration.cpp: Copied from Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp.
(WebCore::AudioTrackConfiguration::toJSON const):
* Source/WebCore/html/track/AudioTrackConfiguration.h:
* Source/WebCore/html/track/AudioTrackList.cpp:
(WebCore::AudioTrackList::firstEnabled const):
* Source/WebCore/html/track/AudioTrackList.h:
* Source/WebCore/html/track/VideoTrackConfiguration.cpp: Copied from Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp.
(WebCore::VideoTrackConfiguration::toJSON const):
* Source/WebCore/html/track/VideoTrackConfiguration.h:
* Source/WebCore/html/track/VideoTrackList.cpp:
(WebCore::VideoTrackList::selectedItem const):
* Source/WebCore/html/track/VideoTrackList.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::getMediaStats):
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/platform/graphics/CodecUtilities.cpp: Added.
(WebCore::humanReadableStringFromCodecString):
* Source/WebCore/platform/graphics/CodecUtilities.h: Copied from Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp.
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode):
* Source/WebInspectorUI/UserInterface/Protocol/Legacy/iOS/17.0/InspectorBackendCommands.js:
* Source/WebInspectorUI/UserInterface/Protocol/Legacy/macOS/14.0/InspectorBackendCommands.js:
* Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js:
(WI.ElementsTabContentView):
* Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.css: Added.
* Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js: Added.
(WI.MediaDetailsSidebarPanel):
(WI.MediaDetailsSidebarPanel.prototype.supportsDOMNode):
(WI.MediaDetailsSidebarPanel.prototype.initialLayout):
(WI.MediaDetailsSidebarPanel.prototype.async layout):
(WI.MediaDetailsSidebarPanel.prototype.get source):
(WI.MediaDetailsSidebarPanel.prototype.set source):
(WI.MediaDetailsSidebarPanel.prototype._updateViewportRow):
(WI.MediaDetailsSidebarPanel.prototype.get viewport):
(WI.MediaDetailsSidebarPanel.prototype.set viewport):
(WI.MediaDetailsSidebarPanel.prototype.get devicePixelRatio):
(WI.MediaDetailsSidebarPanel.prototype.set devicePixelRatio):
(WI.MediaDetailsSidebarPanel.prototype.get quality):
(WI.MediaDetailsSidebarPanel.prototype.set quality):
(WI.MediaDetailsSidebarPanel.prototype.get videoFormat):
(WI.MediaDetailsSidebarPanel.prototype.set videoFormat):
(WI.MediaDetailsSidebarPanel.prototype.get audioFormat):
(WI.MediaDetailsSidebarPanel.prototype.set audioFormat):
(WI.MediaDetailsSidebarPanel.prototype.get video):
(WI.MediaDetailsSidebarPanel.prototype.set video):
(WI.MediaDetailsSidebarPanel.prototype.get audio):
(WI.MediaDetailsSidebarPanel.prototype.set audio):
(WI.MediaDetailsSidebarPanel.prototype.attached):
(WI.MediaDetailsSidebarPanel.prototype.detached):

Canonical link: <a href="https://commits.webkit.org/273777@main">https://commits.webkit.org/273777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54b1c1b223c333c1510ef192d808669cf3ab0559

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36615 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12634 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11485 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40520 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32990 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36391 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35545 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32313 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43174 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8306 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12167 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->