### PR TITLE
Generate IPC serialization for PlatformCAAnimation enums

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -221,31 +221,31 @@ static PlatformCAAnimation::ValueFunctionType getValueFunctionNameForTransformOp
     // Use literal strings to avoid link-time dependency on those symbols.
     switch (transformType) {
     case TransformOperation::Type::RotateX:
-        return PlatformCAAnimation::RotateX;
+        return PlatformCAAnimation::ValueFunctionType::RotateX;
     case TransformOperation::Type::RotateY:
-        return PlatformCAAnimation::RotateY;
+        return PlatformCAAnimation::ValueFunctionType::RotateY;
     case TransformOperation::Type::Rotate:
-        return PlatformCAAnimation::RotateZ;
+        return PlatformCAAnimation::ValueFunctionType::RotateZ;
     case TransformOperation::Type::ScaleX:
-        return PlatformCAAnimation::ScaleX;
+        return PlatformCAAnimation::ValueFunctionType::ScaleX;
     case TransformOperation::Type::ScaleY:
-        return PlatformCAAnimation::ScaleY;
+        return PlatformCAAnimation::ValueFunctionType::ScaleY;
     case TransformOperation::Type::ScaleZ:
-        return PlatformCAAnimation::ScaleZ;
+        return PlatformCAAnimation::ValueFunctionType::ScaleZ;
     case TransformOperation::Type::TranslateX:
-        return PlatformCAAnimation::TranslateX;
+        return PlatformCAAnimation::ValueFunctionType::TranslateX;
     case TransformOperation::Type::TranslateY:
-        return PlatformCAAnimation::TranslateY;
+        return PlatformCAAnimation::ValueFunctionType::TranslateY;
     case TransformOperation::Type::TranslateZ:
-        return PlatformCAAnimation::TranslateZ;
+        return PlatformCAAnimation::ValueFunctionType::TranslateZ;
     case TransformOperation::Type::Scale:
     case TransformOperation::Type::Scale3D:
-        return PlatformCAAnimation::Scale;
+        return PlatformCAAnimation::ValueFunctionType::Scale;
     case TransformOperation::Type::Translate:
     case TransformOperation::Type::Translate3D:
-        return PlatformCAAnimation::Translate;
+        return PlatformCAAnimation::ValueFunctionType::Translate;
     default:
-        return PlatformCAAnimation::NoValueFunction;
+        return PlatformCAAnimation::ValueFunctionType::NoValueFunction;
     }
 }
 
@@ -3145,7 +3145,7 @@ void GraphicsLayerCA::updateAnimations()
     auto currentTime = Seconds(CACurrentMediaTime());
 
     auto addAnimationGroup = [&](AnimatedProperty property, const Vector<RefPtr<PlatformCAAnimation>>& animations) {
-        auto caAnimationGroup = createPlatformCAAnimation(PlatformCAAnimation::Group, PlatformCAAnimation::makeGroupKeyPath());
+        auto caAnimationGroup = createPlatformCAAnimation(PlatformCAAnimation::AnimationType::Group, PlatformCAAnimation::makeGroupKeyPath());
         caAnimationGroup->setDuration(infiniteDuration);
         caAnimationGroup->setAnimations(animations);
 
@@ -3192,7 +3192,7 @@ void GraphicsLayerCA::updateAnimations()
         // A base value transform animation needs to last forever and use the same value for its from and to values,
         // unless we're just filling until an animation for this property starts, in which case it must last for duration
         // of the delay until that animation.
-        auto caAnimation = createPlatformCAAnimation(PlatformCAAnimation::Basic, PlatformCAAnimation::makeKeyPath(property));
+        auto caAnimation = createPlatformCAAnimation(PlatformCAAnimation::AnimationType::Basic, PlatformCAAnimation::makeKeyPath(property));
         caAnimation->setDuration(delay ? delay.seconds() : infiniteDuration);
         caAnimation->setFromValue(matrix);
         caAnimation->setToValue(matrix);
@@ -3318,7 +3318,7 @@ void GraphicsLayerCA::updateAnimations()
             // until that animation begins.
             if (earliestAnimation) {
                 auto fillMode = earliestAnimation->m_animation->fillMode();
-                if (fillMode != PlatformCAAnimation::Backwards && fillMode != PlatformCAAnimation::Both) {
+                if (fillMode != PlatformCAAnimation::FillModeType::Backwards && fillMode != PlatformCAAnimation::FillModeType::Both) {
                     Seconds earliestBeginTime = *earliestAnimation->computedBeginTime() + animationGroupBeginTime;
                     if (earliestBeginTime > currentTime) {
                         if (auto* baseValueTransformAnimation = makeBaseValueTransformAnimation(property, TransformationMatrixSource::AskClient, earliestBeginTime)) {
@@ -3657,21 +3657,21 @@ bool GraphicsLayerCA::createFilterAnimationsFromKeyframes(const KeyframeValueLis
 
 Ref<PlatformCAAnimation> GraphicsLayerCA::createBasicAnimation(const Animation* anim, const String& keyPath, bool additive, bool keyframesShouldUseAnimationWideTimingFunction)
 {
-    auto basicAnim = createPlatformCAAnimation(PlatformCAAnimation::Basic, keyPath);
+    auto basicAnim = createPlatformCAAnimation(PlatformCAAnimation::AnimationType::Basic, keyPath);
     setupAnimation(basicAnim.ptr(), anim, additive, keyframesShouldUseAnimationWideTimingFunction);
     return basicAnim;
 }
 
 Ref<PlatformCAAnimation> GraphicsLayerCA::createKeyframeAnimation(const Animation* anim, const String& keyPath, bool additive, bool keyframesShouldUseAnimationWideTimingFunction)
 {
-    auto keyframeAnim = createPlatformCAAnimation(PlatformCAAnimation::Keyframe, keyPath);
+    auto keyframeAnim = createPlatformCAAnimation(PlatformCAAnimation::AnimationType::Keyframe, keyPath);
     setupAnimation(keyframeAnim.ptr(), anim, additive, keyframesShouldUseAnimationWideTimingFunction);
     return keyframeAnim;
 }
 
 Ref<PlatformCAAnimation> GraphicsLayerCA::createSpringAnimation(const Animation* anim, const String& keyPath, bool additive, bool keyframesShouldUseAnimationWideTimingFunction)
 {
-    auto basicAnim = createPlatformCAAnimation(PlatformCAAnimation::Spring, keyPath);
+    auto basicAnim = createPlatformCAAnimation(PlatformCAAnimation::AnimationType::Spring, keyPath);
     setupAnimation(basicAnim.ptr(), anim, additive, keyframesShouldUseAnimationWideTimingFunction);
     return basicAnim;
 }
@@ -3688,19 +3688,19 @@ void GraphicsLayerCA::setupAnimation(PlatformCAAnimation* propertyAnim, const An
     else if (anim->direction() == Animation::Direction::Alternate || anim->direction() == Animation::Direction::AlternateReverse)
         repeatCount /= 2;
 
-    PlatformCAAnimation::FillModeType fillMode = PlatformCAAnimation::NoFillMode;
+    PlatformCAAnimation::FillModeType fillMode = PlatformCAAnimation::FillModeType::NoFillMode;
     switch (anim->fillMode()) {
     case AnimationFillMode::None:
-        fillMode = PlatformCAAnimation::Forwards; // Use "forwards" rather than "removed" because the style system will remove the animation when it is finished. This avoids a flash.
+        fillMode = PlatformCAAnimation::FillModeType::Forwards; // Use "forwards" rather than "removed" because the style system will remove the animation when it is finished. This avoids a flash.
         break;
     case AnimationFillMode::Backwards:
-        fillMode = PlatformCAAnimation::Both; // Use "both" rather than "backwards" because the style system will remove the animation when it is finished. This avoids a flash.
+        fillMode = PlatformCAAnimation::FillModeType::Both; // Use "both" rather than "backwards" because the style system will remove the animation when it is finished. This avoids a flash.
         break;
     case AnimationFillMode::Forwards:
-        fillMode = PlatformCAAnimation::Forwards;
+        fillMode = PlatformCAAnimation::FillModeType::Forwards;
         break;
     case AnimationFillMode::Both:
-        fillMode = PlatformCAAnimation::Both;
+        fillMode = PlatformCAAnimation::FillModeType::Both;
         break;
     }
 
@@ -3844,7 +3844,7 @@ bool GraphicsLayerCA::setTransformAnimationEndpoints(const KeyframeValueList& va
     }
 
     auto valueFunction = getValueFunctionNameForTransformOperation(transformOpType);
-    if (valueFunction != PlatformCAAnimation::NoValueFunction)
+    if (valueFunction != PlatformCAAnimation::ValueFunctionType::NoValueFunction)
         basicAnim->setValueFunction(valueFunction);
 
     return true;
@@ -3907,7 +3907,7 @@ bool GraphicsLayerCA::setTransformAnimationKeyframes(const KeyframeValueList& va
     keyframeAnim->setTimingFunctions(timingFunctions, !forwards);
 
     PlatformCAAnimation::ValueFunctionType valueFunction = getValueFunctionNameForTransformOperation(transformOpType);
-    if (valueFunction != PlatformCAAnimation::NoValueFunction)
+    if (valueFunction != PlatformCAAnimation::ValueFunctionType::NoValueFunction)
         keyframeAnim->setValueFunction(valueFunction);
 
     return true;

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.cpp
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.cpp
@@ -34,10 +34,10 @@ namespace WebCore {
 TextStream& operator<<(TextStream& ts, PlatformCAAnimation::AnimationType type)
 {
     switch (type) {
-    case PlatformCAAnimation::Basic: ts << "basic"; break;
-    case PlatformCAAnimation::Group: ts << "group"; break;
-    case PlatformCAAnimation::Keyframe: ts << "keyframe"; break;
-    case PlatformCAAnimation::Spring: ts << "spring"; break;
+    case PlatformCAAnimation::AnimationType::Basic: ts << "basic"; break;
+    case PlatformCAAnimation::AnimationType::Group: ts << "group"; break;
+    case PlatformCAAnimation::AnimationType::Keyframe: ts << "keyframe"; break;
+    case PlatformCAAnimation::AnimationType::Spring: ts << "spring"; break;
     }
     return ts;
 }
@@ -45,10 +45,10 @@ TextStream& operator<<(TextStream& ts, PlatformCAAnimation::AnimationType type)
 TextStream& operator<<(TextStream& ts, PlatformCAAnimation::FillModeType fillMode)
 {
     switch (fillMode) {
-    case PlatformCAAnimation::NoFillMode: ts << "none"; break;
-    case PlatformCAAnimation::Forwards: ts << "forwards"; break;
-    case PlatformCAAnimation::Backwards: ts << "backwards"; break;
-    case PlatformCAAnimation::Both: ts << "both"; break;
+    case PlatformCAAnimation::FillModeType::NoFillMode: ts << "none"; break;
+    case PlatformCAAnimation::FillModeType::Forwards: ts << "forwards"; break;
+    case PlatformCAAnimation::FillModeType::Backwards: ts << "backwards"; break;
+    case PlatformCAAnimation::FillModeType::Both: ts << "both"; break;
     }
     return ts;
 }
@@ -56,25 +56,25 @@ TextStream& operator<<(TextStream& ts, PlatformCAAnimation::FillModeType fillMod
 TextStream& operator<<(TextStream& ts, PlatformCAAnimation::ValueFunctionType valueFunctionType)
 {
     switch (valueFunctionType) {
-    case PlatformCAAnimation::NoValueFunction: ts << "none"; break;
-    case PlatformCAAnimation::RotateX: ts << "rotateX"; break;
-    case PlatformCAAnimation::RotateY: ts << "rotateY"; break;
-    case PlatformCAAnimation::RotateZ: ts << "rotateX"; break;
-    case PlatformCAAnimation::ScaleX: ts << "scaleX"; break;
-    case PlatformCAAnimation::ScaleY: ts << "scaleY"; break;
-    case PlatformCAAnimation::ScaleZ: ts << "scaleX"; break;
-    case PlatformCAAnimation::Scale: ts << "scale"; break;
-    case PlatformCAAnimation::TranslateX: ts << "translateX"; break;
-    case PlatformCAAnimation::TranslateY: ts << "translateY"; break;
-    case PlatformCAAnimation::TranslateZ: ts << "translateZ"; break;
-    case PlatformCAAnimation::Translate: ts << "translate"; break;
+    case PlatformCAAnimation::ValueFunctionType::NoValueFunction: ts << "none"; break;
+    case PlatformCAAnimation::ValueFunctionType::RotateX: ts << "rotateX"; break;
+    case PlatformCAAnimation::ValueFunctionType::RotateY: ts << "rotateY"; break;
+    case PlatformCAAnimation::ValueFunctionType::RotateZ: ts << "rotateZ"; break;
+    case PlatformCAAnimation::ValueFunctionType::ScaleX: ts << "scaleX"; break;
+    case PlatformCAAnimation::ValueFunctionType::ScaleY: ts << "scaleY"; break;
+    case PlatformCAAnimation::ValueFunctionType::ScaleZ: ts << "scaleZ"; break;
+    case PlatformCAAnimation::ValueFunctionType::Scale: ts << "scale"; break;
+    case PlatformCAAnimation::ValueFunctionType::TranslateX: ts << "translateX"; break;
+    case PlatformCAAnimation::ValueFunctionType::TranslateY: ts << "translateY"; break;
+    case PlatformCAAnimation::ValueFunctionType::TranslateZ: ts << "translateZ"; break;
+    case PlatformCAAnimation::ValueFunctionType::Translate: ts << "translate"; break;
     }
     return ts;
 }
 
 bool PlatformCAAnimation::isBasicAnimation() const
 {
-    return animationType() == Basic || animationType() == Spring;
+    return animationType() == AnimationType::Basic || animationType() == AnimationType::Spring;
 }
 
 static constexpr auto transformKeyPath = "transform"_s;

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
@@ -42,11 +42,40 @@ namespace WebCore {
 class FloatRect;
 class TimingFunction;
 
+enum class PlatformCAAnimationType : uint8_t {
+    Basic,
+    Group,
+    Keyframe,
+    Spring
+};
+
+enum class PlatformCAAnimationFillModeType : uint8_t {
+    NoFillMode,
+    Forwards,
+    Backwards,
+    Both
+};
+
+enum class PlatformCAAnimationValueFunctionType : uint8_t {
+    NoValueFunction,
+    RotateX,
+    RotateY,
+    RotateZ,
+    ScaleX,
+    ScaleY,
+    ScaleZ,
+    Scale,
+    TranslateX,
+    TranslateY,
+    TranslateZ,
+    Translate
+};
+
 class PlatformCAAnimation : public RefCounted<PlatformCAAnimation> {
 public:
-    enum AnimationType { Basic, Group, Keyframe, Spring };
-    enum FillModeType { NoFillMode, Forwards, Backwards, Both };
-    enum ValueFunctionType { NoValueFunction, RotateX, RotateY, RotateZ, ScaleX, ScaleY, ScaleZ, Scale, TranslateX, TranslateY, TranslateZ, Translate };
+    using AnimationType = PlatformCAAnimationType;
+    using FillModeType = PlatformCAAnimationFillModeType;
+    using ValueFunctionType = PlatformCAAnimationValueFunctionType;
 
     virtual ~PlatformCAAnimation() = default;
 
@@ -138,7 +167,7 @@ public:
     WEBCORE_EXPORT static bool isValidKeyPath(const String&, AnimationType = AnimationType::Basic);
 
 protected:
-    PlatformCAAnimation(AnimationType type = Basic)
+    PlatformCAAnimation(AnimationType type = AnimationType::Basic)
         : m_type(type)
     {
     }
@@ -159,45 +188,3 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformCAAnimation
 SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \
     static bool isType(const WebCore::PlatformCAAnimation& animation) { return animation.predicate; } \
 SPECIALIZE_TYPE_TRAITS_END()
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlatformCAAnimation::AnimationType> {
-    using values = EnumValues<
-        WebCore::PlatformCAAnimation::AnimationType,
-        WebCore::PlatformCAAnimation::AnimationType::Basic,
-        WebCore::PlatformCAAnimation::AnimationType::Group,
-        WebCore::PlatformCAAnimation::AnimationType::Keyframe,
-        WebCore::PlatformCAAnimation::AnimationType::Spring
-    >;
-};
-
-template<> struct EnumTraits<WebCore::PlatformCAAnimation::FillModeType> {
-    using values = EnumValues<
-        WebCore::PlatformCAAnimation::FillModeType,
-        WebCore::PlatformCAAnimation::FillModeType::NoFillMode,
-        WebCore::PlatformCAAnimation::FillModeType::Forwards,
-        WebCore::PlatformCAAnimation::FillModeType::Backwards,
-        WebCore::PlatformCAAnimation::FillModeType::Both
-    >;
-};
-
-template<> struct EnumTraits<WebCore::PlatformCAAnimation::ValueFunctionType> {
-    using values = EnumValues<
-        WebCore::PlatformCAAnimation::ValueFunctionType,
-        WebCore::PlatformCAAnimation::ValueFunctionType::NoValueFunction,
-        WebCore::PlatformCAAnimation::ValueFunctionType::RotateX,
-        WebCore::PlatformCAAnimation::ValueFunctionType::RotateY,
-        WebCore::PlatformCAAnimation::ValueFunctionType::RotateZ,
-        WebCore::PlatformCAAnimation::ValueFunctionType::ScaleX,
-        WebCore::PlatformCAAnimation::ValueFunctionType::ScaleY,
-        WebCore::PlatformCAAnimation::ValueFunctionType::ScaleZ,
-        WebCore::PlatformCAAnimation::ValueFunctionType::Scale,
-        WebCore::PlatformCAAnimation::ValueFunctionType::TranslateX,
-        WebCore::PlatformCAAnimation::ValueFunctionType::TranslateY,
-        WebCore::PlatformCAAnimation::ValueFunctionType::TranslateZ,
-        WebCore::PlatformCAAnimation::ValueFunctionType::Translate
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -51,10 +51,10 @@ void setHasExplicitBeginTime(CAAnimation *animation, bool value)
 NSString* toCAFillModeType(PlatformCAAnimation::FillModeType type)
 {
     switch (type) {
-    case PlatformCAAnimation::NoFillMode:
-    case PlatformCAAnimation::Forwards: return kCAFillModeForwards;
-    case PlatformCAAnimation::Backwards: return kCAFillModeBackwards;
-    case PlatformCAAnimation::Both: return kCAFillModeBoth;
+    case PlatformCAAnimation::FillModeType::NoFillMode:
+    case PlatformCAAnimation::FillModeType::Forwards: return kCAFillModeForwards;
+    case PlatformCAAnimation::FillModeType::Backwards: return kCAFillModeBackwards;
+    case PlatformCAAnimation::FillModeType::Both: return kCAFillModeBoth;
     }
     return @"";
 }
@@ -62,29 +62,29 @@ NSString* toCAFillModeType(PlatformCAAnimation::FillModeType type)
 static PlatformCAAnimation::FillModeType fromCAFillModeType(NSString* string)
 {
     if ([string isEqualToString:kCAFillModeBackwards])
-        return PlatformCAAnimation::Backwards;
+        return PlatformCAAnimation::FillModeType::Backwards;
 
     if ([string isEqualToString:kCAFillModeBoth])
-        return PlatformCAAnimation::Both;
+        return PlatformCAAnimation::FillModeType::Both;
 
-    return PlatformCAAnimation::Forwards;
+    return PlatformCAAnimation::FillModeType::Forwards;
 }
 
 NSString* toCAValueFunctionType(PlatformCAAnimation::ValueFunctionType type)
 {
     switch (type) {
-    case PlatformCAAnimation::NoValueFunction: return @"";
-    case PlatformCAAnimation::RotateX: return kCAValueFunctionRotateX;
-    case PlatformCAAnimation::RotateY: return kCAValueFunctionRotateY;
-    case PlatformCAAnimation::RotateZ: return kCAValueFunctionRotateZ;
-    case PlatformCAAnimation::ScaleX: return kCAValueFunctionScaleX;
-    case PlatformCAAnimation::ScaleY: return kCAValueFunctionScaleY;
-    case PlatformCAAnimation::ScaleZ: return kCAValueFunctionScaleZ;
-    case PlatformCAAnimation::Scale: return kCAValueFunctionScale;
-    case PlatformCAAnimation::TranslateX: return kCAValueFunctionTranslateX;
-    case PlatformCAAnimation::TranslateY: return kCAValueFunctionTranslateY;
-    case PlatformCAAnimation::TranslateZ: return kCAValueFunctionTranslateZ;
-    case PlatformCAAnimation::Translate: return kCAValueFunctionTranslate;
+    case PlatformCAAnimation::ValueFunctionType::NoValueFunction: return @"";
+    case PlatformCAAnimation::ValueFunctionType::RotateX: return kCAValueFunctionRotateX;
+    case PlatformCAAnimation::ValueFunctionType::RotateY: return kCAValueFunctionRotateY;
+    case PlatformCAAnimation::ValueFunctionType::RotateZ: return kCAValueFunctionRotateZ;
+    case PlatformCAAnimation::ValueFunctionType::ScaleX: return kCAValueFunctionScaleX;
+    case PlatformCAAnimation::ValueFunctionType::ScaleY: return kCAValueFunctionScaleY;
+    case PlatformCAAnimation::ValueFunctionType::ScaleZ: return kCAValueFunctionScaleZ;
+    case PlatformCAAnimation::ValueFunctionType::Scale: return kCAValueFunctionScale;
+    case PlatformCAAnimation::ValueFunctionType::TranslateX: return kCAValueFunctionTranslateX;
+    case PlatformCAAnimation::ValueFunctionType::TranslateY: return kCAValueFunctionTranslateY;
+    case PlatformCAAnimation::ValueFunctionType::TranslateZ: return kCAValueFunctionTranslateZ;
+    case PlatformCAAnimation::ValueFunctionType::Translate: return kCAValueFunctionTranslate;
     }
     return @"";
 }
@@ -92,39 +92,39 @@ NSString* toCAValueFunctionType(PlatformCAAnimation::ValueFunctionType type)
 static PlatformCAAnimation::ValueFunctionType fromCAValueFunctionType(NSString* string)
 {
     if ([string isEqualToString:kCAValueFunctionRotateX])
-        return PlatformCAAnimation::RotateX;
+        return PlatformCAAnimation::ValueFunctionType::RotateX;
 
     if ([string isEqualToString:kCAValueFunctionRotateY])
-        return PlatformCAAnimation::RotateY;
+        return PlatformCAAnimation::ValueFunctionType::RotateY;
 
     if ([string isEqualToString:kCAValueFunctionRotateZ])
-        return PlatformCAAnimation::RotateZ;
+        return PlatformCAAnimation::ValueFunctionType::RotateZ;
 
     if ([string isEqualToString:kCAValueFunctionScaleX])
-        return PlatformCAAnimation::ScaleX;
+        return PlatformCAAnimation::ValueFunctionType::ScaleX;
 
     if ([string isEqualToString:kCAValueFunctionScaleY])
-        return PlatformCAAnimation::ScaleY;
+        return PlatformCAAnimation::ValueFunctionType::ScaleY;
 
     if ([string isEqualToString:kCAValueFunctionScaleZ])
-        return PlatformCAAnimation::ScaleZ;
+        return PlatformCAAnimation::ValueFunctionType::ScaleZ;
 
     if ([string isEqualToString:kCAValueFunctionScale])
-        return PlatformCAAnimation::Scale;
+        return PlatformCAAnimation::ValueFunctionType::Scale;
 
     if ([string isEqualToString:kCAValueFunctionTranslateX])
-        return PlatformCAAnimation::TranslateX;
+        return PlatformCAAnimation::ValueFunctionType::TranslateX;
 
     if ([string isEqualToString:kCAValueFunctionTranslateY])
-        return PlatformCAAnimation::TranslateY;
+        return PlatformCAAnimation::ValueFunctionType::TranslateY;
 
     if ([string isEqualToString:kCAValueFunctionTranslateZ])
-        return PlatformCAAnimation::TranslateZ;
+        return PlatformCAAnimation::ValueFunctionType::TranslateZ;
 
     if ([string isEqualToString:kCAValueFunctionTranslate])
-        return PlatformCAAnimation::Translate;
+        return PlatformCAAnimation::ValueFunctionType::Translate;
 
-    return PlatformCAAnimation::NoValueFunction;
+    return PlatformCAAnimation::ValueFunctionType::NoValueFunction;
 }
 
 CAMediaTimingFunction* toCAMediaTimingFunction(const TimingFunction& timingFunction, bool reverse)
@@ -164,16 +164,16 @@ PlatformCAAnimationCocoa::PlatformCAAnimationCocoa(AnimationType type, const Str
     : PlatformCAAnimation(type)
 {
     switch (type) {
-    case Basic:
+    case AnimationType::Basic:
         m_animation = [CABasicAnimation animationWithKeyPath:keyPath];
         break;
-    case Group:
+    case AnimationType::Group:
         m_animation = [CAAnimationGroup animation];
         break;
-    case Keyframe:
+    case AnimationType::Keyframe:
         m_animation = [CAKeyframeAnimation animationWithKeyPath:keyPath];
         break;
-    case Spring:
+    case AnimationType::Spring:
         m_animation = [CASpringAnimation animationWithKeyPath:keyPath];
         break;
     }
@@ -184,13 +184,13 @@ PlatformCAAnimationCocoa::PlatformCAAnimationCocoa(PlatformAnimationRef animatio
     auto caAnimation = static_cast<CAAnimation *>(animation);
     if ([caAnimation isKindOfClass:[CABasicAnimation class]]) {
         if ([caAnimation isKindOfClass:[CASpringAnimation class]])
-            setType(Spring);
+            setType(AnimationType::Spring);
         else
-            setType(Basic);
+            setType(AnimationType::Basic);
     } else if ([caAnimation isKindOfClass:[CAKeyframeAnimation class]])
-        setType(Keyframe);
+        setType(AnimationType::Keyframe);
     else if ([caAnimation isKindOfClass:[CAAnimationGroup class]])
-        setType(Group);
+        setType(AnimationType::Group);
     else {
         ASSERT_NOT_REACHED();
         return;
@@ -222,7 +222,7 @@ Ref<PlatformCAAnimation> PlatformCAAnimationCocoa::copy() const
     setHasExplicitBeginTime(downcast<PlatformCAAnimationCocoa>(animation.get()).platformAnimation(), hasExplicitBeginTime(platformAnimation()));
     
     // Copy the specific Basic or Keyframe values.
-    if (animationType() == Keyframe) {
+    if (animationType() == AnimationType::Keyframe) {
         animation->copyValuesFrom(*this);
         animation->copyKeyTimesFrom(*this);
         animation->copyTimingFunctionsFrom(*this);
@@ -241,7 +241,7 @@ PlatformAnimationRef PlatformCAAnimationCocoa::platformAnimation() const
 
 String PlatformCAAnimationCocoa::keyPath() const
 {
-    if (animationType() == Group)
+    if (animationType() == AnimationType::Group)
         return emptyString();
 
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAPropertyAnimation class]]);
@@ -329,11 +329,11 @@ void PlatformCAAnimationCocoa::setTimingFunction(const TimingFunction* timingFun
 {
     ASSERT(timingFunction);
     switch (animationType()) {
-    case Basic:
-    case Keyframe:
+    case AnimationType::Basic:
+    case AnimationType::Keyframe:
         [m_animation setTimingFunction:toCAMediaTimingFunction(*timingFunction, reverse)];
         break;
-    case Spring:
+    case AnimationType::Spring:
         if (timingFunction->isSpringTimingFunction()) {
             // FIXME: Handle reverse.
             auto& function = *static_cast<const SpringTimingFunction*>(timingFunction);
@@ -344,7 +344,7 @@ void PlatformCAAnimationCocoa::setTimingFunction(const TimingFunction* timingFun
             springAnimation.initialVelocity = function.initialVelocity();
         }
         break;
-    case Group:
+    case AnimationType::Group:
         break;
     }
 }
@@ -366,7 +366,7 @@ void PlatformCAAnimationCocoa::setRemovedOnCompletion(bool value)
 
 bool PlatformCAAnimationCocoa::isAdditive() const
 {
-    if (animationType() == Group)
+    if (animationType() == AnimationType::Group)
         return false;
 
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAPropertyAnimation class]]);
@@ -375,7 +375,7 @@ bool PlatformCAAnimationCocoa::isAdditive() const
 
 void PlatformCAAnimationCocoa::setAdditive(bool value)
 {
-    if (animationType() == Group)
+    if (animationType() == AnimationType::Group)
         return;
 
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAPropertyAnimation class]]);
@@ -384,8 +384,8 @@ void PlatformCAAnimationCocoa::setAdditive(bool value)
 
 PlatformCAAnimation::ValueFunctionType PlatformCAAnimationCocoa::valueFunction() const
 {
-    if (animationType() == Group)
-        return NoValueFunction;
+    if (animationType() == AnimationType::Group)
+        return ValueFunctionType::NoValueFunction;
 
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAPropertyAnimation class]]);
     return fromCAValueFunctionType([[static_cast<CAPropertyAnimation *>(m_animation.get()) valueFunction] name]);
@@ -393,7 +393,7 @@ PlatformCAAnimation::ValueFunctionType PlatformCAAnimationCocoa::valueFunction()
 
 void PlatformCAAnimationCocoa::setValueFunction(ValueFunctionType value)
 {
-    if (animationType() == Group)
+    if (animationType() == AnimationType::Group)
         return;
 
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAPropertyAnimation class]]);
@@ -491,7 +491,7 @@ void PlatformCAAnimationCocoa::copyToValueFrom(const PlatformCAAnimation& value)
 // Keyframe-animation properties.
 void PlatformCAAnimationCocoa::setValues(const Vector<float>& value)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(value, [] (float number) {
@@ -501,7 +501,7 @@ void PlatformCAAnimationCocoa::setValues(const Vector<float>& value)
 
 void PlatformCAAnimationCocoa::setValues(const Vector<TransformationMatrix>& value)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(value, [] (auto& matrix) {
@@ -511,7 +511,7 @@ void PlatformCAAnimationCocoa::setValues(const Vector<TransformationMatrix>& val
 
 void PlatformCAAnimationCocoa::setValues(const Vector<FloatPoint3D>& value)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(value, [] (auto& point) {
@@ -521,7 +521,7 @@ void PlatformCAAnimationCocoa::setValues(const Vector<FloatPoint3D>& value)
 
 void PlatformCAAnimationCocoa::setValues(const Vector<Color>& value)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(value, [] (auto& color) {
@@ -532,7 +532,7 @@ void PlatformCAAnimationCocoa::setValues(const Vector<Color>& value)
 
 void PlatformCAAnimationCocoa::setValues(const Vector<RefPtr<FilterOperation>>& values)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(values, [&] (auto& value) {
@@ -542,7 +542,7 @@ void PlatformCAAnimationCocoa::setValues(const Vector<RefPtr<FilterOperation>>& 
 
 void PlatformCAAnimationCocoa::copyValuesFrom(const PlatformCAAnimation& value)
 {
-    if (animationType() != Keyframe || value.animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe || value.animationType() != AnimationType::Keyframe)
         return;
 
     auto otherAnimation = static_cast<CAKeyframeAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
@@ -577,7 +577,7 @@ void PlatformCAAnimationCocoa::copyTimingFunctionsFrom(const PlatformCAAnimation
 
 void PlatformCAAnimationCocoa::setAnimations(const Vector<RefPtr<PlatformCAAnimation>>& value)
 {
-    ASSERT(animationType() == Group);
+    ASSERT(animationType() == AnimationType::Group);
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAAnimationGroup class]]);
 
     [static_cast<CAAnimationGroup *>(m_animation.get()) setAnimations:createNSArray(value, [&] (auto& animation) -> CAAnimation * {
@@ -589,8 +589,8 @@ void PlatformCAAnimationCocoa::setAnimations(const Vector<RefPtr<PlatformCAAnima
 
 void PlatformCAAnimationCocoa::copyAnimationsFrom(const PlatformCAAnimation& value)
 {
-    ASSERT(animationType() == Group);
-    ASSERT(value.animationType() == Group);
+    ASSERT(animationType() == AnimationType::Group);
+    ASSERT(value.animationType() == AnimationType::Group);
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAAnimationGroup class]]);
     ASSERT([static_cast<CAAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get()) isKindOfClass:[CAAnimationGroup class]]);
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -117,3 +117,35 @@ enum class WebCore::ApplePayShippingContactEditingMode : uint8_t {
     StorePickup,
 };
 #endif
+
+header: <WebCore/PlatformCAAnimation.h>
+enum class WebCore::PlatformCAAnimationType : uint8_t {
+    Basic,
+    Group,
+    Keyframe,
+    Spring
+};
+
+header: <WebCore/PlatformCAAnimation.h>
+enum class WebCore::PlatformCAAnimationFillModeType : uint8_t {
+    NoFillMode,
+    Forwards,
+    Backwards,
+    Both
+};
+
+header: <WebCore/PlatformCAAnimation.h>
+enum class WebCore::PlatformCAAnimationValueFunctionType : uint8_t {
+    NoValueFunction,
+    RotateX,
+    RotateY,
+    RotateZ,
+    ScaleX,
+    ScaleY,
+    ScaleZ,
+    Scale,
+    TranslateX,
+    TranslateY,
+    TranslateZ,
+    Translate
+};

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -129,7 +129,7 @@ Ref<PlatformCAAnimation> PlatformCAAnimationRemote::copy() const
     downcast<PlatformCAAnimationRemote>(animation.get()).setHasExplicitBeginTime(hasExplicitBeginTime());
     
     // Copy the specific Basic or Keyframe values.
-    if (animationType() == Keyframe) {
+    if (animationType() == AnimationType::Keyframe) {
         animation->copyValuesFrom(*this);
         animation->copyKeyTimesFrom(*this);
         animation->copyTimingFunctionsFrom(*this);
@@ -277,7 +277,7 @@ void PlatformCAAnimationRemote::setValueFunction(ValueFunctionType value)
 
 void PlatformCAAnimationRemote::setFromValue(float value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -286,7 +286,7 @@ void PlatformCAAnimationRemote::setFromValue(float value)
 
 void PlatformCAAnimationRemote::setFromValue(const TransformationMatrix& value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -295,7 +295,7 @@ void PlatformCAAnimationRemote::setFromValue(const TransformationMatrix& value)
 
 void PlatformCAAnimationRemote::setFromValue(const FloatPoint3D& value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -304,7 +304,7 @@ void PlatformCAAnimationRemote::setFromValue(const FloatPoint3D& value)
 
 void PlatformCAAnimationRemote::setFromValue(const Color& value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -313,7 +313,7 @@ void PlatformCAAnimationRemote::setFromValue(const Color& value)
 
 void PlatformCAAnimationRemote::setFromValue(const FilterOperation* operation)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -333,7 +333,7 @@ void PlatformCAAnimationRemote::copyFromValueFrom(const PlatformCAAnimation& val
 
 void PlatformCAAnimationRemote::setToValue(float value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -342,7 +342,7 @@ void PlatformCAAnimationRemote::setToValue(float value)
 
 void PlatformCAAnimationRemote::setToValue(const TransformationMatrix& value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -351,7 +351,7 @@ void PlatformCAAnimationRemote::setToValue(const TransformationMatrix& value)
 
 void PlatformCAAnimationRemote::setToValue(const FloatPoint3D& value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -360,7 +360,7 @@ void PlatformCAAnimationRemote::setToValue(const FloatPoint3D& value)
 
 void PlatformCAAnimationRemote::setToValue(const Color& value)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
@@ -369,7 +369,7 @@ void PlatformCAAnimationRemote::setToValue(const Color& value)
 
 void PlatformCAAnimationRemote::setToValue(const FilterOperation* operation)
 {
-    if (animationType() != Basic)
+    if (animationType() != AnimationType::Basic)
         return;
     
     ASSERT(operation);
@@ -390,7 +390,7 @@ void PlatformCAAnimationRemote::copyToValueFrom(const PlatformCAAnimation& value
 // Keyframe-animation properties.
 void PlatformCAAnimationRemote::setValues(const Vector<float>& values)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     m_properties.keyValues = toKeyframeValueVector(values);
@@ -398,7 +398,7 @@ void PlatformCAAnimationRemote::setValues(const Vector<float>& values)
 
 void PlatformCAAnimationRemote::setValues(const Vector<TransformationMatrix>& values)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     m_properties.keyValues = toKeyframeValueVector(values);
@@ -406,7 +406,7 @@ void PlatformCAAnimationRemote::setValues(const Vector<TransformationMatrix>& va
 
 void PlatformCAAnimationRemote::setValues(const Vector<FloatPoint3D>& values)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     m_properties.keyValues = toKeyframeValueVector(values);
@@ -414,7 +414,7 @@ void PlatformCAAnimationRemote::setValues(const Vector<FloatPoint3D>& values)
 
 void PlatformCAAnimationRemote::setValues(const Vector<Color>& values)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     m_properties.keyValues = toKeyframeValueVector(values);
@@ -422,7 +422,7 @@ void PlatformCAAnimationRemote::setValues(const Vector<Color>& values)
 
 void PlatformCAAnimationRemote::setValues(const Vector<RefPtr<FilterOperation>>& values)
 {
-    if (animationType() != Keyframe)
+    if (animationType() != AnimationType::Keyframe)
         return;
 
     m_properties.keyValues = toKeyframeValueVector(values);
@@ -496,7 +496,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
 {
     RetainPtr<CAAnimation> caAnimation;
     switch (properties.animationType) {
-    case PlatformCAAnimation::Basic: {
+    case PlatformCAAnimation::AnimationType::Basic: {
         auto basicAnimation = [CABasicAnimation animationWithKeyPath:properties.keyPath];
 
         if (properties.keyValues.size() > 1) {
@@ -510,7 +510,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         caAnimation = basicAnimation;
         break;
     }
-    case PlatformCAAnimation::Group: {
+    case PlatformCAAnimation::AnimationType::Group: {
         auto animationGroup = [CAAnimationGroup animation];
 
         if (properties.animations.size()) {
@@ -522,7 +522,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         caAnimation = animationGroup;
         break;
     }
-    case PlatformCAAnimation::Keyframe: {
+    case PlatformCAAnimation::AnimationType::Keyframe: {
         auto keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:properties.keyPath];
 
         if (properties.keyValues.size()) {
@@ -549,7 +549,7 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
         caAnimation = keyframeAnimation;
         break;
     }
-    case PlatformCAAnimation::Spring: {
+    case PlatformCAAnimation::AnimationType::Spring: {
         auto springAnimation = [CASpringAnimation animationWithKeyPath:properties.keyPath];
 
         if (properties.keyValues.size() > 1) {
@@ -582,11 +582,11 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
 
     if ([caAnimation isKindOfClass:[CAPropertyAnimation class]]) {
         [(CAPropertyAnimation *)caAnimation setAdditive:properties.additive];
-        if (properties.valueFunction != PlatformCAAnimation::NoValueFunction)
+        if (properties.valueFunction != PlatformCAAnimation::ValueFunctionType::NoValueFunction)
             [(CAPropertyAnimation *)caAnimation setValueFunction:[CAValueFunction functionWithName:toCAValueFunctionType(properties.valueFunction)]];
     }
 
-    if (properties.fillMode != PlatformCAAnimation::NoFillMode)
+    if (properties.fillMode != PlatformCAAnimation::FillModeType::NoFillMode)
         [caAnimation setFillMode:toCAFillModeType(properties.fillMode)];
 
     if (properties.hasExplicitBeginTime)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h
@@ -32,7 +32,7 @@ namespace WebKit {
 
 struct PlatformCAAnimationRemoteProperties {
     String keyPath;
-    WebCore::PlatformCAAnimation::AnimationType animationType { WebCore::PlatformCAAnimation::Basic };
+    WebCore::PlatformCAAnimation::AnimationType animationType { WebCore::PlatformCAAnimation::AnimationType::Basic };
 
     CFTimeInterval beginTime { 0 };
     double duration { 0 };
@@ -40,8 +40,8 @@ struct PlatformCAAnimationRemoteProperties {
     float repeatCount { 1 };
     float speed { 1 };
 
-    WebCore::PlatformCAAnimation::FillModeType fillMode { WebCore::PlatformCAAnimation::NoFillMode };
-    WebCore::PlatformCAAnimation::ValueFunctionType valueFunction { WebCore::PlatformCAAnimation::NoValueFunction };
+    WebCore::PlatformCAAnimation::FillModeType fillMode { WebCore::PlatformCAAnimation::FillModeType::NoFillMode };
+    WebCore::PlatformCAAnimation::ValueFunctionType valueFunction { WebCore::PlatformCAAnimation::ValueFunctionType::NoValueFunction };
     RefPtr<WebCore::TimingFunction> timingFunction;
 
     bool autoReverses { false };


### PR DESCRIPTION
#### 589e429f93fa0a826f6393f782e232a0bc55664b
<pre>
Generate IPC serialization for PlatformCAAnimation enums
<a href="https://bugs.webkit.org/show_bug.cgi?id=265439">https://bugs.webkit.org/show_bug.cgi?id=265439</a>

Reviewed by Chris Dumez.

Rework the enumerations in the PlatformCAAnimation header to enable providing
IPC serialization specification and removing the accompanying EnumTraits
specializations.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::getValueFunctionNameForTransformOperation):
(WebCore::GraphicsLayerCA::updateAnimations):
(WebCore::GraphicsLayerCA::createBasicAnimation):
(WebCore::GraphicsLayerCA::createKeyframeAnimation):
(WebCore::GraphicsLayerCA::createSpringAnimation):
(WebCore::GraphicsLayerCA::setupAnimation):
(WebCore::GraphicsLayerCA::setTransformAnimationEndpoints):
(WebCore::GraphicsLayerCA::setTransformAnimationKeyframes):
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::PlatformCAAnimation::isBasicAnimation const):
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h:
(WebCore::PlatformCAAnimation::PlatformCAAnimation):
(): Deleted.
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::toCAFillModeType):
(WebCore::fromCAFillModeType):
(WebCore::toCAValueFunctionType):
(WebCore::fromCAValueFunctionType):
(WebCore::PlatformCAAnimationCocoa::PlatformCAAnimationCocoa):
(WebCore::PlatformCAAnimationCocoa::copy const):
(WebCore::PlatformCAAnimationCocoa::keyPath const):
(WebCore::PlatformCAAnimationCocoa::setTimingFunction):
(WebCore::PlatformCAAnimationCocoa::isAdditive const):
(WebCore::PlatformCAAnimationCocoa::setAdditive):
(WebCore::PlatformCAAnimationCocoa::valueFunction const):
(WebCore::PlatformCAAnimationCocoa::setValueFunction):
(WebCore::PlatformCAAnimationCocoa::setValues):
(WebCore::PlatformCAAnimationCocoa::copyValuesFrom):
(WebCore::PlatformCAAnimationCocoa::setAnimations):
(WebCore::PlatformCAAnimationCocoa::copyAnimationsFrom):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::PlatformCAAnimationRemote::copy const):
(WebKit::PlatformCAAnimationRemote::setFromValue):
(WebKit::PlatformCAAnimationRemote::setToValue):
(WebKit::PlatformCAAnimationRemote::setValues):
(WebKit::createAnimation):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h:

Canonical link: <a href="https://commits.webkit.org/271475@main">https://commits.webkit.org/271475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5348f86409c930141fe0968cb33a27fea62dbd05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25956 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28998 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9309 "Failed to checkout and rebase branch from PR 20980") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4515 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24524 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5160 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5302 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31714 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31556 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29325 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6844 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6828 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->