### PR TITLE
Remove ENABLE_APNG directive

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -132,10 +132,6 @@
 #define ENABLE_ALTERNATE_WEBM_PLAYER 0
 #endif
 
-#if !defined(ENABLE_APNG)
-#define ENABLE_APNG 1
-#endif
-
 #if !defined(ENABLE_APP_HIGHLIGHTS)
 #define ENABLE_APP_HIGHLIGHTS 0
 #endif

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -87,9 +87,7 @@ constexpr ComparableCaseFoldingASCIILiteral supportedImageMIMETypeArray[] = {
     "application/x-tiff",
     "application/x-win-bitmap",
 #endif
-#if USE(CG) || ENABLE(APNG)
     "image/apng",
-#endif
 #if HAVE(AVIF) || USE(AVIF)
     "image/avif",
 #endif

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h
@@ -26,9 +26,7 @@
 #pragma once
 
 #include "ScalableImageDecoder.h"
-#if ENABLE(APNG)
 #include <png.h>
-#endif
 
 #if USE(LCMS)
 #include "LCMSUniquePtr.h"
@@ -50,10 +48,8 @@ namespace WebCore {
 
         // ScalableImageDecoder
         String filenameExtension() const override { return "png"_s; }
-#if ENABLE(APNG)
         size_t frameCount() const override { return m_frameCount; }
         RepetitionCount repetitionCount() const override;
-#endif
         ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) override;
         // CAUTION: setFailed() deletes |m_reader|.  Be careful to avoid
         // accessing deleted memory, especially when calling this from inside
@@ -64,13 +60,11 @@ namespace WebCore {
         void headerAvailable();
         void rowAvailable(unsigned char* rowBuffer, unsigned rowIndex, int interlacePass);
         void pngComplete();
-#if ENABLE(APNG)
         void readChunks(png_unknown_chunkp);
         void frameHeader();
 
         void init();
         void clearFrameBufferCache(size_t clearBeforeFrame) override;
-#endif
 
         bool isComplete() const
         {
@@ -98,20 +92,17 @@ namespace WebCore {
         // calculating the image size.  If decoding fails but there is no more
         // data coming, sets the "decode failure" flag.
         void decode(bool onlySize, unsigned haltAtFrame, bool allDataReceived);
-#if ENABLE(APNG)
         void initFrameBuffer(size_t frameIndex);
         void frameComplete();
         int processingStart(png_unknown_chunkp);
         int processingFinish();
         void fallbackNotAnimated();
-#endif
 
         void clear();
 
         std::unique_ptr<PNGImageReader> m_reader;
         bool m_doNothingOnFailure;
         unsigned m_currentFrame;
-#if ENABLE(APNG)
         png_structp m_png;
         png_infop m_info;
         bool m_isAnimated;
@@ -136,7 +127,6 @@ namespace WebCore {
         png_byte m_dataIHDR[12 + 13];
         png_byte m_dataPLTE[12 + 256 * 3];
         png_byte m_datatRNS[12 + 256];
-#endif
 #if USE(LCMS)
     LCMSTransformPtr m_iccTransform;
 #endif


### PR DESCRIPTION
#### e0f0c61dbb25b29a4bab5daadc0d1bd6403502e7
<pre>
Remove ENABLE_APNG directive
<a href="https://bugs.webkit.org/show_bug.cgi?id=265443">https://bugs.webkit.org/show_bug.cgi?id=265443</a>

Reviewed by Alex Christensen.

It&apos;s already enabled everywhere and APNG isn&apos;t going anywhere.

* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::readChunks):
(WebCore::PNGImageReader::PNGImageReader):
(WebCore::PNGImageDecoder::PNGImageDecoder):
(WebCore::PNGImageDecoder::repetitionCount const):
(WebCore::PNGImageDecoder::frameBufferAtIndex):
(WebCore::PNGImageDecoder::headerAvailable):
(WebCore::PNGImageDecoder::rowAvailable):
(WebCore::PNGImageDecoder::pngComplete):
(WebCore::PNGImageDecoder::fallbackNotAnimated):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.h:

Canonical link: <a href="https://commits.webkit.org/271221@main">https://commits.webkit.org/271221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88174dff47fad3581d394becffa28dcd29c056a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29895 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25055 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30535 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30687 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/26840 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2736 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28651 "Found 1 new API test failure: /TestWTF:WTF_ParkingLot.UnparkOneOneFast (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6087 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34306 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6657 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5043 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7416 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->