### PR TITLE
REGRESSION ( 271130@main ): [ macOS wk1 ] 4 tests in http/tests/security/mixedContent are a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2481,6 +2481,10 @@ http/tests/security/contentSecurityPolicy/video-with-https-url-allowed-by-csp-me
 http/tests/security/mixedContent/websocket/insecure-websocket-in-iframe.html [ Pass Failure ]
 http/tests/security/contentSecurityPolicy/script-src-parsing-implicit-and-explicit-port-number.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webmessaging/broadcastchannel/cross-partition.https.tentative.html [ DumpJSConsoleLogInStdErr ]
+http/tests/security/mixedContent/insecure-image-redirects-to-basic-auth-secure-image.html [ DumpJSConsoleLogInStdErr ]
+http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https.html [ DumpJSConsoleLogInStdErr ]
+http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-insecure-image.https.html [ DumpJSConsoleLogInStdErr ]
+http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https.html [ DumpJSConsoleLogInStdErr ]
 
 # These tests have been flaky on WK1 since their import.
 imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss [ Pass Failure ]
@@ -2711,9 +2715,3 @@ imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-s
 
 # webkit.org/b/263870 [scroll-animations] lots of scroll-animations WPT tests are timing out
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html [ Skip ]
-
-# rdar://118836741 (REGRESSION ( 271130@main ): [ macOS wk1 ] 4 tests in http/tests/security/mixedContent are a consistent failure)
-http/tests/security/mixedContent/insecure-image-redirects-to-basic-auth-secure-image.html [ Pass Failure ]
-http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https.html [ Pass Failure ]
-http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-insecure-image.https.html [ Pass Failure ]
-http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/insecure-image-redirects-to-basic-auth-secure-image-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/insecure-image-redirects-to-basic-auth-secure-image-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-image-redirects-to-basic-auth-secure-image.html was allowed to display insecure content from http://127.0.0.1:8080/resources/redirect.py?url=https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py.
-
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
 This test opens a new window to a secure page that loads an insecure image that redirects to a secure image guarded by basic authentication. The secure image should be blocked because it requires credentials and was loaded via an insecure redirect.
 
 PASS did not load image.

--- a/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: The page at https://127.0.0.1:8443/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https.html was allowed to display insecure content from http://127.0.0.1:8080/resources/redirect.py?url=https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py.
-
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
 This test loads a secure image that redirects to an insecure image that redirects to a secure image guarded by basic authentication. The secure image should be blocked because it requires credentials and was loaded via an insecure redirect.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-insecure-image.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-insecure-image.https-expected.txt
@@ -1,0 +1,10 @@
+This test loads a secure image that redirects to an secure image that redirects to an insecure image guarded by basic authentication. The insecure image should be blocked because it requires credentials.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS did not load image.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
-CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
 This test loads a secure image that redirects to a secure image that redirects to a secure image guarded by basic authentication. The secure image should not load because it is cross-origin.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".


### PR DESCRIPTION
#### bb9db9eb4700460bfd8e892b9826df24e6435b47
<pre>
REGRESSION ( 271130@main ): [ macOS wk1 ] 4 tests in http/tests/security/mixedContent are a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=265388">https://bugs.webkit.org/show_bug.cgi?id=265388</a>
<a href="https://rdar.apple.com/118836741">rdar://118836741</a>

Reviewed by Alex Christensen.

Remove console output for WebKitLegacy as it varies per run and became
much worse after removing a preference.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/insecure-image-redirects-to-basic-auth-secure-image-expected.txt:
* LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https-expected.txt:
* LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-insecure-image.https-expected.txt: Added.
* LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https-expected.txt:

Canonical link: <a href="https://commits.webkit.org/271220@main">https://commits.webkit.org/271220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b78c4d2c7b9ad624706b62194a4748c60637a5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25294 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25056 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23742 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4398 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30532 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28657 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6084 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5040 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->